### PR TITLE
[gql][2/n] output nodes estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11863,6 +11863,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
+ "async-graphql-value",
  "async-trait",
  "axum",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ arc-swap = { version = "1.5.1", features = ["serde"] }
 assert_cmd = "2.0.6"
 async-graphql = "6.0.7"
 async-graphql-axum = "6.0.7"
+async-graphql-value = "6.0.7"
 async-recursion = "1.0.4"
 async-trait = "0.1.61"
 atomic_float = "0.1"

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -75,7 +75,7 @@ Response: {
 task 15 'run-graphql'. lines 68-74:
 Headers: {
     "content-type": "application/json",
-    "content-length": "136",
+    "content-length": "157",
     "x-sui-rpc-version": "0.1.0",
 }
 Service version: 0.1.0
@@ -87,7 +87,8 @@ Response: {
   },
   "extensions": {
     "usage": {
-      "nodes": 2,
+      "inputNodes": 2,
+      "outputNodes": 2,
       "depth": 2,
       "variables": 0,
       "fragments": 0,

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
@@ -7,9 +7,7 @@ Response: {
       "edges": [
         {
           "node": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ]
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
           }
         }
       ]
@@ -22,7 +20,7 @@ Response: {
       "depth": 4,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 176
+      "queryPayload": 172
     }
   }
 }
@@ -37,9 +35,7 @@ Response: {
             "edges": [
               {
                 "txns": {
-                  "signatures": [
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-                  ]
+                  "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
                 }
               }
             ]
@@ -55,7 +51,7 @@ Response: {
       "depth": 6,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 219
+      "queryPayload": 215
     }
   }
 }
@@ -70,9 +66,7 @@ Response: {
             "edges": [
               {
                 "txns": {
-                  "signatures": [
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-                  ]
+                  "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
                 }
               }
             ]
@@ -81,9 +75,7 @@ Response: {
             "edges": [
               {
                 "txns": {
-                  "signatures": [
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-                  ]
+                  "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
                 }
               }
             ]
@@ -99,7 +91,7 @@ Response: {
       "depth": 6,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 332
+      "queryPayload": 324
     }
   }
 }
@@ -114,9 +106,7 @@ Response: {
             "edges": [
               {
                 "txns": {
-                  "signatures": [
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-                  ]
+                  "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
                 }
               }
             ]
@@ -135,7 +125,7 @@ Response: {
       "depth": 6,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 334
+      "queryPayload": 326
     }
   }
 }
@@ -147,9 +137,7 @@ Response: {
       "edges": [
         {
           "txns": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ]
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
           }
         }
       ]
@@ -162,7 +150,7 @@ Response: {
       "depth": 4,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 158
+      "queryPayload": 154
     }
   }
 }
@@ -174,9 +162,7 @@ Response: {
       "edges": [
         {
           "txns": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ]
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv"
           }
         }
       ]
@@ -189,7 +175,7 @@ Response: {
       "depth": 4,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 156
+      "queryPayload": 152
     }
   }
 }
@@ -201,9 +187,7 @@ Response: {
       "edges": [
         {
           "txns": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ],
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv",
             "first": null,
             "last": null
           }
@@ -218,7 +202,7 @@ Response: {
       "depth": 8,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 514
+      "queryPayload": 510
     }
   }
 }
@@ -229,9 +213,7 @@ Response: {
     "transactionBlockConnection": {
       "nodes": [
         {
-          "signatures": [
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-          ],
+          "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv",
           "first": null,
           "last": null
         }
@@ -245,7 +227,7 @@ Response: {
       "depth": 7,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 546
+      "queryPayload": 542
     }
   }
 }
@@ -257,9 +239,7 @@ Response: {
       "edges": [
         {
           "txns": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ],
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv",
             "a": null,
             "b": null
           }
@@ -277,7 +257,7 @@ Response: {
       "depth": 11,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 1443
+      "queryPayload": 1431
     }
   }
 }
@@ -289,9 +269,7 @@ Response: {
       "edges": [
         {
           "node": {
-            "signatures": [
-              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-            ],
+            "digest": "FbaziGbTUgv1hCfsnzivvm4e7BuWvYjCibecqkLEohLv",
             "a": null
           }
         }
@@ -305,7 +283,7 @@ Response: {
       "depth": 11,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 730
+      "queryPayload": 722
     }
   }
 }
@@ -320,7 +298,7 @@ Response: {
       "depth": 4,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 167
+      "queryPayload": 163
     }
   },
   "errors": [
@@ -352,7 +330,7 @@ Response: {
       "depth": 4,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 160
+      "queryPayload": 156
     }
   },
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
@@ -1,0 +1,369 @@
+processed 13 tasks
+
+task 1 'run-graphql'. lines 6-16:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "node": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 4,
+      "outputNodes": 80,
+      "depth": 4,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 176
+    }
+  }
+}
+
+task 2 'run-graphql'. lines 18-32:
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "transactionBlockConnection": {
+            "edges": [
+              {
+                "txns": {
+                  "signatures": [
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 6,
+      "outputNodes": 1640,
+      "depth": 6,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 219
+    }
+  }
+}
+
+task 3 'run-graphql'. lines 34-55:
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "notOne": {
+            "edges": [
+              {
+                "txns": {
+                  "signatures": [
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+                  ]
+                }
+              }
+            ]
+          },
+          "isOne": {
+            "edges": [
+              {
+                "txns": {
+                  "signatures": [
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 10,
+      "outputNodes": 1720,
+      "depth": 6,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 332
+    }
+  }
+}
+
+task 4 'run-graphql'. lines 57-78:
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "notZero": {
+            "edges": [
+              {
+                "txns": {
+                  "signatures": [
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+                  ]
+                }
+              }
+            ]
+          },
+          "isZero": {
+            "edges": []
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 10,
+      "outputNodes": 1640,
+      "depth": 6,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 334
+    }
+  }
+}
+
+task 5 'run-graphql'. lines 80-90:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "txns": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 4,
+      "outputNodes": 4,
+      "depth": 4,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 158
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 92-102:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "txns": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 4,
+      "outputNodes": 4,
+      "depth": 4,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 156
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 104-132:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "txns": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ],
+            "first": null,
+            "last": null
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 14,
+      "outputNodes": 3320,
+      "depth": 8,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 514
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 134-160:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "nodes": [
+        {
+          "signatures": [
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+          ],
+          "first": null,
+          "last": null
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 13,
+      "outputNodes": 3300,
+      "depth": 7,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 546
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 162-211:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "txns": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ],
+            "a": null,
+            "b": null
+          }
+        }
+      ]
+    },
+    "eventConnection": {
+      "edges": []
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 24,
+      "outputNodes": 86340,
+      "depth": 11,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 1443
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 213-238:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "edges": [
+        {
+          "node": {
+            "signatures": [
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            ],
+            "a": null
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 12,
+      "outputNodes": 33300,
+      "depth": 11,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 730
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 240-250:
+Response: {
+  "data": null,
+  "extensions": {
+    "usage": {
+      "inputNodes": 4,
+      "outputNodes": 80,
+      "depth": 4,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 167
+    }
+  },
+  "errors": [
+    {
+      "message": "'first' and 'last' must not be used together",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "path": [
+        "transactionBlockConnection"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 12 'run-graphql'. lines 252-262:
+Response: {
+  "data": null,
+  "extensions": {
+    "usage": {
+      "inputNodes": 4,
+      "outputNodes": 80,
+      "depth": 4,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 160
+    }
+  },
+  "errors": [
+    {
+      "message": "Invalid value for argument \"first\", expected type \"Int\"",
+      "locations": [
+        {
+          "line": 3,
+          "column": 30
+        }
+      ]
+    }
+  ]
+}

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
@@ -1,6 +1,27 @@
-processed 13 tasks
+processed 14 tasks
 
-task 1 'run-graphql'. lines 6-16:
+task 1 'run-graphql'. lines 6-14:
+Response: {
+  "data": {
+    "transactionBlockConnection": {
+      "pageInfo": {
+        "hasPreviousPage": false
+      }
+    }
+  },
+  "extensions": {
+    "usage": {
+      "inputNodes": 3,
+      "outputNodes": 3,
+      "depth": 3,
+      "variables": 0,
+      "fragments": 0,
+      "queryPayload": 141
+    }
+  }
+}
+
+task 2 'run-graphql'. lines 16-26:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -25,7 +46,7 @@ Response: {
   }
 }
 
-task 2 'run-graphql'. lines 18-32:
+task 3 'run-graphql'. lines 28-42:
 Response: {
   "data": {
     "checkpoints": {
@@ -56,7 +77,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 34-55:
+task 4 'run-graphql'. lines 44-65:
 Response: {
   "data": {
     "checkpoints": {
@@ -96,7 +117,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 57-78:
+task 5 'run-graphql'. lines 67-88:
 Response: {
   "data": {
     "checkpoints": {
@@ -130,7 +151,7 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 80-90:
+task 6 'run-graphql'. lines 90-100:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -155,7 +176,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 92-102:
+task 7 'run-graphql'. lines 102-112:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -180,7 +201,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 104-132:
+task 8 'run-graphql'. lines 114-142:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -207,7 +228,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 134-160:
+task 9 'run-graphql'. lines 144-170:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -232,7 +253,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 162-211:
+task 10 'run-graphql'. lines 172-221:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -262,7 +283,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 213-238:
+task 11 'run-graphql'. lines 223-248:
 Response: {
   "data": {
     "transactionBlockConnection": {
@@ -288,7 +309,7 @@ Response: {
   }
 }
 
-task 11 'run-graphql'. lines 240-250:
+task 12 'run-graphql'. lines 250-260:
 Response: {
   "data": null,
   "extensions": {
@@ -320,7 +341,7 @@ Response: {
   ]
 }
 
-task 12 'run-graphql'. lines 252-262:
+task 13 'run-graphql'. lines 262-272:
 Response: {
   "data": null,
   "extensions": {

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -9,7 +9,7 @@
   transactionBlockConnection {
     edges {
       node {
-        signatures
+        digest
       }
     }
   }
@@ -23,7 +23,7 @@
       transactionBlockConnection {
         edges {
           txns: node {
-            signatures
+            digest
           }
         }
       }
@@ -39,14 +39,14 @@
       notOne: transactionBlockConnection {
         edges {
           txns: node {
-            signatures
+            digest
           }
         }
       }
       isOne: transactionBlockConnection(first: 1) {
         edges {
           txns: node {
-            signatures
+            digest
           }
         }
       }
@@ -62,14 +62,14 @@
       notZero: transactionBlockConnection {
         edges {
           txns: node {
-            signatures
+            digest
           }
         }
       }
       isZero: transactionBlockConnection(first: 0) {
         edges {
           txns: node {
-            signatures
+            digest
           }
         }
       }
@@ -83,7 +83,7 @@
   transactionBlockConnection(first: 1) {
     edges {
       txns: node {
-        signatures
+        digest
       }
     }
   }
@@ -95,7 +95,7 @@
   transactionBlockConnection(last: 1) {
     edges {
       txns: node {
-        signatures
+        digest
       }
     }
   }
@@ -107,7 +107,7 @@
   transactionBlockConnection {
     edges {
       txns: node {
-        signatures
+        digest
         first: expiration {
           checkpoints(first: 20) {
             edges {
@@ -136,7 +136,7 @@
 {
   transactionBlockConnection {
     nodes {
-      signatures
+      digest
       first: expiration { # 80 cumulative
         checkpoints(first: 20) {
           edges {
@@ -167,7 +167,7 @@
   transactionBlockConnection(first: 50) { # 50, 50
     edges { # 50, 100
       txns: node { # 50, 150
-        signatures # 50, 200
+        digest # 50, 200
         a: expiration { # 50, 250
           checkpoints(last: 20) { # 50 * 20 = 1000, 1250
             edges { # 1000, 2250
@@ -175,7 +175,7 @@
                 transactionBlockConnection(first: 10) { # 50 * 20 * 10 = 10000, 13250
                   edges { # 10000, 23250
                     node { # 10000, 33250
-                      signatures # 10000, 43250
+                      digest # 10000, 43250
                     }
                   }
                 }
@@ -190,7 +190,7 @@
                 transactionBlockConnection(last: 10) { # 50 * 20 * 10 = 10000, 56300
                   edges { # 10000, 66300
                     node { # 10000, 76300
-                      signatures # 10000, 86300
+                      digest # 10000, 86300
                     }
                   }
                 }
@@ -216,7 +216,7 @@ query NullVariableForLimit($howMany: Int) {
   transactionBlockConnection(last: $howMany) { # 20, 20
     edges { # 20, 40
       node { # 20, 60
-        signatures # 20, 80
+        digest # 20, 80
         a: expiration { # 20, 100
           checkpoints { # 20 * 20， 500
             edges { # 400, 900
@@ -224,7 +224,7 @@ query NullVariableForLimit($howMany: Int) {
                 transactionBlockConnection(first: $howMany) { # 20 * 20 * 20 = 8000， 9300
                   edges { # 8000, 17300
                     node { # 8000, 25300
-                      signatures # 8000, 33300
+                      digest # 8000, 33300
                     }
                   }
                 }
@@ -243,7 +243,7 @@ query NullVariableForLimit($howMany: Int) {
   transactionBlockConnection(first: 20, last: 30) {
     edges {
       node {
-        signatures
+        digest
       }
     }
   }
@@ -255,7 +255,7 @@ query NullVariableForLimit($howMany: Int) {
   transactionBlockConnection(first: 36893488147419103000) {
     edges {
       node {
-        signatures
+        digest
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -4,6 +4,16 @@
 //# init --addresses A=0x42 --simulator
 
 //# run-graphql --show-usage
+# pageInfo does not inherit connection's weights
+{
+  transactionBlockConnection(first: 20) {
+    pageInfo {
+      hasPreviousPage
+    }
+  }
+}
+
+//# run-graphql --show-usage
 # if connection does not have 'first' or 'last' set, use default_page_size (20)
 {
   transactionBlockConnection {

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -1,0 +1,262 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses A=0x42 --simulator
+
+//# run-graphql --show-usage
+# if connection does not have 'first' or 'last' set, use default_page_size (20)
+{
+  transactionBlockConnection {
+    edges {
+      node {
+        signatures
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# build on previous example with nested connection
+{
+  checkpoints {
+    nodes {
+      transactionBlockConnection {
+        edges {
+          txns: node {
+            signatures
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# handles 1
+{
+  checkpoints {
+    nodes {
+      notOne: transactionBlockConnection {
+        edges {
+          txns: node {
+            signatures
+          }
+        }
+      }
+      isOne: transactionBlockConnection(first: 1) {
+        edges {
+          txns: node {
+            signatures
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# handles 0
+{
+  checkpoints {
+    nodes {
+      notZero: transactionBlockConnection {
+        edges {
+          txns: node {
+            signatures
+          }
+        }
+      }
+      isZero: transactionBlockConnection(first: 0) {
+        edges {
+          txns: node {
+            signatures
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# if connection does have 'first' set, use it
+{
+  transactionBlockConnection(first: 1) {
+    edges {
+      txns: node {
+        signatures
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# if connection does have 'last' set, use it
+{
+  transactionBlockConnection(last: 1) {
+    edges {
+      txns: node {
+        signatures
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# first and last should behave the same
+{
+  transactionBlockConnection {
+    edges {
+      txns: node {
+        signatures
+        first: expiration {
+          checkpoints(first: 20) {
+            edges {
+              node {
+                sequenceNumber
+              }
+            }
+          }
+        }
+        last: expiration {
+          checkpoints(last: 20) {
+            edges {
+              node {
+                sequenceNumber
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# edges incur additional cost over nodes
+{
+  transactionBlockConnection {
+    nodes {
+      signatures
+      first: expiration { # 80 cumulative
+        checkpoints(first: 20) {
+          edges {
+            node {
+              sequenceNumber
+            }
+          }
+        }
+      } # 1680 cumulative
+      last: expiration { # 20 + 1680 = 1700 cumulative
+        checkpoints(last: 20) {
+          edges {
+            node {
+              sequenceNumber
+            }
+          }
+        } # another 1600, 3300 cumulative
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# example lifted from complex query at
+# https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#node-limit
+# our costing will be different since we consider all nodes
+{
+  transactionBlockConnection(first: 50) { # 50, 50
+    edges { # 50, 100
+      txns: node { # 50, 150
+        signatures # 50, 200
+        a: expiration { # 50, 250
+          checkpoints(last: 20) { # 50 * 20 = 1000, 1250
+            edges { # 1000, 2250
+              node { # 1000, 3250
+                transactionBlockConnection(first: 10) { # 50 * 20 * 10 = 10000, 13250
+                  edges { # 10000, 23250
+                    node { # 10000, 33250
+                      signatures # 10000, 43250
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        b: expiration { # 50, 43300
+          checkpoints(first: 20) { # 50 * 20 = 1000, 44300
+            edges { # 1000, 45300
+              node { # 1000, 46300
+                transactionBlockConnection(last: 10) { # 50 * 20 * 10 = 10000, 56300
+                  edges { # 10000, 66300
+                    node { # 10000, 76300
+                      signatures # 10000, 86300
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  eventConnection(last: 10) { # 10
+    edges {
+      node {
+        timestamp
+      }
+    }
+  } # 40, 86340
+}
+
+//# run-graphql --show-usage
+# Null value for variable passed to limit will use default_page_size
+query NullVariableForLimit($howMany: Int) {
+  transactionBlockConnection(last: $howMany) { # 20, 20
+    edges { # 20, 40
+      node { # 20, 60
+        signatures # 20, 80
+        a: expiration { # 20, 100
+          checkpoints { # 20 * 20， 500
+            edges { # 400, 900
+              node { # 400, 1300
+                transactionBlockConnection(first: $howMany) { # 20 * 20 * 20 = 8000， 9300
+                  edges { # 8000, 17300
+                    node { # 8000, 25300
+                      signatures # 8000, 33300
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# error state - can't use first and last together
+{
+  transactionBlockConnection(first: 20, last: 30) {
+    edges {
+      node {
+        signatures
+      }
+    }
+  }
+}
+
+//# run-graphql --show-usage
+# error state - exceed max integer
+{
+  transactionBlockConnection(first: 36893488147419103000) {
+    edges {
+      node {
+        signatures
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 anyhow.workspace = true
 async-graphql = {workspace = true, features = ["dataloader", "apollo_tracing", "tracing", "opentelemetry"] }
 async-graphql-axum.workspace = true
+async-graphql-value.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 chrono.workspace = true

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2076,13 +2076,14 @@ type ServiceConfig {
 	"""
 	The maximum number of output nodes in a GraphQL response.
 	
-	If a node is a connection, it is counted as the specified 'first' or 'last' number of items,
-	or the default_page_size as set by the server. Non-connection nodes and fields are not included
-	in this count.
+	Non-connection nodes have a count of 1, while connection nodes are counted as
+	the specified 'first' or 'last' number of items, or the default_page_size
+	as set by the server if those arguments are not set.
 	
-	The count of output nodes is multiplicative. For example, if the current node is a connection
-	with first: 10 and has a field to a connection with last: 20, the total estimated output nodes
-	would be 10 * 20 = 200.
+	Counts accumulate multiplicatively down the query tree. For example, if a query starts
+	with a connection of first: 10 and has a field to a connection with last: 20, the count
+	at the second level would be 200 nodes. This is then summed to the count of 10 nodes
+	at the first level, for a total of 210 nodes.
 	"""
 	maxOutputNodes: Int!
 	"""

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -219,13 +219,14 @@ impl ServiceConfig {
 
     /// The maximum number of output nodes in a GraphQL response.
     ///
-    /// If a node is a connection, it is counted as the specified 'first' or 'last' number of items,
-    /// or the default_page_size as set by the server. Non-connection nodes and fields are not included
-    /// in this count.
+    /// Non-connection nodes have a count of 1, while connection nodes are counted as
+    /// the specified 'first' or 'last' number of items, or the default_page_size
+    /// as set by the server if those arguments are not set.
     ///
-    /// The count of output nodes is multiplicative. For example, if the current node is a connection
-    /// with first: 10 and has a field to a connection with last: 20, the total estimated output nodes
-    /// would be 10 * 20 = 200.
+    /// Counts accumulate multiplicatively down the query tree. For example, if a query starts
+    /// with a connection of first: 10 and has a field to a connection with last: 20, the count
+    /// at the second level would be 200 nodes. This is then summed to the count of 10 nodes
+    /// at the first level, for a total of 210 nodes.
     pub async fn max_output_nodes(&self) -> u64 {
         self.limits.max_output_nodes
     }

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -238,7 +238,7 @@ impl QueryLimitsChecker {
                 parent_node_count: 1,
             });
             cost.input_nodes += 1;
-            check_limits(limits, &cost, Some(selection.pos))?;
+            check_limits(limits, cost, Some(selection.pos))?;
         }
 
         // Track the number of nodes at first level if any
@@ -247,7 +247,7 @@ impl QueryLimitsChecker {
         while !que.is_empty() {
             // Signifies the start of a new level
             cost.depth += 1;
-            check_limits(limits, &cost, None)?;
+            check_limits(limits, cost, None)?;
             while level_len > 0 {
                 // Ok to unwrap since we checked for empty queue
                 // and level_len > 0
@@ -274,7 +274,7 @@ impl QueryLimitsChecker {
                                 parent_node_count: current_count,
                             });
                             cost.input_nodes += 1;
-                            check_limits(limits, &cost, Some(field_sel.pos))?;
+                            check_limits(limits, cost, Some(field_sel.pos))?;
                         }
                     }
 
@@ -301,7 +301,7 @@ impl QueryLimitsChecker {
                                 parent_node_count,
                             });
                             cost.input_nodes += 1;
-                            check_limits(limits, &cost, Some(selection.pos))?;
+                            check_limits(limits, cost, Some(selection.pos))?;
                         }
                     }
 
@@ -313,7 +313,7 @@ impl QueryLimitsChecker {
                                 parent_node_count,
                             });
                             cost.input_nodes += 1;
-                            check_limits(limits, &cost, Some(selection.pos))?;
+                            check_limits(limits, cost, Some(selection.pos))?;
                         }
                     }
                 }

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -5,15 +5,20 @@ use prometheus::{register_histogram_with_registry, Histogram, Registry};
 
 #[derive(Clone, Debug)]
 pub struct RequestMetrics {
-    pub(crate) num_nodes: Histogram,
+    pub(crate) input_nodes: Histogram,
+    pub(crate) output_nodes: Histogram,
     pub(crate) query_depth: Histogram,
     pub(crate) query_payload_size: Histogram,
     pub(crate) _db_query_cost: Histogram,
 }
 
 // TODO: finetune buckets as we learn more about the distribution of queries
-const NUM_NODES_BUCKETS: &[f64] = &[
+const INPUT_NODES_BUCKETS: &[f64] = &[
     1., 2., 4., 8., 12., 16., 24., 32., 48., 64., 96., 128., 256., 512., 1024.,
+];
+const OUTPUT_NODES_BUCKETS: &[f64] = &[
+    100., 200., 400., 800., 1200., 1600., 2400., 3200., 4800., 6400., 9600., 12800., 25600.,
+    51200., 102400.,
 ];
 const QUERY_DEPTH_BUCKETS: &[f64] = &[
     1., 2., 4., 8., 12., 16., 24., 32., 48., 64., 96., 128., 256., 512., 1024.,
@@ -29,10 +34,17 @@ const DB_QUERY_COST_BUCKETS: &[f64] = &[
 impl RequestMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
-            num_nodes: register_histogram_with_registry!(
-                "num_nodes",
-                "Number of nodes in the query",
-                NUM_NODES_BUCKETS.to_vec(),
+            input_nodes: register_histogram_with_registry!(
+                "input_nodes",
+                "Number of input nodes in the query",
+                INPUT_NODES_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            output_nodes: register_histogram_with_registry!(
+                "output_nodes",
+                "Number of output nodes in the response",
+                OUTPUT_NODES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -655,17 +655,17 @@ pub mod tests {
             .build_schema();
         let _ = schema.execute("{ chainIdentifier }").await;
 
-        assert_eq!(metrics2.num_nodes.get_sample_count(), 1);
+        assert_eq!(metrics2.input_nodes.get_sample_count(), 1);
         assert_eq!(metrics2.query_depth.get_sample_count(), 1);
-        assert_eq!(metrics2.num_nodes.get_sample_sum(), 1.);
+        assert_eq!(metrics2.input_nodes.get_sample_sum(), 1.);
         assert_eq!(metrics2.query_depth.get_sample_sum(), 1.);
 
         let _ = schema
             .execute("{ chainIdentifier protocolConfig { configs { value key }} }")
             .await;
-        assert_eq!(metrics2.num_nodes.get_sample_count(), 2);
+        assert_eq!(metrics2.input_nodes.get_sample_count(), 2);
         assert_eq!(metrics2.query_depth.get_sample_count(), 2);
-        assert_eq!(metrics2.num_nodes.get_sample_sum(), 2. + 4.);
+        assert_eq!(metrics2.input_nodes.get_sample_sum(), 2. + 4.);
         assert_eq!(metrics2.query_depth.get_sample_sum(), 1. + 3.);
     }
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -656,16 +656,20 @@ pub mod tests {
         let _ = schema.execute("{ chainIdentifier }").await;
 
         assert_eq!(metrics2.input_nodes.get_sample_count(), 1);
+        assert_eq!(metrics2.output_nodes.get_sample_count(), 1);
         assert_eq!(metrics2.query_depth.get_sample_count(), 1);
         assert_eq!(metrics2.input_nodes.get_sample_sum(), 1.);
+        assert_eq!(metrics2.output_nodes.get_sample_sum(), 1.);
         assert_eq!(metrics2.query_depth.get_sample_sum(), 1.);
 
         let _ = schema
             .execute("{ chainIdentifier protocolConfig { configs { value key }} }")
             .await;
         assert_eq!(metrics2.input_nodes.get_sample_count(), 2);
+        assert_eq!(metrics2.output_nodes.get_sample_count(), 2);
         assert_eq!(metrics2.query_depth.get_sample_count(), 2);
         assert_eq!(metrics2.input_nodes.get_sample_sum(), 2. + 4.);
+        assert_eq!(metrics2.output_nodes.get_sample_sum(), 2. + 4.);
         assert_eq!(metrics2.query_depth.get_sample_sum(), 1. + 3.);
     }
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// #[cfg(feature = "pg_integration")]
+#[cfg(feature = "pg_integration")]
 mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -135,7 +135,7 @@ mod tests {
         assert!(res.errors().is_empty());
 
         let usage = res.usage().unwrap().unwrap();
-        assert_eq!(*usage.get("nodes").unwrap(), 1);
+        assert_eq!(*usage.get("inputNodes").unwrap(), 1);
         assert_eq!(*usage.get("depth").unwrap(), 1);
         assert_eq!(*usage.get("variables").unwrap(), 0);
         assert_eq!(*usage.get("fragments").unwrap(), 0);

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "pg_integration")]
+// #[cfg(feature = "pg_integration")]
 mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
@@ -136,6 +136,7 @@ mod tests {
 
         let usage = res.usage().unwrap().unwrap();
         assert_eq!(*usage.get("inputNodes").unwrap(), 1);
+        assert_eq!(*usage.get("outputNodes").unwrap(), 1);
         assert_eq!(*usage.get("depth").unwrap(), 1);
         assert_eq!(*usage.get("variables").unwrap(), 0);
         assert_eq!(*usage.get("fragments").unwrap(), 0);

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2080,13 +2080,14 @@ type ServiceConfig {
 	"""
 	The maximum number of output nodes in a GraphQL response.
 	
-	If a node is a connection, it is counted as the specified 'first' or 'last' number of items,
-	or the default_page_size as set by the server. Non-connection nodes and fields are not included
-	in this count.
+	Non-connection nodes have a count of 1, while connection nodes are counted as
+	the specified 'first' or 'last' number of items, or the default_page_size
+	as set by the server if those arguments are not set.
 	
-	The count of output nodes is multiplicative. For example, if the current node is a connection
-	with first: 10 and has a field to a connection with last: 20, the total estimated output nodes
-	would be 10 * 20 = 200.
+	Counts accumulate multiplicatively down the query tree. For example, if a query starts
+	with a connection of first: 10 and has a field to a connection with last: 20, the count
+	at the second level would be 200 nodes. This is then summed to the count of 10 nodes
+	at the first level, for a total of 210 nodes.
 	"""
 	maxOutputNodes: Int!
 	"""


### PR DESCRIPTION
## Description 

Implements output nodes estimation. A node adds a cost of 1, unless it is a connection field, where it would then have a cost of default_page_size, or min(first, last) if so provided. This is multiplicative - at the next child connection, that child's estimated output will be multiplied with its parent's to yield the cumulative result.

## Test Plan 

1. check that we get this back in the headers when showUsage is provided
4. output_node_estimation.move

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
