### PR TITLE
[Consensus] add `Context` for epoch configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "fastcrypto",
  "prometheus",
  "serde",
+ "sui-protocol-config",
  "tokio",
  "tracing",
  "workspace-hack",

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -17,5 +17,6 @@ tracing.workspace = true
 async-trait.workspace = true
 
 consensus-config.workspace = true
+sui-protocol-config.workspace = true
 
 workspace-hack.workspace = true

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -139,3 +139,5 @@ impl fmt::Debug for BlockDigest {
         )
     }
 }
+
+// TODO: add basic verification for BlockRef and BlockDigest computations.

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -23,3 +23,22 @@ pub(crate) struct Context {
     /// Metrics of this authority.
     pub metrics: Arc<Metrics>,
 }
+
+impl Context {
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        own_index: AuthorityIndex,
+        committee: Committee,
+        parameters: Parameters,
+        protocol_config: ProtocolConfig,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        Self {
+            own_index,
+            committee,
+            parameters,
+            protocol_config,
+            metrics,
+        }
+    }
+}

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use consensus_config::{AuthorityIndex, Committee, Parameters};
+use sui_protocol_config::ProtocolConfig;
+
+use crate::metrics::Metrics;
+
+/// Context contains per-epoch configuration and metrics shared by all components
+/// of this authority.
+#[allow(dead_code)]
+pub(crate) struct Context {
+    /// Index of this authority in the committee.
+    pub own_index: AuthorityIndex,
+    /// Committee of the current epoch.
+    pub committee: Committee,
+    /// Parameters of this authority.
+    pub parameters: Parameters,
+    /// Protocol configuration of current epoch.
+    pub protocol_config: ProtocolConfig,
+    /// Metrics of this authority.
+    pub metrics: Arc<Metrics>,
+}

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -3,5 +3,6 @@
 
 mod block;
 mod block_verifier;
+mod context;
 mod metrics;
 mod validator;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{register_histogram_with_registry, Histogram, Registry};
 use std::sync::Arc;
+
+use prometheus::{register_histogram_with_registry, Histogram, Registry};
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4,
@@ -10,7 +11,7 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
     12.5, 15., 17.5, 20., 25., 30., 60., 90., 120., 180., 300.,
 ];
 
-pub struct Metrics {
+pub(crate) struct Metrics {
     pub node_metrics: NodeMetrics,
 }
 
@@ -20,7 +21,7 @@ pub(crate) fn initialise_metrics(registry: Registry) -> Arc<Metrics> {
     Arc::new(Metrics { node_metrics })
 }
 
-pub struct NodeMetrics {
+pub(crate) struct NodeMetrics {
     pub uptime: Histogram,
 }
 

--- a/consensus/core/src/validator.rs
+++ b/consensus/core/src/validator.rs
@@ -32,13 +32,13 @@ impl Validator {
         registry: Registry,
     ) -> Self {
         info!("Boot validator with authority index {}", own_index);
-        let context = Arc::new(Context {
+        let context = Arc::new(Context::new(
             own_index,
             committee,
             parameters,
             protocol_config,
-            metrics: initialise_metrics(registry),
-        });
+            initialise_metrics(registry),
+        ));
         let start_time = Instant::now();
 
         Self {

--- a/consensus/core/src/validator.rs
+++ b/consensus/core/src/validator.rs
@@ -1,36 +1,49 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block_verifier::BlockVerifier;
-use crate::metrics::{initialise_metrics, Metrics};
-use consensus_config::{AuthorityIndex, Committee, Parameters, ProtocolKeyPair};
-use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Instant;
+
+use consensus_config::{AuthorityIndex, Committee, Parameters, ProtocolKeyPair};
+use prometheus::Registry;
+use sui_protocol_config::ProtocolConfig;
 use tracing::info;
 
+use crate::block_verifier::BlockVerifier;
+use crate::context::Context;
+use crate::metrics::initialise_metrics;
+
 pub struct Validator {
+    context: Arc<Context>,
     start_time: Instant,
-    metrics: Arc<Metrics>,
 }
 
 impl Validator {
     #[allow(unused)]
     async fn start(
-        authority: AuthorityIndex,
-        _committee: Committee,
-        _parameters: Parameters,
+        own_index: AuthorityIndex,
+        committee: Committee,
+        parameters: Parameters,
+        protocol_config: ProtocolConfig,
+        // To avoid accidentally leaking the private key, the key pair should only be
+        // stored in the Block signer.
         _signer: ProtocolKeyPair,
         _block_verifier: impl BlockVerifier,
         registry: Registry,
     ) -> Self {
-        info!("Boot validator with index {}", authority);
-        let metrics = initialise_metrics(registry);
+        info!("Boot validator with authority index {}", own_index);
+        let context = Arc::new(Context {
+            own_index,
+            committee,
+            parameters,
+            protocol_config,
+            metrics: initialise_metrics(registry),
+        });
         let start_time = Instant::now();
 
         Self {
+            context,
             start_time,
-            metrics,
         }
     }
 
@@ -40,7 +53,8 @@ impl Validator {
             "Stopping validator. Total run time: {:?}",
             self.start_time.elapsed()
         );
-        self.metrics
+        self.context
+            .metrics
             .node_metrics
             .uptime
             .observe(self.start_time.elapsed().as_secs_f64());
@@ -54,6 +68,7 @@ mod tests {
     use consensus_config::{Committee, Parameters, ProtocolKeyPair};
     use fastcrypto::traits::ToFromBytes;
     use prometheus::Registry;
+    use sui_protocol_config::ProtocolConfig;
 
     #[tokio::test]
     async fn validator_start_and_stop() {
@@ -62,18 +77,23 @@ mod tests {
         let parameters = Parameters::default();
         let block_verifier = TestBlockVerifier {};
 
-        let (authority_index, _) = committee.authorities().last().unwrap();
-        let singer = ProtocolKeyPair::from_bytes(keypairs[0].1.as_bytes()).unwrap();
+        let (own_index, _) = committee.authorities().last().unwrap();
+        let signer = ProtocolKeyPair::from_bytes(keypairs[0].1.as_bytes()).unwrap();
 
         let validator = Validator::start(
-            authority_index,
+            own_index,
             committee,
             parameters,
-            singer,
+            ProtocolConfig::get_for_min_version(),
+            signer,
             block_verifier,
             registry,
         )
         .await;
+
+        assert_eq!(validator.context.own_index, own_index);
+        assert_eq!(validator.context.committee.epoch(), 0);
+        assert_eq!(validator.context.committee.size(), 1);
 
         validator.stop().await;
     }


### PR DESCRIPTION
## Description 

There are a number of values used by most components and they do not change within an epoch. Pull these values into an `Arc<Context>`, so initializations and task spawming are cleaner and easier.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
