### PR TITLE
[GraphQL/Digest] Refactor Digest type for use as Scalar.

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -557,10 +557,11 @@ impl PgManager {
         }
     }
 
-    pub(crate) async fn fetch_tx(&self, digest: &str) -> Result<Option<TransactionBlock>, Error> {
-        let digest = Digest::from_str(digest)?.into_vec();
-
-        self.get_tx(digest)
+    pub(crate) async fn fetch_tx(
+        &self,
+        digest: &Digest,
+    ) -> Result<Option<TransactionBlock>, Error> {
+        self.get_tx(digest.to_vec())
             .await?
             .map(TransactionBlock::try_from)
             .transpose()
@@ -669,7 +670,7 @@ impl PgManager {
             paid_address: None,
             input_object: None,
             changed_object: None,
-            transaction_ids: Some(digests.iter().map(|x| x.to_string()).collect::<Vec<_>>()),
+            transaction_ids: Some(digests.iter().map(|d| Digest::from(*d)).collect()),
         };
         let txs = self
             .multi_get_txs(None, None, None, None, Some(tx_block_filter))

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -76,10 +76,6 @@ pub enum Error {
     DbValidation(#[from] DbValidationError),
     #[error("Invalid coin type: {0}")]
     InvalidCoinType(String),
-    #[error("String is not valid base58: {0}")]
-    InvalidBase58(String),
-    #[error("Invalid digest length: expected {expected}, actual {actual}")]
-    InvalidDigestLength { expected: usize, actual: usize },
     #[error("'before' and 'after' must not be used together")]
     CursorNoBeforeAfter,
     #[error("'first' and 'last' must not be used together")]
@@ -117,8 +113,6 @@ impl ErrorExtensions for Error {
             | Error::InvalidCursor(_)
             | Error::_CursorConnectionFetchFailed(_)
             | Error::MultiGet(_)
-            | Error::InvalidBase58(_)
-            | Error::InvalidDigestLength { .. }
             | Error::Client(_) => {
                 e.set("code", code::BAD_USER_INPUT);
             }

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -5,6 +5,7 @@ use super::{
     base64::Base64,
     cursor::{self, Page, Target},
     date_time::DateTime,
+    digest::Digest,
     epoch::Epoch,
     gas::GasCostSummary,
     transaction_block::{TransactionBlock, TransactionBlockFilter},
@@ -26,7 +27,7 @@ use sui_types::messages_checkpoint::{CheckpointCommitment, CheckpointDigest};
 /// Filter either by the digest, or the sequence number, or neither, to get the latest checkpoint.
 #[derive(Default, InputObject)]
 pub(crate) struct CheckpointId {
-    pub digest: Option<String>,
+    pub digest: Option<Digest>,
     pub sequence_number: Option<u64>,
 }
 
@@ -161,12 +162,7 @@ impl Checkpoint {
     pub(crate) async fn query(db: &Db, filter: CheckpointId) -> Result<Option<Self>, Error> {
         use checkpoints::dsl;
 
-        let digest = filter
-            .digest
-            .map(|d| Base58::decode(&d))
-            .transpose()
-            .map_err(|e| Error::Internal(format!("Bad digest: {e}")))?;
-
+        let digest = filter.digest.map(|d| d.to_vec());
         let seq_num = filter.sequence_number.map(|n| n as i64);
 
         let stored = db

--- a/crates/sui-graphql-rpc/src/types/digest.rs
+++ b/crates/sui-graphql-rpc/src/types/digest.rs
@@ -1,111 +1,68 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::Error;
+use super::string_input::impl_string_input;
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
-use std::fmt;
+use std::{fmt, str::FromStr};
+use sui_types::digests::TransactionDigest;
 
 pub(crate) const BASE58_DIGEST_LENGTH: usize = 32;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Digest([u8; BASE58_DIGEST_LENGTH]);
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Invalid Base58: {0}")]
+    InvalidBase58(String),
+
+    #[error("Expected digest to be {expect}B, but got {actual}B")]
+    BadDigestLength { expect: usize, actual: usize },
+}
+
 impl Digest {
-    pub fn into_vec(self) -> Vec<u8> {
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }
-
-    pub fn from_array(arr: [u8; BASE58_DIGEST_LENGTH]) -> Self {
-        Digest(arr)
-    }
 }
 
-impl TryFrom<Vec<u8>> for Digest {
-    type Error = Error;
+impl_string_input!(Digest);
 
-    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
-        let bytes: [u8; BASE58_DIGEST_LENGTH] = <[u8; BASE58_DIGEST_LENGTH]>::try_from(&bytes[..])
-            .map_err(|_| Error::InvalidDigestLength {
-                expected: BASE58_DIGEST_LENGTH,
-                actual: bytes.len(),
-            })?;
-
-        Ok(Self::from_array(bytes))
-    }
-}
-
-impl TryFrom<&[u8]> for Digest {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes: [u8; BASE58_DIGEST_LENGTH] = <[u8; BASE58_DIGEST_LENGTH]>::try_from(bytes)
-            .map_err(|_| Error::InvalidDigestLength {
-                expected: BASE58_DIGEST_LENGTH,
-                actual: bytes.len(),
-            })?;
-
-        Ok(Self::from_array(bytes))
-    }
-}
-
-impl std::str::FromStr for Digest {
+impl FromStr for Digest {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut result = [0u8; BASE58_DIGEST_LENGTH];
-        result
-            .copy_from_slice(&Base58::decode(s).map_err(|r| Error::InvalidBase58(format!("{r}")))?);
+        let buffer = Base58::decode(s).map_err(|_| Error::InvalidBase58(s.to_string()))?;
+
+        if buffer.len() != BASE58_DIGEST_LENGTH {
+            return Err(Error::BadDigestLength {
+                expect: BASE58_DIGEST_LENGTH,
+                actual: buffer.len(),
+            });
+        }
+
+        result.copy_from_slice(&buffer);
         Ok(Digest(result))
     }
 }
 
-impl std::string::ToString for Digest {
-    fn to_string(&self) -> String {
-        Base58::encode(self.0)
+impl From<TransactionDigest> for Digest {
+    fn from(digest: TransactionDigest) -> Self {
+        Digest(digest.into_inner())
     }
 }
 
-impl fmt::Debug for Digest {
+impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Digest")
-            .field(&Base58::encode(self.0))
-            .finish()
-    }
-}
-
-impl fmt::LowerHex for Digest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-
-        for byte in self.0 {
-            write!(f, "{:02x}", byte)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::UpperHex for Digest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-
-        for byte in self.0 {
-            write!(f, "{:02X}", byte)?;
-        }
-
-        Ok(())
+        write!(f, "{}", Base58::encode(self.0))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
+    use super::Error;
     use super::*;
 
     #[test]
@@ -114,10 +71,27 @@ mod tests {
             183u8, 119, 223, 39, 204, 68, 220, 4, 126, 234, 232, 146, 106, 249, 98, 12, 170, 209,
             98, 203, 243, 77, 154, 225, 177, 216, 169, 101, 51, 116, 79, 223,
         ];
+
         assert_eq!(
             Digest::from_str("DMBdBZnpYR4EeTXzXL8A6BtVafqGjAWGsFZhP2zJYmXU").unwrap(),
             Digest(digest)
         );
-        assert!(Digest::from_str("ILoveBase58").is_err());
+
+        assert!(matches!(
+            Digest::from_str("ILoveBase58").unwrap_err(),
+            Error::InvalidBase58(_),
+        ));
+
+        let long_digest = {
+            let mut bytes = vec![];
+            bytes.extend(digest);
+            bytes.extend(digest);
+            Base58::encode(bytes)
+        };
+
+        assert!(matches!(
+            Digest::from_str(&long_digest).unwrap_err(),
+            Error::BadDigestLength { .. },
+        ))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -9,6 +9,7 @@ use crate::error::Error;
 
 use crate::context_data::db_data_provider::PgManager;
 
+use super::digest::Digest;
 use super::{
     address::Address, base64::Base64, date_time::DateTime, move_module::MoveModule,
     move_value::MoveValue, sui_address::SuiAddress,
@@ -21,7 +22,7 @@ pub(crate) struct Event {
 #[derive(InputObject, Clone)]
 pub(crate) struct EventFilter {
     pub sender: Option<SuiAddress>,
-    pub transaction_digest: Option<String>,
+    pub transaction_digest: Option<Digest>,
     // Enhancement (post-MVP)
     // after_checkpoint
     // before_checkpoint

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod safe_mode;
 pub(crate) mod stake;
 pub(crate) mod stake_subsidy;
 pub(crate) mod storage_fund;
+pub(crate) mod string_input;
 pub(crate) mod sui_address;
 pub(crate) mod suins_registration;
 pub(crate) mod system_parameters;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -159,9 +159,9 @@ impl Object {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<TransactionBlock>> {
-        let digest = self.native.previous_transaction.to_string();
+        let digest = self.native.previous_transaction;
         ctx.data_unchecked::<PgManager>()
-            .fetch_tx(digest.as_str())
+            .fetch_tx(&digest.into())
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -15,6 +15,7 @@ use super::{
     coin::Coin,
     coin_metadata::CoinMetadata,
     cursor::Page,
+    digest::Digest,
     epoch::Epoch,
     event::{Event, EventFilter},
     move_type::MoveType,
@@ -113,7 +114,7 @@ impl Query {
     async fn transaction_block(
         &self,
         ctx: &Context<'_>,
-        digest: String,
+        digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
         ctx.data_unchecked::<PgManager>()
             .fetch_tx(&digest)

--- a/crates/sui-graphql-rpc/src/types/string_input.rs
+++ b/crates/sui-graphql-rpc/src/types/string_input.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Opt-in to an implementation of `ScalarType` for a `$Type` that implements `FromStr`, solely for
+/// use as an input (not an output). The type masquarades as a `String` in the GraphQL schema, to
+/// avoid adding a new scalar.
+macro_rules! impl_string_input {
+    ($Type:ident) => {
+        #[Scalar(name = "String", visible = false)]
+        impl ScalarType for $Type {
+            fn parse(value: Value) -> InputValueResult<Self> {
+                if let Value::String(s) = value {
+                    Ok(Self::from_str(&s)?)
+                } else {
+                    Err(InputValueError::expected_type(value))
+                }
+            }
+
+            fn to_value(&self) -> Value {
+                unimplemented!("String inputs should not be output");
+            }
+        }
+    };
+}
+
+pub(crate) use impl_string_input;

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -13,8 +13,8 @@ use sui_types::{
 use crate::error::Error;
 
 use super::{
-    address::Address, base64::Base64, epoch::Epoch, gas::GasInput, sui_address::SuiAddress,
-    transaction_block_effects::TransactionBlockEffects,
+    address::Address, base64::Base64, digest::Digest, epoch::Epoch, gas::GasInput,
+    sui_address::SuiAddress, transaction_block_effects::TransactionBlockEffects,
     transaction_block_kind::TransactionBlockKind,
 };
 
@@ -53,7 +53,7 @@ pub(crate) struct TransactionBlockFilter {
     pub input_object: Option<SuiAddress>,
     pub changed_object: Option<SuiAddress>,
 
-    pub transaction_ids: Option<Vec<String>>,
+    pub transaction_ids: Option<Vec<Digest>>,
 }
 
 #[Object]


### PR DESCRIPTION
## Description

Create a `impl_string_input` macro that opts a type that implements `FromStr` into being treated as a `ScalarType`, while still appearing as a `String`.

This allows `async-graphql` to handle input validation as part of its own query resolution, which avoids us repeating validation work through-out the codebase.

The `Digest` type is the first type to use the macro (although the pattern is already used by the `Cursor` type), in this PR.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
```

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485
- #15519
- #15520
- #15521
- #15522
- #15523
- #15524
- #15525
- #15526
