### PR TITLE
[mysten-service] 3/n add logging utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,8 +7113,10 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "telemetry-subscribers",
  "tokio",
  "tower",
+ "tracing",
  "workspace-hack",
 ]
 

--- a/crates/mysten-service/Cargo.toml
+++ b/crates/mysten-service/Cargo.toml
@@ -14,6 +14,8 @@ serde.workspace = true
 workspace-hack.workspace = true
 prometheus.workspace = true
 mysten-metrics.workspace = true
+telemetry-subscribers.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tower.workspace = true

--- a/crates/mysten-service/src/lib.rs
+++ b/crates/mysten-service/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod health;
+pub mod logging;
 pub mod metrics;
 mod service;
 

--- a/crates/mysten-service/src/logging.rs
+++ b/crates/mysten-service/src/logging.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use telemetry_subscribers::TelemetryConfig;
+
+pub fn init() -> telemetry_subscribers::TelemetryGuards {
+    let (guard, _handle) = TelemetryConfig::new().with_env().init();
+    guard
+}

--- a/crates/mysten-service/src/service.rs
+++ b/crates/mysten-service/src/service.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use axum::routing::get;
 use axum::Json;
 use axum::Router;
+use tracing::debug;
 
 pub fn get_mysten_service<S>(app_name: &str, app_version: &str) -> Router<S>
 where
@@ -21,7 +22,7 @@ where
 
 pub async fn serve(app: Router) -> Result<()> {
     // run it with hyper on localhost:3000
-    println!("listening on http://localhost:{}", DEFAULT_PORT);
+    debug!("listening on http://localhost:{}", DEFAULT_PORT);
     axum::Server::bind(&format!("0.0.0.0:{}", DEFAULT_PORT).parse()?)
         .serve(app.into_make_service())
         .await?;

--- a/crates/mysten-service/tests/integration_test.rs
+++ b/crates/mysten-service/tests/integration_test.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::body;
 use axum::body::Body;
 use axum::body::HttpBody;
 use axum::http::Request;

--- a/crates/mysten-service/tests/integration_test.rs
+++ b/crates/mysten-service/tests/integration_test.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::body;
 use axum::body::Body;
 use axum::body::HttpBody;
 use axum::http::Request;


### PR DESCRIPTION
## Description 

unify logging initialization to a utility fn

## Test Plan 

cargo test
```

running 3 tests
test health::tests::health_response_new_works ... ok
test tests::package_name_works ... ok
test tests::package_version_works ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/integration_test.rs (/Users/jkjensen/mysten/sui/target/debug/deps/integration_test-2597f82918f87a66)

running 1 test
test test_mysten_service ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests mysten-service

running 1 test
test crates/mysten-service/src/metrics.rs - metrics::start_basic_prometheus_server (line 19) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.80s

```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
