### PR TITLE
[graphql/rpc] allow @skip and @include directives

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.exp
@@ -1,4 +1,4 @@
-processed 3 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
@@ -8,11 +8,11 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Fields with directives are not supported",
+      "message": "Directive `@deprecated` is not supported. Supported directives are `@include`, `@skip`",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 19
         }
       ],
       "extensions": {
@@ -27,11 +27,11 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Fragments with directives are not supported",
+      "message": "Directive `@deprecated` is not supported. Supported directives are `@include`, `@skip`",
       "locations": [
         {
           "line": 1,
-          "column": 1
+          "column": 29
         }
       ],
       "extensions": {
@@ -39,4 +39,28 @@ Response: {
       }
     }
   ]
+}
+
+task 3 'run-graphql'. lines 42-46:
+Response: {
+  "data": {}
+}
+
+task 4 'run-graphql'. lines 48-52:
+Response: {
+  "data": {
+    "chainIdentifier": "d0ebf23a"
+  }
+}
+
+task 5 'run-graphql'. lines 54-58:
+Response: {
+  "data": {
+    "chainIdentifier": "d0ebf23a"
+  }
+}
+
+task 6 'run-graphql'. lines 60-64:
+Response: {
+  "data": {}
 }

--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.move
@@ -38,3 +38,27 @@ fragment Modules on Object  @deprecated {
         }
     }
 }
+
+//# run-graphql
+
+{
+  chainIdentifier @skip(if: true)
+}
+
+//# run-graphql
+
+{
+  chainIdentifier @skip(if: false)
+}
+
+//# run-graphql
+
+{
+  chainIdentifier @include(if: true)
+}
+
+//# run-graphql
+
+{
+  chainIdentifier @include(if: false)
+}


### PR DESCRIPTION
## Description 

As discussed internally, we should allow the default/built-in directives.

## Test Plan 

e2e

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
