### PR TITLE
[mysten-service] 2/n add basic metrics functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,6 +7195,8 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",
+ "mysten-metrics",
+ "prometheus",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/mysten-service/Cargo.toml
+++ b/crates/mysten-service/Cargo.toml
@@ -12,6 +12,8 @@ axum.workspace = true
 tokio.workspace = true
 serde.workspace = true
 workspace-hack.workspace = true
+prometheus.workspace = true
+mysten-metrics.workspace = true
 
 [dev-dependencies]
 tower.workspace = true

--- a/crates/mysten-service/src/lib.rs
+++ b/crates/mysten-service/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod health;
+pub mod metrics;
 mod service;
 
 pub use service::get_mysten_service;

--- a/crates/mysten-service/src/metrics.rs
+++ b/crates/mysten-service/src/metrics.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr};
+
+pub const METRICS_HOST_PORT: u16 = 9184;
+
+/// This is an option if you need to use the underlying method
+pub use mysten_metrics::start_prometheus_server;
+
+/// Use the standard IP (0.0.0.0) and port (9184) to start a new
+/// prometheus server.
+///
+/// Use this function to get a registry and then register your
+/// own application metrics via
+///
+/// ```
+/// use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
+///
+/// pub struct MyMetrics {
+///     pub requests: IntCounter,
+/// }
+///
+/// impl MyMetrics {
+///     pub fn new(registry: &Registry) -> Self {
+///         Self {
+///             requests: register_int_counter_with_registry!(
+///                 "total_requests",
+///                 "Total number of requests received by my service",
+///                 registry
+///             )
+///             .unwrap(),
+///         }
+///     }
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///      let prometheus_registry = mysten_service::metrics::start_basic_prometheus_server();
+///      let metrics = MyMetrics::new(&prometheus_registry);
+/// }
+/// ```
+pub fn start_basic_prometheus_server() -> Registry {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), METRICS_HOST_PORT);
+    mysten_metrics::start_prometheus_server(addr).default_registry()
+}

--- a/crates/mysten-service/src/service.rs
+++ b/crates/mysten-service/src/service.rs
@@ -8,7 +8,10 @@ use axum::routing::get;
 use axum::Json;
 use axum::Router;
 
-pub fn get_mysten_service(app_name: &str, app_version: &str) -> Router {
+pub fn get_mysten_service<S>(app_name: &str, app_version: &str) -> Router<S>
+where
+    S: Send + Clone + Sync + 'static,
+{
     // build our application with a single route
     Router::new().route(
         "/health",

--- a/crates/mysten-service/tests/integration_test.rs
+++ b/crates/mysten-service/tests/integration_test.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::body;
 use axum::body::Body;
 use axum::body::HttpBody;
 use axum::http::Request;

--- a/crates/mysten-service/tests/integration_test.rs
+++ b/crates/mysten-service/tests/integration_test.rs
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::body;
 use axum::body::Body;
 use axum::body::HttpBody;
 use axum::http::Request;
 use tower::ServiceExt;
 
 #[tokio::test]
-async fn test_add() {
+async fn test_mysten_service() {
     let app = mysten_service::get_mysten_service("itest", "0.0.0");
 
     let res = app


### PR DESCRIPTION
## Description 

Add metrics initialization

## Test Plan 

cargo test
```
running 3 tests
test health::tests::health_response_new_works ... ok
test tests::package_name_works ... ok
test tests::package_version_works ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_test.rs (/Users/jkjensen/mysten/sui/target/debug/deps/integration_test-5c35a104ffffed4f)

running 1 test
test test_mysten_service ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests mysten-service

running 1 test
test crates/mysten-service/src/metrics.rs - metrics::start_basic_prometheus_server (line 16) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.68s
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
