### PR TITLE
[gql] consolidate dyn fields type filter

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_and_value_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_and_value_type.exp
@@ -1,0 +1,332 @@
+processed 17 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-64:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 10602000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 66-66:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 68-68:
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6536000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4 'run'. lines 70-70:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 5 'run'. lines 72-72:
+created: object(5,0), object(5,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 6 'run'. lines 74-74:
+created: object(6,0), object(6,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 7 'create-checkpoint'. lines 76-76:
+Checkpoint created: 1
+
+task 8 'view-checkpoint'. lines 78-78:
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 6Ex4fuLtnzCG76YXtszcK1rdRpfpXMVdn5fnS7bedNzs,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 6000000, storage_cost: 38554800, storage_rebate: 8848224, non_refundable_storage_fee: 89376 }}
+
+task 9 'run-graphql'. lines 80-104:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 106-130:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 133-157:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 159-183:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 185-209:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 211-235:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 237-261:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 263-287:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_and_value_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_and_value_type.move
@@ -1,0 +1,287 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::m {
+  use std::string;
+    use sui::dynamic_field as field;
+    use sui::dynamic_object_field as ofield;
+    use sui::object;
+    use sui::tx_context::{sender, TxContext};
+
+    struct Wrapper has key {
+        id: object::UID,
+        o: Parent
+    }
+
+    struct Parent has key, store {
+        id: object::UID,
+    }
+
+    struct Child has key, store {
+        id: object::UID,
+    }
+
+    struct Cup<T> has key, store {
+        id: object::UID,
+        value: T
+    }
+
+    struct Name<T> has copy, drop, store {
+        value: T
+    }
+
+    public entry fun create_obj(ctx: &mut TxContext){
+        let id = object::new(ctx);
+        sui::transfer::public_transfer(Parent { id }, sender(ctx))
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<u64, u64>(id, 0, 0);
+        field::add<vector<u8>, u64>(id, b"", 1);
+        field::add<bool, u64>(id, false, 2);
+    }
+
+    public entry fun add_dof(parent: &mut Parent, ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx) };
+        ofield::add(&mut parent.id, 0, child);
+    }
+
+    public entry fun add_cup_num(parent: &mut Parent, value: u64, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+
+    public entry fun add_cup_string(parent: &mut Parent, value: string::String, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+}
+
+//# run Test::m::create_obj --sender A
+
+//# run Test::m::add_df --sender A --args object(2,0)
+
+//# run Test::m::add_dof --sender A --args object(2,0)
+
+//# run Test::m::add_cup_num --sender A --args object(2,0) 42
+
+//# run Test::m::add_cup_string --sender A --args object(2,0) b"Will"
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  # should yield the 1 df of Field<u64, u64>
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "u64", valueType: "u64" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the single Child dof
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "u64", valueType: "@{Test}" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  # should yield the 2 Cup dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}", valueType: "@{Test}" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 2 Cup dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m", valueType: "@{Test}::m" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 2 Cup dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name", valueType: "@{Test}::m::Cup" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 1 Cup dof with T = u64
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m", valueType: "@{Test}::m::Cup<u64>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 1 Cup dof with T = u64
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name<u64>", valueType: "@{Test}::m::Cup" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield no results
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name<u64>", valueType: "@{Test}::m::Cup<0x1::string::String>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_type.exp
@@ -1,0 +1,526 @@
+processed 23 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-64:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 10602000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 66-66:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 68-68:
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6536000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4 'run'. lines 70-70:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 5 'run'. lines 72-72:
+created: object(5,0), object(5,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 6 'run'. lines 74-74:
+created: object(6,0), object(6,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 7 'create-checkpoint'. lines 76-76:
+Checkpoint created: 1
+
+task 8 'view-checkpoint'. lines 78-78:
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 6Ex4fuLtnzCG76YXtszcK1rdRpfpXMVdn5fnS7bedNzs,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 6000000, storage_cost: 38554800, storage_rebate: 8848224, non_refundable_storage_fee: 89376 }}
+
+task 9 'run-graphql'. lines 80-103:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 105-128:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 130-153:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 155-179:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 181-205:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 208-231:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 233-256:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 258-281:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 17 'run-graphql'. lines 285-309:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 18 'run-graphql'. lines 311-335:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 19 'run-graphql'. lines 337-361:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 20 'run-graphql'. lines 363-386:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 21 'run-graphql'. lines 388-412:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 22 'run-graphql'. lines 414-438:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_name_type.move
@@ -1,0 +1,438 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::m {
+  use std::string;
+    use sui::dynamic_field as field;
+    use sui::dynamic_object_field as ofield;
+    use sui::object;
+    use sui::tx_context::{sender, TxContext};
+
+    struct Wrapper has key {
+        id: object::UID,
+        o: Parent
+    }
+
+    struct Parent has key, store {
+        id: object::UID,
+    }
+
+    struct Child has key, store {
+        id: object::UID,
+    }
+
+    struct Cup<T> has key, store {
+        id: object::UID,
+        value: T
+    }
+
+    struct Name<T> has copy, drop, store {
+        value: T
+    }
+
+    public entry fun create_obj(ctx: &mut TxContext){
+        let id = object::new(ctx);
+        sui::transfer::public_transfer(Parent { id }, sender(ctx))
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<u64, u64>(id, 0, 0);
+        field::add<vector<u8>, u64>(id, b"", 1);
+        field::add<bool, u64>(id, false, 2);
+    }
+
+    public entry fun add_dof(parent: &mut Parent, ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx) };
+        ofield::add(&mut parent.id, 0, child);
+    }
+
+    public entry fun add_cup_num(parent: &mut Parent, value: u64, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+
+    public entry fun add_cup_string(parent: &mut Parent, value: string::String, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+}
+
+//# run Test::m::create_obj --sender A
+
+//# run Test::m::add_df --sender A --args object(2,0)
+
+//# run Test::m::add_dof --sender A --args object(2,0)
+
+//# run Test::m::add_cup_num --sender A --args object(2,0) 42
+
+//# run Test::m::add_cup_string --sender A --args object(2,0) b"Will"
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should be an empty result, as the type of name is u64
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Child" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield a df and the Child dof
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "u64" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name<u64>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Name<0x1::string::String>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+
+
+//# run-graphql
+{
+  # should yield an empty result as the name type of Cup is Name
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Cup" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield an empty result as the name type of Cup is Name
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Cup<u64>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield an empty result as the name type of Cup is Name
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "@{Test}::m::Cup<0x1::string::String>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "vector<u8>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the single bool df
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "bool" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should not yield any results - TODO: decide if this is the expected result
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { nameType: "vector" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_value_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_value_type.exp
@@ -1,0 +1,377 @@
+processed 16 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-64:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 10602000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 66-66:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 68-68:
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6536000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4 'run'. lines 70-70:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 5 'run'. lines 72-72:
+created: object(5,0), object(5,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 6 'run'. lines 74-74:
+created: object(6,0), object(6,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 7 'create-checkpoint'. lines 76-76:
+Checkpoint created: 1
+
+task 8 'view-checkpoint'. lines 78-78:
+CheckpointSummary { epoch: 0, seq: 1, content_digest: 6Ex4fuLtnzCG76YXtszcK1rdRpfpXMVdn5fnS7bedNzs,
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 6000000, storage_cost: 38554800, storage_rebate: 8848224, non_refundable_storage_fee: 89376 }}
+
+task 9 'run-graphql'. lines 80-104:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 106-130:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 133-157:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 159-183:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 186-210:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 212-236:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<u64>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "Number": "42"
+                    }
+                  }
+                ]
+              },
+              "bcs": "KgAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 238-262:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFieldConnection": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "0x43e42ce746642078b5adb6c5ddcb36344b7b3e6478f8e755ae28f67d1abfe4fb::m::Name<0x0000000000000000000000000000000000000000000000000000000000000001::string::String>"
+              },
+              "data": {
+                "Struct": [
+                  {
+                    "name": "value",
+                    "value": {
+                      "String": "Will"
+                    }
+                  }
+                ]
+              },
+              "bcs": "BFdpbGw="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_value_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/dynamic_fields/filter_on_value_type.move
@@ -1,0 +1,262 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::m {
+  use std::string;
+    use sui::dynamic_field as field;
+    use sui::dynamic_object_field as ofield;
+    use sui::object;
+    use sui::tx_context::{sender, TxContext};
+
+    struct Wrapper has key {
+        id: object::UID,
+        o: Parent
+    }
+
+    struct Parent has key, store {
+        id: object::UID,
+    }
+
+    struct Child has key, store {
+        id: object::UID,
+    }
+
+    struct Cup<T> has key, store {
+        id: object::UID,
+        value: T
+    }
+
+    struct Name<T> has copy, drop, store {
+        value: T
+    }
+
+    public entry fun create_obj(ctx: &mut TxContext){
+        let id = object::new(ctx);
+        sui::transfer::public_transfer(Parent { id }, sender(ctx))
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<u64, u64>(id, 0, 0);
+        field::add<vector<u8>, u64>(id, b"", 1);
+        field::add<bool, u64>(id, false, 2);
+    }
+
+    public entry fun add_dof(parent: &mut Parent, ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx) };
+        ofield::add(&mut parent.id, 0, child);
+    }
+
+    public entry fun add_cup_num(parent: &mut Parent, value: u64, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+
+    public entry fun add_cup_string(parent: &mut Parent, value: string::String, ctx: &mut TxContext) {
+        let cup = Cup { id: object::new(ctx), value };
+        let name = Name { value };
+        ofield::add(&mut parent.id, name, cup);
+    }
+}
+
+//# run Test::m::create_obj --sender A
+
+//# run Test::m::add_df --sender A --args object(2,0)
+
+//# run Test::m::add_dof --sender A --args object(2,0)
+
+//# run Test::m::add_cup_num --sender A --args object(2,0) 42
+
+//# run Test::m::add_cup_string --sender A --args object(2,0) b"Will"
+
+//# create-checkpoint
+
+//# view-checkpoint
+
+//# run-graphql
+{
+  # should yield the three dfs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "u64" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the three dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  # should yield the three dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}::m" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the single Child dof
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}::m::Child" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  # should yield the 2 Cup dofs
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}::m::Cup" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 1 Cup dof with T = u64
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}::m::Cup<u64>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # should yield the 1 Cup dof with T = String
+  object(address: "@{obj_2_0}") {
+    dynamicFieldConnection(filter: { valueType: "@{Test}::m::Cup<0x1::string::String>" }) {
+      nodes {
+        name {
+          type {
+            repr
+          }
+          data
+          bcs
+        }
+        value {
+          ... on MoveObject {
+            __typename
+          }
+          ... on MoveValue {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -92,7 +92,7 @@ type Address implements ObjectOwner {
 	This resolver is not supported on the Address type.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 enum AddressTransactionBlockRelationship {
@@ -511,6 +511,31 @@ type DynamicFieldEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+input DynamicFieldFilter {
+	"""
+	Filter the type of dynamic field name.
+	
+	Names can be filtered by their type's package, package::module, or
+	their fully qualified type name.
+	
+	Generic types can be queried by either the generic type name, e.g.
+	`0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	nameType: String
+	"""
+	Filter the type of dynamic field value.
+	
+	Values can be filtered by their type's package, package::module,
+	or their fully qualified type name.
+	
+	Generic types can be queried by either the generic type name, e.g.
+	`0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	valueType: String
 }
 
 input DynamicFieldName {
@@ -1478,7 +1503,7 @@ type Object implements ObjectOwner {
 	The dynamic fields on an object.
 	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """
@@ -1585,7 +1610,7 @@ interface ObjectOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
 	dynamicField(name: DynamicFieldName!): DynamicField
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """
@@ -1694,7 +1719,7 @@ type Owner implements ObjectOwner {
 	The dynamic fields on an object.
 	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -11,6 +11,7 @@ use sui_indexer::{
     types_v2::OwnerType,
 };
 
+use super::db_data_provider::PageLimit;
 use crate::{
     error::Error,
     types::{
@@ -23,7 +24,9 @@ use diesel::{
     sql_types::Text,
 };
 
-use super::db_data_provider::PageLimit;
+pub(crate) const DYNAMIC_FIELD_TYPE: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field";
+pub(crate) const DYNAMIC_OBJECT_FIELD_WRAPPER_TYPE: &str = "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_object_field::Wrapper";
 
 pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     'a,

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -83,7 +83,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn multi_get_dyn_fields(
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
-        limit: i64,
+        limit: PageLimit,
         owner_id: Vec<u8>,
         filter: Option<DynamicFieldFilter>,
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -13,7 +13,10 @@ use sui_indexer::{
 
 use crate::{
     error::Error,
-    types::{event::EventFilter, object::ObjectFilter, transaction_block::TransactionBlockFilter},
+    types::{
+        dynamic_field::DynamicFieldFilter, event::EventFilter, object::ObjectFilter,
+        transaction_block::TransactionBlockFilter,
+    },
 };
 use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
@@ -73,6 +76,13 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
         limit: PageLimit,
         filter: Option<ObjectFilter>,
         owner_type: Option<OwnerType>,
+    ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
+    fn multi_get_dyn_fields(
+        before: Option<Vec<u8>>,
+        after: Option<Vec<u8>>,
+        limit: i64,
+        owner_id: Vec<u8>,
+        filter: Option<DynamicFieldFilter>,
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -625,7 +625,7 @@ impl PgManager {
 
         result
             .map(|mut stored_objs| {
-                let has_next_page = stored_objs.len() as i64 > limit;
+                let has_next_page = stored_objs.len() as i64 > limit.value();
                 if has_next_page {
                     stored_objs.pop();
                 }

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -377,12 +377,12 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
     fn multi_get_dyn_fields(
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
-        limit: i64,
+        limit: PageLimit,
         owner_id: Vec<u8>,
         filter: Option<DynamicFieldFilter>,
     ) -> Result<objects::BoxedQuery<'static, Pg>, Error> {
-        let mut query = order_objs(before, after);
-        query = query.limit(limit + 1);
+        let mut query = order_objs(before, after, &limit);
+        query = query.limit(limit.value() + 1);
 
         query = query
             .filter(objects::dsl::owner_id.eq(owner_id))

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -9,7 +9,7 @@ use crate::{context_data::db_data_provider::PgManager, error::Error};
 use super::{
     balance::Balance,
     coin::Coin,
-    dynamic_field::{DynamicField, DynamicFieldName},
+    dynamic_field::{DynamicField, DynamicFieldFilter, DynamicFieldName},
     object::{Object, ObjectFilter},
     stake::StakedSui,
     sui_address::SuiAddress,
@@ -189,6 +189,7 @@ impl Address {
         _after: Option<String>,
         _last: Option<u64>,
         _before: Option<String>,
+        _filter: Option<DynamicFieldFilter>,
     ) -> Result<Option<Connection<String, DynamicField>>> {
         Err(Error::DynamicFieldOnAddress.extend())
     }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -37,6 +37,29 @@ pub(crate) struct DynamicFieldName {
     pub bcs: Base64,
 }
 
+#[derive(InputObject, Clone)]
+pub(crate) struct DynamicFieldFilter {
+    /// Filter the type of dynamic field name.
+    ///
+    /// Names can be filtered by their type's package, package::module, or
+    /// their fully qualified type name.
+    ///
+    /// Generic types can be queried by either the generic type name, e.g.
+    /// `0x2::coin::Coin`, or by the full type name, such as
+    /// `0x2::coin::Coin<0x2::sui::SUI>`.
+    pub name_type: Option<String>,
+
+    /// Filter the type of dynamic field value.
+    ///
+    /// Values can be filtered by their type's package, package::module,
+    /// or their fully qualified type name.
+    ///
+    /// Generic types can be queried by either the generic type name, e.g.
+    /// `0x2::coin::Coin`, or by the full type name, such as
+    /// `0x2::coin::Coin<0x2::sui::SUI>`.
+    pub value_type: Option<String>,
+}
+
 #[Object]
 impl DynamicField {
     /// The string type, data, and serialized value of the DynamicField's 'name' field.

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -13,7 +13,7 @@ use sui_types::TypeTag;
 
 use super::big_int::BigInt;
 use super::display::{get_rendered_fields, DisplayEntry};
-use super::dynamic_field::{DynamicField, DynamicFieldName};
+use super::dynamic_field::{DynamicField, DynamicFieldFilter, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::suins_registration::SuinsRegistration;
@@ -356,9 +356,10 @@ impl Object {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
+        filter: Option<DynamicFieldFilter>,
     ) -> Result<Option<Connection<String, DynamicField>>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_fields(first, after, last, before, self.address)
+            .fetch_dynamic_fields(first, after, last, before, self.address, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -3,6 +3,7 @@
 
 use super::address::Address;
 use super::dynamic_field::DynamicField;
+use super::dynamic_field::DynamicFieldFilter;
 use super::dynamic_field::DynamicFieldName;
 use super::stake::StakedSui;
 use super::suins_registration::SuinsRegistration;
@@ -85,6 +86,7 @@ use sui_types::dynamic_field::DynamicFieldType;
         arg(name = "after", ty = "Option<String>"),
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<String>"),
+        arg(name = "filter", ty = "Option<DynamicFieldFilter>")
     )
 )]
 #[derive(Clone, Debug)]
@@ -264,9 +266,10 @@ impl Owner {
         after: Option<String>,
         last: Option<u64>,
         before: Option<String>,
+        filter: Option<DynamicFieldFilter>,
     ) -> Result<Option<Connection<String, DynamicField>>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_dynamic_fields(first, after, last, before, self.address)
+            .fetch_dynamic_fields(first, after, last, before, self.address, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -96,7 +96,7 @@ type Address implements ObjectOwner {
 	This resolver is not supported on the Address type.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 enum AddressTransactionBlockRelationship {
@@ -515,6 +515,31 @@ type DynamicFieldEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+input DynamicFieldFilter {
+	"""
+	Filter the type of dynamic field name.
+	
+	Names can be filtered by their type's package, package::module, or
+	their fully qualified type name.
+	
+	Generic types can be queried by either the generic type name, e.g.
+	`0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	nameType: String
+	"""
+	Filter the type of dynamic field value.
+	
+	Values can be filtered by their type's package, package::module,
+	or their fully qualified type name.
+	
+	Generic types can be queried by either the generic type name, e.g.
+	`0x2::coin::Coin`, or by the full type name, such as
+	`0x2::coin::Coin<0x2::sui::SUI>`.
+	"""
+	valueType: String
 }
 
 input DynamicFieldName {
@@ -1482,7 +1507,7 @@ type Object implements ObjectOwner {
 	The dynamic fields on an object.
 	Dynamic fields on wrapped objects can be accessed by using the same API under the Owner type.
 	"""
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """
@@ -1589,7 +1614,7 @@ interface ObjectOwner {
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
 	dynamicField(name: DynamicFieldName!): DynamicField
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """
@@ -1698,7 +1723,7 @@ type Owner implements ObjectOwner {
 	The dynamic fields on an object.
 	This field exists as a convenience when accessing a dynamic field on a wrapped object.
 	"""
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String, filter: DynamicFieldFilter): DynamicFieldConnection
 }
 
 """


### PR DESCRIPTION
## Description 

It looks like a lot of lines, but most of it are just from the e2e snapshot tests. The implementation for the consolidated type filter for dynamic fields follows the same logic for filtering on objects and events.

Because dynamic field objects are represented in the db as either Field<K,V> - a dynamic field or Field<Wrapper<K>,V>, selecting on name_type will always require some form of string matching. The regexp pattern becomes:
`"{DYNAMIC_FIELD_TYPE}<({DYNAMIC_OBJECT_FIELD_WRAPPER_TYPE}<{inner_type}>|{inner_type}),.*?>"

There are three paths for the inner_type to take:
1. If it has no "::", then it is either the package address, or a primitive type.
address -> "{address}::.+?"
primitive -> "{primitive}"

2. If it has a single "::", then it must be a valid package::module. In this scenario, the processed inner_type would look like "{package}::{module}::.+?"

3. Lastly, if it has two "::", then it can be one of fully qualified type, or a generic type. We convert the string into a StructTag to validate it, and check if struct_tag.type_params.is_empty(). 

If type_params is indeed empty, then it is either a fully qualified type or the client is leaving it up to us to match. In this scenario, we expect "{validated_type}<.+?>" or "{validated_type}"

Otherwise, we know that it is a fully qualified type with type params that are also valid, and we can directly pass it as "{validated_type}"

Handling valueType is easier, as there is a dedicated df_object_type column.

## Test Plan 

sui-graphql-e2e-tests/tests/dynamic_fields/*
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
