### PR TITLE
[move] Add freezing for tail expressions

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -682,7 +682,12 @@ fn tail(
             if arms_unreachable {
                 None
             } else {
-                Some(bound_exp)
+                Some(maybe_freeze(
+                    context,
+                    block,
+                    expected_type.cloned(),
+                    bound_exp,
+                ))
             }
         }
         // While loops can't yield values, so we treat them as statements with no binders.
@@ -701,7 +706,7 @@ fn tail(
                 // need to swap the implicit unit out for a trailing unit in tail position
                 trailing_unit_exp(eloc)
             } else {
-                bound_exp
+                maybe_freeze(context, block, expected_type.cloned(), bound_exp)
             };
             context.record_named_block_binders(name, binders);
             context.record_named_block_type(name, out_type.clone());
@@ -733,7 +738,7 @@ fn tail(
                 // need to swap the implicit unit out for a trailing unit in tail position
                 trailing_unit_exp(eloc)
             } else {
-                bound_exp
+                maybe_freeze(context, block, expected_type.cloned(), bound_exp)
             };
             context.record_named_block_binders(name, binders.clone());
             context.record_named_block_type(name, out_type.clone());
@@ -751,7 +756,7 @@ fn tail(
                 result
             })
         }
-        E::Block(seq) => tail_block(context, block, Some(&out_type), seq),
+        E::Block(seq) => tail_block(context, block, expected_type, seq),
 
         // -----------------------------------------------------------------------------------------
         //  statements that need to be hoisted out

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/tail_block_freeze.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/tail_block_freeze.move
@@ -1,0 +1,38 @@
+module a::m {
+
+    public struct S {}
+
+    fun t0(s: &mut S): &S {
+        loop {
+            break s
+        }
+    }
+
+    fun t1(s: &mut S): &S {
+        'block: {
+            s
+        }
+    }
+
+    #[allow(dead_code)]
+    fun t2(s: &mut S): &S {
+        'block: {
+            return 'block s;
+            s
+        }
+    }
+
+    fun t3(s: &mut S): &S {
+        {
+            s
+        }
+    }
+
+    fun t4(s: &mut S): &S {
+        {
+            s
+        }
+    }
+
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/tail_block_freeze.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/tail_block_freeze.move
@@ -34,5 +34,8 @@ module a::m {
         }
     }
 
+    fun t5(s: &mut S): &S {
+        if (true) { s } else { s }
+    }
 
 }


### PR DESCRIPTION
## Description 

There was a small oversight in freezing bound expressions in tail positions introduced during the HLIR rewrite. The VM validator caught the issue, but but would be nice to allow this code since it should ostensibly work.

## Test Plan 

Added a new test file to cover the behavior.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
