### PR TITLE
[move][easy/cleanup] Run cargo fmt on move crates

### DIFF
--- a/external-crates/move/crates/invalid-mutations/src/bounds/code_unit.rs
+++ b/external-crates/move/crates/invalid-mutations/src/bounds/code_unit.rs
@@ -398,10 +398,15 @@ impl<'a> ApplyCodeUnitBoundsContext<'a> {
 
                     // List out the other options explicitly so there's a compile error if a new
                     // bytecode gets added.
-                    ExistsDeprecated(_) | ExistsGenericDeprecated(_) | MutBorrowGlobalDeprecated(_)
-                    | MutBorrowGlobalGenericDeprecated(_) | ImmBorrowGlobalDeprecated(_)
-                    | ImmBorrowGlobalGenericDeprecated(_) | MoveFromDeprecated(_)
-                    | MoveFromGenericDeprecated(_) | MoveToDeprecated(_)
+                    ExistsDeprecated(_)
+                    | ExistsGenericDeprecated(_)
+                    | MutBorrowGlobalDeprecated(_)
+                    | MutBorrowGlobalGenericDeprecated(_)
+                    | ImmBorrowGlobalDeprecated(_)
+                    | ImmBorrowGlobalGenericDeprecated(_)
+                    | MoveFromDeprecated(_)
+                    | MoveFromGenericDeprecated(_)
+                    | MoveToDeprecated(_)
                     | MoveToGenericDeprecated(_) => {
                         panic!("Bytecode deprecated: {:?}", code[bytecode_idx])
                     }
@@ -454,10 +459,16 @@ fn is_interesting(bytecode: &Bytecode) -> bool {
         | VecUnpack(..)
         | VecSwap(_) => true,
         // Deprecated bytecodes
-        | ExistsDeprecated(_) | ExistsGenericDeprecated(_) | MutBorrowGlobalDeprecated(_)
-        | MutBorrowGlobalGenericDeprecated(_) | ImmBorrowGlobalDeprecated(_)
-        | ImmBorrowGlobalGenericDeprecated(_) | MoveFromDeprecated(_)
-        | MoveFromGenericDeprecated(_) | MoveToDeprecated(_) | MoveToGenericDeprecated(_) => false,
+        ExistsDeprecated(_)
+        | ExistsGenericDeprecated(_)
+        | MutBorrowGlobalDeprecated(_)
+        | MutBorrowGlobalGenericDeprecated(_)
+        | ImmBorrowGlobalDeprecated(_)
+        | ImmBorrowGlobalGenericDeprecated(_)
+        | MoveFromDeprecated(_)
+        | MoveFromGenericDeprecated(_)
+        | MoveToDeprecated(_)
+        | MoveToGenericDeprecated(_) => false,
         // List out the other options explicitly so there's a compile error if a new
         // bytecode gets added.
         FreezeRef | Pop | Ret | LdU8(_) | LdU16(_) | LdU32(_) | LdU64(_) | LdU128(_)

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -121,9 +121,11 @@ fn main() {
         // determine if linting is on or off based on what the editor requested
         let mut lint = false;
         if let Some(init_options) = initialize_params.initialization_options {
-            lint = init_options.get("lintOpt").and_then(serde_json::Value::as_bool).unwrap_or(false);
+            lint = init_options
+                .get("lintOpt")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
         }
-
 
         symbolicator_runner = symbols::SymbolicatorRunner::new(symbols.clone(), diag_sender, lint);
 

--- a/external-crates/move/crates/move-binary-format/src/check_bounds.rs
+++ b/external-crates/move/crates/move-binary-format/src/check_bounds.rs
@@ -441,13 +441,17 @@ impl<'a> BoundsChecker<'a> {
                         }
                     }
                 }
-                Pack(idx) | Unpack(idx) | ExistsDeprecated(idx) | ImmBorrowGlobalDeprecated(idx)
-                | MutBorrowGlobalDeprecated(idx) | MoveFromDeprecated(idx) | MoveToDeprecated(idx) => self
-                    .check_code_unit_bounds_impl_opt(
-                        &self.view.struct_defs(),
-                        *idx,
-                        bytecode_offset,
-                    )?,
+                Pack(idx)
+                | Unpack(idx)
+                | ExistsDeprecated(idx)
+                | ImmBorrowGlobalDeprecated(idx)
+                | MutBorrowGlobalDeprecated(idx)
+                | MoveFromDeprecated(idx)
+                | MoveToDeprecated(idx) => self.check_code_unit_bounds_impl_opt(
+                    &self.view.struct_defs(),
+                    *idx,
+                    bytecode_offset,
+                )?,
                 PackGeneric(idx)
                 | UnpackGeneric(idx)
                 | ExistsGenericDeprecated(idx)

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -1583,21 +1583,33 @@ fn load_code(cursor: &mut VersionedCursor, code: &mut Vec<Bytecode>) -> BinaryLo
             Opcodes::CAST_U32 => Bytecode::CastU32,
             Opcodes::CAST_U256 => Bytecode::CastU256,
             // ******** DEPRECATED BYTECODES ********
-            Opcodes::EXISTS_DEPRECATED => Bytecode::ExistsDeprecated(load_struct_def_index(cursor)?),
-            Opcodes::EXISTS_GENERIC_DEPRECATED => Bytecode::ExistsGenericDeprecated(load_struct_def_inst_index(cursor)?),
-            Opcodes::MUT_BORROW_GLOBAL_DEPRECATED => Bytecode::MutBorrowGlobalDeprecated(load_struct_def_index(cursor)?),
+            Opcodes::EXISTS_DEPRECATED => {
+                Bytecode::ExistsDeprecated(load_struct_def_index(cursor)?)
+            }
+            Opcodes::EXISTS_GENERIC_DEPRECATED => {
+                Bytecode::ExistsGenericDeprecated(load_struct_def_inst_index(cursor)?)
+            }
+            Opcodes::MUT_BORROW_GLOBAL_DEPRECATED => {
+                Bytecode::MutBorrowGlobalDeprecated(load_struct_def_index(cursor)?)
+            }
             Opcodes::MUT_BORROW_GLOBAL_GENERIC_DEPRECATED => {
                 Bytecode::MutBorrowGlobalGenericDeprecated(load_struct_def_inst_index(cursor)?)
             }
-            Opcodes::IMM_BORROW_GLOBAL_DEPRECATED => Bytecode::ImmBorrowGlobalDeprecated(load_struct_def_index(cursor)?),
+            Opcodes::IMM_BORROW_GLOBAL_DEPRECATED => {
+                Bytecode::ImmBorrowGlobalDeprecated(load_struct_def_index(cursor)?)
+            }
             Opcodes::IMM_BORROW_GLOBAL_GENERIC_DEPRECATED => {
                 Bytecode::ImmBorrowGlobalGenericDeprecated(load_struct_def_inst_index(cursor)?)
             }
-            Opcodes::MOVE_FROM_DEPRECATED => Bytecode::MoveFromDeprecated(load_struct_def_index(cursor)?),
+            Opcodes::MOVE_FROM_DEPRECATED => {
+                Bytecode::MoveFromDeprecated(load_struct_def_index(cursor)?)
+            }
             Opcodes::MOVE_FROM_GENERIC_DEPRECATED => {
                 Bytecode::MoveFromGenericDeprecated(load_struct_def_inst_index(cursor)?)
             }
-            Opcodes::MOVE_TO_DEPRECATED => Bytecode::MoveToDeprecated(load_struct_def_index(cursor)?),
+            Opcodes::MOVE_TO_DEPRECATED => {
+                Bytecode::MoveToDeprecated(load_struct_def_index(cursor)?)
+            }
             Opcodes::MOVE_TO_GENERIC_DEPRECATED => {
                 Bytecode::MoveToGenericDeprecated(load_struct_def_inst_index(cursor)?)
             }

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -1664,9 +1664,13 @@ impl ::std::fmt::Debug for Bytecode {
             Bytecode::ImmBorrowField(a) => write!(f, "ImmBorrowField({:?})", a),
             Bytecode::ImmBorrowFieldGeneric(a) => write!(f, "ImmBorrowFieldGeneric({:?})", a),
             Bytecode::MutBorrowGlobalDeprecated(a) => write!(f, "MutBorrowGlobal({:?})", a),
-            Bytecode::MutBorrowGlobalGenericDeprecated(a) => write!(f, "MutBorrowGlobalGeneric({:?})", a),
+            Bytecode::MutBorrowGlobalGenericDeprecated(a) => {
+                write!(f, "MutBorrowGlobalGeneric({:?})", a)
+            }
             Bytecode::ImmBorrowGlobalDeprecated(a) => write!(f, "ImmBorrowGlobal({:?})", a),
-            Bytecode::ImmBorrowGlobalGenericDeprecated(a) => write!(f, "ImmBorrowGlobalGeneric({:?})", a),
+            Bytecode::ImmBorrowGlobalGenericDeprecated(a) => {
+                write!(f, "ImmBorrowGlobalGeneric({:?})", a)
+            }
             Bytecode::Add => write!(f, "Add"),
             Bytecode::Sub => write!(f, "Sub"),
             Bytecode::Mul => write!(f, "Mul"),

--- a/external-crates/move/crates/move-binary-format/src/normalized.rs
+++ b/external-crates/move/crates/move-binary-format/src/normalized.rs
@@ -625,20 +625,32 @@ impl Bytecode {
             FB::ImmBorrowFieldGeneric(fhi_idx) => {
                 B::ImmBorrowFieldGeneric(field_instantiation(m, fhi_idx))
             }
-            FB::MutBorrowGlobalDeprecated(s_idx) => B::MutBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned()),
+            FB::MutBorrowGlobalDeprecated(s_idx) => {
+                B::MutBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned())
+            }
             FB::MutBorrowGlobalGenericDeprecated(si_idx) => {
                 B::MutBorrowGlobalGenericDeprecated(struct_instantiation(m, si_idx))
             }
-            FB::ImmBorrowGlobalDeprecated(s_idx) => B::ImmBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned()),
+            FB::ImmBorrowGlobalDeprecated(s_idx) => {
+                B::ImmBorrowGlobalDeprecated(m.struct_name(*s_idx).to_owned())
+            }
             FB::ImmBorrowGlobalGenericDeprecated(si_idx) => {
                 B::ImmBorrowGlobalGenericDeprecated(struct_instantiation(m, si_idx))
             }
             FB::ExistsDeprecated(s_idx) => B::ExistsDeprecated(m.struct_name(*s_idx).to_owned()),
-            FB::ExistsGenericDeprecated(si_idx) => B::ExistsGenericDeprecated(struct_instantiation(m, si_idx)),
-            FB::MoveFromDeprecated(s_idx) => B::MoveFromDeprecated(m.struct_name(*s_idx).to_owned()),
-            FB::MoveFromGenericDeprecated(si_idx) => B::MoveFromGenericDeprecated(struct_instantiation(m, si_idx)),
+            FB::ExistsGenericDeprecated(si_idx) => {
+                B::ExistsGenericDeprecated(struct_instantiation(m, si_idx))
+            }
+            FB::MoveFromDeprecated(s_idx) => {
+                B::MoveFromDeprecated(m.struct_name(*s_idx).to_owned())
+            }
+            FB::MoveFromGenericDeprecated(si_idx) => {
+                B::MoveFromGenericDeprecated(struct_instantiation(m, si_idx))
+            }
             FB::MoveToDeprecated(s_idx) => B::MoveToDeprecated(m.struct_name(*s_idx).to_owned()),
-            FB::MoveToGenericDeprecated(si_idx) => B::MoveToGenericDeprecated(struct_instantiation(m, si_idx)),
+            FB::MoveToGenericDeprecated(si_idx) => {
+                B::MoveToGenericDeprecated(struct_instantiation(m, si_idx))
+            }
             FB::VecPack(sig_idx, len) => B::VecPack(signature_to_single_type(m, sig_idx), *len),
             FB::VecLen(sig_idx) => B::VecLen(signature_to_single_type(m, sig_idx)),
             FB::VecImmBorrow(sig_idx) => B::VecImmBorrow(signature_to_single_type(m, sig_idx)),

--- a/external-crates/move/crates/move-bytecode-verifier/src/signature.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/signature.rs
@@ -209,14 +209,65 @@ impl<'a> SignatureChecker<'a> {
 
                 // List out the other options explicitly so there's a compile error if a new
                 // bytecode gets added.
-                Pop | Ret | Branch(_) | BrTrue(_) | BrFalse(_) | LdU8(_) | LdU16(_) | LdU32(_)
-                | LdU64(_) | LdU128(_) | LdU256(_) | LdConst(_) | CastU8 | CastU16 | CastU32
-                | CastU64 | CastU128 | CastU256 | LdTrue | LdFalse | Call(_) | Pack(_)
-                | Unpack(_) | ReadRef | WriteRef | FreezeRef | Add | Sub | Mul | Mod | Div
-                | BitOr | BitAnd | Xor | Shl | Shr | Or | And | Not | Eq | Neq | Lt | Gt | Le
-                | Ge | CopyLoc(_) | MoveLoc(_) | StLoc(_) | MutBorrowLoc(_) | ImmBorrowLoc(_)
-                | MutBorrowField(_) | ImmBorrowField(_) | MutBorrowGlobalDeprecated(_)
-                | ImmBorrowGlobalDeprecated(_) | ExistsDeprecated(_) | MoveToDeprecated(_) | MoveFromDeprecated(_) | Abort | Nop => Ok(()),
+                Pop
+                | Ret
+                | Branch(_)
+                | BrTrue(_)
+                | BrFalse(_)
+                | LdU8(_)
+                | LdU16(_)
+                | LdU32(_)
+                | LdU64(_)
+                | LdU128(_)
+                | LdU256(_)
+                | LdConst(_)
+                | CastU8
+                | CastU16
+                | CastU32
+                | CastU64
+                | CastU128
+                | CastU256
+                | LdTrue
+                | LdFalse
+                | Call(_)
+                | Pack(_)
+                | Unpack(_)
+                | ReadRef
+                | WriteRef
+                | FreezeRef
+                | Add
+                | Sub
+                | Mul
+                | Mod
+                | Div
+                | BitOr
+                | BitAnd
+                | Xor
+                | Shl
+                | Shr
+                | Or
+                | And
+                | Not
+                | Eq
+                | Neq
+                | Lt
+                | Gt
+                | Le
+                | Ge
+                | CopyLoc(_)
+                | MoveLoc(_)
+                | StLoc(_)
+                | MutBorrowLoc(_)
+                | ImmBorrowLoc(_)
+                | MutBorrowField(_)
+                | ImmBorrowField(_)
+                | MutBorrowGlobalDeprecated(_)
+                | ImmBorrowGlobalDeprecated(_)
+                | ExistsDeprecated(_)
+                | MoveToDeprecated(_)
+                | MoveFromDeprecated(_)
+                | Abort
+                | Nop => Ok(()),
             };
             result.map_err(|err| {
                 err.append_message_with_separator(' ', format!("at offset {} ", offset))

--- a/external-crates/move/crates/move-prover-boogie-backend/src/bytecode_translator.rs
+++ b/external-crates/move/crates/move-prover-boogie-backend/src/bytecode_translator.rs
@@ -14,8 +14,8 @@ use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info, log, warn, Level};
 
-use move_core_types::language_storage::StructTag;
 use move_compiler::interface_generator::NATIVE_INTERFACE;
+use move_core_types::language_storage::StructTag;
 use move_model::{
     ast::{Attribute, TempIndex, TraceKind},
     code_writer::CodeWriter,

--- a/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/src/stackless_bytecode_generator.rs
@@ -1021,7 +1021,8 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                 ));
             }
 
-            MoveBytecode::MutBorrowGlobalDeprecated(idx) | MoveBytecode::ImmBorrowGlobalDeprecated(idx) => {
+            MoveBytecode::MutBorrowGlobalDeprecated(idx)
+            | MoveBytecode::ImmBorrowGlobalDeprecated(idx) => {
                 let struct_env = self.func_env.module_env.get_struct_by_def_idx(*idx);
                 let is_mut = matches!(bytecode, MoveBytecode::MutBorrowGlobalDeprecated(..));
                 let operand_index = self.temp_stack.pop().unwrap();

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -29,8 +29,8 @@ use move_vm_types::{
     gas::{GasMeter, SimpleInstruction},
     loaded_data::runtime_types::Type,
     values::{
-        self, IntegerValue, Locals, Reference, Struct, StructRef, VMValueCast, Value,
-        Vector, VectorRef,
+        self, IntegerValue, Locals, Reference, Struct, StructRef, VMValueCast, Value, Vector,
+        VectorRef,
     },
     views::TypeView,
 };
@@ -187,10 +187,9 @@ impl Interpreter {
             .map_err(|err| self.set_location(err))?;
         loop {
             let resolver = current_frame.resolver(link_context, loader);
-            let exit_code =
-                current_frame //self
-                    .execute_code(&resolver, &mut self, gas_meter)
-                    .map_err(|err| self.maybe_core_dump(err, &current_frame))?;
+            let exit_code = current_frame //self
+                .execute_code(&resolver, &mut self, gas_meter)
+                .map_err(|err| self.maybe_core_dump(err, &current_frame))?;
             match exit_code {
                 ExitCode::Return => {
                     let non_ref_vals = current_frame
@@ -234,13 +233,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(
-                            &resolver,
-                            gas_meter,
-                            extensions,
-                            func,
-                            vec![],
-                        )?;
+                        self.call_native(&resolver, gas_meter, extensions, func, vec![])?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
 
                         profile_close_frame!(gas_meter, func_name);
@@ -358,23 +351,17 @@ impl Interpreter {
         ty_args: Vec<Type>,
     ) -> VMResult<()> {
         // Note: refactor if native functions push a frame on the stack
-        self.call_native_impl(
-            resolver,
-            gas_meter,
-            extensions,
-            function.clone(),
-            ty_args,
-        )
-        .map_err(|e| {
-            let id = function.module_id();
-            let e = if resolver.loader().vm_config().error_execution_state {
-                e.with_exec_state(self.get_internal_state())
-            } else {
-                e
-            };
-            e.at_code_offset(function.index(), 0)
-                .finish(Location::Module(id.clone()))
-        })
+        self.call_native_impl(resolver, gas_meter, extensions, function.clone(), ty_args)
+            .map_err(|e| {
+                let id = function.module_id();
+                let e = if resolver.loader().vm_config().error_execution_state {
+                    e.with_exec_state(self.get_internal_state())
+                } else {
+                    e
+                };
+                e.at_code_offset(function.index(), 0)
+                    .finish(Location::Module(id.clone()))
+            })
     }
 
     fn call_native_impl(
@@ -417,12 +404,8 @@ impl Interpreter {
             args.push_front(self.operand_stack.pop()?);
         }
 
-        let mut native_context = NativeContext::new(
-            self,
-            resolver,
-            extensions,
-            gas_meter.remaining_gas(),
-        );
+        let mut native_context =
+            NativeContext::new(self, resolver, extensions, gas_meter.remaining_gas());
         let native_function = function.get_native()?;
 
         gas_meter.charge_native_function_before_execution(

--- a/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
@@ -511,12 +511,18 @@ pub fn zero_cost_instruction_table() -> Vec<(Bytecode, GasCost)> {
     use Bytecode::*;
 
     vec![
-        (MoveToDeprecated(StructDefinitionIndex::new(0)), GasCost::new(0, 0)),
+        (
+            MoveToDeprecated(StructDefinitionIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
         (
             MoveToGenericDeprecated(StructDefInstantiationIndex::new(0)),
             GasCost::new(0, 0),
         ),
-        (MoveFromDeprecated(StructDefinitionIndex::new(0)), GasCost::new(0, 0)),
+        (
+            MoveFromDeprecated(StructDefinitionIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
         (
             MoveFromGenericDeprecated(StructDefInstantiationIndex::new(0)),
             GasCost::new(0, 0),
@@ -578,7 +584,10 @@ pub fn zero_cost_instruction_table() -> Vec<(Bytecode, GasCost)> {
         (LdTrue, GasCost::new(0, 0)),
         (Mod, GasCost::new(0, 0)),
         (BrFalse(0), GasCost::new(0, 0)),
-        (ExistsDeprecated(StructDefinitionIndex::new(0)), GasCost::new(0, 0)),
+        (
+            ExistsDeprecated(StructDefinitionIndex::new(0)),
+            GasCost::new(0, 0),
+        ),
         (
             ExistsGenericDeprecated(StructDefInstantiationIndex::new(0)),
             GasCost::new(0, 0),
@@ -650,7 +659,10 @@ pub fn unit_cost_schedule() -> CostTable {
 pub fn bytecode_instruction_costs() -> Vec<(Bytecode, GasCost)> {
     use Bytecode::*;
     vec![
-        (MoveToDeprecated(StructDefinitionIndex::new(0)), GasCost::new(13, 1)),
+        (
+            MoveToDeprecated(StructDefinitionIndex::new(0)),
+            GasCost::new(13, 1),
+        ),
         (
             MoveToGenericDeprecated(StructDefInstantiationIndex::new(0)),
             GasCost::new(27, 1),
@@ -720,7 +732,10 @@ pub fn bytecode_instruction_costs() -> Vec<(Bytecode, GasCost)> {
         (LdTrue, GasCost::new(1, 1)),
         (Mod, GasCost::new(1, 1)),
         (BrFalse(0), GasCost::new(1, 1)),
-        (ExistsDeprecated(StructDefinitionIndex::new(0)), GasCost::new(41, 1)),
+        (
+            ExistsDeprecated(StructDefinitionIndex::new(0)),
+            GasCost::new(41, 1),
+        ),
         (
             ExistsGenericDeprecated(StructDefInstantiationIndex::new(0)),
             GasCost::new(34, 1),

--- a/external-crates/move/crates/move-vm-types/src/data_store.rs
+++ b/external-crates/move/crates/move-vm-types/src/data_store.rs
@@ -2,10 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    loaded_data::runtime_types::Type,
-    values::GlobalValue,
-};
+use crate::{loaded_data::runtime_types::Type, values::GlobalValue};
 use move_binary_format::errors::{PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::NumBytes, identifier::IdentStr,

--- a/external-crates/move/crates/test-generation/src/summaries.rs
+++ b/external-crates/move/crates/test-generation/src/summaries.rs
@@ -8,19 +8,18 @@ use crate::{
     function_instantiation_for_state, state_control_flow, state_create_struct,
     state_create_struct_from_inst, state_local_availability_is, state_local_exists,
     state_local_has_ability, state_local_place, state_local_set, state_local_take,
-    state_local_take_borrow, state_memory_safe, state_never,
-    state_register_dereference, state_stack_bin_op, state_stack_function_call,
-    state_stack_function_inst_call, state_stack_function_inst_popn, state_stack_function_popn,
-    state_stack_has, state_stack_has_ability, state_stack_has_integer,
-    state_stack_has_polymorphic_eq, state_stack_has_reference, state_stack_has_struct,
-    state_stack_has_struct_inst, state_stack_is_castable, state_stack_local_polymorphic_eq,
-    state_stack_pop, state_stack_push, state_stack_push_register, state_stack_push_register_borrow,
-    state_stack_ref_polymorphic_eq, state_stack_satisfies_function_inst_signature,
-    state_stack_satisfies_function_signature, state_stack_satisfies_struct_signature,
-    state_stack_struct_borrow_field, state_stack_struct_borrow_field_inst,
-    state_stack_struct_has_field, state_stack_struct_has_field_inst, state_stack_struct_inst_popn,
-    state_stack_struct_popn, state_stack_unpack_struct, state_stack_unpack_struct_inst,
-    struct_instantiation_for_state,
+    state_local_take_borrow, state_memory_safe, state_never, state_register_dereference,
+    state_stack_bin_op, state_stack_function_call, state_stack_function_inst_call,
+    state_stack_function_inst_popn, state_stack_function_popn, state_stack_has,
+    state_stack_has_ability, state_stack_has_integer, state_stack_has_polymorphic_eq,
+    state_stack_has_reference, state_stack_has_struct, state_stack_has_struct_inst,
+    state_stack_is_castable, state_stack_local_polymorphic_eq, state_stack_pop, state_stack_push,
+    state_stack_push_register, state_stack_push_register_borrow, state_stack_ref_polymorphic_eq,
+    state_stack_satisfies_function_inst_signature, state_stack_satisfies_function_signature,
+    state_stack_satisfies_struct_signature, state_stack_struct_borrow_field,
+    state_stack_struct_borrow_field_inst, state_stack_struct_has_field,
+    state_stack_struct_has_field_inst, state_stack_struct_inst_popn, state_stack_struct_popn,
+    state_stack_unpack_struct, state_stack_unpack_struct_inst, struct_instantiation_for_state,
     transitions::*,
     unpack_instantiation_for_state, with_ty_param,
 };
@@ -471,11 +470,16 @@ pub fn instruction_summary(instruction: Bytecode, exact: bool) -> Summary {
             effects: Effects::NoTyParams(vec![]),
         },
         // Deprecated bytecodes
-        Bytecode::ExistsDeprecated(_) | Bytecode::ExistsGenericDeprecated(_)
-        | Bytecode::MutBorrowGlobalDeprecated(_) | Bytecode::MutBorrowGlobalGenericDeprecated(_)
-        | Bytecode::ImmBorrowGlobalDeprecated(_) | Bytecode::ImmBorrowGlobalGenericDeprecated(_)
-        | Bytecode::MoveFromDeprecated(_) | Bytecode::MoveFromGenericDeprecated(_)
-        | Bytecode::MoveToDeprecated(_) | Bytecode::MoveToGenericDeprecated(_) => {
+        Bytecode::ExistsDeprecated(_)
+        | Bytecode::ExistsGenericDeprecated(_)
+        | Bytecode::MutBorrowGlobalDeprecated(_)
+        | Bytecode::MutBorrowGlobalGenericDeprecated(_)
+        | Bytecode::ImmBorrowGlobalDeprecated(_)
+        | Bytecode::ImmBorrowGlobalGenericDeprecated(_)
+        | Bytecode::MoveFromDeprecated(_)
+        | Bytecode::MoveFromGenericDeprecated(_)
+        | Bytecode::MoveToDeprecated(_)
+        | Bytecode::MoveToGenericDeprecated(_) => {
             unreachable!("Deprecated bytecode")
         }
         // TODO: implement summaries for vector-related instructions


### PR DESCRIPTION
## Description 

What it says on the tin: cargo fmt keeps shifting these files, and I'd rather not have to keep restoring them after calling `fmt` in `move/ccrates` on unrelated diffs.

## Test Plan 

Everything still works, with no observable change.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
