### PR TITLE
[gql] use objects_history to support consistent reads for single object fetches

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -7,7 +7,7 @@ use diesel::{
 };
 use sui_indexer::{
     models_v2::epoch::QueryableEpochInfo,
-    schema_v2::{checkpoints, display, epochs, events, objects, transactions},
+    schema_v2::{checkpoints, display, epochs, events, objects, objects_history, transactions},
     types_v2::OwnerType,
 };
 
@@ -38,7 +38,13 @@ pub type QueryableEpochInfoType<DB> = SqlTypeOf<AsSelect<QueryableEpochInfo, DB>
 
 pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, DB>;
-    fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, DB>;
+    fn get_obj(address: Vec<u8>) -> objects::BoxedQuery<'static, DB>;
+    fn get_obj_at_version(
+        address: Vec<u8>,
+        version: i64,
+        range_left: i64,
+        range_right: i64,
+    ) -> objects_history::BoxedQuery<'static, DB>;
     fn get_obj_by_type(object_type: String) -> objects::BoxedQuery<'static, DB>;
     fn get_epoch_info(epoch_id: i64)
         -> epochs::BoxedQuery<'static, DB, QueryableEpochInfoType<DB>>;

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -900,7 +900,6 @@ impl PgManager {
     ) -> Result<Option<Object>, Error> {
         let address = address.into_vec();
         let version = version.map(|v| v as i64);
-        println!("fetch_obj: address: {:?}, version: {:?}", address, version);
 
         match version {
             Some(version) => self


### PR DESCRIPTION
## Description 

Since the Active and WrappedOrDeleted states for an object are not too different, we can hook into the existing fetching logic to return an object for the former and null for the latter. However, we can improve dev ex by providing some information on why they received null, and one approach is covered in the stack of PRs below. If things look good, I add tests in one more stacked PR and merge down into this one.

1. Split out get_obj(address) and get_obj(address, version) into two queries since they hit different tables - this will reduce pains from working with diesel
2. get_obj_at_version will always require a range to work with as well. Otherwise, as mentioned in the docs (should this be a comment instead?) we end up reading through many more partitions than necessary. It's a tradeoff between 3 round trips to fulfill a fetch, vs one that taxes the db more.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
