### PR TITLE
Use deny list during signing

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -123,7 +123,7 @@ impl EpochState {
             self.epoch_start_state.reference_gas_price(),
             transaction.data().transaction_data(),
             input_objects,
-            receiving_objects,
+            &receiving_objects,
             &self.bytecode_verifier_metrics,
         )?;
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -26,7 +26,7 @@ use prometheus::{
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -77,6 +77,7 @@ use sui_storage::IndexStore;
 use sui_types::authenticator_state::get_authenticator_state;
 use sui_types::committee::{EpochId, ProtocolVersion};
 use sui_types::crypto::{default_hash, AuthoritySignInfo, Signer};
+use sui_types::deny_list::DenyList;
 use sui_types::digests::ChainIdentifier;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType};
@@ -747,9 +748,13 @@ impl AuthorityState {
             epoch_store.reference_gas_price(),
             tx_data,
             input_objects,
-            receiving_objects,
+            &receiving_objects,
             &self.metrics.bytecode_verifier_metrics,
         )?;
+
+        if epoch_store.coin_deny_list_state_enabled() {
+            self.check_coin_deny(tx_data.sender(), &checked_input_objects, &receiving_objects)?;
+        }
 
         let owned_objects = checked_input_objects.inner().filter_owned_objects();
 
@@ -1489,7 +1494,7 @@ impl AuthorityState {
                     epoch_store.reference_gas_price(),
                     &transaction,
                     input_objects,
-                    receiving_objects,
+                    &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
                 )?,
                 None,
@@ -4380,6 +4385,26 @@ impl AuthorityState {
             self.database.revert_state_update(&digest).await?;
         }
         info!("All uncommitted local transactions reverted");
+        Ok(())
+    }
+
+    fn check_coin_deny(
+        &self,
+        sender: SuiAddress,
+        input_objects: &CheckedInputObjects,
+        receiving_objects: &ReceivingObjects,
+    ) -> SuiResult {
+        let all_objects = input_objects
+            .inner()
+            .iter_objects()
+            .chain(receiving_objects.iter_objects());
+        let coin_types = all_objects
+            .filter_map(|obj| {
+                obj.coin_type_maybe()
+                    .map(|type_tag| type_tag.to_canonical_string(false))
+            })
+            .collect::<BTreeSet<_>>();
+        DenyList::check_coin_deny_list(sender, coin_types, &self.database)?;
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -833,6 +833,10 @@ impl AuthorityPerEpochStore {
             .is_some()
     }
 
+    pub fn coin_deny_list_state_enabled(&self) -> bool {
+        self.protocol_config().enable_coin_deny_list() && self.coin_deny_list_state_exists()
+    }
+
     pub fn get_parent_path(&self) -> PathBuf {
         self.parent_path.clone()
     }

--- a/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
@@ -1,18 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::ident_str;
+use move_core_types::language_storage::TypeTag;
+use std::path::PathBuf;
 use sui_core::authority::epoch_start_configuration::EpochStartConfigTrait;
 use sui_json_rpc_types::SuiTransactionBlockKind;
 use sui_json_rpc_types::{SuiTransactionBlockDataAPI, SuiTransactionBlockResponseOptions};
+use sui_json_rpc_types::{SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse};
 use sui_macros::sim_test;
+use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::coin::COIN_MODULE_NAME;
+use sui_types::deny_list::RegulatedCoinMetadata;
 use sui_types::deny_list::{
     get_coin_deny_list, get_deny_list_obj_initial_shared_version, get_deny_list_root_object,
-    DenyList,
+    CoinDenyCap, DenyList,
 };
+use sui_types::error::UserInputError;
 use sui_types::id::UID;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::storage::ObjectStore;
-use sui_types::SUI_DENY_LIST_OBJECT_ID;
-use test_cluster::TestClusterBuilder;
+use sui_types::transaction::{CallArg, ObjectArg};
+use sui_types::{SUI_DENY_LIST_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID};
+use test_cluster::{TestCluster, TestClusterBuilder};
+use tracing::debug;
 
 #[sim_test]
 async fn test_coin_deny_list_creation() {
@@ -94,5 +105,405 @@ async fn test_coin_deny_list_creation() {
                 prev_tx
             );
         });
+    }
+}
+
+#[sim_test]
+async fn test_coin_deny_transfer() {
+    // This test creates a new coin and denies the sender address for the coin.
+    // A transfer transaction is subsequently denied.
+    // The sender address is then undenied and the transfer transaction is allowed.
+
+    let mut test_context = TestContext::new().await;
+    // Deny the sender address for the new coin.
+    test_context
+        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Deny)
+        .await;
+    // After the address is denied, sending the coin should fail to sign.
+    let transfer_result = test_context
+        .transfer_new_coin(test_context.test_cluster.get_address_2())
+        .await;
+    let expected_error = UserInputError::AddressDeniedForCoin {
+        address: test_context.new_coin_owner,
+        coin_type: test_context
+            .get_new_coin_type()
+            .await
+            .to_canonical_string(false),
+    };
+    assert!(transfer_result
+        .unwrap_err()
+        .to_string()
+        .contains(&expected_error.to_string()));
+
+    // Sending SUI coin should still work.
+    let tx_data = test_context
+        .test_cluster
+        .test_transaction_builder_with_sender(test_context.new_coin_owner)
+        .await
+        .transfer_sui(Some(1), test_context.test_cluster.get_address_2())
+        .build();
+    test_context
+        .test_cluster
+        .sign_and_execute_transaction(&tx_data)
+        .await;
+
+    // Undeny the address.
+    test_context
+        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Undeny)
+        .await;
+
+    // After the address is undenied, sending the coin should work now.
+    assert!(test_context
+        .transfer_new_coin(test_context.test_cluster.get_address_2())
+        .await
+        .is_ok_and(|r| r.effects.unwrap().status().is_ok()));
+}
+
+#[sim_test]
+async fn test_coin_deny_move_call() {
+    // This test creates a new coin and denies the sender address for the coin.
+    // A Move call transaction that uses the new coin from the denied address is subsequently denied.
+    // The sender address is then undenied and the Move call transaction is allowed.
+
+    let test_context = TestContext::new().await;
+    // Deny the sender address for the new coin.
+    test_context
+        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Deny)
+        .await;
+
+    // After the address is denied, using the coin in a Move call should fail to sign.
+    let mut pt = ProgrammableTransactionBuilder::new();
+    let object_arg = pt
+        .obj(ObjectArg::ImmOrOwnedObject(
+            test_context
+                .test_cluster
+                .get_latest_object_ref(&test_context.new_coin_id)
+                .await,
+        ))
+        .unwrap();
+    let pure_arg = pt.pure(1u64).unwrap();
+    let split_result = pt.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        ident_str!("coin").to_owned(),
+        ident_str!("split").to_owned(),
+        vec![test_context.get_new_coin_type().await],
+        vec![object_arg, pure_arg],
+    );
+    pt.transfer_arg(test_context.test_cluster.get_address_2(), split_result);
+    let tx_data = test_context
+        .test_cluster
+        .test_transaction_builder_with_sender(test_context.new_coin_owner)
+        .await
+        .programmable(pt.finish())
+        .build();
+    let tx = test_context.test_cluster.sign_transaction(&tx_data);
+    let result = test_context
+        .test_cluster
+        .wallet
+        .execute_transaction_may_fail(tx.clone())
+        .await;
+    let expected_error = UserInputError::AddressDeniedForCoin {
+        address: test_context.new_coin_owner,
+        coin_type: test_context
+            .get_new_coin_type()
+            .await
+            .to_canonical_string(false),
+    };
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains(&expected_error.to_string()));
+
+    // Undeny the address.
+    test_context
+        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Undeny)
+        .await;
+
+    // After the address is undenied, the same transaction should work now.
+    test_context.test_cluster.execute_transaction(tx).await;
+}
+
+#[sim_test]
+async fn test_coin_deny_tto_receiving() {
+    // This test creates a new coin and denies the sender address for the coin.
+    // A transaction that attempts to receive the new coin from the denied address is subsequently denied.
+    // The sender address is then undenied and the transaction is allowed.
+
+    let mut test_context = TestContext::new().await;
+    let new_sender = test_context.test_cluster.get_address_2();
+    // Deny this new address for the new coin.
+    test_context
+        .call_deny_list_api(new_sender, DenyAction::Deny)
+        .await;
+
+    // Even though the new address is denied, it can still call the contract of the coin package to do other things.
+    let package_id = test_context.get_new_coin_package_id().await;
+    let tx_data = test_context
+        .test_cluster
+        .test_transaction_builder_with_sender(new_sender)
+        .await
+        .move_call(package_id, "regulated_coin", "new_wallet", vec![])
+        .build();
+    let wallet_oref = test_context
+        .test_cluster
+        .sign_and_execute_transaction(&tx_data)
+        .await
+        .effects
+        .unwrap()
+        .created()[0]
+        .reference
+        .to_object_ref();
+    test_context
+        .transfer_new_coin(wallet_oref.0.into())
+        .await
+        .unwrap();
+
+    // After the address is denied, trying to receive the coin in a Move call should fail to sign.
+    let mut pt = ProgrammableTransactionBuilder::new();
+    pt.move_call(
+        package_id,
+        ident_str!("regulated_coin").to_owned(),
+        ident_str!("receive_coin").to_owned(),
+        vec![],
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(wallet_oref)),
+            CallArg::Object(ObjectArg::Receiving(
+                test_context
+                    .test_cluster
+                    .get_latest_object_ref(&test_context.new_coin_id)
+                    .await,
+            )),
+        ],
+    )
+    .unwrap();
+    let tx_data = test_context
+        .test_cluster
+        .test_transaction_builder_with_sender(new_sender)
+        .await
+        .programmable(pt.finish())
+        .build();
+    let tx = test_context.test_cluster.sign_transaction(&tx_data);
+    let result = test_context
+        .test_cluster
+        .wallet
+        .execute_transaction_may_fail(tx.clone())
+        .await;
+    let expected_error = UserInputError::AddressDeniedForCoin {
+        address: new_sender,
+        coin_type: test_context
+            .get_new_coin_type()
+            .await
+            .to_canonical_string(false),
+    };
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains(&expected_error.to_string()));
+
+    // Undeny the address.
+    test_context
+        .call_deny_list_api(new_sender, DenyAction::Undeny)
+        .await;
+
+    // After the address is undenied, the same transaction should work now.
+    test_context.test_cluster.execute_transaction(tx).await;
+}
+
+struct TestContext {
+    test_cluster: TestCluster,
+    new_coin_id: ObjectID,
+    new_coin_owner: SuiAddress,
+    deny_cap_object_id: ObjectID,
+    deny_cap_object_owner: SuiAddress,
+}
+
+#[derive(Debug)]
+enum DenyAction {
+    Deny,
+    Undeny,
+}
+
+impl TestContext {
+    // Returns the test cluster and the deny cap.
+    async fn new() -> Self {
+        let test_cluster = TestClusterBuilder::new().build().await;
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/move_test_code");
+        let tx_data = test_cluster
+            .test_transaction_builder()
+            .await
+            .publish(path)
+            .build();
+        let effects = test_cluster
+            .sign_and_execute_transaction(&tx_data)
+            .await
+            .effects
+            .unwrap();
+        let mut new_coin_object = None;
+        let mut deny_cap_object = None;
+        let mut metadata_object = None;
+        let mut regulated_metadata_object = None;
+        for created in effects.created() {
+            let object = test_cluster
+                .get_object_from_fullnode_store(&created.object_id())
+                .await
+                .unwrap();
+            if object.is_package() {
+                continue;
+            }
+            let t = object.type_().unwrap();
+            if t.is_coin() {
+                assert!(new_coin_object.is_none());
+                new_coin_object = Some(object);
+            } else if t.is_coin_deny_cap() {
+                assert!(deny_cap_object.is_none());
+                deny_cap_object = Some(object);
+            } else if t.is_regulated_coin_metadata() {
+                assert!(regulated_metadata_object.is_none());
+                regulated_metadata_object = Some(object);
+            } else if t.is_coin_metadata() {
+                assert!(metadata_object.is_none());
+                metadata_object = Some(object);
+            }
+        }
+        // Check that publishing the package minted the new coin, along with
+        // the metadata, deny cap, and regulated metadata.
+        // Check that all their fields are consistent.
+        let new_coin_object = new_coin_object.unwrap();
+        let metadata_object = metadata_object.unwrap();
+        let deny_cap_object = deny_cap_object.unwrap();
+        let deny_cap: CoinDenyCap = deny_cap_object.to_rust().unwrap();
+        assert_eq!(deny_cap.id.id.bytes, deny_cap_object.id());
+
+        let regulated_metadata_object = regulated_metadata_object.unwrap();
+        let regulated_metadata: RegulatedCoinMetadata =
+            regulated_metadata_object.to_rust().unwrap();
+        assert_eq!(
+            regulated_metadata.id.id.bytes,
+            regulated_metadata_object.id()
+        );
+        assert_eq!(
+            regulated_metadata.deny_cap_object.bytes,
+            deny_cap_object.id()
+        );
+        assert_eq!(
+            regulated_metadata.coin_metadata_object.bytes,
+            metadata_object.id()
+        );
+
+        let mut test_context = Self {
+            test_cluster,
+            new_coin_id: new_coin_object.id(),
+            new_coin_owner: new_coin_object.owner.get_address_owner_address().unwrap(),
+            deny_cap_object_id: deny_cap_object.id(),
+            deny_cap_object_owner: deny_cap_object.owner.get_address_owner_address().unwrap(),
+        };
+        // Transfer the new coin to a new address just so that it's different from the deny cap owner.
+        // This helps make sure we don't have bugs like always denying the deny cap owner.
+        let receiver = test_context.test_cluster.get_address_1();
+        assert_ne!(test_context.new_coin_owner, receiver);
+        test_context.transfer_new_coin(receiver).await.unwrap();
+
+        test_context
+    }
+
+    async fn transfer_new_coin(
+        &mut self,
+        receiver: SuiAddress,
+    ) -> anyhow::Result<SuiTransactionBlockResponse> {
+        let tx_data = self
+            .test_cluster
+            .test_transaction_builder_with_sender(self.new_coin_owner)
+            .await
+            .transfer(
+                self.test_cluster
+                    .get_latest_object_ref(&self.new_coin_id)
+                    .await,
+                receiver,
+            )
+            .build();
+        let tx = self.test_cluster.sign_transaction(&tx_data);
+        let result = self
+            .test_cluster
+            .wallet
+            .execute_transaction_may_fail(tx)
+            .await;
+        if result
+            .as_ref()
+            .is_ok_and(|r| r.effects.as_ref().unwrap().status().is_ok())
+        {
+            self.new_coin_owner = receiver;
+        }
+        result
+    }
+
+    async fn call_deny_list_api(&self, address: SuiAddress, action: DenyAction) {
+        let function = match action {
+            DenyAction::Deny => "deny_list_add",
+            DenyAction::Undeny => "deny_list_remove",
+        };
+        let tx_data = self
+            .test_cluster
+            .test_transaction_builder_with_sender(self.deny_cap_object_owner)
+            .await
+            .move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                COIN_MODULE_NAME.as_str(),
+                function,
+                vec![
+                    CallArg::Object(self.get_deny_list_object_arg().await),
+                    CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                        self.test_cluster
+                            .get_latest_object_ref(&self.deny_cap_object_id)
+                            .await,
+                    )),
+                    CallArg::Pure(bcs::to_bytes(&address).unwrap()),
+                ],
+            )
+            .with_type_args(vec![self.get_new_coin_type().await])
+            .build();
+        let effects = self
+            .test_cluster
+            .sign_and_execute_transaction(&tx_data)
+            .await
+            .effects
+            .unwrap();
+        debug!(
+            "call_deny_list_api with action {:?} effects: {:?}",
+            action, effects
+        );
+    }
+
+    async fn get_deny_list_object_arg(&self) -> ObjectArg {
+        let coin_deny_list_object_init_version = self
+            .test_cluster
+            .fullnode_handle
+            .sui_node
+            .state()
+            .epoch_store_for_testing()
+            .epoch_start_config()
+            .coin_deny_list_obj_initial_shared_version()
+            .unwrap();
+        ObjectArg::SharedObject {
+            id: SUI_DENY_LIST_OBJECT_ID,
+            initial_shared_version: coin_deny_list_object_init_version,
+            mutable: true,
+        }
+    }
+
+    async fn get_new_coin_type(&self) -> TypeTag {
+        self.test_cluster
+            .get_object_from_fullnode_store(&self.new_coin_id)
+            .await
+            .unwrap()
+            .coin_type_maybe()
+            .unwrap()
+    }
+
+    async fn get_new_coin_package_id(&self) -> ObjectID {
+        match self.get_new_coin_type().await {
+            TypeTag::Struct(struct_tag) => ObjectID::from(struct_tag.address),
+            _ => panic!("Expected Struct TypeTag"),
+        }
     }
 }

--- a/crates/sui-e2e-tests/tests/move_test_code/sources/regulated_coin.move
+++ b/crates/sui-e2e-tests/tests/move_test_code/sources/regulated_coin.move
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module move_test_code::regulated_coin {
+    use std::option;
+    use sui::coin;
+    use sui::coin::Coin;
+    use sui::object;
+    use sui::object::UID;
+    use sui::transfer;
+    use sui::transfer::Receiving;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    struct REGULATED_COIN has drop {}
+
+    struct Wallet has key {
+        id: UID,
+    }
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+
+    public fun new_wallet(ctx: &mut TxContext) {
+        let wallet = Wallet {
+            id: object::new(ctx),
+        };
+        transfer::transfer(wallet, tx_context::sender(ctx));
+    }
+
+    public fun receive_coin(wallet: &mut Wallet, coin: Receiving<Coin<REGULATED_COIN>>, ctx: &TxContext) {
+        let coin = transfer::public_receive(&mut wallet.id, coin);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+    }
+}

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -296,7 +296,11 @@ impl WalletContext {
         tx: Transaction,
     ) -> SuiTransactionBlockResponse {
         let response = self.execute_transaction_may_fail(tx).await.unwrap();
-        assert!(response.status_ok().unwrap());
+        assert!(
+            response.status_ok().unwrap(),
+            "Transaction failed: {:?}",
+            response
+        );
         response
     }
 

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -71,7 +71,7 @@ mod checked {
         reference_gas_price: u64,
         transaction: &TransactionData,
         input_objects: InputObjects,
-        receiving_objects: ReceivingObjects,
+        receiving_objects: &ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
     ) -> SuiResult<(SuiGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
@@ -81,7 +81,7 @@ mod checked {
             &input_objects,
             &[],
         )?;
-        check_receiving_objects(&input_objects, &receiving_objects)?;
+        check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.
         check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -306,6 +306,24 @@ impl MoveObjectType {
         }
     }
 
+    pub fn is_upgrade_cap(&self) -> bool {
+        self.address() == SUI_FRAMEWORK_ADDRESS
+            && self.module().as_str() == "package"
+            && self.name().as_str() == "UpgradeCap"
+    }
+
+    pub fn is_regulated_coin_metadata(&self) -> bool {
+        self.address() == SUI_FRAMEWORK_ADDRESS
+            && self.module().as_str() == "coin"
+            && self.name().as_str() == "RegulatedCoinMetadata"
+    }
+
+    pub fn is_coin_deny_cap(&self) -> bool {
+        self.address() == SUI_FRAMEWORK_ADDRESS
+            && self.module().as_str() == "coin"
+            && self.name().as_str() == "DenyCap"
+    }
+
     pub fn is_dynamic_field(&self) -> bool {
         match &self.0 {
             MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
@@ -348,7 +366,7 @@ impl MoveObjectType {
         }
     }
 
-    /// Returns the string representation of this object's type using the canonical display.    
+    /// Returns the string representation of this object's type using the canonical display.
     pub fn to_canonical_string(&self, with_prefix: bool) -> String {
         StructTag::from(self.clone()).to_canonical_string(with_prefix)
     }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -248,6 +248,12 @@ pub enum UserInputError {
 
     #[error("Immutable parameter provided, mutable parameter expected.")]
     MutableParameterExpected { object_id: ObjectID },
+
+    #[error("Address {address:?} is denied for coin {coin_type}")]
+    AddressDeniedForCoin {
+        address: SuiAddress,
+        coin_type: String,
+    },
 }
 
 #[derive(

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -226,6 +226,12 @@ pub trait MoveTypeTagTrait {
     fn get_type_tag() -> TypeTag;
 }
 
+impl MoveTypeTagTrait for u8 {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::U8
+    }
+}
+
 impl MoveTypeTagTrait for u64 {
     fn get_type_tag() -> TypeTag {
         TypeTag::U64
@@ -241,6 +247,12 @@ impl MoveTypeTagTrait for ObjectID {
 impl MoveTypeTagTrait for SuiAddress {
     fn get_type_tag() -> TypeTag {
         TypeTag::Address
+    }
+}
+
+impl<T: MoveTypeTagTrait> MoveTypeTagTrait for Vec<T> {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Vector(Box::new(T::get_type_tag()))
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2962,6 +2962,10 @@ impl InputObjects {
     pub fn iter(&self) -> impl Iterator<Item = &ObjectReadResult> {
         self.objects.iter()
     }
+
+    pub fn iter_objects(&self) -> impl Iterator<Item = &Object> {
+        self.objects.iter().filter_map(|o| o.as_object())
+    }
 }
 
 // Result of attempting to read a receiving object (currently only at signing time).
@@ -3014,6 +3018,10 @@ pub struct ReceivingObjects {
 impl ReceivingObjects {
     pub fn iter(&self) -> impl Iterator<Item = &ReceivingObjectReadResult> {
         self.objects.iter()
+    }
+
+    pub fn iter_objects(&self) -> impl Iterator<Item = &Object> {
+        self.objects.iter().filter_map(|o| o.object.as_object())
     }
 }
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -227,6 +227,13 @@ impl TestCluster {
             .await
     }
 
+    pub async fn get_latest_object_ref(&self, object_id: &ObjectID) -> ObjectRef {
+        self.get_object_from_fullnode_store(object_id)
+            .await
+            .unwrap()
+            .compute_object_reference()
+    }
+
     pub async fn get_object_or_tombstone_from_fullnode_store(
         &self,
         object_id: ObjectID,
@@ -440,6 +447,20 @@ impl TestCluster {
 
     pub async fn test_transaction_builder(&self) -> TestTransactionBuilder {
         let (sender, gas) = self.wallet.get_one_gas_object().await.unwrap().unwrap();
+        self.test_transaction_builder_with_gas_object(sender, gas)
+            .await
+    }
+
+    pub async fn test_transaction_builder_with_sender(
+        &self,
+        sender: SuiAddress,
+    ) -> TestTransactionBuilder {
+        let gas = self
+            .wallet
+            .get_one_gas_object_owned_by_address(sender)
+            .await
+            .unwrap()
+            .unwrap();
         self.test_transaction_builder_with_gas_object(sender, gas)
             .await
     }


### PR DESCRIPTION
## Description 

This PR checks the deny list during signing to see if the sender address is denied in any of the Coin<T> types of the input objects (including receiving objects).

## Test Plan 

1. Test that denylist works for transfer objects
2. Test that denylist works for receiving objects
3. Test that denylist works for Move call input objects
4. Test that undeny works
5. Test that one coin denied an address doesn't affect use of other coins

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR introduces the ability to deny specific addresses for newly created regulated coins.
Coin issuer who owns the deny cap can send transactions to deny addresses, and transactions that use that regulated coins as input sent from denied addresses will fail to process on validators. This ensures that regulated coins are able to comply to regulations.
