### PR TITLE
move [chore]: remove version field from Move.toml

### DIFF
--- a/crates/sui-axelar-cgp/move/Move.toml
+++ b/crates/sui-axelar-cgp/move/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "sui-axelar-cgp"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local= "../../sui-framework/packages/sui-framework" }

--- a/crates/sui-benchmark/src/workloads/data/adversarial/Move.toml
+++ b/crates/sui-benchmark/src/workloads/data/adversarial/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "adversarial"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-benchmark/src/workloads/data/max_package/Move.toml
+++ b/crates/sui-benchmark/src/workloads/data/max_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "max_package"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-benchmark/tests/data/deepbook_client/Move.toml
+++ b/crates/sui-benchmark/tests/data/deepbook_client/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "deepbook_client"
-version = "0.0.1"
 
 [dependencies]
 DeepBook = { local = "../../../../sui-framework/packages/deepbook" }

--- a/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_dependency_invalid_published_at/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_dependency_invalid_published_at/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "CustomPropertiesInManifestDependencyInvalidPublishedAt"
-version = "0.0.0"
 # oops we put a non-ID value for published-at...
 published-at = "mystery"
 

--- a/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_dependency_missing_published_at/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_dependency_missing_published_at/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "CustomPropertiesInManifestDependencyMissingPublishedAt"
-version = "0.0.0"
 # oops we there's no published-at field, so a package that depends on us should fail when published...
 # published-at = "0x777"
 

--- a/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_ensure_published_at/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/custom_properties_in_manifest_ensure_published_at/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "CustomPropertiesInManifestEnsurePublishedAt"
-version = "0.0.0"
 
 [dependencies]
 CustomPropertiesInManifestDependencyMissingPublishedAt = { local = "../custom_properties_in_manifest_dependency_missing_published_at" }

--- a/crates/sui-core/src/unit_tests/data/depends_on_basics/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/depends_on_basics/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "DependsOnBasics"
-version = "0.0.0"
 
 [dependencies]
 Examples = { local = "../object_basics" }

--- a/crates/sui-core/src/unit_tests/data/entry_point_types/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/entry_point_types/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "entry_point_types"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "entry_point_vector"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/generate_move_lock_file/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/generate_move_lock_file/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "GenerateMoveLockFile"
-version = "0.0.0"
 
 [dependencies]
 Examples = { local = "../object_basics" }

--- a/crates/sui-core/src/unit_tests/data/managed_coin/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/managed_coin/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "FungibleTokens"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_package/A/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/A/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "A"
-version = "0.0.1"
 
 [addresses]
 a = "0xa1"

--- a/crates/sui-core/src/unit_tests/data/move_package/B/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/B/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "B"
-version = "0.0.1"
 
 [addresses]
 b = "0xb1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "B"
-version = "0.0.1"
 
 [addresses]
 b = "0xb1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "C"
-version = "0.0.1"
 published-at = "0xc1"
 
 [addresses]

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "C"
-version = "0.0.2"
 published-at = "0xc2"
 
 [addresses]

--- a/crates/sui-core/src/unit_tests/data/move_random/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_random/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "additive_upgrade"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "additive_upgrade_invalid"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "_"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "compatibility_invalid"
-version = "0.0.2"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dep_on_dep"
-version = "0.0.1"
 
 [dependencies]
 dep_on_upgrading_package = { local = "../dep_on_upgrading_package_upgradeable" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dep_on_upgrading_package"
-version = "0.0.1"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_transitive/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_transitive/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dep_on_upgrading_package_transitive"
-version = "0.0.1"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dep_on_upgrading_package"
-version = "0.0.1"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/makes_another_object/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/makes_another_object/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "makes_another_object"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "makes_new_object"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v1/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v2/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v2_module_removed/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/missing_type_v2_module_removed/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "package_upgrade_base"
-version = "0.0.1"
 
 [addresses]
 base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "new_object"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_cross_module_ref"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_cross_module_ref1"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_cross_module_ref2"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "stage1_basic_compatibility_valid"
-version = "0.0.2"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "stage2_basic_compatibility_valid"
-version = "0.0.3"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/object_basics/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/object_basics/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/object_no_id/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/object_no_id/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_no_id"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/object_owner/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/object_owner/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_owner"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/object_wrapping/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/object_wrapping/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "object_wrapping"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/package_deny/a/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/package_deny/a/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "A"
-version = "0.0.1"
 
 [dependencies]
 B = { local = "../b" }

--- a/crates/sui-core/src/unit_tests/data/package_deny/b/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/package_deny/b/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "B"
-version = "0.0.1"
 
 [dependencies]
 C = { local = "../c" }

--- a/crates/sui-core/src/unit_tests/data/package_deny/c/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/package_deny/c/Move.toml
@@ -1,3 +1,2 @@
 [package]
 name = "C"
-version = "0.0.1"

--- a/crates/sui-core/src/unit_tests/data/publish_with_event/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/publish_with_event/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/shared_object_deletion/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/shared_object_deletion/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shared_object_deletion"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/a/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/a/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "A"
-version = "0.0.1"
 
 [dependencies]
 B = { local = "../b" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/b/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/b/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "B"
-version = "0.0.1"
 
 [dependencies]
 C = { local = "../c" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/c/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/c/Move.toml
@@ -1,4 +1,3 @@
 [package]
 name = "C"
-version = "0.0.1"
 

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/root/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/root/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/tto/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/tto/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tto"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/type_params/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/type_params/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "type_params"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/type_params_extra/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/type_params_extra/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "type_params_extra"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-cost/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/sui-cost/tests/data/dummy_modules_publish/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraAddKeyAbility"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/add_struct_ability/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/add_struct_ability/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraAddStructAbility"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/base/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraBase"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_entry_function_signature/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_entry_function_signature/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraChangeEntryFunctionSignature"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_public_function_signature/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_public_function_signature/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraChangePublicFunctionSignature"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_ability/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_ability/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraChangeStructAbility"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_layout/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_struct_layout/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraChangeStructLayout"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/change_type_constraint/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/change_type_constraint/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraChangeTypeConstraint"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/compatible/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/compatible/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtraCompatible"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/extra_package/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/extra_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiExtra"
-version = "0.0.1"
 
 [dependencies]
 SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MockSuiSystemBase"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiSystemDeepUpgrade"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/safe_mode/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/safe_mode/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MockSuiSystemSafeMode"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/Move.toml
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiSystemShallowUpgrade"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-e2e-tests/tests/move_test_code/Move.toml
+++ b/crates/sui-e2e-tests/tests/move_test_code/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "move_test_code"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-framework/packages/deepbook/Move.toml
+++ b/crates/sui-framework/packages/deepbook/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "DeepBook"
-version = "0.0.1"
 published-at = "0xdee9"
 
 [dependencies]

--- a/crates/sui-framework/packages/move-stdlib/Move.toml
+++ b/crates/sui-framework/packages/move-stdlib/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
 published-at = "0x1"
 
 [addresses]

--- a/crates/sui-framework/packages/sui-framework/Move.toml
+++ b/crates/sui-framework/packages/sui-framework/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Sui"
-version = "0.0.1"
 published-at = "0x2"
 
 [dependencies]

--- a/crates/sui-framework/packages/sui-system/Move.toml
+++ b/crates/sui-framework/packages/sui-system/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "SuiSystem"
-version = "0.0.1"
 published-at = "0x3"
 
 [dependencies]

--- a/crates/sui-json-rpc-tests/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/sui-json-rpc-tests/tests/data/dummy_modules_publish/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-package-resolver/tests/packages/a0/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/a0/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "A"
-version = "0.0.1"
 published-at = "0xa0"
 
 [addresses]

--- a/crates/sui-package-resolver/tests/packages/a1/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/a1/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "A"
-version = "0.0.1"
 published-at = "0xa1"
 
 [addresses]

--- a/crates/sui-package-resolver/tests/packages/b0/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/b0/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "B"
-version = "0.0.1"
 published-at = "0xb0"
 
 [dependencies]

--- a/crates/sui-package-resolver/tests/packages/c0/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/c0/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "C"
-version = "0.0.1"
 published-at = "0xc0"
 
 [dependencies]

--- a/crates/sui-package-resolver/tests/packages/d0/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/d0/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "D"
-version = "0.0.1"
 published-at = "0xd0"
 
 [dependencies]

--- a/crates/sui-package-resolver/tests/packages/s0/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/s0/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "S"
-version = "0.0.1"
 published-at = "0x1"
 
 [addresses]

--- a/crates/sui-package-resolver/tests/packages/s1/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/s1/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "S"
-version = "0.0.1"
 published-at = "0x1"
 
 [addresses]

--- a/crates/sui-package-resolver/tests/packages/sui/Move.toml
+++ b/crates/sui-package-resolver/tests/packages/sui/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Sui"
-version = "0.0.1"
 published-at = "0x2"
 
 [addresses]

--- a/crates/sui-single-node-benchmark/move_package/Move.toml
+++ b/crates/sui-single-node-benchmark/move_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveBenchmark"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../sui-framework/packages/sui-framework" }

--- a/crates/sui-source-validation-service/tests/fixture/custom/Move.toml
+++ b/crates/sui-source-validation-service/tests/fixture/custom/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "custom"
-version = "0.0.1"
 
 [addresses]
 custom = "0x0"

--- a/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/Move.toml
+++ b/crates/sui-source-validation-service/tests/fixture/sui/move-stdlib/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
 published-at = "0x1"
 
 [addresses]

--- a/crates/sui-source-validation/fixture/a/Move.toml
+++ b/crates/sui-source-validation/fixture/a/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "a"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [dependencies]

--- a/crates/sui-source-validation/fixture/b-v2/Move.toml
+++ b/crates/sui-source-validation/fixture/b-v2/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "b"
-version = "0.0.2"
 published-at = "$STORAGE_ID"
 
 [addresses]

--- a/crates/sui-source-validation/fixture/b/Move.toml
+++ b/crates/sui-source-validation/fixture/b/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "b"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [addresses]

--- a/crates/sui-source-validation/fixture/c/Move.toml
+++ b/crates/sui-source-validation/fixture/c/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "c"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [addresses]

--- a/crates/sui-source-validation/fixture/d/Move.toml
+++ b/crates/sui-source-validation/fixture/d/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "d"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [dependencies]

--- a/crates/sui-source-validation/fixture/e/Move.toml
+++ b/crates/sui-source-validation/fixture/e/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "e"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [dependencies]

--- a/crates/sui-source-validation/fixture/z/Move.toml
+++ b/crates/sui-source-validation/fixture/z/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "z"
-version = "0.0.1"
 published-at = "$STORAGE_ID"
 
 [dependencies]

--- a/crates/sui-surfer/tests/move_building_blocks/Move.toml
+++ b/crates/sui-surfer/tests/move_building_blocks/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveBuildingBlocks"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_name_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_name_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_name_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_name_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_value_changed/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_value_changed/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_value_changed/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/constant_value_changed/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_function_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_function_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_function_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/friend_function_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_rename/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_rename/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_rename/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/public_fun_rename/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_layout_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_layout_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_layout_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_layout_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_name_change/base/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_name_change/base/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_name_change/upgraded/Move.toml
+++ b/crates/sui-upgrade-compatibility-transactional-tests/tests/struct_name_change/upgraded/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "base"
-version = "0.0.1"
 
 [addresses]
 base =  "0x0"

--- a/crates/sui/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/sui/tests/data/dummy_modules_publish/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/dummy_modules_upgrade/Move.toml
+++ b/crates/sui/tests/data/dummy_modules_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [addresses]
 examples = "0x0"

--- a/crates/sui/tests/data/linter/Move.toml
+++ b/crates/sui/tests/data/linter/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "linter"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/module_dependency_invalid/Move.toml
+++ b/crates/sui/tests/data/module_dependency_invalid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Invalid"
-version = "0.0.1"
 published-at = "mystery"
 
 [addresses]

--- a/crates/sui/tests/data/module_dependency_nonexistent/Move.toml
+++ b/crates/sui/tests/data/module_dependency_nonexistent/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Nonexistent"
-version = "0.0.1"
 published-at = "0xabc123"
 
 [addresses]

--- a/crates/sui/tests/data/module_dependency_unpublished/Move.toml
+++ b/crates/sui/tests/data/module_dependency_unpublished/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Unpublished"
-version = "0.0.1"
 # No published-at address for this package.
 # published-at = "0x0"
 

--- a/crates/sui/tests/data/module_dependency_unpublished_non_zero_address/Move.toml
+++ b/crates/sui/tests/data/module_dependency_unpublished_non_zero_address/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "UnpublishedNonZeroAddress"
-version = "0.0.1"
 # No published-at address for this package.
 # published-at = "0x0"
 

--- a/crates/sui/tests/data/module_publish_failure_invalid/Move.toml
+++ b/crates/sui/tests/data/module_publish_failure_invalid/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/module_publish_with_nonexistent_dependency/Move.toml
+++ b/crates/sui/tests/data/module_publish_with_nonexistent_dependency/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/module_publish_with_unpublished_dependency/Move.toml
+++ b/crates/sui/tests/data/module_publish_with_unpublished_dependency/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
+++ b/crates/sui/tests/data/module_publish_with_unpublished_dependency_with_non_zero_address/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/move_call_args_linter/Move.toml
+++ b/crates/sui/tests/data/move_call_args_linter/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Examples"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/sod/Move.toml
+++ b/crates/sui/tests/data/sod/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "sod"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui/tests/data/tto/Move.toml
+++ b/crates/sui/tests/data/tto/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tto"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../sui-framework/packages/sui-framework" }

--- a/crates/transaction-fuzzer/data/coin_factory/Move.toml
+++ b/crates/transaction-fuzzer/data/coin_factory/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coin_factory"
-version = "0.0.1"
 
 [dependencies.Sui]
 local = "../../../sui-framework/packages/sui-framework"

--- a/crates/transaction-fuzzer/data/type_factory/Move.toml
+++ b/crates/transaction-fuzzer/data/type_factory/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "type_factory"
-version = "0.0.1"
 
 [addresses]
 typer =  "0x0"

--- a/dapps/regulated-token/Move.toml
+++ b/dapps/regulated-token/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "regulated-token"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/color_object/Move.toml
+++ b/examples/move/color_object/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "color_object"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/dynamic_fields/Move.toml
+++ b/examples/move/dynamic_fields/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dynamic_fields"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/entry_functions/Move.toml
+++ b/examples/move/entry_functions/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "entry_functions"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/escrow/Move.toml
+++ b/examples/move/escrow/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "escrow"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/first_package/Move.toml
+++ b/examples/move/first_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "first_package"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/flash_lender/Move.toml
+++ b/examples/move/flash_lender/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "flash_lender"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/hero/Move.toml
+++ b/examples/move/hero/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hero"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/locked_stake/Move.toml
+++ b/examples/move/locked_stake/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Locked Stake"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/object_bound/Move.toml
+++ b/examples/move/object_bound/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "ObjectBound"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/simple_warrior/Move.toml
+++ b/examples/move/simple_warrior/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "simple_warrior"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/token/Move.toml
+++ b/examples/move/token/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Closed Loop Token"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/examples/move/trusted_swap/Move.toml
+++ b/examples/move/trusted_swap/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "trusted_swap"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/external-crates/move/crates/move-analyzer/tests/symbols/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/symbols/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Symbols"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_missing_minimal_required_field_name/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_missing_minimal_required_field_name/Move.toml
@@ -1,2 +1,1 @@
 [package]
-version = "0.1.1"

--- a/external-crates/move/documentation/examples/experimental/math-puzzle/Move.toml
+++ b/external-crates/move/documentation/examples/experimental/math-puzzle/Move.toml
@@ -1,3 +1,2 @@
 [package]
 name = "math-puzzle"
-version = "0.0.0"

--- a/external-crates/move/documentation/examples/experimental/rounding-error/Move.toml
+++ b/external-crates/move/documentation/examples/experimental/rounding-error/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "RoundingError"
-version = "0.0.0"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/documentation/examples/experimental/verify-sort/Move.toml
+++ b/external-crates/move/documentation/examples/experimental/verify-sort/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Loop"
-version = "0.0.0"
 
 [addresses]
 Loop = "0x42"

--- a/external-crates/move/move-execution/next-vm/crates/move-stdlib/Move.toml
+++ b/external-crates/move/move-execution/next-vm/crates/move-stdlib/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
 
 [addresses]
 std = "_"

--- a/external-crates/move/move-execution/next-vm/crates/move-stdlib/nursery/Move.toml
+++ b/external-crates/move/move-execution/next-vm/crates/move-stdlib/nursery/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveNursery"
-version = "1.5.0"
 
 [dependencies]
 MoveStdlib = { local = ".." }

--- a/external-crates/move/move-execution/v0/move-stdlib/Move.toml
+++ b/external-crates/move/move-execution/v0/move-stdlib/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
 
 [addresses]
 std = "_"

--- a/external-crates/move/move-execution/v0/move-stdlib/nursery/Move.toml
+++ b/external-crates/move/move-execution/v0/move-stdlib/nursery/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveNursery"
-version = "1.5.0"
 
 [dependencies]
 MoveStdlib = { local = ".." }

--- a/external-crates/move/move-execution/v1/crates/move-stdlib/Move.toml
+++ b/external-crates/move/move-execution/v1/crates/move-stdlib/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
 
 [addresses]
 std = "_"

--- a/external-crates/move/move-execution/v1/crates/move-stdlib/nursery/Move.toml
+++ b/external-crates/move/move-execution/v1/crates/move-stdlib/nursery/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MoveNursery"
-version = "1.5.0"
 
 [dependencies]
 MoveStdlib = { local = ".." }

--- a/external-crates/move/tools/move-cli/tests/move_unit_tests/test_with_warnings/Move.toml
+++ b/external-crates/move/tools/move-cli/tests/move_unit_tests/test_with_warnings/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Test"
-version = "0.0.0"
 
 [dev-addresses]
 std = "0x1"

--- a/kiosk/Move.toml
+++ b/kiosk/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Kiosk"
-version = "0.0.1"
 
 # for Sui testnet
 published-at = "0x43bb2146b6d4985f3b4a9538ae9187eccc1d9d6e4d9f54bc569164951d8eeeb1"

--- a/sdk/create-dapp/templates/react-e2e-counter/move/counter/Move.toml
+++ b/sdk/create-dapp/templates/react-e2e-counter/move/counter/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "counter"
-version = "0.0.1"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }

--- a/sdk/deepbook/test/e2e/data/test_coin/Move.toml
+++ b/sdk/deepbook/test/e2e/data/test_coin/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "test_coin"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/kiosk/test/e2e/data/hero/Move.toml
+++ b/sdk/kiosk/test/e2e/data/hero/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hero"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/coin_metadata/Move.toml
+++ b/sdk/typescript/test/e2e/data/coin_metadata/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coin_metadata"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/display_test/Move.toml
+++ b/sdk/typescript/test/e2e/data/display_test/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "display_test"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/dynamic_fields/Move.toml
+++ b/sdk/typescript/test/e2e/data/dynamic_fields/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dynamic_fields"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/id_entry_args/Move.toml
+++ b/sdk/typescript/test/e2e/data/id_entry_args/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "id_entry_args"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/serializer/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "serializer"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "serializer"
-version = "0.0.2"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sdk/typescript/test/e2e/data/tto/Move.toml
+++ b/sdk/typescript/test/e2e/data/tto/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tto"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/basics/Move.toml
+++ b/sui_programmability/examples/basics/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Basics"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/capy/Move.toml
+++ b/sui_programmability/examples/capy/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "sui-capybaras"
-version = "0.1.0"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/defi/Move.toml
+++ b/sui_programmability/examples/defi/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "DeFi"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/ecommerce/Move.toml
+++ b/sui_programmability/examples/ecommerce/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "ecommerce"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/fungible_tokens/Move.toml
+++ b/sui_programmability/examples/fungible_tokens/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "FungibleTokens"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/games/Move.toml
+++ b/sui_programmability/examples/games/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Games"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/math/Move.toml
+++ b/sui_programmability/examples/math/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Math"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/move_tutorial/Move.toml
+++ b/sui_programmability/examples/move_tutorial/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MyFirstPackage"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/multi_package/dep_package/Move.toml
+++ b/sui_programmability/examples/multi_package/dep_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "DepPackage"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/multi_package/main_package/Move.toml
+++ b/sui_programmability/examples/multi_package/main_package/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "MainPackage"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/nfts/Move.toml
+++ b/sui_programmability/examples/nfts/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "NFTs"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }

--- a/sui_programmability/examples/objects_tutorial/Move.toml
+++ b/sui_programmability/examples/objects_tutorial/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "Tutorial"
-version = "0.0.1"
 
 [dependencies]
 MoveStdlib = { local = "../../../crates/sui-framework/packages/move-stdlib/" }

--- a/sui_programmability/examples/utils/Move.toml
+++ b/sui_programmability/examples/utils/Move.toml
@@ -1,6 +1,5 @@
 [package]
 name = "utils"
-version = "0.0.1"
 
 [dependencies]
 Sui = { local = "../../../crates/sui-framework//packages/sui-framework" }


### PR DESCRIPTION
## Description 

With https://github.com/MystenLabs/sui/pull/15148 we don't need this any more.

Automated with

```
comby ':[~^version] = "..."' ''  Move.toml  
```

## Test Plan 

No functional change, relying on existing tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
