### PR TITLE
Gql object reorg

### DIFF
--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -95,7 +95,11 @@ impl TryFrom<&Object> for MoveObject {
     type Error = MoveObjectDowncastError;
 
     fn try_from(object: &Object) -> Result<Self, Self::Error> {
-        if let Data::Move(move_object) = &object.native.data {
+        let Some(native) = object.state.native() else {
+            return Err(MoveObjectDowncastError);
+        };
+
+        if let Data::Move(move_object) = &native.data {
             Ok(Self {
                 super_: object.clone(),
                 native: move_object.clone(),


### PR DESCRIPTION
## Description 

WIP 
When we fetch an object, if we receive "null" we do not know if it:
1. truly does not exist
2. is deletedOrWrapped
3. outside the consistent read range the graphql's backing store supports

With pruning, we can't really answer 1, but we can provide some info on 2. and 3. This PR is 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
