### PR TITLE
Write manifest based on output store

### DIFF
--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -300,14 +300,6 @@ impl DBCheckpointHandler {
                     self.prune_and_compact(local_db_path, *epoch).await?;
                 }
 
-                // This writes a single "MANIFEST" file which contains a list of all files that make up a db snapshot
-                write_snapshot_manifest(
-                    db_path,
-                    &self.input_object_store,
-                    format!("epoch_{}/", epoch),
-                )
-                .await?;
-
                 info!("Copying db checkpoint for epoch: {epoch} to remote storage");
                 copy_recursively(
                     db_path,
@@ -316,6 +308,10 @@ impl DBCheckpointHandler {
                     NonZeroUsize::new(20).unwrap(),
                 )
                 .await?;
+
+                // This writes a single "MANIFEST" file which contains a list of all files that make up a db snapshot
+                write_snapshot_manifest(db_path, &object_store, format!("epoch_{}/", epoch))
+                    .await?;
                 // Drop marker in the output directory that upload completed successfully
                 let bytes = Bytes::from_static(b"success");
                 let success_marker = db_path.child(SUCCESS_MARKER);

--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -338,11 +338,11 @@ pub fn get_path(prefix: &str) -> Path {
 // this simplicty enables easy parsing for scripts to download snapshots
 pub async fn write_snapshot_manifest<S: ObjectStoreListExt + ObjectStorePutExt>(
     dir: &Path,
-    local_disk: &S,
+    store: &S,
     epoch_prefix: String,
 ) -> Result<()> {
     let mut file_names = vec![];
-    let mut paths = local_disk.list_objects(Some(dir)).await?;
+    let mut paths = store.list_objects(Some(dir)).await?;
     while let Some(res) = paths.next().await {
         if let Ok(object_metadata) = res {
             // trim the "epoch_XX/" dir prefix here
@@ -360,7 +360,7 @@ pub async fn write_snapshot_manifest<S: ObjectStoreListExt + ObjectStorePutExt>(
 
     let bytes = Bytes::from(file_names.join("\n"));
     put(
-        local_disk,
+        store,
         &Path::from(format!("{}/{}", dir, MANIFEST_FILENAME)),
         bytes,
     )


### PR DESCRIPTION
## Description 

Write manifest based on output directory file list so we can be guaranteed of the contents being present
