### PR TITLE
[Kiosk SDK] Fixes lock function parameter type

### DIFF
--- a/.changeset/young-toys-relax.md
+++ b/.changeset/young-toys-relax.md
@@ -1,0 +1,5 @@
+---
+'@mysten/kiosk': patch
+---
+
+Fixes `lock` function arguments. `itemId` is replaced by `item`, which accepts an ObjectArgument instead of a string. `itemId` is still supported but deprecated, and will be removed in future versions.

--- a/sdk/kiosk/src/client/kiosk-transaction.ts
+++ b/sdk/kiosk/src/client/kiosk-transaction.ts
@@ -285,12 +285,25 @@ export class KioskTransaction {
 	 * A function to take lock an item in the kiosk.
 
 	 * @param itemType The type `T` of the item
-	 * @param itemId The ID of the item
+	 * @param item The ID or Transaction Argument of the item
+	 * @param itemId The ID of the item - Deprecated: This function accepts transaction arguments too, not plain ID.
 	 * @param policy The Policy ID or Transaction Argument for item T
 	 */
-	lock({ itemType, itemId, policy }: ItemId & { policy: ObjectArgument }) {
+	lock({
+		itemType,
+		item,
+		itemId,
+		policy,
+	}: ItemReference & { policy: ObjectArgument; itemId?: string }) {
 		this.#validateKioskIsSet();
-		kioskTx.lock(this.transactionBlock, itemType, this.kiosk!, this.kioskCap!, policy, itemId);
+		kioskTx.lock(
+			this.transactionBlock,
+			itemType,
+			this.kiosk!,
+			this.kioskCap!,
+			policy,
+			itemId ?? item,
+		);
 		return this;
 	}
 

--- a/sdk/kiosk/src/client/kiosk-transaction.ts
+++ b/sdk/kiosk/src/client/kiosk-transaction.ts
@@ -286,7 +286,7 @@ export class KioskTransaction {
 
 	 * @param itemType The type `T` of the item
 	 * @param item The ID or Transaction Argument of the item
-	 * @param itemId The ID of the item - Deprecated: This function accepts transaction arguments too, not plain ID.
+	 * @param itemId The ID of the item - Deprecated: Use `item` instead.
 	 * @param policy The Policy ID or Transaction Argument for item T
 	 */
 	lock({

--- a/sdk/kiosk/test/e2e/helper.ts
+++ b/sdk/kiosk/test/e2e/helper.ts
@@ -83,7 +83,7 @@ export async function testLockItemFlow(
 	kioskTx
 		.lock({
 			itemType,
-			itemId,
+			item: itemId,
 			policy: policies[0].id,
 		})
 		.finalize();


### PR DESCRIPTION
## Description 

Fixes the `lock` function parameter to be `item` and its type to be `ObjectArgument`.

@hayes-mysten I kept the `itemId` for backwards compatibility, do you think I should make this a minor instead of a patch and break compatibility or keep it like this?

## Test Plan 

Updated the test & run the e2e tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
