### PR TITLE
[GraphQL/Checkpoint][EASY] Remove get_earliest_complete_checkpoint

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -47,9 +47,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_checkpoint_by_sequence_number(
         sequence_number: i64,
     ) -> checkpoints::BoxedQuery<'static, DB>;
-    /// This gets the earliest checkpoint for which we can satisfy all queries
-    /// related to that checkpoint.
-    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
     fn multi_get_txs(

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -95,13 +95,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
             .into_boxed()
     }
 
-    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
-        checkpoints::dsl::checkpoints
-            .order_by(checkpoints::dsl::sequence_number.asc())
-            .limit(1)
-            .into_boxed()
-    }
-
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, Pg> {
         display::dsl::display
             .filter(display::dsl::object_type.eq(object_type))

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -55,28 +55,19 @@ impl AuthenticatorStateUpdateTransaction {
     ) -> Result<Connection<String, ActiveJwk>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
-        let total = self.0.new_active_jwks.len();
-        let mut lo = page.after().map_or(0, |a| *a + 1);
-        let mut hi = page.before().map_or(total, |b| *b);
-
         let mut connection = Connection::new(false, false);
-        if hi <= lo {
+        let Some((prev, next, cs)) = page.select(self.0.new_active_jwks.len()) else {
             return Ok(connection);
-        } else if (hi - lo) > page.limit() {
-            if page.is_from_front() {
-                hi = lo + page.limit();
-            } else {
-                lo = hi - page.limit();
-            }
-        }
+        };
 
-        connection.has_previous_page = 0 < lo;
-        connection.has_next_page = hi < total;
+        connection.has_previous_page = prev;
+        connection.has_next_page = next;
 
-        for idx in lo..hi {
-            let active_jwk = ActiveJwk(self.0.new_active_jwks[idx].clone());
-            let cursor = Cursor::new(idx).encode_cursor();
-            connection.edges.push(Edge::new(cursor, active_jwk));
+        for c in cs {
+            let active_jwk = ActiveJwk(self.0.new_active_jwks[*c].clone());
+            connection
+                .edges
+                .push(Edge::new(c.encode_cursor(), active_jwk));
         }
 
         Ok(connection)


### PR DESCRIPTION
## Description

We interrupt the scheduled cursor framework PRs to do some clean-ups.

We no longer need this function with the introduction of the new implementation for `availableRange`.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485