### PR TITLE
[GraphQL/DB][EASY] (Re)move conversion to/from SuiAddress

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -47,9 +47,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_checkpoint_by_sequence_number(
         sequence_number: i64,
     ) -> checkpoints::BoxedQuery<'static, DB>;
-    /// This gets the earliest checkpoint for which we can satisfy all queries
-    /// related to that checkpoint.
-    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
     fn multi_get_txs(

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -95,13 +95,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
             .into_boxed()
     }
 
-    fn get_earliest_complete_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
-        checkpoints::dsl::checkpoints
-            .order_by(checkpoints::dsl::sequence_number.asc())
-            .limit(1)
-            .into_boxed()
-    }
-
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, Pg> {
         display::dsl::display
             .filter(display::dsl::object_type.eq(object_type))

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -43,7 +43,9 @@ pub(crate) struct GasEffects {
 impl GasInput {
     /// Address of the owner of the gas object(s) used
     async fn gas_sponsor(&self) -> Option<Address> {
-        Some(Address::from(SuiAddress::from(self.owner)))
+        Some(Address {
+            address: SuiAddress::from(self.owner),
+        })
     }
 
     /// Objects used to pay for a transaction's execution and storage

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use async_graphql::*;
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
-use sui_types::base_types::ObjectID;
+use sui_types::base_types::{ObjectID, SuiAddress as NativeSuiAddress};
 use thiserror::Error;
 
 const SUI_ADDRESS_LENGTH: usize = 32;
@@ -96,6 +96,12 @@ impl From<AccountAddress> for SuiAddress {
 impl From<ObjectID> for SuiAddress {
     fn from(value: ObjectID) -> Self {
         SuiAddress(value.into_bytes())
+    }
+}
+
+impl From<NativeSuiAddress> for SuiAddress {
+    fn from(value: NativeSuiAddress) -> Self {
+        SuiAddress(value.to_inner())
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -55,28 +55,19 @@ impl AuthenticatorStateUpdateTransaction {
     ) -> Result<Connection<String, ActiveJwk>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
-        let total = self.0.new_active_jwks.len();
-        let mut lo = page.after().map_or(0, |a| *a + 1);
-        let mut hi = page.before().map_or(total, |b| *b);
-
         let mut connection = Connection::new(false, false);
-        if hi <= lo {
+        let Some((prev, next, cs)) = page.select(self.0.new_active_jwks.len()) else {
             return Ok(connection);
-        } else if (hi - lo) > page.limit() {
-            if page.is_from_front() {
-                hi = lo + page.limit();
-            } else {
-                lo = hi - page.limit();
-            }
-        }
+        };
 
-        connection.has_previous_page = 0 < lo;
-        connection.has_next_page = hi < total;
+        connection.has_previous_page = prev;
+        connection.has_next_page = next;
 
-        for idx in lo..hi {
-            let active_jwk = ActiveJwk(self.0.new_active_jwks[idx].clone());
-            let cursor = Cursor::new(idx).encode_cursor();
-            connection.edges.push(Edge::new(cursor, active_jwk));
+        for c in cs {
+            let active_jwk = ActiveJwk(self.0.new_active_jwks[*c].clone());
+            connection
+                .edges
+                .push(Edge::new(c.encode_cursor(), active_jwk));
         }
 
         Ok(connection)

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -323,7 +323,9 @@ impl IndexerApiServer for IndexerApiV2 {
         _cursor: Option<ObjectID>,
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
-        let reverse_record_id = self.name_service_config.reverse_record_field_id(address.as_ref());
+        let reverse_record_id = self
+            .name_service_config
+            .reverse_record_field_id(address.as_ref());
 
         let field_reverse_record_object = match self
             .inner

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -323,7 +323,7 @@ impl IndexerApiServer for IndexerApiV2 {
         _cursor: Option<ObjectID>,
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
-        let reverse_record_id = self.name_service_config.reverse_record_field_id(address);
+        let reverse_record_id = self.name_service_config.reverse_record_field_id(address.as_ref());
 
         let field_reverse_record_object = match self
             .inner

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -402,7 +402,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
         with_tracing!(async move {
-            let reverse_record_id = self.name_service_config.reverse_record_field_id(address);
+            let reverse_record_id = self.name_service_config.reverse_record_field_id(address.as_ref());
 
             let field_reverse_record_object =
                 match self.state.get_object(&reverse_record_id).await? {

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -402,7 +402,9 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
         with_tracing!(async move {
-            let reverse_record_id = self.name_service_config.reverse_record_field_id(address.as_ref());
+            let reverse_record_id = self
+                .name_service_config
+                .reverse_record_field_id(address.as_ref());
 
             let field_reverse_record_object =
                 match self.state.get_object(&reverse_record_id).await? {

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -96,11 +96,11 @@ impl NameServiceConfig {
         .unwrap()
     }
 
-    pub fn reverse_record_field_id(&self, address: SuiAddress) -> ObjectID {
+    pub fn reverse_record_field_id(&self, address: &[u8]) -> ObjectID {
         sui_types::dynamic_field::derive_dynamic_field_id(
             self.reverse_registry_id,
             &TypeTag::Address,
-            address.as_ref(),
+            address,
         )
         .unwrap()
     }


### PR DESCRIPTION
## Description

If we need conversion operators to/from `SuiAddress` and `Address`, move them into `sui_address.rs` or `address.rs` as appropriate, but in most cases, we don't need those operations.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485
- #15519