### PR TITLE
update testnet ssfn seed-peer config

### DIFF
--- a/docs/content/guides/operator/sui-full-node.mdx
+++ b/docs/content/guides/operator/sui-full-node.mdx
@@ -117,13 +117,17 @@ Open a terminal or console to the `sui` directory you downloaded in the previous
 1. Testnet Full nodes only: Edit the `fullnode.yaml` file to include peer nodes for state synchronization. Append the following to the end of the current configuration:
     ```shell
     p2p-config:
-        seed-peers:
-            - peer-id: df8a8d128051c249e224f95fcc463f518a0ebed8986bbdcc11ed751181fecd38
-              address: /dns/lax-tnt-ssfn-00.testnet.sui.io/udp/8084
-            - peer-id: f9a72a0a6c17eed09c27898eab389add704777c03e135846da2428f516a0c11d
-              address: /dns/lhr-tnt-ssfn-00.testnet.sui.io/udp/8084
-            - peer-id: 9393d6056bb9c9d8475a3cf3525c747257f17c6a698a7062cbbd1875bc6ef71e
-              address: /dns/mel-tnt-ssfn-00.testnet.sui.io/udp/8084
+      seed-peers:
+        - address: /dns/nrt-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: 23a1f7cd901b6277cbedaa986b3fc183f171d800cabba863d48f698f518967e1
+        - address: /dns/ewr-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: df8a8d128051c249e224f95fcc463f518a0ebed8986bbdcc11ed751181fecd38
+        - address: /dns/lax-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: f9a72a0a6c17eed09c27898eab389add704777c03e135846da2428f516a0c11d
+        - address: /dns/lhr-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: 9393d6056bb9c9d8475a3cf3525c747257f17c6a698a7062cbbd1875bc6ef71e
+        - address: /dns/mel-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: c88742f46e66a11cb8c84aca488065661401ef66f726cb9afeb8a5786d83456e
     ```
 1. Optional: Skip this step to accept the default paths to resources. Edit the fullnode.yaml file to use custom paths.
 1. Update the `db-path` field with the path to the Full node database.


### PR DESCRIPTION
## Description 

Docs change:
- page: https://docs.sui.io/guides/operator/sui-full-node#set-up-from-source
- update incorrect/legacy SSFN's

## Test Plan 

- started syncing a fullnode using these peers
