### PR TITLE
[gql][easy] change event.senders to single sender

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -53,11 +53,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "0"
           },
@@ -70,11 +68,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "1"
           },
@@ -87,11 +83,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "2"
           },
@@ -104,11 +98,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "3"
           },
@@ -131,11 +123,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "0"
           },
@@ -148,11 +138,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "1"
           },
@@ -165,11 +153,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "2"
           },
@@ -182,11 +168,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M2::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "3"
           },
@@ -209,11 +193,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "0"
           },
@@ -226,11 +208,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "1"
           },
@@ -243,9 +223,11 @@ Response: {
 
 task 12 'run-graphql'. lines 166-185:
 Response: {
-  "data": {
-    "eventConnection": {
-      "nodes": [
+  "data": null,
+  "errors": [
+    {
+      "message": " --> 3:90\n  |\n3 |     filter: {sender: \"0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e\"\", eventType: \"0x4b4d63f32254c457bec65b04df4d83b0b88e04f6443f977f63ac4c9fd672d099::M1::EventA\"}\n  |                                                                                          ^---\n  |\n  = expected name",
+      "locations": [
         {
           "sendingModule": {
             "name": "M1"
@@ -265,7 +247,7 @@ Response: {
         }
       ]
     }
-  }
+  ]
 }
 
 task 13 'run-graphql'. lines 187-206:
@@ -280,11 +262,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventB<0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::Object>"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "1"
           },

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -223,11 +223,9 @@ Response: {
 
 task 12 'run-graphql'. lines 166-185:
 Response: {
-  "data": null,
-  "errors": [
-    {
-      "message": " --> 3:90\n  |\n3 |     filter: {sender: \"0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e\"\", eventType: \"0x4b4d63f32254c457bec65b04df4d83b0b88e04f6443f977f63ac4c9fd672d099::M1::EventA\"}\n  |                                                                                          ^---\n  |\n  = expected name",
-      "locations": [
+  "data": {
+    "eventConnection": {
+      "nodes": [
         {
           "sendingModule": {
             "name": "M1"
@@ -247,7 +245,7 @@ Response: {
         }
       ]
     }
-  ]
+  }
 }
 
 task 13 'run-graphql'. lines 187-206:

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -233,11 +233,9 @@ Response: {
           "type": {
             "repr": "0x52a2986f3c7d2f12dccb6d48877bbbe18a09e368dc4a270094ea4eeaa021f7d3::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "0"
           },

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -112,7 +112,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -133,7 +133,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -154,7 +154,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -175,7 +175,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -196,7 +196,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -217,7 +217,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -238,7 +238,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -259,7 +259,7 @@ module Test::M2 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -166,7 +166,7 @@ module Test::M2 {
 //# run-graphql
 {
   eventConnection(
-    filter: {sender: "@{A}"", eventType: "@{Test}::M1::EventA"}
+    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventA"}
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -100,10 +100,10 @@ module Test::M2 {
 
 //# create-checkpoint
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}"}
+    filter: {sender: $A}
   ) {
     nodes {
       sendingModule {
@@ -121,10 +121,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}"}
+    filter: {sender: $A, eventType: "@{Test}"}
   ) {
     nodes {
       sendingModule {
@@ -142,10 +142,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}::M1"}
+    filter: {sender: $A, eventType: "@{Test}::M1"}
   ) {
     nodes {
       sendingModule {
@@ -163,10 +163,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventA"}
+    filter: {sender: $A, eventType: "@{Test}::M1::EventA"}
   ) {
     nodes {
       sendingModule {
@@ -184,10 +184,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB"}
+    filter: {sender: $A, eventType: "@{Test}::M1::EventB"}
   ) {
     nodes {
       sendingModule {
@@ -205,10 +205,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB<"}
+    filter: {sender: $A, eventType: "@{Test}::M1::EventB<"}
   ) {
     nodes {
       sendingModule {
@@ -226,10 +226,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "::M1"}
+    filter: {sender: $A, eventType: "::M1"}
   ) {
     nodes {
       sendingModule {
@@ -247,10 +247,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql
+//# run-graphql --variables A
 {
   eventConnection(
-    filter: {sender: "@{A}", eventType: "@{Test}::"}
+    filter: {sender: $A, eventType: "@{Test}::"}
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -121,10 +121,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql --variables A Test
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}"}
+    filter: {sender: $A, eventType: $Test}
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -100,10 +100,10 @@ module Test::M2 {
 
 //# create-checkpoint
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A}
+    filter: {sender: "@{A}"}
   ) {
     nodes {
       sendingModule {
@@ -121,10 +121,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A Test
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: $Test}
+    filter: {sender: "@{A}", eventType: "@{Test}"}
   ) {
     nodes {
       sendingModule {
@@ -142,10 +142,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1"}
+    filter: {sender: "@{A}", eventType: "@{Test}::M1"}
   ) {
     nodes {
       sendingModule {
@@ -163,10 +163,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventA"}
+    filter: {sender: "@{A}"", eventType: "@{Test}::M1::EventA"}
   ) {
     nodes {
       sendingModule {
@@ -184,10 +184,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB"}
+    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB"}
   ) {
     nodes {
       sendingModule {
@@ -205,10 +205,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::M1::EventB<"}
+    filter: {sender: "@{A}", eventType: "@{Test}::M1::EventB<"}
   ) {
     nodes {
       sendingModule {
@@ -226,10 +226,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "::M1"}
+    filter: {sender: "@{A}", eventType: "::M1"}
   ) {
     nodes {
       sendingModule {
@@ -247,10 +247,10 @@ module Test::M2 {
   }
 }
 
-//# run-graphql --variables A
+//# run-graphql
 {
   eventConnection(
-    filter: {sender: $A, eventType: "@{Test}::"}
+    filter: {sender: "@{A}", eventType: "@{Test}::"}
   ) {
     nodes {
       sendingModule {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.exp
@@ -28,11 +28,9 @@ Response: {
           "type": {
             "repr": "0x937d602eeaadcd617458c3e785e14d636fc247217b2fcc175e30c298d51a8f4b::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "2"
           },
@@ -55,11 +53,9 @@ Response: {
           "type": {
             "repr": "0x937d602eeaadcd617458c3e785e14d636fc247217b2fcc175e30c298d51a8f4b::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "2"
           },
@@ -100,11 +96,9 @@ Response: {
           "type": {
             "repr": "0x937d602eeaadcd617458c3e785e14d636fc247217b2fcc175e30c298d51a8f4b::M1::EventA"
           },
-          "senders": [
-            {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            }
-          ],
+          "sender": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
           "json": {
             "new_value": "2"
           },

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
@@ -52,7 +52,7 @@ module Test::M3 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -73,7 +73,7 @@ module Test::M3 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -94,7 +94,7 @@ module Test::M3 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -115,7 +115,7 @@ module Test::M3 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json
@@ -136,7 +136,7 @@ module Test::M3 {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       json

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -35,11 +35,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "0"
             },
@@ -55,11 +53,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "1"
             },
@@ -75,11 +71,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "2"
             },
@@ -105,11 +99,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "1"
             },
@@ -125,11 +117,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "2"
             },
@@ -155,11 +145,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "0"
             },
@@ -175,11 +163,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "1"
             },
@@ -205,11 +191,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "1"
             },
@@ -225,11 +209,9 @@ Response: {
             "type": {
               "repr": "0xa4ddd30b4331104c68e0512dabdec03202ac72e99f66ff82eab5e14f926ca3bd::M1::EventA"
             },
-            "senders": [
-              {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            ],
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
             "json": {
               "new_value": "2"
             },

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -39,7 +39,7 @@ module Test::M1 {
         type {
           repr
         }
-        senders {
+        sender {
           address
         }
         json
@@ -61,7 +61,7 @@ module Test::M1 {
         type {
           repr
         }
-        senders {
+        sender {
           address
         }
         json
@@ -83,7 +83,7 @@ module Test::M1 {
         type {
           repr
         }
-        senders {
+        sender {
           address
         }
         json
@@ -105,7 +105,7 @@ module Test::M1 {
         type {
           repr
         }
-        senders {
+        sender {
           address
         }
         json

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -711,7 +711,7 @@
 >      type {
 >        repr
 >      }
->      senders {
+>      sender {
 >        address
 >      }
 >      timestamp

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -681,7 +681,7 @@
 >      type {
 >        repr
 >      }
->      senders {
+>      sender {
 >        address
 >      }
 >      timestamp
@@ -740,7 +740,7 @@
 >      type {
 >        repr
 >      }
->      senders {
+>      sender {
 >        address
 >      }
 >      timestamp

--- a/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/event_connection.graphql
@@ -14,7 +14,7 @@
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       timestamp

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
@@ -15,7 +15,7 @@ query byEmittingPackageModuleAndEventType {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       timestamp

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_sender.graphql
@@ -14,7 +14,7 @@ query byTxSender {
       type {
         repr
       }
-      senders {
+      sender {
         address
       }
       timestamp

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -710,9 +710,9 @@ type Event {
 	"""
 	sendingModule: MoveModule
 	"""
-	Addresses of the senders of the event
+	Address of the sender of the event
 	"""
-	senders: Address
+	sender: Address
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -712,7 +712,7 @@ type Event {
 	"""
 	Addresses of the senders of the event
 	"""
-	senders: [Address!]
+	senders: Address
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -85,7 +85,8 @@ impl Event {
         if address.as_slice() != NativeSuiAddress::ZERO.as_ref() {
             return Ok(Some(Address { address }));
         }
-        return Ok(None);
+
+        Ok(None)
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -82,11 +82,11 @@ impl Event {
             .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
             .extend()?;
 
-        if address.as_slice() != NativeSuiAddress::ZERO.as_ref() {
-            return Ok(Some(Address { address }));
+        if address.as_slice() == NativeSuiAddress::ZERO.as_ref() {
+            return Ok(None);
         }
 
-        Ok(None)
+        Ok(Some(Address { address }))
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -72,16 +72,16 @@ impl Event {
     }
 
     /// Addresses of the senders of the event
-    async fn senders(&self) -> Result<Option<Vec<Address>>> {
-        let mut addrs = Vec::with_capacity(self.stored.senders.len());
-        for sender in &self.stored.senders {
-            let Some(sender) = &sender else { continue };
-            let address = SuiAddress::from_bytes(sender)
-                .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
-                .extend()?;
-            addrs.push(Address { address });
-        }
-        Ok(Some(addrs))
+    async fn senders(&self) -> Result<Option<Address>> {
+        let Some(Some(sender)) = self.stored.senders.first() else {
+            return Ok(None);
+        };
+
+        let address = SuiAddress::from_bytes(sender)
+            .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
+            .extend()?;
+
+        Ok(Some(Address { address }))
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -716,7 +716,7 @@ type Event {
 	"""
 	Addresses of the senders of the event
 	"""
-	senders: [Address!]
+	senders: Address
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -714,9 +714,9 @@ type Event {
 	"""
 	sendingModule: MoveModule
 	"""
-	Addresses of the senders of the event
+	Address of the sender of the event
 	"""
-	senders: Address
+	sender: Address
 	"""
 	UTC timestamp in milliseconds since epoch (1/1/1970)
 	"""


### PR DESCRIPTION
## Description 

As title, to keep event.sender aligned with transaction_block.sender

## Test Plan 

existing tests should pass after modifying senders -> sender
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
