### PR TITLE
[gql][1/n][easy] add max_output_nodes to ServiceConfig for output node estimation

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2001,6 +2001,18 @@ type ServiceConfig {
 	"""
 	maxQueryNodes: Int!
 	"""
+	The maximum number of output nodes in a GraphQL response.
+	
+	If a node is a connection, it is counted as the specified 'first' or 'last' number of items,
+	or the default_page_size as set by the server. Non-connection nodes and fields are not included
+	in this count.
+	
+	The count of output nodes is multiplicative. For example, if the current node is a connection
+	with first: 10 and has a field to a connection with last: 20, the total estimated output nodes
+	would be 10 * 20 = 200.
+	"""
+	maxOutputNodes: Int!
+	"""
 	Maximum estimated cost of a database query used to serve a GraphQL request.  This is
 	measured in the same units that the database uses in EXPLAIN queries.
 	"""

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -420,6 +420,7 @@ type ServiceConfig {
 
   maxQueryDepth: Int!
   maxQueryNodes: Int!
+  maxOutputNodes: Int!
   defaultPageSize: Int!
   maxPageSize: Int!
   requestTimeoutMs: Int!

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2005,6 +2005,18 @@ type ServiceConfig {
 	"""
 	maxQueryNodes: Int!
 	"""
+	The maximum number of output nodes in a GraphQL response.
+	
+	If a node is a connection, it is counted as the specified 'first' or 'last' number of items,
+	or the default_page_size as set by the server. Non-connection nodes and fields are not included
+	in this count.
+	
+	The count of output nodes is multiplicative. For example, if the current node is a connection
+	with first: 10 and has a field to a connection with last: 20, the total estimated output nodes
+	would be 10 * 20 = 200.
+	"""
+	maxOutputNodes: Int!
+	"""
 	Maximum estimated cost of a database query used to serve a GraphQL request.  This is
 	measured in the same units that the database uses in EXPLAIN queries.
 	"""


### PR DESCRIPTION
## Description 

Small change to add max_output_nodes to ServiceConfig for output node estimation

## Test Plan 

Existing tests. Functionality will be tested in follow-up PR

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
