### PR TITLE
[bridge 23/n] move changes - set up committee, handle already claimed/approved case and fix messages

### DIFF
--- a/examples/move/bridge/sources/bridge.move
+++ b/examples/move/bridge/sources/bridge.move
@@ -16,7 +16,7 @@ module bridge::bridge {
     use sui::vec_map::{Self, VecMap};
     use sui::versioned::{Self, Versioned};
 
-    use bridge::chain_ids;
+    use bridge::chain_ids::{Self, sui_testnet};
     use bridge::committee::{Self, BridgeCommittee};
     use bridge::message::{Self, BridgeMessage, BridgeMessageKey};
     use bridge::message_types;
@@ -62,13 +62,30 @@ module bridge::bridge {
     // const ENotSystemAddress: u64 = 5;
     const EUnexpectedSeqNum: u64 = 6;
     const EWrongInnerVersion: u64 = 7;
-    const EAlreadyClaimed: u64 = 8;
-    const ERecordAlreadyExists: u64 = 9;
     const EBridgeUnavailable: u64 = 10;
     const EUnexpectedOperation: u64 = 11;
     const EInvalidBridgeRoute: u64 = 12;
 
+    const EInvariantSuiInitializedTokenTransferShouldNotBeClaimed: u64 = 13;
+    const EMessageNotFoundInRecords: u64 = 14;
+
     const CURRENT_VERSION: u64 = 1;
+
+    struct TokenTransferApproved has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferClaimed has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferAlreadyApproved has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferAlreadyClaimed has copy, drop {
+        message_key: BridgeMessageKey,
+    }
 
     fun init(ctx: &mut TxContext) {
 
@@ -76,7 +93,8 @@ module bridge::bridge {
 
         let bridge_inner = BridgeInner {
             bridge_version: CURRENT_VERSION,
-            chain_id: 0,
+            // TODO: how do we make this configurable?
+            chain_id: sui_testnet(),
             sequence_nums: vec_map::empty<u8, u64>(),
             committee: committee::create(ctx),
             treasury: treasury,
@@ -164,6 +182,7 @@ module bridge::bridge {
     }
 
     // Record bridge message approvals in Sui, called by the bridge client
+    // If already approved, return early instead of aborting.
     public fun approve_bridge_message(
         self: &mut Bridge,
         message: BridgeMessage,
@@ -172,39 +191,59 @@ module bridge::bridge {
         let inner = load_inner_mut(self);
         let key = message::key(&message);
 
+        // TODO: use borrow mut
+
         // retrieve pending message if source chain is Sui, the initial message must exist on chain.
-        if (message::message_type(&message) == message_types::token()) {
-            if (message::source_chain(&message) == inner.chain_id) {
-                let record = linked_table::remove(&mut inner.bridge_records, key);
-                assert!(record.message == message, EMalformedMessageError);
-                // The message should be in pending state (no approval and not claimed)
-                assert!(option::is_none(&record.verified_signatures), ERecordAlreadyExists);
-                assert!(!record.claimed, EAlreadyClaimed)
+        if (message::message_type(&message) == message_types::token() && message::source_chain(&message) == inner.chain_id) {
+            let record = linked_table::remove(&mut inner.bridge_records, key);
+            assert!(record.message == message, EMalformedMessageError);
+            assert!(!record.claimed, EInvariantSuiInitializedTokenTransferShouldNotBeClaimed);
+
+            // If record already has verified signatures, it means the message has been approved.
+            // Then we push this message back to bridge_records and exit early.
+            if (option::is_some(&record.verified_signatures)) {
+                emit(TokenTransferAlreadyApproved { message_key: key });
+                linked_table::push_back(&mut inner.bridge_records, key, record);
+                return
             }
         };
 
-        // ensure bridge massage not exist
-        assert!(!linked_table::contains(&inner.bridge_records, key), ERecordAlreadyExists);
+        // At this point, if this message is in bridge_records, we know it's already approved
+        // because we only add a message to bridge_records after verifying the signatures.
+        if (linked_table::contains(&inner.bridge_records, key)) {
+            emit(TokenTransferAlreadyApproved { message_key: key });
+            return
+        };
 
+        // At this point, we know the message has not been approved, hence has not been claimed.
         // verify signatures
         committee::verify_signatures(&inner.committee, message, signatures);
+
+        // Critical: here we set `claimed` as false. It's vitally important to make sure
+        // the token transfer has not been claimed already.
         // Store approval
         linked_table::push_back(&mut inner.bridge_records, key, BridgeRecord {
             message,
             verified_signatures: some(signatures),
             claimed: false
-        })
+        });
+        emit(TokenTransferApproved { message_key: key });
     }
 
     // Claim token from approved bridge message
+    // Returns Some(Coin) if coin can be claimed. If already claimed, return None
     fun claim_token_internal<T>(
         self: &mut Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
         ctx: &mut TxContext
-    ): (Coin<T>, address) {
+    ): (Option<Coin<T>>, address) {
         let inner = load_inner_mut(self);
         let key = message::create_key(source_chain, message_types::token(), bridge_seq_num);
+        if (!linked_table::contains(&inner.bridge_records, key)) {
+            abort EMessageNotFoundInRecords
+        };
+        // TODO: use borrow mut
         // retrieve approved bridge message
         let BridgeRecord {
             message,
@@ -215,17 +254,31 @@ module bridge::bridge {
         assert!(message::message_type(&message) == message_types::token(), EUnexpectedMessageType);
         // Ensure it's signed
         assert!(option::is_some(&signatures), EUnauthorisedClaim);
-        // Ensure it is not claimed already
-        assert!(!claimed, EAlreadyClaimed);
+
         // extract token message
         let token_payload = message::extract_token_bridge_payload(&message);
-        let target_chain = message::token_target_chain(&token_payload);
-        // ensure target chain is matches self.chain_id
-        assert!(target_chain == inner.chain_id, EUnexpectedChainID);
-        // Ensure route is valid
-        assert!(chain_ids::is_valid_route(source_chain, target_chain), EInvalidBridgeRoute);
         // get owner address
         let owner = address::from_bytes(message::token_target_address(&token_payload));
+
+        // If already claimed, exit early
+        if (claimed) {
+            emit(TokenTransferAlreadyClaimed { message_key: key });
+            linked_table::push_back(&mut inner.bridge_records, key, BridgeRecord {
+                message,
+                verified_signatures: signatures,
+                claimed: true // <-- this is important
+            });
+            return (option::none(), owner)
+        };
+
+        let target_chain = message::token_target_chain(&token_payload);
+        // ensure target chain matches self.chain_id
+        assert!(target_chain == inner.chain_id, EUnexpectedChainID);
+
+        // TODO: why do we check validity of the route here? what if inconsistency?
+
+        // Ensure route is valid
+        assert!(chain_ids::is_valid_route(source_chain, target_chain), EInvalidBridgeRoute);
         // check token type
         assert!(treasury::token_id<T>() == message::token_type(&token_payload), EUnexpectedTokenType);
         // claim from treasury
@@ -236,11 +289,13 @@ module bridge::bridge {
             verified_signatures: signatures,
             claimed: true
         });
-        (token, owner)
+        emit(TokenTransferClaimed { message_key: key });
+        (option::some(token), owner)
     }
 
     // This function can only be called by the token recipient
-    public fun claim_token<T>(self: &mut Bridge, source_chain: u8, bridge_seq_num: u64, ctx: &mut TxContext): Coin<T> {
+    // Returns None if the token has already been claimed.
+    public fun claim_token<T>(self: &mut Bridge, source_chain: u8, bridge_seq_num: u64, ctx: &mut TxContext): Option<Coin<T>> {
         let (token, owner) = claim_token_internal<T>(self, source_chain, bridge_seq_num, ctx);
         // Only token owner can claim the token
         assert!(tx_context::sender(ctx) == owner, EUnauthorisedClaim);
@@ -248,6 +303,7 @@ module bridge::bridge {
     }
 
     // This function can be called by anyone to claim and transfer the token to the recipient
+    // If the token has already been claimed, it will return instead of aborting.
     public fun claim_and_transfer_token<T>(
         self: &mut Bridge,
         source_chain: u8,
@@ -255,7 +311,11 @@ module bridge::bridge {
         ctx: &mut TxContext
     ) {
         let (token, owner) = claim_token_internal<T>(self, source_chain, bridge_seq_num, ctx);
-        transfer::public_transfer(token, owner)
+        if (option::is_none(&token)) {
+            option::destroy_none(token);
+            return
+        };
+        transfer::public_transfer(option::destroy_some(token), owner)
     }
 
     public fun execute_emergency_op(

--- a/examples/move/bridge/sources/committee.move
+++ b/examples/move/bridge/sources/committee.move
@@ -51,26 +51,45 @@ module bridge::committee {
         // TODO: change this to real committe members
         let members = vec_map::empty<vector<u8>, CommitteeMember>();
 
-        let bridge_pubkey_bytes = hex::decode(b"029bef8d556d80e43ae7e0becb3a7e6838b95defe45896ed6075bb9035d06c9964");
+        let bridge_pubkey_bytes = hex::decode(b"02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4");
         vec_map::insert(&mut members, bridge_pubkey_bytes, CommitteeMember {
+            // TODO: why do we need sui_address?
             sui_address: address::from_u256(1),
             bridge_pubkey_bytes,
-            voting_power: 10,
-            http_rest_url: b"https://127.0.0.1:9191",
+            voting_power: 2500,
+            http_rest_url: b"http://127.0.0.1:9191",
             blocklisted: false
         });
 
-        let bridge_pubkey_bytes = hex::decode(b"033e99a541db69bd32040dfe5037fbf5210dafa8151a71e21c5204b05d95ce0a62");
+        let bridge_pubkey_bytes = hex::decode(b"027f1178ff417fc9f5b8290bd8876f0a157a505a6c52db100a8492203ddd1d4279");
         vec_map::insert(&mut members, bridge_pubkey_bytes, CommitteeMember {
             sui_address: address::from_u256(2),
             bridge_pubkey_bytes,
-            voting_power: 10,
-            http_rest_url: b"https://127.0.0.1:9192",
+            voting_power: 2500,
+            http_rest_url: b"http://127.0.0.1:9192",
+            blocklisted: false
+        });
+
+        let bridge_pubkey_bytes = hex::decode(b"026f311bcd1c2664c14277c7a80e4857c690626597064f89edc33b8f67b99c6bc0");
+        vec_map::insert(&mut members, bridge_pubkey_bytes, CommitteeMember {
+            sui_address: address::from_u256(3),
+            bridge_pubkey_bytes,
+            voting_power: 2500,
+            http_rest_url: b"http://127.0.0.1:9193",
+            blocklisted: false
+        });
+
+        let bridge_pubkey_bytes = hex::decode(b"03a57b85771aedeb6d31c808be9a6e73194e4b70e679608f2bca68bcc684773736");
+        vec_map::insert(&mut members, bridge_pubkey_bytes, CommitteeMember {
+            sui_address: address::from_u256(4),
+            bridge_pubkey_bytes,
+            voting_power: 2500,
+            http_rest_url: b"http://127.0.0.1:9194",
             blocklisted: false
         });
 
         let thresholds = vec_map::empty();
-        vec_map::insert(&mut thresholds, message_types::token(), 10);
+        vec_map::insert(&mut thresholds, message_types::token(), 3334);
         BridgeCommittee { members, thresholds }
     }
 

--- a/examples/move/bridge/sources/message.move
+++ b/examples/move/bridge/sources/message.move
@@ -168,13 +168,7 @@ module bridge::message {
     }
 
     public fun key(self: &BridgeMessage): BridgeMessageKey {
-        let source_chain = if (self.message_type == message_types::token()) {
-            let bcs = bcs::new(self.payload);
-            bcs::peel_u8(&mut bcs)
-        } else {
-            0
-        };
-        create_key(source_chain, self.message_type, self.seq_num)
+        create_key(self.source_chain, self.message_type, self.seq_num)
     }
 
     // BridgeMessage getters


### PR DESCRIPTION
## Description 

This PR includes the following changes:
1. set up committee for local testing
2. if a message is already approved/handled, instead of aborting, return success. This is to make it much easier to handle concurrent txes for bridge clients
3. some other small fixes

## Test Plan 

tested locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
