### PR TITLE
[GraphQL/Cursor] MoveModule.functions

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.exp
@@ -245,53 +245,62 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 134-166:
+task 8 'run-graphql'. lines 134-169:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "all": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -300,30 +309,36 @@ Response: {
             }
           },
           "after": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -332,32 +347,38 @@ Response: {
             }
           },
           "before": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -371,23 +392,26 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 168-236:
+task 9 'run-graphql'. lines 171-242:
 Response: {
   "data": {
     "object": {
       "asMovePackage": {
         "module": {
           "prefix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -396,30 +420,36 @@ Response: {
             }
           },
           "prefixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -428,30 +458,36 @@ Response: {
             }
           },
           "prefixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "timestamp_ms",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  }
-                ],
-                "return": [
-                  {
-                    "repr": "u64"
-                  }
-                ]
+                "cursor": "InRpbWVzdGFtcF9tcyI",
+                "node": {
+                  "name": "timestamp_ms",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    }
+                  ],
+                  "return": [
+                    {
+                      "repr": "u64"
+                    }
+                  ]
+                }
               }
             ],
             "pageInfo": {
@@ -460,16 +496,19 @@ Response: {
             }
           },
           "suffix": {
-            "nodes": [
+            "edges": [
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -478,32 +517,38 @@ Response: {
             }
           },
           "suffixAll": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {
@@ -512,32 +557,38 @@ Response: {
             }
           },
           "suffixExcess": {
-            "nodes": [
+            "edges": [
               {
-                "name": "consensus_commit_prologue",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
-                  },
-                  {
-                    "repr": "u64"
-                  },
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNvbnNlbnN1c19jb21taXRfcHJvbG9ndWUi",
+                "node": {
+                  "name": "consensus_commit_prologue",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&mut 0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock"
+                    },
+                    {
+                      "repr": "u64"
+                    },
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               },
               {
-                "name": "create",
-                "typeParameters": [],
-                "parameters": [
-                  {
-                    "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
-                  }
-                ],
-                "return": []
+                "cursor": "ImNyZWF0ZSI",
+                "node": {
+                  "name": "create",
+                  "typeParameters": [],
+                  "parameters": [
+                    {
+                      "repr": "&0x0000000000000000000000000000000000000000000000000000000000000002::tx_context::TxContext"
+                    }
+                  ],
+                  "return": []
+                }
               }
             ],
             "pageInfo": {

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.move
@@ -131,14 +131,17 @@ fragment Functions on Object {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
 
 fragment Signatures on MoveFunctionConnection {
-    nodes {
-        name
-        typeParameters { constraints }
-        parameters { repr }
-        return { repr }
+    edges {
+        cursor
+        node {
+            name
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
     }
     pageInfo { hasNextPage hasPreviousPage }
 }
@@ -148,16 +151,16 @@ fragment Signatures on MoveFunctionConnection {
         asMovePackage {
             module(name: "clock") {
                 # Get the signatures of all functions.
-                all: functionConnection { ...Signatures }
+                all: functions { ...Signatures }
 
                 # Functions are iterated in lexicographical order of
                 # name, so this should skip the first one.
-                after: functionConnection(after: "consensus_commit_prologue") {
+                after: functions(after: "@{cursor_0}") {
                     ...Signatures
                 }
 
                 # ...and this should skip the last one.
-                before: functionConnection(before: "timestamp_ms") {
+                before: functions(before: "@{cursor_1}") {
                     ...Signatures
                 }
             }
@@ -165,14 +168,17 @@ fragment Signatures on MoveFunctionConnection {
     }
 }
 
-//# run-graphql
+//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
 
 fragment Signatures on MoveFunctionConnection {
-    nodes {
-        name
-        typeParameters { constraints }
-        parameters { repr }
-        return { repr }
+    edges {
+        cursor
+        node {
+            name
+            typeParameters { constraints }
+            parameters { repr }
+            return { repr }
+        }
     }
     pageInfo { hasNextPage hasPreviousPage }
 }
@@ -183,50 +189,50 @@ fragment Signatures on MoveFunctionConnection {
             module(name: "clock") {
                 # Limit the number of elements in the page using
                 # `first` and skip elements using `after.
-                prefix: functionConnection(
+                prefix: functions(
                     first: 1,
-                    after: "consensus_commit_prologue",
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # No limit, because there are only two other
                 # functions, other than `consensus_commit_prologue`.
-                prefixAll: functionConnection(
+                prefixAll: functions(
                     first: 2,
-                    after: "consensus_commit_prologue",
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # No limit, because we are asking for way more
                 # functions than we have.
-                prefixExcess: functionConnection(
-                    first: 100,
-                    after: "consensus_commit_prologue",
+                prefixExcess: functions(
+                    first: 20,
+                    after: "@{cursor_0}",
                 ) {
                     ...Signatures
                 }
 
                 # Remaining tests are similar but replacing
                 # after/first with before/last.
-                suffix: functionConnection(
+                suffix: functions(
                     last: 1,
-                    before: "timestamp_ms",
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }
 
-                suffixAll: functionConnection(
+                suffixAll: functions(
                     last: 2,
-                    before: "timestamp_ms",
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }
 
-                suffixExcess: functionConnection(
-                    last: 100,
-                    before: "timestamp_ms",
+                suffixExcess: functions(
+                    last: 20,
+                    before: "@{cursor_1}",
                 ) {
                     ...Signatures
                 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1086,7 +1086,7 @@ type MoveModule {
 	"""
 	Iterate through the signatures of functions defined in this module.
 	"""
-	functionConnection(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
+	functions(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -217,7 +217,7 @@ impl MoveModule {
         let function_range = self.parsed.functions(after, before);
 
         let mut connection = Connection::new(false, false);
-        let function_names = if page.is_from_start() {
+        let function_names = if page.is_from_front() {
             function_range.take(page.limit()).collect()
         } else {
             let mut names: Vec<_> = function_range.rev().take(page.limit()).collect();

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -8,8 +8,7 @@ use move_binary_format::binary_views::BinaryIndexedView;
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Loc;
 
-use crate::config::ServiceConfig;
-use crate::context_data::db_data_provider::{validate_cursor_pagination, PgManager};
+use crate::context_data::db_data_provider::PgManager;
 use crate::error::Error;
 use sui_package_resolver::Module as ParsedMoveModule;
 
@@ -27,6 +26,7 @@ pub(crate) struct MoveModule {
 
 pub(crate) type CFriend = Cursor<usize>;
 pub(crate) type CStruct = Cursor<String>;
+pub(crate) type CFunction = Cursor<String>;
 
 /// Represents a module in Move, a library that defines struct types
 /// and functions that operate on these types.
@@ -203,37 +203,37 @@ impl MoveModule {
     }
 
     /// Iterate through the signatures of functions defined in this module.
-    async fn function_connection(
+    async fn functions(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<CFunction>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<CFunction>,
     ) -> Result<Option<Connection<String, MoveFunction>>> {
-        let default_page_size = ctx
-            .data::<ServiceConfig>()
-            .map_err(|_| Error::Internal("Unable to fetch service configuration.".to_string()))
-            .extend()?
-            .limits
-            .max_page_size;
-
-        // TODO: make cursor opaque.
-        // for now it same as function name
-        validate_cursor_pagination(&first, &after, &last, &before).extend()?;
-
-        let function_range = self.parsed.functions(after.as_deref(), before.as_deref());
-
-        let total = function_range.clone().count() as u64;
-        let (skip, take) = match (first, last) {
-            (Some(first), Some(last)) if last < first => (first - last, last),
-            (Some(first), _) => (0, first),
-            (None, Some(last)) if last < total => (total - last, last),
-            (None, _) => (0, default_page_size),
-        };
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        let after = page.after().map(String::as_str);
+        let before = page.before().map(String::as_str);
+        let function_range = self.parsed.functions(after, before);
 
         let mut connection = Connection::new(false, false);
-        for name in function_range.skip(skip as usize).take(take as usize) {
+        let function_names = if page.is_from_start() {
+            function_range.take(page.limit()).collect()
+        } else {
+            let mut names: Vec<_> = function_range.rev().take(page.limit()).collect();
+            names.reverse();
+            names
+        };
+
+        connection.has_previous_page = function_names
+            .first()
+            .is_some_and(|fst| self.parsed.functions(None, Some(fst)).next().is_some());
+
+        connection.has_next_page = function_names
+            .last()
+            .is_some_and(|lst| self.parsed.functions(Some(lst), None).next().is_some());
+
+        for name in function_names {
             let Some(function) = self.function_impl(name.to_string()).extend()? else {
                 return Err(Error::Internal(format!(
                     "Cannot deserialize function {name} in module {}::{}",
@@ -243,22 +243,9 @@ impl MoveModule {
                 .extend();
             };
 
-            connection.edges.push(Edge::new(name.to_string(), function));
+            let cursor = Cursor::new(name.to_string()).encode_cursor();
+            connection.edges.push(Edge::new(cursor, function));
         }
-
-        connection.has_previous_page = connection.edges.first().is_some_and(|fst| {
-            self.parsed
-                .functions(None, Some(&fst.cursor))
-                .next()
-                .is_some()
-        });
-
-        connection.has_next_page = connection.edges.last().is_some_and(|lst| {
-            self.parsed
-                .functions(Some(&lst.cursor), None)
-                .next()
-                .is_some()
-        });
 
         if connection.edges.is_empty() {
             Ok(None)

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1090,7 +1090,7 @@ type MoveModule {
 	"""
 	Iterate through the signatures of functions defined in this module.
 	"""
-	functionConnection(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
+	functions(first: Int, after: String, last: Int, before: String): MoveFunctionConnection
 	"""
 	The Base64 encoded bcs serialization of the module.
 	"""

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -553,7 +553,7 @@ impl Module {
         &self,
         after: Option<&str>,
         before: Option<&str>,
-    ) -> impl Iterator<Item = &str> + Clone {
+    ) -> impl DoubleEndedIterator<Item = &str> + Clone {
         use std::ops::Bound as B;
         self.function_index
             .range::<str, _>((


### PR DESCRIPTION
## Description

Use cursor framework for functions.  This makes the cursor value itself opaque, and standardises the behaviour around default and max page sizes.

## Test Plan

Updated E2E tests to expose cursors:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- functions.move
```

## Stack
- #15467 
- #15470 