### PR TITLE
[snapshots] split db download and formal download snapshot commands

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -821,13 +821,12 @@ impl ToolCommand {
                         }
                     });
 
-                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or({
-                    if formal {
-                        ObjectStoreType::GCS
-                    } else {
-                        ObjectStoreType::S3
-                    }
-                });
+                let snapshot_bucket_type = if no_sign_request {
+                    ObjectStoreType::S3
+                } else {
+                    snapshot_bucket_type
+                        .expect("--snapshot-bucket-type must be set if not using --no-sign-request")
+                };
 
                 // index staging is not yet supported for formal snapshots
                 let skip_indexes = skip_indexes || formal;

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -254,7 +254,10 @@ pub enum ToolCommand {
         db_checkpoint_path: PathBuf,
     },
 
-    #[clap(name = "download-db-snapshot")]
+    #[clap(
+        name = "download-db-snapshot",
+        about = "Downloads the legacy database snapshot via cloud object store, outputs to local disk"
+    )]
     DownloadDBSnapshot {
         #[clap(long = "epoch")]
         epoch: u64,
@@ -273,7 +276,10 @@ pub enum ToolCommand {
         /// If true, restore from formal (slim, DB agnostic) snapshot. Note that this is only supported
         /// for protocol versions supporting `commit_root_state_digest`. For mainnet, this is
         /// epoch 20+, and for testnet this is epoch 12+
-        #[clap(long = "formal")]
+        #[clap(
+            long = "formal",
+            help = "Deprecated: use download-formal-snapshot instead"
+        )]
         formal: bool,
         /// If true, perform snapshot and checkpoint summary verification. Only
         /// applicable if `--formal` flag is specified. Defaults to true.
@@ -311,7 +317,10 @@ pub enum ToolCommand {
         verbose: bool,
     },
 
-    #[clap(name = "download-formal-snapshot")]
+    #[clap(
+        name = "download-formal-snapshot",
+        about = "Downloads formal database snapshot via cloud object store, outputs to local disk"
+    )]
     DownloadFormalSnapshot {
         #[clap(long = "epoch")]
         epoch: u64,
@@ -774,6 +783,9 @@ impl ToolCommand {
                         .checked_sub(1)
                         .expect("Failed to get number of CPUs")
                 });
+                if formal {
+                    println!("Warning: download-db-snapshot --formal is deprecated. Please use download-formal-snapshot.");
+                }
                 let snapshot_bucket =
                     snapshot_bucket.or_else(|| match (formal, network, no_sign_request) {
                         (true, Chain::Mainnet, false) => Some(

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -258,13 +258,8 @@ pub enum ToolCommand {
     DownloadDBSnapshot {
         #[clap(long = "epoch")]
         epoch: u64,
-        #[clap(long = "genesis")]
-        genesis: PathBuf,
         #[clap(long = "path", default_value = "/tmp")]
         path: PathBuf,
-        /// skip downloading checkpoints dir. Overridden to `true` if `--formal` flag specified
-        #[clap(long = "skip-checkpoints")]
-        skip_checkpoints: bool,
         /// skip downloading indexes dir. Overridden to `true` if `--formal` flag specified,
         /// as index staging is not yet supported for formal snapshots.
         #[clap(long = "skip-indexes")]
@@ -273,11 +268,44 @@ pub enum ToolCommand {
         /// value based on number of available logical cores.
         #[clap(long = "num-parallel-downloads")]
         num_parallel_downloads: Option<usize>,
-        /// If true, restore from formal (slim, DB agnostic) snapshot. Note that this is only supported
-        /// for protocol versions supporting `commit_root_state_digest`. For mainnet, this is
-        /// epoch 20+, and for testnet this is epoch 12+
-        #[clap(long = "formal")]
-        formal: bool,
+        /// Network to download snapshot for. Defaults to "mainnet".
+        /// If `--snapshot-bucket` or `--archive-bucket` is not specified,
+        /// the value of this flag is used to construct default bucket names.
+        #[clap(long = "network", default_value = "mainnet")]
+        network: Chain,
+        /// Snapshot bucket name. If not specified, defaults are
+        /// based on value of `--network` and `--formal` flags.
+        #[clap(long = "snapshot-bucket")]
+        snapshot_bucket: Option<String>,
+        /// Snapshot bucket type. Defaults to "gcs" if `--formal`
+        /// flag specified, otherwise "s3".
+        #[clap(long = "snapshot-bucket-type")]
+        snapshot_bucket_type: Option<ObjectStoreType>,
+        /// Path to snapshot directory on local filesystem.
+        /// Only applicable if `--snapshot-bucket-type` is "file".
+        #[clap(long = "snapshot-path")]
+        snapshot_path: Option<PathBuf>,
+        /// If true, no authentication is needed for snapshot restores
+        #[clap(long = "no-sign-request")]
+        no_sign_request: bool,
+        /// If false (default), log level will be overridden to "off",
+        /// and output will be reduced to necessary status information.
+        #[clap(long = "verbose")]
+        verbose: bool,
+    },
+
+    #[clap(name = "download-formal-snapshot")]
+    DownloadFormalSnapshot {
+        #[clap(long = "epoch")]
+        epoch: u64,
+        #[clap(long = "genesis")]
+        genesis: PathBuf,
+        #[clap(long = "path", default_value = "/tmp")]
+        path: PathBuf,
+        /// Number of parallel downloads to perform. Defaults to a reasonable
+        /// value based on number of available logical cores.
+        #[clap(long = "num-parallel-downloads")]
+        num_parallel_downloads: Option<usize>,
         /// If true, perform snapshot and checkpoint summary verification. Only
         /// applicable if `--formal` flag is specified. Defaults to true.
         #[clap(long = "verify")]
@@ -513,14 +541,11 @@ impl ToolCommand {
                 let config = sui_config::NodeConfig::load(config_path)?;
                 restore_from_db_checkpoint(&config, &db_checkpoint_path).await?;
             }
-            ToolCommand::DownloadDBSnapshot {
+            ToolCommand::DownloadFormalSnapshot {
                 epoch,
                 genesis,
                 path,
-                skip_checkpoints,
-                skip_indexes,
                 num_parallel_downloads,
-                formal,
                 verify,
                 network,
                 snapshot_bucket,
@@ -542,55 +567,24 @@ impl ToolCommand {
                         .expect("Failed to get number of CPUs")
                 });
                 let snapshot_bucket =
-                    snapshot_bucket.or_else(|| match (formal, network, no_sign_request) {
-                        (true, Chain::Mainnet, false) => Some(
+                    snapshot_bucket.or_else(|| match (network, no_sign_request) {
+                        (Chain::Mainnet, false) => Some(
                             env::var("MAINNET_FORMAL_SIGNED_BUCKET")
                                 .unwrap_or("mysten-mainnet-formal".to_string()),
                         ),
-                        (false, Chain::Mainnet, false) => Some(
-                            env::var("MAINNET_DB_SIGNED_BUCKET")
-                                .unwrap_or("mysten-mainnet-snapshots".to_string()),
-                        ),
-                        (true, Chain::Mainnet, true) => {
-                            env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok()
-                        }
-                        (false, Chain::Mainnet, true) => {
-                            env::var("MAINNET_DB_UNSIGNED_BUCKET").ok()
-                        }
-                        (true, Chain::Testnet, true) => {
-                            env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok()
-                        }
-                        (false, Chain::Testnet, true) => {
-                            env::var("TESTNET_DB_UNSIGNED_BUCKET").ok()
-                        }
-                        (true, Chain::Testnet, _) => Some(
+                        (Chain::Mainnet, true) => env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok(),
+                        (Chain::Testnet, true) => env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok(),
+                        (Chain::Testnet, _) => Some(
                             env::var("TESTNET_FORMAL_SIGNED_BUCKET")
                                 .unwrap_or("mysten-testnet-formal".to_string()),
                         ),
-                        (false, Chain::Testnet, _) => Some(
-                            env::var("TESTNET_DB_SIGNED_BUCKET")
-                                .unwrap_or("mysten-testnet-snapshots".to_string()),
-                        ),
-                        (_, Chain::Unknown, _) => {
+                        (Chain::Unknown, _) => {
                             panic!("Cannot generate default snapshot bucket for unknown network");
                         }
                     });
 
-                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or({
-                    if formal {
-                        ObjectStoreType::GCS
-                    } else {
-                        ObjectStoreType::S3
-                    }
-                });
-
-                // index staging is not yet supported for formal snapshots
-                let skip_indexes = skip_indexes || formal;
-                // Checkpoint db does not exist in formal snapshots and
-                // is not reconstructed during formal snapshot restore
-                let skip_checkpoints = skip_checkpoints || formal;
                 let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
-                    if formal && no_sign_request {
+                    if no_sign_request {
                         if network == Chain::Mainnet {
                             Some("https://formal-snapshot.mainnet.sui.io".to_string())
                         } else if network == Chain::Testnet {
@@ -602,6 +596,13 @@ impl ToolCommand {
                         None
                     }
                 });
+
+                let snapshot_bucket_type = if no_sign_request {
+                    ObjectStoreType::S3
+                } else {
+                    snapshot_bucket_type
+                        .expect("--snapshot-bucket-type must be set if not using --no-sign-request")
+                };
                 let snapshot_store_config = match snapshot_bucket_type {
                     ObjectStoreType::S3 => ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),
@@ -615,7 +616,7 @@ impl ToolCommand {
                         )
                         .ok()
                         .and_then(|b| b.parse().ok())
-                        .unwrap_or(formal && no_sign_request),
+                        .unwrap_or(no_sign_request),
                         object_store_connection_limit: 200,
                         no_sign_request,
                         ..Default::default()
@@ -716,32 +717,131 @@ impl ToolCommand {
                         e
                     );
                 }
-                if formal {
-                    let verify = verify.unwrap_or(true);
-                    download_formal_snapshot(
-                        &path,
-                        epoch,
-                        &genesis,
-                        snapshot_store_config,
-                        archive_store_config,
-                        num_parallel_downloads,
-                        network,
-                        verify,
-                    )
-                    .await?;
-                } else {
-                    download_db_snapshot(
-                        &path,
-                        epoch,
-                        &genesis,
-                        snapshot_store_config,
-                        archive_store_config,
-                        skip_checkpoints,
-                        skip_indexes,
-                        num_parallel_downloads,
-                    )
-                    .await?;
+                let verify = verify.unwrap_or(true);
+                download_formal_snapshot(
+                    &path,
+                    epoch,
+                    &genesis,
+                    snapshot_store_config,
+                    archive_store_config,
+                    num_parallel_downloads,
+                    network,
+                    verify,
+                )
+                .await?;
+            }
+            ToolCommand::DownloadDBSnapshot {
+                epoch,
+                path,
+                skip_indexes,
+                num_parallel_downloads,
+                network,
+                snapshot_bucket,
+                snapshot_bucket_type,
+                snapshot_path,
+                no_sign_request,
+                verbose,
+            } => {
+                if !verbose {
+                    tracing_handle
+                        .update_log("off")
+                        .expect("Failed to update log level");
                 }
+                let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
+                    num_cpus::get()
+                        .checked_sub(1)
+                        .expect("Failed to get number of CPUs")
+                });
+                let snapshot_bucket =
+                    snapshot_bucket.or_else(|| match (network, no_sign_request) {
+                        (Chain::Mainnet, false) => Some(
+                            env::var("MAINNET_DB_SIGNED_BUCKET")
+                                .unwrap_or("mysten-mainnet-snapshots".to_string()),
+                        ),
+                        (Chain::Mainnet, true) => env::var("MAINNET_DB_UNSIGNED_BUCKET").ok(),
+                        (Chain::Testnet, true) => env::var("TESTNET_DB_UNSIGNED_BUCKET").ok(),
+                        (Chain::Testnet, _) => Some(
+                            env::var("TESTNET_DB_SIGNED_BUCKET")
+                                .unwrap_or("mysten-testnet-snapshots".to_string()),
+                        ),
+                        (Chain::Unknown, _) => {
+                            panic!("Cannot generate default snapshot bucket for unknown network");
+                        }
+                    });
+
+                let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok();
+                let snapshot_bucket_type = if no_sign_request {
+                    ObjectStoreType::S3
+                } else {
+                    snapshot_bucket_type
+                        .expect("--snapshot-bucket-type must be set if not using --no-sign-request")
+                };
+                let snapshot_store_config = match snapshot_bucket_type {
+                    ObjectStoreType::S3 => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::S3),
+                        bucket: snapshot_bucket.filter(|s| !s.is_empty()),
+                        aws_access_key_id: env::var("AWS_SNAPSHOT_ACCESS_KEY_ID").ok(),
+                        aws_secret_access_key: env::var("AWS_SNAPSHOT_SECRET_ACCESS_KEY").ok(),
+                        aws_region: env::var("AWS_SNAPSHOT_REGION").ok(),
+                        aws_endpoint: aws_endpoint.filter(|s| !s.is_empty()),
+                        aws_virtual_hosted_style_request: env::var(
+                            "AWS_SNAPSHOT_VIRTUAL_HOSTED_REQUESTS",
+                        )
+                        .ok()
+                        .and_then(|b| b.parse().ok())
+                        .unwrap_or(no_sign_request),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::GCS => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::GCS),
+                        bucket: snapshot_bucket,
+                        google_service_account: env::var("GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::Azure => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::Azure),
+                        bucket: snapshot_bucket,
+                        azure_storage_account: env::var("AZURE_SNAPSHOT_STORAGE_ACCOUNT").ok(),
+                        azure_storage_access_key: env::var("AZURE_SNAPSHOT_STORAGE_ACCESS_KEY")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::File => {
+                        if snapshot_path.is_some() {
+                            ObjectStoreConfig {
+                                object_store: Some(ObjectStoreType::File),
+                                directory: snapshot_path,
+                                ..Default::default()
+                            }
+                        } else {
+                            panic!(
+                                "--snapshot-path must be specified for --snapshot-bucket-type=file"
+                            );
+                        }
+                    }
+                };
+
+                if let Err(e) = check_completed_snapshot(&snapshot_store_config, epoch).await {
+                    panic!(
+                        "Aborting snapshot restore: {}, snapshot may not be uploaded yet",
+                        e
+                    );
+                }
+                download_db_snapshot(
+                    &path,
+                    epoch,
+                    snapshot_store_config,
+                    skip_indexes,
+                    num_parallel_downloads,
+                )
+                .await?;
             }
             ToolCommand::Replay {
                 rpc_url,

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -258,6 +258,8 @@ pub enum ToolCommand {
     DownloadDBSnapshot {
         #[clap(long = "epoch")]
         epoch: u64,
+        #[clap(long = "genesis")]
+        genesis: PathBuf,
         #[clap(long = "path", default_value = "/tmp")]
         path: PathBuf,
         /// skip downloading indexes dir. Overridden to `true` if `--formal` flag specified,
@@ -268,6 +270,15 @@ pub enum ToolCommand {
         /// value based on number of available logical cores.
         #[clap(long = "num-parallel-downloads")]
         num_parallel_downloads: Option<usize>,
+        /// If true, restore from formal (slim, DB agnostic) snapshot. Note that this is only supported
+        /// for protocol versions supporting `commit_root_state_digest`. For mainnet, this is
+        /// epoch 20+, and for testnet this is epoch 12+
+        #[clap(long = "formal")]
+        formal: bool,
+        /// If true, perform snapshot and checkpoint summary verification. Only
+        /// applicable if `--formal` flag is specified. Defaults to true.
+        #[clap(long = "verify")]
+        verify: Option<bool>,
         /// Network to download snapshot for. Defaults to "mainnet".
         /// If `--snapshot-bucket` or `--archive-bucket` is not specified,
         /// the value of this flag is used to construct default bucket names.
@@ -285,6 +296,12 @@ pub enum ToolCommand {
         /// Only applicable if `--snapshot-bucket-type` is "file".
         #[clap(long = "snapshot-path")]
         snapshot_path: Option<PathBuf>,
+        /// Archival bucket name. If not specified, defaults are
+        /// based on value of `--network` and `--formal` flags.
+        #[clap(long = "archive-bucket")]
+        archive_bucket: Option<String>,
+        #[clap(long = "archive-bucket-type", default_value = "s3")]
+        archive_bucket_type: ObjectStoreType,
         /// If true, no authentication is needed for snapshot restores
         #[clap(long = "no-sign-request")]
         no_sign_request: bool,
@@ -732,13 +749,18 @@ impl ToolCommand {
             }
             ToolCommand::DownloadDBSnapshot {
                 epoch,
+                genesis,
                 path,
                 skip_indexes,
                 num_parallel_downloads,
+                formal,
+                verify,
                 network,
                 snapshot_bucket,
                 snapshot_bucket_type,
                 snapshot_path,
+                archive_bucket,
+                archive_bucket_type,
                 no_sign_request,
                 verbose,
             } => {
@@ -753,29 +775,63 @@ impl ToolCommand {
                         .expect("Failed to get number of CPUs")
                 });
                 let snapshot_bucket =
-                    snapshot_bucket.or_else(|| match (network, no_sign_request) {
-                        (Chain::Mainnet, false) => Some(
+                    snapshot_bucket.or_else(|| match (formal, network, no_sign_request) {
+                        (true, Chain::Mainnet, false) => Some(
+                            env::var("MAINNET_FORMAL_SIGNED_BUCKET")
+                                .unwrap_or("mysten-mainnet-formal".to_string()),
+                        ),
+                        (false, Chain::Mainnet, false) => Some(
                             env::var("MAINNET_DB_SIGNED_BUCKET")
                                 .unwrap_or("mysten-mainnet-snapshots".to_string()),
                         ),
-                        (Chain::Mainnet, true) => env::var("MAINNET_DB_UNSIGNED_BUCKET").ok(),
-                        (Chain::Testnet, true) => env::var("TESTNET_DB_UNSIGNED_BUCKET").ok(),
-                        (Chain::Testnet, _) => Some(
+                        (true, Chain::Mainnet, true) => {
+                            env::var("MAINNET_FORMAL_UNSIGNED_BUCKET").ok()
+                        }
+                        (false, Chain::Mainnet, true) => {
+                            env::var("MAINNET_DB_UNSIGNED_BUCKET").ok()
+                        }
+                        (true, Chain::Testnet, true) => {
+                            env::var("TESTNET_FORMAL_UNSIGNED_BUCKET").ok()
+                        }
+                        (false, Chain::Testnet, true) => {
+                            env::var("TESTNET_DB_UNSIGNED_BUCKET").ok()
+                        }
+                        (true, Chain::Testnet, _) => Some(
+                            env::var("TESTNET_FORMAL_SIGNED_BUCKET")
+                                .unwrap_or("mysten-testnet-formal".to_string()),
+                        ),
+                        (false, Chain::Testnet, _) => Some(
                             env::var("TESTNET_DB_SIGNED_BUCKET")
                                 .unwrap_or("mysten-testnet-snapshots".to_string()),
                         ),
-                        (Chain::Unknown, _) => {
+                        (_, Chain::Unknown, _) => {
                             panic!("Cannot generate default snapshot bucket for unknown network");
                         }
                     });
 
-                let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok();
-                let snapshot_bucket_type = if no_sign_request {
-                    ObjectStoreType::S3
-                } else {
-                    snapshot_bucket_type
-                        .expect("--snapshot-bucket-type must be set if not using --no-sign-request")
-                };
+                let snapshot_bucket_type = snapshot_bucket_type.unwrap_or({
+                    if formal {
+                        ObjectStoreType::GCS
+                    } else {
+                        ObjectStoreType::S3
+                    }
+                });
+
+                // index staging is not yet supported for formal snapshots
+                let skip_indexes = skip_indexes || formal;
+                let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
+                    if formal && no_sign_request {
+                        if network == Chain::Mainnet {
+                            Some("https://formal-snapshot.mainnet.sui.io".to_string())
+                        } else if network == Chain::Testnet {
+                            Some("https://formal-snapshot.testnet.sui.io".to_string())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                });
                 let snapshot_store_config = match snapshot_bucket_type {
                     ObjectStoreType::S3 => ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),
@@ -789,7 +845,7 @@ impl ToolCommand {
                         )
                         .ok()
                         .and_then(|b| b.parse().ok())
-                        .unwrap_or(no_sign_request),
+                        .unwrap_or(formal && no_sign_request),
                         object_store_connection_limit: 200,
                         no_sign_request,
                         ..Default::default()
@@ -828,20 +884,91 @@ impl ToolCommand {
                     }
                 };
 
+                let archive_bucket = archive_bucket.or_else(|| match network {
+                    Chain::Mainnet => Some(
+                        env::var("MAINNET_ARCHIVE_BUCKET")
+                            .unwrap_or("mysten-mainnet-archives".to_string()),
+                    ),
+                    Chain::Testnet => Some(
+                        env::var("TESTNET_ARCHIVE_BUCKET")
+                            .unwrap_or("mysten-testnet-archives".to_string()),
+                    ),
+                    Chain::Unknown => {
+                        panic!("Cannot generate default archive bucket for unknown network");
+                    }
+                });
+                let aws_region =
+                    Some(env::var("AWS_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
+                let archive_store_config = match archive_bucket_type {
+                    ObjectStoreType::S3 => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::S3),
+                        bucket: archive_bucket.filter(|s| !s.is_empty()),
+                        aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
+                        aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
+                        aws_region: aws_region.filter(|s| !s.is_empty()),
+                        aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
+                        aws_virtual_hosted_style_request: env::var(
+                            "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
+                        )
+                        .ok()
+                        .and_then(|b| b.parse().ok())
+                        .unwrap_or(false),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::GCS => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::GCS),
+                        bucket: archive_bucket,
+                        google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH")
+                            .ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::Azure => ObjectStoreConfig {
+                        object_store: Some(ObjectStoreType::Azure),
+                        bucket: archive_bucket,
+                        azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
+                        azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
+                        object_store_connection_limit: 200,
+                        no_sign_request,
+                        ..Default::default()
+                    },
+                    ObjectStoreType::File => {
+                        panic!("Download from local filesystem is not supported")
+                    }
+                };
+
                 if let Err(e) = check_completed_snapshot(&snapshot_store_config, epoch).await {
                     panic!(
                         "Aborting snapshot restore: {}, snapshot may not be uploaded yet",
                         e
                     );
                 }
-                download_db_snapshot(
-                    &path,
-                    epoch,
-                    snapshot_store_config,
-                    skip_indexes,
-                    num_parallel_downloads,
-                )
-                .await?;
+                if formal {
+                    let verify = verify.unwrap_or(true);
+                    download_formal_snapshot(
+                        &path,
+                        epoch,
+                        &genesis,
+                        snapshot_store_config,
+                        archive_store_config,
+                        num_parallel_downloads,
+                        network,
+                        verify,
+                    )
+                    .await?;
+                } else {
+                    download_db_snapshot(
+                        &path,
+                        epoch,
+                        snapshot_store_config,
+                        skip_indexes,
+                        num_parallel_downloads,
+                    )
+                    .await?;
+                }
             }
             ToolCommand::Replay {
                 rpc_url,

--- a/docs/content/guides/operator/snapshots.mdx
+++ b/docs/content/guides/operator/snapshots.mdx
@@ -80,9 +80,28 @@ To restore from a RocksDB snapshot, follow these steps:
 1. Download the snapshot for the epoch you want to restore to your local disk. There is one snapshot per epoch in s3 bucket.
 1. Place the snapshot into the directory that the `db-config` value points to in your fullnode.yaml file. For example, if the `db-config` value points to `/opt/sui/db/authorities_db/full_node_db` and you want to restore from epoch 10, then copy the snapshot to the directory with this command:
 
+   You can use the aws cli (provided you have credentials to associate with the download):
    `aws s3 cp s3://<BUCKET_NAME>/epoch_10 /opt/sui/db/authorities_db/full_node_db/live --recursive`.
    
-   Use `--no-sign-request` to bypass setting AWS credentials for the CLI.
+   An alternative is to use `sui-tool` to copy the files:
+   ```
+   sui-tool download-db-snapshot --epoch "<EPOCH-NUMBER>" \
+       --network <NETWORK> --snapshot-bucket <BUCKET-NAME> \
+       --snapshot-bucket-type <TYPE> --path <PATH-TO-NODE-DB> \
+       --num-parallel-downloads 50 \
+       --no-sign-request
+   ```
+   - `--epoch`: The epoch that you want to download, for example `200`. Mysten Labs hosted buckets will only keep the last 90 epochs.
+   - `--network`: Network to download snapshot for. Defaults to "mainnet".
+   - `--path`: Path to snapshot directory on local filesystem.
+   - `--no-sign-request`: If set, `--snapshot-bucket` and `--snapshot-bucket-type` are ignored, and Cloudflare R2 is used.
+   - `--snapshot-bucket`: Source snapshot bucket name, eg `mysten-mainnet-snapshots`.
+   - `--snapshot-bucket-type`: Snapshot bucket type. GCS and S3 currently supported.
+
+   The following environment variables are used if `--no-sign-request` is not set:
+   * *AWS*: `AWS_SNAPSHOT_ACCESS_KEY_ID`, `AWS_SNAPSHOT_SECRET_ACCESS_KEY`, `AWS_SNAPSHOT_REGION`
+   * *GCS*: `GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH`
+   * *AZURE*: `AZURE_SNAPSHOT_STORAGE_ACCOUNT`, `AZURE_SNAPSHOT_STORAGE_ACCESS_KEY`
 
 1. Make sure you update the ownership of the downloaded directory to the sui user (whichever linux user you run `sui-node` as)
    `sudo chown -R sui:sui  /opt/sui/db/authorities_db/full_node_db/live`.
@@ -104,17 +123,22 @@ The following steps can be used to restore a node from a Formal snapshot:
 1. If it's running, stop the node.
 2. Run the command:
    ```
-   sui-tool download-db-snapshot --epoch "<EPOCH-NUMBER>" --genesis "<PATH-TO-GENESIS-BLOB>" \
-        --formal --network <NETWORK> --snapshot-bucket <BUCKET-NAME> --snapshot-bucket-type <TYPE> --path <PATH-TO-NODE-DB> --num-parallel-downloads 50 --no-sign-request --snapshot-bucket-type=s3
+   sui-tool download-formal-snapshot --epoch "<EPOCH-NUMBER>" --genesis "<PATH-TO-GENESIS-BLOB>" \
+        --network <NETWORK> --snapshot-bucket <BUCKET-NAME> --snapshot-bucket-type <TYPE> \
+        --path <PATH-TO-NODE-DB> --num-parallel-downloads 50 --no-sign-request
    ```
    - `--epoch`: The epoch that you want to download, for example `200`. Mysten Labs hosted buckets will only keep the last 90 epochs. 
    - `--genesis`: The path to the location of the network's `genesis.blob`.
-   - `--formal`: If set, restore from formal (slim, DB agnostic) snapshot.
    - `--network`: Network to download snapshot for. Defaults to "mainnet".
+   - `--path`: Path to snapshot directory on local filesystem.
+   - `--no-sign-request`: If set, `--snapshot-bucket` and `--snapshot-bucket-type` are ignored, and Cloudflare R2 is used.
    - `--snapshot-bucket`: Source snapshot bucket name, eg `mysten-mainnet-snapshots`.
    - `--snapshot-bucket-type`: Snapshot bucket type. GCS and S3 currently supported.
-   - `--path`: Path to snapshot directory on local filesystem.
-   - `--no-sign-request`: If true, no authentication is needed for snapshot restores.
+
+   The following environment variables are used if `--no-sign-request` is not set:
+   * *AWS*: `AWS_SNAPSHOT_ACCESS_KEY_ID`, `AWS_SNAPSHOT_SECRET_ACCESS_KEY`, `AWS_SNAPSHOT_REGION`
+   * *GCS*: `GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH`
+   * *AZURE*: `AZURE_SNAPSHOT_STORAGE_ACCOUNT`, `AZURE_SNAPSHOT_STORAGE_ACCESS_KEY`
 
 
 ## Mysten Labs managed snapshots


### PR DESCRIPTION
## Description 
~Removes `--skip-checkpoints`, `--formal`, `--verify`, and `--genesis`, from the `download-db-snapshot` command~
```
ToolCommand::DownloadDBSnapshot {
                epoch,
                path,
                skip_indexes,
                num_parallel_downloads,
                network,
                snapshot_bucket,
                snapshot_bucket_type,
                snapshot_path,
                no_sign_request, # support TODO
                verbose,
            }
```
**Adds**: `download-formal-snapshot` as a future replacement for the `--formal` flag.


## Test Plan 

Tested with both formal snapshot and db snapshot changes via: https://github.com/MystenLabs/sui/pull/15509

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Breaking change for the `sui-tool` command. This breaks the `sui-tool download-db-snapshot` into `sui-tool download-db-snapshot` and `sui-tool download-formal-snapshot` commands

