### PR TITLE
easy/chore: Fix Codewner warning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,8 @@
 /crates/sui-keys/ @joyqvq @patrickkuo
 /crates/sui-protocol-config @mystenmark
 
-*.md @randall-Mysten @ronny-mysten
+# *.md @randall-Mysten @ronny-mysten
+*.md @ronny-mysten
 # Omit auto-generated changelogs and changesets from docs review:
 /.changeset/*.md
 CHANGELOG.md


### PR DESCRIPTION
## Description 

Codeowner has [error](https://github.com/MystenLabs/sui/pull/15433/files) due to Randall's name
![Uploading Screenshot 2023-12-22 at 14.40.12.png…]()


## Test Plan 

N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
