### PR TITLE
[CI] Run split cluster check on pull requests

### DIFF
--- a/.github/workflows/split-cluster.yml
+++ b/.github/workflows/split-cluster.yml
@@ -1,0 +1,54 @@
+name: Split Cluster Check
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  validate-mainnet:
+    runs-on: ubuntu-ghcloud
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          fetch-depth: 0
+      - name: Run split cluster check script
+        id: mn-split-cluster-check
+        continue-on-error: true  # if failure, continue to bisect
+        run: | 
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
+            scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+      - name: Bisect
+        if: steps.mn-split-cluster-check.outcome == 'failure' && github.event_name == 'push'
+        run: |
+            git bisect start ${{ github.event.pull_request.head.sha }} origin/mainnet
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
+            git bisect run scripts/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+            git bisect reset
+      - name: Mark Failures
+        if: failure()
+        run: exit 1
+
+  validate-testnet:
+    runs-on: ubuntu-ghcloud
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+        with:
+          fetch-depth: 0
+      - name: Run split cluster check script
+        id: tn-split-cluster-check
+        continue-on-error: true  # if failure, continue to bisect
+        run: | 
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
+            scripts/compatibility/split-cluster-check.sh origin/testnet ${{ github.sha }}
+      - name: Bisect
+        if: steps.tn-split-cluster-check.outcome == 'failure' && github.event_name == 'push'
+        run: |
+            git bisect start ${{ github.event.pull_request.head.sha }} origin/testnet
+            SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
+            git bisect run scripts/split-cluster-check.sh origin/testnet ${{ github.sha }}
+            git bisect reset
+      - name: Mark Failures
+        if: failure()
+        run: exit 1

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -698,8 +698,7 @@ fn get_genesis_protocol_config(version: ProtocolVersion) -> ProtocolConfig {
     // depends on protocol config.
     //
     // ChainIdentifier::default().chain() which can be overridden by the
-    // SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE if necessary (this is mainly used for compatibility tests
-    // in which we want to start a cluster that thinks it is mainnet).
+    // SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE if necessary
     ProtocolConfig::get_for_version(version, ChainIdentifier::default().chain())
 }
 


### PR DESCRIPTION
## Description 

Introduces a workflow to be run on new pull requests. Workflow calls into a script which spins up a local cluster of 4 nodes on the host, with 2 nodes running mainnet release branch and 2 nodes running a release candidate (in this case, the PR branch head). The new cluster is regenesis'ed and overridden to identify as mainnet, therefore it can provide merge-blocking for changes that could introduce backwards incompatibility or other issues.

If run on merges to main, will also bisect if this fails

## Test Plan 

https://github.com/MystenLabs/sui/actions/runs/7428260893

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
