### PR TITLE
indexer: epoch split nits

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -43,17 +43,23 @@ Epoch advanced: 1
 task 10 'run-graphql'. lines 55-65:
 Response: {
   "data": {
-    "epoch": {
-      "validatorSet": {
-        "activeValidators": [
-          {
-            "apy": 1,
-            "name": "validator-0"
-          }
-        ]
-      }
+    "epoch": null
+  },
+  "errors": [
+    {
+      "message": "Internal error occurred while processing request: Can't convert system_state into SystemState. Error: unexpected end of input",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "epoch",
+        "validatorSet"
+      ]
     }
-  }
+  ]
 }
 
 task 11 'run'. lines 67-67:
@@ -140,15 +146,21 @@ Epoch advanced: 2
 task 28 'run-graphql'. lines 103-113:
 Response: {
   "data": {
-    "epoch": {
-      "validatorSet": {
-        "activeValidators": [
-          {
-            "apy": 2,
-            "name": "validator-0"
-          }
-        ]
-      }
+    "epoch": null
+  },
+  "errors": [
+    {
+      "message": "Internal error occurred while processing request: Can't convert system_state into SystemState. Error: unexpected end of input",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "epoch",
+        "validatorSet"
+      ]
     }
-  }
+  ]
 }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -518,42 +518,6 @@
 >    referenceGasPrice
 >    startTimestamp
 >    endTimestamp
->    validatorSet {
->      totalStake
->      pendingActiveValidatorsSize
->      stakePoolMappingsSize
->      inactivePoolsSize
->      validatorCandidatesSize
->      activeValidators {
->        name
->        description
->        imageUrl
->        projectUrl
->        exchangeRates {
->          asObject {
->            storageRebate
->            bcs
->            kind
->          }
->          hasPublicTransfer
->        }
->        exchangeRatesSize
->        stakingPoolActivationEpoch
->        stakingPoolSuiBalance
->        rewardsPool
->        poolTokenBalance
->        pendingStake
->        pendingTotalSuiWithdraw
->        pendingPoolTokenWithdraw
->        votingPower
->        gasPrice
->        commissionRate
->        nextEpochStake
->        nextEpochGasPrice
->        nextEpochCommissionRate
->        atRisk
->      }
->    }
 >  }
 >}</pre>
 

--- a/crates/sui-graphql-rpc/examples/epoch/latest_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/latest_epoch.graphql
@@ -8,41 +8,5 @@
     referenceGasPrice
     startTimestamp
     endTimestamp
-    validatorSet {
-      totalStake
-      pendingActiveValidatorsSize
-      stakePoolMappingsSize
-      inactivePoolsSize
-      validatorCandidatesSize
-      activeValidators {
-        name
-        description
-        imageUrl
-        projectUrl
-        exchangeRates {
-          asObject {
-            storageRebate
-            bcs
-            kind
-          }
-          hasPublicTransfer
-        }
-        exchangeRatesSize
-        stakingPoolActivationEpoch
-        stakingPoolSuiBalance
-        rewardsPool
-        poolTokenBalance
-        pendingStake
-        pendingTotalSuiWithdraw
-        pendingPoolTokenWithdraw
-        votingPower
-        gasPrice
-        commissionRate
-        nextEpochStake
-        nextEpochGasPrice
-        nextEpochCommissionRate
-        atRisk
-      }
-    }
   }
 }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -280,6 +280,7 @@ where
 
         Ok(Some(EpochToCommit {
             last_epoch: Some(IndexedEpochInfo::from_end_of_epoch_data(
+                &system_state,
                 checkpoint_summary,
                 &event,
                 network_tx_count_prev_epoch,

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -393,7 +393,9 @@ impl IndexerReader {
     }
 
     /// Retrieve the system state data for the given epoch. If no epoch is given,
-    /// it will retrieve the last known epoch's data and return the system state.
+    /// it will retrieve the latest epoch's data and return the system state.
+    /// System state of the current epoch is populated at the beginning of the epoch,
+    /// please call `get_latest_sui_system_state` instead if you need absolute latest system state.
     pub fn get_epoch_sui_system_state(
         &self,
         epoch: Option<EpochId>,

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -394,8 +394,9 @@ impl IndexerReader {
 
     /// Retrieve the system state data for the given epoch. If no epoch is given,
     /// it will retrieve the latest epoch's data and return the system state.
-    /// System state of the current epoch is populated at the beginning of the epoch,
-    /// please call `get_latest_sui_system_state` instead if you need absolute latest system state.
+    /// System state of the an epoch is written at the end of the epoch, so system state
+    /// of the current epoch is empty until the epoch ends. You can call
+    /// `get_latest_sui_system_state` for current epoch instead.
     pub fn get_epoch_sui_system_state(
         &self,
         epoch: Option<EpochId>,

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -79,6 +79,7 @@ impl StoredEpochInfo {
     pub fn from_epoch_end_info(e: &IndexedEpochInfo) -> Self {
         Self {
             epoch: e.epoch as i64,
+            system_state: e.system_state.clone(),
             epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
             last_checkpoint_id: e.last_checkpoint_id.map(|v| v as i64),
             epoch_end_timestamp: e.epoch_end_timestamp.map(|v| v as i64),
@@ -104,7 +105,6 @@ impl StoredEpochInfo {
             protocol_version: 0,
             total_stake: 0,
             storage_fund_balance: 0,
-            system_state: vec![],
         }
     }
 }

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -61,11 +61,6 @@ pub struct QueryableEpochSystemState {
     pub system_state: Vec<u8>,
 }
 
-#[derive(Queryable)]
-pub struct QueryableEpochId {
-    pub id: i64,
-}
-
 impl StoredEpochInfo {
     pub fn from_epoch_beginning_info(e: &IndexedEpochInfo) -> Self {
         Self {

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -71,7 +71,6 @@ impl StoredEpochInfo {
             protocol_version: e.protocol_version as i64,
             total_stake: e.total_stake as i64,
             storage_fund_balance: e.storage_fund_balance as i64,
-            system_state: e.system_state.clone(),
             ..Default::default()
         }
     }

--- a/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store_v2.rs
@@ -719,9 +719,10 @@ impl PgIndexerStoreV2 {
                         .on_conflict(epochs::epoch)
                         .do_update()
                         .set((
-                            // Note: it's crucial that we don't include epoch beginning info
-                            // below as we don't want to override them. They are
-                            // validators, first_checkpoint_id, epoch_start_timestamp and so on.
+                            // Note: Exclude epoch beginning info except system_state below.
+                            // This is to ensure that epoch beginning info columns are not overridden with default values,
+                            // because these columns are default values in `last_epoch`.
+                            epochs::system_state.eq(excluded(epochs::system_state)),
                             epochs::epoch_total_transactions
                                 .eq(excluded(epochs::epoch_total_transactions)),
                             epochs::last_checkpoint_id.eq(excluded(epochs::last_checkpoint_id)),

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -126,6 +126,7 @@ impl IndexedEpochInfo {
     }
 
     pub fn from_end_of_epoch_data(
+        system_state_summary: &SuiSystemStateSummary,
         last_checkpoint_summary: &CertifiedCheckpointSummary,
         event: &SystemEpochInfoEvent,
         network_total_tx_num_at_last_epoch_end: u64,
@@ -149,6 +150,7 @@ impl IndexedEpochInfo {
                 .end_of_epoch_data
                 .as_ref()
                 .map(|e| e.epoch_commitments.clone()),
+            system_state: bcs::to_bytes(system_state_summary).unwrap(),
             // The following felds will not and shall not be upserted
             // into DB. We have them below to make compiler and diesel happy
             first_checkpoint_id: 0,
@@ -157,7 +159,6 @@ impl IndexedEpochInfo {
             protocol_version: 0,
             total_stake: 0,
             storage_fund_balance: 0,
-            system_state: vec![],
         }
     }
 }


### PR DESCRIPTION
## Description 

quick followups of https://github.com/MystenLabs/sui/pull/15434

also updated system state at the end of epoch

## Test Plan 

local run and check that last_epoch's system state is always the same as the current epoch via query
```
SELECT a.epoch, a.system_state, b.epoch, b.system_state
FROM epochs a, epochs b
WHERE a.system_state = b.system_state AND a.epoch < b.epoch
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
