### PR TITLE
[graphql] Improve doc comments for references doc

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -109,7 +109,7 @@ The possible relationship types for a transaction block: sign, sent, received, o
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed
+	Transactions this address has signed either as a sender or as a sponsor
 	"""
 	SIGN
 	"""
@@ -117,11 +117,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that received objects into this address
+	Transactions that sent objects to this addres
 	"""
 	RECV
 	"""
-	Transactions that were paid for by this address
+	Transactions that were paid for by this address either as a sender or as a sponsor
 	"""
 	PAID
 }
@@ -1027,23 +1027,23 @@ type MergeCoinsTransaction {
 }
 
 """
-The basic four abilities for a move object
+Abilities are keywords in Sui Move that define how types behave at the compiler level.
 """
 enum MoveAbility {
 	"""
-	Allows values of types with this ability to be copied.
+	Enables values to be copied.
 	"""
 	COPY
 	"""
-	Allows values of types with this ability to be popped/dropped.
+	Enables values to be popped/dropped.
 	"""
 	DROP
 	"""
-	Allows the type to serve as a key for global storage operations.
+	Enables values to be held directly in global storage.
 	"""
 	KEY
 	"""
-	Allows values of types with this ability to exist inside a struct in global storage.
+	Enables values to be held inside a struct in global storage.
 	"""
 	STORE
 }
@@ -1481,25 +1481,21 @@ type MoveValue {
 }
 
 """
-Module functions, by default, can only be called within the same module.
-These internal (sometimes called private) functions cannot be called from
-other modules or from scripts.
+The visibility modifier describes which modules can access this module member.
+A module member, by default, can only be called within the same module.
 """
 enum MoveVisibility {
 	"""
-	A public function can be called by any function defined in any module or script.
+	A public member can be accessed by any module.
 	"""
 	PUBLIC
 	"""
-	A private function can only be called from the module where it was defined.
+	A private member can be accessed in the module it is defined in.
 	"""
 	PRIVATE
 	"""
-	The friend visibility modifier is a more restricted form of the public modifier
-	to give more control about where a function can be used. A public(friend) function
-	can be called by:
-	1) other functions defined in the same module, or
-	2) functions defined in modules which are explicitly specified in the friend list.
+	A friend member can be accessed in the module it is defined in and any other module in
+	its package that is explicitly specified in its friend list.
 	"""
 	FRIEND
 }
@@ -2658,6 +2654,9 @@ input TransactionBlockFilter {
 	package: SuiAddress
 	module: String
 	function: String
+	"""
+	An input filter selecting for either system or programmable transactions.
+	"""
 	kind: TransactionBlockKindInput
 	afterCheckpoint: Int
 	atCheckpoint: Int
@@ -2672,12 +2671,12 @@ input TransactionBlockFilter {
 }
 
 """
-The kind of transaction blocks that exist.
+The kind of transaction block, either a programmable transaction or a system transaction.
 """
 union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
 """
-The kind of transaction block: a system transaction or a programmable transaction.
+An input filter selecting for either system or programmable transactions.
 """
 enum TransactionBlockKindInput {
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -104,10 +104,25 @@ type AddressOwner {
 	owner: Owner
 }
 
+"""
+The possible relationship types for a transaction block: sign, sent, received, or paid.
+"""
 enum AddressTransactionBlockRelationship {
+	"""
+	Transactions this address has signed
+	"""
 	SIGN
+	"""
+	Transactions that transferred objects from this address
+	"""
 	SENT
+	"""
+	Transactions that received objects into this address
+	"""
 	RECV
+	"""
+	Transactions that were paid for by this address
+	"""
 	PAID
 }
 
@@ -811,8 +826,17 @@ type ExecutionResult {
 	digest: String!
 }
 
+"""
+The execution status of this transaction block: success or failure.
+"""
 enum ExecutionStatus {
+	"""
+	The transaction block was successfully executed
+	"""
 	SUCCESS
+	"""
+	The transaction block could not be executed
+	"""
 	FAILURE
 }
 
@@ -1002,10 +1026,25 @@ type MergeCoinsTransaction {
 	coins: [TransactionArgument!]!
 }
 
+"""
+The basic four abilities for a move object
+"""
 enum MoveAbility {
+	"""
+	Allows values of types with this ability to be copied.
+	"""
 	COPY
+	"""
+	Allows values of types with this ability to be popped/dropped.
+	"""
 	DROP
+	"""
+	Allows the type to serve as a key for global storage operations.
+	"""
 	KEY
+	"""
+	Allows values of types with this ability to exist inside a struct in global storage.
+	"""
 	STORE
 }
 
@@ -1441,9 +1480,27 @@ type MoveValue {
 	json: JSON!
 }
 
+"""
+Module functions, by default, can only be called within the same module.
+These internal (sometimes called private) functions cannot be called from
+other modules or from scripts.
+"""
 enum MoveVisibility {
+	"""
+	A public function can be called by any function defined in any module or script.
+	"""
 	PUBLIC
+	"""
+	A private function can only be called from the module where it was defined.
+	"""
 	PRIVATE
+	"""
+	The friend visibility modifier is a more restricted form of the public modifier
+	to give more control about where a function can be used. A public(friend) function
+	can be called by:
+	1) other functions defined in the same module, or
+	2) functions defined in modules which are explicitly specified in the friend list.
+	"""
 	FRIEND
 }
 
@@ -2239,6 +2296,9 @@ type SplitCoinsTransaction {
 	amounts: [TransactionArgument!]!
 }
 
+"""
+The stake's possible status: active, pending, or unstaked.
+"""
 enum StakeStatus {
 	"""
 	The stake object is active in a staking pool and it is generating rewards
@@ -2611,10 +2671,23 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
+"""
+The kind of transaction blocks that exist.
+"""
 union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
+"""
+The kind of transaction block: a system transaction or a programmable transaction.
+"""
 enum TransactionBlockKindInput {
+	"""
+	A system transaction can be one of several types of transactions.
+	See [unions/transaction-block-kind] for more details.
+	"""
 	SYSTEM_TX
+	"""
+	A user submitted transaction block
+	"""
 	PROGRAMMABLE_TX
 }
 

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1482,7 +1482,7 @@ type MoveValue {
 
 """
 The visibility modifier describes which modules can access this module member.
-A module member, by default, can only be called within the same module.
+By default, a module member can be called only within the same module.
 """
 enum MoveVisibility {
 	"""

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -22,16 +22,16 @@ pub(crate) struct Address {
     pub address: SuiAddress,
 }
 
-#[derive(Enum, Copy, Clone, Eq, PartialEq)]
 /// The possible relationship types for a transaction block: sign, sent, received, or paid.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum AddressTransactionBlockRelationship {
-    /// Transactions this address has signed
+    /// Transactions this address has signed either as a sender or as a sponsor
     Sign,
     /// Transactions that transferred objects from this address
     Sent,
-    /// Transactions that received objects into this address
+    /// Transactions that sent objects to this addres
     Recv,
-    /// Transactions that were paid for by this address
+    /// Transactions that were paid for by this address either as a sender or as a sponsor
     Paid,
 }
 

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -23,11 +23,16 @@ pub(crate) struct Address {
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
+/// The possible relationship types for a transaction block: sign, sent, received, or paid.
 pub(crate) enum AddressTransactionBlockRelationship {
-    Sign, // Transactions this address has signed
-    Sent, // Transactions that transferred objects from this address
-    Recv, // Transactions that received objects into this address
-    Paid, // Transactions that were paid for by this address
+    /// Transactions this address has signed
+    Sign,
+    /// Transactions that transferred objects from this address
+    Sent,
+    /// Transactions that received objects into this address
+    Recv,
+    /// Transactions that were paid for by this address
+    Paid,
 }
 
 #[Object]

--- a/crates/sui-graphql-rpc/src/types/open_move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/open_move_type.rs
@@ -12,33 +12,29 @@ pub(crate) struct OpenMoveType {
     signature: OpenMoveTypeSignature,
 }
 
-/// The basic four abilities for a move object
+/// Abilities are keywords in Sui Move that define how types behave at the compiler level.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum MoveAbility {
-    /// Allows values of types with this ability to be copied.
+    /// Enables values to be copied.
     Copy,
-    /// Allows values of types with this ability to be popped/dropped.
+    /// Enables values to be popped/dropped.
     Drop,
-    /// Allows the type to serve as a key for global storage operations.
+    /// Enables values to be held directly in global storage.
     Key,
-    /// Allows values of types with this ability to exist inside a struct in global storage.
+    /// Enables values to be held inside a struct in global storage.
     Store,
 }
 
-/// Module functions, by default, can only be called within the same module.
-/// These internal (sometimes called private) functions cannot be called from
-/// other modules or from scripts.
+/// The visibility modifier describes which modules can access this module member.
+/// A module member, by default, can only be called within the same module.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum MoveVisibility {
-    /// A public function can be called by any function defined in any module or script.
+    /// A public member can be accessed by any module.
     Public,
-    /// A private function can only be called from the module where it was defined.
+    /// A private member can be accessed in the module it is defined in.
     Private,
-    /// The friend visibility modifier is a more restricted form of the public modifier
-    /// to give more control about where a function can be used. A public(friend) function
-    /// can be called by:
-    /// 1) other functions defined in the same module, or
-    /// 2) functions defined in modules which are explicitly specified in the friend list.
+    /// A friend member can be accessed in the module it is defined in and any other module in
+    /// its package that is explicitly specified in its friend list.
     Friend,
 }
 

--- a/crates/sui-graphql-rpc/src/types/open_move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/open_move_type.rs
@@ -12,18 +12,33 @@ pub(crate) struct OpenMoveType {
     signature: OpenMoveTypeSignature,
 }
 
+/// The basic four abilities for a move object
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum MoveAbility {
+    /// Allows values of types with this ability to be copied.
     Copy,
+    /// Allows values of types with this ability to be popped/dropped.
     Drop,
+    /// Allows the type to serve as a key for global storage operations.
     Key,
+    /// Allows values of types with this ability to exist inside a struct in global storage.
     Store,
 }
 
+/// Module functions, by default, can only be called within the same module.
+/// These internal (sometimes called private) functions cannot be called from
+/// other modules or from scripts.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum MoveVisibility {
+    /// A public function can be called by any function defined in any module or script.
     Public,
+    /// A private function can only be called from the module where it was defined.
     Private,
+    /// The friend visibility modifier is a more restricted form of the public modifier
+    /// to give more control about where a function can be used. A public(friend) function
+    /// can be called by:
+    /// 1) other functions defined in the same module, or
+    /// 2) functions defined in modules which are explicitly specified in the friend list.
     Friend,
 }
 

--- a/crates/sui-graphql-rpc/src/types/open_move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/open_move_type.rs
@@ -26,7 +26,7 @@ pub(crate) enum MoveAbility {
 }
 
 /// The visibility modifier describes which modules can access this module member.
-/// A module member, by default, can only be called within the same module.
+/// By default, a module member can be called only within the same module.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum MoveVisibility {
     /// A public member can be accessed by any module.

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -10,6 +10,7 @@ use sui_json_rpc_types::{Stake as RpcStakedSui, StakeStatus as RpcStakeStatus};
 use sui_types::governance::StakedSui as NativeStakedSui;
 
 #[derive(Copy, Clone, Enum, PartialEq, Eq)]
+/// The stake's possible status: active, pending, or unstaked.
 pub(crate) enum StakeStatus {
     /// The stake object is active in a staking pool and it is generating rewards
     Active,

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -42,7 +42,7 @@ pub(crate) struct TransactionBlock {
     pub native: NativeSenderSignedData,
 }
 
-/// The kind of transaction block: a system transaction or a programmable transaction.
+/// An input filter selecting for either system or programmable transactions.
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum TransactionBlockKindInput {
     /// A system transaction can be one of several types of transactions.
@@ -58,6 +58,7 @@ pub(crate) struct TransactionBlockFilter {
     pub module: Option<String>,
     pub function: Option<String>,
 
+    /// An input filter selecting for either system or programmable transactions.
     pub kind: Option<TransactionBlockKindInput>,
     pub after_checkpoint: Option<u64>,
     pub at_checkpoint: Option<u64>,

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -42,9 +42,13 @@ pub(crate) struct TransactionBlock {
     pub native: NativeSenderSignedData,
 }
 
+/// The kind of transaction block: a system transaction or a programmable transaction.
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub(crate) enum TransactionBlockKindInput {
+    /// A system transaction can be one of several types of transactions.
+    /// See [unions/transaction-block-kind] for more details.
     SystemTx = 0,
+    /// A user submitted transaction block
     ProgrammableTx = 1,
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -37,9 +37,12 @@ pub(crate) struct TransactionBlockEffects {
     pub native: NativeTransactionEffects,
 }
 
+/// The execution status of this transaction block: success or failure.
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub enum ExecutionStatus {
+    /// The transaction block was successfully executed
     Success,
+    /// The transaction block could not be executed
     Failure,
 }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod genesis;
 pub(crate) mod programmable;
 pub(crate) mod randomness_state_update;
 
-/// The kind of transaction blocks that exist.
+/// The kind of transaction block, either a programmable transaction or a system transaction.
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {
     ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod genesis;
 pub(crate) mod programmable;
 pub(crate) mod randomness_state_update;
 
+/// The kind of transaction blocks that exist.
 #[derive(Union, PartialEq, Clone, Eq)]
 pub(crate) enum TransactionBlockKind {
     ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -113,7 +113,7 @@ The possible relationship types for a transaction block: sign, sent, received, o
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has signed
+	Transactions this address has signed either as a sender or as a sponsor
 	"""
 	SIGN
 	"""
@@ -121,11 +121,11 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that received objects into this address
+	Transactions that sent objects to this addres
 	"""
 	RECV
 	"""
-	Transactions that were paid for by this address
+	Transactions that were paid for by this address either as a sender or as a sponsor
 	"""
 	PAID
 }
@@ -1031,23 +1031,23 @@ type MergeCoinsTransaction {
 }
 
 """
-The basic four abilities for a move object
+Abilities are keywords in Sui Move that define how types behave at the compiler level.
 """
 enum MoveAbility {
 	"""
-	Allows values of types with this ability to be copied.
+	Enables values to be copied.
 	"""
 	COPY
 	"""
-	Allows values of types with this ability to be popped/dropped.
+	Enables values to be popped/dropped.
 	"""
 	DROP
 	"""
-	Allows the type to serve as a key for global storage operations.
+	Enables values to be held directly in global storage.
 	"""
 	KEY
 	"""
-	Allows values of types with this ability to exist inside a struct in global storage.
+	Enables values to be held inside a struct in global storage.
 	"""
 	STORE
 }
@@ -1485,25 +1485,21 @@ type MoveValue {
 }
 
 """
-Module functions, by default, can only be called within the same module.
-These internal (sometimes called private) functions cannot be called from
-other modules or from scripts.
+The visibility modifier describes which modules can access this module member.
+A module member, by default, can only be called within the same module.
 """
 enum MoveVisibility {
 	"""
-	A public function can be called by any function defined in any module or script.
+	A public member can be accessed by any module.
 	"""
 	PUBLIC
 	"""
-	A private function can only be called from the module where it was defined.
+	A private member can be accessed in the module it is defined in.
 	"""
 	PRIVATE
 	"""
-	The friend visibility modifier is a more restricted form of the public modifier
-	to give more control about where a function can be used. A public(friend) function
-	can be called by:
-	1) other functions defined in the same module, or
-	2) functions defined in modules which are explicitly specified in the friend list.
+	A friend member can be accessed in the module it is defined in and any other module in
+	its package that is explicitly specified in its friend list.
 	"""
 	FRIEND
 }
@@ -2662,6 +2658,9 @@ input TransactionBlockFilter {
 	package: SuiAddress
 	module: String
 	function: String
+	"""
+	An input filter selecting for either system or programmable transactions.
+	"""
 	kind: TransactionBlockKindInput
 	afterCheckpoint: Int
 	atCheckpoint: Int
@@ -2676,12 +2675,12 @@ input TransactionBlockFilter {
 }
 
 """
-The kind of transaction blocks that exist.
+The kind of transaction block, either a programmable transaction or a system transaction.
 """
 union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
 """
-The kind of transaction block: a system transaction or a programmable transaction.
+An input filter selecting for either system or programmable transactions.
 """
 enum TransactionBlockKindInput {
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -108,10 +108,25 @@ type AddressOwner {
 	owner: Owner
 }
 
+"""
+The possible relationship types for a transaction block: sign, sent, received, or paid.
+"""
 enum AddressTransactionBlockRelationship {
+	"""
+	Transactions this address has signed
+	"""
 	SIGN
+	"""
+	Transactions that transferred objects from this address
+	"""
 	SENT
+	"""
+	Transactions that received objects into this address
+	"""
 	RECV
+	"""
+	Transactions that were paid for by this address
+	"""
 	PAID
 }
 
@@ -815,8 +830,17 @@ type ExecutionResult {
 	digest: String!
 }
 
+"""
+The execution status of this transaction block: success or failure.
+"""
 enum ExecutionStatus {
+	"""
+	The transaction block was successfully executed
+	"""
 	SUCCESS
+	"""
+	The transaction block could not be executed
+	"""
 	FAILURE
 }
 
@@ -1006,10 +1030,25 @@ type MergeCoinsTransaction {
 	coins: [TransactionArgument!]!
 }
 
+"""
+The basic four abilities for a move object
+"""
 enum MoveAbility {
+	"""
+	Allows values of types with this ability to be copied.
+	"""
 	COPY
+	"""
+	Allows values of types with this ability to be popped/dropped.
+	"""
 	DROP
+	"""
+	Allows the type to serve as a key for global storage operations.
+	"""
 	KEY
+	"""
+	Allows values of types with this ability to exist inside a struct in global storage.
+	"""
 	STORE
 }
 
@@ -1445,9 +1484,27 @@ type MoveValue {
 	json: JSON!
 }
 
+"""
+Module functions, by default, can only be called within the same module.
+These internal (sometimes called private) functions cannot be called from
+other modules or from scripts.
+"""
 enum MoveVisibility {
+	"""
+	A public function can be called by any function defined in any module or script.
+	"""
 	PUBLIC
+	"""
+	A private function can only be called from the module where it was defined.
+	"""
 	PRIVATE
+	"""
+	The friend visibility modifier is a more restricted form of the public modifier
+	to give more control about where a function can be used. A public(friend) function
+	can be called by:
+	1) other functions defined in the same module, or
+	2) functions defined in modules which are explicitly specified in the friend list.
+	"""
 	FRIEND
 }
 
@@ -2243,6 +2300,9 @@ type SplitCoinsTransaction {
 	amounts: [TransactionArgument!]!
 }
 
+"""
+The stake's possible status: active, pending, or unstaked.
+"""
 enum StakeStatus {
 	"""
 	The stake object is active in a staking pool and it is generating rewards
@@ -2615,10 +2675,23 @@ input TransactionBlockFilter {
 	transactionIds: [String!]
 }
 
+"""
+The kind of transaction blocks that exist.
+"""
 union TransactionBlockKind = ConsensusCommitPrologueTransaction | GenesisTransaction | ChangeEpochTransaction | ProgrammableTransactionBlock | AuthenticatorStateUpdateTransaction | RandomnessStateUpdateTransaction | EndOfEpochTransaction
 
+"""
+The kind of transaction block: a system transaction or a programmable transaction.
+"""
 enum TransactionBlockKindInput {
+	"""
+	A system transaction can be one of several types of transactions.
+	See [unions/transaction-block-kind] for more details.
+	"""
 	SYSTEM_TX
+	"""
+	A user submitted transaction block
+	"""
 	PROGRAMMABLE_TX
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1486,7 +1486,7 @@ type MoveValue {
 
 """
 The visibility modifier describes which modules can access this module member.
-A module member, by default, can only be called within the same module.
+By default, a module member can be called only within the same module.
 """
 enum MoveVisibility {
 	"""


### PR DESCRIPTION
## Description 

Try to add doc comments to most Enums to improve the docs for the reference page that will be autogenerated from the schema.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
