### PR TITLE
[graphql] Refactor ObjectOwner

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
@@ -5,7 +5,7 @@ created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run-graphql'. lines 39-53:
+task 2 'run-graphql'. lines 39-57:
 Response: {
   "data": {
     "address": {
@@ -16,20 +16,20 @@ Response: {
   }
 }
 
-task 3 'run'. lines 55-55:
+task 3 'run'. lines 59-59:
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4 'view-object'. lines 57-57:
+task 4 'view-object'. lines 61-61:
 Owner: Account Address ( A )
 Version: 3
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, value: 0u64}
 
-task 5 'create-checkpoint'. lines 59-59:
+task 5 'create-checkpoint'. lines 63-63:
 Checkpoint created: 1
 
-task 6 'run-graphql'. lines 61-75:
+task 6 'run-graphql'. lines 65-83:
 Response: {
   "data": {
     "address": {
@@ -37,9 +37,11 @@ Response: {
         "edges": [
           {
             "node": {
-              "kind": "OWNED",
               "owner": {
-                "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                "__typename": "AddressOwner",
+                "owner": {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                }
               }
             }
           }
@@ -49,7 +51,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 77-91:
+task 7 'run-graphql'. lines 85-103:
 Response: {
   "data": {
     "address": {
@@ -57,9 +59,11 @@ Response: {
         "edges": [
           {
             "node": {
-              "kind": "OWNED",
               "owner": {
-                "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                "__typename": "AddressOwner",
+                "owner": {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                }
               }
             }
           }
@@ -69,7 +73,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 93-107:
+task 8 'run-graphql'. lines 105-123:
 Response: {
   "data": {
     "address": {
@@ -77,9 +81,11 @@ Response: {
         "edges": [
           {
             "node": {
-              "kind": "OWNED",
               "owner": {
-                "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                "__typename": "AddressOwner",
+                "owner": {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                }
               }
             }
           }
@@ -89,7 +95,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 109-123:
+task 9 'run-graphql'. lines 125-143:
 Response: {
   "data": {
     "owner": {
@@ -97,9 +103,11 @@ Response: {
         "edges": [
           {
             "node": {
-              "kind": "OWNED",
               "owner": {
-                "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                "__typename": "AddressOwner",
+                "owner": {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                }
               }
             }
           }
@@ -109,7 +117,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 125-139:
+task 10 'run-graphql'. lines 145-163:
 Response: {
   "data": {
     "object": null

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -42,9 +42,13 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }
@@ -64,9 +68,13 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }
@@ -80,9 +88,13 @@ module Test::M1 {
     objectConnection(filter: {owner: "0x42"}) {
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }
@@ -96,9 +108,13 @@ module Test::M1 {
     objectConnection(filter: {owner: "0x888"}) {
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }
@@ -112,9 +128,13 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }
@@ -128,9 +148,13 @@ module Test::M1 {
     objectConnection{
       edges {
         node {
-          kind
           owner {
-            address
+            __typename
+            ... on AddressOwner {
+              owner {
+                address
+              }
+            }
           }
         }
       }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -103,7 +103,7 @@ CheckpointSummary { epoch: 6, seq: 11, content_digest: D3oWLCcqoa1D15gxzvMaDemNN
 task 17 'advance-epoch'. lines 78-81:
 Epoch advanced: 6
 
-task 18 'run-graphql'. lines 83-96:
+task 18 'run-graphql'. lines 83-98:
 Response: {
   "data": {
     "address": {
@@ -113,7 +113,9 @@ Response: {
             "node": {
               "address": "0x8b0e0310a07085ad13f91adb49a9ee30b002c2074addc4b0487f7195d44e928a",
               "digest": "85b8jVWZrQNAaJ7suXm8w8cdDbq85tkQRo4CGrY5cS4H",
-              "kind": "OWNED"
+              "owner": {
+                "__typename": "AddressOwner"
+              }
             }
           }
         ]
@@ -122,7 +124,7 @@ Response: {
   }
 }
 
-task 19 'run-graphql'. lines 98-145:
+task 19 'run-graphql'. lines 100-155:
 Response: {
   "data": {
     "address": {
@@ -137,7 +139,9 @@ Response: {
             "node": {
               "address": "0x8b0e0310a07085ad13f91adb49a9ee30b002c2074addc4b0487f7195d44e928a",
               "digest": "85b8jVWZrQNAaJ7suXm8w8cdDbq85tkQRo4CGrY5cS4H",
-              "kind": "OWNED"
+              "owner": {
+                "__typename": "AddressOwner"
+              }
             }
           }
         ]
@@ -150,9 +154,8 @@ Response: {
             "node": {
               "address": "0x511fd9ce0b6943a3968d0d5cc377322cd0118433f65dcb51e9d1727d771047f0",
               "digest": "HMRSJr7gKNHC1nYbt8nBsXxdiJ1wnoHZuMRN1DA3jhXo",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           },
@@ -160,9 +163,8 @@ Response: {
             "node": {
               "address": "0x7827de2a83a6b4ac36d2ac1764ad0f811308521407a5b72ae69559dda2cd2058",
               "digest": "DMMSd4mQuDW3VnySiLcZQzwX9zK6SKPnKJ17NwVBHuzz",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           },
@@ -170,9 +172,8 @@ Response: {
             "node": {
               "address": "0x936681de92a7306429f56748932bfbf17e199363edafa8ab973cd2e203c0c384",
               "digest": "D3ybZDPxmpsbm5Ufr5sRmfHzYW8eSRDtyVUsGjqGyrQu",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           },
@@ -180,9 +181,8 @@ Response: {
             "node": {
               "address": "0xc9234d34e6067dc9ef92cbc2480dee6776e9884eba8fbda5c3f01f4fe96195ed",
               "digest": "4wBDM7bxAQvBf51jftjwCx7rdeZ2zcBbgvW2P6rkxokW",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           },
@@ -190,9 +190,8 @@ Response: {
             "node": {
               "address": "0xd92d2142638f7d211143788ea1ad6e51185869bc4469f744aabd4f29e05ee5f2",
               "digest": "5tdgwqrvoKVcRcyNzKo8Usz2MtPCok2oV3G3ncaxWH4c",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           },
@@ -200,9 +199,8 @@ Response: {
             "node": {
               "address": "0xfe3f0fecd990aa6e3be0409a7f22fca7b45b98d9003f9f5d27d08f90cd39441b",
               "digest": "3zkW5RrBhsdMphKHbeGP5jJB498ZfKwMH563SZGC94JA",
-              "kind": "OWNED",
               "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+                "__typename": "AddressOwner"
               }
             }
           }
@@ -212,13 +210,16 @@ Response: {
     "object": {
       "version": 3,
       "owner": {
-        "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+        "__typename": "AddressOwner",
+        "owner": {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+        }
       }
     }
   }
 }
 
-task 20 'view-graphql-variables'. lines 148-149:
+task 20 'view-graphql-variables'. lines 158-159:
 Name: A
 Type: SuiAddress!
 Value: "0x42"
@@ -315,7 +316,7 @@ Name: validator_0_opt
 Type: SuiAddress
 Value: "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
 
-task 21 'run-graphql'. lines 152-166:
+task 21 'run-graphql'. lines 162-176:
 Response: {
   "data": {
     "epoch": {
@@ -335,7 +336,7 @@ Response: {
   }
 }
 
-task 22 'run-graphql'. lines 168-174:
+task 22 'run-graphql'. lines 178-184:
 Response: {
   "data": {
     "epoch": {
@@ -344,17 +345,17 @@ Response: {
   }
 }
 
-task 23 'run'. lines 176-176:
+task 23 'run'. lines 186-186:
 created: object(23,0)
 mutated: object(0,1)
 gas summary: computation_cost: 999000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 178-178:
+task 24 'run'. lines 188-188:
 created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run'. lines 180-180:
+task 25 'run'. lines 190-190:
 created: object(25,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -88,7 +88,9 @@ module Test::M1 {
         node {
           address
           digest
-          kind
+          owner {
+            __typename
+          }
         }
       }
     }
@@ -103,7 +105,9 @@ module Test::M1 {
         node {
           address
           digest
-          kind
+          owner {
+            __typename
+          }
         }
       }
     }
@@ -114,7 +118,9 @@ module Test::M1 {
         node {
           address
           digest
-          kind
+          owner {
+            __typename
+          }
         }
       }
     }
@@ -126,9 +132,8 @@ module Test::M1 {
         node {
           address
           digest
-          kind
-            owner {
-            address
+          owner {
+            __typename
           }
         }
       }
@@ -138,7 +143,12 @@ module Test::M1 {
   object(address: $obj_2_0) {
     version
     owner {
-      address
+      __typename
+      ... on AddressOwner {
+        owner {
+          address
+        }
+      }
     }
   }
 

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -530,7 +530,6 @@
 >          asObject {
 >            storageRebate
 >            bcs
->            owner
 >          }
 >          hasPublicTransfer
 >        }
@@ -791,7 +790,7 @@
 >    owner {
 >      __typename
 >      ... on Shared {
->        initial_shared_version
+>        initialSharedVersion
 >      }
 >      __typename
 >      ... on Parent {
@@ -832,7 +831,7 @@
 >        owner {
 >          __typename
 >          ... on Shared {
->            initial_shared_version
+>            initialSharedVersion
 >          }
 >          __typename
 >          ... on Parent {
@@ -906,7 +905,7 @@
 >        owner {
 >          __typename
 >          ... on Shared {
->            initial_shared_version
+>            initialSharedVersion
 >          }
 >          __typename
 >          ... on Parent {
@@ -1659,7 +1658,7 @@
 >    owner {
 >      __typename
 >      ... on Shared {
->        initial_shared_version
+>        initialSharedVersion
 >      }
 >      __typename
 >      ... on Parent {

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -530,7 +530,7 @@
 >          asObject {
 >            storageRebate
 >            bcs
->            kind
+>            owner
 >          }
 >          hasPublicTransfer
 >        }
@@ -789,12 +789,26 @@
 >    digest
 >    storageRebate
 >    owner {
->      defaultNameServiceName
+>      __typename
+>      ... on Shared {
+>        initial_shared_version
+>      }
+>      __typename
+>      ... on Parent {
+>        parent {
+>          address
+>        }
+>      }
+>      __typename
+>      ... on AddressOwner {
+>        owner {
+>          address
+>        }
+>      }
 >    }
 >    previousTransactionBlock {
 >      digest
 >    }
->    kind
 >  }
 >}</pre>
 
@@ -815,7 +829,24 @@
 >    edges {
 >      node {
 >        storageRebate
->        kind
+>        owner {
+>          __typename
+>          ... on Shared {
+>            initial_shared_version
+>          }
+>          __typename
+>          ... on Parent {
+>            parent {
+>              address
+>            }
+>          }
+>          __typename
+>          ... on AddressOwner {
+>            owner {
+>              address
+>            }
+>          }
+>        }
 >      }
 >    }
 >  }
@@ -872,7 +903,24 @@
 >    edges {
 >      node {
 >        storageRebate
->        kind
+>        owner {
+>          __typename
+>          ... on Shared {
+>            initial_shared_version
+>          }
+>          __typename
+>          ... on Parent {
+>            parent {
+>              address
+>            }
+>          }
+>          __typename
+>          ... on AddressOwner {
+>            owner {
+>              address
+>            }
+>          }
+>        }
 >      }
 >    }
 >  }
@@ -1608,7 +1656,24 @@
 >    address: "0x0bba1e7d907dc2832edfc3bf4468b6deacd9a2df435a35b17e640e135d2d5ddc"
 >  ) {
 >    version
->    kind
+>    owner {
+>      __typename
+>      ... on Shared {
+>        initial_shared_version
+>      }
+>      __typename
+>      ... on Parent {
+>        parent {
+>          address
+>        }
+>      }
+>      __typename
+>      ... on AddressOwner {
+>        owner {
+>          address
+>        }
+>      }
+>    }
 >    previousTransactionBlock {
 >      effects {
 >        status

--- a/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
@@ -23,7 +23,6 @@
           asObject {
             storageRebate
             bcs
-            kind
           }
           hasPublicTransfer
         }

--- a/crates/sui-graphql-rpc/examples/object/object.graphql
+++ b/crates/sui-graphql-rpc/examples/object/object.graphql
@@ -7,11 +7,25 @@
     digest
     storageRebate
     owner {
-      defaultNameServiceName
+      __typename
+      ... on Shared {
+        initialSharedVersion
+      }
+      __typename
+      ... on Parent {
+        parent {
+          address
+        }
+      }
+      __typename
+      ... on AddressOwner {
+        owner {
+          address
+        }
+      }
     }
     previousTransactionBlock {
       digest
     }
-    kind
   }
 }

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_object_ids.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_object_ids.graphql
@@ -10,7 +10,24 @@
     edges {
       node {
         storageRebate
-        kind
+        owner {
+          __typename
+          ... on Shared {
+            initialSharedVersion
+          }
+          __typename
+          ... on Parent {
+            parent {
+              address
+            }
+          }
+          __typename
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
       }
     }
   }

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_owner.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_owner.graphql
@@ -8,7 +8,24 @@
     edges {
       node {
         storageRebate
-        kind
+        owner {
+          __typename
+          ... on Shared {
+            initialSharedVersion
+          }
+          __typename
+          ... on Parent {
+            parent {
+              address
+            }
+          }
+          __typename
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
       }
     }
   }

--- a/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
+++ b/crates/sui-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
@@ -3,7 +3,24 @@
     address: "0x0bba1e7d907dc2832edfc3bf4468b6deacd9a2df435a35b17e640e135d2d5ddc"
   ) {
     version
-    kind
+    owner {
+      __typename
+      ... on Shared {
+        initialSharedVersion
+      }
+      __typename
+      ... on Parent {
+        parent {
+          address
+        }
+      }
+      __typename
+      ... on AddressOwner {
+        owner {
+          address
+        }
+      }
+    }
     previousTransactionBlock {
       effects {
         status

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -58,7 +58,7 @@ type ActiveJwkEdge {
 	cursor: String!
 }
 
-type Address implements Iowner {
+type Address implements IOwner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
 	supports additional `AddressTransactionBlockRelationship` filter
@@ -911,6 +911,20 @@ type GenesisTransaction {
 }
 
 
+interface IOwner {
+	address: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	defaultNameServiceName: String
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+}
+
 """
 An immutable object is an object that can't be mutated, transferred, or deleted.
 Immutable objects have no owner, so anyone can use them.
@@ -929,20 +943,6 @@ type Input {
 	ix: Int!
 }
 
-
-interface Iowner {
-	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
-	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
-	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
-	defaultNameServiceName: String
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
-	dynamicField(name: DynamicFieldName!): DynamicField
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
-}
 
 """
 Arbitrary JSON data.
@@ -1456,7 +1456,7 @@ type Mutation {
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
 
-type Object implements Iowner {
+type Object implements IOwner {
 	version: Int!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
@@ -1736,7 +1736,7 @@ type OwnedOrImmutable {
 	object: Object
 }
 
-type Owner implements Iowner {
+type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
@@ -2147,7 +2147,8 @@ type ServiceConfig {
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
 and is accessible to everyone.
-Unlike owned objects, anyone can access shared objects on the network.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+Note that despite all published packages and modules in Sui being shared, they are immutable objects.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -2147,8 +2147,9 @@ type ServiceConfig {
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
 and is accessible to everyone.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-Note that despite all published packages and modules in Sui being shared, they are immutable objects.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
+unless it is made immutable. An example of immutable shared objects are all published packages
+and modules on Sui.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -58,7 +58,7 @@ type ActiveJwkEdge {
 	cursor: String!
 }
 
-type Address implements ObjectOwner {
+type Address implements Iowner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
 	supports additional `AddressTransactionBlockRelationship` filter
@@ -95,6 +95,11 @@ type Address implements ObjectOwner {
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
+"""
+An address-owned object is owned by a specific 32-byte address that is
+either an account address (derived from a particular signature scheme) or
+an object ID. An address-owned object is accessible only to its owner and no others.
+"""
 type AddressOwner {
 	owner: Owner
 }
@@ -906,8 +911,12 @@ type GenesisTransaction {
 }
 
 
+"""
+An immutable object is an object that can't be mutated, transferred, or deleted.
+Immutable objects have no owner, so anyone can use them.
+"""
 type Immutable {
-	dummy: Boolean
+	_: Boolean
 }
 
 """
@@ -920,6 +929,20 @@ type Input {
 	ix: Int!
 }
 
+
+interface Iowner {
+	address: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	defaultNameServiceName: String
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+}
 
 """
 Arbitrary JSON data.
@@ -1433,7 +1456,7 @@ type Mutation {
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
 
-type Object implements ObjectOwner {
+type Object implements Iowner {
 	version: Int!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
@@ -1460,9 +1483,10 @@ type Object implements ObjectOwner {
 	previousTransactionBlock: TransactionBlock
 	"""
 	The owner type of this Object.
+	The owner can be one of the following types: Immutable, Shared, Parent, Address
 	Immutable and Shared Objects do not have owners.
 	"""
-	owner: ObjectOwnerNew
+	owner: ObjectOwner
 	"""
 	Attempts to convert the object into a MoveObject
 	"""
@@ -1644,21 +1668,10 @@ input ObjectKey {
 	version: Int!
 }
 
-interface ObjectOwner {
-	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
-	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
-	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
-	defaultNameServiceName: String
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
-	dynamicField(name: DynamicFieldName!): DynamicField
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
-}
-
-union ObjectOwnerNew = Immutable | Shared | Parent | AddressOwner
+"""
+The object's owner type: Immutable, Shared, Parent, or Address.
+"""
+union ObjectOwner = Immutable | Shared | Parent | AddressOwner
 
 """
 Represents types that could contain references or free type parameters.  Such types can appear
@@ -1723,7 +1736,7 @@ type OwnedOrImmutable {
 	object: Object
 }
 
-type Owner implements ObjectOwner {
+type Owner implements Iowner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
@@ -1791,6 +1804,9 @@ type PageInfo {
 	endCursor: String
 }
 
+"""
+The parent of this object
+"""
 type Parent {
 	parent: Object
 }
@@ -2128,6 +2144,11 @@ type ServiceConfig {
 	maxMoveValueDepth: Int!
 }
 
+"""
+A shared object is an object that is shared using the 0x2::transfer::share_object function
+and is accessible to everyone.
+Unlike owned objects, anyone can access shared objects on the network.
+"""
 type Shared {
 	initialSharedVersion: Int!
 }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -95,6 +95,10 @@ type Address implements ObjectOwner {
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
+type AddressOwner {
+	owner: Owner
+}
+
 enum AddressTransactionBlockRelationship {
 	SIGN
 	SENT
@@ -902,6 +906,10 @@ type GenesisTransaction {
 }
 
 
+type Immutable {
+	dummy: Boolean
+}
+
 """
 One of the input objects or primitive values to the programmable transaction block.
 """
@@ -1451,15 +1459,10 @@ type Object implements ObjectOwner {
 	"""
 	previousTransactionBlock: TransactionBlock
 	"""
-	Objects can either be immutable, shared, owned by an address,
-	or are child objects (part of a dynamic field)
+	The owner type of this Object.
+	Immutable and Shared Objects do not have owners.
 	"""
-	kind: ObjectKind
-	"""
-	The Address or Object that owns this Object.  Immutable and Shared Objects do not have
-	owners.
-	"""
-	owner: Owner
+	owner: ObjectOwnerNew
 	"""
 	Attempts to convert the object into a MoveObject
 	"""
@@ -1641,13 +1644,6 @@ input ObjectKey {
 	version: Int!
 }
 
-enum ObjectKind {
-	OWNED
-	CHILD
-	SHARED
-	IMMUTABLE
-}
-
 interface ObjectOwner {
 	address: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
@@ -1661,6 +1657,8 @@ interface ObjectOwner {
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
+
+union ObjectOwnerNew = Immutable | Shared | Parent | AddressOwner
 
 """
 Represents types that could contain references or free type parameters.  Such types can appear
@@ -1791,6 +1789,10 @@ type PageInfo {
 	When paginating forwards, the cursor to continue.
 	"""
 	endCursor: String
+}
+
+type Parent {
+	parent: Object
 }
 
 """
@@ -1929,7 +1931,7 @@ type Query {
 	Configuration for this RPC service
 	"""
 	serviceConfig: ServiceConfig!
-	owner(address: SuiAddress!): ObjectOwner
+	owner(address: SuiAddress!): Owner
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
 	"""
@@ -2124,6 +2126,10 @@ type ServiceConfig {
 	Maximum nesting allowed in struct fields when calculating the layout of a single Move Type.
 	"""
 	maxMoveValueDepth: Int!
+}
+
+type Shared {
+	initialSharedVersion: Int!
 }
 
 """

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -18,13 +18,13 @@ mod types;
 
 use async_graphql::*;
 use mutation::Mutation;
-use types::owner::ObjectOwner;
+use types::owner::IOwner;
 
 use crate::types::query::Query;
 
 pub fn schema_sdl_export() -> String {
     let schema = Schema::build(Query, Mutation, EmptySubscription)
-        .register_output_type::<ObjectOwner>()
+        .register_output_type::<IOwner>()
         .finish();
     schema.sdl()
 }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -87,8 +87,9 @@ pub struct Immutable {
 
 /// A shared object is an object that is shared using the 0x2::transfer::share_object function
 /// and is accessible to everyone.
-/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-/// Note that despite all published packages and modules in Sui being shared, they are immutable objects.
+/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
+/// unless it is made immutable. An example of immutable shared objects are all published packages
+/// and modules on Sui.
 #[derive(SimpleObject, Clone)]
 pub struct Shared {
     initial_shared_version: u64,

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -87,7 +87,8 @@ pub struct Immutable {
 
 /// A shared object is an object that is shared using the 0x2::transfer::share_object function
 /// and is accessible to everyone.
-/// Unlike owned objects, anyone can access shared objects on the network.
+/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+/// Note that despite all published packages and modules in Sui being shared, they are immutable objects.
 #[derive(SimpleObject, Clone)]
 pub struct Shared {
     initial_shared_version: u64,

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -88,6 +88,7 @@ use sui_types::dynamic_field::DynamicFieldType;
     )
 )]
 #[derive(Clone, Debug)]
+#[graphql(name = "IOwner")]
 pub(crate) enum IOwner {
     Address(Address),
     Owner(Owner),

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -88,7 +88,7 @@ use sui_types::dynamic_field::DynamicFieldType;
     )
 )]
 #[derive(Clone, Debug)]
-pub(crate) enum ObjectOwner {
+pub(crate) enum IOwner {
     Address(Address),
     Owner(Owner),
     Object(Object),

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -20,7 +20,7 @@ use super::{
     event::{Event, EventFilter},
     move_type::MoveType,
     object::{Object, ObjectFilter},
-    owner::{ObjectOwner, Owner},
+    owner::Owner,
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
     transaction_block::{TransactionBlock, TransactionBlockFilter},
@@ -63,8 +63,8 @@ impl Query {
     // dryRunTransactionBlock
     // coinMetadata
 
-    async fn owner(&self, address: SuiAddress) -> Option<ObjectOwner> {
-        Some(ObjectOwner::Owner(Owner { address }))
+    async fn owner(&self, address: SuiAddress) -> Option<Owner> {
+        Some(Owner { address })
     }
 
     async fn object(

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -62,7 +62,7 @@ type ActiveJwkEdge {
 	cursor: String!
 }
 
-type Address implements ObjectOwner {
+type Address implements Iowner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
 	supports additional `AddressTransactionBlockRelationship` filter
@@ -99,6 +99,11 @@ type Address implements ObjectOwner {
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
+"""
+An address-owned object is owned by a specific 32-byte address that is
+either an account address (derived from a particular signature scheme) or
+an object ID. An address-owned object is accessible only to its owner and no others.
+"""
 type AddressOwner {
 	owner: Owner
 }
@@ -910,8 +915,12 @@ type GenesisTransaction {
 }
 
 
+"""
+An immutable object is an object that can't be mutated, transferred, or deleted.
+Immutable objects have no owner, so anyone can use them.
+"""
 type Immutable {
-	dummy: Boolean
+	_: Boolean
 }
 
 """
@@ -924,6 +933,20 @@ type Input {
 	ix: Int!
 }
 
+
+interface Iowner {
+	address: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	defaultNameServiceName: String
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+}
 
 """
 Arbitrary JSON data.
@@ -1437,7 +1460,7 @@ type Mutation {
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
 
-type Object implements ObjectOwner {
+type Object implements Iowner {
 	version: Int!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
@@ -1464,9 +1487,10 @@ type Object implements ObjectOwner {
 	previousTransactionBlock: TransactionBlock
 	"""
 	The owner type of this Object.
+	The owner can be one of the following types: Immutable, Shared, Parent, Address
 	Immutable and Shared Objects do not have owners.
 	"""
-	owner: ObjectOwnerNew
+	owner: ObjectOwner
 	"""
 	Attempts to convert the object into a MoveObject
 	"""
@@ -1648,21 +1672,10 @@ input ObjectKey {
 	version: Int!
 }
 
-interface ObjectOwner {
-	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
-	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
-	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
-	defaultNameServiceName: String
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
-	dynamicField(name: DynamicFieldName!): DynamicField
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
-}
-
-union ObjectOwnerNew = Immutable | Shared | Parent | AddressOwner
+"""
+The object's owner type: Immutable, Shared, Parent, or Address.
+"""
+union ObjectOwner = Immutable | Shared | Parent | AddressOwner
 
 """
 Represents types that could contain references or free type parameters.  Such types can appear
@@ -1727,7 +1740,7 @@ type OwnedOrImmutable {
 	object: Object
 }
 
-type Owner implements ObjectOwner {
+type Owner implements Iowner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
@@ -1795,6 +1808,9 @@ type PageInfo {
 	endCursor: String
 }
 
+"""
+The parent of this object
+"""
 type Parent {
 	parent: Object
 }
@@ -2132,6 +2148,11 @@ type ServiceConfig {
 	maxMoveValueDepth: Int!
 }
 
+"""
+A shared object is an object that is shared using the 0x2::transfer::share_object function
+and is accessible to everyone.
+Unlike owned objects, anyone can access shared objects on the network.
+"""
 type Shared {
 	initialSharedVersion: Int!
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -2151,8 +2151,9 @@ type ServiceConfig {
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
 and is accessible to everyone.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-Note that despite all published packages and modules in Sui being shared, they are immutable objects.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
+unless it is made immutable. An example of immutable shared objects are all published packages
+and modules on Sui.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -99,6 +99,10 @@ type Address implements ObjectOwner {
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
 
+type AddressOwner {
+	owner: Owner
+}
+
 enum AddressTransactionBlockRelationship {
 	SIGN
 	SENT
@@ -906,6 +910,10 @@ type GenesisTransaction {
 }
 
 
+type Immutable {
+	dummy: Boolean
+}
+
 """
 One of the input objects or primitive values to the programmable transaction block.
 """
@@ -1455,15 +1463,10 @@ type Object implements ObjectOwner {
 	"""
 	previousTransactionBlock: TransactionBlock
 	"""
-	Objects can either be immutable, shared, owned by an address,
-	or are child objects (part of a dynamic field)
+	The owner type of this Object.
+	Immutable and Shared Objects do not have owners.
 	"""
-	kind: ObjectKind
-	"""
-	The Address or Object that owns this Object.  Immutable and Shared Objects do not have
-	owners.
-	"""
-	owner: Owner
+	owner: ObjectOwnerNew
 	"""
 	Attempts to convert the object into a MoveObject
 	"""
@@ -1645,13 +1648,6 @@ input ObjectKey {
 	version: Int!
 }
 
-enum ObjectKind {
-	OWNED
-	CHILD
-	SHARED
-	IMMUTABLE
-}
-
 interface ObjectOwner {
 	address: SuiAddress!
 	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
@@ -1665,6 +1661,8 @@ interface ObjectOwner {
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 }
+
+union ObjectOwnerNew = Immutable | Shared | Parent | AddressOwner
 
 """
 Represents types that could contain references or free type parameters.  Such types can appear
@@ -1795,6 +1793,10 @@ type PageInfo {
 	When paginating forwards, the cursor to continue.
 	"""
 	endCursor: String
+}
+
+type Parent {
+	parent: Object
 }
 
 """
@@ -1933,7 +1935,7 @@ type Query {
 	Configuration for this RPC service
 	"""
 	serviceConfig: ServiceConfig!
-	owner(address: SuiAddress!): ObjectOwner
+	owner(address: SuiAddress!): Owner
 	object(address: SuiAddress!, version: Int): Object
 	address(address: SuiAddress!): Address
 	"""
@@ -2128,6 +2130,10 @@ type ServiceConfig {
 	Maximum nesting allowed in struct fields when calculating the layout of a single Move Type.
 	"""
 	maxMoveValueDepth: Int!
+}
+
+type Shared {
+	initialSharedVersion: Int!
 }
 
 """

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -62,7 +62,7 @@ type ActiveJwkEdge {
 	cursor: String!
 }
 
-type Address implements Iowner {
+type Address implements IOwner {
 	"""
 	Similar behavior to the `transactionBlockConnection` in Query but
 	supports additional `AddressTransactionBlockRelationship` filter
@@ -915,6 +915,20 @@ type GenesisTransaction {
 }
 
 
+interface IOwner {
+	address: SuiAddress!
+	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	balance(type: String): Balance
+	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
+	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	defaultNameServiceName: String
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	dynamicField(name: DynamicFieldName!): DynamicField
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+}
+
 """
 An immutable object is an object that can't be mutated, transferred, or deleted.
 Immutable objects have no owner, so anyone can use them.
@@ -933,20 +947,6 @@ type Input {
 	ix: Int!
 }
 
-
-interface Iowner {
-	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
-	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
-	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
-	defaultNameServiceName: String
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
-	dynamicField(name: DynamicFieldName!): DynamicField
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	dynamicFieldConnection(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
-}
 
 """
 Arbitrary JSON data.
@@ -1460,7 +1460,7 @@ type Mutation {
 	executeTransactionBlock(txBytes: String!, signatures: [String!]!): ExecutionResult!
 }
 
-type Object implements Iowner {
+type Object implements IOwner {
 	version: Int!
 	"""
 	32-byte hash that identifies the object's current contents, encoded as a Base58 string.
@@ -1740,7 +1740,7 @@ type OwnedOrImmutable {
 	object: Object
 }
 
-type Owner implements Iowner {
+type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
@@ -2151,7 +2151,8 @@ type ServiceConfig {
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
 and is accessible to everyone.
-Unlike owned objects, anyone can access shared objects on the network.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+Note that despite all published packages and modules in Sui being shared, they are immutable objects.
 """
 type Shared {
 	initialSharedVersion: Int!


### PR DESCRIPTION
## Description 

Refactors ObjectOwner to be a union of four different owner types, as per our draft schema.

## Test Plan 

Running existing tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
