### PR TITLE
move: versioned compilation 1/n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6582,6 +6582,7 @@ dependencies = [
  "tempfile",
  "toml 0.5.10",
  "toml_edit 0.14.4",
+ "tracing",
  "treeline",
  "walkdir",
  "whoami",

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -38,11 +38,14 @@ pub struct Calib {
     summarize: bool,
 }
 
+const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub fn execute_move_command(
     package_path: Option<PathBuf>,
     mut build_config: BuildConfig,
     command: Command,
 ) -> anyhow::Result<()> {
+    build_config.compiler_version = Some(CARGO_PKG_VERSION.into());
     if let Some(err_msg) = set_sui_flavor(&mut build_config) {
         anyhow::bail!(err_msg);
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -70,6 +70,8 @@ use tracing::info;
 
 use crate::key_identity::{get_identity_address, KeyIdentity};
 
+const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 macro_rules! serialize_or_execute {
     ($tx_data:expr, $serialize_unsigned:expr, $serialize_signed:expr, $context:expr, $result_variant:ident) => {{
         assert!(
@@ -723,7 +725,7 @@ impl SuiClientCommands {
             SuiClientCommands::Upgrade {
                 package_path,
                 upgrade_capability,
-                build_config,
+                mut build_config,
                 gas,
                 gas_budget,
                 skip_dependency_verification,
@@ -731,6 +733,7 @@ impl SuiClientCommands {
                 serialize_unsigned_transaction,
                 serialize_signed_transaction,
             } => {
+                build_config.compiler_version = Some(CARGO_PKG_VERSION.into());
                 let sender = context.try_get_object_owner(&gas).await?;
                 let sender = sender.unwrap_or(context.active_address()?);
 
@@ -811,13 +814,14 @@ impl SuiClientCommands {
             SuiClientCommands::Publish {
                 package_path,
                 gas,
-                build_config,
+                mut build_config,
                 gas_budget,
                 skip_dependency_verification,
                 with_unpublished_dependencies,
                 serialize_unsigned_transaction,
                 serialize_signed_transaction,
             } => {
+                build_config.compiler_version = Some(CARGO_PKG_VERSION.into());
                 if build_config.test_mode {
                     return Err(SuiError::ModulePublishFailure {
                         error:
@@ -867,8 +871,9 @@ impl SuiClientCommands {
 
             SuiClientCommands::VerifyBytecodeMeter {
                 package_path,
-                build_config,
+                mut build_config,
             } => {
+                build_config.compiler_version = Some(CARGO_PKG_VERSION.into());
                 let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
                 let registry = &Registry::new();
                 let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit 0.14.4",
+ "tracing",
  "treeline",
  "walkdir",
  "whoami",

--- a/external-crates/move/crates/move-package/Cargo.toml
+++ b/external-crates/move/crates/move-package/Cargo.toml
@@ -20,6 +20,7 @@ serde_yaml.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
 regex.workspace = true
+tracing.workspace = true
 treeline.workspace = true
 once_cell.workspace = true
 named-lock.workspace = true

--- a/external-crates/move/crates/move-package/src/compilation/mod.rs
+++ b/external-crates/move/crates/move-package/src/compilation/mod.rs
@@ -6,3 +6,4 @@ pub mod build_plan;
 pub mod compiled_package;
 pub mod model_builder;
 pub mod package_layout;
+pub mod versioned_compilation;

--- a/external-crates/move/crates/move-package/src/compilation/versioned_compilation.rs
+++ b/external-crates/move/crates/move-package/src/compilation/versioned_compilation.rs
@@ -1,0 +1,196 @@
+use crate::{
+    lock_file::{self, schema::ToolchainVersion},
+    source_package::layout::SourcePackageLayout,
+};
+use anyhow::{anyhow, bail, Result};
+use colored::Colorize;
+use move_command_line_common::env::MOVE_HOME;
+use move_compiler::shared::PackagePaths;
+use move_symbol_pool::Symbol;
+
+use std::process::Command;
+use std::{
+    ffi::OsStr,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+use tracing::debug;
+
+/// partitions `deps` by whether we need to compile dependent packages with a
+/// prior toolchain (which we find by looking at Move.lock contents) or
+/// whether we can compile them with the current binary.
+pub fn partition_deps_by_toolchain<W: Write>(
+    deps: Vec<PackagePaths>,
+    current_compiler_version: Option<String>,
+    w: &mut W,
+) -> Result<(Vec<PackagePaths>, Vec<PackagePaths>)> {
+    let current_compiler_version = current_compiler_version.unwrap_or_else(|| "0.0.0".into());
+    debug!("current compiler: {current_compiler_version}");
+    let mut deps_for_current_compiler = vec![];
+    let mut deps_for_prior_compiler = vec![];
+    for dep in deps {
+        let a_source_path = dep.paths[0].as_str();
+        let root = SourcePackageLayout::try_find_root(Path::new(a_source_path))?;
+        let lock_file = root.join("Move.lock");
+        if !lock_file.exists() {
+            deps_for_current_compiler.push(dep);
+            continue;
+        }
+
+        let mut lock_file = File::open(lock_file)?;
+        let toolchain_version = lock_file::schema::ToolchainVersion::read(&mut lock_file)?;
+        match toolchain_version {
+            // No ToolchainVersion implies current compiler
+            None => deps_for_current_compiler.push(dep),
+            // This dependency uses the current compiler
+            Some(ToolchainVersion {
+                compiler_version, ..
+            }) if compiler_version == current_compiler_version => {
+                deps_for_current_compiler.push(dep)
+            }
+            // This dependency needs a prior compiler. Mark it and compile.
+            Some(toolchain_version) => {
+                let dep_name = match dep.name.clone() {
+                    Some((name, _)) => name,
+                    None => "unnamed dependency".into(),
+                };
+                writeln!(
+                    w,
+                    "{} {} compiler @ {}",
+                    "REQUIRE".bold().green(),
+                    dep_name,
+                    toolchain_version.compiler_version.yellow(),
+                )?;
+                download_and_compile(root, toolchain_version, dep_name, w)?;
+                deps_for_prior_compiler.push(dep)
+            }
+        }
+    }
+    Ok((deps_for_current_compiler, deps_for_prior_compiler))
+}
+
+fn detect_platform() -> Result<String> {
+    let s = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => "macos-arm64",
+        ("macos", "x86_64") => "macos-x86_64",
+        ("linux", "x86_64") => "ubuntu-x86_64",
+        ("windows", "x86_64") => "windows-x86_64",
+        (os, arch) => bail!("unsupported os {os} and arch {arch}"),
+    };
+    Ok(s.into())
+}
+
+fn download_and_compile<W: Write>(
+    root: PathBuf,
+    ToolchainVersion {
+        compiler_version,
+        edition,
+        flavor,
+    }: ToolchainVersion,
+    dep_name: Symbol,
+    w: &mut W,
+) -> Result<()> {
+    let binaries_path = &*MOVE_HOME; // E.g., ~/.move/binaries
+    let mut dest_dir = PathBuf::from(binaries_path);
+    dest_dir = dest_dir.join("binaries");
+    let dest_version = dest_dir.join(compiler_version.clone());
+    let platform = detect_platform()?;
+    let dest_binary = dest_version.join(format!("target/release/sui-{}", platform));
+    let dest_binary_os = OsStr::new(dest_binary.as_path());
+
+    if !dest_binary.exists() {
+        // Download if binary does not exist.
+        let url = format!("https://github.com/MystenLabs/sui/releases/download/mainnet-v{}/sui-mainnet-v{}-{}.tgz", compiler_version, compiler_version, platform);
+        let release_url = OsStr::new(url.as_str());
+        let dest_tarball = dest_version.join(format!("{}.tgz", compiler_version));
+        debug!(
+            "curl -L --create-dirs -o {} {}",
+            dest_tarball.display(),
+            url
+        );
+        writeln!(
+            w,
+            "{} compiler @ {}",
+            "DOWNLOADING".bold().green(),
+            compiler_version.yellow()
+        )?;
+        Command::new("curl")
+            .args([
+                OsStr::new("-L"),
+                OsStr::new("--create-dirs"),
+                OsStr::new("-o"),
+                OsStr::new(dest_tarball.as_path()),
+                OsStr::new(release_url),
+            ])
+            .output()
+            .map_err(|e| {
+                anyhow!("failed to download compiler binary for {compiler_version}: {e}",)
+            })?;
+
+        debug!(
+            "tar -xzf {} -C {}",
+            dest_tarball.display(),
+            dest_version.display()
+        );
+        Command::new("tar")
+            .args([
+                OsStr::new("-xzf"),
+                OsStr::new(dest_tarball.as_path()),
+                OsStr::new("-C"),
+                OsStr::new(dest_version.as_path()),
+            ])
+            .output()
+            .map_err(|e| anyhow!("failed to untar compiler binary: {e}"))?;
+
+        set_executable_permission(dest_binary_os)?;
+    }
+
+    debug!(
+        "sui move build --default-move-edition {} --default-move-flavor {} -p {}",
+        edition.to_string().as_str(),
+        flavor.to_string().as_str(),
+        root.display()
+    );
+    writeln!(
+        w,
+        "{} {} (compiler @ {})",
+        "BUILDING".bold().green(),
+        dep_name.as_str(),
+        compiler_version.yellow()
+    )?;
+    Command::new(dest_binary_os)
+        .args([
+            OsStr::new("move"),
+            OsStr::new("build"),
+            OsStr::new("--default-move-edition"),
+            OsStr::new(edition.to_string().as_str()),
+            OsStr::new("--default-move-flavor"),
+            OsStr::new(flavor.to_string().as_str()),
+            OsStr::new("-p"),
+            OsStr::new(root.as_path()),
+        ])
+        .output()
+        .map_err(|e| {
+            anyhow!("failed to build package from compiler binary {compiler_version}: {e}",)
+        })?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable_permission(path: &OsStr) -> Result<()> {
+    use std::fs;
+    use std::os::unix::prelude::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable_permission(path: &OsStr) -> Result<()> {
+    Command::new("icacls")
+        .args([path, OsStr::new("/grant"), OsStr::new("Everyone:(RX)")])
+        .status()?;
+    Ok(())
+}

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -102,6 +102,10 @@ pub struct BuildConfig {
     /// If `true`, disable linters
     #[clap(long, global = true)]
     pub no_lint: bool,
+
+    #[clap(skip)]
+    /// A field specifying this compiler version, derived from sui-move crate version.
+    pub compiler_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
@@ -24,5 +24,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -117,6 +117,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -93,6 +93,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -99,6 +99,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -103,6 +103,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -118,6 +118,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -143,6 +143,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -101,6 +101,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -135,6 +135,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -151,6 +151,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -151,6 +151,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -151,6 +151,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -93,6 +93,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -127,6 +127,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -127,6 +127,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -93,6 +93,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -72,6 +72,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -108,6 +108,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -80,6 +80,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -68,6 +68,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -68,6 +68,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -68,6 +68,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
@@ -28,5 +28,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -76,6 +76,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -109,6 +109,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "More": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -93,6 +93,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -51,6 +51,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -32,6 +32,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -93,6 +93,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -101,6 +101,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        compiler_version: None,
     },
 }


### PR DESCRIPTION
## Description 

This PR adds the first set of code changes to compile Move package dependencies against previous compiler versions (by inspecting if `Move.lock` files specify that such packages should be compiled with a previous compiler). AKA: toolchain versioning. Important points for this PR:

- All behavioral changes are guarded by an environment variable `VERIFIED_SOURCE_BUILD`. This is so that there can be incremental progress / changes without batching a whole lot of unguarded logic. The changes to our build model changes significantly and we need a toggle to test existing behavior against new planned behavior.

- This PR does not contain tests because it does not enable the main behavioral changes yet (and also guarded, by env variable as above). I ran some locally sanity checks, but need to include more changes to test various parts. Currently, it's possible to build move packages but not test / publish with this flow yet. It's unclear how we'll test end-to-end behavior (we either need to avoid downloading binaries for testing, because of flakiness, so far checking in a binary for testing may be best, but it is a large binary, which is not ideal. This to be decided).

- Next up:
  - Add changes allowing `sui client publish` to work with toolchain versioning

More comments inline

## Test Plan 

Local testing with `VERIFIED_SOURCE_BUILD=1 sui move build`. Here's an example compiling `kiosk` with manually changing a dependency to target the `1.15.1` compiler:

<img width="454" alt="Screenshot 2024-01-08 at 10 53 40 PM" src="https://github.com/MystenLabs/sui/assets/888624/f3582dc9-4920-45f4-b524-5c4ad8245f65">

Known limitations: `VERIFIED_SOURCE_BUILD=1sui client publish` does not work yet.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
