### PR TITLE
[transfer-to-object] Turn on for mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -99,6 +99,7 @@ const MAX_PROTOCOL_VERSION: u64 = 33;
 //             Make critbit tree and order getters public in deepbook.
 // Version 33: Add support for `receiving_object_id` function in framework
 //             Hardened OTW check.
+//             Enable transfer-to-object in mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1707,6 +1708,10 @@ impl ProtocolConfig {
                 33 => {
                     cfg.feature_flags.hardened_otw_check = true;
                     cfg.feature_flags.allow_receiving_object_id = true;
+
+                    // Enable transfer-to-object in mainnet
+                    cfg.transfer_receive_object_cost_base = Some(52);
+                    cfg.feature_flags.receive_objects = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
@@ -30,6 +30,7 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
+  receive_objects: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
@@ -136,6 +137,7 @@ object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2


### PR DESCRIPTION
## Description 

Turns on transfer-to-object in mainnet.

## Test Plan 

Tested and has been running in devnet and testnet for the past couple months.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Enables transfer-to-object functionality on mainnet.