### PR TITLE
[shared object deletion] Enable in testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -100,6 +100,7 @@ const MAX_PROTOCOL_VERSION: u64 = 33;
 // Version 33: Add support for `receiving_object_id` function in framework
 //             Hardened OTW check.
 //             Enable transfer-to-object in mainnet.
+//             Enable shared object deletion in testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1712,6 +1713,11 @@ impl ProtocolConfig {
                     // Enable transfer-to-object in mainnet
                     cfg.transfer_receive_object_cost_base = Some(52);
                     cfg.feature_flags.receive_objects = true;
+
+                    // Enable shared object deletion in testnet and devnet
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.shared_object_deletion = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_33.snap
@@ -24,6 +24,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
   narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   enable_jwk_consensus_updates: true


### PR DESCRIPTION
## Description 

Enables shared object deletion in testnet.

## Test Plan 

Existing tests + baking in devnet for the past couple months.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Shared object deletion is now enabled in testnet.
