### PR TITLE
indexer: handle df module not found

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler_v2.rs
@@ -568,15 +568,19 @@ where
                             )
                         });
                         assert_eq!(oref.1, object.version());
-                        let df_info =
-                            try_create_dynamic_field_info(object, &objects, module_resolver)
-                                .unwrap_or_else(|e| {
-                                    panic!(
+                        let df_info = try_create_dynamic_field_info(
+                            object,
+                            &objects,
+                            module_resolver,
+                        )
+                        .unwrap_or_else(|e| {
+                            tracing::error!(
                                 "failed to create dynamic field info for obj: {:?}:{:?}. Err: {e}",
                                 object.id(),
                                 object.version()
-                            )
-                                });
+                            );
+                            None
+                        });
 
                         Some(IndexedObject::from_object(
                             checkpoint_seq,


### PR DESCRIPTION
## Description 

instead of panic, indexer will skip the DF indexing and move forward with an err

## Test Plan 

deployed to tnt with https://github.com/MystenLabs/sui-operations/pull/3050

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
