### PR TITLE
[GraphQL][EASY] Ensure fields are generally output in camelCase

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -75,7 +75,7 @@ Response: {
 task 15 'run-graphql'. lines 68-74:
 Headers: {
     "content-type": "application/json",
-    "content-length": "137",
+    "content-length": "136",
     "x-sui-rpc-version": "0.1.0",
 }
 Service version: 0.1.0
@@ -91,7 +91,7 @@ Response: {
       "depth": 2,
       "variables": 0,
       "fragments": 0,
-      "query_payload": 41
+      "queryPayload": 41
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.exp
@@ -33,7 +33,7 @@ Response: {
                         "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
                         "module": "object",
                         "type": "UID",
-                        "type_parameters": []
+                        "typeParameters": []
                       }
                     }
                   }
@@ -50,7 +50,7 @@ Response: {
                         "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
                         "module": "balance",
                         "type": "Balance",
-                        "type_parameters": [
+                        "typeParameters": [
                           {
                             "typeParameter": 0
                           }
@@ -296,7 +296,7 @@ Response: {
                                     "package": "0x5b4048d5feccd5da11502967e637f53420746735757e54d68bf45269be3c0356",
                                     "module": "m",
                                     "type": "S",
-                                    "type_parameters": []
+                                    "typeParameters": []
                                   }
                                 }
                               }

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.exp
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.exp
@@ -10,19 +10,19 @@ Response: {
           "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
           "module": "priority_queue",
           "type": "PriorityQueue",
-          "type_parameters": [
+          "typeParameters": [
             {
               "struct": {
                 "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
                 "module": "coin",
                 "type": "Coin",
-                "type_parameters": [
+                "typeParameters": [
                   {
                     "struct": {
                       "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
                       "module": "sui",
                       "type": "SUI",
-                      "type_parameters": []
+                      "typeParameters": []
                     }
                   }
                 ]
@@ -164,7 +164,7 @@ Response: {
           "package": "0x0000000000000000000000000000000000000000000000000000000000000042",
           "module": "not",
           "type": "Here",
-          "type_parameters": []
+          "typeParameters": []
         }
       }
     }

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -107,7 +107,7 @@ impl Extension for QueryLimitsChecker {
                     "depth": validation_result.depth,
                     "variables": validation_result.num_variables,
                     "fragments": validation_result.num_fragments,
-                    "query_payload": validation_result.query_payload,
+                    "queryPayload": validation_result.query_payload,
                 }),
             )
         } else {

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -74,6 +74,7 @@ pub(crate) enum MoveTypeSignature {
         module: String,
         #[serde(rename = "type")]
         type_: String,
+        #[serde(rename = "typeParameters")]
         type_parameters: Vec<MoveTypeSignature>,
     },
 }

--- a/crates/sui-graphql-rpc/src/types/open_move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/open_move_type.rs
@@ -88,6 +88,7 @@ pub(crate) enum OpenMoveTypeSignatureBody {
         module: String,
         #[serde(rename = "type")]
         type_: String,
+        #[serde(rename = "typeParameters")]
         type_parameters: Vec<OpenMoveTypeSignatureBody>,
     },
 }

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -79,7 +79,7 @@ mod tests {
                 let depth = *usage.get("depth").unwrap_or_else(|| {
                     panic!("Depth usage should be present for query: {}", query.name)
                 });
-                let payload = *usage.get("query_payload").unwrap_or_else(|| {
+                let payload = *usage.get("queryPayload").unwrap_or_else(|| {
                     panic!("Payload usage should be present for query: {}", query.name)
                 });
                 *max_nodes = max(*max_nodes, nodes);


### PR DESCRIPTION
## Description

Make sure all fields are correctly serialized in camelcase.  This was not the case for `typeParameters` or for `queryPayload`.

## Test Plan

E2E tests

```
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

Also, do an audit of all GraphQL responses in E2E tests to make sure they are appropriately formatted:

```
sui-graphql-e2e-tests/tests$ sed -n '/^Response: {$/,/^}$/p' **/*.exp \
  | sed 's/Response: //'                                              \
  | jq -r 'paths | map(tostring) | join(".")'                         \
  | awk -F'.' '$NF ~ /[a-zA-Z]+_/ && $0 !~ /\.json\./ { print $NF }'
```

(all remaining names that include underscores come from field aliases).