### PR TITLE
[GraphQL/E2E][EASY] Finish porting variables to interpolation

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -61,9 +61,9 @@ module Test::m {
 
 //# create-checkpoint
 
-//# run-graphql --variables obj_2_0
+//# run-graphql
 {
-  object(address: $obj_2_0) {
+  object(address: "@{obj_2_0}") {
     dynamicFieldConnection {
       nodes {
         name {
@@ -90,9 +90,9 @@ module Test::m {
 
 //# create-checkpoint
 
-//# run-graphql --variables obj_2_0
+//# run-graphql
 {
-  object(address: $obj_2_0) {
+  object(address: "@{obj_2_0}") {
     dynamicFieldConnection {
       nodes {
         name {
@@ -115,9 +115,9 @@ module Test::m {
   }
 }
 
-//# run-graphql --variables obj_2_0
+//# run-graphql
 {
-  owner(address: $obj_2_0) {
+  owner(address: "@{obj_2_0}") {
     dynamicFieldConnection {
       nodes {
         name {
@@ -142,9 +142,9 @@ module Test::m {
   }
 }
 
-//# run-graphql --variables obj_2_0
+//# run-graphql
 {
-  owner(address: $obj_2_0) {
+  owner(address: "@{obj_2_0}") {
     dynamicField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
       name {
         type {
@@ -164,9 +164,9 @@ module Test::m {
   }
 }
 
-//# run-graphql --variables obj_2_0
+//# run-graphql
 {
-  owner(address: $obj_2_0) {
+  owner(address: "@{obj_2_0}") {
     dynamicObjectField(name: {type: "u64", bcs: "AAAAAAAAAAA="}) {
       value {
         ... on MoveObject {

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -1,4 +1,4 @@
-processed 26 tasks
+processed 25 tasks
 
 init:
 validator_0: object(0,0)
@@ -40,14 +40,14 @@ task 8 'view-checkpoint'. lines 42-42:
 CheckpointSummary { epoch: 0, seq: 4, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, storage_cost: 10176400, storage_rebate: 1956240, non_refundable_storage_fee: 19760 }}
 
-task 9 'advance-epoch'. lines 45-45:
+task 9 'advance-epoch'. lines 44-44:
 Epoch advanced: 5
 
-task 10 'view-checkpoint'. lines 47-47:
+task 10 'view-checkpoint'. lines 46-46:
 CheckpointSummary { epoch: 5, seq: 10, content_digest: B5upjfaYHdtnxEmH68QF7iQC5PcqZFDuCEJgfZGuX7Nt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 11 'run-graphql'. lines 49-55:
+task 11 'run-graphql'. lines 48-53:
 Response: {
   "data": {
     "checkpoint": {
@@ -56,14 +56,14 @@ Response: {
   }
 }
 
-task 12 'create-checkpoint'. lines 56-56:
+task 12 'create-checkpoint'. lines 55-55:
 Checkpoint created: 11
 
-task 13 'view-checkpoint'. lines 58-58:
+task 13 'view-checkpoint'. lines 57-57:
 CheckpointSummary { epoch: 6, seq: 11, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 14 'run-graphql'. lines 60-66:
+task 14 'run-graphql'. lines 59-64:
 Response: {
   "data": {
     "checkpoint": {
@@ -72,7 +72,7 @@ Response: {
   }
 }
 
-task 15 'run-graphql'. lines 68-74:
+task 15 'run-graphql'. lines 66-71:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
@@ -97,14 +97,14 @@ Response: {
   }
 }
 
-task 16 'view-checkpoint'. lines 76-76:
+task 16 'view-checkpoint'. lines 73-73:
 CheckpointSummary { epoch: 6, seq: 11, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 17 'advance-epoch'. lines 78-81:
+task 17 'advance-epoch'. lines 75-78:
 Epoch advanced: 6
 
-task 18 'run-graphql'. lines 83-98:
+task 18 'run-graphql'. lines 80-95:
 Response: {
   "data": {
     "address": {
@@ -125,7 +125,7 @@ Response: {
   }
 }
 
-task 19 'run-graphql'. lines 100-155:
+task 19 'run-graphql'. lines 97-152:
 Response: {
   "data": {
     "address": {
@@ -220,104 +220,7 @@ Response: {
   }
 }
 
-task 20 'view-graphql-variables'. lines 158-159:
-Name: A
-Type: SuiAddress!
-Value: "0x42"
-
-Name: A_opt
-Type: SuiAddress
-Value: "0x42"
-
-Name: Test
-Type: SuiAddress!
-Value: "0xdc7a6a72118903b903eb2a890903e0a4290e16cdd995e63b6a88491d231ab41f"
-
-Name: Test_opt
-Type: SuiAddress
-Value: "0xdc7a6a72118903b903eb2a890903e0a4290e16cdd995e63b6a88491d231ab41f"
-
-Name: deepbook
-Type: SuiAddress!
-Value: "0xdee9"
-
-Name: deepbook_opt
-Type: SuiAddress
-Value: "0xdee9"
-
-Name: obj_0_0
-Type: SuiAddress!
-Value: "0x15185c3222855fbd3dedb8d89302127683df515a5180ca6b8c2d1d469c5419a8"
-
-Name: obj_0_0_opt
-Type: SuiAddress
-Value: "0x15185c3222855fbd3dedb8d89302127683df515a5180ca6b8c2d1d469c5419a8"
-
-Name: obj_0_1
-Type: SuiAddress!
-Value: "0x2fbcf16a09621693013ade94d19616a74d4ce9f8338d5cf0a3f2d041d1f3d694"
-
-Name: obj_0_1_opt
-Type: SuiAddress
-Value: "0x2fbcf16a09621693013ade94d19616a74d4ce9f8338d5cf0a3f2d041d1f3d694"
-
-Name: obj_1_0
-Type: SuiAddress!
-Value: "0xdc7a6a72118903b903eb2a890903e0a4290e16cdd995e63b6a88491d231ab41f"
-
-Name: obj_1_0_opt
-Type: SuiAddress
-Value: "0xdc7a6a72118903b903eb2a890903e0a4290e16cdd995e63b6a88491d231ab41f"
-
-Name: obj_2_0
-Type: SuiAddress!
-Value: "0x8e9a6c3b9d73fec551cb042c7283de0076fbdb60b8b2c41f6f916f9b1d11a114"
-
-Name: obj_2_0_opt
-Type: SuiAddress
-Value: "0x8e9a6c3b9d73fec551cb042c7283de0076fbdb60b8b2c41f6f916f9b1d11a114"
-
-Name: obj_3_0
-Type: SuiAddress!
-Value: "0x5421f975384c0c0a3a22ce771dd616bde2acbb6ffc16a8a8b4595e33f79d2aa5"
-
-Name: obj_3_0_opt
-Type: SuiAddress
-Value: "0x5421f975384c0c0a3a22ce771dd616bde2acbb6ffc16a8a8b4595e33f79d2aa5"
-
-Name: std
-Type: SuiAddress!
-Value: "0x1"
-
-Name: std_opt
-Type: SuiAddress
-Value: "0x1"
-
-Name: sui
-Type: SuiAddress!
-Value: "0x2"
-
-Name: sui_opt
-Type: SuiAddress
-Value: "0x2"
-
-Name: sui_system
-Type: SuiAddress!
-Value: "0x3"
-
-Name: sui_system_opt
-Type: SuiAddress
-Value: "0x3"
-
-Name: validator_0
-Type: SuiAddress!
-Value: "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-
-Name: validator_0_opt
-Type: SuiAddress
-Value: "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-
-task 21 'run-graphql'. lines 162-176:
+task 20 'run-graphql'. lines 154-168:
 Response: {
   "data": {
     "epoch": {
@@ -337,7 +240,7 @@ Response: {
   }
 }
 
-task 22 'run-graphql'. lines 178-184:
+task 21 'run-graphql'. lines 170-176:
 Response: {
   "data": {
     "epoch": {
@@ -346,17 +249,17 @@ Response: {
   }
 }
 
-task 23 'run'. lines 186-186:
-created: object(23,0)
+task 22 'run'. lines 178-178:
+created: object(22,0)
 mutated: object(0,1)
 gas summary: computation_cost: 999000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 188-188:
-created: object(24,0)
+task 23 'run'. lines 180-180:
+created: object(23,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run'. lines 190-190:
-created: object(25,0)
+task 24 'run'. lines 182-182:
+created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -41,24 +41,22 @@ module Test::M1 {
 
 //# view-checkpoint
 
-
 //# advance-epoch 6
 
 //# view-checkpoint
 
 //# run-graphql
-
 {
   checkpoint {
     sequenceNumber
   }
 }
+
 //# create-checkpoint
 
 //# view-checkpoint
 
 //# run-graphql
-
 {
   checkpoint {
     sequenceNumber
@@ -66,7 +64,6 @@ module Test::M1 {
 }
 
 //# run-graphql --show-usage --show-headers --show-service-version
-
 {
   checkpoint {
     sequenceNumber
@@ -80,9 +77,9 @@ module Test::M1 {
 // Demonstrates using variables
 // If the variable ends in _opt, this is the optional variant
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  address(address: $A) {
+  address(address: "@{A}") {
     objectConnection{
       edges {
         node {
@@ -97,9 +94,9 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --variables Test A obj_2_0 validator_0
+//# run-graphql
 {
-  address(address: $Test) {
+  address(address: "@{Test}") {
     objectConnection{
       edges {
         node {
@@ -112,21 +109,7 @@ module Test::M1 {
       }
     }
   }
-  second: address(address: $A) {
-    objectConnection{
-      edges {
-        node {
-          address
-          digest
-          owner {
-            __typename
-          }
-        }
-      }
-    }
-  }
-
-  val_objs: address(address: $validator_0) {
+  second: address(address: "@{A}") {
     objectConnection{
       edges {
         node {
@@ -140,7 +123,21 @@ module Test::M1 {
     }
   }
 
-  object(address: $obj_2_0) {
+  val_objs: address(address: "@{validator_0}") {
+    objectConnection{
+      edges {
+        node {
+          address
+          digest
+          owner {
+            __typename
+          }
+        }
+      }
+    }
+  }
+
+  object(address: "@{obj_2_0}") {
     version
     owner {
       __typename
@@ -154,12 +151,7 @@ module Test::M1 {
 
 }
 
-
-//# view-graphql-variables
-// List all the graphql variables
-
-
-//# run-graphql --variables validator_0
+//# run-graphql
 {
   epoch {
     validatorSet {
@@ -170,7 +162,7 @@ module Test::M1 {
       }
     }
   }
-  address(address: $validator_0) {
+  address(address: "@{validator_0}") {
     address
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -41,298 +41,325 @@ gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 
 task 8 'create-checkpoint'. lines 101-101:
 Checkpoint created: 1
 
-task 9 'run-graphql'. lines 103-122:
+task 9 'run-graphql'. lines 103-123:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "2"
+            },
+            "bcs": "AgAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "3"
-          },
-          "bcs": "AwAAAAAAAAA="
+          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "3"
+            },
+            "bcs": "AwAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 10 'run-graphql'. lines 124-143:
+task 10 'run-graphql'. lines 125-145:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "2"
-          },
-          "bcs": "AgAAAAAAAAA="
+          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "2"
+            },
+            "bcs": "AgAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M2"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "3"
-          },
-          "bcs": "AwAAAAAAAAA="
+          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M2"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M2::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "3"
+            },
+            "bcs": "AwAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 11 'run-graphql'. lines 145-164:
+task 11 'run-graphql'. lines 147-167:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         },
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 12 'run-graphql'. lines 166-185:
+task 12 'run-graphql'. lines 169-189:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "0"
-          },
-          "bcs": "AAAAAAAAAAA="
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventA"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "0"
+            },
+            "bcs": "AAAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 13 'run-graphql'. lines 187-206:
+task 13 'run-graphql'. lines 191-211:
 Response: {
   "data": {
-    "eventConnection": {
-      "nodes": [
+    "events": {
+      "edges": [
         {
-          "sendingModule": {
-            "name": "M1"
-          },
-          "type": {
-            "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
-          },
-          "sender": {
-            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-          },
-          "json": {
-            "new_value": "1"
-          },
-          "bcs": "AQAAAAAAAAA="
+          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "node": {
+            "sendingModule": {
+              "name": "M1"
+            },
+            "type": {
+              "repr": "0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::Object>"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "json": {
+              "new_value": "1"
+            },
+            "bcs": "AQAAAAAAAAA="
+          }
         }
       ]
     }
   }
 }
 
-task 14 'run-graphql'. lines 208-227:
+task 14 'run-graphql'. lines 213-233:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid struct type: 0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::M1::EventB<. Got error: unexpected end of tokens",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }
 
-task 15 'run-graphql'. lines 229-248:
+task 15 'run-graphql'. lines 235-255:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid format in '::M1' - if '::' is present, there must be a non-empty string on both sides. Expected format like 'package[::module[::type[<type_params>]]]'",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }
 
-task 16 'run-graphql'. lines 250-269:
+task 16 'run-graphql'. lines 257-277:
 Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid format in '0xd3d80179bea4aa285f2484b4161933e976dbbf3d6a3bafcb3450c39e6047fb4d::' - if '::' is present, there must be a non-empty string on both sides. Expected format like 'package[::module[::type[<type_params>]]]'",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"EventFilter\")",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 18
         }
       ],
       "path": [
-        "eventConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "events"
+      ]
     }
   ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -100,170 +100,178 @@ module Test::M2 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A Test
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: $Test}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventA"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventA"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB<"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB<"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "::M1"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "::M1"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::"}
-  ) {
-    nodes {
-      sendingModule {
-        name
+  events(filter: {sender: "@{A}", eventType: "@{Test}::"}) {
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
       }
-      type {
-        repr
-      }
-      sender {
-        address
-      }
-      json
-      bcs
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
@@ -16,10 +16,10 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0
 task 3 'create-checkpoint'. lines 41-41:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 43-62:
+task 4 'run-graphql'. lines 43-60:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {
@@ -41,10 +41,10 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 64-83:
+task 5 'run-graphql'. lines 62-79:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {
@@ -66,28 +66,28 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 85-104:
+task 6 'run-graphql'. lines 81-98:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": []
     }
   }
 }
 
-task 7 'run-graphql'. lines 106-125:
+task 7 'run-graphql'. lines 100-117:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": []
     }
   }
 }
 
-task 8 'run-graphql'. lines 127-146:
+task 8 'run-graphql'. lines 119-136:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
@@ -40,11 +40,9 @@ module Test::M3 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A}
-  ) {
+  events(filter: {sender: "@{A}"}) {
     nodes {
       sendingModule {
         name
@@ -61,11 +59,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A Test
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: $Test}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}"}) {
     nodes {
       sendingModule {
         name
@@ -82,11 +78,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M1"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M1"}) {
     nodes {
       sendingModule {
         name
@@ -103,11 +97,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M2"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M2"}) {
     nodes {
       sendingModule {
         name
@@ -124,11 +116,9 @@ module Test::M3 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
-  eventConnection(
-    filter: {sender: $A, emittingModule: "@{Test}::M3"}
-  ) {
+  events(filter: {sender: "@{A}", emittingModule: "@{Test}::M3"}) {
     nodes {
       sendingModule {
         name

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -21,13 +21,17 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 4 'create-checkpoint'. lines 28-28:
 Checkpoint created: 1
 
-task 5 'run-graphql'. lines 30-50:
+task 5 'run-graphql'. lines 30-54:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "2:0",
+          "cursor": "eyJ0eCI6MiwiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -45,7 +49,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -63,7 +67,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -85,13 +89,17 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 52-72:
+task 6 'run-graphql'. lines 56-80:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -109,7 +117,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -131,13 +139,17 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 74-94:
+task 7 'run-graphql'. lines 82-106:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
       "edges": [
         {
-          "cursor": "2:0",
+          "cursor": "eyJ0eCI6MiwiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -155,7 +167,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -177,13 +189,17 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 96-116:
+task 8 'run-graphql'. lines 108-132:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
       "edges": [
         {
-          "cursor": "3:0",
+          "cursor": "eyJ0eCI6MywiZSI6MH0",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -201,7 +217,7 @@ Response: {
           }
         },
         {
-          "cursor": "3:1",
+          "cursor": "eyJ0eCI6MywiZSI6MX0",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -29,7 +29,63 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(filter: {sender: "@{A}"}) {
+  events(filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":2,"e":0}
+{
+  events(first: 2 after: "@{cursor_0}", filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        sendingModule {
+          name
+        }
+        type {
+          repr
+        }
+        sender {
+          address
+        }
+        json
+        bcs
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"tx":3,"e":1}
+{
+  events(last: 2 before: "@{cursor_0}", filter: {sender: "@{A}"}) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
     edges {
       cursor
       node {
@@ -51,51 +107,11 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(first: 2 after: "2:0", filter: {sender: "@{A}"}) {
-    edges {
-      cursor
-      node {
-        sendingModule {
-          name
-        }
-        type {
-          repr
-        }
-        sender {
-          address
-        }
-        json
-        bcs
-      }
+  events(last: 2) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
     }
-  }
-}
-
-//# run-graphql
-{
-  eventConnection(last: 2 before: "3:1", filter: {sender: "@{A}"}) {
-    edges {
-      cursor
-      node {
-        sendingModule {
-          name
-        }
-        type {
-          repr
-        }
-        sender {
-          address
-        }
-        json
-        bcs
-      }
-    }
-  }
-}
-
-//# run-graphql
-{
-  eventConnection(last: 2) {
     edges {
       cursor
       node {

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.exp
@@ -267,7 +267,7 @@ Response: {
         }
       ]
     },
-    "eventConnection": {
+    "events": {
       "edges": []
     }
   },
@@ -278,7 +278,7 @@ Response: {
       "depth": 11,
       "variables": 0,
       "fragments": 0,
-      "queryPayload": 1431
+      "queryPayload": 1422
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -211,7 +211,7 @@
       }
     }
   }
-  eventConnection(last: 10) { # 10
+  events(last: 10) { # 10
     edges {
       node {
         timestamp

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.exp
@@ -123,7 +123,7 @@ Response: {
 task 7 'run-graphql'. lines 57-68:
 Response: {
   "data": {
-    "eventConnection": {
+    "events": {
       "nodes": [
         {
           "sendingModule": {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/events.move
@@ -56,7 +56,7 @@ module Test::M1 {
 
 //# run-graphql
 {
-  eventConnection(filter: {sender: "@{A}"}) {
+  events(filter: {sender: "@{A}"}) {
     nodes {
       sendingModule {
         name

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -666,8 +666,10 @@
 ### Event Connection
 
 ><pre>{
->  eventConnection(
->    filter: {eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"}
+>  events(
+>    filter: {
+>      eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"
+>    }
 >  ) {
 >    nodes {
 >      sendingModule {
@@ -694,11 +696,14 @@
 ### <a id=524281></a>
 ### Filter By Emitting Package Module And Event Type
 
-><pre>query byEmittingPackageModuleAndEventType {
->  eventConnection(
+><pre>query ByEmittingPackageModuleAndEventType {
+>  events(
 >    first: 1
->    after: "85173:0"
->    filter: {emittingModule: "0x3::sui_system", eventType: "0x3::validator::StakingRequestEvent"}
+>    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+>    filter: {
+>      emittingModule: "0x3::sui_system",
+>      eventType: "0x3::validator::StakingRequestEvent"
+>    }
 >  ) {
 >    pageInfo {
 >      hasNextPage
@@ -724,10 +729,12 @@
 ### <a id=524282></a>
 ### Filter By Sender
 
-><pre>query byTxSender {
->  eventConnection(
+><pre>query ByTxSender {
+>  events(
 >    first: 1
->    filter: {sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"}
+>    filter: {
+>      sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"
+>    }
 >  ) {
 >    pageInfo {
 >      hasNextPage

--- a/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
@@ -1,6 +1,8 @@
 {
-  eventConnection(
-    filter: {eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"}
+  events(
+    filter: {
+      eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::sui::SUI>"
+    }
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
@@ -1,8 +1,11 @@
-query byEmittingPackageModuleAndEventType {
-  eventConnection(
+query ByEmittingPackageModuleAndEventType {
+  events(
     first: 1
-    after: "85173:0"
-    filter: {emittingModule: "0x3::sui_system", eventType: "0x3::validator::StakingRequestEvent"}
+    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+    filter: {
+      emittingModule: "0x3::sui_system",
+      eventType: "0x3::validator::StakingRequestEvent"
+    }
   ) {
     pageInfo {
       hasNextPage

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
@@ -1,7 +1,9 @@
-query byTxSender {
-  eventConnection(
+query ByTxSender {
+  events(
     first: 1
-    filter: {sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"}
+    filter: {
+      sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"
+    }
   ) {
     pageInfo {
       hasNextPage

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1977,7 +1977,7 @@ type Query {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
-	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -3,13 +3,13 @@
 
 use diesel::backend::Backend;
 use sui_indexer::{
-    schema_v2::{display, events, objects, transactions},
+    schema_v2::{display, objects, transactions},
     types_v2::OwnerType,
 };
 
 use crate::{
     error::Error,
-    types::{event::EventFilter, object::ObjectFilter, transaction_block::TransactionBlockFilter},
+    types::{object::ObjectFilter, transaction_block::TransactionBlockFilter},
 };
 use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
@@ -59,12 +59,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
     fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
-    fn multi_get_events(
-        before: Option<(i64, i64)>,
-        after: Option<(i64, i64)>,
-        limit: PageLimit,
-        filter: Option<EventFilter>,
-    ) -> Result<events::BoxedQuery<'static, DB>, Error>;
 }
 
 /// The struct returned for query.explain()

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -68,8 +68,6 @@ pub enum Error {
     DynamicFieldOnAddress,
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),
-    #[error("Invalid filter option or value provided")]
-    InvalidFilter,
     #[error(transparent)]
     DomainParse(#[from] DomainParseError),
     #[error(transparent)]
@@ -102,7 +100,6 @@ impl ErrorExtensions for Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
             Error::InvalidCoinType(_)
             | Error::DynamicFieldOnAddress
-            | Error::InvalidFilter
             | Error::ProtocolVersionUnsupported { .. }
             | Error::DomainParse(_)
             | Error::DbValidation(_)

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -1,24 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::*;
-use sui_indexer::models_v2::events::StoredEvent;
-use sui_indexer::models_v2::transactions::StoredTransaction;
-use sui_types::base_types::SuiAddress as NativeSuiAddress;
-use sui_types::event::Event as NativeEvent;
-use sui_types::{parse_sui_struct_tag, TypeTag};
-
-use crate::error::Error;
-
+use super::cursor::{self, Page, Target};
 use super::digest::Digest;
+use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
     address::Address, base64::Base64, date_time::DateTime, move_module::MoveModule,
     move_value::MoveValue, sui_address::SuiAddress,
+};
+use crate::data::BoxedQuery;
+use crate::{data::Db, error::Error};
+use async_graphql::connection::{Connection, CursorType, Edge};
+use async_graphql::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
+use serde::{Deserialize, Serialize};
+use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
+use sui_indexer::schema_v2::{events, transactions, tx_senders};
+use sui_types::{
+    base_types::SuiAddress as NativeSuiAddress, event::Event as NativeEvent, parse_sui_struct_tag,
+    TypeTag,
 };
 
 pub(crate) struct Event {
     pub stored: StoredEvent,
 }
+
+/// Contents of an Event's cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct EventKey {
+    /// Transaction Sequence Number
+    tx: u64,
+
+    /// Event Sequence Number
+    e: u64,
+}
+
+pub(crate) type Cursor = cursor::Cursor<EventKey>;
+type Query<ST, GB> = BoxedQuery<ST, events::table, Db, GB>;
 
 #[derive(InputObject, Clone, Default)]
 pub(crate) struct EventFilter {
@@ -32,7 +50,7 @@ pub(crate) struct EventFilter {
     /// PTB and emits an event.
     ///
     /// Modules can be filtered by their package, or package::module.
-    pub emitting_module: Option<String>,
+    pub emitting_module: Option<ModuleFilter>,
 
     /// This field is used to specify the type of event emitted.
     ///
@@ -42,7 +60,7 @@ pub(crate) struct EventFilter {
     /// Generic types can be queried by either the generic type name, e.g.
     /// `0x2::coin::Coin`, or by the full type name, such as
     /// `0x2::coin::Coin<0x2::sui::SUI>`.
-    pub event_type: Option<String>,
+    pub event_type: Option<TypeFilter>,
     // Enhancement (post-MVP)
     // pub start_time
     // pub end_time
@@ -103,6 +121,62 @@ impl Event {
 }
 
 impl Event {
+    /// Query the database for a `page` of events. The Page uses a combination of transaction and
+    /// event sequence numbers as the cursor, and can optionally be further `filter`-ed by the
+    /// `EventFilter`.
+    pub(crate) async fn paginate(
+        db: &Db,
+        page: Page<EventKey>,
+        filter: EventFilter,
+    ) -> Result<Connection<String, Event>, Error> {
+        let (prev, next, results) = page
+            .paginate_query::<StoredEvent, _, _, _>(db, move || {
+                let mut query = events::dsl::events.into_boxed();
+
+                // The transactions table doesn't have an index on the senders column, so use
+                // `tx_senders`.
+                if let Some(sender) = &filter.sender {
+                    query = query.filter(
+                        events::dsl::tx_sequence_number.eq_any(
+                            tx_senders::dsl::tx_senders
+                                .select(tx_senders::dsl::tx_sequence_number)
+                                .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
+                        ),
+                    )
+                }
+
+                if let Some(digest) = &filter.transaction_digest {
+                    query = query.filter(
+                        events::dsl::tx_sequence_number.eq_any(
+                            transactions::dsl::transactions
+                                .select(transactions::dsl::tx_sequence_number)
+                                .filter(transactions::dsl::transaction_digest.eq(digest.to_vec())),
+                        ),
+                    )
+                }
+
+                if let Some(module_filter) = &filter.emitting_module {
+                    query = module_filter.apply(query, events::dsl::package, events::dsl::module);
+                }
+
+                if let Some(type_filter) = &filter.event_type {
+                    query = type_filter.apply(query, events::dsl::event_type);
+                }
+
+                query
+            })
+            .await?;
+
+        let mut conn = Connection::new(prev, next);
+
+        for stored in results {
+            let cursor = Cursor::new(stored.cursor()).encode_cursor();
+            conn.edges.push(Edge::new(cursor, Event { stored }));
+        }
+
+        Ok(conn)
+    }
+
     pub(crate) fn try_from_stored_transaction(
         stored_tx: &StoredTransaction,
         idx: usize,
@@ -139,5 +213,45 @@ impl Event {
         Ok(Self {
             stored: stored_event,
         })
+    }
+}
+
+impl Target<EventKey> for StoredEvent {
+    type Source = events::table;
+
+    fn filter_ge<ST, GB>(cursor: &EventKey, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl::{event_sequence_number as event, tx_sequence_number as tx};
+        query.filter(
+            tx.gt(cursor.tx as i64)
+                .or(tx.eq(cursor.tx as i64).and(event.ge(cursor.e as i64))),
+        )
+    }
+
+    fn filter_le<ST, GB>(cursor: &EventKey, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl::{event_sequence_number as event, tx_sequence_number as tx};
+        query.filter(
+            tx.lt(cursor.tx as i64)
+                .or(tx.eq(cursor.tx as i64).and(event.le(cursor.e as i64))),
+        )
+    }
+
+    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
+        use events::dsl;
+        if asc {
+            query
+                .order_by(dsl::tx_sequence_number.asc())
+                .then_order_by(dsl::event_sequence_number.asc())
+        } else {
+            query
+                .order_by(dsl::tx_sequence_number.desc())
+                .then_order_by(dsl::event_sequence_number.desc())
+        }
+    }
+
+    fn cursor(&self) -> EventKey {
+        EventKey {
+            tx: self.tx_sequence_number as u64,
+            e: self.event_sequence_number as u64,
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -47,6 +47,7 @@ pub(crate) mod system_state_summary;
 pub(crate) mod transaction_block;
 pub(crate) mod transaction_block_effects;
 pub(crate) mod transaction_block_kind;
+pub(crate) mod type_filter;
 pub(crate) mod unchanged_shared_object;
 pub(crate) mod validator;
 pub(crate) mod validator_credentials;

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -17,7 +17,7 @@ use super::{
     cursor::Page,
     digest::Digest,
     epoch::Epoch,
-    event::{Event, EventFilter},
+    event::{self, Event, EventFilter},
     move_type::MoveType,
     object::{Object, ObjectFilter},
     owner::Owner,
@@ -169,17 +169,17 @@ impl Query {
             .extend()
     }
 
-    async fn event_connection(
+    async fn events(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<event::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<event::Cursor>,
         filter: Option<EventFilter>,
-    ) -> Result<Option<Connection<String, Event>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_events(first, after, last, before, filter)
+    ) -> Result<Connection<String, Event>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -1,0 +1,359 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{string_input::impl_string_input, sui_address::SuiAddress};
+use crate::data::{BoxedQuery, Db, DbBackend};
+use async_graphql::*;
+use diesel::{
+    expression::{is_aggregate::No, ValidGrouping},
+    query_builder::QueryFragment,
+    sql_types::{Binary, Text},
+    AppearsOnTable, BoolExpressionMethods, Expression, ExpressionMethods, QueryDsl, QuerySource,
+    TextExpressionMethods,
+};
+use std::str::FromStr;
+use sui_types::{parse_sui_address, parse_sui_module_id, parse_sui_type_tag, TypeTag};
+
+/// GraphQL scalar containing a filter on types.
+#[derive(Clone, Debug)]
+pub(crate) enum TypeFilter {
+    /// Filter the type by the package or module it's from.
+    ByModule(ModuleFilter),
+
+    /// If the type tag has type parameters, treat it as an exact filter on that instantiation,
+    /// otherwise treat it as either a filter on all generic instantiations of the type, or an exact
+    /// match on the type with no type parameters. E.g.
+    ///
+    ///  0x2::coin::Coin
+    ///
+    /// would match both 0x2::coin::Coin and 0x2::coin::Coin<0x2::sui::SUI>.
+    ByType(TypeTag),
+}
+
+/// GraphQL scalar containing a filter on modules.
+#[derive(Clone, Debug)]
+pub(crate) enum ModuleFilter {
+    /// Filter the module by the package it's from.
+    ByPackage(SuiAddress),
+
+    /// Exact match on the module.
+    ByModule(SuiAddress, String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Invalid filter, expected: {0}")]
+    InvalidFormat(&'static str),
+}
+
+impl TypeFilter {
+    /// Modify `query` to apply this filter to `field`, returning the new query.
+    pub(crate) fn apply<E, QS, ST, GB>(
+        &self,
+        query: BoxedQuery<ST, QS, Db, GB>,
+        field: E,
+    ) -> BoxedQuery<ST, QS, Db, GB>
+    where
+        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
+        E: ExpressionMethods + TextExpressionMethods,
+        E: Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        E: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        E: Clone + Send + 'static,
+        QS: QuerySource,
+    {
+        match self {
+            TypeFilter::ByModule(ModuleFilter::ByPackage(p)) => {
+                query.filter(field.like(format!("{p}::%")))
+            }
+
+            TypeFilter::ByModule(ModuleFilter::ByModule(p, m)) => {
+                query.filter(field.like(format!("{p}::{m}::%")))
+            }
+
+            // A type filter without type parameters is interpreted as either an exact match, or a
+            // match for all generic instantiations of the type.
+            TypeFilter::ByType(TypeTag::Struct(tag)) if tag.type_params.is_empty() => {
+                let f1 = field.clone();
+                let f2 = field;
+                let exact = tag.to_canonical_string(/* with_prefix */ true);
+                let prefix = format!("{}<%", tag.to_canonical_display(/* with_prefix */ true));
+                query.filter(f1.eq(exact).or(f2.like(prefix)))
+            }
+
+            TypeFilter::ByType(tag) => {
+                let exact = tag.to_canonical_string(/* with_prefix */ true);
+                query.filter(field.eq(exact))
+            }
+        }
+    }
+}
+
+impl ModuleFilter {
+    /// Modify `query` to apply this filter, treating `package` as the column containing the package
+    /// address and `module` as the module containing the module name.
+    pub(crate) fn apply<P, M, QS, ST, GB>(
+        &self,
+        query: BoxedQuery<ST, QS, Db, GB>,
+        package: P,
+        module: M,
+    ) -> BoxedQuery<ST, QS, Db, GB>
+    where
+        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
+        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DbBackend>,
+        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        P: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        M: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
+        P: Send + 'static,
+        M: Send + 'static,
+        QS: QuerySource,
+    {
+        match self {
+            ModuleFilter::ByPackage(p) => query.filter(package.eq(p.into_vec())),
+            ModuleFilter::ByModule(p, m) => query
+                .filter(package.eq(p.into_vec()))
+                .filter(module.eq(m.clone())),
+        }
+    }
+}
+
+impl_string_input!(TypeFilter);
+impl_string_input!(ModuleFilter);
+
+impl FromStr for TypeFilter {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        if let Ok(tag) = parse_sui_type_tag(s) {
+            Ok(TypeFilter::ByType(tag))
+        } else if let Ok(filter) = ModuleFilter::from_str(s) {
+            Ok(TypeFilter::ByModule(filter))
+        } else {
+            Err(Error::InvalidFormat(
+                "package[::module[::type[<type_params>]]] or primitive type",
+            ))
+        }
+    }
+}
+
+impl FromStr for ModuleFilter {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        if let Ok(module) = parse_sui_module_id(s) {
+            Ok(ModuleFilter::ByModule(
+                SuiAddress::from(*module.address()),
+                module.name().to_string(),
+            ))
+        } else if let Ok(package) = parse_sui_address(s) {
+            Ok(ModuleFilter::ByPackage(package.into()))
+        } else {
+            Err(Error::InvalidFormat("package[::module]"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn test_valid_filters() {
+        let inputs = [
+            "u8",
+            "address",
+            "bool",
+            "0x2",
+            "0x2::coin",
+            "0x2::coin::Coin",
+            "0x2::coin::Coin<0x2::sui::SUI>",
+            "vector<u256>",
+            "vector<0x3::staking_pool::StakedSui>",
+        ]
+        .into_iter();
+
+        let filters: Vec<_> = inputs.map(|i| TypeFilter::from_str(i).unwrap()).collect();
+
+        let expect = expect![[r#"
+            [
+                ByType(
+                    U8,
+                ),
+                ByType(
+                    Address,
+                ),
+                ByType(
+                    Bool,
+                ),
+                ByModule(
+                    ByPackage(
+                        SuiAddress(
+                            [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                2,
+                            ],
+                        ),
+                    ),
+                ),
+                ByModule(
+                    ByModule(
+                        SuiAddress(
+                            [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                2,
+                            ],
+                        ),
+                        "coin",
+                    ),
+                ),
+                ByType(
+                    Struct(
+                        StructTag {
+                            address: 0000000000000000000000000000000000000000000000000000000000000002,
+                            module: Identifier(
+                                "coin",
+                            ),
+                            name: Identifier(
+                                "Coin",
+                            ),
+                            type_params: [],
+                        },
+                    ),
+                ),
+                ByType(
+                    Struct(
+                        StructTag {
+                            address: 0000000000000000000000000000000000000000000000000000000000000002,
+                            module: Identifier(
+                                "coin",
+                            ),
+                            name: Identifier(
+                                "Coin",
+                            ),
+                            type_params: [
+                                Struct(
+                                    StructTag {
+                                        address: 0000000000000000000000000000000000000000000000000000000000000002,
+                                        module: Identifier(
+                                            "sui",
+                                        ),
+                                        name: Identifier(
+                                            "SUI",
+                                        ),
+                                        type_params: [],
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                ByType(
+                    Vector(
+                        U256,
+                    ),
+                ),
+                ByType(
+                    Vector(
+                        Struct(
+                            StructTag {
+                                address: 0000000000000000000000000000000000000000000000000000000000000003,
+                                module: Identifier(
+                                    "staking_pool",
+                                ),
+                                name: Identifier(
+                                    "StakedSui",
+                                ),
+                                type_params: [],
+                            },
+                        ),
+                    ),
+                ),
+            ]"#]];
+        expect.assert_eq(&format!("{filters:#?}"))
+    }
+
+    #[test]
+    fn test_invalid_type_filters() {
+        for invalid_type_filters in [
+            "not_a_real_type",
+            "0x1:missing::colon",
+            "0x2::trailing::",
+            "0x3::mismatched::bra<0x4::ke::ts",
+        ] {
+            assert!(TypeFilter::from_str(invalid_type_filters).is_err());
+        }
+    }
+
+    #[test]
+    fn test_invalid_module_filters() {
+        for invalid_module_filters in [
+            "u8",
+            "address",
+            "bool",
+            "0x2::coin::Coin",
+            "0x2::coin::Coin<0x2::sui::SUI>",
+            "vector<u256>",
+            "vector<0x3::staking_pool::StakedSui>",
+        ] {
+            assert!(ModuleFilter::from_str(invalid_module_filters).is_err());
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1981,7 +1981,7 @@ type Query {
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
 	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	transactionBlockConnection(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection
-	eventConnection(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection
+	events(first: Int, after: String, last: Int, before: String, filter: EventFilter): EventConnection!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -157,8 +157,6 @@ pub struct RunGraphqlCommand {
     #[clap(long = "show-service-version")]
     pub show_service_version: bool,
     #[clap(long, num_args(1..))]
-    pub variables: Vec<String>,
-    #[clap(long, num_args(1..))]
     pub cursors: Vec<String>,
 }
 
@@ -212,8 +210,6 @@ pub enum SuiSubcommand {
     ViewCheckpoint,
     #[clap(name = "run-graphql")]
     RunGraphql(RunGraphqlCommand),
-    #[clap(name = "view-graphql-variables")]
-    ViewGraphqlVariables,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description

Replace all remaining instances of GraphQL variable-based binding to interpolation-based binding (which is more general), so that we can clean-up the code in the E2E test runner that deals with GraphQL variable substitution and printing.

## Test Plan

```
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```


## Stack
- #15467 
- #15470 
- #15471 
- #15472 
- #15473
- #15474 
- #15475 
- #15484 
- #15485
- #15519
- #15520
- #15521
- #15522
- #15523
- #15524
- #15525
- #15526
- #15527
- #15625 
- #15528
