### PR TITLE
[GraphQL/Cursor] Cursor Framework

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.exp
@@ -1,4 +1,4 @@
-processed 8 tasks
+processed 9 tasks
 
 init:
 A: object(0,0)
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 7379600,  storage_rebate: 
 task 2 'create-checkpoint'. lines 19-19:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 21-62:
+task 3 'run-graphql'. lines 21-77:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -29,15 +29,24 @@ Response: {
                   "asMovePackage": {
                     "module": {
                       "all": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m0"
+                            "cursor": "MA",
+                            "node": {
+                              "name": "m0"
+                            }
                           },
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           },
                           {
-                            "name": "m2"
+                            "cursor": "Mg",
+                            "node": {
+                              "name": "m2"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -46,12 +55,18 @@ Response: {
                         }
                       },
                       "after": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           },
                           {
-                            "name": "m2"
+                            "cursor": "Mg",
+                            "node": {
+                              "name": "m2"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -60,12 +75,18 @@ Response: {
                         }
                       },
                       "before": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m0"
+                            "cursor": "MA",
+                            "node": {
+                              "name": "m0"
+                            }
                           },
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -90,7 +111,66 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 65-113:
+task 4 'run-graphql'. lines 80-107:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "effects": {
+            "objectChanges": [
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": {
+                    "module": null
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "asMovePackage": null
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Connection's page size of 1000 exceeds max of 50",
+      "locations": [
+        {
+          "line": 5,
+          "column": 13
+        }
+      ],
+      "path": [
+        "transactionBlockConnection",
+        "nodes",
+        0,
+        "effects",
+        "objectChanges",
+        1,
+        "outputState",
+        "asMovePackage",
+        "module",
+        "friends"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 5 'run-graphql'. lines 109-169:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -108,9 +188,12 @@ Response: {
                   "asMovePackage": {
                     "module": {
                       "prefix": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -119,12 +202,18 @@ Response: {
                         }
                       },
                       "prefixAll": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           },
                           {
-                            "name": "m2"
+                            "cursor": "Mg",
+                            "node": {
+                              "name": "m2"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -133,9 +222,12 @@ Response: {
                         }
                       },
                       "suffix": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -144,12 +236,18 @@ Response: {
                         }
                       },
                       "suffixAll": {
-                        "nodes": [
+                        "edges": [
                           {
-                            "name": "m0"
+                            "cursor": "MA",
+                            "node": {
+                              "name": "m0"
+                            }
                           },
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           }
                         ],
                         "pageInfo": {
@@ -174,15 +272,15 @@ Response: {
   }
 }
 
-task 5 'upgrade'. lines 115-129:
-created: object(5,0)
+task 6 'upgrade'. lines 171-185:
+created: object(6,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 8139600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 6 'create-checkpoint'. lines 131-131:
+task 7 'create-checkpoint'. lines 187-187:
 Checkpoint created: 2
 
-task 7 'run-graphql'. lines 133-161:
+task 8 'run-graphql'. lines 189-220:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -194,19 +292,31 @@ Response: {
                 "outputState": {
                   "asMovePackage": {
                     "module": {
-                      "friendConnection": {
-                        "nodes": [
+                      "friends": {
+                        "edges": [
                           {
-                            "name": "m0"
+                            "cursor": "MA",
+                            "node": {
+                              "name": "m0"
+                            }
                           },
                           {
-                            "name": "m1"
+                            "cursor": "MQ",
+                            "node": {
+                              "name": "m1"
+                            }
                           },
                           {
-                            "name": "m2"
+                            "cursor": "Mg",
+                            "node": {
+                              "name": "m2"
+                            }
                           },
                           {
-                            "name": "m3"
+                            "cursor": "Mw",
+                            "node": {
+                              "name": "m3"
+                            }
                           }
                         ]
                       }

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
@@ -245,53 +245,62 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 134-166:
+task 8 'run-graphql'. lines 134-169:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "all": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -300,30 +309,36 @@ Response: {
             }
           },
           "after": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -332,32 +347,38 @@ Response: {
             }
           },
           "before": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -371,23 +392,26 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 168-236:
+task 9 'run-graphql'. lines 171-242:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "prefix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -396,30 +420,36 @@ Response: {
             }
           },
           "prefixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -428,30 +458,36 @@ Response: {
             }
           },
           "prefixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -460,16 +496,19 @@ Response: {
             }
           },
           "suffix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -478,32 +517,38 @@ Response: {
             }
           },
           "suffixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -512,32 +557,38 @@ Response: {
             }
           },
           "suffixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.move
@@ -131,14 +131,17 @@ fragment Functions on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
 
 fragment Signatures on MoveFunctionConnection {
-    nodes {
-        name
-        typeParameters { constraints }
-        parameters { repr }
-        return { repr }
+    edges {
+        cursor
+        node {
+            name
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
     }
     pageInfo { hasNextPage hasPreviousPage }
 }
@@ -148,16 +151,16 @@ fragment Signatures on MoveFunctionConnection {
         asMovePackage {
             module(name: "clock") {
                 # Get the signatures of all functions.
-                all: functionConnection { ...Signatures }
+                all: functions { ...Signatures }
 
                 # Functions are iterated in lexicographical order of
                 # name, so this should skip the first one.
-                after: functionConnection(after: "consensus_commit_prologue") {
+                after: functions(after: "@{cursor_0}") {
                     ...Signatures
                 }
 
                 # ...and this should skip the last one.
-                before: functionConnection(before: "timestamp_ms") {
+                before: functions(before: "@{cursor_1}") {
                     ...Signatures
                 }
             }
@@ -165,14 +168,17 @@ fragment Signatures on MoveFunctionConnection {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
 
 fragment Signatures on MoveFunctionConnection {
-    nodes {
-        name
-        typeParameters { constraints }
-        parameters { repr }
-        return { repr }
+    edges {
+        cursor
+        node {
+            name
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
     }
     pageInfo { hasNextPage hasPreviousPage }
 }
@@ -183,50 +189,50 @@ fragment Signatures on MoveFunctionConnection {
             module(name: "clock") {
                 # Limit the number of elements in the page using
                 # `first` and skip elements using `after.
-                prefix: functionConnection(
+                prefix: functions(
                     first: 1,
-                    after: "consensus_commit_prologue",
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # No limit, because there are only two other
                 # functions, other than `consensus_commit_prologue`.
-                prefixAll: functionConnection(
+                prefixAll: functions(
                     first: 2,
-                    after: "consensus_commit_prologue",
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # No limit, because we are asking for way more
                 # functions than we have.
-                prefixExcess: functionConnection(
-                    first: 100,
-                    after: "consensus_commit_prologue",
+                prefixExcess: functions(
+                    first: 20,
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # Remaining tests are similar but replacing
                 # after/first with before/last.
-                suffix: functionConnection(
+                suffix: functions(
                     last: 1,
-                    before: "timestamp_ms",
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }
 
-                suffixAll: functionConnection(
+                suffixAll: functions(
                     last: 2,
-                    before: "timestamp_ms",
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }
 
-                suffixExcess: functionConnection(
-                    last: 100,
-                    before: "timestamp_ms",
+                suffixExcess: functions(
+                    last: 20,
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.exp
@@ -48,7 +48,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 65-97:
+task 4 'run-graphql'. lines 65-100:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -67,15 +67,24 @@ Response: {
                   "address": "0xde1998d07504e61cd97532c5d233cbf7f7f5cbad19f5ef844aadcdd03c295491",
                   "asMovePackage": {
                     "all": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "m"
+                          "cursor": "Im0i",
+                          "node": {
+                            "name": "m"
+                          }
                         },
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         },
                         {
-                          "name": "o"
+                          "cursor": "Im8i",
+                          "node": {
+                            "name": "o"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -84,12 +93,18 @@ Response: {
                       }
                     },
                     "after": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         },
                         {
-                          "name": "o"
+                          "cursor": "Im8i",
+                          "node": {
+                            "name": "o"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -98,12 +113,18 @@ Response: {
                       }
                     },
                     "before": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "m"
+                          "cursor": "Im0i",
+                          "node": {
+                            "name": "m"
+                          }
                         },
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -122,7 +143,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 99-134:
+task 5 'run-graphql'. lines 102-140:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -141,9 +162,12 @@ Response: {
                   "address": "0xde1998d07504e61cd97532c5d233cbf7f7f5cbad19f5ef844aadcdd03c295491",
                   "asMovePackage": {
                     "prefix": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -152,12 +176,18 @@ Response: {
                       }
                     },
                     "prefixAll": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         },
                         {
-                          "name": "o"
+                          "cursor": "Im8i",
+                          "node": {
+                            "name": "o"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -166,12 +196,18 @@ Response: {
                       }
                     },
                     "prefixExcess": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         },
                         {
-                          "name": "o"
+                          "cursor": "Im8i",
+                          "node": {
+                            "name": "o"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -180,9 +216,12 @@ Response: {
                       }
                     },
                     "suffix": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -191,12 +230,18 @@ Response: {
                       }
                     },
                     "suffixAll": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "m"
+                          "cursor": "Im0i",
+                          "node": {
+                            "name": "m"
+                          }
                         },
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         }
                       ],
                       "pageInfo": {
@@ -205,12 +250,18 @@ Response: {
                       }
                     },
                     "suffixExcess": {
-                      "nodes": [
+                      "edges": [
                         {
-                          "name": "m"
+                          "cursor": "Im0i",
+                          "node": {
+                            "name": "m"
+                          }
                         },
                         {
-                          "name": "n"
+                          "cursor": "Im4i",
+                          "node": {
+                            "name": "n"
+                          }
                         }
                       ],
                       "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.move
@@ -62,9 +62,12 @@ fragment Modules on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "m" "o"
 fragment NodeNames on MoveModuleConnection {
-    nodes { name }
+    edges {
+        cursor
+        node { name }
+    }
     pageInfo { hasNextPage hasPreviousPage }
 }
 
@@ -76,9 +79,9 @@ fragment Modules on Object {
         # correctly detect the existence of predecessor or successor
         # pages.
 
-        all: moduleConnection { ...NodeNames }
-        after: moduleConnection(after: "m") { ...NodeNames }
-        before: moduleConnection(before: "o") { ...NodeNames }
+        all: modules { ...NodeNames }
+        after: modules(after: "@{cursor_0}") { ...NodeNames }
+        before: modules(before: "@{cursor_1}") { ...NodeNames }
     }
 }
 
@@ -96,9 +99,12 @@ fragment Modules on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "m" "o"
 fragment NodeNames on MoveModuleConnection {
-    nodes { name }
+    edges {
+        cursor
+        node { name }
+    }
     pageInfo { hasNextPage hasPreviousPage }
 }
 
@@ -109,13 +115,13 @@ fragment Modules on Object {
         # number of modules returned and correctly detect the
         # existence of predecessor or successor pages.
 
-        prefix: moduleConnection(after: "m", first: 1) { ...NodeNames }
-        prefixAll: moduleConnection(after: "m", first: 2) { ...NodeNames }
-        prefixExcess: moduleConnection(after: "m", first: 100) { ...NodeNames }
+        prefix: modules(after: "@{cursor_0}", first: 1) { ...NodeNames }
+        prefixAll: modules(after: "@{cursor_0}", first: 2) { ...NodeNames }
+        prefixExcess: modules(after: "@{cursor_0}", first: 20) { ...NodeNames }
 
-        suffix: moduleConnection(before: "o", last: 1) { ...NodeNames }
-        suffixAll: moduleConnection(before: "o", last: 2) { ...NodeNames }
-        suffixExcess: moduleConnection(before: "o", last: 100) { ...NodeNames }
+        suffix: modules(before: "@{cursor_1}", last: 1) { ...NodeNames }
+        suffixAll: modules(before: "@{cursor_1}", last: 2) { ...NodeNames }
+        suffixExcess: modules(before: "@{cursor_1}", last: 20) { ...NodeNames }
     }
 }
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -385,7 +385,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 205-239:
+task 9 'run-graphql'. lines 205-245:
 Response: {
   "data": {
     "object": {
@@ -486,15 +486,24 @@ Response: {
             }
           },
           "after": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -503,15 +512,24 @@ Response: {
             }
           },
           "before": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -525,19 +543,25 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 241-285:
+task 10 'run-graphql'. lines 247-294:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "prefix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -546,15 +570,24 @@ Response: {
             }
           },
           "prefixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -563,15 +596,24 @@ Response: {
             }
           },
           "prefixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -580,12 +622,18 @@ Response: {
             }
           },
           "suffix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -594,15 +642,24 @@ Response: {
             }
           },
           "suffixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -611,15 +668,24 @@ Response: {
             }
           },
           "suffixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -202,13 +202,13 @@ fragment Structs on Object {
 }
 
 
-//# run-graphql
+//# run-graphql --cursors "Coin" "TreasuryCap"
 {
     object(address: "0x2") {
         asMovePackage {
             module(name: "coin") {
                 # Get all the types defined in coin
-                all: structConnection {
+                all: structs {
                     nodes {
                         name
                         fields {
@@ -223,14 +223,20 @@ fragment Structs on Object {
                 # exclusive lower bound, so this query should indicate
                 # there is a previous page, and not include `Coin` in
                 # the output.
-                after: structConnection(after: "Coin") {
-                    nodes { name }
+                after: structs(after: "@{cursor_0}") {
+                    edges {
+                        cursor
+                        node { name }
+                    }
                     pageInfo { hasNextPage hasPreviousPage }
                 }
 
                 # Before: Similar to `after` but at the end of the range.
-                before: structConnection(before: "TreasuryCap") {
-                    nodes { name }
+                before: structs(before: "@{cursor_1}") {
+                    edges {
+                        cursor
+                        node { name }
+                    }
                     pageInfo { hasNextPage hasPreviousPage }
                 }
             }
@@ -238,9 +244,12 @@ fragment Structs on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "Coin" "TreasuryCap"
 fragment NodeNames on MoveStructConnection {
-    nodes { name }
+    edges {
+        cursor
+        node { name }
+    }
     pageInfo { hasNextPage hasPreviousPage }
 }
 
@@ -250,33 +259,33 @@ fragment NodeNames on MoveStructConnection {
             module(name: "coin") {
                 # Limit the number of elements in the page using
                 # `first` and skip elements using `after`.
-                prefix: structConnection(after: "Coin", first: 2) {
+                prefix: structs(after: "@{cursor_0}", first: 2) {
                     ...NodeNames
                 }
 
                 # Limit has no effect because it matches the total
                 # number of entries in the page.
-                prefixAll: structConnection(after: "Coin", first: 3) {
+                prefixAll: structs(after: "@{cursor_0}", first: 3) {
                     ...NodeNames
                 }
 
                 # Limit also has no effect, because it exceeds the
                 # total number of entries in the page.
-                prefixExcess: structConnection(after: "Coin", first: 100) {
+                prefixExcess: structs(after: "@{cursor_0}", first: 20) {
                     ...NodeNames
                 }
 
                 # Remaining tests are similar to after/first but with
                 # before/last.
-                suffix: structConnection(before: "TreasuryCap", last: 2) {
+                suffix: structs(before: "@{cursor_1}", last: 2) {
                     ...NodeNames
                 }
 
-                suffixAll: structConnection(before: "TreasuryCap", last: 3) {
+                suffixAll: structs(before: "@{cursor_1}", last: 3) {
                     ...NodeNames
                 }
 
-                suffixExcess: structConnection(before: "TreasuryCap", last: 100) {
+                suffixExcess: structs(before: "@{cursor_1}", last: 20) {
                     ...NodeNames
                 }
             }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 6315600,  storage_rebate: 
 task 2 'create-checkpoint'. lines 21-21:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 23-186:
+task 3 'run-graphql'. lines 23-196:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -40,38 +40,47 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "inputConnection": {
-              "nodes": [
+            "inputs": {
+              "edges": [
                 {
-                  "__typename": "Pure",
-                  "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                  }
                 }
               ]
             },
-            "transactionConnection": {
-              "nodes": [
+            "transactions": {
+              "edges": [
                 {
-                  "__typename": "PublishTransaction",
-                  "modules": [
-                    "oRzrCwYAAAAIAQAGAgYMAxIKBRwRBy0wCF1ACp0BCQymAQ8ABAEGAQcAAAwAAQIEAAIBAgAABQABAAEFAwQAAgoDBwgCAQgAAAEHCAIBCAEDRm9vCVR4Q29udGV4dANVSUQCaWQBbQNuZXcGb2JqZWN0CnR4X2NvbnRleHQCeHMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAICAwgBCAoDAAEAAAIFCwERAQsAEgACAA=="
-                  ],
-                  "dependencies": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000001",
-                    "0x0000000000000000000000000000000000000000000000000000000000000002"
-                  ]
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "PublishTransaction",
+                    "modules": [
+                      "oRzrCwYAAAAIAQAGAgYMAxIKBRwRBy0wCF1ACp0BCQymAQ8ABAEGAQcAAAwAAQIEAAIBAgAABQABAAEFAwQAAgoDBwgCAQgAAAEHCAIBCAEDRm9vCVR4Q29udGV4dANVSUQCaWQBbQNuZXcGb2JqZWN0CnR4X2NvbnRleHQCeHMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAICAwgBCAoDAAEAAAIFCwERAQsAEgACAA=="
+                    ],
+                    "dependencies": [
+                      "0x0000000000000000000000000000000000000000000000000000000000000001",
+                      "0x0000000000000000000000000000000000000000000000000000000000000002"
+                    ]
+                  }
                 },
                 {
-                  "__typename": "TransferObjectsTransaction",
-                  "inputs": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 0,
-                      "ix": null
+                  "cursor": "MQ",
+                  "node": {
+                    "__typename": "TransferObjectsTransaction",
+                    "inputs": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 0,
+                        "ix": null
+                      }
+                    ],
+                    "address": {
+                      "__typename": "Input",
+                      "ix": 0
                     }
-                  ],
-                  "address": {
-                    "__typename": "Input",
-                    "ix": 0
                   }
                 }
               ]
@@ -155,15 +164,15 @@ Response: {
   }
 }
 
-task 4 'upgrade'. lines 188-206:
+task 4 'upgrade'. lines 198-216:
 created: object(4,0)
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 6589200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
-task 5 'create-checkpoint'. lines 208-208:
+task 5 'create-checkpoint'. lines 218-218:
 Checkpoint created: 2
 
-task 6 'run-graphql'. lines 210-373:
+task 6 'run-graphql'. lines 220-393:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -192,113 +201,131 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "inputConnection": {
-              "nodes": [
+            "inputs": {
+              "edges": [
                 {
-                  "__typename": "OwnedOrImmutable",
-                  "address": "0xf828e6de58892cf4b7d01515dad7be809be7dedef5f9910bf560d5a06ee8b99f",
-                  "version": 2,
-                  "digest": "J4U9NbbJDppz8Dz8LKYQAnL3DgZcRDWxtyiA2QJZ6T5N",
-                  "object": null
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "OwnedOrImmutable",
+                    "address": "0xf828e6de58892cf4b7d01515dad7be809be7dedef5f9910bf560d5a06ee8b99f",
+                    "version": 2,
+                    "digest": "J4U9NbbJDppz8Dz8LKYQAnL3DgZcRDWxtyiA2QJZ6T5N",
+                    "object": null
+                  }
                 },
                 {
-                  "__typename": "Pure",
-                  "bytes": "AA=="
+                  "cursor": "MQ",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "AA=="
+                  }
                 },
                 {
-                  "__typename": "Pure",
-                  "bytes": "IKtSxFg0BLyRn8vrtIRqeqpsihVPvPFxPFBg5s0K+UqS"
+                  "cursor": "Mg",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "IKtSxFg0BLyRn8vrtIRqeqpsihVPvPFxPFBg5s0K+UqS"
+                  }
                 }
               ]
             },
-            "transactionConnection": {
-              "nodes": [
+            "transactions": {
+              "edges": [
                 {
-                  "__typename": "MoveCallTransaction",
-                  "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                  "module": "package",
-                  "functionName": "authorize_upgrade",
-                  "typeArguments": [],
-                  "arguments": [
-                    {
-                      "__typename": "Input",
-                      "ix": 0
-                    },
-                    {
-                      "__typename": "Input",
-                      "ix": 1
-                    },
-                    {
-                      "__typename": "Input",
-                      "ix": 2
-                    }
-                  ],
-                  "function": {
-                    "isEntry": false,
-                    "typeParameters": [],
-                    "parameters": [
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "MoveCallTransaction",
+                    "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "module": "package",
+                    "functionName": "authorize_upgrade",
+                    "typeArguments": [],
+                    "arguments": [
                       {
-                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                        "__typename": "Input",
+                        "ix": 0
                       },
                       {
-                        "repr": "u8"
+                        "__typename": "Input",
+                        "ix": 1
                       },
                       {
-                        "repr": "vector<u8>"
+                        "__typename": "Input",
+                        "ix": 2
                       }
                     ],
-                    "return": [
-                      {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeTicket"
-                      }
-                    ]
+                    "function": {
+                      "isEntry": false,
+                      "typeParameters": [],
+                      "parameters": [
+                        {
+                          "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                        },
+                        {
+                          "repr": "u8"
+                        },
+                        {
+                          "repr": "vector<u8>"
+                        }
+                      ],
+                      "return": [
+                        {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeTicket"
+                        }
+                      ]
+                    }
                   }
                 },
                 {
-                  "__typename": "UpgradeTransaction",
-                  "modules": [
-                    "oRzrCwYAAAAIAQAGAgYMAxIUBSYRBzc8CHNACrMBCQy8AR0ABgEIAQkAAAwAAQIEAAIBAgAABwABAAADAQIAAQQEAgABBwMEAAIKAwcIAgEIAAABBwgCAQgBA0ZvbwlUeENvbnRleHQDVUlEBGJ1cm4GZGVsZXRlAmlkAW0DbmV3Bm9iamVjdAp0eF9jb250ZXh0AnhzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgACAgUIAQoKAwABAAACBQsBEQMLABIAAgEBAAACBQsAEwABEQICAA=="
-                  ],
-                  "dependencies": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000001",
-                    "0x0000000000000000000000000000000000000000000000000000000000000002"
-                  ],
-                  "currentPackage": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9",
-                  "upgradeTicket": {
-                    "__typename": "Result",
-                    "cmd": 0,
-                    "ix": null
-                  }
-                },
-                {
-                  "__typename": "MoveCallTransaction",
-                  "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                  "module": "package",
-                  "functionName": "commit_upgrade",
-                  "typeArguments": [],
-                  "arguments": [
-                    {
-                      "__typename": "Input",
-                      "ix": 0
-                    },
-                    {
+                  "cursor": "MQ",
+                  "node": {
+                    "__typename": "UpgradeTransaction",
+                    "modules": [
+                      "oRzrCwYAAAAIAQAGAgYMAxIUBSYRBzc8CHNACrMBCQy8AR0ABgEIAQkAAAwAAQIEAAIBAgAABwABAAADAQIAAQQEAgABBwMEAAIKAwcIAgEIAAABBwgCAQgBA0ZvbwlUeENvbnRleHQDVUlEBGJ1cm4GZGVsZXRlAmlkAW0DbmV3Bm9iamVjdAp0eF9jb250ZXh0AnhzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgACAgUIAQoKAwABAAACBQsBEQMLABIAAgEBAAACBQsAEwABEQICAA=="
+                    ],
+                    "dependencies": [
+                      "0x0000000000000000000000000000000000000000000000000000000000000001",
+                      "0x0000000000000000000000000000000000000000000000000000000000000002"
+                    ],
+                    "currentPackage": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9",
+                    "upgradeTicket": {
                       "__typename": "Result",
-                      "cmd": 1,
+                      "cmd": 0,
                       "ix": null
                     }
-                  ],
-                  "function": {
-                    "isEntry": false,
-                    "typeParameters": [],
-                    "parameters": [
+                  }
+                },
+                {
+                  "cursor": "Mg",
+                  "node": {
+                    "__typename": "MoveCallTransaction",
+                    "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "module": "package",
+                    "functionName": "commit_upgrade",
+                    "typeArguments": [],
+                    "arguments": [
                       {
-                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                        "__typename": "Input",
+                        "ix": 0
                       },
                       {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeReceipt"
+                        "__typename": "Result",
+                        "cmd": 1,
+                        "ix": null
                       }
                     ],
-                    "return": []
+                    "function": {
+                      "isEntry": false,
+                      "typeParameters": [],
+                      "parameters": [
+                        {
+                          "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                        },
+                        {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeReceipt"
+                        }
+                      ],
+                      "return": []
+                    }
                   }
                 }
               ]
@@ -385,15 +412,15 @@ Response: {
   }
 }
 
-task 7 'programmable'. lines 375-384:
+task 7 'programmable'. lines 395-404:
 created: object(7,0), object(7,1)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3328800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8 'create-checkpoint'. lines 386-386:
+task 8 'create-checkpoint'. lines 406-406:
 Checkpoint created: 3
 
-task 9 'run-graphql'. lines 388-560:
+task 9 'run-graphql'. lines 408-590:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -422,194 +449,233 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "inputConnection": {
-              "nodes": [
+            "inputs": {
+              "edges": [
                 {
-                  "__typename": "Pure",
-                  "bytes": "KgAAAAAAAAA="
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "KgAAAAAAAAA="
+                  }
                 },
                 {
-                  "__typename": "Pure",
-                  "bytes": "KwAAAAAAAAA="
+                  "cursor": "MQ",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "KwAAAAAAAAA="
+                  }
                 },
                 {
-                  "__typename": "Pure",
-                  "bytes": "6AMAAAAAAAA="
+                  "cursor": "Mg",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "6AMAAAAAAAA="
+                  }
                 },
                 {
-                  "__typename": "Pure",
-                  "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                  "cursor": "Mw",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+                  }
                 }
               ]
             },
-            "transactionConnection": {
-              "nodes": [
+            "transactions": {
+              "edges": [
                 {
-                  "__typename": "MakeMoveVecTransaction",
-                  "type": {
-                    "repr": "u64"
-                  },
-                  "elements": [
-                    {
-                      "__typename": "Input",
-                      "ix": 0
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "MakeMoveVecTransaction",
+                    "type": {
+                      "repr": "u64"
                     },
-                    {
-                      "__typename": "Input",
-                      "ix": 1
-                    }
-                  ]
-                },
-                {
-                  "__typename": "MakeMoveVecTransaction",
-                  "type": {
-                    "repr": "u64"
-                  },
-                  "elements": []
-                },
-                {
-                  "__typename": "SplitCoinsTransaction",
-                  "coin": {
-                    "__typename": "GasCoin"
-                  },
-                  "amounts": [
-                    {
-                      "__typename": "Input",
-                      "ix": 2
-                    },
-                    {
-                      "__typename": "Input",
-                      "ix": 2
-                    }
-                  ]
-                },
-                {
-                  "__typename": "MoveCallTransaction",
-                  "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
-                  "module": "m",
-                  "functionName": "new",
-                  "typeArguments": [],
-                  "arguments": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 0,
-                      "ix": null
-                    }
-                  ],
-                  "function": {
-                    "isEntry": false,
-                    "typeParameters": [],
-                    "parameters": [
+                    "elements": [
                       {
-                        "repr": "vector<u64>"
+                        "__typename": "Input",
+                        "ix": 0
                       },
                       {
-                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                      }
-                    ],
-                    "return": [
-                      {
-                        "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        "__typename": "Input",
+                        "ix": 1
                       }
                     ]
                   }
                 },
                 {
-                  "__typename": "TransferObjectsTransaction",
-                  "inputs": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 3,
-                      "ix": null
-                    }
-                  ],
-                  "address": {
-                    "__typename": "Input",
-                    "ix": 3
+                  "cursor": "MQ",
+                  "node": {
+                    "__typename": "MakeMoveVecTransaction",
+                    "type": {
+                      "repr": "u64"
+                    },
+                    "elements": []
                   }
                 },
                 {
-                  "__typename": "MoveCallTransaction",
-                  "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
-                  "module": "m",
-                  "functionName": "new",
-                  "typeArguments": [],
-                  "arguments": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 1,
-                      "ix": null
-                    }
-                  ],
-                  "function": {
-                    "isEntry": false,
-                    "typeParameters": [],
-                    "parameters": [
+                  "cursor": "Mg",
+                  "node": {
+                    "__typename": "SplitCoinsTransaction",
+                    "coin": {
+                      "__typename": "GasCoin"
+                    },
+                    "amounts": [
                       {
-                        "repr": "vector<u64>"
+                        "__typename": "Input",
+                        "ix": 2
                       },
                       {
-                        "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                      }
-                    ],
-                    "return": [
-                      {
-                        "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        "__typename": "Input",
+                        "ix": 2
                       }
                     ]
                   }
                 },
                 {
-                  "__typename": "MoveCallTransaction",
-                  "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
-                  "module": "m",
-                  "functionName": "burn",
-                  "typeArguments": [],
-                  "arguments": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 5,
-                      "ix": null
-                    }
-                  ],
-                  "function": {
-                    "isEntry": false,
-                    "typeParameters": [],
-                    "parameters": [
+                  "cursor": "Mw",
+                  "node": {
+                    "__typename": "MoveCallTransaction",
+                    "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
+                    "module": "m",
+                    "functionName": "new",
+                    "typeArguments": [],
+                    "arguments": [
                       {
-                        "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        "__typename": "Result",
+                        "cmd": 0,
+                        "ix": null
                       }
                     ],
-                    "return": []
+                    "function": {
+                      "isEntry": false,
+                      "typeParameters": [],
+                      "parameters": [
+                        {
+                          "repr": "vector<u64>"
+                        },
+                        {
+                          "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                        }
+                      ],
+                      "return": [
+                        {
+                          "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        }
+                      ]
+                    }
                   }
                 },
                 {
-                  "__typename": "MergeCoinsTransaction",
-                  "coin": {
-                    "__typename": "Result",
-                    "cmd": 2,
-                    "ix": 0
-                  },
-                  "coins": [
-                    {
-                      "__typename": "Result",
-                      "cmd": 2,
-                      "ix": 1
+                  "cursor": "NA",
+                  "node": {
+                    "__typename": "TransferObjectsTransaction",
+                    "inputs": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 3,
+                        "ix": null
+                      }
+                    ],
+                    "address": {
+                      "__typename": "Input",
+                      "ix": 3
                     }
-                  ]
+                  }
                 },
                 {
-                  "__typename": "TransferObjectsTransaction",
-                  "inputs": [
-                    {
+                  "cursor": "NQ",
+                  "node": {
+                    "__typename": "MoveCallTransaction",
+                    "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
+                    "module": "m",
+                    "functionName": "new",
+                    "typeArguments": [],
+                    "arguments": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 1,
+                        "ix": null
+                      }
+                    ],
+                    "function": {
+                      "isEntry": false,
+                      "typeParameters": [],
+                      "parameters": [
+                        {
+                          "repr": "vector<u64>"
+                        },
+                        {
+                          "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                        }
+                      ],
+                      "return": [
+                        {
+                          "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "cursor": "Ng",
+                  "node": {
+                    "__typename": "MoveCallTransaction",
+                    "package": "0xf396946ce5c87a5fc6441ecd6a1c9be6a7b645018b9a4d58ce5958aff62a7eed",
+                    "module": "m",
+                    "functionName": "burn",
+                    "typeArguments": [],
+                    "arguments": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 5,
+                        "ix": null
+                      }
+                    ],
+                    "function": {
+                      "isEntry": false,
+                      "typeParameters": [],
+                      "parameters": [
+                        {
+                          "repr": "0xd7af1cd4112fcd54f410553133edae9b3ef79ba8927749da5418fd79341609f9::m::Foo"
+                        }
+                      ],
+                      "return": []
+                    }
+                  }
+                },
+                {
+                  "cursor": "Nw",
+                  "node": {
+                    "__typename": "MergeCoinsTransaction",
+                    "coin": {
                       "__typename": "Result",
                       "cmd": 2,
                       "ix": 0
+                    },
+                    "coins": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 2,
+                        "ix": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cursor": "OA",
+                  "node": {
+                    "__typename": "TransferObjectsTransaction",
+                    "inputs": [
+                      {
+                        "__typename": "Result",
+                        "cmd": 2,
+                        "ix": 0
+                      }
+                    ],
+                    "address": {
+                      "__typename": "Input",
+                      "ix": 3
                     }
-                  ],
-                  "address": {
-                    "__typename": "Input",
-                    "ix": 3
                   }
                 }
               ]
@@ -733,14 +799,14 @@ Response: {
   }
 }
 
-task 10 'programmable'. lines 562-563:
+task 10 'programmable'. lines 592-593:
 Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: None, command: None } }
 
-task 11 'create-checkpoint'. lines 565-565:
+task 11 'create-checkpoint'. lines 595-595:
 Checkpoint created: 4
 
-task 12 'run-graphql'. lines 567-730:
+task 12 'run-graphql'. lines 597-770:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -769,27 +835,33 @@ Response: {
           },
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "inputConnection": {
-              "nodes": [
+            "inputs": {
+              "edges": [
                 {
-                  "__typename": "Pure",
-                  "bytes": "6AMAAAAAAAA="
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "Pure",
+                    "bytes": "6AMAAAAAAAA="
+                  }
                 }
               ]
             },
-            "transactionConnection": {
-              "nodes": [
+            "transactions": {
+              "edges": [
                 {
-                  "__typename": "SplitCoinsTransaction",
-                  "coin": {
-                    "__typename": "GasCoin"
-                  },
-                  "amounts": [
-                    {
-                      "__typename": "Input",
-                      "ix": 0
-                    }
-                  ]
+                  "cursor": "MA",
+                  "node": {
+                    "__typename": "SplitCoinsTransaction",
+                    "coin": {
+                      "__typename": "GasCoin"
+                    },
+                    "amounts": [
+                      {
+                        "__typename": "Input",
+                        "ix": 0
+                      }
+                    ]
+                  }
                 }
               ]
             }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -121,8 +121,18 @@ fragment Tx on ProgrammableTransaction {
 }
 
 fragment ComprehensivePTB on ProgrammableTransactionBlock {
-    inputConnection { nodes { __typename ...TxInput } }
-    transactionConnection { nodes { __typename ...Tx } }
+    inputs {
+        edges {
+            cursor
+            node { __typename ...TxInput }
+        }
+    }
+    transactions {
+        edges {
+            cursor
+            node { __typename ...Tx }
+        }
+    }
 }
 
 {
@@ -308,8 +318,18 @@ fragment Tx on ProgrammableTransaction {
 }
 
 fragment ComprehensivePTB on ProgrammableTransactionBlock {
-    inputConnection { nodes { __typename ...TxInput } }
-    transactionConnection { nodes { __typename ...Tx } }
+    inputs {
+        edges {
+            cursor
+            node { __typename ...TxInput }
+        }
+    }
+    transactions {
+        edges {
+            cursor
+            node { __typename ...Tx }
+        }
+    }
 }
 
 {
@@ -486,8 +506,18 @@ fragment Tx on ProgrammableTransaction {
 }
 
 fragment ComprehensivePTB on ProgrammableTransactionBlock {
-    inputConnection { nodes { __typename ...TxInput } }
-    transactionConnection { nodes { __typename ...Tx } }
+    inputs {
+        edges {
+            cursor
+            node { __typename ...TxInput }
+        }
+    }
+    transactions {
+        edges {
+            cursor
+            node { __typename ...Tx }
+        }
+    }
 }
 
 {
@@ -665,8 +695,18 @@ fragment Tx on ProgrammableTransaction {
 }
 
 fragment ComprehensivePTB on ProgrammableTransactionBlock {
-    inputConnection { nodes { __typename ...TxInput } }
-    transactionConnection { nodes { __typename ...Tx } }
+    inputs {
+        edges {
+            cursor
+            node { __typename ...TxInput }
+        }
+    }
+    transactions {
+        edges {
+            cursor
+            node { __typename ...Tx }
+        }
+    }
 }
 
 {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/shared.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/shared.exp
@@ -28,7 +28,7 @@ Response: {
         {
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "transactionConnection": {
+            "transactions": {
               "nodes": [
                 {
                   "package": "0x393f595499787b01dcb7e57d19da4fd1a11e14195bf5d083fb1a577d55e4172d",
@@ -51,7 +51,7 @@ Response: {
         {
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "transactionConnection": {
+            "transactions": {
               "nodes": [
                 {
                   "package": "0x393f595499787b01dcb7e57d19da4fd1a11e14195bf5d083fb1a577d55e4172d",
@@ -69,7 +69,7 @@ Response: {
         {
           "kind": {
             "__typename": "ProgrammableTransactionBlock",
-            "transactionConnection": {
+            "transactions": {
               "nodes": [
                 {
                   "package": "0x393f595499787b01dcb7e57d19da4fd1a11e14195bf5d083fb1a577d55e4172d",

--- a/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
@@ -44,7 +44,7 @@ module P0::m {
             kind {
                 __typename
                 ... on ProgrammableTransactionBlock {
-                    transactionConnection {
+                    transactions {
                         nodes {
                             ... on MoveCallTransaction {
                                 package

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -1,6 +1,6 @@
 processed 8 tasks
 
-task 1 'run-graphql'. lines 8-93:
+task 1 'run-graphql'. lines 8-96:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -23,946 +23,1000 @@ Response: {
           },
           "kind": {
             "__typename": "GenesisTransaction",
-            "objectConnection": {
-              "nodes": [
+            "objects": {
+              "edges": [
                 {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-                  "asMoveObject": null,
-                  "asMovePackage": {
-                    "modules": {
-                      "edges": [
-                        {
-                          "cursor": "ImFkZHJlc3Mi",
-                          "node": {
-                            "name": "address"
+                  "cursor": "MA",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "asMoveObject": null,
+                    "asMovePackage": {
+                      "modules": {
+                        "edges": [
+                          {
+                            "cursor": "ImFkZHJlc3Mi",
+                            "node": {
+                              "name": "address"
+                            }
+                          },
+                          {
+                            "cursor": "ImFzY2lpIg",
+                            "node": {
+                              "name": "ascii"
+                            }
+                          },
+                          {
+                            "cursor": "ImJjcyI",
+                            "node": {
+                              "name": "bcs"
+                            }
+                          },
+                          {
+                            "cursor": "ImJpdF92ZWN0b3Ii",
+                            "node": {
+                              "name": "bit_vector"
+                            }
+                          },
+                          {
+                            "cursor": "ImRlYnVnIg",
+                            "node": {
+                              "name": "debug"
+                            }
+                          },
+                          {
+                            "cursor": "ImZpeGVkX3BvaW50MzIi",
+                            "node": {
+                              "name": "fixed_point32"
+                            }
+                          },
+                          {
+                            "cursor": "Imhhc2gi",
+                            "node": {
+                              "name": "hash"
+                            }
+                          },
+                          {
+                            "cursor": "Im9wdGlvbiI",
+                            "node": {
+                              "name": "option"
+                            }
+                          },
+                          {
+                            "cursor": "InN0cmluZyI",
+                            "node": {
+                              "name": "string"
+                            }
+                          },
+                          {
+                            "cursor": "InR5cGVfbmFtZSI",
+                            "node": {
+                              "name": "type_name"
+                            }
+                          },
+                          {
+                            "cursor": "InZlY3RvciI",
+                            "node": {
+                              "name": "vector"
+                            }
                           }
-                        },
-                        {
-                          "cursor": "ImFzY2lpIg",
-                          "node": {
-                            "name": "ascii"
-                          }
-                        },
-                        {
-                          "cursor": "ImJjcyI",
-                          "node": {
-                            "name": "bcs"
-                          }
-                        },
-                        {
-                          "cursor": "ImJpdF92ZWN0b3Ii",
-                          "node": {
-                            "name": "bit_vector"
-                          }
-                        },
-                        {
-                          "cursor": "ImRlYnVnIg",
-                          "node": {
-                            "name": "debug"
-                          }
-                        },
-                        {
-                          "cursor": "ImZpeGVkX3BvaW50MzIi",
-                          "node": {
-                            "name": "fixed_point32"
-                          }
-                        },
-                        {
-                          "cursor": "Imhhc2gi",
-                          "node": {
-                            "name": "hash"
-                          }
-                        },
-                        {
-                          "cursor": "Im9wdGlvbiI",
-                          "node": {
-                            "name": "option"
-                          }
-                        },
-                        {
-                          "cursor": "InN0cmluZyI",
-                          "node": {
-                            "name": "string"
-                          }
-                        },
-                        {
-                          "cursor": "InR5cGVfbmFtZSI",
-                          "node": {
-                            "name": "type_name"
-                          }
-                        },
-                        {
-                          "cursor": "InZlY3RvciI",
-                          "node": {
-                            "name": "vector"
-                          }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   }
                 },
                 {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                  "asMoveObject": null,
-                  "asMovePackage": {
-                    "modules": {
-                      "edges": [
-                        {
-                          "cursor": "ImFkZHJlc3Mi",
-                          "node": {
-                            "name": "address"
+                  "cursor": "MQ",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "asMoveObject": null,
+                    "asMovePackage": {
+                      "modules": {
+                        "edges": [
+                          {
+                            "cursor": "ImFkZHJlc3Mi",
+                            "node": {
+                              "name": "address"
+                            }
+                          },
+                          {
+                            "cursor": "ImF1dGhlbnRpY2F0b3Jfc3RhdGUi",
+                            "node": {
+                              "name": "authenticator_state"
+                            }
+                          },
+                          {
+                            "cursor": "ImJhZyI",
+                            "node": {
+                              "name": "bag"
+                            }
+                          },
+                          {
+                            "cursor": "ImJhbGFuY2Ui",
+                            "node": {
+                              "name": "balance"
+                            }
+                          },
+                          {
+                            "cursor": "ImJjcyI",
+                            "node": {
+                              "name": "bcs"
+                            }
+                          },
+                          {
+                            "cursor": "ImJsczEyMzgxIg",
+                            "node": {
+                              "name": "bls12381"
+                            }
+                          },
+                          {
+                            "cursor": "ImJvcnJvdyI",
+                            "node": {
+                              "name": "borrow"
+                            }
+                          },
+                          {
+                            "cursor": "ImNsb2NrIg",
+                            "node": {
+                              "name": "clock"
+                            }
+                          },
+                          {
+                            "cursor": "ImNvaW4i",
+                            "node": {
+                              "name": "coin"
+                            }
+                          },
+                          {
+                            "cursor": "ImRpc3BsYXki",
+                            "node": {
+                              "name": "display"
+                            }
+                          },
+                          {
+                            "cursor": "ImR5bmFtaWNfZmllbGQi",
+                            "node": {
+                              "name": "dynamic_field"
+                            }
+                          },
+                          {
+                            "cursor": "ImR5bmFtaWNfb2JqZWN0X2ZpZWxkIg",
+                            "node": {
+                              "name": "dynamic_object_field"
+                            }
+                          },
+                          {
+                            "cursor": "ImVjZHNhX2sxIg",
+                            "node": {
+                              "name": "ecdsa_k1"
+                            }
+                          },
+                          {
+                            "cursor": "ImVjZHNhX3IxIg",
+                            "node": {
+                              "name": "ecdsa_r1"
+                            }
+                          },
+                          {
+                            "cursor": "ImVjdnJmIg",
+                            "node": {
+                              "name": "ecvrf"
+                            }
+                          },
+                          {
+                            "cursor": "ImVkMjU1MTki",
+                            "node": {
+                              "name": "ed25519"
+                            }
+                          },
+                          {
+                            "cursor": "ImV2ZW50Ig",
+                            "node": {
+                              "name": "event"
+                            }
+                          },
+                          {
+                            "cursor": "Imdyb3RoMTYi",
+                            "node": {
+                              "name": "groth16"
+                            }
+                          },
+                          {
+                            "cursor": "Imhhc2gi",
+                            "node": {
+                              "name": "hash"
+                            }
+                          },
+                          {
+                            "cursor": "ImhleCI",
+                            "node": {
+                              "name": "hex"
+                            }
                           }
-                        },
-                        {
-                          "cursor": "ImF1dGhlbnRpY2F0b3Jfc3RhdGUi",
-                          "node": {
-                            "name": "authenticator_state"
-                          }
-                        },
-                        {
-                          "cursor": "ImJhZyI",
-                          "node": {
-                            "name": "bag"
-                          }
-                        },
-                        {
-                          "cursor": "ImJhbGFuY2Ui",
-                          "node": {
-                            "name": "balance"
-                          }
-                        },
-                        {
-                          "cursor": "ImJjcyI",
-                          "node": {
-                            "name": "bcs"
-                          }
-                        },
-                        {
-                          "cursor": "ImJsczEyMzgxIg",
-                          "node": {
-                            "name": "bls12381"
-                          }
-                        },
-                        {
-                          "cursor": "ImJvcnJvdyI",
-                          "node": {
-                            "name": "borrow"
-                          }
-                        },
-                        {
-                          "cursor": "ImNsb2NrIg",
-                          "node": {
-                            "name": "clock"
-                          }
-                        },
-                        {
-                          "cursor": "ImNvaW4i",
-                          "node": {
-                            "name": "coin"
-                          }
-                        },
-                        {
-                          "cursor": "ImRpc3BsYXki",
-                          "node": {
-                            "name": "display"
-                          }
-                        },
-                        {
-                          "cursor": "ImR5bmFtaWNfZmllbGQi",
-                          "node": {
-                            "name": "dynamic_field"
-                          }
-                        },
-                        {
-                          "cursor": "ImR5bmFtaWNfb2JqZWN0X2ZpZWxkIg",
-                          "node": {
-                            "name": "dynamic_object_field"
-                          }
-                        },
-                        {
-                          "cursor": "ImVjZHNhX2sxIg",
-                          "node": {
-                            "name": "ecdsa_k1"
-                          }
-                        },
-                        {
-                          "cursor": "ImVjZHNhX3IxIg",
-                          "node": {
-                            "name": "ecdsa_r1"
-                          }
-                        },
-                        {
-                          "cursor": "ImVjdnJmIg",
-                          "node": {
-                            "name": "ecvrf"
-                          }
-                        },
-                        {
-                          "cursor": "ImVkMjU1MTki",
-                          "node": {
-                            "name": "ed25519"
-                          }
-                        },
-                        {
-                          "cursor": "ImV2ZW50Ig",
-                          "node": {
-                            "name": "event"
-                          }
-                        },
-                        {
-                          "cursor": "Imdyb3RoMTYi",
-                          "node": {
-                            "name": "groth16"
-                          }
-                        },
-                        {
-                          "cursor": "Imhhc2gi",
-                          "node": {
-                            "name": "hash"
-                          }
-                        },
-                        {
-                          "cursor": "ImhleCI",
-                          "node": {
-                            "name": "hex"
-                          }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   }
                 },
                 {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
-                  "asMoveObject": null,
-                  "asMovePackage": {
-                    "modules": {
-                      "edges": [
-                        {
-                          "cursor": "ImdlbmVzaXMi",
-                          "node": {
-                            "name": "genesis"
+                  "cursor": "Mg",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    "asMoveObject": null,
+                    "asMovePackage": {
+                      "modules": {
+                        "edges": [
+                          {
+                            "cursor": "ImdlbmVzaXMi",
+                            "node": {
+                              "name": "genesis"
+                            }
+                          },
+                          {
+                            "cursor": "InN0YWtlX3N1YnNpZHki",
+                            "node": {
+                              "name": "stake_subsidy"
+                            }
+                          },
+                          {
+                            "cursor": "InN0YWtpbmdfcG9vbCI",
+                            "node": {
+                              "name": "staking_pool"
+                            }
+                          },
+                          {
+                            "cursor": "InN0b3JhZ2VfZnVuZCI",
+                            "node": {
+                              "name": "storage_fund"
+                            }
+                          },
+                          {
+                            "cursor": "InN1aV9zeXN0ZW0i",
+                            "node": {
+                              "name": "sui_system"
+                            }
+                          },
+                          {
+                            "cursor": "InN1aV9zeXN0ZW1fc3RhdGVfaW5uZXIi",
+                            "node": {
+                              "name": "sui_system_state_inner"
+                            }
+                          },
+                          {
+                            "cursor": "InZhbGlkYXRvciI",
+                            "node": {
+                              "name": "validator"
+                            }
+                          },
+                          {
+                            "cursor": "InZhbGlkYXRvcl9jYXAi",
+                            "node": {
+                              "name": "validator_cap"
+                            }
+                          },
+                          {
+                            "cursor": "InZhbGlkYXRvcl9zZXQi",
+                            "node": {
+                              "name": "validator_set"
+                            }
+                          },
+                          {
+                            "cursor": "InZhbGlkYXRvcl93cmFwcGVyIg",
+                            "node": {
+                              "name": "validator_wrapper"
+                            }
+                          },
+                          {
+                            "cursor": "InZvdGluZ19wb3dlciI",
+                            "node": {
+                              "name": "voting_power"
+                            }
                           }
-                        },
-                        {
-                          "cursor": "InN0YWtlX3N1YnNpZHki",
-                          "node": {
-                            "name": "stake_subsidy"
-                          }
-                        },
-                        {
-                          "cursor": "InN0YWtpbmdfcG9vbCI",
-                          "node": {
-                            "name": "staking_pool"
-                          }
-                        },
-                        {
-                          "cursor": "InN0b3JhZ2VfZnVuZCI",
-                          "node": {
-                            "name": "storage_fund"
-                          }
-                        },
-                        {
-                          "cursor": "InN1aV9zeXN0ZW0i",
-                          "node": {
-                            "name": "sui_system"
-                          }
-                        },
-                        {
-                          "cursor": "InN1aV9zeXN0ZW1fc3RhdGVfaW5uZXIi",
-                          "node": {
-                            "name": "sui_system_state_inner"
-                          }
-                        },
-                        {
-                          "cursor": "InZhbGlkYXRvciI",
-                          "node": {
-                            "name": "validator"
-                          }
-                        },
-                        {
-                          "cursor": "InZhbGlkYXRvcl9jYXAi",
-                          "node": {
-                            "name": "validator_cap"
-                          }
-                        },
-                        {
-                          "cursor": "InZhbGlkYXRvcl9zZXQi",
-                          "node": {
-                            "name": "validator_set"
-                          }
-                        },
-                        {
-                          "cursor": "InZhbGlkYXRvcl93cmFwcGVyIg",
-                          "node": {
-                            "name": "validator_wrapper"
-                          }
-                        },
-                        {
-                          "cursor": "InZvdGluZ19wb3dlciI",
-                          "node": {
-                            "name": "voting_power"
-                          }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   }
                 },
                 {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::sui_system::SuiSystemState"
-                      },
-                      "json": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                        "version": "1"
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                      },
-                      "json": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                        "timestamp_ms": "0"
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorState"
-                      },
-                      "json": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000007",
-                        "version": "1"
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::random::Random"
-                      },
-                      "json": {
-                        "id": "0x0000000000000000000000000000000000000000000000000000000000000008",
-                        "inner": {
-                          "id": "0x422ac8fb34c58821362d0b4c9ac1cff1a6d40251e02a61c368fecc62bde73a3f",
+                  "cursor": "Mw",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::sui_system::SuiSystemState"
+                        },
+                        "json": {
+                          "id": "0x0000000000000000000000000000000000000000000000000000000000000005",
                           "version": "1"
                         }
                       }
-                    }
-                  },
-                  "asMovePackage": null
+                    },
+                    "asMovePackage": null
+                  }
                 },
                 {
-                  "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
-                  "asMoveObject": null,
-                  "asMovePackage": {
-                    "modules": {
-                      "edges": [
-                        {
-                          "cursor": "ImNsb2Ii",
-                          "node": {
-                            "name": "clob"
-                          }
+                  "cursor": "NA",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
                         },
-                        {
-                          "cursor": "ImNsb2JfdjIi",
-                          "node": {
-                            "name": "clob_v2"
-                          }
+                        "json": {
+                          "id": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                          "timestamp_ms": "0"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "NQ",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorState"
                         },
-                        {
-                          "cursor": "ImNyaXRiaXQi",
-                          "node": {
-                            "name": "critbit"
-                          }
+                        "json": {
+                          "id": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                          "version": "1"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "Ng",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::random::Random"
                         },
-                        {
-                          "cursor": "ImN1c3RvZGlhbiI",
-                          "node": {
-                            "name": "custodian"
-                          }
-                        },
-                        {
-                          "cursor": "ImN1c3RvZGlhbl92MiI",
-                          "node": {
-                            "name": "custodian_v2"
-                          }
-                        },
-                        {
-                          "cursor": "Im1hdGgi",
-                          "node": {
-                            "name": "math"
-                          }
-                        },
-                        {
-                          "cursor": "Im9yZGVyX3F1ZXJ5Ig",
-                          "node": {
-                            "name": "order_query"
+                        "json": {
+                          "id": "0x0000000000000000000000000000000000000000000000000000000000000008",
+                          "inner": {
+                            "id": "0x422ac8fb34c58821362d0b4c9ac1cff1a6d40251e02a61c368fecc62bde73a3f",
+                            "version": "1"
                           }
                         }
-                      ]
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "Nw",
+                  "node": {
+                    "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+                    "asMoveObject": null,
+                    "asMovePackage": {
+                      "modules": {
+                        "edges": [
+                          {
+                            "cursor": "ImNsb2Ii",
+                            "node": {
+                              "name": "clob"
+                            }
+                          },
+                          {
+                            "cursor": "ImNsb2JfdjIi",
+                            "node": {
+                              "name": "clob_v2"
+                            }
+                          },
+                          {
+                            "cursor": "ImNyaXRiaXQi",
+                            "node": {
+                              "name": "critbit"
+                            }
+                          },
+                          {
+                            "cursor": "ImN1c3RvZGlhbiI",
+                            "node": {
+                              "name": "custodian"
+                            }
+                          },
+                          {
+                            "cursor": "ImN1c3RvZGlhbl92MiI",
+                            "node": {
+                              "name": "custodian_v2"
+                            }
+                          },
+                          {
+                            "cursor": "Im1hdGgi",
+                            "node": {
+                              "name": "math"
+                            }
+                          },
+                          {
+                            "cursor": "Im9yZGVyX3F1ZXJ5Ig",
+                            "node": {
+                              "name": "order_query"
+                            }
+                          }
+                        ]
+                      }
                     }
                   }
                 },
                 {
-                  "address": "0x02e8b9ef09559c54e4afb77adca7679575e42b20b3a8ff6fb8daf0e009d7cb52",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
-                      },
-                      "json": {
-                        "id": "0x02e8b9ef09559c54e4afb77adca7679575e42b20b3a8ff6fb8daf0e009d7cb52",
-                        "name": "0",
-                        "value": {
-                          "sui_amount": "0",
-                          "pool_token_amount": "0"
-                        }
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x1f5de3c4c73a79df873afad8928d4db2f7b92dfb2a98ab117fd2b06bcb1c06ef",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedSui"
-                      },
-                      "json": {
-                        "id": "0x1f5de3c4c73a79df873afad8928d4db2f7b92dfb2a98ab117fd2b06bcb1c06ef",
-                        "pool_id": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
-                        "stake_activation_epoch": "0",
-                        "principal": {
-                          "value": "20000000000000000"
-                        }
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x52cf80120b0345307c0f09300dd5b27ae4f2ff46b8f11e6bee7f5bb9269eb32a",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                      },
-                      "json": {
-                        "id": "0x52cf80120b0345307c0f09300dd5b27ae4f2ff46b8f11e6bee7f5bb9269eb32a",
-                        "balance": {
-                          "value": "300000000000000"
-                        }
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x541a3c3a405c83f1d8339976fccf17c16d687c9cf521dfeafea6044973a4bfc7",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                      },
-                      "json": {
-                        "id": "0x541a3c3a405c83f1d8339976fccf17c16d687c9cf521dfeafea6044973a4bfc7",
-                        "decimals": 9,
-                        "name": "Sui",
-                        "symbol": "SUI",
-                        "description": "",
-                        "icon_url": null
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::sui_system_state_inner::SuiSystemStateInner>"
-                      },
-                      "json": {
-                        "id": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
-                        "name": "1",
-                        "value": {
-                          "epoch": "0",
-                          "protocol_version": "32",
-                          "system_state_version": "1",
-                          "validators": {
-                            "total_stake": "20000000000000000",
-                            "active_validators": [
-                              {
-                                "metadata": {
-                                  "sui_address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a",
-                                  "protocol_pubkey_bytes": [
-                                    168,
-                                    10,
-                                    113,
-                                    148,
-                                    146,
-                                    18,
-                                    4,
-                                    206,
-                                    160,
-                                    17,
-                                    65,
-                                    3,
-                                    192,
-                                    72,
-                                    69,
-                                    3,
-                                    34,
-                                    62,
-                                    177,
-                                    119,
-                                    149,
-                                    119,
-                                    28,
-                                    226,
-                                    120,
-                                    84,
-                                    208,
-                                    34,
-                                    33,
-                                    221,
-                                    215,
-                                    26,
-                                    19,
-                                    43,
-                                    135,
-                                    198,
-                                    111,
-                                    189,
-                                    25,
-                                    213,
-                                    111,
-                                    170,
-                                    66,
-                                    24,
-                                    110,
-                                    12,
-                                    78,
-                                    20,
-                                    10,
-                                    27,
-                                    128,
-                                    57,
-                                    246,
-                                    144,
-                                    114,
-                                    82,
-                                    79,
-                                    96,
-                                    215,
-                                    59,
-                                    240,
-                                    247,
-                                    211,
-                                    18,
-                                    143,
-                                    1,
-                                    109,
-                                    137,
-                                    179,
-                                    82,
-                                    215,
-                                    118,
-                                    63,
-                                    135,
-                                    18,
-                                    31,
-                                    123,
-                                    40,
-                                    235,
-                                    25,
-                                    153,
-                                    189,
-                                    81,
-                                    129,
-                                    128,
-                                    219,
-                                    99,
-                                    215,
-                                    146,
-                                    145,
-                                    113,
-                                    132,
-                                    99,
-                                    76,
-                                    126,
-                                    246
-                                  ],
-                                  "network_pubkey_bytes": [
-                                    222,
-                                    193,
-                                    56,
-                                    253,
-                                    223,
-                                    140,
-                                    108,
-                                    228,
-                                    161,
-                                    246,
-                                    151,
-                                    172,
-                                    42,
-                                    190,
-                                    219,
-                                    243,
-                                    212,
-                                    210,
-                                    59,
-                                    152,
-                                    5,
-                                    6,
-                                    236,
-                                    134,
-                                    82,
-                                    53,
-                                    90,
-                                    224,
-                                    105,
-                                    93,
-                                    152,
-                                    85
-                                  ],
-                                  "worker_pubkey_bytes": [
-                                    172,
-                                    116,
-                                    152,
-                                    220,
-                                    228,
-                                    127,
-                                    173,
-                                    148,
-                                    84,
-                                    44,
-                                    112,
-                                    162,
-                                    74,
-                                    125,
-                                    50,
-                                    95,
-                                    124,
-                                    147,
-                                    55,
-                                    36,
-                                    241,
-                                    143,
-                                    223,
-                                    60,
-                                    129,
-                                    224,
-                                    221,
-                                    102,
-                                    15,
-                                    35,
-                                    217,
-                                    101
-                                  ],
-                                  "proof_of_possession": [
-                                    128,
-                                    156,
-                                    67,
-                                    33,
-                                    58,
-                                    1,
-                                    39,
-                                    117,
-                                    201,
-                                    238,
-                                    255,
-                                    186,
-                                    75,
-                                    160,
-                                    126,
-                                    112,
-                                    202,
-                                    232,
-                                    153,
-                                    37,
-                                    253,
-                                    202,
-                                    71,
-                                    140,
-                                    94,
-                                    117,
-                                    125,
-                                    17,
-                                    181,
-                                    101,
-                                    235,
-                                    149,
-                                    12,
-                                    103,
-                                    135,
-                                    36,
-                                    124,
-                                    64,
-                                    40,
-                                    191,
-                                    203,
-                                    204,
-                                    20,
-                                    212,
-                                    46,
-                                    230,
-                                    32,
-                                    74
-                                  ],
-                                  "name": "validator-0",
-                                  "description": "",
-                                  "image_url": {
-                                    "url": ""
-                                  },
-                                  "project_url": {
-                                    "url": ""
-                                  },
-                                  "net_address": "/ip4/127.0.0.1/tcp/8000/http",
-                                  "p2p_address": "/ip4/127.0.0.1/udp/8001/http",
-                                  "primary_address": "/ip4/127.0.0.1/udp/8004/http",
-                                  "worker_address": "/ip4/127.0.0.1/udp/8005/http",
-                                  "next_epoch_protocol_pubkey_bytes": null,
-                                  "next_epoch_proof_of_possession": null,
-                                  "next_epoch_network_pubkey_bytes": null,
-                                  "next_epoch_worker_pubkey_bytes": null,
-                                  "next_epoch_net_address": null,
-                                  "next_epoch_p2p_address": null,
-                                  "next_epoch_primary_address": null,
-                                  "next_epoch_worker_address": null,
-                                  "extra_fields": {
-                                    "id": "0xe2def1332d7a789fb6bc20e398f3891bb74d92ca2725efe83f369f7e244eae7f",
-                                    "size": "0"
-                                  }
-                                },
-                                "voting_power": "10000",
-                                "operation_cap_id": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
-                                "gas_price": "1000",
-                                "staking_pool": {
-                                  "id": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
-                                  "activation_epoch": "0",
-                                  "deactivation_epoch": null,
-                                  "sui_balance": "20000000000000000",
-                                  "rewards_pool": {
-                                    "value": "0"
-                                  },
-                                  "pool_token_balance": "20000000000000000",
-                                  "exchange_rates": {
-                                    "id": "0x53bf19496e7662e85163791ff9202b62ce6ae21a76977f3fddddc715990dead5",
-                                    "size": "1"
-                                  },
-                                  "pending_stake": "0",
-                                  "pending_total_sui_withdraw": "0",
-                                  "pending_pool_token_withdraw": "0",
-                                  "extra_fields": {
-                                    "id": "0xf640099d45f3a491db58f1d8fca00dece35438584fd754d05dd3759572335601",
-                                    "size": "0"
-                                  }
-                                },
-                                "commission_rate": "200",
-                                "next_epoch_stake": "20000000000000000",
-                                "next_epoch_gas_price": "1000",
-                                "next_epoch_commission_rate": "200",
-                                "extra_fields": {
-                                  "id": "0x6f3394bb27d4399fadba0127c48ad1d473542f6af80ded1866bdea1c91c02fbc",
-                                  "size": "0"
-                                }
-                              }
-                            ],
-                            "pending_active_validators": {
-                              "contents": {
-                                "id": "0x2154cd9b3278884d4bf6356b882b42d832713913e5322043c877079af884a9d3",
-                                "size": "0"
-                              }
-                            },
-                            "pending_removals": [],
-                            "staking_pool_mappings": {
-                              "id": "0x32bfa456c49a72ac32d4393b185d047a148637cc8c88318f77516e6b1ca6eb16",
-                              "size": "1"
-                            },
-                            "inactive_validators": {
-                              "id": "0x2332cdd36f59a568903fd91a9c27ec7f51a6901a544f686f191314f267ddc339",
-                              "size": "0"
-                            },
-                            "validator_candidates": {
-                              "id": "0x05b7e61dec1a2fe6099c59feddfcf3fc768172b4be2ef4ac0c19ef5a63fa55e1",
-                              "size": "0"
-                            },
-                            "at_risk_validators": {
-                              "contents": []
-                            },
-                            "extra_fields": {
-                              "id": "0xb6b803a9e7a235574e4d8ff664e21219f33bd784a751b2ab04e1177ac665078e",
-                              "size": "0"
-                            }
-                          },
-                          "storage_fund": {
-                            "total_object_storage_rebates": {
-                              "value": "0"
-                            },
-                            "non_refundable_balance": {
-                              "value": "0"
-                            }
-                          },
-                          "parameters": {
-                            "epoch_duration_ms": "86400000",
-                            "stake_subsidy_start_epoch": "0",
-                            "max_validator_count": "150",
-                            "min_validator_joining_stake": "30000000000000000",
-                            "validator_low_stake_threshold": "20000000000000000",
-                            "validator_very_low_stake_threshold": "15000000000000000",
-                            "validator_low_stake_grace_period": "7",
-                            "extra_fields": {
-                              "id": "0xeabe454f65add9c92b1ac5d3d33852f59b4f60ff0f44fe575ed716e7c4551b63",
-                              "size": "0"
-                            }
-                          },
-                          "reference_gas_price": "1000",
-                          "validator_report_records": {
-                            "contents": []
-                          },
-                          "stake_subsidy": {
-                            "balance": {
-                              "value": "9949700000000000000"
-                            },
-                            "distribution_counter": "0",
-                            "current_distribution_amount": "1000000000000000",
-                            "stake_subsidy_period_length": "10",
-                            "stake_subsidy_decrease_rate": 1000,
-                            "extra_fields": {
-                              "id": "0x1faf2a713e4531708d6916bb8fe6d656ed34d21ddad26110014ddacbe2c57b31",
-                              "size": "0"
-                            }
-                          },
-                          "safe_mode": false,
-                          "safe_mode_storage_rewards": {
-                            "value": "0"
-                          },
-                          "safe_mode_computation_rewards": {
-                            "value": "0"
-                          },
-                          "safe_mode_storage_rebates": "0",
-                          "safe_mode_non_refundable_storage_fee": "0",
-                          "epoch_start_timestamp_ms": "0",
-                          "extra_fields": {
-                            "id": "0x64536f2f395db503f1b43e3f7bfdbd06e0bb87d2598da522d0b5044df39f9ad2",
-                            "size": "0"
+                  "cursor": "OA",
+                  "node": {
+                    "address": "0x02e8b9ef09559c54e4afb77adca7679575e42b20b3a8ff6fb8daf0e009d7cb52",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
+                        },
+                        "json": {
+                          "id": "0x02e8b9ef09559c54e4afb77adca7679575e42b20b3a8ff6fb8daf0e009d7cb52",
+                          "name": "0",
+                          "value": {
+                            "sui_amount": "0",
+                            "pool_token_amount": "0"
                           }
                         }
                       }
-                    }
-                  },
-                  "asMovePackage": null
+                    },
+                    "asMovePackage": null
+                  }
                 },
                 {
-                  "address": "0x7f55a19cb0b02c451494cc64e9f670fce8dbc646179fedbf1aa18d36c057ab04",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
-                      },
-                      "json": {
-                        "id": "0x7f55a19cb0b02c451494cc64e9f670fce8dbc646179fedbf1aa18d36c057ab04",
-                        "name": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
-                        "value": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0xaaf72a2f08943ad57c8850cb1b7d191b4c8ecc8ad07d64fffd19c6f3b16ca3bd",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
-                      },
-                      "json": {
-                        "id": "0xaaf72a2f08943ad57c8850cb1b7d191b4c8ecc8ad07d64fffd19c6f3b16ca3bd",
-                        "balance": {
-                          "value": "30000000000000000"
+                  "cursor": "OQ",
+                  "node": {
+                    "address": "0x1f5de3c4c73a79df873afad8928d4db2f7b92dfb2a98ab117fd2b06bcb1c06ef",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedSui"
+                        },
+                        "json": {
+                          "id": "0x1f5de3c4c73a79df873afad8928d4db2f7b92dfb2a98ab117fd2b06bcb1c06ef",
+                          "pool_id": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
+                          "stake_activation_epoch": "0",
+                          "principal": {
+                            "value": "20000000000000000"
+                          }
                         }
                       }
-                    }
-                  },
-                  "asMovePackage": null
+                    },
+                    "asMovePackage": null
+                  }
                 },
                 {
-                  "address": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::validator_cap::UnverifiedValidatorOperationCap"
-                      },
-                      "json": {
-                        "id": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
-                        "authorizer_validator_address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-                      }
-                    }
-                  },
-                  "asMovePackage": null
-                },
-                {
-                  "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorStateInner>"
-                      },
-                      "json": {
-                        "id": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
-                        "name": "1",
-                        "value": {
-                          "version": "1",
-                          "active_jwks": []
+                  "cursor": "MTA",
+                  "node": {
+                    "address": "0x52cf80120b0345307c0f09300dd5b27ae4f2ff46b8f11e6bee7f5bb9269eb32a",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0x52cf80120b0345307c0f09300dd5b27ae4f2ff46b8f11e6bee7f5bb9269eb32a",
+                          "balance": {
+                            "value": "300000000000000"
+                          }
                         }
                       }
-                    }
-                  },
-                  "asMovePackage": null
+                    },
+                    "asMovePackage": null
+                  }
                 },
                 {
-                  "address": "0xeeb81ea330cef64e124f04bdc1437ac7b3640471cf282318b19536f93f61ad47",
-                  "asMoveObject": {
-                    "contents": {
-                      "type": {
-                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::random::RandomInner>"
-                      },
-                      "json": {
-                        "id": "0xeeb81ea330cef64e124f04bdc1437ac7b3640471cf282318b19536f93f61ad47",
-                        "name": "1",
-                        "value": {
-                          "version": "1",
-                          "epoch": "0",
-                          "randomness_round": "0",
-                          "random_bytes": []
+                  "cursor": "MTE",
+                  "node": {
+                    "address": "0x541a3c3a405c83f1d8339976fccf17c16d687c9cf521dfeafea6044973a4bfc7",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0x541a3c3a405c83f1d8339976fccf17c16d687c9cf521dfeafea6044973a4bfc7",
+                          "decimals": 9,
+                          "name": "Sui",
+                          "symbol": "SUI",
+                          "description": "",
+                          "icon_url": null
                         }
                       }
-                    }
-                  },
-                  "asMovePackage": null
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTI",
+                  "node": {
+                    "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::sui_system_state_inner::SuiSystemStateInner>"
+                        },
+                        "json": {
+                          "id": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                          "name": "1",
+                          "value": {
+                            "epoch": "0",
+                            "protocol_version": "32",
+                            "system_state_version": "1",
+                            "validators": {
+                              "total_stake": "20000000000000000",
+                              "active_validators": [
+                                {
+                                  "metadata": {
+                                    "sui_address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a",
+                                    "protocol_pubkey_bytes": [
+                                      168,
+                                      10,
+                                      113,
+                                      148,
+                                      146,
+                                      18,
+                                      4,
+                                      206,
+                                      160,
+                                      17,
+                                      65,
+                                      3,
+                                      192,
+                                      72,
+                                      69,
+                                      3,
+                                      34,
+                                      62,
+                                      177,
+                                      119,
+                                      149,
+                                      119,
+                                      28,
+                                      226,
+                                      120,
+                                      84,
+                                      208,
+                                      34,
+                                      33,
+                                      221,
+                                      215,
+                                      26,
+                                      19,
+                                      43,
+                                      135,
+                                      198,
+                                      111,
+                                      189,
+                                      25,
+                                      213,
+                                      111,
+                                      170,
+                                      66,
+                                      24,
+                                      110,
+                                      12,
+                                      78,
+                                      20,
+                                      10,
+                                      27,
+                                      128,
+                                      57,
+                                      246,
+                                      144,
+                                      114,
+                                      82,
+                                      79,
+                                      96,
+                                      215,
+                                      59,
+                                      240,
+                                      247,
+                                      211,
+                                      18,
+                                      143,
+                                      1,
+                                      109,
+                                      137,
+                                      179,
+                                      82,
+                                      215,
+                                      118,
+                                      63,
+                                      135,
+                                      18,
+                                      31,
+                                      123,
+                                      40,
+                                      235,
+                                      25,
+                                      153,
+                                      189,
+                                      81,
+                                      129,
+                                      128,
+                                      219,
+                                      99,
+                                      215,
+                                      146,
+                                      145,
+                                      113,
+                                      132,
+                                      99,
+                                      76,
+                                      126,
+                                      246
+                                    ],
+                                    "network_pubkey_bytes": [
+                                      222,
+                                      193,
+                                      56,
+                                      253,
+                                      223,
+                                      140,
+                                      108,
+                                      228,
+                                      161,
+                                      246,
+                                      151,
+                                      172,
+                                      42,
+                                      190,
+                                      219,
+                                      243,
+                                      212,
+                                      210,
+                                      59,
+                                      152,
+                                      5,
+                                      6,
+                                      236,
+                                      134,
+                                      82,
+                                      53,
+                                      90,
+                                      224,
+                                      105,
+                                      93,
+                                      152,
+                                      85
+                                    ],
+                                    "worker_pubkey_bytes": [
+                                      172,
+                                      116,
+                                      152,
+                                      220,
+                                      228,
+                                      127,
+                                      173,
+                                      148,
+                                      84,
+                                      44,
+                                      112,
+                                      162,
+                                      74,
+                                      125,
+                                      50,
+                                      95,
+                                      124,
+                                      147,
+                                      55,
+                                      36,
+                                      241,
+                                      143,
+                                      223,
+                                      60,
+                                      129,
+                                      224,
+                                      221,
+                                      102,
+                                      15,
+                                      35,
+                                      217,
+                                      101
+                                    ],
+                                    "proof_of_possession": [
+                                      128,
+                                      156,
+                                      67,
+                                      33,
+                                      58,
+                                      1,
+                                      39,
+                                      117,
+                                      201,
+                                      238,
+                                      255,
+                                      186,
+                                      75,
+                                      160,
+                                      126,
+                                      112,
+                                      202,
+                                      232,
+                                      153,
+                                      37,
+                                      253,
+                                      202,
+                                      71,
+                                      140,
+                                      94,
+                                      117,
+                                      125,
+                                      17,
+                                      181,
+                                      101,
+                                      235,
+                                      149,
+                                      12,
+                                      103,
+                                      135,
+                                      36,
+                                      124,
+                                      64,
+                                      40,
+                                      191,
+                                      203,
+                                      204,
+                                      20,
+                                      212,
+                                      46,
+                                      230,
+                                      32,
+                                      74
+                                    ],
+                                    "name": "validator-0",
+                                    "description": "",
+                                    "image_url": {
+                                      "url": ""
+                                    },
+                                    "project_url": {
+                                      "url": ""
+                                    },
+                                    "net_address": "/ip4/127.0.0.1/tcp/8000/http",
+                                    "p2p_address": "/ip4/127.0.0.1/udp/8001/http",
+                                    "primary_address": "/ip4/127.0.0.1/udp/8004/http",
+                                    "worker_address": "/ip4/127.0.0.1/udp/8005/http",
+                                    "next_epoch_protocol_pubkey_bytes": null,
+                                    "next_epoch_proof_of_possession": null,
+                                    "next_epoch_network_pubkey_bytes": null,
+                                    "next_epoch_worker_pubkey_bytes": null,
+                                    "next_epoch_net_address": null,
+                                    "next_epoch_p2p_address": null,
+                                    "next_epoch_primary_address": null,
+                                    "next_epoch_worker_address": null,
+                                    "extra_fields": {
+                                      "id": "0xe2def1332d7a789fb6bc20e398f3891bb74d92ca2725efe83f369f7e244eae7f",
+                                      "size": "0"
+                                    }
+                                  },
+                                  "voting_power": "10000",
+                                  "operation_cap_id": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
+                                  "gas_price": "1000",
+                                  "staking_pool": {
+                                    "id": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
+                                    "activation_epoch": "0",
+                                    "deactivation_epoch": null,
+                                    "sui_balance": "20000000000000000",
+                                    "rewards_pool": {
+                                      "value": "0"
+                                    },
+                                    "pool_token_balance": "20000000000000000",
+                                    "exchange_rates": {
+                                      "id": "0x53bf19496e7662e85163791ff9202b62ce6ae21a76977f3fddddc715990dead5",
+                                      "size": "1"
+                                    },
+                                    "pending_stake": "0",
+                                    "pending_total_sui_withdraw": "0",
+                                    "pending_pool_token_withdraw": "0",
+                                    "extra_fields": {
+                                      "id": "0xf640099d45f3a491db58f1d8fca00dece35438584fd754d05dd3759572335601",
+                                      "size": "0"
+                                    }
+                                  },
+                                  "commission_rate": "200",
+                                  "next_epoch_stake": "20000000000000000",
+                                  "next_epoch_gas_price": "1000",
+                                  "next_epoch_commission_rate": "200",
+                                  "extra_fields": {
+                                    "id": "0x6f3394bb27d4399fadba0127c48ad1d473542f6af80ded1866bdea1c91c02fbc",
+                                    "size": "0"
+                                  }
+                                }
+                              ],
+                              "pending_active_validators": {
+                                "contents": {
+                                  "id": "0x2154cd9b3278884d4bf6356b882b42d832713913e5322043c877079af884a9d3",
+                                  "size": "0"
+                                }
+                              },
+                              "pending_removals": [],
+                              "staking_pool_mappings": {
+                                "id": "0x32bfa456c49a72ac32d4393b185d047a148637cc8c88318f77516e6b1ca6eb16",
+                                "size": "1"
+                              },
+                              "inactive_validators": {
+                                "id": "0x2332cdd36f59a568903fd91a9c27ec7f51a6901a544f686f191314f267ddc339",
+                                "size": "0"
+                              },
+                              "validator_candidates": {
+                                "id": "0x05b7e61dec1a2fe6099c59feddfcf3fc768172b4be2ef4ac0c19ef5a63fa55e1",
+                                "size": "0"
+                              },
+                              "at_risk_validators": {
+                                "contents": []
+                              },
+                              "extra_fields": {
+                                "id": "0xb6b803a9e7a235574e4d8ff664e21219f33bd784a751b2ab04e1177ac665078e",
+                                "size": "0"
+                              }
+                            },
+                            "storage_fund": {
+                              "total_object_storage_rebates": {
+                                "value": "0"
+                              },
+                              "non_refundable_balance": {
+                                "value": "0"
+                              }
+                            },
+                            "parameters": {
+                              "epoch_duration_ms": "86400000",
+                              "stake_subsidy_start_epoch": "0",
+                              "max_validator_count": "150",
+                              "min_validator_joining_stake": "30000000000000000",
+                              "validator_low_stake_threshold": "20000000000000000",
+                              "validator_very_low_stake_threshold": "15000000000000000",
+                              "validator_low_stake_grace_period": "7",
+                              "extra_fields": {
+                                "id": "0xeabe454f65add9c92b1ac5d3d33852f59b4f60ff0f44fe575ed716e7c4551b63",
+                                "size": "0"
+                              }
+                            },
+                            "reference_gas_price": "1000",
+                            "validator_report_records": {
+                              "contents": []
+                            },
+                            "stake_subsidy": {
+                              "balance": {
+                                "value": "9949700000000000000"
+                              },
+                              "distribution_counter": "0",
+                              "current_distribution_amount": "1000000000000000",
+                              "stake_subsidy_period_length": "10",
+                              "stake_subsidy_decrease_rate": 1000,
+                              "extra_fields": {
+                                "id": "0x1faf2a713e4531708d6916bb8fe6d656ed34d21ddad26110014ddacbe2c57b31",
+                                "size": "0"
+                              }
+                            },
+                            "safe_mode": false,
+                            "safe_mode_storage_rewards": {
+                              "value": "0"
+                            },
+                            "safe_mode_computation_rewards": {
+                              "value": "0"
+                            },
+                            "safe_mode_storage_rebates": "0",
+                            "safe_mode_non_refundable_storage_fee": "0",
+                            "epoch_start_timestamp_ms": "0",
+                            "extra_fields": {
+                              "id": "0x64536f2f395db503f1b43e3f7bfdbd06e0bb87d2598da522d0b5044df39f9ad2",
+                              "size": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTM",
+                  "node": {
+                    "address": "0x7f55a19cb0b02c451494cc64e9f670fce8dbc646179fedbf1aa18d36c057ab04",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
+                        },
+                        "json": {
+                          "id": "0x7f55a19cb0b02c451494cc64e9f670fce8dbc646179fedbf1aa18d36c057ab04",
+                          "name": "0x385908baa1a0de1492dd64ddbda1d7e1e5e359519a103afc6a6eca1735d6bcfa",
+                          "value": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTQ",
+                  "node": {
+                    "address": "0xaaf72a2f08943ad57c8850cb1b7d191b4c8ecc8ad07d64fffd19c6f3b16ca3bd",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0xaaf72a2f08943ad57c8850cb1b7d191b4c8ecc8ad07d64fffd19c6f3b16ca3bd",
+                          "balance": {
+                            "value": "30000000000000000"
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTU",
+                  "node": {
+                    "address": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::validator_cap::UnverifiedValidatorOperationCap"
+                        },
+                        "json": {
+                          "id": "0xbbd4d0d866687bc423d279e3b0b6ee7b98fb6d0c383ea35c2b7a3ac8bc1dc5cc",
+                          "authorizer_validator_address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTY",
+                  "node": {
+                    "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::authenticator_state::AuthenticatorStateInner>"
+                        },
+                        "json": {
+                          "id": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
+                          "name": "1",
+                          "value": {
+                            "version": "1",
+                            "active_jwks": []
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "MTc",
+                  "node": {
+                    "address": "0xeeb81ea330cef64e124f04bdc1437ac7b3640471cf282318b19536f93f61ad47",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::random::RandomInner>"
+                        },
+                        "json": {
+                          "id": "0xeeb81ea330cef64e124f04bdc1437ac7b3640471cf282318b19536f93f61ad47",
+                          "name": "1",
+                          "value": {
+                            "version": "1",
+                            "epoch": "0",
+                            "randomness_round": "0",
+                            "random_bytes": []
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
                 }
               ]
             }
@@ -1183,10 +1237,10 @@ Response: {
   }
 }
 
-task 3 'create-checkpoint'. lines 97-97:
+task 3 'create-checkpoint'. lines 100-100:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 99-168:
+task 4 'run-graphql'. lines 102-171:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -1264,10 +1318,10 @@ Response: {
   }
 }
 
-task 6 'advance-epoch'. lines 172-172:
+task 6 'advance-epoch'. lines 175-175:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 174-252:
+task 7 'run-graphql'. lines 177-255:
 Response: {
   "data": {
     "transactionBlockConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.exp
@@ -1,6 +1,6 @@
 processed 8 tasks
 
-task 1 'run-graphql'. lines 8-90:
+task 1 'run-graphql'. lines 8-93:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -29,40 +29,73 @@ Response: {
                   "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
                   "asMoveObject": null,
                   "asMovePackage": {
-                    "moduleConnection": {
-                      "nodes": [
+                    "modules": {
+                      "edges": [
                         {
-                          "name": "address"
+                          "cursor": "ImFkZHJlc3Mi",
+                          "node": {
+                            "name": "address"
+                          }
                         },
                         {
-                          "name": "ascii"
+                          "cursor": "ImFzY2lpIg",
+                          "node": {
+                            "name": "ascii"
+                          }
                         },
                         {
-                          "name": "bcs"
+                          "cursor": "ImJjcyI",
+                          "node": {
+                            "name": "bcs"
+                          }
                         },
                         {
-                          "name": "bit_vector"
+                          "cursor": "ImJpdF92ZWN0b3Ii",
+                          "node": {
+                            "name": "bit_vector"
+                          }
                         },
                         {
-                          "name": "debug"
+                          "cursor": "ImRlYnVnIg",
+                          "node": {
+                            "name": "debug"
+                          }
                         },
                         {
-                          "name": "fixed_point32"
+                          "cursor": "ImZpeGVkX3BvaW50MzIi",
+                          "node": {
+                            "name": "fixed_point32"
+                          }
                         },
                         {
-                          "name": "hash"
+                          "cursor": "Imhhc2gi",
+                          "node": {
+                            "name": "hash"
+                          }
                         },
                         {
-                          "name": "option"
+                          "cursor": "Im9wdGlvbiI",
+                          "node": {
+                            "name": "option"
+                          }
                         },
                         {
-                          "name": "string"
+                          "cursor": "InN0cmluZyI",
+                          "node": {
+                            "name": "string"
+                          }
                         },
                         {
-                          "name": "type_name"
+                          "cursor": "InR5cGVfbmFtZSI",
+                          "node": {
+                            "name": "type_name"
+                          }
                         },
                         {
-                          "name": "vector"
+                          "cursor": "InZlY3RvciI",
+                          "node": {
+                            "name": "vector"
+                          }
                         }
                       ]
                     }
@@ -72,67 +105,127 @@ Response: {
                   "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
                   "asMoveObject": null,
                   "asMovePackage": {
-                    "moduleConnection": {
-                      "nodes": [
+                    "modules": {
+                      "edges": [
                         {
-                          "name": "address"
+                          "cursor": "ImFkZHJlc3Mi",
+                          "node": {
+                            "name": "address"
+                          }
                         },
                         {
-                          "name": "authenticator_state"
+                          "cursor": "ImF1dGhlbnRpY2F0b3Jfc3RhdGUi",
+                          "node": {
+                            "name": "authenticator_state"
+                          }
                         },
                         {
-                          "name": "bag"
+                          "cursor": "ImJhZyI",
+                          "node": {
+                            "name": "bag"
+                          }
                         },
                         {
-                          "name": "balance"
+                          "cursor": "ImJhbGFuY2Ui",
+                          "node": {
+                            "name": "balance"
+                          }
                         },
                         {
-                          "name": "bcs"
+                          "cursor": "ImJjcyI",
+                          "node": {
+                            "name": "bcs"
+                          }
                         },
                         {
-                          "name": "bls12381"
+                          "cursor": "ImJsczEyMzgxIg",
+                          "node": {
+                            "name": "bls12381"
+                          }
                         },
                         {
-                          "name": "borrow"
+                          "cursor": "ImJvcnJvdyI",
+                          "node": {
+                            "name": "borrow"
+                          }
                         },
                         {
-                          "name": "clock"
+                          "cursor": "ImNsb2NrIg",
+                          "node": {
+                            "name": "clock"
+                          }
                         },
                         {
-                          "name": "coin"
+                          "cursor": "ImNvaW4i",
+                          "node": {
+                            "name": "coin"
+                          }
                         },
                         {
-                          "name": "display"
+                          "cursor": "ImRpc3BsYXki",
+                          "node": {
+                            "name": "display"
+                          }
                         },
                         {
-                          "name": "dynamic_field"
+                          "cursor": "ImR5bmFtaWNfZmllbGQi",
+                          "node": {
+                            "name": "dynamic_field"
+                          }
                         },
                         {
-                          "name": "dynamic_object_field"
+                          "cursor": "ImR5bmFtaWNfb2JqZWN0X2ZpZWxkIg",
+                          "node": {
+                            "name": "dynamic_object_field"
+                          }
                         },
                         {
-                          "name": "ecdsa_k1"
+                          "cursor": "ImVjZHNhX2sxIg",
+                          "node": {
+                            "name": "ecdsa_k1"
+                          }
                         },
                         {
-                          "name": "ecdsa_r1"
+                          "cursor": "ImVjZHNhX3IxIg",
+                          "node": {
+                            "name": "ecdsa_r1"
+                          }
                         },
                         {
-                          "name": "ecvrf"
+                          "cursor": "ImVjdnJmIg",
+                          "node": {
+                            "name": "ecvrf"
+                          }
                         },
                         {
-                          "name": "ed25519"
+                          "cursor": "ImVkMjU1MTki",
+                          "node": {
+                            "name": "ed25519"
+                          }
                         },
                         {
-                          "name": "event"
+                          "cursor": "ImV2ZW50Ig",
+                          "node": {
+                            "name": "event"
+                          }
                         },
                         {
-                          "name": "groth16"
+                          "cursor": "Imdyb3RoMTYi",
+                          "node": {
+                            "name": "groth16"
+                          }
                         },
                         {
-                          "name": "hash"
+                          "cursor": "Imhhc2gi",
+                          "node": {
+                            "name": "hash"
+                          }
                         },
                         {
-                          "name": "hex"
+                          "cursor": "ImhleCI",
+                          "node": {
+                            "name": "hex"
+                          }
                         }
                       ]
                     }
@@ -142,40 +235,73 @@ Response: {
                   "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
                   "asMoveObject": null,
                   "asMovePackage": {
-                    "moduleConnection": {
-                      "nodes": [
+                    "modules": {
+                      "edges": [
                         {
-                          "name": "genesis"
+                          "cursor": "ImdlbmVzaXMi",
+                          "node": {
+                            "name": "genesis"
+                          }
                         },
                         {
-                          "name": "stake_subsidy"
+                          "cursor": "InN0YWtlX3N1YnNpZHki",
+                          "node": {
+                            "name": "stake_subsidy"
+                          }
                         },
                         {
-                          "name": "staking_pool"
+                          "cursor": "InN0YWtpbmdfcG9vbCI",
+                          "node": {
+                            "name": "staking_pool"
+                          }
                         },
                         {
-                          "name": "storage_fund"
+                          "cursor": "InN0b3JhZ2VfZnVuZCI",
+                          "node": {
+                            "name": "storage_fund"
+                          }
                         },
                         {
-                          "name": "sui_system"
+                          "cursor": "InN1aV9zeXN0ZW0i",
+                          "node": {
+                            "name": "sui_system"
+                          }
                         },
                         {
-                          "name": "sui_system_state_inner"
+                          "cursor": "InN1aV9zeXN0ZW1fc3RhdGVfaW5uZXIi",
+                          "node": {
+                            "name": "sui_system_state_inner"
+                          }
                         },
                         {
-                          "name": "validator"
+                          "cursor": "InZhbGlkYXRvciI",
+                          "node": {
+                            "name": "validator"
+                          }
                         },
                         {
-                          "name": "validator_cap"
+                          "cursor": "InZhbGlkYXRvcl9jYXAi",
+                          "node": {
+                            "name": "validator_cap"
+                          }
                         },
                         {
-                          "name": "validator_set"
+                          "cursor": "InZhbGlkYXRvcl9zZXQi",
+                          "node": {
+                            "name": "validator_set"
+                          }
                         },
                         {
-                          "name": "validator_wrapper"
+                          "cursor": "InZhbGlkYXRvcl93cmFwcGVyIg",
+                          "node": {
+                            "name": "validator_wrapper"
+                          }
                         },
                         {
-                          "name": "voting_power"
+                          "cursor": "InZvdGluZ19wb3dlciI",
+                          "node": {
+                            "name": "voting_power"
+                          }
                         }
                       ]
                     }
@@ -248,28 +374,49 @@ Response: {
                   "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
                   "asMoveObject": null,
                   "asMovePackage": {
-                    "moduleConnection": {
-                      "nodes": [
+                    "modules": {
+                      "edges": [
                         {
-                          "name": "clob"
+                          "cursor": "ImNsb2Ii",
+                          "node": {
+                            "name": "clob"
+                          }
                         },
                         {
-                          "name": "clob_v2"
+                          "cursor": "ImNsb2JfdjIi",
+                          "node": {
+                            "name": "clob_v2"
+                          }
                         },
                         {
-                          "name": "critbit"
+                          "cursor": "ImNyaXRiaXQi",
+                          "node": {
+                            "name": "critbit"
+                          }
                         },
                         {
-                          "name": "custodian"
+                          "cursor": "ImN1c3RvZGlhbiI",
+                          "node": {
+                            "name": "custodian"
+                          }
                         },
                         {
-                          "name": "custodian_v2"
+                          "cursor": "ImN1c3RvZGlhbl92MiI",
+                          "node": {
+                            "name": "custodian_v2"
+                          }
                         },
                         {
-                          "name": "math"
+                          "cursor": "Im1hdGgi",
+                          "node": {
+                            "name": "math"
+                          }
                         },
                         {
-                          "name": "order_query"
+                          "cursor": "Im9yZGVyX3F1ZXJ5Ig",
+                          "node": {
+                            "name": "order_query"
+                          }
                         }
                       ]
                     }
@@ -1036,10 +1183,10 @@ Response: {
   }
 }
 
-task 3 'create-checkpoint'. lines 94-94:
+task 3 'create-checkpoint'. lines 97-97:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 96-165:
+task 4 'run-graphql'. lines 99-168:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -1117,10 +1264,10 @@ Response: {
   }
 }
 
-task 6 'advance-epoch'. lines 169-169:
+task 6 'advance-epoch'. lines 172-172:
 Epoch advanced: 0
 
-task 7 'run-graphql'. lines 171-249:
+task 7 'run-graphql'. lines 174-252:
 Response: {
   "data": {
     "transactionBlockConnection": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -36,8 +36,11 @@
                             }
 
                             asMovePackage {
-                                moduleConnection {
-                                    nodes { name }
+                                modules {
+                                    edges {
+                                        cursor
+                                        node { name }
+                                    }
                                 }
                             }
                         }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -24,22 +24,25 @@
             kind {
                 __typename
                 ... on GenesisTransaction {
-                    objectConnection {
-                        nodes {
-                            address
+                    objects {
+                        edges {
+                            cursor
+                            node {
+                                address
 
-                            asMoveObject {
-                                contents {
-                                    type { repr }
-                                    json
+                                asMoveObject {
+                                    contents {
+                                        type { repr }
+                                        json
+                                    }
                                 }
-                            }
 
-                            asMovePackage {
-                                modules {
-                                    edges {
-                                        cursor
-                                        node { name }
+                                asMovePackage {
+                                    modules {
+                                        edges {
+                                            cursor
+                                            node { name }
+                                        }
                                     }
                                 }
                             }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1330,7 +1330,7 @@
 >          storageRebate
 >        }
 >        ... on GenesisTransaction {
->          objectConnection {
+>          objects {
 >            nodes { address }
 >          }
 >        }

--- a/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
@@ -24,7 +24,7 @@
           storageRebate
         }
         ... on GenesisTransaction {
-          objectConnection {
+          objects {
             nodes { address }
           }
         }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1070,7 +1070,7 @@ type MoveModule {
 	Modules that this module considers friends (these modules can access `public(friend)`
 	functions from this module).
 	"""
-	friendConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
+	friends(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
 	"""
 	Look-up the definition of a struct defined in this module, by its name.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1167,7 +1167,7 @@ type MovePackage {
 	"""
 	Paginate through the MoveModules defined in this package.
 	"""
-	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
 	The transitive dependencies of this package.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -853,7 +853,7 @@ type GenesisTransaction {
 	"""
 	Objects to be created during genesis.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection!
 }
 
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1086,7 +1086,7 @@ type MoveModule {
 	"""
 	Iterate through the signatures of functions defined in this module.
 	"""
-	functionConnection(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
+	functions(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1732,11 +1732,11 @@ type ProgrammableTransactionBlock {
 	"""
 	Input objects or primitive values.
 	"""
-	inputConnection(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
-	transactionConnection(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
 }
 
 type ProgrammableTransactionConnection {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -135,7 +135,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
-	newActiveJwkConnection(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
+	newActiveJwks(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1078,7 +1078,7 @@ type MoveModule {
 	"""
 	Iterate through the structs defined in this module.
 	"""
-	structConnection(first: Int, after: String, last: Int, before: String): MoveStructConnection
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 	"""
 	Look-up the signature of a function defined in this module, by its name.
 	"""

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -88,6 +88,8 @@ pub enum Error {
     CursorNoFirstLast,
     #[error("reverse pagination is not supported")]
     _CursorNoReversePagination,
+    #[error("Connection's page size of {0} exceeds max of {1}")]
+    PageTooLarge(u64, u64),
     #[error("Invalid cursor: {0}")]
     InvalidCursor(String),
     #[error("Data has changed since cursor was generated: {0}")]
@@ -114,6 +116,7 @@ impl ErrorExtensions for Error {
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast
             | Error::_CursorNoReversePagination
+            | Error::PageTooLarge(_, _)
             | Error::InvalidCursor(_)
             | Error::_CursorConnectionFetchFailed(_)
             | Error::MultiGet(_)

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -1,0 +1,380 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt, ops::Deref};
+
+use async_graphql::{
+    connection::{CursorType, OpaqueCursor},
+    *,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{config::ServiceConfig, error::Error};
+
+/// Wrap the `OpaqueCursor` type to implement Scalar for it.
+pub(crate) struct Cursor<C>(OpaqueCursor<C>);
+
+/// Connection field parameters parsed into a single type that encodes the bounds of a single page
+/// in a paginated response.
+#[derive(Debug)]
+pub(crate) struct Page<C> {
+    /// The exclusive lower bound of the page (no bound means start from the beginning of the
+    /// data-set).
+    after: Option<Cursor<C>>,
+
+    /// The exclusive upper bound of the page (no bound means continue to the end of the data-set).
+    before: Option<Cursor<C>>,
+
+    /// Maximum number of entries in the page.
+    limit: u64,
+
+    /// In case there are more than `limit` entries in the range described by `(after, before)`,
+    /// this field states whether the entries up to limit are taken fron the `Front` or `Back` of
+    /// that range.
+    end: End,
+}
+
+/// Whether the page is extracted from the beginning or the end of the range bounded by the cursors.
+#[derive(PartialEq, Eq, Debug)]
+enum End {
+    Front,
+    Back,
+}
+
+impl<C> Cursor<C> {
+    pub(crate) fn new(cursor: C) -> Self {
+        Cursor(OpaqueCursor(cursor))
+    }
+}
+
+impl<C> Page<C> {
+    /// Convert connection parameters into a page. Entries for the page are drawn from the range
+    /// `(after, before)` (Both bounds are optional). The number of entries in the page is
+    /// controlled by `first` and `last`.
+    ///
+    /// - Setting both is in an error.
+    /// - Setting `first` indicates that the entries are taken from the front of the range.
+    /// - Setting `last` indicates that the entries are taken from the end of the range.
+    /// - Setting neither defaults the limit to the default page size in `config`, taken from the
+    ///   front of the range.
+    ///
+    /// It is an error to set a limit on page size that is greater than the `config`'s max page
+    /// size.
+    pub(crate) fn from_params(
+        config: &ServiceConfig,
+        first: Option<u64>,
+        after: Option<Cursor<C>>,
+        last: Option<u64>,
+        before: Option<Cursor<C>>,
+    ) -> Result<Self> {
+        let limits = &config.limits;
+        let page = match (first, after, last, before) {
+            (Some(_), _, Some(_), _) => return Err(Error::CursorNoFirstLast.extend()),
+
+            (limit, after, None, before) => Page {
+                after,
+                before,
+                limit: limit.unwrap_or(limits.default_page_size),
+                end: End::Front,
+            },
+
+            (None, after, Some(limit), before) => Page {
+                after,
+                before,
+                limit,
+                end: End::Back,
+            },
+        };
+
+        if page.limit > limits.max_page_size {
+            return Err(Error::PageTooLarge(page.limit, limits.max_page_size).extend());
+        }
+
+        Ok(page)
+    }
+
+    pub(crate) fn after(&self) -> Option<&Cursor<C>> {
+        self.after.as_ref()
+    }
+
+    pub(crate) fn before(&self) -> Option<&Cursor<C>> {
+        self.before.as_ref()
+    }
+
+    pub(crate) fn limit(&self) -> usize {
+        self.limit as usize
+    }
+
+    pub(crate) fn is_from_front(&self) -> bool {
+        matches!(self.end, End::Front)
+    }
+}
+
+#[Scalar(name = "String", visible = false)]
+impl<C> ScalarType for Cursor<C>
+where
+    C: Send + Sync,
+    C: Serialize + DeserializeOwned,
+{
+    fn parse(value: Value) -> InputValueResult<Self> {
+        let Value::String(s) = value else {
+            return Err(InputValueError::expected_type(value));
+        };
+
+        Ok(Cursor(OpaqueCursor::decode_cursor(&s)?))
+    }
+
+    /// Just check that the value is a string, as we'll do more involved tests during parsing.
+    fn is_valid(value: &Value) -> bool {
+        matches!(value, Value::String(_))
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.0.encode_cursor())
+    }
+}
+
+/// Wrapping implementation of `CursorType` directly forwarding to `OpaqueCursor`.
+impl<C> CursorType for Cursor<C>
+where
+    C: Send + Sync,
+    C: Serialize + DeserializeOwned,
+{
+    type Error = <OpaqueCursor<C> as CursorType>::Error;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        Ok(Cursor(OpaqueCursor::decode_cursor(s)?))
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.0.encode_cursor()
+    }
+}
+
+impl<C> Deref for Cursor<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<C: fmt::Debug> fmt::Debug for Cursor<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", *self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn test_default_page() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> = Page::from_params(&config, None, None, None, None).unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: None,
+                before: None,
+                limit: 20,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_prefix_page() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> =
+            Page::from_params(&config, None, Some(Cursor::new(42)), None, None).unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: Some(
+                    42,
+                ),
+                before: None,
+                limit: 20,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_prefix_page_limited() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> =
+            Page::from_params(&config, Some(10), Some(Cursor::new(42)), None, None).unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: Some(
+                    42,
+                ),
+                before: None,
+                limit: 10,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_suffix_page() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> =
+            Page::from_params(&config, None, None, None, Some(Cursor::new(42))).unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: None,
+                before: Some(
+                    42,
+                ),
+                limit: 20,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_suffix_page_limited() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> =
+            Page::from_params(&config, None, None, Some(10), Some(Cursor::new(42))).unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: None,
+                before: Some(
+                    42,
+                ),
+                limit: 10,
+                end: Back,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_between_page_prefix() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> = Page::from_params(
+            &config,
+            Some(10),
+            Some(Cursor::new(40)),
+            None,
+            Some(Cursor::new(42)),
+        )
+        .unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: Some(
+                    40,
+                ),
+                before: Some(
+                    42,
+                ),
+                limit: 10,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_between_page_suffix() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> = Page::from_params(
+            &config,
+            None,
+            Some(Cursor::new(40)),
+            Some(10),
+            Some(Cursor::new(42)),
+        )
+        .unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: Some(
+                    40,
+                ),
+                before: Some(
+                    42,
+                ),
+                limit: 10,
+                end: Back,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_between_page() {
+        let config = ServiceConfig::default();
+        let page: Page<u64> = Page::from_params(
+            &config,
+            None,
+            Some(Cursor::new(40)),
+            None,
+            Some(Cursor::new(42)),
+        )
+        .unwrap();
+
+        let expect = expect![[r#"
+            Page {
+                after: Some(
+                    40,
+                ),
+                before: Some(
+                    42,
+                ),
+                limit: 20,
+                end: Front,
+            }"#]];
+        expect.assert_eq(&format!("{page:#?}"));
+    }
+
+    #[test]
+    fn test_err_first_and_last() {
+        let config = ServiceConfig::default();
+        let err = Page::<u64>::from_params(&config, Some(1), None, Some(1), None).unwrap_err();
+
+        let expect = expect![[r#"
+            Error {
+                message: "'first' and 'last' must not be used together",
+                extensions: Some(
+                    ErrorExtensionValues(
+                        {
+                            "code": String(
+                                "BAD_USER_INPUT",
+                            ),
+                        },
+                    ),
+                ),
+            }"#]];
+        expect.assert_eq(&format!("{err:#?}"));
+    }
+
+    #[test]
+    fn test_err_page_too_big() {
+        let config = ServiceConfig::default();
+        let too_big = config.limits.max_page_size + 1;
+        let err = Page::<u64>::from_params(&config, Some(too_big), None, None, None).unwrap_err();
+
+        let expect = expect![[r#"
+            Error {
+                message: "Connection's page size of 51 exceeds max of 50",
+                extensions: Some(
+                    ErrorExtensionValues(
+                        {
+                            "code": String(
+                                "BAD_USER_INPUT",
+                            ),
+                        },
+                    ),
+                ),
+            }"#]];
+        expect.assert_eq(&format!("{err:#?}"));
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -93,12 +93,12 @@ impl<C> Page<C> {
         Ok(page)
     }
 
-    pub(crate) fn after(&self) -> Option<&Cursor<C>> {
-        self.after.as_ref()
+    pub(crate) fn after(&self) -> Option<&C> {
+        self.after.as_deref()
     }
 
-    pub(crate) fn before(&self) -> Option<&Cursor<C>> {
-        self.before.as_ref()
+    pub(crate) fn before(&self) -> Option<&C> {
+        self.before.as_deref()
     }
 
     pub(crate) fn limit(&self) -> usize {

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod checkpoint;
 pub(crate) mod coin;
 pub(crate) mod coin_metadata;
 pub(crate) mod committee_member;
+pub(crate) mod cursor;
 pub(crate) mod date_time;
 pub(crate) mod digest;
 pub(crate) mod display;

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{
-    connection::{Connection, Edge},
+    connection::{Connection, CursorType, Edge},
     *,
 };
 use sui_types::transaction::{
@@ -12,16 +12,22 @@ use sui_types::transaction::{
 };
 
 use crate::{
-    context_data::db_data_provider::{validate_cursor_pagination, PgManager},
-    error::Error,
+    context_data::db_data_provider::PgManager,
     types::{
-        base64::Base64, move_function::MoveFunction, move_type::MoveType, object_read::ObjectRead,
+        base64::Base64,
+        cursor::{Cursor, Page},
+        move_function::MoveFunction,
+        move_type::MoveType,
+        object_read::ObjectRead,
         sui_address::SuiAddress,
     },
 };
 
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct ProgrammableTransactionBlock(pub NativeProgrammableTransactionBlock);
+
+pub(crate) type CInput = Cursor<usize>;
+pub(crate) type CTxn = Cursor<usize>;
 
 #[derive(Union, Clone, Eq, PartialEq)]
 enum TransactionInput {
@@ -191,130 +197,76 @@ struct TxResult {
 #[Object]
 impl ProgrammableTransactionBlock {
     /// Input objects or primitive values.
-    async fn input_connection(
+    async fn inputs(
         &self,
+        ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<CInput>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<CInput>,
     ) -> Result<Connection<String, TransactionInput>> {
-        // TODO: make cursor opaque (currently just an offset).
-        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let total = self.0.inputs.len();
-
-        let mut lo = if let Some(after) = after {
-            1 + after
-                .parse::<usize>()
-                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
-                .extend()?
-        } else {
-            0
-        };
-
-        let mut hi = if let Some(before) = before {
-            before
-                .parse::<usize>()
-                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
-                .extend()?
-        } else {
-            total
-        };
+        let mut lo = page.after().map_or(0, |a| *a + 1);
+        let mut hi = page.before().map_or(total, |b| *b);
 
         let mut connection = Connection::new(false, false);
         if hi <= lo {
             return Ok(connection);
-        }
-
-        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
-        // lowerbound.
-        if let Some(first) = first {
-            let first = first as usize;
-            if hi - lo > first {
-                hi = lo + first;
-            }
-        }
-
-        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
-        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
-        if let Some(last) = last {
-            let last = last as usize;
-            if hi - lo > last {
-                lo = hi - last;
+        } else if (hi - lo) > page.limit() {
+            if page.is_from_front() {
+                hi = lo + page.limit();
+            } else {
+                lo = hi - page.limit();
             }
         }
 
         connection.has_previous_page = 0 < lo;
         connection.has_next_page = hi < total;
 
-        for (idx, input) in self.0.inputs.iter().enumerate().skip(lo).take(hi - lo) {
-            let input = TransactionInput::from(input.clone());
-            connection.edges.push(Edge::new(idx.to_string(), input));
+        for idx in lo..hi {
+            let input = TransactionInput::from(self.0.inputs[idx].clone());
+            let cursor = Cursor::new(idx).encode_cursor();
+            connection.edges.push(Edge::new(cursor, input));
         }
 
         Ok(connection)
     }
 
     /// The transaction commands, executed sequentially.
-    async fn transaction_connection(
+    async fn transactions(
         &self,
+        ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<CTxn>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<CTxn>,
     ) -> Result<Connection<String, ProgrammableTransaction>> {
-        // TODO: make cursor opaque (currently just an offset).
-        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let total = self.0.commands.len();
-
-        let mut lo = if let Some(after) = after {
-            1 + after
-                .parse::<usize>()
-                .map_err(|_| Error::InvalidCursor("Failed to parse 'after' cursor.".to_string()))
-                .extend()?
-        } else {
-            0
-        };
-
-        let mut hi = if let Some(before) = before {
-            before
-                .parse::<usize>()
-                .map_err(|_| Error::InvalidCursor("Failed to parse 'before' cursor.".to_string()))
-                .extend()?
-        } else {
-            total
-        };
+        let mut lo = page.after().map_or(0, |a| *a + 1);
+        let mut hi = page.before().map_or(total, |b| *b);
 
         let mut connection = Connection::new(false, false);
         if hi <= lo {
             return Ok(connection);
-        }
-
-        // If there's a `first` limit, bound the upperbound to be at most `first` away from the
-        // lowerbound.
-        if let Some(first) = first {
-            let first = first as usize;
-            if hi - lo > first {
-                hi = lo + first;
-            }
-        }
-
-        // If there's a `last` limit, bound the lowerbound to be at most `last` away from the
-        // upperbound.  NB. This applies after we bounded the upperbound, using `first`.
-        if let Some(last) = last {
-            let last = last as usize;
-            if hi - lo > last {
-                lo = hi - last;
+        } else if (hi - lo) > page.limit() {
+            if page.is_from_front() {
+                hi = lo + page.limit();
+            } else {
+                lo = hi - page.limit();
             }
         }
 
         connection.has_previous_page = 0 < lo;
         connection.has_next_page = hi < total;
 
-        for (idx, cmd) in self.0.commands.iter().enumerate().skip(lo).take(hi - lo) {
-            let input = ProgrammableTransaction::from(cmd.clone());
-            connection.edges.push(Edge::new(idx.to_string(), input));
+        for idx in lo..hi {
+            let txn = ProgrammableTransaction::from(self.0.commands[idx].clone());
+            let cursor = Cursor::new(idx).encode_cursor();
+            connection.edges.push(Edge::new(cursor, txn));
         }
 
         Ok(connection)

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1171,7 +1171,7 @@ type MovePackage {
 	"""
 	Paginate through the MoveModules defined in this package.
 	"""
-	moduleConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection
+	modules(first: Int, after: String, last: Int, before: String): MoveModuleConnection
 	"""
 	The transitive dependencies of this package.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1090,7 +1090,7 @@ type MoveModule {
 	"""
 	Iterate through the signatures of functions defined in this module.
 	"""
-	functionConnection(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
+	functions(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1082,7 +1082,7 @@ type MoveModule {
 	"""
 	Iterate through the structs defined in this module.
 	"""
-	structConnection(first: Int, after: String, last: Int, before: String): MoveStructConnection
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 	"""
 	Look-up the signature of a function defined in this module, by its name.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -139,7 +139,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Newly active JWKs (JSON Web Keys).
 	"""
-	newActiveJwkConnection(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
+	newActiveJwks(first: Int, after: String, last: Int, before: String): ActiveJwkConnection!
 	"""
 	The initial version of the authenticator object that it was shared at.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -857,7 +857,7 @@ type GenesisTransaction {
 	"""
 	Objects to be created during genesis.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection!
 }
 
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1736,11 +1736,11 @@ type ProgrammableTransactionBlock {
 	"""
 	Input objects or primitive values.
 	"""
-	inputConnection(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
-	transactionConnection(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
 }
 
 type ProgrammableTransactionConnection {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1074,7 +1074,7 @@ type MoveModule {
 	Modules that this module considers friends (these modules can access `public(friend)`
 	functions from this module).
 	"""
-	friendConnection(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
+	friends(first: Int, after: String, last: Int, before: String): MoveModuleConnection!
 	"""
 	Look-up the definition of a struct defined in this module, by its name.
 	"""

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -553,7 +553,7 @@ impl Module {
         &self,
         after: Option<&str>,
         before: Option<&str>,
-    ) -> impl Iterator<Item = &str> + Clone {
+    ) -> impl DoubleEndedIterator<Item = &str> + Clone {
         use std::ops::Bound as B;
         self.function_index
             .range::<str, _>((

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -503,7 +503,7 @@ impl Module {
         &self,
         after: Option<&str>,
         before: Option<&str>,
-    ) -> impl Iterator<Item = &str> + Clone {
+    ) -> impl DoubleEndedIterator<Item = &str> + Clone {
         use std::ops::Bound as B;
         self.struct_index
             .range::<str, _>((

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -156,8 +156,10 @@ pub struct RunGraphqlCommand {
     pub show_headers: bool,
     #[clap(long = "show-service-version")]
     pub show_service_version: bool,
-    #[clap(long = "variables", num_args(1..))]
+    #[clap(long, num_args(1..))]
     pub variables: Vec<String>,
+    #[clap(long, num_args(1..))]
+    pub cursors: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
## Description

Add a generic framework for opaque cursors.  There is already a type in `async_graphql` that serializes cursors as JSON and then Base64 -- `OpaqueCursor<T>` -- but it doesn't implement `ScalarType`, so this PR introduces a `Cursor<C>` that wraps `OpaqueCursor` to implement both `ScalarType` and `CursorType` so the same type can be used as a parameter for connections and for a field on `Connection`s.

`MoveModule.friendConnection` has been updated to
`MoveModule.friends`, and to use the new cursor framework.

## Test Plan

New unit test:

```
sui-graphql-rpc$ cargo nextest run -- types::cursor
```

Updated E2E test:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- friends.move
```

E2E tests have been updated to support injecting cursor variables into the interpolation system. They are accepted as strings (which should contain JSON), Base64 encoded and then bound to a `cursor_<x>` variable.