### PR TITLE
make fullnode txn post processing and event handling upgrade aware

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -48,7 +48,9 @@ use sui_json_rpc_types::{
     Balance, Coin as SuiCoin, SuiCoinMetadata, SuiTransactionBlockEffects,
     SuiTransactionBlockEffectsAPI,
 };
-use sui_types::{balance::Supply, coin::TreasuryCap, dynamic_field::DynamicFieldName};
+use sui_types::{
+    balance::Supply, coin::TreasuryCap, dynamic_field::DynamicFieldName, object::MoveObject,
+};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, VersionNumber},
     committee::EpochId,
@@ -1019,12 +1021,13 @@ impl IndexerReader {
             .into_iter()
             .enumerate()
             .map(|(i, event)| {
+                let layout = MoveObject::get_layout_from_struct_tag(event.type_.clone(), self)?;
                 sui_json_rpc_types::SuiEvent::try_from(
                     event,
                     digest,
                     i as u64,
                     Some(timestamp_ms as u64),
-                    self,
+                    layout,
                 )
             })
             .collect::<Result<Vec<_>, _>>()

--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -156,8 +156,12 @@ impl StoredTransaction {
                 .collect::<Result<Vec<Event>, IndexerError>>()?;
             let timestamp = self.timestamp_ms as u64;
             let tx_events = TransactionEvents { data: events };
-            let tx_events =
-                SuiTransactionBlockEvents::try_from(tx_events, tx_digest, Some(timestamp), module)?;
+            let tx_events = SuiTransactionBlockEvents::try_from_using_module_resolver(
+                tx_events,
+                tx_digest,
+                Some(timestamp),
+                module,
+            )?;
             Some(tx_events)
         } else {
             None

--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::{Base58, Base64};
-use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::annotated_value::MoveStructLayout;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 use mysten_metrics::monitored_scope;
@@ -99,7 +99,7 @@ impl SuiEvent {
         tx_digest: TransactionDigest,
         event_seq: u64,
         timestamp_ms: Option<u64>,
-        resolver: &impl GetModule,
+        layout: MoveStructLayout,
     ) -> SuiResult<Self> {
         let Event {
             package_id,
@@ -111,7 +111,7 @@ impl SuiEvent {
 
         let bcs = contents.to_vec();
 
-        let move_struct = Event::move_event_to_move_struct(&type_, &contents, resolver)?;
+        let move_struct = Event::move_event_to_move_struct(&contents, layout)?;
         let (type_, field) = type_and_fields_from_move_struct(&type_, move_struct);
 
         Ok(SuiEvent {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -872,12 +872,13 @@ impl ReadApiServer for ReadApi {
                 .into_iter()
                 .enumerate()
                 .map(|(seq, e)| {
+                    let layout = store.executor().type_layout_resolver(Box::new(state.get_db())).get_annotated_layout(&e.type_)?;
                     SuiEvent::try_from(
                         e,
                         *effect.transaction_digest(),
                         seq as u64,
                         None,
-                        store.module_cache(),
+                        layout,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()
@@ -1053,20 +1054,15 @@ fn to_sui_transaction_events(
     tx_digest: TransactionDigest,
     events: TransactionEvents,
 ) -> Result<SuiTransactionBlockEvents, Error> {
+    let epoch_store = fullnode_api.state.load_epoch_store_one_call_per_task();
+    let mut layout_resolver = epoch_store
+        .executor()
+        .type_layout_resolver(Box::new(fullnode_api.state.get_db()));
     Ok(SuiTransactionBlockEvents::try_from(
         events,
         tx_digest,
         None,
-        // threading the epoch_store through this API does not
-        // seem possible, so we just read it from the state and fetch
-        // the module cache out of it.
-        // Notice that no matter what module cache we get things
-        // should work
-        fullnode_api
-            .state
-            .load_epoch_store_one_call_per_task()
-            .module_cache()
-            .as_ref(),
+        layout_resolver.as_mut(),
     )?)
 }
 

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -157,16 +157,15 @@ impl TransactionExecutionApi {
         let (effects, transaction_events, is_executed_locally) = *cert;
         let mut events: Option<SuiTransactionBlockEvents> = None;
         if opts.show_events {
-            let module_cache = self
-                .state
-                .load_epoch_store_one_call_per_task()
-                .module_cache()
-                .clone();
+            let epoch_store = self.state.load_epoch_store_one_call_per_task();
+            let mut layout_resolver = epoch_store
+                .executor()
+                .type_layout_resolver(Box::new(self.state.get_db()));
             events = Some(SuiTransactionBlockEvents::try_from(
                 transaction_events,
                 digest,
                 None,
-                module_cache.as_ref(),
+                layout_resolver.as_mut(),
             )?);
         }
 

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -4,9 +4,9 @@
 use std::str::FromStr;
 
 use anyhow::ensure;
-use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value::MoveStruct;
+use move_core_types::annotated_value::MoveStructLayout;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use move_core_types::identifier::Identifier;
@@ -19,7 +19,6 @@ use serde_with::Bytes;
 
 use crate::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use crate::error::{SuiError, SuiResult};
-use crate::object::MoveObject;
 use crate::sui_serde::BigInt;
 use crate::sui_serde::Readable;
 use crate::SUI_SYSTEM_ADDRESS;
@@ -126,11 +125,9 @@ impl Event {
         }
     }
     pub fn move_event_to_move_struct(
-        type_: &StructTag,
         contents: &[u8],
-        resolver: &impl GetModule,
+        layout: MoveStructLayout,
     ) -> SuiResult<MoveStruct> {
-        let layout = MoveObject::get_layout_from_struct_tag(type_.clone(), resolver)?;
         MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
             SuiError::ObjectSerializationError {
                 error: e.to_string(),

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -3,9 +3,10 @@
 
 use crate::base_types::{SequenceNumber, VersionDigest};
 use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
+use crate::error::SuiResult;
 use crate::execution::DynamicallyLoadedObjectMetadata;
-use crate::storage::InputKey;
 use crate::storage::PackageObject;
+use crate::storage::{BackingPackageStore, InputKey};
 use crate::{
     base_types::ObjectID,
     object::{Object, Owner},
@@ -121,5 +122,34 @@ where
             }
         }
         self.fallback.get_module_by_id(id)
+    }
+}
+
+pub struct TemporaryPackageStore<'a, R> {
+    temp_store: &'a InnerTemporaryStore,
+    fallback: R,
+}
+
+impl<'a, R> TemporaryPackageStore<'a, R> {
+    pub fn new(temp_store: &'a InnerTemporaryStore, fallback: R) -> Self {
+        Self {
+            temp_store,
+            fallback,
+        }
+    }
+}
+
+impl<R> BackingPackageStore for TemporaryPackageStore<'_, R>
+where
+    R: BackingPackageStore,
+{
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
+        // We first check the objects in the temporary store it is possible to read packages that are
+        // just written in the same transaction.
+        if let Some(obj) = self.temp_store.written.get(package_id) {
+            Ok(Some(PackageObject::new(obj.clone())))
+        } else {
+            self.fallback.get_package_object(package_id)
+        }
     }
 }

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -376,7 +376,7 @@ impl MoveObject {
                 *balances.entry(type_tag).or_insert(0) += balance;
             }
         } else {
-            let layout = layout_resolver.get_annotated_layout(self)?;
+            let layout = layout_resolver.get_annotated_layout(&self.type_().clone().into())?;
             let move_struct = self.to_move_struct(&layout)?;
             Self::get_coin_balances_in_struct(&move_struct, &mut balances, 0)?;
         }

--- a/crates/sui-types/src/type_resolver.rs
+++ b/crates/sui-types/src/type_resolver.rs
@@ -1,17 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    error::{ExecutionError, SuiError},
-    object::MoveObject,
+use crate::error::{ExecutionError, SuiError};
+use move_core_types::{
+    annotated_value as A,
+    language_storage::{StructTag, TypeTag},
 };
-use move_core_types::{annotated_value as A, language_storage::TypeTag};
 use move_vm_types::loaded_data::runtime_types::Type;
 
 pub trait LayoutResolver {
     fn get_annotated_layout(
         &mut self,
-        object: &MoveObject,
+        struct_tag: &StructTag,
     ) -> Result<A::MoveStructLayout, SuiError>;
 }
 

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{BackingPackageStore, PackageObject};
-use sui_types::{error::SuiError, object::MoveObject, type_resolver::LayoutResolver};
+use sui_types::{error::SuiError, type_resolver::LayoutResolver};
 
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
@@ -36,11 +36,9 @@ impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
 impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
     fn get_annotated_layout(
         &mut self,
-        object: &MoveObject,
+        struct_tag: &StructTag,
     ) -> Result<A::MoveStructLayout, SuiError> {
-        let struct_tag: StructTag = object.type_().clone().into();
-        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], &struct_tag)
-        else {
+        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], struct_tag) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),
             });

--- a/sui-execution/next-vm/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/next-vm/sui-adapter/src/type_layout_resolver.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{BackingPackageStore, PackageObject};
-use sui_types::{error::SuiError, object::MoveObject, type_resolver::LayoutResolver};
+use sui_types::{error::SuiError, type_resolver::LayoutResolver};
 
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
@@ -36,11 +36,9 @@ impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
 impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
     fn get_annotated_layout(
         &mut self,
-        object: &MoveObject,
+        struct_tag: &StructTag,
     ) -> Result<A::MoveStructLayout, SuiError> {
-        let struct_tag: StructTag = object.type_().clone().into();
-        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], &struct_tag)
-        else {
+        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], struct_tag) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),
             });

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -15,7 +15,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{BackingPackageStore, PackageObject};
-use sui_types::{error::SuiError, object::MoveObject, type_resolver::LayoutResolver};
+use sui_types::{error::SuiError, type_resolver::LayoutResolver};
 
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
@@ -41,9 +41,8 @@ impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
 impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
     fn get_annotated_layout(
         &mut self,
-        object: &MoveObject,
+        struct_tag: &StructTag,
     ) -> Result<A::MoveStructLayout, SuiError> {
-        let struct_tag: StructTag = object.type_().clone().into();
         let type_tag: TypeTag = TypeTag::from(struct_tag.clone());
         let Ok(ty) = load_type(&mut self.session, &type_tag) else {
             return Err(SuiError::FailObjectLayout {

--- a/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{BackingPackageStore, PackageObject};
-use sui_types::{error::SuiError, object::MoveObject, type_resolver::LayoutResolver};
+use sui_types::{error::SuiError, type_resolver::LayoutResolver};
 
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
@@ -36,11 +36,9 @@ impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
 impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
     fn get_annotated_layout(
         &mut self,
-        object: &MoveObject,
+        struct_tag: &StructTag,
     ) -> Result<A::MoveStructLayout, SuiError> {
-        let struct_tag: StructTag = object.type_().clone().into();
-        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], &struct_tag)
-        else {
+        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], struct_tag) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),
             });


### PR DESCRIPTION
## Description 

This PR mostly involves changing usages of module cache to layout resolver, so that deserialization of structs can be package upgrade aware in fullnode txn post processing.

## Test Plan 

Tested against @amnn's repro script.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
