### PR TITLE
[gql] refactor events to allow construction from StoredTransaction

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -1385,7 +1385,7 @@ impl PgManager {
         let mut connection = Connection::new(false, has_next_page);
         for stored_event in events {
             let cursor = self.build_event_cursor(&stored_event);
-            let event = Event::try_from(stored_event)?;
+            let event = Event::from(stored_event);
             connection.edges.push(Edge::new(cursor, event));
         }
 

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::*;
 use sui_indexer::models_v2::events::StoredEvent;
-use sui_types::{parse_sui_struct_tag, TypeTag};
+use sui_types::{event::Event as NativeEvent, parse_sui_struct_tag, TypeTag};
 
 use crate::error::Error;
 
@@ -15,7 +15,8 @@ use super::{
 };
 
 pub(crate) struct Event {
-    pub stored: StoredEvent,
+    pub stored: Option<StoredEvent>,
+    pub native: NativeEvent,
 }
 
 #[derive(InputObject, Clone, Default)]
@@ -51,6 +52,34 @@ pub(crate) struct EventFilter {
     // pub not
 }
 
+impl Event {
+    fn package_impl(&self) -> Result<SuiAddress, Error> {
+        if let Some(stored) = &self.stored {
+            SuiAddress::from_bytes(&stored.package).map_err(|e| Error::Internal(e.to_string()))
+        } else {
+            Ok(SuiAddress::from(self.native.package_id))
+        }
+    }
+
+    fn module_impl(&self) -> &str {
+        if let Some(stored) = &self.stored {
+            &stored.module
+        } else {
+            self.native.transaction_module.as_ident_str().as_str()
+        }
+    }
+
+    fn type_tag_impl(&self) -> Result<TypeTag, Error> {
+        let struct_tag = match &self.stored {
+            Some(stored) => parse_sui_struct_tag(&stored.event_type)
+                .map_err(|e| Error::Internal(e.to_string()))?,
+            None => self.native.type_.clone(),
+        };
+
+        Ok(TypeTag::from(struct_tag))
+    }
+}
+
 #[Object]
 impl Event {
     /// The Move module containing some function that when called by
@@ -59,40 +88,67 @@ impl Event {
     /// calls A::m2::emit_event to emit an event,
     /// the sending module would be A::m1.
     async fn sending_module(&self, ctx: &Context<'_>) -> Result<Option<MoveModule>> {
-        let sending_package = SuiAddress::from_bytes(&self.stored.package)
-            .map_err(|e| Error::Internal(e.to_string()))
-            .extend()?;
+        let sending_package = self.package_impl().extend()?;
+        let module = self.module_impl();
+
         ctx.data_unchecked::<PgManager>()
-            .fetch_move_module(sending_package, &self.stored.module)
+            .fetch_move_module(sending_package, module)
             .await
             .extend()
     }
 
     /// Addresses of the senders of the event
     async fn senders(&self) -> Result<Option<Vec<Address>>> {
-        let mut addrs = Vec::with_capacity(self.stored.senders.len());
-        for sender in &self.stored.senders {
-            let Some(sender) = &sender else { continue };
-            let address = SuiAddress::from_bytes(sender)
-                .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
-                .extend()?;
-            addrs.push(Address { address });
+        if let Some(stored) = &self.stored {
+            let mut addrs = Vec::with_capacity(stored.senders.len());
+            for sender in &stored.senders {
+                let Some(sender) = &sender else { continue };
+                let address = SuiAddress::from_bytes(sender)
+                    .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
+                    .extend()?;
+                addrs.push(Address { address });
+            }
+            Ok(Some(addrs))
+        } else {
+            Ok(Some(vec![Address {
+                address: SuiAddress::from(self.native.sender),
+            }]))
         }
-        Ok(Some(addrs))
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        Ok(DateTime::from_ms(self.stored.timestamp_ms).ok())
+        let Some(stored) = &self.stored else {
+            return Ok(None);
+        };
+        Ok(DateTime::from_ms(stored.timestamp_ms).ok())
     }
 
     #[graphql(flatten)]
     async fn move_value(&self) -> Result<MoveValue> {
-        let type_ = TypeTag::from(
-            parse_sui_struct_tag(&self.stored.event_type)
-                .map_err(|e| Error::Internal(e.to_string()))
-                .extend()?,
-        );
-        Ok(MoveValue::new(type_, Base64::from(self.stored.bcs.clone())))
+        let type_tag = self.type_tag_impl().extend()?;
+
+        Ok(MoveValue::new(
+            type_tag,
+            Base64::from(self.native.contents.clone()),
+        ))
+    }
+}
+
+impl TryFrom<StoredEvent> for Event {
+    type Error = Error;
+
+    fn try_from(stored_event: StoredEvent) -> Result<Self, Error> {
+        let native_event: NativeEvent = bcs::from_bytes(&stored_event.bcs).map_err(|_| {
+            Error::Internal(format!(
+                "Failed to deserialize event with {} at transaction {}",
+                stored_event.event_sequence_number, stored_event.tx_sequence_number
+            ))
+        })?;
+
+        Ok(Self {
+            stored: Some(stored_event),
+            native: native_event,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::*;
-use sui_indexer::models_v2::events::StoredEvent;
+use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
 use sui_types::{event::Event as NativeEvent, parse_sui_struct_tag, TypeTag};
 
 use crate::error::Error;
@@ -14,9 +14,14 @@ use super::{
     move_value::MoveValue, sui_address::SuiAddress,
 };
 
-pub(crate) struct Event {
-    pub stored: Option<StoredEvent>,
+pub(crate) struct EventFromTransaction {
     pub native: NativeEvent,
+    pub timestamp_ms: i64,
+}
+
+pub(crate) enum Event {
+    Stored(StoredEvent),
+    Native(EventFromTransaction),
 }
 
 #[derive(InputObject, Clone, Default)]
@@ -53,38 +58,74 @@ pub(crate) struct EventFilter {
 }
 
 impl Event {
+    pub fn try_from(stored_transaction: &StoredTransaction, idx: usize) -> Result<Self, Error> {
+        let event = stored_transaction
+            .events
+            .get(idx as usize)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "Failed to get event with {} at transaction {}",
+                    idx, stored_transaction.tx_sequence_number
+                ))
+            })?
+            .as_ref()
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "Failed to get event with {} at transaction {}",
+                    idx, stored_transaction.tx_sequence_number
+                ))
+            })?;
+
+        let native_event: NativeEvent = bcs::from_bytes(&event).map_err(|_| {
+            Error::Internal(format!(
+                "Failed to deserialize event with {} at transaction {}",
+                idx, stored_transaction.tx_sequence_number
+            ))
+        })?;
+
+        Ok(Self::Native(EventFromTransaction {
+            native: native_event,
+            timestamp_ms: stored_transaction.timestamp_ms,
+        }))
+    }
+
     fn package_impl(&self) -> Result<SuiAddress, Error> {
-        if let Some(stored) = &self.stored {
-            SuiAddress::from_bytes(&stored.package).map_err(|e| Error::Internal(e.to_string()))
-        } else {
-            Ok(SuiAddress::from(self.native.package_id))
+        match self {
+            Self::Stored(stored) => SuiAddress::from_bytes(&stored.package)
+                .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}"))),
+            Self::Native(e) => Ok(SuiAddress::from(e.native.package_id)),
         }
     }
 
     fn module_impl(&self) -> &str {
-        if let Some(stored) = &self.stored {
-            &stored.module
-        } else {
-            self.native.transaction_module.as_ident_str().as_str()
+        match self {
+            Self::Stored(stored) => &stored.module,
+            Self::Native(e) => e.native.transaction_module.as_ident_str().as_str(),
         }
     }
 
-    fn timestamp_ms_impl(&self) -> Option<i64> {
-        if let Some(stored) = &self.stored {
-            Some(stored.timestamp_ms)
-        } else {
-            None
+    fn timestamp_ms_impl(&self) -> i64 {
+        match self {
+            Self::Stored(stored) => stored.timestamp_ms,
+            Self::Native(e) => e.timestamp_ms,
         }
     }
 
     fn type_tag_impl(&self) -> Result<TypeTag, Error> {
-        let struct_tag = match &self.stored {
-            Some(stored) => parse_sui_struct_tag(&stored.event_type)
+        let struct_tag = match self {
+            Self::Stored(stored) => parse_sui_struct_tag(&stored.event_type)
                 .map_err(|e| Error::Internal(e.to_string()))?,
-            None => self.native.type_.clone(),
+            Self::Native(e) => e.native.type_.clone(),
         };
 
         Ok(TypeTag::from(struct_tag))
+    }
+
+    fn bcs_impl(&self) -> &Vec<u8> {
+        match self {
+            Self::Stored(stored) => &stored.bcs,
+            Self::Native(e) => &e.native.contents,
+        }
     }
 }
 
@@ -107,56 +148,39 @@ impl Event {
 
     /// Addresses of the senders of the event
     async fn senders(&self) -> Result<Option<Vec<Address>>> {
-        if let Some(stored) = &self.stored {
-            let mut addrs = Vec::with_capacity(stored.senders.len());
-            for sender in &stored.senders {
-                let Some(sender) = &sender else { continue };
-                let address = SuiAddress::from_bytes(sender)
-                    .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
-                    .extend()?;
-                addrs.push(Address { address });
+        match self {
+            Self::Stored(stored) => {
+                let mut addrs = Vec::with_capacity(stored.senders.len());
+                for sender in &stored.senders {
+                    let Some(sender) = &sender else { continue };
+                    let address = SuiAddress::from_bytes(sender)
+                        .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
+                        .extend()?;
+                    addrs.push(Address { address });
+                }
+                Ok(Some(addrs))
             }
-            Ok(Some(addrs))
-        } else {
-            Ok(Some(vec![Address {
-                address: SuiAddress::from(self.native.sender),
-            }]))
+            Self::Native(e) => Ok(Some(vec![Address {
+                address: SuiAddress::from(e.native.sender),
+            }])),
         }
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        let Some(timestamp_ms) = self.timestamp_ms_impl() else {
-            return Ok(None);
-        };
-        Ok(Some(DateTime::from_ms(timestamp_ms)?))
+        Ok(Some(DateTime::from_ms(self.timestamp_ms_impl())?))
     }
 
     #[graphql(flatten)]
     async fn move_value(&self) -> Result<MoveValue> {
         let type_tag = self.type_tag_impl().extend()?;
 
-        Ok(MoveValue::new(
-            type_tag,
-            Base64::from(self.native.contents.clone()),
-        ))
+        Ok(MoveValue::new(type_tag, Base64::from(self.bcs_impl())))
     }
 }
 
-impl TryFrom<StoredEvent> for Event {
-    type Error = Error;
-
-    fn try_from(stored_event: StoredEvent) -> Result<Self, Error> {
-        let native_event: NativeEvent = bcs::from_bytes(&stored_event.bcs).map_err(|_| {
-            Error::Internal(format!(
-                "Failed to deserialize event with {} at transaction {}",
-                stored_event.event_sequence_number, stored_event.tx_sequence_number
-            ))
-        })?;
-
-        Ok(Self {
-            stored: Some(stored_event),
-            native: native_event,
-        })
+impl From<StoredEvent> for Event {
+    fn from(stored_event: StoredEvent) -> Self {
+        Self::Stored(stored_event)
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -69,6 +69,14 @@ impl Event {
         }
     }
 
+    fn timestamp_ms_impl(&self) -> Option<i64> {
+        if let Some(stored) = &self.stored {
+            Some(stored.timestamp_ms)
+        } else {
+            None
+        }
+    }
+
     fn type_tag_impl(&self) -> Result<TypeTag, Error> {
         let struct_tag = match &self.stored {
             Some(stored) => parse_sui_struct_tag(&stored.event_type)
@@ -118,10 +126,10 @@ impl Event {
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        let Some(stored) = &self.stored else {
+        let Some(timestamp_ms) = self.timestamp_ms_impl() else {
             return Ok(None);
         };
-        Ok(DateTime::from_ms(stored.timestamp_ms).ok())
+        Ok(Some(DateTime::from_ms(timestamp_ms)?))
     }
 
     #[graphql(flatten)]


### PR DESCRIPTION
## Description 

A StoredTransaction has the Event from sui-types serialized onto it. To resolve StoredTransaction.events, rather than making another db roundtrip, we can construct the graphql Event directly from the information available on StoredTransaction. I've changed the type of Event from struct to enum, since we'd either have its StoredEvent representation, or if deriving from StoredTransaction, the NativeEvent and any other useful fields from StoredTransaction. Of course, it's also possible to have the second variant be just the StoredTransaction, for example to support getting the transaction block from an event. But I think this would be naive as:

1. without dataloaders, we would need to clone StoredTransaction n times for each element in the events vec
2. with dataloaders, the above would be made redundant since we can just make a fetch, and dataloader would gather and cache the repeated calls

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
