### PR TITLE
[GraphQL/Cursor] Checkpoint querying and pagination

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,36 +1,380 @@
-processed 11 tasks
+processed 12 tasks
 
-task 1 'create-checkpoint'. lines 21-21:
+task 1 'create-checkpoint'. lines 22-22:
 Checkpoint created: 12
 
-task 2 'run-graphql'. lines 23-30:
+task 2 'run-graphql'. lines 24-36:
 Response: {
   "data": {
-    "checkpointConnection": {
-      "nodes": [
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
         {
-          "sequenceNumber": 7
+          "cursor": "Nw",
+          "node": {
+            "sequenceNumber": 7
+          }
         },
         {
-          "sequenceNumber": 8
+          "cursor": "OA",
+          "node": {
+            "sequenceNumber": 8
+          }
         },
         {
-          "sequenceNumber": 9
+          "cursor": "OQ",
+          "node": {
+            "sequenceNumber": 9
+          }
         },
         {
-          "sequenceNumber": 10
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
         }
       ]
     }
   }
 }
 
-task 3 'run-graphql'. lines 32-39:
+task 3 'run-graphql'. lines 38-50:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "Nw",
+          "node": {
+            "sequenceNumber": 7
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 4 'run-graphql'. lines 52-64:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "MA",
+          "node": {
+            "sequenceNumber": 0
+          }
+        },
+        {
+          "cursor": "MQ",
+          "node": {
+            "sequenceNumber": 1
+          }
+        },
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "Mw",
+          "node": {
+            "sequenceNumber": 3
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 5 'run-graphql'. lines 66-78:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "OQ",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
+        },
+        {
+          "cursor": "MTE",
+          "node": {
+            "sequenceNumber": 11
+          }
+        },
+        {
+          "cursor": "MTI",
+          "node": {
+            "sequenceNumber": 12
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 80-92:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "Mw",
+          "node": {
+            "sequenceNumber": 3
+          }
+        },
+        {
+          "cursor": "NA",
+          "node": {
+            "sequenceNumber": 4
+          }
+        },
+        {
+          "cursor": "NQ",
+          "node": {
+            "sequenceNumber": 5
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 94-106:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "NA",
+          "node": {
+            "sequenceNumber": 4
+          }
+        },
+        {
+          "cursor": "NQ",
+          "node": {
+            "sequenceNumber": 5
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 8 'run-graphql'. lines 108-120:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "MA",
+          "node": {
+            "sequenceNumber": 0
+          }
+        },
+        {
+          "cursor": "MQ",
+          "node": {
+            "sequenceNumber": 1
+          }
+        },
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "Mw",
+          "node": {
+            "sequenceNumber": 3
+          }
+        },
+        {
+          "cursor": "NA",
+          "node": {
+            "sequenceNumber": 4
+          }
+        },
+        {
+          "cursor": "NQ",
+          "node": {
+            "sequenceNumber": 5
+          }
+        },
+        {
+          "cursor": "Ng",
+          "node": {
+            "sequenceNumber": 6
+          }
+        },
+        {
+          "cursor": "Nw",
+          "node": {
+            "sequenceNumber": 7
+          }
+        },
+        {
+          "cursor": "OA",
+          "node": {
+            "sequenceNumber": 8
+          }
+        },
+        {
+          "cursor": "OQ",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
+        },
+        {
+          "cursor": "MTE",
+          "node": {
+            "sequenceNumber": 11
+          }
+        },
+        {
+          "cursor": "MTI",
+          "node": {
+            "sequenceNumber": 12
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 122-134:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "MA",
+          "node": {
+            "sequenceNumber": 0
+          }
+        },
+        {
+          "cursor": "MQ",
+          "node": {
+            "sequenceNumber": 1
+          }
+        },
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "Mw",
+          "node": {
+            "sequenceNumber": 3
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 136-148:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "OQ",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
+        },
+        {
+          "cursor": "MTE",
+          "node": {
+            "sequenceNumber": 11
+          }
+        },
+        {
+          "cursor": "MTI",
+          "node": {
+            "sequenceNumber": 12
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 150-162:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "'first' can only be used with 'after",
+      "message": "'first' and 'last' must not be used together",
       "locations": [
         {
           "line": 2,
@@ -38,192 +382,11 @@ Response: {
         }
       ],
       "path": [
-        "checkpointConnection"
+        "checkpoints"
       ],
       "extensions": {
         "code": "BAD_USER_INPUT"
       }
     }
   ]
-}
-
-task 4 'run-graphql'. lines 41-48:
-Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": "'first' can only be used with 'after",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "checkpointConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
-}
-
-task 5 'run-graphql'. lines 50-57:
-Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": "'last' can only be used with 'before'",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "checkpointConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
-}
-
-task 6 'run-graphql'. lines 59-66:
-Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
-        {
-          "sequenceNumber": 2
-        },
-        {
-          "sequenceNumber": 3
-        },
-        {
-          "sequenceNumber": 4
-        },
-        {
-          "sequenceNumber": 5
-        }
-      ]
-    }
-  }
-}
-
-task 7 'run-graphql'. lines 68-75:
-Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": "'last' can only be used with 'before'",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "checkpointConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
-}
-
-task 8 'run-graphql'. lines 77-84:
-Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
-        {
-          "sequenceNumber": 0
-        },
-        {
-          "sequenceNumber": 1
-        },
-        {
-          "sequenceNumber": 2
-        },
-        {
-          "sequenceNumber": 3
-        },
-        {
-          "sequenceNumber": 4
-        },
-        {
-          "sequenceNumber": 5
-        },
-        {
-          "sequenceNumber": 6
-        },
-        {
-          "sequenceNumber": 7
-        },
-        {
-          "sequenceNumber": 8
-        },
-        {
-          "sequenceNumber": 9
-        },
-        {
-          "sequenceNumber": 10
-        },
-        {
-          "sequenceNumber": 11
-        },
-        {
-          "sequenceNumber": 12
-        }
-      ]
-    }
-  }
-}
-
-task 9 'run-graphql'. lines 87-94:
-Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
-        {
-          "sequenceNumber": 0
-        },
-        {
-          "sequenceNumber": 1
-        },
-        {
-          "sequenceNumber": 2
-        },
-        {
-          "sequenceNumber": 3
-        }
-      ]
-    }
-  }
-}
-
-task 10 'run-graphql'. lines 97-104:
-Response: {
-  "data": {
-    "checkpointConnection": {
-      "nodes": [
-        {
-          "sequenceNumber": 9
-        },
-        {
-          "sequenceNumber": 10
-        },
-        {
-          "sequenceNumber": 11
-        },
-        {
-          "sequenceNumber": 12
-        }
-      ]
-    }
-  }
 }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -6,99 +6,157 @@
 // Currently implemented only for items ordered in ascending order by `sequenceNumber`.
 
 // Assuming checkpoints 0 through 12
-// first: 4, after: "6" -> checkpoints 7, 8, 9, 10
-// first: 4, after: "6", before: "8" -> checkpoints 7
-// first: 4, before: "6" -> error
-// last: 4, after: "6" -> error
-// last: 4, before: "6" -> checkpoints 2, 3, 4, 5
-// last: 4, before: "6", after: "3" -> error
-// no first or last -> checkpoints 0, 1, 2, 3
+// first: 4, after: 6 -> checkpoints 7, 8, 9, 10
+// first: 4, after: 6, before: 8 -> checkpoints 7
+// first: 4, before: 6 -> checkpoints 0, 1, 2, 3
+// last: 4, after: 6 -> checkpoints 9, 10, 11, 12
+// last: 4, before: 6 -> checkpoints 2, 3, 4, 5
+// last: 4, after: 3, before: 6 -> checkpoints 4, 5
+// no first or last -> checkpoints 0, 1, ..., 11, 12
 // first: 4 -> checkpoints 0, 1, 2, 3
 // last: 4 -> checkpoints 9, 10, 11, 12
+// first: 4, last: 2 -> error
 
 //# init --addresses Test=0x0 --simulator
 
 //# create-checkpoint 12
 
-//# run-graphql
+//# run-graphql --cursors 6
 {
-  checkpointConnection(first: 4, after: "6") {
-    nodes {
-      sequenceNumber
+  checkpoints(first: 4, after: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 6 8
+{
+  checkpoints(first: 4, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 6
+{
+  checkpoints(first: 4, before: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 6
+{
+  checkpoints(last: 4, after: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 6
+{
+  checkpoints(last: 4, before: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 3 6
+{
+  checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
     }
   }
 }
 
 //# run-graphql
 {
-  checkpointConnection(first: 4, after: "6", before: "8") {
-    nodes {
-      sequenceNumber
+  checkpoints {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
     }
   }
 }
 
 //# run-graphql
 {
-  checkpointConnection(first: 4, before: "6") {
-    nodes {
-      sequenceNumber
+  checkpoints(first: 4) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
     }
   }
 }
 
 //# run-graphql
 {
-  checkpointConnection(last: 4, after: "6") {
-    nodes {
-      sequenceNumber
+  checkpoints(last: 4) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
     }
   }
 }
 
 //# run-graphql
 {
-  checkpointConnection(last: 4, before: "6") {
-    nodes {
-      sequenceNumber
+  checkpoints(first: 4, last: 2) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
     }
-  }
-}
-
-//# run-graphql
-{
-  checkpointConnection(last: 4, before: "6", after: "3") {
-    nodes {
-      sequenceNumber
-    }
-  }
-}
-
-//# run-graphql
-{
-  checkpointConnection {
-    nodes {
-      sequenceNumber
-    }
-  }
-}
-
-
-//# run-graphql
-{
-  checkpointConnection(first: 4) {
-    nodes {
-      sequenceNumber
-    }
-  }
-}
-
-
-//# run-graphql
-{
-  checkpointConnection(last: 4) {
-    nodes {
-      sequenceNumber
+    edges {
+      cursor
+      node { sequenceNumber }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/datetime/datetime.exp
+++ b/crates/sui-graphql-e2e-tests/tests/datetime/datetime.exp
@@ -36,7 +36,7 @@ Epoch advanced: 1
 task 21 'run-graphql'. lines 55-66:
 Response: {
   "data": {
-    "checkpointConnection": {
+    "checkpoints": {
       "nodes": [
         {
           "sequenceNumber": 2,

--- a/crates/sui-graphql-e2e-tests/tests/datetime/datetime.move
+++ b/crates/sui-graphql-e2e-tests/tests/datetime/datetime.move
@@ -54,7 +54,7 @@
 
 //# run-graphql
 {
-  checkpointConnection(last: 10) {
+  checkpoints(last: 10) {
     nodes {
       sequenceNumber
       timestamp

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -394,7 +394,7 @@
 ####  Use the checkpoint connection to fetch some default amount of checkpoints in an ascending order
 
 ><pre>{
->  checkpointConnection {
+>  checkpoints {
 >    nodes {
 >      digest
 >      sequenceNumber
@@ -419,10 +419,10 @@
 
 ### <a id=262141></a>
 ### First Ten After Checkpoint
-####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that cursor will be opaque
+####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
 
 ><pre>{
->  checkpointConnection(first: 10, after: "11") {
+>  checkpoints(first: 10, after: "MTE=") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -435,7 +435,7 @@
 ####  Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 
 ><pre>{
->  checkpointConnection(last: 20, before: "100") {
+>  checkpoints(last: 20, before: "MTAw") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -559,7 +559,7 @@
 
 ><pre>{
 >  epoch {
->    checkpointConnection {
+>    checkpoints {
 >      nodes {
 >        transactionBlockConnection(first: 10) {
 >          pageInfo {

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/ascending_fetch.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/ascending_fetch.graphql
@@ -1,6 +1,6 @@
 # Use the checkpoint connection to fetch some default amount of checkpoints in an ascending order
 {
-  checkpointConnection {
+  checkpoints {
     nodes {
       digest
       sequenceNumber

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
-# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that cursor will be opaque
+# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
 {
-  checkpointConnection(first: 10, after: "11") {
+  checkpoints(first: 10, after: "MTE=") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
 # Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 {
-  checkpointConnection(last: 20, before: "100") {
+  checkpoints(last: 20, before: "MTAw") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/epoch/with_checkpoint_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/with_checkpoint_connection.graphql
@@ -1,6 +1,6 @@
 {
   epoch {
-    checkpointConnection {
+    checkpoints {
       nodes {
         transactionBlockConnection(first: 10) {
           pageInfo {

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -26,7 +26,7 @@ type ActiveJwk {
 	"""
 	The most recent epoch in which the JWK was validated.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 }
 
 type ActiveJwkConnection {
@@ -113,7 +113,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	Expire JWKs that have a lower epoch than this.
 	"""
-	minEpoch: Epoch!
+	minEpoch: Epoch
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
@@ -127,7 +127,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Epoch of the authenticator state update transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Consensus round of the authenticator state update.
 	"""
@@ -228,7 +228,7 @@ type ChangeEpochTransaction {
 	"""
 	The next (to become) epoch.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	The protocol version in effect in the new epoch.
 	"""
@@ -426,7 +426,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Consensus round of the commit.
 	"""
@@ -627,7 +627,7 @@ type Epoch {
 	"""
 	The epoch's corresponding protocol configuration, including the feature flags and the configuration options
 	"""
-	protocolConfigs: ProtocolConfigs
+	protocolConfigs: ProtocolConfigs!
 	"""
 	SUI set aside to account for objects stored on-chain, at the start of the epoch.
 	This is also used for storage rebates.
@@ -655,7 +655,7 @@ type Epoch {
 	"""
 	The epoch's corresponding checkpoints
 	"""
-	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	The epoch's corresponding transaction blocks
 	"""
@@ -1789,7 +1789,7 @@ A single protocol configuration value.
 """
 type ProtocolConfigAttr {
 	key: String!
-	value: String!
+	value: String
 }
 
 """
@@ -1899,7 +1899,7 @@ type Query {
 	(e.g. `0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
 	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
@@ -1929,7 +1929,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Epoch of the randomness state update transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Randomness round of the update.
 	"""

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -1,13 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::{
-    backend::Backend,
-    helper_types::{AsSelect, SqlTypeOf},
-};
+use diesel::backend::Backend;
 use sui_indexer::{
-    models_v2::epoch::QueryableEpochInfo,
-    schema_v2::{checkpoints, display, epochs, events, objects, transactions},
+    schema_v2::{display, events, objects, transactions},
     types_v2::OwnerType,
 };
 
@@ -34,20 +30,10 @@ pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
     objects::dsl::coin_type,
 >;
 
-pub type QueryableEpochInfoType<DB> = SqlTypeOf<AsSelect<QueryableEpochInfo, DB>>;
-
 pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_tx_by_digest(digest: Vec<u8>) -> transactions::BoxedQuery<'static, DB>;
     fn get_obj(address: Vec<u8>, version: Option<i64>) -> objects::BoxedQuery<'static, DB>;
     fn get_obj_by_type(object_type: String) -> objects::BoxedQuery<'static, DB>;
-    fn get_epoch_info(epoch_id: i64)
-        -> epochs::BoxedQuery<'static, DB, QueryableEpochInfoType<DB>>;
-    fn get_latest_epoch_info() -> epochs::BoxedQuery<'static, DB, QueryableEpochInfoType<DB>>;
-    fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, DB>;
-    fn get_checkpoint_by_sequence_number(
-        sequence_number: i64,
-    ) -> checkpoints::BoxedQuery<'static, DB>;
-    fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, DB>;
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
     fn multi_get_txs(
         cursor: Option<i64>,
@@ -73,12 +59,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
-    fn multi_get_checkpoints(
-        before: Option<i64>,
-        after: Option<i64>,
-        limit: PageLimit,
-        epoch: Option<i64>,
-    ) -> checkpoints::BoxedQuery<'static, DB>;
     fn multi_get_events(
         before: Option<(i64, i64)>,
         after: Option<(i64, i64)>,

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder, QueryableEpochInfoType},
+    db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder},
     db_data_provider::{DbValidationError, PageLimit, TypeFilterError},
 };
 use crate::{
@@ -22,18 +22,15 @@ use diesel::{
 };
 use std::str::FromStr;
 use sui_indexer::{
-    models_v2::epoch::QueryableEpochInfo,
     schema_v2::{
-        checkpoints, display, epochs, events, objects, transactions, tx_calls, tx_changed_objects,
-        tx_input_objects, tx_recipients, tx_senders,
+        display, events, objects, transactions, tx_calls, tx_changed_objects, tx_input_objects,
+        tx_recipients, tx_senders,
     },
     types_v2::OwnerType,
 };
 use sui_types::parse_sui_struct_tag;
 use tap::TapFallible;
 use tracing::{info, warn};
-
-use diesel::SelectableHelper;
 
 pub(crate) const EXPLAIN_COSTING_LOG_TARGET: &str = "gql-explain-costing";
 
@@ -58,40 +55,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         objects::dsl::objects
             .filter(objects::dsl::object_type.eq(object_type))
             .limit(1) // Fetches for a single object and as such has a limit of 1
-            .into_boxed()
-    }
-    fn get_epoch_info(
-        epoch_id: i64,
-    ) -> epochs::BoxedQuery<'static, Pg, QueryableEpochInfoType<Pg>> {
-        epochs::dsl::epochs
-            .filter(epochs::dsl::epoch.eq(epoch_id))
-            .select(QueryableEpochInfo::as_select())
-            .into_boxed()
-    }
-
-    fn get_latest_epoch_info() -> epochs::BoxedQuery<'static, Pg, QueryableEpochInfoType<Pg>> {
-        epochs::dsl::epochs
-            .order_by(epochs::dsl::epoch.desc())
-            .limit(1)
-            .select(QueryableEpochInfo::as_select())
-            .into_boxed()
-    }
-    fn get_checkpoint_by_digest(digest: Vec<u8>) -> checkpoints::BoxedQuery<'static, Pg> {
-        checkpoints::dsl::checkpoints
-            .filter(checkpoints::dsl::checkpoint_digest.eq(digest))
-            .into_boxed()
-    }
-    fn get_checkpoint_by_sequence_number(
-        sequence_number: i64,
-    ) -> checkpoints::BoxedQuery<'static, Pg> {
-        checkpoints::dsl::checkpoints
-            .filter(checkpoints::dsl::sequence_number.eq(sequence_number))
-            .into_boxed()
-    }
-    fn get_latest_checkpoint() -> checkpoints::BoxedQuery<'static, Pg> {
-        checkpoints::dsl::checkpoints
-            .order_by(checkpoints::dsl::sequence_number.desc())
-            .limit(1)
             .into_boxed()
     }
 
@@ -385,21 +348,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         let query = PgQueryBuilder::multi_get_balances(address);
         query.filter(objects::dsl::coin_type.eq(coin_type))
     }
-    fn multi_get_checkpoints(
-        before: Option<i64>,
-        after: Option<i64>,
-        limit: PageLimit,
-        epoch: Option<i64>,
-    ) -> checkpoints::BoxedQuery<'static, Pg> {
-        let mut query = order_checkpoints(before, after, &limit);
-        query = query.limit(limit.value() + 1);
-
-        if let Some(epoch) = epoch {
-            query = query.filter(checkpoints::dsl::epoch.eq(epoch));
-        }
-
-        query
-    }
     fn multi_get_events(
         before: Option<(i64, i64)>,
         after: Option<(i64, i64)>,
@@ -685,29 +633,6 @@ fn order_objs(
                 query = query.filter(objects::dsl::object_id.lt(before));
             }
             query = query.order(objects::dsl::object_id.desc());
-        }
-    }
-    query
-}
-
-fn order_checkpoints(
-    before: Option<i64>,
-    after: Option<i64>,
-    limit: &PageLimit,
-) -> checkpoints::BoxedQuery<'static, Pg> {
-    let mut query = checkpoints::dsl::checkpoints.into_boxed();
-    match limit {
-        PageLimit::First(_) => {
-            if let Some(after) = after {
-                query = query.filter(checkpoints::dsl::sequence_number.gt(after));
-            }
-            query = query.order(checkpoints::dsl::sequence_number.asc());
-        }
-        PageLimit::Last(_) => {
-            if let Some(before) = before {
-                query = query.filter(checkpoints::dsl::sequence_number.lt(before));
-            }
-            query = query.order(checkpoints::dsl::sequence_number.desc());
         }
     }
     query

--- a/crates/sui-graphql-rpc/src/data.rs
+++ b/crates/sui-graphql-rpc/src/data.rs
@@ -15,6 +15,10 @@ use crate::error::Error;
 /// Database Backend in use -- abstracting a specific implementation.
 pub(crate) type Db = pg::PgManager_;
 
+/// Helper types to access associated types on `Db`.
+pub(crate) type DbConnection = <Db as QueryExecutor>::Connection;
+pub(crate) type DbBackend = <DbConnection as Connection>::Backend;
+
 /// A generic boxed query (compatible with the return type of `into_boxed` on diesel's table DSL).
 ///
 /// - ST is the SqlType of the rows selected.

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -74,8 +74,6 @@ pub enum Error {
     DomainParse(#[from] DomainParseError),
     #[error(transparent)]
     DbValidation(#[from] DbValidationError),
-    #[error("Provide one of digest or sequence_number, not both")]
-    InvalidCheckpointQuery,
     #[error("Invalid coin type: {0}")]
     InvalidCoinType(String),
     #[error("String is not valid base58: {0}")]
@@ -112,7 +110,6 @@ impl ErrorExtensions for Error {
             | Error::ProtocolVersionUnsupported { .. }
             | Error::DomainParse(_)
             | Error::DbValidation(_)
-            | Error::InvalidCheckpointQuery
             | Error::CursorNoBeforeAfter
             | Error::CursorNoFirstLast
             | Error::_CursorNoReversePagination

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -365,11 +365,13 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader, Limits::default());
             let mut cfg = ServiceConfig::default();
             cfg.limits.request_timeout_ms = timeout.as_millis() as u64;
 
+            let db = Db::new(reader.clone(), cfg.limits);
+            let pg_conn_pool = PgManager::new(reader, cfg.limits);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+                .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(cfg)
                 .extension(TimedExecuteExt {
@@ -409,17 +411,19 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader, Limits::default());
-            let server_config = ServiceConfig {
+            let service_config = ServiceConfig {
                 limits: Limits {
                     max_query_depth: depth,
                     ..Default::default()
                 },
                 ..Default::default()
             };
+            let db = Db::new(reader.clone(), service_config.limits);
+            let pg_conn_pool = PgManager::new(reader, service_config.limits);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+                .context_data(db)
                 .context_data(pg_conn_pool)
-                .context_data(server_config)
+                .context_data(service_config)
                 .extension(QueryLimitsChecker::default())
                 .build_schema();
             schema.execute(query).await
@@ -476,17 +480,19 @@ pub mod tests {
         ) -> Response {
             let db_url: String = connection_config.db_url.clone();
             let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-            let pg_conn_pool = PgManager::new(reader, Limits::default());
-            let server_config = ServiceConfig {
+            let service_config = ServiceConfig {
                 limits: Limits {
                     max_query_nodes: nodes,
                     ..Default::default()
                 },
                 ..Default::default()
             };
+            let db = Db::new(reader.clone(), service_config.limits);
+            let pg_conn_pool = PgManager::new(reader, service_config.limits);
             let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+                .context_data(db)
                 .context_data(pg_conn_pool)
-                .context_data(server_config)
+                .context_data(service_config)
                 .extension(QueryLimitsChecker::default())
                 .build_schema();
             schema.execute(query).await
@@ -541,15 +547,21 @@ pub mod tests {
         sim.create_checkpoint();
 
         let connection_config = ConnectionConfig::ci_integration_test_cfg();
-        let limits = Limits {
-            default_page_size: 1,
+        let service_config = ServiceConfig {
+            limits: Limits {
+                default_page_size: 1,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-        let pg_conn_pool = PgManager::new(reader, limits);
+        let db = Db::new(reader.clone(), service_config.limits);
+        let pg_conn_pool = PgManager::new(reader, service_config.limits);
         let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+            .context_data(db)
             .context_data(pg_conn_pool)
+            .context_data(service_config)
             .build_schema();
 
         let resp = schema
@@ -631,10 +643,12 @@ pub mod tests {
 
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
+        let db = Db::new(reader.clone(), service_config.limits);
         let pg_conn_pool = PgManager::new(reader, service_config.limits);
         let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
-            .context_data(service_config)
+            .context_data(db)
             .context_data(pg_conn_pool)
+            .context_data(service_config)
             .context_data(metrics)
             .extension(QueryLimitsChecker::default())
             .build_schema();

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -553,11 +553,11 @@ pub mod tests {
             .build_schema();
 
         let resp = schema
-            .execute("{ checkpointConnection { nodes { sequenceNumber } } }")
+            .execute("{ checkpoints { nodes { sequenceNumber } } }")
             .await;
         let data = resp.data.clone().into_json().unwrap();
         let checkpoints = data
-            .get("checkpointConnection")
+            .get("checkpoints")
             .unwrap()
             .get("nodes")
             .unwrap()
@@ -570,11 +570,11 @@ pub mod tests {
         );
 
         let resp = schema
-            .execute("{ checkpointConnection(first: 2) { nodes { sequenceNumber } } }")
+            .execute("{ checkpoints(first: 2) { nodes { sequenceNumber } } }")
             .await;
         let data = resp.data.clone().into_json().unwrap();
         let checkpoints = data
-            .get("checkpointConnection")
+            .get("checkpoints")
             .unwrap()
             .get("nodes")
             .unwrap()

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::checkpoint::Checkpoint;
-use crate::context_data::db_data_provider::PgManager;
+use super::checkpoint::{Checkpoint, CheckpointId};
 use async_graphql::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -15,15 +14,13 @@ pub(crate) struct AvailableRange {
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_checkpoint(None, Some(self.first))
+        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.first))
             .await
             .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_checkpoint(None, Some(self.last))
+        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.last))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data::{Db, QueryExecutor},
+    error::Error,
+};
+use async_graphql::*;
+use diesel::{ExpressionMethods, QueryDsl};
+use sui_indexer::schema_v2::checkpoints;
+use sui_types::{
+    digests::ChainIdentifier as NativeChainIdentifier, messages_checkpoint::CheckpointDigest,
+};
+
+pub(crate) struct ChainIdentifier;
+
+impl ChainIdentifier {
+    /// Query the Chain Identifier from the DB.
+    pub(crate) async fn query(db: &Db) -> Result<NativeChainIdentifier, Error> {
+        use checkpoints::dsl;
+
+        let digest_bytes = db
+            .first(move || {
+                dsl::checkpoints
+                    .select(dsl::checkpoint_digest)
+                    .order_by(dsl::sequence_number.asc())
+                    .into_boxed()
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch genesis digest: {e}")))?;
+
+        Self::from_bytes(digest_bytes)
+    }
+
+    /// TODO Docs
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Result<NativeChainIdentifier, Error> {
+        let genesis_digest = CheckpointDigest::try_from(bytes)
+            .map_err(|e| Error::Internal(format!("Failed to deserialize genesis digest: {e}")))?;
+        Ok(NativeChainIdentifier::from(genesis_digest))
+    }
+}

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -3,19 +3,28 @@
 
 use super::{
     base64::Base64,
+    cursor::{self, Page, Target},
     date_time::DateTime,
     epoch::Epoch,
     gas::GasCostSummary,
     transaction_block::{TransactionBlock, TransactionBlockFilter},
 };
-use crate::{context_data::db_data_provider::PgManager, error::Error};
-use async_graphql::{connection::Connection, *};
+use crate::{
+    context_data::db_data_provider::PgManager,
+    data::{BoxedQuery, Db, QueryExecutor},
+    error::Error,
+};
+use async_graphql::{
+    connection::{Connection, CursorType, Edge},
+    *,
+};
+use diesel::{ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
-use sui_indexer::models_v2::checkpoints::StoredCheckpoint;
-use sui_types::messages_checkpoint::CheckpointCommitment;
+use sui_indexer::{models_v2::checkpoints::StoredCheckpoint, schema_v2::checkpoints};
+use sui_types::messages_checkpoint::{CheckpointCommitment, CheckpointDigest};
 
 /// Filter either by the digest, or the sequence number, or neither, to get the latest checkpoint.
-#[derive(InputObject)]
+#[derive(Default, InputObject)]
 pub(crate) struct CheckpointId {
     pub digest: Option<String>,
     pub sequence_number: Option<u64>,
@@ -28,13 +37,16 @@ pub(crate) struct Checkpoint {
     pub stored: StoredCheckpoint,
 }
 
+pub(crate) type Cursor = cursor::Cursor<u64>;
+type Query<ST, GB> = BoxedQuery<ST, checkpoints::table, Db, GB>;
+
 #[Object]
 impl Checkpoint {
     /// A 32-byte hash that uniquely identifies the checkpoint contents, encoded in Base58. This
     /// hash can be used to verify checkpoint contents by checking signatures against the committee,
     /// Hashing contents to match digest, and checking that the previous checkpoint digest matches.
-    async fn digest(&self) -> String {
-        Base58::encode(&self.stored.checkpoint_digest)
+    async fn digest(&self) -> Result<String> {
+        Ok(self.digest_impl().extend()?.base58_encode())
     }
 
     /// This checkpoint's position in the total order of finalized checkpoints, agreed upon by
@@ -99,13 +111,9 @@ impl Checkpoint {
 
     /// The epoch this checkpoint is part of.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        let epoch = ctx
-            .data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.stored.epoch as u64)
+        Epoch::query(ctx.data_unchecked(), Some(self.stored.epoch as u64))
             .await
-            .extend()?;
-
-        Ok(Some(epoch))
+            .extend()
     }
 
     /// Transactions in this checkpoint.
@@ -128,8 +136,114 @@ impl Checkpoint {
     }
 }
 
+impl CheckpointId {
+    pub(crate) fn by_seq_num(seq_num: u64) -> Self {
+        CheckpointId {
+            sequence_number: Some(seq_num),
+            digest: None,
+        }
+    }
+}
+
 impl Checkpoint {
     pub(crate) fn sequence_number_impl(&self) -> u64 {
         self.stored.sequence_number as u64
+    }
+
+    pub(crate) fn digest_impl(&self) -> Result<CheckpointDigest, Error> {
+        CheckpointDigest::try_from(self.stored.checkpoint_digest.clone())
+            .map_err(|e| Error::Internal(format!("Failed to deserialize checkpoint digest: {e}")))
+    }
+
+    /// Look up a `Checkpoint` in the database, filtered by either sequence number or digest. If
+    /// both filters are supplied they will both be applied. If none are supplied, the latest
+    /// checkpoint is fetched.
+    pub(crate) async fn query(db: &Db, filter: CheckpointId) -> Result<Option<Self>, Error> {
+        use checkpoints::dsl;
+
+        let digest = filter
+            .digest
+            .map(|d| Base58::decode(&d))
+            .transpose()
+            .map_err(|e| Error::Internal(format!("Bad digest: {e}")))?;
+
+        let seq_num = filter.sequence_number.map(|n| n as i64);
+
+        let stored = db
+            .optional(move || {
+                let mut query = dsl::checkpoints
+                    .order_by(dsl::sequence_number.desc())
+                    .limit(1)
+                    .into_boxed();
+
+                if let Some(digest) = digest.clone() {
+                    query = query.filter(dsl::checkpoint_digest.eq(digest));
+                }
+
+                if let Some(seq_num) = seq_num {
+                    query = query.filter(dsl::sequence_number.eq(seq_num));
+                }
+
+                query
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))?;
+
+        Ok(stored.map(|stored| Checkpoint { stored }))
+    }
+
+    /// Query the database for a `page` of checkpoints. The Page uses checkpoint sequence numbers as
+    /// the cursor, and can optionally be further `filter`-ed by an epoch number (to only return
+    /// checkpoints within that epoch).
+    pub(crate) async fn paginate(
+        db: &Db,
+        page: Page<u64>,
+        filter: Option<u64>,
+    ) -> Result<Connection<String, Checkpoint>, Error> {
+        use checkpoints::dsl;
+
+        let (prev, next, results) = page
+            .paginate_query::<StoredCheckpoint, _, _, _>(db, move || {
+                let mut query = dsl::checkpoints.into_boxed();
+                if let Some(epoch) = filter {
+                    query = query.filter(dsl::epoch.eq(epoch as i64));
+                }
+
+                query
+            })
+            .await?;
+
+        let mut conn = Connection::new(prev, next);
+        for stored in results {
+            let cursor = Cursor::new(stored.cursor()).encode_cursor();
+            conn.edges.push(Edge::new(cursor, Checkpoint { stored }));
+        }
+
+        Ok(conn)
+    }
+}
+
+impl Target<u64> for StoredCheckpoint {
+    type Source = checkpoints::table;
+
+    fn filter_above<ST, GB>(cursor: &u64, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(checkpoints::dsl::sequence_number.ge(*cursor as i64))
+    }
+
+    fn filter_below<ST, GB>(cursor: &u64, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(checkpoints::dsl::sequence_number.le(*cursor as i64))
+    }
+
+    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
+        use checkpoints::dsl;
+        if asc {
+            query.order(dsl::sequence_number)
+        } else {
+            query.order(dsl::sequence_number.desc())
+        }
+    }
+
+    fn cursor(&self) -> u64 {
+        self.sequence_number as u64
     }
 }

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -1,22 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt, ops::Deref};
+use std::{fmt, ops::Deref, vec};
 
 use async_graphql::{
     connection::{CursorType, OpaqueCursor},
     *,
 };
+use diesel::{query_builder::QueryFragment, query_dsl::LoadQuery, QueryDsl, QuerySource};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{config::ServiceConfig, error::Error};
+use crate::{
+    config::ServiceConfig,
+    data::{BoxedQuery, Db, DbBackend, DbConnection, QueryExecutor},
+    error::Error,
+};
 
 /// Wrap the `OpaqueCursor` type to implement Scalar for it.
 pub(crate) struct Cursor<C>(OpaqueCursor<C>);
 
 /// Connection field parameters parsed into a single type that encodes the bounds of a single page
 /// in a paginated response.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Page<C> {
     /// The exclusive lower bound of the page (no bound means start from the beginning of the
     /// data-set).
@@ -35,10 +40,40 @@ pub(crate) struct Page<C> {
 }
 
 /// Whether the page is extracted from the beginning or the end of the range bounded by the cursors.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 enum End {
     Front,
     Back,
+}
+
+/// Results from the database that are pointed to by cursors.
+pub(crate) trait Target<C> {
+    type Source: QuerySource;
+
+    /// Adds a filter to `query` to bound its result to be greater than or equal to `cursor`
+    /// (returning the new query).
+    fn filter_above<ST, GB>(
+        cursor: &C,
+        query: BoxedQuery<ST, Self::Source, Db, GB>,
+    ) -> BoxedQuery<ST, Self::Source, Db, GB>;
+
+    /// Adds a filter to `query` to bound its results to be less than or equal to `cursor`
+    /// (returning the new query).
+    fn filter_below<ST, GB>(
+        cursor: &C,
+        query: BoxedQuery<ST, Self::Source, Db, GB>,
+    ) -> BoxedQuery<ST, Self::Source, Db, GB>;
+
+    /// Adds an `ORDER BY` clause to `query` to order rows according to their cursor values
+    /// (returning the new query). The `asc` parameter controls whether the ordering is ASCending
+    /// (`true`) or descending (`false`).
+    fn order<ST, GB>(
+        asc: bool,
+        query: BoxedQuery<ST, Self::Source, Db, GB>,
+    ) -> BoxedQuery<ST, Self::Source, Db, GB>;
+
+    /// The cursor pointing at this target value.
+    fn cursor(&self) -> C;
 }
 
 impl<C> Cursor<C> {
@@ -135,6 +170,133 @@ impl Page<usize> {
     }
 }
 
+impl<C: Eq + Clone + Send + Sync + 'static> Page<C> {
+    /// Treat the cursors of this page as upper- and lowerbound filters for a database `query`.
+    /// Returns two booleans indicating whether there is a previous or next page in the range,
+    /// followed by an iterator of values in the page, fetched from the database.
+    ///
+    /// The values returned implement `Target<C>`, so are able to compute their own cursors.
+    pub(crate) async fn paginate_query<T, Q, ST, GB>(
+        &self,
+        db: &Db,
+        query: Q,
+    ) -> Result<(bool, bool, impl Iterator<Item = T>), Error>
+    where
+        Q: Fn() -> BoxedQuery<ST, T::Source, Db, GB>,
+        BoxedQuery<ST, T::Source, Db, GB>: LoadQuery<'static, DbConnection, T>,
+        BoxedQuery<ST, T::Source, Db, GB>: QueryFragment<DbBackend>,
+        <T as Target<C>>::Source: Send + 'static,
+        <<T as Target<C>>::Source as QuerySource>::FromClause: Send + 'static,
+        Q: Send + 'static,
+        T: Send + Target<C> + 'static,
+        ST: Send + 'static,
+        GB: Send + 'static,
+    {
+        let page = self.clone();
+        let query = move || {
+            let mut query = query();
+            if let Some(after) = page.after() {
+                query = T::filter_above(after, query);
+            }
+
+            if let Some(before) = page.before() {
+                query = T::filter_below(before, query);
+            }
+
+            // Load extra rows to detect the existence of pages on either side.
+            query = query.limit(page.limit() as i64 + 2);
+            T::order(page.is_from_front(), query)
+        };
+
+        let results: Vec<T> = if self.limit() == 0 {
+            // Avoid the database roundtrip in the degenerate case.
+            vec![]
+        } else {
+            let mut results = db.results(query).await?;
+            if !self.is_from_front() {
+                results.reverse();
+            }
+            results
+        };
+
+        // Detect whether the results imply the existence of a previous or next page.
+        let (prev, next, prefix, suffix) = match (
+            self.after(),
+            results.first(),
+            results.last(),
+            self.before(),
+            self.end,
+        ) {
+            // Results came back empty, despite supposedly including the `after` and `before`
+            // cursors, so the bounds must have been invalid, no matter which end the page was
+            // drawn from.
+            (_, None, _, _, _) | (_, _, None, _, _) => {
+                return Ok((false, false, vec![].into_iter()));
+            }
+
+            // Page drawn from the front, and the cursor for the first element does not match
+            // `after`. This implies the bound was invalid, so we return an empty result.
+            (Some(a), Some(f), _, _, End::Front) if f.cursor() != *a => {
+                return Ok((false, false, vec![].into_iter()));
+            }
+
+            // Similar to above case, but for back of results.
+            (_, _, Some(l), Some(b), End::Back) if l.cursor() != *b => {
+                return Ok((false, false, vec![].into_iter()));
+            }
+
+            // From here onwards, we know that the results are non-empty and if a cursor was
+            // supplied on the end the page is being drawn from, it was found in the results
+            // (implying a page follows in that direction).
+
+            // If both cursors are provided, and match both edges of the results, then we are in a
+            // special case where the limit, or the end of the page being drawn from do not matter,
+            // because the subsequence defined by the cursors is smaller than the limit.
+            (Some(a), Some(f), Some(l), Some(b), _) if f.cursor() == *a && l.cursor() == *b => {
+                (true, true, 1, 1)
+            }
+
+            // From here onwards, to detect whether there is a page on the other side than the page
+            // is being drawn from, it is enough to check the length of the results.
+            (after, _, _, _, End::Front) => {
+                let has_previous_page = after.is_some();
+                let prefix = has_previous_page as usize;
+                let suffix = results.len() - results.len().min(self.limit() + prefix);
+                let has_next_page = suffix > 0;
+
+                (has_previous_page, has_next_page, prefix, suffix)
+            }
+
+            (_, _, _, before, End::Back) => {
+                let has_next_page = before.is_some();
+                let suffix = has_next_page as usize;
+                let prefix = results.len() - results.len().min(self.limit() + suffix);
+                let has_previous_page = prefix > 0;
+
+                (has_previous_page, has_next_page, prefix, suffix)
+            }
+        };
+
+        // If after trimming, we're going to return no elements, then forget whether there's a
+        // previous or next page, because there will be no start or end cursor for this page to
+        // anchor on.
+        if results.len() == prefix + suffix {
+            return Ok((false, false, vec![].into_iter()));
+        }
+
+        // We finally made it -- trim the prefix and suffix rows from the result and send it!
+        let mut results = results.into_iter();
+        if prefix > 0 {
+            results.nth(prefix - 1);
+        }
+        if suffix > 0 {
+            results.nth_back(suffix - 1);
+        }
+
+        Ok((prev, next, results))
+    }
+}
+
 #[Scalar(name = "String", visible = false)]
 impl<C> ScalarType for Cursor<C>
 where
@@ -187,6 +349,12 @@ impl<C> Deref for Cursor<C> {
 impl<C: fmt::Debug> fmt::Debug for Cursor<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", *self.0)
+    }
+}
+
+impl<C: Clone> Clone for Cursor<C> {
+    fn clone(&self) -> Self {
+        Cursor::new(self.0 .0.clone())
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod balance;
 pub(crate) mod balance_change;
 pub(crate) mod base64;
 pub(crate) mod big_int;
+pub(crate) mod chain_identifier;
 pub(crate) mod checkpoint;
 pub(crate) mod coin;
 pub(crate) mod coin_metadata;

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -2,50 +2,122 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
+use diesel::{ExpressionMethods, QueryDsl};
+use sui_indexer::schema_v2::{checkpoints, epochs};
+use sui_protocol_config::{ProtocolConfig as NativeProtocolConfig, ProtocolVersion};
+
+use crate::{
+    data::{Db, QueryExecutor},
+    error::Error,
+    types::chain_identifier::ChainIdentifier,
+};
 
 /// A single protocol configuration value.
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct ProtocolConfigAttr {
     pub key: String,
-    pub value: String,
+    pub value: Option<String>,
 }
 
 /// Whether or not a single feature is enabled in the protocol config.
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+#[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct ProtocolConfigFeatureFlag {
     pub key: String,
     pub value: bool,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ProtocolConfigs {
+    native: NativeProtocolConfig,
+}
+
 /// Constants that control how the chain operates.
 ///
 /// These can only change during protocol upgrades which happen on epoch boundaries.
-#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
-#[graphql(complex)]
-pub(crate) struct ProtocolConfigs {
+#[Object]
+impl ProtocolConfigs {
     /// The protocol is not required to change on every epoch boundary, so the protocol version
     /// tracks which change to the protocol these configs are from.
-    pub protocol_version: u64,
+    async fn protocol_version(&self) -> u64 {
+        self.native.version.as_u64()
+    }
 
     /// List all available feature flags and their values.  Feature flags are a form of boolean
     /// configuration that are usually used to gate features while they are in development.  Once a
     /// flag has been enabled, it is rare for it to be disabled.
-    pub feature_flags: Vec<ProtocolConfigFeatureFlag>,
+    async fn feature_flags(&self) -> Vec<ProtocolConfigFeatureFlag> {
+        self.native
+            .feature_map()
+            .into_iter()
+            .map(|(key, value)| ProtocolConfigFeatureFlag { key, value })
+            .collect()
+    }
 
     /// List all available configurations and their values.  These configurations can take any value
     /// (but they will all be represented in string form), and do not include feature flags.
-    pub configs: Vec<ProtocolConfigAttr>,
-}
+    async fn configs(&self) -> Vec<ProtocolConfigAttr> {
+        self.native
+            .attr_map()
+            .into_iter()
+            .map(|(key, value)| ProtocolConfigAttr {
+                key,
+                value: value.map(|v| v.to_string()),
+            })
+            .collect()
+    }
 
-#[ComplexObject]
-impl ProtocolConfigs {
     /// Query for the value of the configuration with name `key`.
-    async fn config(&self, key: String) -> Option<&ProtocolConfigAttr> {
-        self.configs.iter().find(|config| config.key == key)
+    async fn config(&self, key: String) -> Option<ProtocolConfigAttr> {
+        self.native
+            .attr_map()
+            .get(&key)
+            .map(|value| ProtocolConfigAttr {
+                key,
+                value: value.as_ref().map(|v| v.to_string()),
+            })
     }
 
     /// Query for the state of the feature flag with name `key`.
-    async fn feature_flag(&self, key: String) -> Option<&ProtocolConfigFeatureFlag> {
-        self.feature_flags.iter().find(|config| config.key == key)
+    async fn feature_flag(&self, key: String) -> Option<ProtocolConfigFeatureFlag> {
+        self.native
+            .feature_map()
+            .get(&key)
+            .map(|value| ProtocolConfigFeatureFlag { key, value: *value })
+    }
+}
+
+impl ProtocolConfigs {
+    pub(crate) async fn query(db: &Db, protocol_version: Option<u64>) -> Result<Self, Error> {
+        use checkpoints::dsl as c;
+        use epochs::dsl as e;
+
+        let (latest_version, digest_bytes): (i64, Option<Vec<u8>>) = db
+            .first(move || {
+                e::epochs
+                    .select((
+                        e::protocol_version,
+                        c::checkpoints
+                            .select(c::checkpoint_digest)
+                            .filter(c::sequence_number.eq(0))
+                            .single_value(),
+                    ))
+                    .order_by(e::epoch.desc())
+                    .into_boxed()
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch system details: {e}")))?;
+
+        let native = NativeProtocolConfig::get_for_version_if_supported(
+            protocol_version.unwrap_or(latest_version as u64).into(),
+            ChainIdentifier::from_bytes(digest_bytes.unwrap_or_default())?.chain(),
+        )
+        .ok_or_else(|| {
+            Error::ProtocolVersionUnsupported(
+                ProtocolVersion::MIN.as_u64(),
+                ProtocolVersion::MAX.as_u64(),
+            )
+        })?;
+
+        Ok(ProtocolConfigs { native })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -10,7 +10,7 @@ use sui_types::{
     },
 };
 
-use crate::{context_data::db_data_provider::PgManager, error::Error};
+use crate::error::Error;
 
 use super::{
     address::Address, base64::Base64, epoch::Epoch, gas::GasInput, sui_address::SuiAddress,
@@ -117,12 +117,7 @@ impl TransactionBlock {
             return Ok(None);
         };
 
-        Ok(Some(
-            ctx.data_unchecked::<PgManager>()
-                .fetch_epoch_strict(*id)
-                .await
-                .extend()?,
-        ))
+        Epoch::query(ctx.data_unchecked(), Some(*id)).await.extend()
     }
 
     /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -11,12 +11,9 @@ use sui_types::{
     transaction::AuthenticatorStateUpdate as NativeAuthenticatorStateUpdateTransaction,
 };
 
-use crate::{
-    context_data::db_data_provider::PgManager,
-    types::{
-        cursor::{Cursor, Page},
-        epoch::Epoch,
-    },
+use crate::types::{
+    cursor::{Cursor, Page},
+    epoch::Epoch,
 };
 
 #[derive(Clone, PartialEq, Eq)]
@@ -32,9 +29,8 @@ struct ActiveJwk(NativeActiveJwk);
 #[Object]
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
-    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.0.epoch)
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
             .await
             .extend()
     }
@@ -112,9 +108,8 @@ impl ActiveJwk {
     }
 
     /// The most recent epoch in which the JWK was validated.
-    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.0.epoch)
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    context_data::db_data_provider::PgManager,
-    types::{date_time::DateTime, epoch::Epoch},
-};
+use crate::types::{date_time::DateTime, epoch::Epoch};
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_types::{
@@ -34,9 +31,8 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 #[Object]
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
-    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.epoch)
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.epoch))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -18,7 +18,6 @@ use sui_types::{
 use crate::types::cursor::{Cursor, Page};
 use crate::types::sui_address::SuiAddress;
 use crate::{
-    context_data::db_data_provider::PgManager,
     error::Error,
     types::{
         big_int::BigInt, date_time::DateTime, epoch::Epoch, move_package::MovePackage,
@@ -103,9 +102,8 @@ impl EndOfEpochTransaction {
 #[Object]
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
-    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.0.epoch)
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
             .await
             .extend()
     }
@@ -194,9 +192,8 @@ impl ChangeEpochTransaction {
 #[Object]
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
-    async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.0.min_epoch)
+    async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    context_data::db_data_provider::PgManager,
-    types::{base64::Base64, epoch::Epoch},
-};
+use crate::types::{base64::Base64, epoch::Epoch};
 use async_graphql::*;
 use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
 
@@ -15,9 +12,8 @@ pub(crate) struct RandomnessStateUpdateTransaction(pub NativeRandomnessStateUpda
 #[Object]
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
-    async fn epoch(&self, ctx: &Context<'_>) -> Result<Epoch> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_epoch_strict(self.0.epoch)
+    async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -30,7 +30,7 @@ type ActiveJwk {
 	"""
 	The most recent epoch in which the JWK was validated.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 }
 
 type ActiveJwkConnection {
@@ -117,7 +117,7 @@ type AuthenticatorStateExpireTransaction {
 	"""
 	Expire JWKs that have a lower epoch than this.
 	"""
-	minEpoch: Epoch!
+	minEpoch: Epoch
 	"""
 	The initial version that the AuthenticatorStateUpdate was shared at.
 	"""
@@ -131,7 +131,7 @@ type AuthenticatorStateUpdateTransaction {
 	"""
 	Epoch of the authenticator state update transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Consensus round of the authenticator state update.
 	"""
@@ -232,7 +232,7 @@ type ChangeEpochTransaction {
 	"""
 	The next (to become) epoch.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	The protocol version in effect in the new epoch.
 	"""
@@ -430,7 +430,7 @@ type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Consensus round of the commit.
 	"""
@@ -631,7 +631,7 @@ type Epoch {
 	"""
 	The epoch's corresponding protocol configuration, including the feature flags and the configuration options
 	"""
-	protocolConfigs: ProtocolConfigs
+	protocolConfigs: ProtocolConfigs!
 	"""
 	SUI set aside to account for objects stored on-chain, at the start of the epoch.
 	This is also used for storage rebates.
@@ -659,7 +659,7 @@ type Epoch {
 	"""
 	The epoch's corresponding checkpoints
 	"""
-	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	The epoch's corresponding transaction blocks
 	"""
@@ -1793,7 +1793,7 @@ A single protocol configuration value.
 """
 type ProtocolConfigAttr {
 	key: String!
-	value: String!
+	value: String
 }
 
 """
@@ -1903,7 +1903,7 @@ type Query {
 	(e.g. `0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	checkpointConnection(first: Int, after: String, last: Int, before: String): CheckpointConnection
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
 	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
@@ -1933,7 +1933,7 @@ type RandomnessStateUpdateTransaction {
 	"""
 	Epoch of the randomness state update transaction.
 	"""
-	epoch: Epoch!
+	epoch: Epoch
 	"""
 	Randomness round of the update.
 	"""


### PR DESCRIPTION
## Description

Introduce a generic function for paginating DB queries, and use it for checkpoint pagination. The generic algorithm fixes handling of `has_previous_page` and supports more combinations of `first`/`after`/`last`/`before` (only combining `first` and `last` is not supported currently, and even this could be permitted as long as we specify that both limits are individually less than the page size).

Adopting the new pagination algorithm for checkpoints also required moving it to the new `QueryExecutor` interface, which had several knock-on implications, and/or moved my through parts of the codebase that needed clean-ups:

- `Epoch`, `ProtocolConfigs`, `Query.availableRange` and `Query.chainIdentifier` were all also moved to the new query interface.
- Querying for the `chainIdentifier` now no longer over-fetches the entire checkpoint just to get the digest -- it only queries for the digest (although once we support DataLoaders we may want to undo this).
- The queries issued as part of creating the `ProtocolConfigs` type have been batched into a single query, to avoid doing multiple sequential round-trips to the database.
- `ProtocolConfigs` has adopted the representation where it is largely represented by its native form.
- `StakedSui`'s computed fields were incorrectly returning `Result<_, Error>` rather than just `Result<_>`.  This means that errors produced in the course of fetching these fields would not be correctly annotated with an error code.
- The `Epoch` fields that are part of transactions have been made nullable to account for transactions that are dry-run (and therefore could mention arbitrary epochs).

## Test Plan

Updated E2E tests related to checkpoint pagination:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- checkpoint_connection_pagination.move
```

(+ all the other E2E tests to cover the other refactorings)

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485
- #15519
- #15520
- #15521
- #15522
- #15523
- #15524
- #15525