### PR TITLE
add graphql and json-rpc routes

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -106,6 +106,7 @@ impl ServerBuilder {
         if self.router.is_none() {
             let router: Router = Router::new()
                 .route("/", post(graphql_handler))
+                .route("/graphql", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
                 .layer(middleware::from_fn(check_version_middleware))
                 .layer(middleware::from_fn(set_version_middleware));

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -39,6 +39,7 @@ async fn start_graphiql_server_impl(
     // Add GraphiQL IDE handler on GET request to `/`` endpoint
     let server = server_builder
         .route("/", axum::routing::get(graphiql))
+        .route("/graphql", axum::routing::get(graphiql))
         .layer(axum::extract::Extension(Some(ide_title)))
         .build()?;
 

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -182,14 +182,15 @@ impl JsonRpcServerBuilder {
                 );
             }
             Some(ServerType::Http) => {
-                router = router.route(
-                    "/",
-                    axum::routing::post(crate::axum_router::json_rpc_handler),
-                )
-                .route(
-                    "/json-rpc",
-                    axum::routing::post(crate::axum_router::json_rpc_handler),
-                );
+                router = router
+                    .route(
+                        "/",
+                        axum::routing::post(crate::axum_router::json_rpc_handler),
+                    )
+                    .route(
+                        "/json-rpc",
+                        axum::routing::post(crate::axum_router::json_rpc_handler),
+                    );
             }
             None => {
                 router = router

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -185,6 +185,10 @@ impl JsonRpcServerBuilder {
                 router = router.route(
                     "/",
                     axum::routing::post(crate::axum_router::json_rpc_handler),
+                )
+                .route(
+                    "/json-rpc",
+                    axum::routing::post(crate::axum_router::json_rpc_handler),
                 );
             }
             None => {
@@ -196,6 +200,10 @@ impl JsonRpcServerBuilder {
                     .route(
                         "/",
                         axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
+                    )
+                    .route(
+                        "/json-rpc",
+                        axum::routing::post(crate::axum_router::json_rpc_handler),
                     );
             }
         }


### PR DESCRIPTION
## Description 

Adding `/json-rpc` route to the `sui-indexer` service and `/graphql` route to the `sui-graphql` service. These mirror the behaviors of their respective `/` routes.

## Test Plan 

Test new routes:

```
curl -s -i http://localhost:8001/graphql | egrep '(200 OK|GraphiQL)'
HTTP/1.1 200 OK
        React.createElement(GraphiQL, {
          fetcher: GraphiQL.createFetcher({
```

```
curl -s -X POST -H "Content-Type: application/json" --data '{ "query": "query { chainIdentifier }", "variables": { "userId": "123" } }' http://localhost:8001/graphql | jq
{
  "data": {
    "chainIdentifier": "4c78adac"
  }
}
```

```
% curl -w "%{http_code}" http://localhost:9000/json-rpc -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200
```

Test existing routes:

```
% curl -s -i http://localhost:8001 | egrep '(200 OK|GraphiQL)'
HTTP/1.1 200 OK
        React.createElement(GraphiQL, {
          fetcher: GraphiQL.createFetcher({
```

```
% curl -s -X POST -H "Content-Type: application/json" --data '{ "query": "query { chainIdentifier }", "variables": { "userId": "123" } }' http://localhost:8001 | jq

{
  "data": {
    "chainIdentifier": "4c78adac"
  }
}
```

```
% curl -w "%{http_code}" http://localhost:9000 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200
```


also test `sui-node` service `/` route which touches the same code paths:

```
curl -w "%{http_code}" http://localhost:9000 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200
```

