### PR TITLE
[GraphQL/Cursor] MoveModule.structs

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -385,7 +385,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 205-239:
+task 9 'run-graphql'. lines 205-245:
 Response: {
   "data": {
     "object": {
@@ -486,15 +486,24 @@ Response: {
             }
           },
           "after": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -503,15 +512,24 @@ Response: {
             }
           },
           "before": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -525,19 +543,25 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 241-285:
+task 10 'run-graphql'. lines 247-294:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "prefix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -546,15 +570,24 @@ Response: {
             }
           },
           "prefixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -563,15 +596,24 @@ Response: {
             }
           },
           "prefixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               },
               {
-                "name": "TreasuryCap"
+                "cursor": "IlRyZWFzdXJ5Q2FwIg",
+                "node": {
+                  "name": "TreasuryCap"
+                }
               }
             ],
             "pageInfo": {
@@ -580,12 +622,18 @@ Response: {
             }
           },
           "suffix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -594,15 +642,24 @@ Response: {
             }
           },
           "suffixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {
@@ -611,15 +668,24 @@ Response: {
             }
           },
           "suffixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "Coin"
+                "cursor": "IkNvaW4i",
+                "node": {
+                  "name": "Coin"
+                }
               },
               {
-                "name": "CoinMetadata"
+                "cursor": "IkNvaW5NZXRhZGF0YSI",
+                "node": {
+                  "name": "CoinMetadata"
+                }
               },
               {
-                "name": "CurrencyCreated"
+                "cursor": "IkN1cnJlbmN5Q3JlYXRlZCI",
+                "node": {
+                  "name": "CurrencyCreated"
+                }
               }
             ],
             "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -202,13 +202,13 @@ fragment Structs on Object {
 }
 
 
-//# run-graphql
+//# run-graphql --cursors "Coin" "TreasuryCap"
 {
     object(address: "0x2") {
         asMovePackage {
             module(name: "coin") {
                 # Get all the types defined in coin
-                all: structConnection {
+                all: structs {
                     nodes {
                         name
                         fields {
@@ -223,14 +223,20 @@ fragment Structs on Object {
                 # exclusive lower bound, so this query should indicate
                 # there is a previous page, and not include `Coin` in
                 # the output.
-                after: structConnection(after: "Coin") {
-                    nodes { name }
+                after: structs(after: "@{cursor_0}") {
+                    edges {
+                        cursor
+                        node { name }
+                    }
                     pageInfo { hasNextPage hasPreviousPage }
                 }
 
                 # Before: Similar to `after` but at the end of the range.
-                before: structConnection(before: "TreasuryCap") {
-                    nodes { name }
+                before: structs(before: "@{cursor_1}") {
+                    edges {
+                        cursor
+                        node { name }
+                    }
                     pageInfo { hasNextPage hasPreviousPage }
                 }
             }
@@ -238,9 +244,12 @@ fragment Structs on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "Coin" "TreasuryCap"
 fragment NodeNames on MoveStructConnection {
-    nodes { name }
+    edges {
+        cursor
+        node { name }
+    }
     pageInfo { hasNextPage hasPreviousPage }
 }
 
@@ -250,33 +259,33 @@ fragment NodeNames on MoveStructConnection {
             module(name: "coin") {
                 # Limit the number of elements in the page using
                 # `first` and skip elements using `after`.
-                prefix: structConnection(after: "Coin", first: 2) {
+                prefix: structs(after: "@{cursor_0}", first: 2) {
                     ...NodeNames
                 }
 
                 # Limit has no effect because it matches the total
                 # number of entries in the page.
-                prefixAll: structConnection(after: "Coin", first: 3) {
+                prefixAll: structs(after: "@{cursor_0}", first: 3) {
                     ...NodeNames
                 }
 
                 # Limit also has no effect, because it exceeds the
                 # total number of entries in the page.
-                prefixExcess: structConnection(after: "Coin", first: 100) {
+                prefixExcess: structs(after: "@{cursor_0}", first: 20) {
                     ...NodeNames
                 }
 
                 # Remaining tests are similar to after/first but with
                 # before/last.
-                suffix: structConnection(before: "TreasuryCap", last: 2) {
+                suffix: structs(before: "@{cursor_1}", last: 2) {
                     ...NodeNames
                 }
 
-                suffixAll: structConnection(before: "TreasuryCap", last: 3) {
+                suffixAll: structs(before: "@{cursor_1}", last: 3) {
                     ...NodeNames
                 }
 
-                suffixExcess: structConnection(before: "TreasuryCap", last: 100) {
+                suffixExcess: structs(before: "@{cursor_1}", last: 20) {
                     ...NodeNames
                 }
             }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1078,7 +1078,7 @@ type MoveModule {
 	"""
 	Iterate through the structs defined in this module.
 	"""
-	structConnection(first: Int, after: String, last: Int, before: String): MoveStructConnection
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 	"""
 	Look-up the signature of a function defined in this module, by its name.
 	"""

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -93,12 +93,12 @@ impl<C> Page<C> {
         Ok(page)
     }
 
-    pub(crate) fn after(&self) -> Option<&Cursor<C>> {
-        self.after.as_ref()
+    pub(crate) fn after(&self) -> Option<&C> {
+        self.after.as_deref()
     }
 
-    pub(crate) fn before(&self) -> Option<&Cursor<C>> {
-        self.before.as_ref()
+    pub(crate) fn before(&self) -> Option<&C> {
+        self.before.as_deref()
     }
 
     pub(crate) fn limit(&self) -> usize {

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -26,6 +26,7 @@ pub(crate) struct MoveModule {
 }
 
 pub(crate) type CFriend = Cursor<usize>;
+pub(crate) type CStruct = Cursor<String>;
 
 /// Represents a module in Move, a library that defines struct types
 /// and functions that operate on these types.
@@ -73,8 +74,8 @@ impl MoveModule {
         let total = bytecode.friend_decls.len();
 
         // Add one to make [lo, hi) a half-open interval ((after, before) is an open interval).
-        let mut lo = page.after().map_or(0, |a| **a + 1);
-        let mut hi = page.before().map_or(total, |b| **b);
+        let mut lo = page.after().map_or(0, |a| *a + 1);
+        let mut hi = page.before().map_or(total, |b| *b);
 
         let mut connection = Connection::new(false, false);
         if hi <= lo {
@@ -145,37 +146,37 @@ impl MoveModule {
     }
 
     /// Iterate through the structs defined in this module.
-    async fn struct_connection(
+    async fn structs(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<CStruct>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<CStruct>,
     ) -> Result<Option<Connection<String, MoveStruct>>> {
-        let default_page_size = ctx
-            .data::<ServiceConfig>()
-            .map_err(|_| Error::Internal("Unable to fetch service configuration.".to_string()))
-            .extend()?
-            .limits
-            .max_page_size;
-
-        // TODO: make cursor opaque.
-        // for now it same as struct name
-        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
-
-        let struct_range = self.parsed.structs(after.as_deref(), before.as_deref());
-
-        let total = struct_range.clone().count() as u64;
-        let (skip, take) = match (first, last) {
-            (Some(first), Some(last)) if last < first => (first - last, last),
-            (Some(first), _) => (0, first),
-            (None, Some(last)) if last < total => (total - last, last),
-            (None, _) => (0, default_page_size),
-        };
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        let after = page.after().map(String::as_str);
+        let before = page.before().map(String::as_str);
+        let struct_range = self.parsed.structs(after, before);
 
         let mut connection = Connection::new(false, false);
-        for name in struct_range.skip(skip as usize).take(take as usize) {
+        let struct_names = if page.is_from_start() {
+            struct_range.take(page.limit()).collect()
+        } else {
+            let mut names: Vec<_> = struct_range.rev().take(page.limit()).collect();
+            names.reverse();
+            names
+        };
+
+        connection.has_previous_page = struct_names
+            .first()
+            .is_some_and(|fst| self.parsed.structs(None, Some(fst)).next().is_some());
+
+        connection.has_next_page = struct_names
+            .last()
+            .is_some_and(|lst| self.parsed.structs(Some(lst), None).next().is_some());
+
+        for name in struct_names {
             let Some(struct_) = self.struct_impl(name.to_string()).extend()? else {
                 return Err(Error::Internal(format!(
                     "Cannot deserialize struct {name} in module {}::{}",
@@ -185,22 +186,9 @@ impl MoveModule {
                 .extend();
             };
 
-            connection.edges.push(Edge::new(name.to_string(), struct_));
+            let cursor = Cursor::new(name.to_string()).encode_cursor();
+            connection.edges.push(Edge::new(cursor, struct_));
         }
-
-        connection.has_previous_page = connection.edges.first().is_some_and(|fst| {
-            self.parsed
-                .structs(None, Some(&fst.cursor))
-                .next()
-                .is_some()
-        });
-
-        connection.has_next_page = connection.edges.last().is_some_and(|lst| {
-            self.parsed
-                .structs(Some(&lst.cursor), None)
-                .next()
-                .is_some()
-        });
 
         if connection.edges.is_empty() {
             Ok(None)

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -160,7 +160,7 @@ impl MoveModule {
         let struct_range = self.parsed.structs(after, before);
 
         let mut connection = Connection::new(false, false);
-        let struct_names = if page.is_from_start() {
+        let struct_names = if page.is_from_front() {
             struct_range.take(page.limit()).collect()
         } else {
             let mut names: Vec<_> = struct_range.rev().take(page.limit()).collect();

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1082,7 +1082,7 @@ type MoveModule {
 	"""
 	Iterate through the structs defined in this module.
 	"""
-	structConnection(first: Int, after: String, last: Int, before: String): MoveStructConnection
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 	"""
 	Look-up the signature of a function defined in this module, by its name.
 	"""

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -503,7 +503,7 @@ impl Module {
         &self,
         after: Option<&str>,
         before: Option<&str>,
-    ) -> impl Iterator<Item = &str> + Clone {
+    ) -> impl DoubleEndedIterator<Item = &str> + Clone {
         use std::ops::Bound as B;
         self.struct_index
             .range::<str, _>((


### PR DESCRIPTION
##  Description

Use the cursor framework for `MoveModule.structConnection` and rename it to `structs`.

## Test Plan

Updated E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- structs.move
```

## Stack

- #15467 