### PR TITLE
local grafana adds metrics collection for benchmark clients

### DIFF
--- a/docker/grafana-local/prometheus.yaml
+++ b/docker/grafana-local/prometheus.yaml
@@ -30,6 +30,24 @@ scrape_configs:
         labels:
           host: validator3
           network: local
+  - job_name: "Client_1"
+    static_configs:
+      - targets: ["host.docker.internal:8081"]
+        labels:
+          host: client1
+          network: local
+  - job_name: "Client_2"
+    static_configs:
+      - targets: ["host.docker.internal:8082"]
+        labels:
+          host: client2
+          network: local
+  - job_name: "Client_3"
+    static_configs:
+      - targets: ["host.docker.internal:8083"]
+        labels:
+          host: client3
+          network: local
   - job_name: "tempo"
     static_configs:
       - targets: ["tempo:3200"]


### PR DESCRIPTION
## Description 

Added benchmark client metrics collection for analyzing client side metrics. 8081 is the default port and also adds a few custom port.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
