### PR TITLE
[NameService] Adds support to more input formats

### DIFF
--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
-use sui_json_rpc::name_service;
+use sui_json_rpc::name_service::{self, Domain};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     collection_types::VecMap,
@@ -10,11 +10,11 @@ use sui_types::{
 
 #[test]
 fn test_parent_extraction() {
-    let mut name = name_service::Domain::from_str("leaf.node.test.sui").unwrap();
+    let mut name = Domain::from_str("leaf.node.test.sui").unwrap();
 
     assert_eq!(name.parent().to_string(), "node.test.sui");
 
-    name = name_service::Domain::from_str("node.test.sui").unwrap();
+    name = Domain::from_str("node.test.sui").unwrap();
 
     assert_eq!(name.parent().to_string(), "test.sui");
 }
@@ -35,4 +35,60 @@ fn test_expirations() {
     name.expiration_timestamp_ms = system_time - 10;
 
     assert!(name.is_node_expired(system_time));
+}
+
+#[test]
+fn test_name_service_outputs() {
+    assert_eq!("@test".parse::<Domain>().unwrap().to_string(), "test.sui");
+    assert_eq!(
+        "test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.sui"
+    );
+    assert_eq!(
+        "test@sld".parse::<Domain>().unwrap().to_string(),
+        "test.sld.sui"
+    );
+    assert_eq!(
+        "test.test@example".parse::<Domain>().unwrap().to_string(),
+        "test.test.example.sui"
+    );
+    assert_eq!(
+        "sui@sui".parse::<Domain>().unwrap().to_string(),
+        "sui.sui.sui"
+    );
+
+    assert_eq!("@sui".parse::<Domain>().unwrap().to_string(), "sui.sui");
+
+    assert_eq!(
+        "test*test@test".parse::<Domain>().unwrap().to_string(),
+        "test.test.test.sui"
+    );
+    assert_eq!(
+        "test.test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.test.sui"
+    );
+    assert_eq!(
+        "test.test.test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.test.test.sui"
+    );
+}
+
+#[test]
+fn test_different_wildcard() {
+    assert_eq!("test.sui".parse::<Domain>(), "test*sui".parse::<Domain>(),);
+
+    assert_eq!("@test".parse::<Domain>(), "test*sui".parse::<Domain>(),);
+}
+
+#[test]
+fn test_invalid_inputs() {
+    assert!("*".parse::<Domain>().is_err());
+    assert!(".".parse::<Domain>().is_err());
+    assert!("@".parse::<Domain>().is_err());
+    assert!("@inner.sui".parse::<Domain>().is_err());
+    assert!("@inner*sui".parse::<Domain>().is_err());
+    assert!("test@".parse::<Domain>().is_err());
+    assert!("sui".parse::<Domain>().is_err());
+    assert!("test.test@example.sui".parse::<Domain>().is_err());
+    assert!("test@test@example".parse::<Domain>().is_err());
 }

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -26,6 +26,9 @@ const NAME_SERVICE_DEFAULT_REVERSE_REGISTRY: &str =
 const _NAME_SERVICE_OBJECT_ADDRESS: &str =
     "0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871";
 const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
+const DEFAULT_TLD: &str = "sui";
+const ACCEPTED_SEPARATORS: [char; 2] = ['.', '*'];
+const SUI_NEW_FORMAT_SEPARATOR: char = '@';
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Registry {
@@ -155,21 +158,75 @@ impl FromStr for Domain {
                 MAX_DOMAIN_LENGTH,
             ));
         }
+        let separator = separator(s)?;
 
-        let labels = s
-            .split('.')
+        let formatted_string = convert_from_new_format(s, &separator)?;
+
+        let labels = formatted_string
+            .split(separator)
             .rev()
             .map(validate_label)
             .collect::<Result<Vec<_>, Self::Err>>()?;
 
+        // A valid domain in our system has at least a TLD and an SLD (len == 2).
         if labels.len() < 2 {
             return Err(NameServiceError::LabelsEmpty);
         }
 
         let labels = labels.into_iter().map(ToOwned::to_owned).collect();
-
         Ok(Domain { labels })
     }
+}
+
+/// Parses a separator from the domain string input.
+/// E.g.  `example.sui` -> `.` | example*sui -> `@` | `example*sui` -> `*`
+fn separator(s: &str) -> Result<char, NameServiceError> {
+    let mut domain_separator: Option<char> = None;
+
+    for separator in ACCEPTED_SEPARATORS.iter() {
+        if s.contains(*separator) {
+            if domain_separator.is_some() {
+                return Err(NameServiceError::InvalidSeparator);
+            }
+
+            domain_separator = Some(*separator);
+        }
+    }
+
+    match domain_separator {
+        Some(separator) => Ok(separator),
+        None => Ok(ACCEPTED_SEPARATORS[0]),
+    }
+}
+
+/// Converts @label ending to label{separator}sui ending.
+///
+/// E.g. `@example` -> `example.sui` | `test@example` -> `test.example.sui`
+fn convert_from_new_format(s: &str, separator: &char) -> Result<String, NameServiceError> {
+    let mut splits = s.split(SUI_NEW_FORMAT_SEPARATOR);
+
+    let Some(before) = splits.next() else {
+        return Err(NameServiceError::InvalidSeparator);
+    };
+
+    let Some(after) = splits.next() else {
+        return Ok(before.to_string());
+    };
+
+    if splits.next().is_some() || after.contains(*separator) || after.is_empty() {
+        return Err(NameServiceError::InvalidSeparator);
+    }
+
+    let mut parts = vec![];
+
+    if !before.is_empty() {
+        parts.push(before);
+    }
+
+    parts.push(after);
+    parts.push(DEFAULT_TLD);
+
+    Ok(parts.join(&separator.to_string()))
 }
 
 fn validate_label(label: &str) -> Result<&str, NameServiceError> {


### PR DESCRIPTION
## Description 

**Updated the description (16-01-2024) due to a change in our support (we won't omit TLDs and `@` is a special format after all, not another wildcard)**

With this PR, we add support for wildcard `.` or `*` as the separator for a valid domain, and also support the new SuiNS display format, based on `@`.

Some examples:
`@test` -> `test.sui`
`sub@test` -> `sub.test.sui`
`inner.sub@test` -> `inner.sub.test.sui`
`more.inner.sub@test` -> `more.inner.sub.test.sui`

All of the above would work with `*` instead of `.` too.

## Test Plan 

Added a new test file (We didn't have one for the name service). Not sure if this is the right way to test stuff on our crates, so please advise me here if it's not right.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
