### PR TITLE
[graphql] Make datetime::from_ms return result instead of option

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -662,7 +662,7 @@ type Event {
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""
-	timestamp: DateTime!
+	timestamp: DateTime
 	type: MoveType!
 	bcs: Base64!
 	"""
@@ -2506,7 +2506,7 @@ type TransactionBlockEffects {
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""
-	timestamp: DateTime!
+	timestamp: DateTime
 	"""
 	The epoch this transaction was finalized in.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -253,7 +253,7 @@ type ChangeEpochTransaction {
 	"""
 	Time at which the next epoch will start.
 	"""
-	startTimestamp: DateTime
+	startTimestamp: DateTime!
 	"""
 	System packages (specifically framework and move stdlib) that are written before the new
 	epoch starts, to upgrade them on-chain. Validators write these packages out when running the
@@ -277,7 +277,7 @@ type Checkpoint {
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	"""
 	This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
 	"""
@@ -437,7 +437,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Unix timestamp from consensus.
 	"""
-	commitTimestamp: DateTime
+	commitTimestamp: DateTime!
 	"""
 	Digest of consensus output, encoded as a Base58 string (only available from V2 of the
 	transaction).
@@ -591,7 +591,7 @@ type Epoch {
 	"""
 	The epoch's starting timestamp
 	"""
-	startTimestamp: DateTime
+	startTimestamp: DateTime!
 	"""
 	The epoch's ending timestamp
 	"""
@@ -662,7 +662,7 @@ type Event {
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	type: MoveType!
 	bcs: Base64!
 	"""
@@ -2506,7 +2506,7 @@ type TransactionBlockEffects {
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	"""
 	The epoch this transaction was finalized in.
 	"""

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -979,7 +979,7 @@ type TransactionBlockEffects {
     before: String,
   ): BalanceChangeConnection!
 
-  timestamp: DateTime
+  timestamp: DateTime!
   epoch: Epoch
   checkpoint: Checkpoint
 
@@ -1064,7 +1064,7 @@ type Event {
   sendingModule: MoveModule
 
   sender: Address
-  timestamp: DateTime
+  timestamp: DateTime!
 
   type: MoveType!
   bcs: Base64!

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -979,7 +979,7 @@ type TransactionBlockEffects {
     before: String,
   ): BalanceChangeConnection!
 
-  timestamp: DateTime!
+  timestamp: DateTime
   epoch: Epoch
   checkpoint: Checkpoint
 
@@ -1064,7 +1064,7 @@ type Event {
   sendingModule: MoveModule
 
   sender: Address
-  timestamp: DateTime!
+  timestamp: DateTime
 
   type: MoveType!
   bcs: Base64!

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1653,7 +1653,7 @@ impl TryFrom<StoredCheckpoint> for Checkpoint {
         Ok(Self {
             digest: Digest::try_from(c.checkpoint_digest)?.to_string(),
             sequence_number: c.sequence_number as u64,
-            timestamp: DateTime::from_ms(c.timestamp_ms),
+            timestamp: DateTime::from_ms(c.timestamp_ms)?,
             validator_signature: Some(c.validator_signature.into()),
             previous_checkpoint_digest: c
                 .previous_checkpoint_digest
@@ -1688,13 +1688,7 @@ impl TryFrom<NativeSuiSystemStateSummary> for SuiSystemStateSummary {
             ))
         })?;
 
-        let start_timestamp = DateTime::from_ms(start_timestamp).ok_or_else(|| {
-            Error::Internal(format!(
-                "Cannot convert start timestamp ({}) of system state into a DateTime",
-                start_timestamp
-            ))
-        })?;
-
+        let start_timestamp = DateTime::from_ms(start_timestamp)?;
         Ok(SuiSystemStateSummary {
             epoch_id: system_state.epoch,
             system_state_version: Some(BigInt::from(system_state.system_state_version)),

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -31,7 +31,7 @@ pub(crate) struct Checkpoint {
     pub sequence_number: u64,
     /// The timestamp at which the checkpoint is agreed to have happened according to consensus.
     /// Transactions that access time in this checkpoint will observe this timestamp.
-    pub timestamp: Option<DateTime>,
+    pub timestamp: DateTime,
     /// This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
     pub validator_signature: Option<Base64>,
     /// The digest of the checkpoint at the previous sequence number.

--- a/crates/sui-graphql-rpc/src/types/date_time.rs
+++ b/crates/sui-graphql-rpc/src/types/date_time.rs
@@ -9,17 +9,17 @@ use chrono::{
     ParseError as ChronoParseError,
 };
 
+use crate::error::Error;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct DateTime(ChronoDateTime<ChronoUtc>);
 
 impl DateTime {
-    pub fn from_ms(timestamp_ms: i64) -> Option<Self> {
-        // TODO: `timestamp_millis_opt` returns an optional to handle ambiguous time conversions
-        // which UTC does not have, so this should be converted to return a Result, with an
-        // `InternalError`.
+    pub fn from_ms(timestamp_ms: i64) -> Result<Self, Error> {
         ChronoUtc
             .timestamp_millis_opt(timestamp_ms)
             .single()
+            .ok_or_else(|| Error::Internal("Cannot convert timestamp into DateTime".to_string()))
             .map(Self)
     }
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -51,7 +51,7 @@ impl Epoch {
 
     /// The epoch's starting timestamp
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        DateTime::from_ms(self.stored.epoch_start_timestamp)?
+        DateTime::from_ms(self.stored.epoch_start_timestamp)
     }
 
     /// The epoch's ending timestamp

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -51,7 +51,7 @@ impl Epoch {
 
     /// The epoch's starting timestamp
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        Ok(DateTime::from_ms(self.stored.epoch_start_timestamp)?)
+        DateTime::from_ms(self.stored.epoch_start_timestamp)?
     }
 
     /// The epoch's ending timestamp

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -50,13 +50,16 @@ impl Epoch {
     }
 
     /// The epoch's starting timestamp
-    async fn start_timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.stored.epoch_start_timestamp)
+    async fn start_timestamp(&self) -> Result<DateTime, Error> {
+        Ok(DateTime::from_ms(self.stored.epoch_start_timestamp)?)
     }
 
     /// The epoch's ending timestamp
-    async fn end_timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.stored.epoch_end_timestamp?)
+    async fn end_timestamp(&self) -> Result<Option<DateTime>, Error> {
+        self.stored
+            .epoch_end_timestamp
+            .map(DateTime::from_ms)
+            .transpose()
     }
 
     /// The total number of checkpoints in this epoch.

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -82,8 +82,8 @@ impl Event {
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    async fn timestamp(&self) -> Result<DateTime, Error> {
-        Ok(DateTime::from_ms(self.stored.timestamp_ms)?)
+    async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
+        Ok(DateTime::from_ms(self.stored.timestamp_ms).ok())
     }
 
     #[graphql(flatten)]

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -82,8 +82,8 @@ impl Event {
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    async fn timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.stored.timestamp_ms)
+    async fn timestamp(&self) -> Result<DateTime, Error> {
+        Ok(DateTime::from_ms(self.stored.timestamp_ms)?)
     }
 
     #[graphql(flatten)]

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -137,8 +137,9 @@ impl TransactionBlockEffects {
     }
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized in.
-    async fn timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.tx_data.as_ref().left()?.timestamp_ms)
+    async fn timestamp(&self) -> Result<DateTime, Error> {
+        let ts = self.tx_data.as_ref().left().ok_or_else(|| Error::Internal("Cannot get the timestamp corresponding to this checkpoint {self.sequence_number}".to_string()))?.timestamp_ms;
+        Ok(DateTime::from_ms(ts)?)
     }
 
     /// The epoch this transaction was finalized in.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -137,9 +137,12 @@ impl TransactionBlockEffects {
     }
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized in.
-    async fn timestamp(&self) -> Result<DateTime, Error> {
-        let ts = self.tx_data.as_ref().left().ok_or_else(|| Error::Internal("Cannot get the timestamp corresponding to this checkpoint {self.sequence_number}".to_string()))?.timestamp_ms;
-        Ok(DateTime::from_ms(ts)?)
+    async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
+        self.tx_data
+            .as_ref()
+            .left()
+            .map(|ts| DateTime::from_ms(ts.timestamp_ms))
+            .transpose()
     }
 
     /// The epoch this transaction was finalized in.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -47,8 +47,8 @@ impl ConsensusCommitPrologueTransaction {
     }
 
     /// Unix timestamp from consensus.
-    async fn commit_timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.commit_timestamp_ms as i64)
+    async fn commit_timestamp(&self) -> Result<DateTime, Error> {
+        Ok(DateTime::from_ms(self.commit_timestamp_ms as i64)?)
     }
 
     /// Digest of consensus output, encoded as a Base58 string (only available from V2 of the

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -172,7 +172,7 @@ impl ChangeEpochTransaction {
 
     /// Time at which the next epoch will start.
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        Ok(DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)?)
+        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)?
     }
 
     /// System packages (specifically framework and move stdlib) that are written before the new

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -172,7 +172,7 @@ impl ChangeEpochTransaction {
 
     /// Time at which the next epoch will start.
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)?
+        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)
     }
 
     /// System packages (specifically framework and move stdlib) that are written before the new

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -171,8 +171,8 @@ impl ChangeEpochTransaction {
     }
 
     /// Time at which the next epoch will start.
-    async fn start_timestamp(&self) -> Option<DateTime> {
-        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)
+    async fn start_timestamp(&self) -> Result<DateTime, Error> {
+        Ok(DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)?)
     }
 
     /// System packages (specifically framework and move stdlib) that are written before the new

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -666,7 +666,7 @@ type Event {
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""
-	timestamp: DateTime!
+	timestamp: DateTime
 	type: MoveType!
 	bcs: Base64!
 	"""
@@ -2510,7 +2510,7 @@ type TransactionBlockEffects {
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""
-	timestamp: DateTime!
+	timestamp: DateTime
 	"""
 	The epoch this transaction was finalized in.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -257,7 +257,7 @@ type ChangeEpochTransaction {
 	"""
 	Time at which the next epoch will start.
 	"""
-	startTimestamp: DateTime
+	startTimestamp: DateTime!
 	"""
 	System packages (specifically framework and move stdlib) that are written before the new
 	epoch starts, to upgrade them on-chain. Validators write these packages out when running the
@@ -281,7 +281,7 @@ type Checkpoint {
 	The timestamp at which the checkpoint is agreed to have happened according to consensus.
 	Transactions that access time in this checkpoint will observe this timestamp.
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	"""
 	This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
 	"""
@@ -441,7 +441,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Unix timestamp from consensus.
 	"""
-	commitTimestamp: DateTime
+	commitTimestamp: DateTime!
 	"""
 	Digest of consensus output, encoded as a Base58 string (only available from V2 of the
 	transaction).
@@ -595,7 +595,7 @@ type Epoch {
 	"""
 	The epoch's starting timestamp
 	"""
-	startTimestamp: DateTime
+	startTimestamp: DateTime!
 	"""
 	The epoch's ending timestamp
 	"""
@@ -666,7 +666,7 @@ type Event {
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	type: MoveType!
 	bcs: Base64!
 	"""
@@ -2510,7 +2510,7 @@ type TransactionBlockEffects {
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""
-	timestamp: DateTime
+	timestamp: DateTime!
 	"""
 	The epoch this transaction was finalized in.
 	"""


### PR DESCRIPTION
## Description 

Make datetime to return a result instead of option and fix all associated code that uses DateTime::from_ms

## Test Plan 

Ran existing unit tests, updated schema.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
