### PR TITLE
indexer: separate cmd for DB reset

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -94,7 +94,7 @@ pub struct IndexerConfig {
     pub db_port: Option<u16>,
     #[clap(long)]
     pub db_name: Option<String>,
-    #[clap(long)]
+    #[clap(long, default_value = "http://0.0.0.0:9000", global = true)]
     pub rpc_client_url: String,
     #[clap(long, default_value = "0.0.0.0", global = true)]
     pub client_metric_host: String,


### PR DESCRIPTION
## Description 

To automate DB reset on CI, staging and devnet more easily

## Test Plan 

```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --reset-db
```

```
2023-12-21T19:23:13.733316Z  INFO sui_indexer::utils: Resetting database ...
2023-12-21T19:23:13.733365Z  INFO sui_indexer::utils: Dropping all tables in the database
2023-12-21T19:23:13.756210Z  INFO sui_indexer::utils: Dropped all tables in the database
2023-12-21T19:23:13.798343Z  INFO sui_indexer::utils: Reset database complete.
2023-12-21T19:23:13.799022Z  WARN sui_indexer: Failed to convert full node url http://0.0.0.0:9000 to a shorter version
2023-12-21T19:23:13.799138Z  INFO sui_indexer: Starting prometheus server with labels: {"indexer_fullnode": "unknown_url"}
2023-12-21T19:23:13.802157Z  INFO sui_indexer: DB connection pool size: 100, with idle conn: 99.
2023-12-21T19:23:13.803570Z  INFO sui_indexer::store::pg_indexer_store: Found 1 tables with partitions : [{"objects_history": 0}]
2023-12-21T19:23:13.803653Z  INFO sui_indexer: Sui indexer of version "1.16.0" started...
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
