### PR TITLE
[mysten-service] 1/n initialize crate for service dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,6 +7184,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mysten-service"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "workspace-hack",
+]
+
+[[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "crates/mysten-common",
     "crates/mysten-metrics",
     "crates/mysten-network",
+    "crates/mysten-service",
     "crates/mysten-util-mem",
     "crates/mysten-util-mem-derive",
     "crates/prometheus-closure-metric",

--- a/crates/mysten-service/Cargo.toml
+++ b/crates/mysten-service/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mysten-service"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+tokio.workspace = true
+serde.workspace = true
+workspace-hack.workspace = true
+
+[dev-dependencies]
+tower.workspace = true
+serde_json.workspace = true

--- a/crates/mysten-service/src/health.rs
+++ b/crates/mysten-service/src/health.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// service health related utilities
+///
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceStatus {
+    Up,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HealthResponse {
+    name: String,
+    version: String,
+    status: ServiceStatus,
+}
+
+impl HealthResponse {
+    pub fn new(package_name: &str, package_version: &str) -> Self {
+        Self {
+            name: package_name.to_owned(),
+            version: package_version.to_owned(),
+            status: ServiceStatus::Up,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_response_new_works() {
+        let result = HealthResponse::new("myslib", "0.0.1");
+        assert_eq!(
+            result,
+            HealthResponse {
+                name: "myslib".to_owned(),
+                version: "0.0.1".to_owned(),
+                status: ServiceStatus::Up
+            }
+        );
+    }
+}

--- a/crates/mysten-service/src/lib.rs
+++ b/crates/mysten-service/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod health;
+mod service;
+
+pub use service::get_mysten_service;
+pub use service::serve;
+
+pub const DEFAULT_PORT: u16 = 2024;
+
+#[macro_export]
+macro_rules! package_name {
+    () => {
+        env!("CARGO_PKG_NAME")
+    };
+}
+
+#[macro_export]
+macro_rules! package_version {
+    () => {
+        env!("CARGO_PKG_VERSION")
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_name_works() {
+        assert_eq!(package_name!(), "mysten-service",);
+    }
+
+    #[test]
+    fn package_version_works() {
+        assert_eq!(package_version!(), "0.0.1",);
+    }
+}

--- a/crates/mysten-service/src/service.rs
+++ b/crates/mysten-service/src/service.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::health::HealthResponse;
+use crate::DEFAULT_PORT;
+use anyhow::Result;
+use axum::routing::get;
+use axum::Json;
+use axum::Router;
+
+pub fn get_mysten_service(app_name: &str, app_version: &str) -> Router {
+    // build our application with a single route
+    Router::new().route(
+        "/health",
+        get(Json(HealthResponse::new(app_name, app_version))),
+    )
+}
+
+pub async fn serve(app: Router) -> Result<()> {
+    // run it with hyper on localhost:3000
+    println!("listening on http://localhost:{}", DEFAULT_PORT);
+    axum::Server::bind(&format!("0.0.0.0:{}", DEFAULT_PORT).parse()?)
+        .serve(app.into_make_service())
+        .await?;
+    Ok(())
+}

--- a/crates/mysten-service/tests/integration_test.rs
+++ b/crates/mysten-service/tests/integration_test.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::body::Body;
+use axum::body::HttpBody;
+use axum::http::Request;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_add() {
+    let app = mysten_service::get_mysten_service("itest", "0.0.0");
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let mut body = res.into_body();
+    let body_data = body.data().await.unwrap().unwrap();
+    println!("{}", std::str::from_utf8(&body_data).unwrap());
+    assert_eq!(
+        &body_data[..],
+        br#"{"name":"itest","version":"0.0.0","status":"up"}"#
+    );
+}


### PR DESCRIPTION
## Description 

Doing some work to bring this to the sui repo – basic service utilities for new services.

Full list of items to eventually include in [this notion doc](https://www.notion.so/mystenlabs/code-bootstrapping-de278ec675c6473ba6004f22baf610eb?pvs=4)

## Test Plan 

cargo test
```

running 3 tests
test health::tests::health_response_new_works ... ok
test tests::package_name_works ... ok
test tests::package_version_works ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_test.rs (/Users/jkjensen/mysten/sui/target/debug/deps/integration_test-85ebcfb09adf53fc)

running 1 test
test test_add ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests mysten-service

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
