### PR TITLE
[gql] get object at version

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/historical.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/historical.exp
@@ -1,0 +1,259 @@
+processed 26 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 13-54:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7014800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 56-56:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'create-checkpoint'. lines 58-58:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 60-73:
+Response: {
+  "data": {
+    "object": {
+      "status": "LIVE",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 5 'run'. lines 75-75:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 1301652, non_refundable_storage_fee: 13148
+
+task 6 'create-checkpoint'. lines 77-77:
+Checkpoint created: 2
+
+task 7 'run-graphql'. lines 79-92:
+Response: {
+  "data": {
+    "object": {
+      "status": "LIVE",
+      "version": 4,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "1"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 94-108:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 9 'run'. lines 110-110:
+created: object(9,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2553600,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 10 'create-checkpoint'. lines 112-112:
+Checkpoint created: 3
+
+task 11 'run-graphql'. lines 114-127:
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 12 'run-graphql'. lines 130-144:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 4,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "1"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 146-160:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 14 'run'. lines 162-162:
+mutated: object(0,0)
+unwrapped: object(2,0)
+deleted: object(9,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2528064, non_refundable_storage_fee: 25536
+
+task 15 'create-checkpoint'. lines 164-164:
+Checkpoint created: 4
+
+task 16 'run-graphql'. lines 166-179:
+Response: {
+  "data": {
+    "object": {
+      "status": "LIVE",
+      "version": 6,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "1"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 17 'run-graphql'. lines 181-195:
+Response: {
+  "data": {
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 5,
+      "asMoveObject": null
+    }
+  }
+}
+
+task 18 'run-graphql'. lines 197-211:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 4,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "1"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 19 'run-graphql'. lines 213-227:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 20 'run'. lines 229-229:
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 21 'create-checkpoint'. lines 231-231:
+Checkpoint created: 5
+
+task 22 'run-graphql'. lines 233-246:
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 23 'run-graphql'. lines 248-262:
+Response: {
+  "data": {
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 7,
+      "asMoveObject": null
+    }
+  }
+}
+
+task 24 'run-graphql'. lines 264-278:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 6,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0x525878f17a6177aa29f6a385600344daf90c45b1c2d3f1c6e7e9dc5b07e9cab0",
+            "value": "1"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 25 'run-graphql'. lines 280-294:
+Response: {
+  "data": {
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 5,
+      "asMoveObject": null
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/historical.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/historical.move
@@ -1,0 +1,294 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple test suite to validate expected results from reading objects_history. objects_snapshot
+// remains empty for this test, so we expect the start_cp to coalesce to 0. Every time we modify an
+// object, we create a checkpoint to extend end_cp. Create an object, update, wrap, unwrap, and
+// finally delete it. When the object is WrappedOrDeleted, it should not be findable on the live
+// objects table, but can still be found on the objects_history table. Verify that the object's
+// previous versions are retrievable.
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        o: Object
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun update(o1: &mut Object, value: u64,) {
+        o1.value = value;
+    }
+
+    public entry fun wrap(o: Object, ctx: &mut TxContext) {
+        transfer::transfer(Wrapper { id: object::new(ctx), o }, tx_context::sender(ctx))
+    }
+
+    public entry fun unwrap(w: Wrapper, ctx: &mut TxContext) {
+        let Wrapper { id, o } = w;
+        object::delete(id);
+        transfer::public_transfer(o, tx_context::sender(ctx))
+    }
+
+    public entry fun delete(o: Object) {
+        let Object { id, value: _ } = o;
+        object::delete(id);
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run Test::M1::update --sender A --args object(2,0) 1
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 3
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run Test::M1::wrap --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 4
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 3
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run Test::M1::unwrap --sender A --args object(9,0)
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 5
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 4
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 3
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run Test::M1::delete --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 7
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 6
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 5
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -208,7 +208,24 @@ Response: {
                     "address": "0x14043fb88ed2857ee366fee3fd2155eb4fe5569e9dab14c48229b89151f1a0a9",
                     "version": 2,
                     "digest": "Ex7H23fectwo59agH3BtGX77gM9rtQbJYm9nUVJGThRV",
-                    "object": null
+                    "object": {
+                      "address": "0x14043fb88ed2857ee366fee3fd2155eb4fe5569e9dab14c48229b89151f1a0a9",
+                      "version": 2,
+                      "digest": "Ex7H23fectwo59agH3BtGX77gM9rtQbJYm9nUVJGThRV",
+                      "asMoveObject": {
+                        "contents": {
+                          "type": {
+                            "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::package::UpgradeCap"
+                          },
+                          "json": {
+                            "id": "0x14043fb88ed2857ee366fee3fd2155eb4fe5569e9dab14c48229b89151f1a0a9",
+                            "package": "0x0dc6221c3bb4d12091bb422710fbe4983f2ff1d1961c779d01f4785f1e21dba1",
+                            "version": "1",
+                            "policy": 0
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/shared.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/shared.exp
@@ -47,7 +47,19 @@ Response: {
                   "address": "0x304d95705285484dfdce6d2c93b322bf4bb53254b3c4a21513cf3632a61a77f6",
                   "version": 2,
                   "digest": "2oW3VzQMCk6AtwLWeD1z1NZVSCZGsHxhus6Xpt2NxB7e",
-                  "object": null
+                  "object": {
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0xd01f94a13ef231248f3c439973a9d714e04f81d2fb42c59d8496695a45e801ec::m::Foo"
+                        },
+                        "json": {
+                          "id": "0x304d95705285484dfdce6d2c93b322bf4bb53254b3c4a21513cf3632a61a77f6",
+                          "x": "0"
+                        }
+                      }
+                    }
+                  }
                 }
               ]
             }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1648,11 +1648,22 @@ with fields) with additional metadata detailing its id, version, transaction dig
 field indicating how this object can be accessed.
 """
 type Object implements IOwner {
-	version: Int!
+	version: Int
+	"""
+	The current status of the object as read from the off-chain store. The possible states are:
+	- NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
+	transaction.
+	- LIVE: the object is currently live and is not deleted or wrapped.
+	- HISTORICAL: the object is referenced at some version, and thus is fetched from the
+	snapshot or historical objects table.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
+	loaded from the indexer.
+	"""
+	status: ObjectKind!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
 	"""
-	digest: String!
+	digest: String
 	"""
 	The amount of SUI we would rebate if this object gets deleted or mutated.
 	This number is recalculated based on the present storage gas price.
@@ -1865,6 +1876,28 @@ input ObjectFilter {
 input ObjectKey {
 	objectId: SuiAddress!
 	version: Int!
+}
+
+enum ObjectKind {
+	"""
+	NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
+	transaction.
+	"""
+	NOT_INDEXED
+	"""
+	LIVE: the object is currently live and is not deleted or wrapped.
+	"""
+	LIVE
+	"""
+	HISTORICAL: the object is referenced at some version, and thus is fetched from the snapshot
+	or historical objects table.
+	"""
+	HISTORICAL
+	"""
+	WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
+	loaded from the indexer.
+	"""
+	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1880,22 +1880,21 @@ input ObjectKey {
 
 enum ObjectKind {
 	"""
-	NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
-	transaction.
+	The object is loaded from serialized data, such as the contents of a transaction.
 	"""
 	NOT_INDEXED
 	"""
-	LIVE: the object is currently live and is not deleted or wrapped.
+	The object is currently live and is not deleted or wrapped.
 	"""
 	LIVE
 	"""
-	HISTORICAL: the object is referenced at some version, and thus is fetched from the snapshot
-	or historical objects table.
+	The object is referenced at some version, and thus is fetched from the snapshot or
+	historical objects table.
 	"""
 	HISTORICAL
 	"""
-	WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
-	loaded from the indexer.
+	The object is deleted or wrapped and only partial information can be loaded from the
+	indexer.
 	"""
 	WRAPPED_OR_DELETED
 }

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -12,7 +12,7 @@ use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 use super::cursor::{Page, Target};
-use super::object::{self, deserialize_move_struct};
+use super::object::{self, deserialize_move_struct, ObjectVersionKey};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
@@ -106,9 +106,13 @@ impl DynamicField {
     /// in which case it is also accessible off-chain via its address.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         if self.df_kind == DynamicFieldType::DynamicObject {
-            let obj = MoveObject::query(ctx.data_unchecked(), self.df_object_id, None)
-                .await
-                .extend()?;
+            let obj = MoveObject::query(
+                ctx.data_unchecked(),
+                self.df_object_id,
+                ObjectVersionKey::Latest,
+            )
+            .await
+            .extend()?;
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
             let resolver: &Resolver<PackageCache> = ctx

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -10,7 +10,7 @@ use sui_types::{
     transaction::GasData,
 };
 
-use super::{address::Address, big_int::BigInt, sui_address::SuiAddress};
+use super::{address::Address, big_int::BigInt, object::ObjectVersionKey, sui_address::SuiAddress};
 use super::{
     cursor::Page,
     object::{self, ObjectFilter, ObjectKey},
@@ -116,7 +116,7 @@ impl GasEffects {
         Object::query(
             ctx.data_unchecked(),
             self.object_id,
-            Some(self.object_version),
+            ObjectVersionKey::Historical(self.object_version),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -658,11 +658,13 @@ impl Object {
                             left.single_value()
                                 .is_null()
                                 .or(history::checkpoint_sequence_number
-                                    .ge(left.single_value().assume_not_null())),
+                                    .nullable()
+                                    .ge(left.single_value())),
                         )
                         .filter(
                             history::checkpoint_sequence_number
-                                .le(right.single_value().assume_not_null()),
+                                .nullable()
+                                .le(right.single_value()),
                         );
 
                     snapshot_query.union(historical_query)
@@ -721,7 +723,8 @@ impl Object {
                         left.single_value()
                             .is_null()
                             .or(history::checkpoint_sequence_number
-                                .ge(left.single_value().assume_not_null())),
+                                .nullable()
+                                .ge(left.single_value())),
                     );
 
                     historical_query = historical_query

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -3,17 +3,20 @@
 
 use std::collections::BTreeMap;
 
+use crate::types::intersect;
 use async_graphql::connection::{CursorType, Edge};
 use async_graphql::{connection::Connection, *};
 use diesel::{
-    BoolExpressionMethods, ExpressionMethods, NullableExpressionMethods, OptionalExtension,
-    QueryDsl,
+    BoolExpressionMethods, CombineDsl, ExpressionMethods, NullableExpressionMethods,
+    OptionalExtension, QueryDsl,
 };
-use fastcrypto::encoding::{Base58, Encoding};
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
-use sui_indexer::models_v2::objects::StoredObject;
-use sui_indexer::schema_v2::objects;
+use sui_indexer::models_v2::objects::{
+    StoredDeletedHistoryObject, StoredHistoryObject, StoredObject,
+};
+use sui_indexer::schema_v2::{checkpoints, objects, objects_history, objects_snapshot};
+use sui_indexer::types_v2::ObjectStatus as NativeObjectStatus;
 use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc::name_service::NameServiceConfig;
 use sui_package_resolver::Resolver;
@@ -39,7 +42,6 @@ use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::types::base64::Base64;
-use crate::types::intersect;
 use sui_types::object::{
     MoveObject as NativeMoveObject, Object as NativeObject, Owner as NativeOwner,
 };
@@ -47,12 +49,35 @@ use sui_types::object::{
 #[derive(Clone, Debug)]
 pub(crate) struct Object {
     pub address: SuiAddress,
+    pub kind: ObjectKind,
+}
 
-    /// Representation of an Object in the Indexer's Store.
-    pub stored: Option<StoredObject>,
+#[derive(Clone, Debug)]
+pub(crate) enum ObjectKind {
+    /// An object loaded from serialized data, such as the contents of a transaction.
+    NotIndexed(NativeObject),
+    /// An object fetched from the live objects table.
+    Live(NativeObject, StoredObject),
+    /// An object fetched from the snapshot or historical objects table.
+    Historical(NativeObject, StoredHistoryObject),
+    /// The object is wrapped or deleted and only partial information can be loaded from the
+    /// indexer.
+    WrappedOrDeleted(StoredDeletedHistoryObject),
+}
 
-    /// Deserialized representation of `stored_object.serialized_object`.
-    pub native: NativeObject,
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+#[graphql(name = "ObjectKind")]
+pub enum ObjectStatus {
+    /// The object is loaded from serialized data, such as the contents of a transaction.
+    NotIndexed,
+    /// The object is currently live and is not deleted or wrapped.
+    Live,
+    /// The object is referenced at some version, and thus is fetched from the snapshot or
+    /// historical objects table.
+    Historical,
+    /// The object is deleted or wrapped and only partial information can be loaded from the
+    /// indexer.
+    WrappedOrDeleted,
 }
 
 /// Constrains the set of objects returned. All filters are optional, and the resulting set of
@@ -129,6 +154,13 @@ pub struct AddressOwner {
     owner: Option<Owner>,
 }
 
+#[allow(dead_code)]
+pub(crate) enum ObjectVersionKey {
+    Latest,
+    LatestAt(u64),   // checkpoint_sequence_number
+    Historical(u64), // version
+}
+
 pub(crate) type Cursor = cursor::BcsCursor<Vec<u8>>;
 type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 
@@ -137,35 +169,48 @@ type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 /// field indicating how this object can be accessed.
 #[Object]
 impl Object {
-    async fn version(&self) -> u64 {
-        self.native.version().value()
+    async fn version(&self) -> Option<u64> {
+        self.version_impl()
+    }
+
+    /// The current status of the object as read from the off-chain store. The possible states are:
+    /// - NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
+    ///   transaction.
+    /// - LIVE: the object is currently live and is not deleted or wrapped.
+    /// - HISTORICAL: the object is referenced at some version, and thus is fetched from the
+    ///   snapshot or historical objects table.
+    /// - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
+    ///   loaded from the indexer.
+    async fn status(&self) -> ObjectStatus {
+        ObjectStatus::from(&self.kind)
     }
 
     /// 32-byte hash that identifies the object's current contents, encoded as a Base58 string.
-    async fn digest(&self) -> String {
-        if let Some(stored) = &self.stored {
-            Base58::encode(&stored.object_digest)
-        } else {
-            self.native.digest().base58_encode()
-        }
+    async fn digest(&self) -> Option<String> {
+        self.native_impl()
+            .map(|native| native.digest().base58_encode())
     }
 
     /// The amount of SUI we would rebate if this object gets deleted or mutated.
     /// This number is recalculated based on the present storage gas price.
     async fn storage_rebate(&self) -> Option<BigInt> {
-        Some(BigInt::from(self.native.storage_rebate))
+        self.native_impl()
+            .map(|native| BigInt::from(native.storage_rebate))
     }
 
     /// The set of named templates defined on-chain for the type of this object,
     /// to be handled off-chain. The server substitutes data from the object
     /// into these templates to generate a display string per template.
     async fn display(&self, ctx: &Context<'_>) -> Result<Option<Vec<DisplayEntry>>> {
+        let Some(native) = self.native_impl() else {
+            return Ok(None);
+        };
+
         let resolver: &Resolver<PackageCache> = ctx
             .data()
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
-        let move_object = self
-            .native
+        let move_object = native
             .data
             .try_as_move()
             .ok_or_else(|| Error::Internal("Failed to convert object into MoveObject".to_string()))
@@ -197,20 +242,24 @@ impl Object {
 
     /// The Base64 encoded bcs serialization of the object's content.
     async fn bcs(&self) -> Result<Option<Base64>> {
-        if let Some(stored) = &self.stored {
-            Ok(Some(Base64::from(&stored.serialized_object)))
-        } else {
-            let bytes = bcs::to_bytes(&self.native)
-                .map_err(|e| {
-                    Error::Internal(format!(
-                        "Failed to serialize object at {}: {e}",
-                        self.address,
-                    ))
-                })
-                .extend()?;
-
-            Ok(Some(Base64::from(&bytes)))
-        }
+        use ObjectKind as K;
+        Ok(match &self.kind {
+            K::WrappedOrDeleted(_) => None,
+            K::Live(_, stored) => Some(Base64::from(&stored.serialized_object)),
+            // WrappedOrDeleted objects do not have a serialized object, thus this column in the db is nullable.
+            K::Historical(_, stored) => stored.serialized_object.as_ref().map(Base64::from),
+            K::NotIndexed(native) => {
+                let bytes = bcs::to_bytes(native)
+                    .map_err(|e| {
+                        Error::Internal(format!(
+                            "Failed to serialize object at {}: {e}",
+                            self.address
+                        ))
+                    })
+                    .extend()?;
+                Some(Base64::from(&bytes))
+            }
+        })
     }
 
     /// The transaction block that created this version of the object.
@@ -218,7 +267,11 @@ impl Object {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<TransactionBlock>> {
-        let digest = self.native.previous_transaction;
+        let Some(native) = self.native_impl() else {
+            return Ok(None);
+        };
+        let digest = native.previous_transaction;
+
         TransactionBlock::query(ctx.data_unchecked(), digest.into())
             .await
             .extend()
@@ -229,7 +282,11 @@ impl Object {
     async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
         use NativeOwner as O;
 
-        match self.native.owner {
+        let Some(native) = self.native_impl() else {
+            return None;
+        };
+
+        match native.owner {
             O::AddressOwner(address) => {
                 let address = SuiAddress::from(address);
                 Some(ObjectOwner::Address(AddressOwner {
@@ -238,10 +295,14 @@ impl Object {
             }
             O::Immutable => Some(ObjectOwner::Immutable(Immutable { dummy: None })),
             O::ObjectOwner(address) => {
-                let parent = Object::query(ctx.data_unchecked(), address.into(), None)
-                    .await
-                    .ok()
-                    .flatten();
+                let parent = Object::query(
+                    ctx.data_unchecked(),
+                    address.into(),
+                    ObjectVersionKey::Latest,
+                )
+                .await
+                .ok()
+                .flatten();
 
                 return Some(ObjectOwner::Parent(Parent { parent }));
             }
@@ -443,41 +504,28 @@ impl Object {
     pub(crate) fn from_native(address: SuiAddress, native: NativeObject) -> Object {
         Object {
             address,
-            stored: None,
-            native,
+            kind: ObjectKind::NotIndexed(native),
         }
     }
 
-    pub(crate) async fn query(
-        db: &Db,
-        address: SuiAddress,
-        version: Option<u64>,
-    ) -> Result<Option<Self>, Error> {
-        use objects::dsl;
+    pub(crate) fn native_impl(&self) -> Option<&NativeObject> {
+        use ObjectKind as K;
 
-        let address = address.into_vec();
-        let version = version.map(|v| v as i64);
+        match &self.kind {
+            K::Live(native, _) | K::NotIndexed(native) | K::Historical(native, _) => Some(native),
+            K::WrappedOrDeleted(_) => None,
+        }
+    }
 
-        let stored_obj: Option<StoredObject> = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    let mut query = dsl::objects
-                        .filter(dsl::object_id.eq(address.clone()))
-                        .into_boxed();
+    pub(crate) fn version_impl(&self) -> Option<u64> {
+        use ObjectKind as K;
 
-                    // TODO: leverage objects_history
-                    if let Some(version) = version {
-                        query = query.filter(dsl::object_version.eq(version));
-                    }
-
-                    query
-                })
-                .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch object: {e}")))?;
-
-        stored_obj.map(Self::try_from).transpose()
+        match &self.kind {
+            K::Live(native, _) | K::NotIndexed(native) | K::Historical(native, _) => {
+                Some(native.version().value())
+            }
+            K::WrappedOrDeleted(stored) => Some(stored.object_version as u64),
+        }
     }
 
     /// Query the database for a `page` of objects, optionally `filter`-ed.
@@ -547,6 +595,177 @@ impl Object {
         }
 
         Ok(conn)
+    }
+
+    async fn query_live(db: &Db, address: SuiAddress) -> Result<Option<Self>, Error> {
+        use objects::dsl as objects;
+        let vec_address = address.into_vec();
+
+        let stored_obj: Option<StoredObject> = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    objects::objects.filter(objects::object_id.eq(vec_address.clone()))
+                })
+                .optional()
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch object: {e}")))?;
+
+        stored_obj.map(Self::try_from).transpose()
+    }
+
+    async fn query_at_version(
+        db: &Db,
+        address: SuiAddress,
+        version: u64,
+    ) -> Result<Option<Self>, Error> {
+        use checkpoints::dsl as checkpoints;
+        use objects_history::dsl as history;
+        use objects_snapshot::dsl as snapshot;
+
+        let version = version as i64;
+
+        let results: Option<Vec<StoredHistoryObject>> = db
+            .execute(move |conn| {
+                conn.results(move || {
+                    // If an object was created or mutated in a checkpoint outside the current
+                    // available range, and never touched again, it will not show up in the
+                    // objects_history table. Thus, we always need to check the objects_snapshot
+                    // table as well.
+                    let snapshot_query = snapshot::objects_snapshot
+                        .filter(snapshot::object_id.eq(address.into_vec()))
+                        .filter(snapshot::object_version.eq(version))
+                        .into_boxed();
+                    let mut historical_query = history::objects_history
+                        .filter(history::object_id.eq(address.into_vec()))
+                        .filter(history::object_version.eq(version))
+                        .order_by(history::object_version.desc())
+                        .limit(1)
+                        .into_boxed();
+
+                    let left = snapshot::objects_snapshot
+                        .select(snapshot::checkpoint_sequence_number)
+                        .order(snapshot::checkpoint_sequence_number.desc())
+                        .limit(1);
+
+                    let right = checkpoints::checkpoints
+                        .select(checkpoints::sequence_number)
+                        .order(checkpoints::sequence_number.desc())
+                        .limit(1);
+
+                    historical_query = historical_query
+                        .filter(
+                            left.single_value()
+                                .is_null()
+                                .or(history::checkpoint_sequence_number
+                                    .ge(left.single_value().assume_not_null())),
+                        )
+                        .filter(
+                            history::checkpoint_sequence_number
+                                .le(right.single_value().assume_not_null()),
+                        );
+
+                    snapshot_query.union(historical_query)
+                })
+                .optional()
+            })
+            .await?;
+
+        // For the moment, if the object existed at some point, it will have eventually be written
+        // to objects_snapshot. Therefore, if both results are None, the object has never existed.
+        let Some(stored_objs) = results else {
+            return Ok(None);
+        };
+
+        // Select the max by key after the union query, because Diesel currently does not support order_by on union
+        stored_objs
+            .into_iter()
+            .max_by_key(|o| o.object_version)
+            .map(Self::try_from)
+            .transpose()
+    }
+
+    async fn query_latest_at_checkpoint(
+        db: &Db,
+        address: SuiAddress,
+        checkpoint_sequence_number: u64,
+    ) -> Result<Option<Self>, Error> {
+        use objects_history::dsl as history;
+        use objects_snapshot::dsl as snapshot;
+
+        let checkpoint_sequence_number = checkpoint_sequence_number as i64;
+
+        let results: Option<Vec<StoredHistoryObject>> = db
+            .execute(move |conn| {
+                conn.results(move || {
+                    // If an object was created or mutated in a checkpoint outside the current
+                    // available range, and never touched again, it will not show up in the
+                    // objects_history table. Thus, we always need to check the objects_snapshot
+                    // table as well.
+                    let mut snapshot_query = snapshot::objects_snapshot
+                        .filter(snapshot::object_id.eq(address.into_vec()))
+                        .into_boxed();
+
+                    let mut historical_query = history::objects_history
+                        .filter(history::object_id.eq(address.into_vec()))
+                        .order_by(history::object_version.desc())
+                        .limit(1)
+                        .into_boxed();
+
+                    let left = snapshot::objects_snapshot
+                        .select(snapshot::checkpoint_sequence_number)
+                        .order(snapshot::checkpoint_sequence_number.desc())
+                        .limit(1);
+
+                    historical_query = historical_query.filter(
+                        left.single_value()
+                            .is_null()
+                            .or(history::checkpoint_sequence_number
+                                .ge(left.single_value().assume_not_null())),
+                    );
+
+                    historical_query = historical_query
+                        .filter(history::checkpoint_sequence_number.le(checkpoint_sequence_number));
+
+                    snapshot_query = snapshot_query.filter(
+                        snapshot::checkpoint_sequence_number.le(checkpoint_sequence_number),
+                    );
+
+                    snapshot_query.union(historical_query)
+                })
+                .optional()
+            })
+            .await?;
+
+        // For the moment, if the object existed at some point, it will have eventually be written
+        // to objects_snapshot. Therefore, if both results are None, the object has never existed.
+        let Some(stored_objs) = results else {
+            return Ok(None);
+        };
+
+        // Select the max by key after the union query, because Diesel currently does not support order_by on union
+        stored_objs
+            .into_iter()
+            .max_by_key(|o| o.object_version)
+            .map(Self::try_from)
+            .transpose()
+    }
+
+    pub(crate) async fn query(
+        db: &Db,
+        address: SuiAddress,
+        key: ObjectVersionKey,
+    ) -> Result<Option<Self>, Error> {
+        match key {
+            ObjectVersionKey::Latest => Self::query_live(db, address).await,
+            ObjectVersionKey::LatestAt(checkpoint_sequence_number) => {
+                Self::query_latest_at_checkpoint(db, address, checkpoint_sequence_number).await
+            }
+            ObjectVersionKey::Historical(version) => {
+                Self::query_at_version(db, address, version).await
+            }
+        }
+        .map_err(|e| Error::Internal(format!("Failed to fetch object: {e}")))
     }
 }
 
@@ -671,9 +890,64 @@ impl TryFrom<StoredObject> for Object {
 
         Ok(Self {
             address,
-            stored: Some(stored_object),
-            native: native_object,
+            kind: ObjectKind::Live(native_object, stored_object),
         })
+    }
+}
+
+impl TryFrom<StoredHistoryObject> for Object {
+    type Error = Error;
+
+    fn try_from(history_object: StoredHistoryObject) -> Result<Self, Error> {
+        let address = addr(&history_object.object_id)?;
+
+        let object_status =
+            NativeObjectStatus::try_from(history_object.object_status).map_err(|_| {
+                Error::Internal(format!(
+                    "Unknown object status {} for object {} at version {}",
+                    history_object.object_status, address, history_object.object_version
+                ))
+            })?;
+
+        match object_status {
+            NativeObjectStatus::Active => {
+                let Some(serialized_object) = &history_object.serialized_object else {
+                    return Err(Error::Internal(format!(
+                        "Live object {} at version {} cannot have missing serialized_object field",
+                        address, history_object.object_version
+                    )));
+                };
+
+                let native_object = bcs::from_bytes(serialized_object).map_err(|_| {
+                    Error::Internal(format!("Failed to deserialize object {address}"))
+                })?;
+
+                Ok(Self {
+                    address,
+                    kind: ObjectKind::Historical(native_object, history_object),
+                })
+            }
+            NativeObjectStatus::WrappedOrDeleted => Ok(Self {
+                address,
+                kind: ObjectKind::WrappedOrDeleted(StoredDeletedHistoryObject {
+                    object_id: history_object.object_id,
+                    object_version: history_object.object_version,
+                    object_status: history_object.object_status,
+                    checkpoint_sequence_number: history_object.checkpoint_sequence_number,
+                }),
+            }),
+        }
+    }
+}
+
+impl From<&ObjectKind> for ObjectStatus {
+    fn from(kind: &ObjectKind) -> Self {
+        match kind {
+            ObjectKind::NotIndexed(_) => ObjectStatus::NotIndexed,
+            ObjectKind::Live(_, _) => ObjectStatus::Live,
+            ObjectKind::Historical(_, _) => ObjectStatus::Historical,
+            ObjectKind::WrappedOrDeleted(_) => ObjectStatus::WrappedOrDeleted,
+        }
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -4,7 +4,10 @@
 use async_graphql::*;
 use sui_types::effects::{IDOperation, ObjectChange as NativeObjectChange};
 
-use super::{object::Object, sui_address::SuiAddress};
+use super::{
+    object::{Object, ObjectVersionKey},
+    sui_address::SuiAddress,
+};
 
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
@@ -27,7 +30,7 @@ impl ObjectChange {
         Object::query(
             ctx.data_unchecked(),
             self.native.id.into(),
-            Some(version.value()),
+            ObjectVersionKey::Historical(version.value()),
         )
         .await
         .extend()
@@ -42,7 +45,7 @@ impl ObjectChange {
         Object::query(
             ctx.data_unchecked(),
             self.native.id.into(),
-            Some(version.value()),
+            ObjectVersionKey::Historical(version.value()),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -4,7 +4,10 @@
 use async_graphql::*;
 use sui_types::base_types::ObjectRef as NativeObjectRef;
 
-use super::{object::Object, sui_address::SuiAddress};
+use super::{
+    object::{Object, ObjectVersionKey},
+    sui_address::SuiAddress,
+};
 
 // A helper type representing the read of a specific version of an object. Intended to be
 // "flattened" into other GraphQL types.
@@ -34,7 +37,7 @@ impl ObjectRead {
         Object::query(
             ctx.data_unchecked(),
             self.address_impl(),
-            Some(self.version_impl()),
+            ObjectVersionKey::Historical(self.version_impl()),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -19,7 +19,7 @@ use super::{
     epoch::Epoch,
     event::{self, Event, EventFilter},
     move_type::MoveType,
-    object::{self, Object, ObjectFilter},
+    object::{self, Object, ObjectFilter, ObjectVersionKey},
     owner::Owner,
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
@@ -77,9 +77,18 @@ impl Query {
         address: SuiAddress,
         version: Option<u64>,
     ) -> Result<Option<Object>> {
-        Object::query(ctx.data_unchecked(), address, version)
+        match version {
+            Some(version) => Object::query(
+                ctx.data_unchecked(),
+                address,
+                ObjectVersionKey::Historical(version),
+            )
             .await
-            .extend()
+            .extend(),
+            None => Object::query(ctx.data_unchecked(), address, ObjectVersionKey::Latest)
+                .await
+                .extend(),
+        }
     }
 
     /// Look-up an Account by its SuiAddress.

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use super::{
     cursor::Page,
     move_object::MoveObject,
-    object::{self, Object, ObjectFilter},
+    object::{self, Object, ObjectFilter, ObjectVersionKey},
     string_input::impl_string_input,
     sui_address::SuiAddress,
 };
@@ -70,7 +70,9 @@ impl SuinsRegistration {
     ) -> Result<Option<NameRecord>, Error> {
         let record_id = config.record_field_id(&domain.0);
 
-        let Some(object) = MoveObject::query(db, record_id.into(), None).await? else {
+        let Some(object) =
+            MoveObject::query(db, record_id.into(), ObjectVersionKey::Latest).await?
+        else {
             return Ok(None);
         };
 
@@ -91,7 +93,9 @@ impl SuinsRegistration {
     ) -> Result<Option<NativeDomain>, Error> {
         let reverse_record_id = config.reverse_record_field_id(address.as_slice());
 
-        let Some(object) = MoveObject::query(db, reverse_record_id.into(), None).await? else {
+        let Some(object) =
+            MoveObject::query(db, reverse_record_id.into(), ObjectVersionKey::Latest).await?
+        else {
             return Ok(None);
         };
 

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -5,6 +5,7 @@ use crate::context_data::db_data_provider::PgManager;
 
 use super::big_int::BigInt;
 use super::move_object::MoveObject;
+use super::object::ObjectVersionKey;
 use super::sui_address::SuiAddress;
 use super::validator_credentials::ValidatorCredentials;
 use super::{address::Address, base64::Base64};
@@ -86,25 +87,37 @@ impl Validator {
     /// the operation ability to another address. The address holding this `Cap` object
     /// can then update the reference gas price and tallying rule on behalf of the validator.
     async fn operation_cap(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        MoveObject::query(ctx.data_unchecked(), self.operation_cap_id(), None)
-            .await
-            .extend()
+        MoveObject::query(
+            ctx.data_unchecked(),
+            self.operation_cap_id(),
+            ObjectVersionKey::Latest,
+        )
+        .await
+        .extend()
     }
 
     /// The validator's current staking pool object, used to track the amount of stake
     /// and to compound staking rewards.
     async fn staking_pool(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        MoveObject::query(ctx.data_unchecked(), self.staking_pool_id(), None)
-            .await
-            .extend()
+        MoveObject::query(
+            ctx.data_unchecked(),
+            self.staking_pool_id(),
+            ObjectVersionKey::Latest,
+        )
+        .await
+        .extend()
     }
 
     /// The validator's current exchange object. The exchange rate is used to determine
     /// the amount of SUI tokens that each past SUI staker can withdraw in the future.
     async fn exchange_rates(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        MoveObject::query(ctx.data_unchecked(), self.exchange_rates_id(), None)
-            .await
-            .extend()
+        MoveObject::query(
+            ctx.data_unchecked(),
+            self.exchange_rates_id(),
+            ObjectVersionKey::Latest,
+        )
+        .await
+        .extend()
     }
 
     /// Number of exchange rates in the table.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1884,22 +1884,21 @@ input ObjectKey {
 
 enum ObjectKind {
 	"""
-	NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
-	transaction.
+	The object is loaded from serialized data, such as the contents of a transaction.
 	"""
 	NOT_INDEXED
 	"""
-	LIVE: the object is currently live and is not deleted or wrapped.
+	The object is currently live and is not deleted or wrapped.
 	"""
 	LIVE
 	"""
-	HISTORICAL: the object is referenced at some version, and thus is fetched from the snapshot
-	or historical objects table.
+	The object is referenced at some version, and thus is fetched from the snapshot or
+	historical objects table.
 	"""
 	HISTORICAL
 	"""
-	WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
-	loaded from the indexer.
+	The object is deleted or wrapped and only partial information can be loaded from the
+	indexer.
 	"""
 	WRAPPED_OR_DELETED
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1652,11 +1652,22 @@ with fields) with additional metadata detailing its id, version, transaction dig
 field indicating how this object can be accessed.
 """
 type Object implements IOwner {
-	version: Int!
+	version: Int
+	"""
+	The current status of the object as read from the off-chain store. The possible states are:
+	- NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
+	transaction.
+	- LIVE: the object is currently live and is not deleted or wrapped.
+	- HISTORICAL: the object is referenced at some version, and thus is fetched from the
+	snapshot or historical objects table.
+	- WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
+	loaded from the indexer.
+	"""
+	status: ObjectKind!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
 	"""
-	digest: String!
+	digest: String
 	"""
 	The amount of SUI we would rebate if this object gets deleted or mutated.
 	This number is recalculated based on the present storage gas price.
@@ -1869,6 +1880,28 @@ input ObjectFilter {
 input ObjectKey {
 	objectId: SuiAddress!
 	version: Int!
+}
+
+enum ObjectKind {
+	"""
+	NOT_INDEXED: the object is loaded from serialized data, such as the contents of a
+	transaction.
+	"""
+	NOT_INDEXED
+	"""
+	LIVE: the object is currently live and is not deleted or wrapped.
+	"""
+	LIVE
+	"""
+	HISTORICAL: the object is referenced at some version, and thus is fetched from the snapshot
+	or historical objects table.
+	"""
+	HISTORICAL
+	"""
+	WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial information can be
+	loaded from the indexer.
+	"""
+	WRAPPED_OR_DELETED
 }
 
 """

--- a/crates/sui-indexer/src/types_v2.rs
+++ b/crates/sui-indexer/src/types_v2.rs
@@ -214,6 +214,22 @@ pub enum ObjectStatus {
     WrappedOrDeleted = 1,
 }
 
+impl TryFrom<i16> for ObjectStatus {
+    type Error = IndexerError;
+
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => ObjectStatus::Active,
+            1 => ObjectStatus::WrappedOrDeleted,
+            value => {
+                return Err(IndexerError::PersistentStorageDataCorruptionError(format!(
+                    "{value} as ObjectStatus"
+                )))
+            }
+        })
+    }
+}
+
 impl TryFrom<i16> for OwnerType {
     type Error = IndexerError;
 


### PR DESCRIPTION
## Description 

Refactor Object’s internal representation to contain a status: ObjectKind enum with variants Live, Historical, NotIndexed, WrappedOrDeleted, and OutsideAvailableRange. This minimizes changes to the current Object schema on graphql, and allows users to look up graphql fields of wrapped objects even if the objects themselves cannot be accessed.

The PR also implements available-range-aware single-object lookups by constructing a union query on objects_snapshot and objects_history. We need to look up both tables when fetching an object at version. To illustrate, if an object was created or mutated at checkpoint 1, and the current available range is now 100-200, a query for the object at version 1 will not show up if we look strictly in the objects_history table, since it only tracks object changes per checkpoint. Instead, we also consult objects_snapshot, which will have snapshotted the object.

## Test Plan 

objects/historical.move

To fully test this feature, I also need to extend transactional-test-runner and graphql's test infra to force objects_snapshot table to update. 

1. https://github.com/MystenLabs/sui/pull/15677 (follows this)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
