### PR TITLE
Minor cleanups in EpochStartConfig

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -6,11 +6,8 @@ use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::hash::HashFunction;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fs, path::Path};
-use sui_types::authenticator_state::{
-    get_authenticator_state, get_authenticator_state_obj_initial_shared_version,
-    AuthenticatorStateInner,
-};
-use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
+use sui_types::authenticator_state::{get_authenticator_state, AuthenticatorStateInner};
+use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::clock::Clock;
 use sui_types::committee::CommitteeWithNetworkMetadata;
 use sui_types::crypto::DefaultHash;
@@ -19,7 +16,6 @@ use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, VerifiedCheckpoint,
 };
-use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
 use sui_types::storage::ObjectStore;
 use sui_types::sui_system_state::{
     get_sui_system_state, get_sui_system_state_wrapper, SuiSystemState, SuiSystemStateTrait,
@@ -155,16 +151,6 @@ impl Genesis {
 
     pub fn sui_system_object(&self) -> SuiSystemState {
         get_sui_system_state(&self.objects()).expect("Sui System State object must always exist")
-    }
-
-    pub fn authenticator_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        get_authenticator_state_obj_initial_shared_version(&self.objects())
-            .expect("Read from genesis cannot fail")
-    }
-
-    pub fn randomness_state_obj_initial_shared_version(&self) -> Option<SequenceNumber> {
-        get_randomness_state_obj_initial_shared_version(&self.objects())
-            .expect("Read from genesis cannot fail")
     }
 
     pub fn clock(&self) -> Clock {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -168,9 +168,8 @@ impl AuthorityStore {
             let epoch_start_configuration = EpochStartConfiguration::new(
                 genesis.sui_system_object().into_epoch_start_state(),
                 *genesis.checkpoint().digest(),
-                genesis.authenticator_state_obj_initial_shared_version(),
-                genesis.randomness_state_obj_initial_shared_version(),
-            );
+                &genesis.objects(),
+            )?;
             perpetual_tables
                 .set_epoch_start_configuration(&epoch_start_configuration)
                 .await?;

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -200,9 +200,9 @@ impl<'a> TestAuthorityBuilder<'a> {
         let epoch_start_configuration = EpochStartConfiguration::new(
             genesis.sui_system_object().into_epoch_start_state(),
             *genesis.checkpoint().digest(),
-            genesis.authenticator_state_obj_initial_shared_version(),
-            genesis.randomness_state_obj_initial_shared_version(),
-        );
+            &genesis.objects(),
+        )
+        .unwrap();
         let expensive_safety_checks = match self.expensive_safety_checks {
             None => ExpensiveSafetyCheckConfig::default(),
             Some(config) => config,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -227,7 +227,12 @@ pub async fn test_checkpoint_executor_cross_epoch() {
             &authority_state.epoch_store_for_testing(),
             SupportedProtocolVersions::SYSTEM_DEFAULT,
             second_committee.committee().clone(),
-            EpochStartConfiguration::new_v1(system_state, Default::default()),
+            EpochStartConfiguration::new(
+                system_state,
+                Default::default(),
+                &authority_state.database,
+            )
+            .unwrap(),
             &executor,
             accumulator,
             &ExpensiveSafetyCheckConfig::default(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -24,11 +24,9 @@ use std::time::Duration;
 use sui_core::authority::CHAIN_IDENTIFIER;
 use sui_core::consensus_adapter::{LazyNarwhalClient, SubmitToConsensus};
 use sui_json_rpc_api::JsonRpcMetrics;
-use sui_types::authenticator_state::get_authenticator_state_obj_initial_shared_version;
 use sui_types::base_types::ConciseableName;
 use sui_types::digests::ChainIdentifier;
 use sui_types::message_envelope::get_google_jwk_bytes;
-use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
 use sui_types::sui_system_state::SuiSystemState;
 use tap::tap::TapFallible;
 use tokio::runtime::Handle;
@@ -1571,19 +1569,12 @@ impl SuiNode {
             .expect("Error loading last checkpoint for current epoch")
             .expect("Could not load last checkpoint for current epoch");
 
-        let authenticator_state_obj_initial_shared_version =
-            get_authenticator_state_obj_initial_shared_version(&state.database)
-                .expect("read cannot fail");
-        let randomness_state_obj_initial_shared_version =
-            get_randomness_state_obj_initial_shared_version(&state.database)
-                .expect("read cannot fail");
-
         let epoch_start_configuration = EpochStartConfiguration::new(
             next_epoch_start_system_state,
             *last_checkpoint.digest(),
-            authenticator_state_obj_initial_shared_version,
-            randomness_state_obj_initial_shared_version,
-        );
+            &state.database,
+        )
+        .expect("EpochStartConfiguration construction cannot fail");
 
         let new_epoch_store = self
             .state

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -43,8 +43,8 @@ use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
 use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_types::storage::{get_module, PackageObject};
 use sui_types::{
-    authenticator_state::get_authenticator_state_obj_initial_shared_version,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, VersionNumber},
     committee::EpochId,
     digests::{ChainIdentifier, CheckpointDigest, ObjectDigest, TransactionDigest},
@@ -63,10 +63,6 @@ use sui_types::{
         TransactionKind, VerifiedCertificate, VerifiedTransaction,
     },
     DEEPBOOK_PACKAGE_ID,
-};
-use sui_types::{
-    randomness_state::get_randomness_state_obj_initial_shared_version,
-    storage::{get_module, PackageObject},
 };
 use tracing::{error, info, warn};
 
@@ -2118,11 +2114,9 @@ async fn create_epoch_store(
     let epoch_start_config = EpochStartConfiguration::new(
         sys_state,
         CheckpointDigest::random(),
-        get_authenticator_state_obj_initial_shared_version(&authority_state.database)
-            .expect("read cannot fail"),
-        get_randomness_state_obj_initial_shared_version(&authority_state.database)
-            .expect("read cannot fail"),
-    );
+        &authority_state.database,
+    )
+    .unwrap();
 
     let registry = Registry::new();
     let cache_metrics = Arc::new(ResolverMetrics::new(&registry));

--- a/crates/sui-snapshot/src/lib.rs
+++ b/crates/sui-snapshot/src/lib.rs
@@ -23,9 +23,7 @@ use sui_core::epoch::committee_store::CommitteeStore;
 use sui_storage::object_store::util::path_to_filesystem;
 use sui_storage::{compute_sha3_checksum, FileCompression, SHA3_BYTES};
 use sui_types::accumulator::Accumulator;
-use sui_types::authenticator_state::get_authenticator_state_obj_initial_shared_version;
 use sui_types::base_types::ObjectID;
-use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::sui_system_state::SuiSystemStateTrait;
@@ -223,10 +221,6 @@ pub async fn setup_db_state(
     // This function should be called once state accumulator based hash verification
     // is complete and live object set state is downloaded to local store
     let system_state_object = get_sui_system_state(&perpetual_db)?;
-    let authenticator_state_obj_initial_shared_version =
-        get_authenticator_state_obj_initial_shared_version(&perpetual_db)?;
-    let randomness_state_obj_initial_shared_version =
-        get_randomness_state_obj_initial_shared_version(&perpetual_db)?;
     let new_epoch_start_state = system_state_object.into_epoch_start_state();
     let next_epoch_committee = new_epoch_start_state.get_sui_committee();
     let last_checkpoint = checkpoint_store
@@ -236,9 +230,9 @@ pub async fn setup_db_state(
     let epoch_start_configuration = EpochStartConfiguration::new(
         new_epoch_start_state,
         *last_checkpoint.digest(),
-        authenticator_state_obj_initial_shared_version,
-        randomness_state_obj_initial_shared_version,
-    );
+        &perpetual_db,
+    )
+    .unwrap();
     perpetual_db
         .set_epoch_start_configuration(&epoch_start_configuration)
         .await?;


### PR DESCRIPTION
## Description 

1. Remove unused old constructors.
2. Dedup all the code that reads the init shared versions of epoch start objects.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
