### PR TITLE
[GraphQL/Cursor] Refactor Events Pagination

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -41,298 +41,325 @@ gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 
 task 8 'create-checkpoint'. lines 101-101:
 Checkpoint created: 1
 
-task 9 'run-graphql'. lines 103-122:
+task 9 'run-graphql'. lines 103-123:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "2"
+            },
+            "bcs": "AgAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "3"
-          },
-          "bcs": "AwAAAAAAAAA="
+          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "3"
+            },
+            "bcs": "AwAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 10 'run-graphql'. lines 124-143:
+task 10 'run-graphql'. lines 125-145:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "2"
+            },
+            "bcs": "AgAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "3"
-          },
-          "bcs": "AwAAAAAAAAA="
+          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "3"
+            },
+            "bcs": "AwAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 11 'run-graphql'. lines 145-164:
+task 11 'run-graphql'. lines 147-167:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 12 'run-graphql'. lines 166-185:
+task 12 'run-graphql'. lines 169-189:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 13 'run-graphql'. lines 187-206:
+task 13 'run-graphql'. lines 191-211:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 14 'run-graphql'. lines 208-227:
+task 14 'run-graphql'. lines 213-233:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid struct type: 0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<. Got error: unexpected end of tokens",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }
 
-task 15 'run-graphql'. lines 229-248:
+task 15 'run-graphql'. lines 235-255:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid format in '::M1' - if '::' is present, there must be a non-empty string on both sides. Expected format like 'package[::module[::type[<type_params>]]]'",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }
 
-task 16 'run-graphql'. lines 250-269:
+task 16 'run-graphql'. lines 257-277:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid format in '0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::' - if '::' is present, there must be a non-empty string on both sides. Expected format like 'package[::module[::type[<type_params>]]]'",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -100,170 +100,178 @@ module Test::M2 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A Test
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: $Test}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventA"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventA"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB<"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB<"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "::M1"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "::M1"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
@@ -16,10 +16,10 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0
 task 3 'create-checkpoint'. lines 41-41:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 43-62:
+task 4 'run-graphql'. lines 43-60:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {
@@ -41,10 +41,10 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 64-83:
+task 5 'run-graphql'. lines 62-79:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {
@@ -66,28 +66,28 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 85-104:
+task 6 'run-graphql'. lines 81-98:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": []
     }
   }
 }
 
-task 7 'run-graphql'. lines 106-125:
+task 7 'run-graphql'. lines 100-117:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": []
     }
   }
 }
 
-task 8 'run-graphql'. lines 127-146:
+task 8 'run-graphql'. lines 119-136:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
@@ -40,11 +40,9 @@ module Test::M3 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A}
-  ) {
+  events(filter: {sender: "@{A}"}) {
     nodes {
       sendingModule {
         name
@@ -61,11 +59,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A Test
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: $Test}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}"}) {
     nodes {
       sendingModule {
         name
@@ -82,11 +78,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M1"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M1"}) {
     nodes {
       sendingModule {
         name
@@ -103,11 +97,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M2"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M2"}) {
     nodes {
       sendingModule {
         name
@@ -124,11 +116,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M3"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M3"}) {
     nodes {
       sendingModule {
         name

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -21,13 +21,17 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 4 'create-checkpoint'. lines 28-28:
 Checkpoint created: 1
 
-task 5 'run-graphql'. lines 30-50:
+task 5 'run-graphql'. lines 30-54:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "2:0",
+          "cursor": "eyJ0eCI6MiwiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -45,7 +49,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -63,7 +67,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -85,13 +89,17 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 52-72:
+task 6 'run-graphql'. lines 56-80:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -109,7 +117,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -131,13 +139,17 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 74-94:
+task 7 'run-graphql'. lines 82-106:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
       "edges": [
         {
-          "cursor": "2:0",
+          "cursor": "eyJ0eCI6MiwiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -155,7 +167,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -177,13 +189,17 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 96-116:
+task 8 'run-graphql'. lines 108-132:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -201,7 +217,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -29,7 +29,63 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(filter: {sender: "@{A}"}) {
+  events(filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":2,"e":0}
+{
+  events(first: 2 after: "@{cursor_0}", filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":3,"e":1}
+{
+  events(last: 2 before: "@{cursor_0}", filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
     edges {
       cursor
       node {
@@ -51,51 +107,11 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(first: 2 after: "2:0", filter: {sender: "@{A}"}) {
-    edges {
-      cursor
-      node {
-        sendingModule {
-          name
-        }
-        type {
-          repr
-        }
-        sender {
-          address
-        }
-        json
-        bcs
-      }
+  events(last: 2) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
     }
-  }
-}
-
-//# run-graphql
-{
-  eventConnection(last: 2 before: "3:1", filter: {sender: "@{A}"}) {
-    edges {
-      cursor
-      node {
-        sendingModule {
-          name
-        }
-        type {
-          repr
-        }
-        sender {
-          address
-        }
-        json
-        bcs
-      }
-    }
-  }
-}
-
-//# run-graphql
-{
-  eventConnection(last: 2) {
     edges {
       cursor
       node {

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
@@ -267,7 +267,7 @@ Response: {
         }
       ]
     },
-    "eventConnection": {
+    "events": {
       "edges": []
     }
   },
@@ -278,7 +278,7 @@ Response: {
       "depth": 11,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 1431
+      "queryPayload": 1422
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -211,7 +211,7 @@
       }
     }
   }
-  eventConnection(last: 10) { # 10
+  events(last: 10) { # 10
     edges {
       node {
         timestamp

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
@@ -123,7 +123,7 @@ Response: {
 task 7 'run-graphql'. lines 57-68:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.move
@@ -56,7 +56,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(filter: {sender: "@{A}"}) {
+  events(filter: {sender: "@{A}"}) {
     nodes {
       sendingModule {
         name

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -666,8 +666,10 @@
 ### Event Connection
 
 ><pre>{
->  eventConnection(
->    filter: {eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"}
+>  events(
+>    filter: {
+>      eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"
+>    }
 >  ) {
 >    nodes {
 >      sendingModule {
@@ -694,11 +696,14 @@
 ### <a id=524281></a>
 ### Filter By Emitting Package Module And Event Type
 
-><pre>query byEmittingPackageModuleAndEventType {
->  eventConnection(
+><pre>query ByEmittingPackageModuleAndEventType {
+>  events(
 >    first: 1
->    after: "85173:0"
->    filter: {emittingModule: "0x3::sui_system", eventType: "0x3::validator::StakingRequestEvent"}
+>    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+>    filter: {
+>      emittingModule: "0x3::sui_system",
+>      eventType: "0x3::validator::StakingRequestEvent"
+>    }
 >  ) {
 >    pageInfo {
 >      hasNextPage
@@ -724,10 +729,12 @@
 ### <a id=524282></a>
 ### Filter By Sender
 
-><pre>query byTxSender {
->  eventConnection(
+><pre>query ByTxSender {
+>  events(
 >    first: 1
->    filter: {sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"}
+>    filter: {
+>      sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"
+>    }
 >  ) {
 >    pageInfo {
 >      hasNextPage

--- a/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
@@ -1,6 +1,8 @@
 {
-  eventConnection(
-    filter: {eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"}
+  events(
+    filter: {
+      eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"
+    }
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
@@ -1,8 +1,11 @@
-query byEmittingPackageModuleAndEventType {
-  eventConnection(
+query ByEmittingPackageModuleAndEventType {
+  events(
     first: 1
-    after: "85173:0"
-    filter: {emittingModule: "0x3::sui_system", eventType: "0x3::validator::StakingRequestEvent"}
+    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+    filter: {
+      emittingModule: "0x3::sui_system",
+      eventType: "0x3::validator::StakingRequestEvent"
+    }
   ) {
     pageInfo {
       hasNextPage

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
@@ -1,7 +1,9 @@
-query byTxSender {
-  eventConnection(
+query ByTxSender {
+  events(
     first: 1
-    filter: {sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"}
+    filter: {
+      sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"
+    }
   ) {
     pageInfo {
       hasNextPage

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1977,7 +1977,7 @@ type Query {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
-	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -3,13 +3,13 @@
 
 use diesel::backend::Backend;
 use sui_indexer::{
-    schema_v2::{display, events, objects, transactions},
+    schema_v2::{display, objects, transactions},
     types_v2::OwnerType,
 };
 
 use crate::{
     error::Error,
-    types::{event::EventFilter, object::ObjectFilter, transaction_block::TransactionBlockFilter},
+    types::{object::ObjectFilter, transaction_block::TransactionBlockFilter},
 };
 use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
@@ -59,12 +59,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
-    fn multi_get_events(
-        before: Option<(i64, i64)>,
-        after: Option<(i64, i64)>,
-        limit: PageLimit,
-        filter: Option<EventFilter>,
-    ) -> Result<events::BoxedQuery<'static, DB>, Error>;
 }
 
 /// The struct returned for query.explain()

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -68,8 +68,6 @@ pub enum Error {
     DynamicFieldOnAddress,
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),
-    #[error("Invalid filter option or value provided")]
-    InvalidFilter,
     #[error(transparent)]
     DomainParse(#[from] DomainParseError),
     #[error(transparent)]
@@ -102,7 +100,6 @@ impl ErrorExtensions for Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
             Error::InvalidCoinType(_)
             | Error::DynamicFieldOnAddress
-            | Error::InvalidFilter
             | Error::ProtocolVersionUnsupported { .. }
             | Error::DomainParse(_)
             | Error::DbValidation(_)

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -1,24 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::*;
-use sui_indexer::models_v2::events::StoredEvent;
-use sui_indexer::models_v2::transactions::StoredTransaction;
-use sui_types::base_types::SuiAddress as NativeSuiAddress;
-use sui_types::event::Event as NativeEvent;
-use sui_types::{parse_sui_struct_tag, TypeTag};
-
-use crate::error::Error;
-
+use super::cursor::{self, Page, Target};
 use super::digest::Digest;
+use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
     address::Address, base64::Base64, date_time::DateTime, move_module::MoveModule,
     move_value::MoveValue, sui_address::SuiAddress,
+};
+use crate::data::BoxedQuery;
+use crate::{data::Db, error::Error};
+use async_graphql::connection::{Connection, CursorType, Edge};
+use async_graphql::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
+use serde::{Deserialize, Serialize};
+use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
+use sui_indexer::schema_v2::{events, transactions, tx_senders};
+use sui_types::{
+    base_types::SuiAddress as NativeSuiAddress, event::Event as NativeEvent, parse_sui_struct_tag,
+    TypeTag,
 };
 
 pub(crate) struct Event {
     pub stored: StoredEvent,
 }
+
+/// Contents of an Event's cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct EventKey {
+    /// Transaction Sequence Number
+    tx: u64,
+
+    /// Event Sequence Number
+    e: u64,
+}
+
+pub(crate) type Cursor = cursor::Cursor<EventKey>;
+type Query<ST, GB> = BoxedQuery<ST, events::table, Db, GB>;
 
 #[derive(InputObject, Clone, Default)]
 pub(crate) struct EventFilter {
@@ -32,7 +50,7 @@ pub(crate) struct EventFilter {
     /// PTB and emits an event.
     ///
     /// Modules can be filtered by their package, or package::module.
-    pub emitting_module: Option<String>,
+    pub emitting_module: Option<ModuleFilter>,
 
     /// This field is used to specify the type of event emitted.
     ///
@@ -42,7 +60,7 @@ pub(crate) struct EventFilter {
     /// Generic types can be queried by either the generic type name, e.g.
     /// `0x2::coin::Coin`, or by the full type name, such as
     /// `0x2::coin::Coin<0x2::sui::SUI>`.
-    pub event_type: Option<String>,
+    pub event_type: Option<TypeFilter>,
     // Enhancement (post-MVP)
     // pub start_time
     // pub end_time
@@ -103,6 +121,62 @@ impl Event {
 }
 
 impl Event {
+    /// Query the database for a `page` of events. The Page uses a combination of transaction and
+    /// event sequence numbers as the cursor, and can optionally be further `filter`-ed by the
+    /// `EventFilter`.
+    pub(crate) async fn paginate(
+        db: &Db,
+        page: Page<EventKey>,
+        filter: EventFilter,
+    ) -> Result<Connection<String, Event>, Error> {
+        let (prev, next, results) = page
+            .paginate_query::<StoredEvent, _, _, _>(db, move || {
+                let mut query = events::dsl::events.into_boxed();
+
+                // The transactions table doesn't have an index on the senders column, so use
+                // `tx_senders`.
+                if let Some(sender) = &filter.sender {
+                    query = query.filter(
+                        events::dsl::tx_sequence_number.eq_any(
+                            tx_senders::dsl::tx_senders
+                                .select(tx_senders::dsl::tx_sequence_number)
+                                .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
+                        ),
+                    )
+                }
+
+                if let Some(digest) = &filter.transaction_digest {
+                    query = query.filter(
+                        events::dsl::tx_sequence_number.eq_any(
+                            transactions::dsl::transactions
+                                .select(transactions::dsl::tx_sequence_number)
+                                .filter(transactions::dsl::transaction_digest.eq(digest.to_vec())),
+                        ),
+                    )
+                }
+
+                if let Some(module_filter) = &filter.emitting_module {
+                    query = module_filter.apply(query, events::dsl::package, events::dsl::module);
+                }
+
+                if let Some(type_filter) = &filter.event_type {
+                    query = type_filter.apply(query, events::dsl::event_type);
+                }
+
+                query
+            })
+            .await?;
+
+        let mut conn = Connection::new(prev, next);
+
+        for stored in results {
+            let cursor = Cursor::new(stored.cursor()).encode_cursor();
+            conn.edges.push(Edge::new(cursor, Event { stored }));
+        }
+
+        Ok(conn)
+    }
+
     pub(crate) fn try_from_stored_transaction(
         stored_tx: &StoredTransaction,
         idx: usize,
@@ -139,5 +213,45 @@ impl Event {
         Ok(Self {
             stored: stored_event,
         })
+    }
+}
+
+impl Target<EventKey> for StoredEvent {
+    type Source = events::table;
+
+    fn filter_ge<ST, GB>(cursor: &EventKey, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl::{event_sequence_number as event, tx_sequence_number as tx};
+        query.filter(
+            tx.gt(cursor.tx as i64)
+                .or(tx.eq(cursor.tx as i64).and(event.ge(cursor.e as i64))),
+        )
+    }
+
+    fn filter_le<ST, GB>(cursor: &EventKey, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl::{event_sequence_number as event, tx_sequence_number as tx};
+        query.filter(
+            tx.lt(cursor.tx as i64)
+                .or(tx.eq(cursor.tx as i64).and(event.le(cursor.e as i64))),
+        )
+    }
+
+    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl;
+        if asc {
+            query
+                .order_by(dsl::tx_sequence_number.asc())
+                .then_order_by(dsl::event_sequence_number.asc())
+        } else {
+            query
+                .order_by(dsl::tx_sequence_number.desc())
+                .then_order_by(dsl::event_sequence_number.desc())
+        }
+    }
+
+    fn cursor(&self) -> EventKey {
+        EventKey {
+            tx: self.tx_sequence_number as u64,
+            e: self.event_sequence_number as u64,
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -47,6 +47,7 @@ pub(crate) mod system_state_summary;
 pub(crate) mod transaction_block;
 pub(crate) mod transaction_block_effects;
 pub(crate) mod transaction_block_kind;
+pub(crate) mod type_filter;
 pub(crate) mod unchanged_shared_object;
 pub(crate) mod validator;
 pub(crate) mod validator_credentials;

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -17,7 +17,7 @@ use super::{
     cursor::Page,
     digest::Digest,
     epoch::Epoch,
-    event::{Event, EventFilter},
+    event::{self, Event, EventFilter},
     move_type::MoveType,
     object::{Object, ObjectFilter},
     owner::Owner,
@@ -169,17 +169,17 @@ impl Query {
             .extend()
     }
 
-    async fn event_connection(
+    async fn events(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<event::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<event::Cursor>,
         filter: Option<EventFilter>,
-    ) -> Result<Option<Connection<String, Event>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_events(first, after, last, before, filter)
+    ) -> Result<Connection<String, Event>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -1,0 +1,359 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{string_input::impl_string_input, sui_address::SuiAddress};
+use crate::data::{BoxedQuery, Db, DbBackend};
+use async_graphql::*;
+use diesel::{
+    expression::{is_aggregate::No, ValidGrouping},
+    query_builder::QueryFragment,
+    sql_types::{Binary, Text},
+    AppearsOnTable, BoolExpressionMethods, Expression, ExpressionMethods, QueryDsl, QuerySource,
+    TextExpressionMethods,
+};
+use std::str::FromStr;
+use sui_types::{parse_sui_address, parse_sui_module_id, parse_sui_type_tag, TypeTag};
+
+/// GraphQL scalar containing a filter on types.
+#[derive(Clone, Debug)]
+pub(crate) enum TypeFilter {
+    /// Filter the type by the package or module it's from.
+    ByModule(ModuleFilter),
+
+    /// If the type tag has type parameters, treat it as an exact filter on that instantiation,
+    /// otherwise treat it as either a filter on all generic instantiations of the type, or an exact
+    /// match on the type with no type parameters. E.g.
+    ///
+    ///  0x2::coin::Coin
+    ///
+    /// would match both 0x2::coin::Coin and 0x2::coin::Coin<0x2::sui::SUI>.
+    ByType(TypeTag),
+}
+
+/// GraphQL scalar containing a filter on modules.
+#[derive(Clone, Debug)]
+pub(crate) enum ModuleFilter {
+    /// Filter the module by the package it's from.
+    ByPackage(SuiAddress),
+
+    /// Exact match on the module.
+    ByModule(SuiAddress, String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Invalid filter, expected: {0}")]
+    InvalidFormat(&'static str),
+}
+
+impl TypeFilter {
+    /// Modify `query` to apply this filter to `field`, returning the new query.
+    pub(crate) fn apply<E, QS, ST, GB>(
+        &self,
+        query: BoxedQuery<ST, QS, Db, GB>,
+        field: E,
+    ) -> BoxedQuery<ST, QS, Db, GB>
+    where
+        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
+        E: ExpressionMethods + TextExpressionMethods,
+        E: Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        E: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        E: Clone + Send + 'static,
+        QS: QuerySource,
+    {
+        match self {
+            TypeFilter::ByModule(ModuleFilter::ByPackage(p)) => {
+                query.filter(field.like(format!("{p}::%")))
+            }
+
+            TypeFilter::ByModule(ModuleFilter::ByModule(p, m)) => {
+                query.filter(field.like(format!("{p}::{m}::%")))
+            }
+
+            // A type filter without type parameters is interpreted as either an exact match, or a
+            // match for all generic instantiations of the type.
+            TypeFilter::ByType(TypeTag::Struct(tag)) if tag.type_params.is_empty() => {
+                let f1 = field.clone();
+                let f2 = field;
+                let exact = tag.to_canonical_string(/* with_prefix */ true);
+                let prefix = format!("{}<%", tag.to_canonical_display(/* with_prefix */ true));
+                query.filter(f1.eq(exact).or(f2.like(prefix)))
+            }
+
+            TypeFilter::ByType(tag) => {
+                let exact = tag.to_canonical_string(/* with_prefix */ true);
+                query.filter(field.eq(exact))
+            }
+        }
+    }
+}
+
+impl ModuleFilter {
+    /// Modify `query` to apply this filter, treating `package` as the column containing the package
+    /// address and `module` as the module containing the module name.
+    pub(crate) fn apply<P, M, QS, ST, GB>(
+        &self,
+        query: BoxedQuery<ST, QS, Db, GB>,
+        package: P,
+        module: M,
+    ) -> BoxedQuery<ST, QS, Db, GB>
+    where
+        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
+        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DbBackend>,
+        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        P: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        M: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        P: Send + 'static,
+        M: Send + 'static,
+        QS: QuerySource,
+    {
+        match self {
+            ModuleFilter::ByPackage(p) => query.filter(package.eq(p.into_vec())),
+            ModuleFilter::ByModule(p, m) => query
+                .filter(package.eq(p.into_vec()))
+                .filter(module.eq(m.clone())),
+        }
+    }
+}
+
+impl_string_input!(TypeFilter);
+impl_string_input!(ModuleFilter);
+
+impl FromStr for TypeFilter {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        if let Ok(tag) = parse_sui_type_tag(s) {
+            Ok(TypeFilter::ByType(tag))
+        } else if let Ok(filter) = ModuleFilter::from_str(s) {
+            Ok(TypeFilter::ByModule(filter))
+        } else {
+            Err(Error::InvalidFormat(
+                "package[::module[::type[<type_params>]]] or primitive type",
+            ))
+        }
+    }
+}
+
+impl FromStr for ModuleFilter {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        if let Ok(module) = parse_sui_module_id(s) {
+            Ok(ModuleFilter::ByModule(
+                SuiAddress::from(*module.address()),
+                module.name().to_string(),
+            ))
+        } else if let Ok(package) = parse_sui_address(s) {
+            Ok(ModuleFilter::ByPackage(package.into()))
+        } else {
+            Err(Error::InvalidFormat("package[::module]"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn test_valid_filters() {
+        let inputs = [
+            "u8",
+            "address",
+            "bool",
+            "0x2",
+            "0x2::coin",
+            "0x2::coin::Coin",
+            "0x2::coin::Coin<0x2::sui::SUI>",
+            "vector<u256>",
+            "vector<0x3::staking_pool::StakedSui>",
+        ]
+        .into_iter();
+
+        let filters: Vec<_> = inputs.map(|i| TypeFilter::from_str(i).unwrap()).collect();
+
+        let expect = expect![[r#"
+            [
+                ByType(
+                    U8,
+                ),
+                ByType(
+                    Address,
+                ),
+                ByType(
+                    Bool,
+                ),
+                ByModule(
+                    ByPackage(
+                        SuiAddress(
+                            [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                2,
+                            ],
+                        ),
+                    ),
+                ),
+                ByModule(
+                    ByModule(
+                        SuiAddress(
+                            [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                2,
+                            ],
+                        ),
+                        "coin",
+                    ),
+                ),
+                ByType(
+                    Struct(
+                        StructTag {
+                            address: 0000000000000000000000000000000000000000000000000000000000000002,
+                            module: Identifier(
+                                "coin",
+                            ),
+                            name: Identifier(
+                                "Coin",
+                            ),
+                            type_params: [],
+                        },
+                    ),
+                ),
+                ByType(
+                    Struct(
+                        StructTag {
+                            address: 0000000000000000000000000000000000000000000000000000000000000002,
+                            module: Identifier(
+                                "coin",
+                            ),
+                            name: Identifier(
+                                "Coin",
+                            ),
+                            type_params: [
+                                Struct(
+                                    StructTag {
+                                        address: 0000000000000000000000000000000000000000000000000000000000000002,
+                                        module: Identifier(
+                                            "sui",
+                                        ),
+                                        name: Identifier(
+                                            "SUI",
+                                        ),
+                                        type_params: [],
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                ByType(
+                    Vector(
+                        U256,
+                    ),
+                ),
+                ByType(
+                    Vector(
+                        Struct(
+                            StructTag {
+                                address: 0000000000000000000000000000000000000000000000000000000000000003,
+                                module: Identifier(
+                                    "staking_pool",
+                                ),
+                                name: Identifier(
+                                    "StakedSui",
+                                ),
+                                type_params: [],
+                            },
+                        ),
+                    ),
+                ),
+            ]"#]];
+        expect.assert_eq(&format!("{filters:#?}"))
+    }
+
+    #[test]
+    fn test_invalid_type_filters() {
+        for invalid_type_filters in [
+            "not_a_real_type",
+            "0x1:missing::colon",
+            "0x2::trailing::",
+            "0x3::mismatched::bra<0x4::ke::ts",
+        ] {
+            assert!(TypeFilter::from_str(invalid_type_filters).is_err());
+        }
+    }
+
+    #[test]
+    fn test_invalid_module_filters() {
+        for invalid_module_filters in [
+            "u8",
+            "address",
+            "bool",
+            "0x2::coin::Coin",
+            "0x2::coin::Coin<0x2::sui::SUI>",
+            "vector<u256>",
+            "vector<0x3::staking_pool::StakedSui>",
+        ] {
+            assert!(ModuleFilter::from_str(invalid_module_filters).is_err());
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1981,7 +1981,7 @@ type Query {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
-	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol


### PR DESCRIPTION
## Descriptions

This PR applies the various preceding abstractions (cursor and pagination frameworks) to `Query.eventConnection`, and renames it to `Query.events`.

Events also support more expressive filters than previous types that we applied these frameworks to, in particular, they support filtering by modules and types, so we introduce `TypeFilter` and `ModuleFilter` (string) scalars as a new abstraction responsible for:

- Parsing cascading filters of this kind.
- Applying them as filters onto existing queries.

The parsing implementation has also been made to uniformly rely on Move's parser for types and identifiers (previously it used Move's parser for types, but string manipulation for package and module based filters), which required exposing some more endpoints to Move's parser.

## Test Plan

Existing E2E tests for events pagination:

```

sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- event_connection/
```

Plus new unit tests for `type_filter` module:

```
sui-graphql-rpc$ cargo nextest run -- type_filter
```

## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485
- #15519
- #15520
- #15521
- #15522
- #15523
- #15524
- #15525
- #15526
- #15527
- #15625 