### PR TITLE
Enable effects v2 in mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -101,6 +101,7 @@ const MAX_PROTOCOL_VERSION: u64 = 33;
 //             Hardened OTW check.
 //             Enable transfer-to-object in mainnet.
 //             Enable shared object deletion in testnet.
+//             Enable effects v2 in mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1718,6 +1719,8 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.shared_object_deletion = true;
                     }
+
+                    cfg.feature_flags.enable_effects_v2 = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_33.snap
@@ -31,6 +31,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true


### PR DESCRIPTION
## Description 

Enable effects v2.

## Test Plan 

Added more tests. Run node catchup with all debug asserts enabled. Baked in testnet for months.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x ] breaking change for FNs (FN binary must upgrade)
- [x ] breaking change for validators or node operators (must upgrade binaries)
- [x ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This is a rework of the core effects data structure that make it simpler, more efficient and extensible.
More details in https://github.com/MystenLabs/sui/issues/12813
