### PR TITLE
[graphql/rpc] make gas price settable everywhere

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -1,4 +1,4 @@
-processed 23 tasks
+processed 26 tasks
 
 init:
 validator_0: object(0,0)
@@ -343,3 +343,18 @@ Response: {
     }
   }
 }
+
+task 23 'run'. lines 176-176:
+created: object(23,0)
+mutated: object(0,1)
+gas summary: computation_cost: 999000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 24 'run'. lines 178-178:
+created: object(24,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 25 'run'. lines 180-180:
+created: object(25,0)
+mutated: object(0,1)
+gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234
+//# init --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
 
 //# publish
 module Test::M1 {
@@ -27,7 +27,7 @@ module Test::M1 {
     }
 }
 
-//# run Test::M1::create --args 0 @A
+//# run Test::M1::create --args 0 @A --gas-price 1000
 
 //# run Test::M1::create --args 0 @validator_0
 
@@ -172,3 +172,9 @@ module Test::M1 {
     referenceGasPrice
   }
 }
+
+//# run Test::M1::create --args 0 @A --gas-price 999
+
+//# run Test::M1::create --args 0 @A --gas-price 1000
+
+//# run Test::M1::create --args 0 @A --gas-price 235

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -38,6 +38,8 @@ pub struct SuiPublishArgs {
     pub upgradeable: bool,
     #[clap(long = "dependencies", num_args(1..))]
     pub dependencies: Vec<String>,
+    #[clap(long = "gas-price")]
+    pub gas_price: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -56,6 +58,8 @@ pub struct SuiInitArgs {
     pub custom_validator_account: bool,
     #[clap(long = "reference-gas-price")]
     pub reference_gas_price: Option<u64>,
+    #[clap(long = "default-gas-price")]
+    pub default_gas_price: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -74,6 +78,8 @@ pub struct TransferObjectCommand {
     pub sender: Option<String>,
     #[clap(long = "gas-budget")]
     pub gas_budget: Option<u64>,
+    #[clap(long = "gas-price")]
+    pub gas_price: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -117,6 +123,8 @@ pub struct UpgradePackageCommand {
     pub syntax: Option<SyntaxChoice>,
     #[clap(long = "policy", default_value="compatible", value_parser = parse_policy)]
     pub policy: u8,
+    #[clap(long = "gas-price")]
+    pub gas_price: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -101,6 +101,8 @@ pub enum FakeID {
     Enumerated(u64, u64),
 }
 
+const DEFAULT_GAS_PRICE: u64 = 1_000;
+
 const WELL_KNOWN_OBJECTS: &[ObjectID] = &[
     MOVE_STDLIB_PACKAGE_ID,
     DEEPBOOK_PACKAGE_ID,
@@ -202,6 +204,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             is_simulator,
             custom_validator_account,
             reference_gas_price,
+            default_gas_price,
         ) = match task_opt.map(|t| t.command) {
             Some((
                 InitCommand { named_addresses },
@@ -213,6 +216,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     simulator,
                     custom_validator_account,
                     reference_gas_price,
+                    default_gas_price,
                 },
             )) => {
                 let map = verify_and_create_named_address_mapping(named_addresses).unwrap();
@@ -247,6 +251,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     simulator,
                     custom_validator_account,
                     reference_gas_price,
+                    default_gas_price,
                 )
             }
             None => {
@@ -257,6 +262,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     protocol_config,
                     false,
                     false,
+                    None,
                     None,
                 )
             }
@@ -309,7 +315,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             object_enumeration: BiBTreeMap::new(),
             next_fake: (0, 0),
             // TODO: make this configurable
-            gas_price: 1000,
+            gas_price: default_gas_price.unwrap_or(DEFAULT_GAS_PRICE),
             staged_modules: BTreeMap::new(),
         };
 
@@ -348,6 +354,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             sender,
             upgradeable,
             dependencies,
+            gas_price,
         } = extra;
         let named_addr_opt = modules.first().unwrap().named_address;
         let first_module_name = modules.first().unwrap().module.self_id().name().to_string();
@@ -371,7 +378,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 Ok(id)
             })
             .collect::<Result<_, _>>()?;
-        let gas_price = self.gas_price;
+        let gas_price = gas_price.unwrap_or(self.gas_price);
         // we are assuming that all packages depend on Move Stdlib and Sui Framework, so these
         // don't have to be provided explicitly as parameters
         dependencies.extend([MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID]);
@@ -658,6 +665,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 recipient,
                 sender,
                 gas_budget,
+                gas_price,
             }) => {
                 let mut builder = ProgrammableTransactionBuilder::new();
                 let obj_arg = SuiValue::Object(fake_id, None).into_argument(&mut builder, self)?;
@@ -666,7 +674,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     None => panic!("Unbound account {}", recipient),
                 };
                 let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
-                let gas_price = self.gas_price;
+                let gas_price: u64 = gas_price.unwrap_or(self.gas_price);
                 let transaction = self.sign_txn(sender, |sender, gas| {
                     let rec_arg = builder.pure(recipient).unwrap();
                     builder.command(sui_types::transaction::Command::TransferObjects(
@@ -775,6 +783,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 gas_budget,
                 syntax,
                 policy,
+                gas_price,
             }) => {
                 let syntax = syntax.unwrap_or_else(|| self.default_syntax());
                 // zero out the package name
@@ -814,6 +823,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                         );
                     original_package_addrs.push((*dep, dep_address));
                 }
+                let gas_price = gas_price.unwrap_or(self.gas_price);
 
                 let result = compile_any(
                     self,
@@ -857,6 +867,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                             sender,
                             gas_budget,
                             policy,
+                            gas_price,
                         ).await?;
                         Ok((output, modules))
                     },
@@ -1156,6 +1167,7 @@ impl<'a> SuiTestAdapter<'a> {
         sender: String,
         gas_budget: Option<u64>,
         policy: u8,
+        gas_price: u64,
     ) -> anyhow::Result<Option<String>> {
         let modules_bytes = modules
             .iter()
@@ -1204,7 +1216,6 @@ impl<'a> SuiTestAdapter<'a> {
 
         let pt = builder.finish();
 
-        let gas_price = self.gas_price;
         let data = |sender, gas| {
             TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, gas_price)
         };


### PR DESCRIPTION
## Description 

Gas price setting wasn't properly exposed per command at at default level

## Test Plan 

e2e

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
