### PR TITLE
[data ingestion] enforce limit on reader side

### DIFF
--- a/crates/sui-data-ingestion/src/worker_pool.rs
+++ b/crates/sui-data-ingestion/src/worker_pool.rs
@@ -62,7 +62,10 @@ impl<W: Worker + 'static> WorkerPool<W> {
                                     .clone()
                                     .process_checkpoint(checkpoint.clone())
                                     .await
-                                    .map_err(backoff::Error::transient)
+                                    .map_err(|err| {
+                                        info!("transient worker execution error {:?}", err);
+                                        backoff::Error::transient(err)
+                                    })
                             })
                             .await
                             .expect("checkpoint processing failed for checkpoint");


### PR DESCRIPTION
the PR prevents various deadlock issues related to mpsc channels in the data ingestion daemon by limiting the number of concurrent tasks on the reader side. This restriction ensures that actor channels won't get congested, as the number of tasks produced by the reader is now capped