### PR TITLE
[Bridge/Move]  add http_rest_url for committee and harden encoding logic

### DIFF
--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -213,8 +213,11 @@ module bridge::bridge {
         let target_chain = message::token_target_chain(&token_payload);
         // ensure target chain is matches self.chain_id
         assert!(target_chain == inner.chain_id, EUnexpectedChainID);
+
         // Ensure route is valid
+        // TODO: add unit tests
         assert!(chain_ids::is_valid_route(source_chain, target_chain), EInvalidBridgeRoute);
+
         // get owner address
         let owner = address::from_bytes(message::token_target_address(&token_payload));
         // check token type

--- a/crates/sui-framework/packages/bridge/sources/committee.move
+++ b/crates/sui-framework/packages/bridge/sources/committee.move
@@ -38,6 +38,9 @@ module bridge::committee {
         bridge_pubkey_bytes: vector<u8>,
         /// Voting power
         voting_power: u64,
+        /// The HTTP REST URL the member's node listens to
+        /// it looks like b'https://127.0.0.1:9191'
+        http_rest_url: vector<u8>,
         /// If this member is blocklisted
         blocklisted: bool,
     }
@@ -53,6 +56,7 @@ module bridge::committee {
             sui_address: address::from_u256(1),
             bridge_pubkey_bytes,
             voting_power: 10,
+            http_rest_url: b"https://127.0.0.1:9191",
             blocklisted: false
         });
 
@@ -61,6 +65,7 @@ module bridge::committee {
             sui_address: address::from_u256(2),
             bridge_pubkey_bytes,
             voting_power: 10,
+            http_rest_url: b"https://127.0.0.1:9192",
             blocklisted: false
         });
 
@@ -186,6 +191,7 @@ module bridge::committee {
             sui_address: address::from_u256(1),
             bridge_pubkey_bytes,
             voting_power: 100,
+            http_rest_url: b"https://127.0.0.1:9191",
             blocklisted: false
         });
 
@@ -194,6 +200,7 @@ module bridge::committee {
             sui_address: address::from_u256(2),
             bridge_pubkey_bytes,
             voting_power: 100,
+            http_rest_url: b"https://127.0.0.1:9192",
             blocklisted: false
         });
 


### PR DESCRIPTION
## Description 

add http_rest_url for committee and harden encoding logic

## Test Plan 

unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
add http_rest_url for committee and harden encoding logic
