### PR TITLE
[GraphQL/Package Resolver] E2E tests for type resolution limits

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -1,4 +1,4 @@
-processed 8 tasks
+processed 12 tasks
 
 task 1 'run-graphql'. lines 6-15:
 Response: {
@@ -226,4 +226,58 @@ Response: {
       ]
     }
   }
+}
+
+task 8 'run-graphql'. lines 104-121:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Internal error occurred while processing request: Error calculating abilities for vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<vector<u8>>>>>>>>>>>>>>>>>: Type parameter nesting exceeded limit of 16",
+      "locations": [
+        {
+          "line": 14,
+          "column": 13
+        }
+      ],
+      "path": [
+        "type",
+        "abilities"
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
+}
+
+task 9 'publish'. lines 123-140:
+created: object(9,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4461200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 10 'create-checkpoint'. lines 142-142:
+Checkpoint created: 1
+
+task 11 'run-graphql'. lines 144-152:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Internal error occurred while processing request: Error calculating layout for 0xebbc039f65a88cb9bae1a412314d4fd6823f3db57c66881b2f5c85da8f7de3ff::m::S1<u32>: Type layout nesting exceeded limit of 128",
+      "locations": [
+        {
+          "line": 4,
+          "column": 9
+        }
+      ],
+      "path": [
+        "type",
+        "layout"
+      ],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -264,7 +264,7 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Internal error occurred while processing request: Error calculating layout for 0xebbc039f65a88cb9bae1a412314d4fd6823f3db57c66881b2f5c85da8f7de3ff::m::S1<u32>: Type layout nesting exceeded limit of 128",
+      "message": "Internal error occurred while processing request: Error calculating layout for 0x72dce866260a09d9bbc5de1680a405e8cc27887d7a11015b091c84ccbf517d55::m::S1<u32>: Type layout nesting exceeded limit of 128",
       "locations": [
         {
           "line": 4,

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator
+//# init --addresses P0=0x0 --simulator
 
 //# run-graphql
 # Happy path -- valid type, get everything
@@ -98,5 +98,55 @@
 
     prim_vector: type(type: "vector<u64>") {
         abilities
+    }
+}
+
+//# run-graphql
+# Unhappy path, type arguments too deep.
+
+{
+    type(type: """
+        vector<vector<vector<vector<
+        vector<vector<vector<vector<
+        vector<vector<vector<vector<
+        vector<vector<vector<vector<
+            vector<u8>
+        >>>>
+        >>>>
+        >>>>
+        >>>>
+        """) {
+            abilities
+        }
+}
+
+//# publish
+module P0::m {
+    struct S0<T> {
+        xs: vector<vector<vector<vector<
+            vector<vector<vector<vector<
+                T
+            >>>>
+            >>>>
+    }
+
+    struct S1<T> {
+        xss: S0<S0<S0<S0<S0<S0<S0<S0<
+             S0<S0<S0<S0<S0<S0<S0<S0<
+                 T
+             >>>>>>>>
+             >>>>>>>>
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+
+# Unhappy path, value nesting too deep.
+
+{
+    type(type: "@{P0}::m::S1<u32>") {
+        layout
     }
 }


### PR DESCRIPTION
## Description

Add tests that the limits implemented in the package resolver help to protect the GraphQL service against malicious type queries.

Note that tests were not added for the `max_type_nodes` and `max_type_argument_width` limits because the RPC limits are the same as the chain limits in these cases, so it's not possible to generate a type that could hit these limits in RPC, because they are already stopped by the chain's protocol config.  These limits have been separately tested in the package resolver crate.

## Test Plan

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- types.move
```

## Stack

- #15393 
- #15407 
- #15408
- #15409 
- #15410
- #15442 
- #15443 
- #15444 
- #15445 
- #15446 
- #15447 