### PR TITLE
[kvstore] improve metrics

### DIFF
--- a/crates/sui-storage/src/key_value_store.rs
+++ b/crates/sui-storage/src/key_value_store.rs
@@ -75,12 +75,12 @@ impl TransactionKeyValueStore {
 
         self.metrics
             .key_value_store_num_fetches_latency_ms
-            .with_label_values(&[self.store_name])
-            .observe(elapsed.as_millis() as u64);
+            .with_label_values(&[self.store_name, "tx"])
+            .observe(elapsed.as_millis() as f64);
         self.metrics
             .key_value_store_num_fetches_batch_size
-            .with_label_values(&[self.store_name])
-            .observe(total_keys);
+            .with_label_values(&[self.store_name, "tx"])
+            .observe(total_keys as f64);
 
         if let Ok(res) = &res {
             let txns_not_found = res.0.iter().filter(|v| v.is_none()).count() as u64;
@@ -173,12 +173,16 @@ impl TransactionKeyValueStore {
 
         self.metrics
             .key_value_store_num_fetches_latency_ms
-            .with_label_values(&[self.store_name])
-            .observe(elapsed.as_millis() as u64);
+            .with_label_values(&[self.store_name, "checkpoint"])
+            .observe(elapsed.as_millis() as f64);
         self.metrics
             .key_value_store_num_fetches_batch_size
-            .with_label_values(&[self.store_name])
-            .observe(num_summaries + num_contents);
+            .with_label_values(&[self.store_name, "checkpoint_summary"])
+            .observe(num_summaries as f64);
+        self.metrics
+            .key_value_store_num_fetches_batch_size
+            .with_label_values(&[self.store_name, "checkpoint_content"])
+            .observe(num_contents as f64);
 
         if let Ok(res) = &res {
             let summaries_not_found = res.0.iter().filter(|v| v.is_none()).count() as u64

--- a/crates/sui-storage/src/key_value_store_metrics.rs
+++ b/crates/sui-storage/src/key_value_store_metrics.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use mysten_metrics::histogram::HistogramVec;
-use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
+use prometheus::{
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry, HistogramVec,
+    IntCounterVec, Registry,
+};
 use std::sync::Arc;
 
 pub struct KeyValueStoreMetrics {
@@ -39,19 +41,27 @@ impl KeyValueStoreMetrics {
             )
             .unwrap(),
 
-            key_value_store_num_fetches_latency_ms: HistogramVec::new_in_registry(
+            key_value_store_num_fetches_latency_ms: register_histogram_vec_with_registry!(
                 "key_value_store_num_fetches_latency_ms",
                 "Latency of fetches from key value store",
-                &["store"],
+                &["store", "type"],
+                prometheus::exponential_buckets(1.0, 1.6, 24)
+                    .unwrap()
+                    .to_vec(),
                 registry,
-            ),
+            )
+            .unwrap(),
 
-            key_value_store_num_fetches_batch_size: HistogramVec::new_in_registry(
+            key_value_store_num_fetches_batch_size: register_histogram_vec_with_registry!(
                 "key_value_store_num_fetches_batch_size",
                 "Number of keys fetched per batch",
-                &["store"],
+                &["store", "type"],
+                prometheus::exponential_buckets(1.0, 1.6, 20)
+                    .unwrap()
+                    .to_vec(),
                 registry,
-            ),
+            )
+            .unwrap(),
         })
     }
 


### PR DESCRIPTION
## Description 

Because the metrics have labels, switch to prometheus histogram.
Label the fetch latency metrics with the data fetched (tx vs checkpoint).
Add trace logs to `multi_get_transaction_blocks_internal()`.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
