### PR TITLE
[GraphQL/Cursor] Abstraction for index-based cursors

### DIFF
--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -55,28 +55,19 @@ impl AuthenticatorStateUpdateTransaction {
     ) -> Result<Connection<String, ActiveJwk>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
-        let total = self.0.new_active_jwks.len();
-        let mut lo = page.after().map_or(0, |a| *a + 1);
-        let mut hi = page.before().map_or(total, |b| *b);
-
         let mut connection = Connection::new(false, false);
-        if hi <= lo {
+        let Some((prev, next, cs)) = page.select(self.0.new_active_jwks.len()) else {
             return Ok(connection);
-        } else if (hi - lo) > page.limit() {
-            if page.is_from_front() {
-                hi = lo + page.limit();
-            } else {
-                lo = hi - page.limit();
-            }
-        }
+        };
 
-        connection.has_previous_page = 0 < lo;
-        connection.has_next_page = hi < total;
+        connection.has_previous_page = prev;
+        connection.has_next_page = next;
 
-        for idx in lo..hi {
-            let active_jwk = ActiveJwk(self.0.new_active_jwks[idx].clone());
-            let cursor = Cursor::new(idx).encode_cursor();
-            connection.edges.push(Edge::new(cursor, active_jwk));
+        for c in cs {
+            let active_jwk = ActiveJwk(self.0.new_active_jwks[*c].clone());
+            connection
+                .edges
+                .push(Edge::new(c.encode_cursor(), active_jwk));
         }
 
         Ok(connection)


### PR DESCRIPTION
## Description

Adds a helper function to `Page<usize>` to treat `usize` cursors as indices into an array of some kind, and convert the page into an iterator over elements in that page, identified by their Cursor.

## Test Plan

```
sui-graphql-e2e-test$ cargo nextest run \
  -j 1 --features pg_integration
```

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 