### PR TITLE
[NameService] Subdomain support

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -6,8 +6,6 @@ use async_graphql_axum::GraphQLResponse;
 use sui_indexer::errors::IndexerError;
 use sui_json_rpc::name_service::NameServiceError;
 
-use crate::context_data::db_data_provider::DbValidationError;
-
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
 /// `<https://www.apollographql.com/docs/apollo-server/data/errors/#built-in-error-codes>`
@@ -68,12 +66,6 @@ pub enum Error {
     ProtocolVersionUnsupported(u64, u64),
     #[error(transparent)]
     NameService(#[from] NameServiceError),
-    #[error(transparent)]
-    DbValidation(#[from] DbValidationError),
-    #[error("Invalid coin type: {0}")]
-    InvalidCoinType(String),
-    #[error("'before' and 'after' must not be used together")]
-    CursorNoBeforeAfter,
     #[error("'first' and 'last' must not be used together")]
     CursorNoFirstLast,
     #[error("Connection's page size of {0} exceeds max of {1}")]
@@ -88,13 +80,7 @@ pub enum Error {
 impl ErrorExtensions for Error {
     fn extend(&self) -> async_graphql::Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            Error::InvalidCoinType(_)
-            | Error::DynamicFieldOnAddress
-            | Error::InvalidFilter
-            | Error::ProtocolVersionUnsupported { .. }
-            | Error::NameService(_)
-            | Error::DbValidation(_)
-            | Error::CursorNoBeforeAfter
+            Error::NameService(_)
             | Error::CursorNoFirstLast
             | Error::PageTooLarge(_, _)
             | Error::ProtocolVersionUnsupported(_, _)

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -296,7 +296,7 @@ impl IndexerApiServer for IndexerApiV2 {
             .parse::<Domain>()
             .map_err(IndexerError::NameServiceError)?;
 
-        let record_id = self.name_service_config.record_field_id(&domain, None);
+        let record_id = self.name_service_config.record_field_id(&domain);
 
         let field_record_object = match self.inner.get_object_in_blocking_task(record_id).await? {
             Some(o) => o,

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -4,6 +4,7 @@
 use fastcrypto::error::FastCryptoError;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::error::CallError;
+use sui_json_rpc::name_service::NameServiceError;
 use thiserror::Error;
 
 use sui_types::base_types::ObjectIDParseError;
@@ -125,6 +126,9 @@ pub enum IndexerError {
 
     #[error("Indexer failed to send item to channel with error: `{0}`")]
     MpscChannelError(String),
+
+    #[error(transparent)]
+    NameServiceError(#[from] NameServiceError),
 }
 
 pub trait Context<T> {

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -47,3 +47,5 @@ fn test_expirations() {
 
     assert!(name.is_expired());
 }
+
+// TODO: Add more test cases here for expiration checks on SubNameRecords (node/leafs).

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+use std::time::SystemTime;
+use sui_json_rpc::name_service;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    collection_types::VecMap,
+};
+
+#[test]
+fn test_parent_extraction() {
+    let mut name = name_service::Domain::from_str("leaf.node.test.sui").unwrap();
+
+    assert_eq!(name.parent().to_string(), "node.test.sui");
+
+    name = name_service::Domain::from_str("node.test.sui").unwrap();
+
+    assert_eq!(name.parent().to_string(), "test.sui");
+}
+
+#[test]
+fn test_sld_extraction() {
+    let name = name_service::Domain::from_str("nested.leaf.node.test.sui").unwrap();
+
+    assert_eq!(name.sld().to_string(), "test.sui");
+}
+
+#[test]
+fn test_expirations() {
+    let expiration = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    let mut name = name_service::NameRecord {
+        nft_id: sui_types::id::ID::new(ObjectID::random()),
+        data: VecMap { contents: vec![] },
+        target_address: Some(SuiAddress::random_for_testing_only()),
+        expiration_timestamp_ms: expiration + 1_000_000,
+    };
+
+    assert!(!name.is_expired());
+
+    name.expiration_timestamp_ms = expiration - 1_000_000;
+
+    assert!(name.is_expired());
+}

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
-use std::time::SystemTime;
 use sui_json_rpc::name_service;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -21,31 +20,19 @@ fn test_parent_extraction() {
 }
 
 #[test]
-fn test_sld_extraction() {
-    let name = name_service::Domain::from_str("nested.leaf.node.test.sui").unwrap();
-
-    assert_eq!(name.sld().to_string(), "test.sui");
-}
-
-#[test]
 fn test_expirations() {
-    let expiration = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
+    let system_time: u64 = 100;
 
     let mut name = name_service::NameRecord {
         nft_id: sui_types::id::ID::new(ObjectID::random()),
         data: VecMap { contents: vec![] },
         target_address: Some(SuiAddress::random_for_testing_only()),
-        expiration_timestamp_ms: expiration + 1_000_000,
+        expiration_timestamp_ms: system_time + 10,
     };
 
-    assert!(!name.is_expired());
+    assert!(!name.is_node_expired(system_time));
 
-    name.expiration_timestamp_ms = expiration - 1_000_000;
+    name.expiration_timestamp_ms = system_time - 10;
 
-    assert!(name.is_expired());
+    assert!(name.is_node_expired(system_time));
 }
-
-// TODO: Add more test cases here for expiration checks on SubNameRecords (node/leafs).

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use tokio::task::JoinError;
 
 use crate::authority_state::StateReadError;
+use crate::name_service::NameServiceError;
 
 pub type RpcInterimResult<T = ()> = Result<T, Error>;
 
@@ -64,6 +65,9 @@ pub enum Error {
 
     #[error("Unsupported Feature: {0}")]
     UnsupportedFeature(String),
+
+    #[error("transparent")]
+    NameServiceError(#[from] NameServiceError),
 }
 
 impl From<SuiError> for Error {
@@ -91,6 +95,17 @@ impl From<Error> for RpcError {
                 | SuiObjectResponseError::DynamicFieldNotFound { .. }
                 | SuiObjectResponseError::Deleted { .. }
                 | SuiObjectResponseError::DisplayError { .. } => {
+                    RpcError::Call(CallError::InvalidParams(err.into()))
+                }
+                _ => RpcError::Call(CallError::Failed(err.into())),
+            },
+            Error::NameServiceError(err) => match err {
+                NameServiceError::ExceedsMaxLength { .. }
+                | NameServiceError::InvalidHyphens { .. }
+                | NameServiceError::InvalidLength { .. }
+                | NameServiceError::InvalidUnderscore { .. }
+                | NameServiceError::LabelsEmpty { .. }
+                | NameServiceError::InvalidSeparator { .. } => {
                     RpcError::Call(CallError::InvalidParams(err.into()))
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -123,7 +123,7 @@ impl<R: ReadApiServer> IndexerApi<R> {
         }
     }
 
-    async fn get_latest_checkpoint_timestamp_ms(&self) -> StateReadResult<u64> {
+    fn get_latest_checkpoint_timestamp_ms(&self) -> StateReadResult<u64> {
         let latest_checkpoint = self.state.get_latest_checkpoint_sequence_number()?;
 
         let checkpoint = self
@@ -388,7 +388,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             let parent_domain = domain.parent();
             let parent_record_id = self.name_service_config.record_field_id(&parent_domain);
 
-            let current_timestamp_ms = self.get_latest_checkpoint_timestamp_ms().await?;
+            let current_timestamp_ms = self.get_latest_checkpoint_timestamp_ms()?;
 
             // Do these two reads in parallel.
             let mut requests = vec![self.state.get_object(&record_id)];

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -269,14 +269,10 @@ impl TryFrom<Object> for NameRecord {
     type Error = NameServiceError;
 
     fn try_from(object: Object) -> Result<Self, NameServiceError> {
-        let obj = object
+        object
             .to_rust::<Field<Domain, Self>>()
-            .map(|record| record.value);
-
-        match obj {
-            Some(record) => Ok(record),
-            None => Err(NameServiceError::MalformedObject(object.id())),
-        }
+            .map(|record| record.value)
+            .ok_or_else(|| NameServiceError::MalformedObject(object.id()))
     }
 }
 


### PR DESCRIPTION
## Description 

IndexerV2 & GraphQL logic will be carried over on the next PRs.

- Adds checks for expiration on SLD names
- Adds subdomain lookup & expiration checks (for both node/leaf subdomains)
- Changes error structure for easier support between the 3 crates that use it

## Test Plan 

Added some unit tests and did some localnet testing for the resolution aspect. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
