### PR TITLE
[graphql/rpc] use new available range logic

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -203,7 +203,7 @@ Response: {
               "name": "M1"
             },
             "type": {
-              "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+              "repr": "0x98066eb7ecf6d012f6cb58b51879a46bf3d310e5db6623fc1777a14db679a0c8::M1::EventA"
             },
             "senders": [
               {
@@ -223,7 +223,7 @@ Response: {
               "name": "M1"
             },
             "type": {
-              "repr": "0xba9d8235634328c134d29355e51c81de5f36a748397cb756614091def06a0307::M1::EventA"
+              "repr": "0x98066eb7ecf6d012f6cb58b51879a46bf3d310e5db6623fc1777a14db679a0c8::M1::EventA"
             },
             "senders": [
               {

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -139,10 +139,10 @@ Response: {
       "objectConnection": {
         "edges": [
           {
-            "cursor": "0x892552efa67a9d4f40ced8bfb35f0b0e2e1b3399c64729b11b8c00f77a539f5e"
+            "cursor": "0xabb3fa78b4533e0ecb704f55f6e29e39d969d13a18d4720e3146ba8a1b1f2227"
           },
           {
-            "cursor": "0x8a9eeae01da257bcab470ef0ba0207ddb51bfd8f7a3b2dba01d439762d9f7b3c"
+            "cursor": "0xc2159190710e56ba56889e6bee1b5737494d0b6e4fbb367ab2344887ef51fc72"
           }
         ]
       }

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -6,21 +6,24 @@ use crate::context_data::db_data_provider::PgManager;
 use async_graphql::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct AvailableRange;
+pub(crate) struct AvailableRange {
+    pub first: u64,
+    pub last: u64,
+}
 
 // TODO: do both in one query?
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_earliest_complete_checkpoint()
+            .fetch_checkpoint(None, Some(self.first))
             .await
             .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
         ctx.data_unchecked::<PgManager>()
-            .fetch_checkpoint(None, None)
+            .fetch_checkpoint(None, Some(self.last))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -44,8 +44,9 @@ impl Query {
 
     /// Range of checkpoints that the RPC has data available for (for data
     /// that can be tied to a particular checkpoint).
-    async fn available_range(&self) -> Result<AvailableRange> {
-        Ok(AvailableRange)
+    async fn available_range(&self, ctx: &Context<'_>) -> Result<AvailableRange> {
+        let (first, last) = ctx.data_unchecked::<PgManager>().available_range().await?;
+        Ok(AvailableRange { first, last })
     }
 
     /// Configuration for this RPC service


### PR DESCRIPTION
## Description 

Use new available range logic provided in [this](https://github.com/MystenLabs/sui/pull/15339/files#r1425718144) PR as specified by `get_consistent_read_range`.

## Test Plan 

Existing test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
