### PR TITLE
[deepBookClient] GetLevel2BookStatus method returns both ask and bid, if side is left undefined

### DIFF
--- a/.changeset/twenty-squids-double.md
+++ b/.changeset/twenty-squids-double.md
@@ -2,4 +2,4 @@
 '@mysten/deepbook': minor
 ---
 
-GetLevel2BookStatus method of deepbook can retrieve both ask and bid side in a single call, if side is left undefined
+GetLevel2BookStatus method of deepbook can retrieve both ask and bid side in a single call, if input argument is equal to 'both'.

--- a/.changeset/twenty-squids-double.md
+++ b/.changeset/twenty-squids-double.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook': minor
+---
+
+GetLevel2BookStatus method of deepbook can retrieve both ask and bid side in a single call, if side is left undefined

--- a/sdk/deepbook/src/client.ts
+++ b/sdk/deepbook/src/client.ts
@@ -665,16 +665,16 @@ export class DeepBookClient {
 	 * @param poolId the pool id, eg: 0xcaee8e1c046b58e55196105f1436a2337dcaa0c340a7a8c8baf65e4afb8823a4
 	 * @param lowerPrice lower price you want to query in the level2 book, eg: 18000000000. The number must be an integer float scaled by `FLOAT_SCALING_FACTOR`.
 	 * @param higherPrice higher price you want to query in the level2 book, eg: 20000000000. The number must be an integer float scaled by `FLOAT_SCALING_FACTOR`.
-	 * @param side { 'bid' | 'ask' } bid or ask side. If left undefined, both sides will be returned.
+	 * @param side { 'bid' | 'ask' | 'both' } bid or ask or both sides.
 	 */
 	async getLevel2BookStatus(
 		poolId: string,
 		lowerPrice: bigint,
 		higherPrice: bigint,
-		side: 'bid' | 'ask' | undefined = undefined,
+		side: 'bid' | 'ask' | 'both',
 	): Promise<Level2BookStatusPoint[] | Level2BookStatusPoint[][]> {
 		const txb = new TransactionBlock();
-		if (side === undefined) {
+		if (side === 'both') {
 			txb.moveCall({
 				typeArguments: await this.getPoolTypeArgs(poolId),
 				target: `${PACKAGE_ID}::${MODULE_CLOB}::get_level2_book_status_bid_side`,
@@ -713,7 +713,7 @@ export class DeepBookClient {
 			sender: this.currentAddress,
 		});
 
-		if (side === undefined) {
+		if (side === 'both') {
 			const bidSide = results.results![0].returnValues!.map(([bytes, _]) =>
 				bcs.de('vector<u64>', Uint8Array.from(bytes)).map((s: string) => BigInt(s)),
 			);

--- a/sdk/deepbook/src/client.ts
+++ b/sdk/deepbook/src/client.ts
@@ -665,35 +665,71 @@ export class DeepBookClient {
 	 * @param poolId the pool id, eg: 0xcaee8e1c046b58e55196105f1436a2337dcaa0c340a7a8c8baf65e4afb8823a4
 	 * @param lowerPrice lower price you want to query in the level2 book, eg: 18000000000. The number must be an integer float scaled by `FLOAT_SCALING_FACTOR`.
 	 * @param higherPrice higher price you want to query in the level2 book, eg: 20000000000. The number must be an integer float scaled by `FLOAT_SCALING_FACTOR`.
-	 * @param side { 'bid' | 'ask' } bid or ask side
+	 * @param side { 'bid' | 'ask' } bid or ask side. If left undefined, both sides will be returned.
 	 */
 	async getLevel2BookStatus(
 		poolId: string,
 		lowerPrice: bigint,
 		higherPrice: bigint,
-		side: 'bid' | 'ask',
-	): Promise<Level2BookStatusPoint[]> {
+		side: 'bid' | 'ask' | undefined = undefined,
+	): Promise<Level2BookStatusPoint[] | Level2BookStatusPoint[][]> {
 		const txb = new TransactionBlock();
-		txb.moveCall({
-			typeArguments: await this.getPoolTypeArgs(poolId),
-			target: `${PACKAGE_ID}::${MODULE_CLOB}::get_level2_book_status_${side}_side`,
-			arguments: [
-				txb.object(poolId),
-				txb.pure.u64(lowerPrice),
-				txb.pure.u64(higherPrice),
-				txb.object(SUI_CLOCK_OBJECT_ID),
-			],
+		if (side === undefined) {
+			txb.moveCall({
+				typeArguments: await this.getPoolTypeArgs(poolId),
+				target: `${PACKAGE_ID}::${MODULE_CLOB}::get_level2_book_status_bid_side`,
+				arguments: [
+					txb.object(poolId),
+					txb.pure.u64(lowerPrice),
+					txb.pure.u64(higherPrice),
+					txb.object(SUI_CLOCK_OBJECT_ID),
+				],
+			});
+			txb.moveCall({
+				typeArguments: await this.getPoolTypeArgs(poolId),
+				target: `${PACKAGE_ID}::${MODULE_CLOB}::get_level2_book_status_ask_side`,
+				arguments: [
+					txb.object(poolId),
+					txb.pure.u64(lowerPrice),
+					txb.pure.u64(higherPrice),
+					txb.object(SUI_CLOCK_OBJECT_ID),
+				],
+			});
+		} else {
+			txb.moveCall({
+				typeArguments: await this.getPoolTypeArgs(poolId),
+				target: `${PACKAGE_ID}::${MODULE_CLOB}::get_level2_book_status_${side}_side`,
+				arguments: [
+					txb.object(poolId),
+					txb.pure.u64(lowerPrice),
+					txb.pure.u64(higherPrice),
+					txb.object(SUI_CLOCK_OBJECT_ID),
+				],
+			});
+		}
+
+		const results = await this.suiClient.devInspectTransactionBlock({
+			transactionBlock: txb,
+			sender: this.currentAddress,
 		});
 
-		const results = (
-			await this.suiClient.devInspectTransactionBlock({
-				transactionBlock: txb,
-				sender: this.currentAddress,
-			})
-		).results![0].returnValues!.map(([bytes, _]) =>
-			bcs.de('vector<u64>', Uint8Array.from(bytes)).map((s: string) => BigInt(s)),
-		);
-		return results[0].map((price: bigint, i: number) => ({ price, depth: results[1][i] }));
+		if (side === undefined) {
+			const bidSide = results.results![0].returnValues!.map(([bytes, _]) =>
+				bcs.de('vector<u64>', Uint8Array.from(bytes)).map((s: string) => BigInt(s)),
+			);
+			const askSide = results.results![1].returnValues!.map(([bytes, _]) =>
+				bcs.de('vector<u64>', Uint8Array.from(bytes)).map((s: string) => BigInt(s)),
+			);
+			return [
+				bidSide[0].map((price: bigint, i: number) => ({ price, depth: bidSide[1][i] })),
+				askSide[0].map((price: bigint, i: number) => ({ price, depth: askSide[1][i] })),
+			];
+		} else {
+			const result = results.results![0].returnValues!.map(([bytes, _]) =>
+				bcs.de('vector<u64>', Uint8Array.from(bytes)).map((s: string) => BigInt(s)),
+			);
+			return result[0].map((price: bigint, i: number) => ({ price, depth: result[1][i] }));
+		}
 	}
 
 	#checkAccountCap(accountCap: string | undefined = undefined): string {

--- a/sdk/deepbook/test/e2e/client.test.ts
+++ b/sdk/deepbook/test/e2e/client.test.ts
@@ -238,6 +238,7 @@ describe('Interacting with the pool', () => {
 			pool.poolId,
 			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
 			3n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+			'both'
 		)) as Level2BookStatusPoint[][];
 		expect(status.length).toBe(2);
 		expect(status[0].length).toBe(1);

--- a/sdk/deepbook/test/e2e/client.test.ts
+++ b/sdk/deepbook/test/e2e/client.test.ts
@@ -238,7 +238,7 @@ describe('Interacting with the pool', () => {
 			pool.poolId,
 			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
 			3n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
-			'both'
+			'both',
 		)) as Level2BookStatusPoint[][];
 		expect(status.length).toBe(2);
 		expect(status[0].length).toBe(1);

--- a/sdk/deepbook/test/e2e/client.test.ts
+++ b/sdk/deepbook/test/e2e/client.test.ts
@@ -4,7 +4,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { DeepBookClient } from '../../src';
-import { PoolSummary } from '../../src/types';
+import { Level2BookStatusPoint, PoolSummary } from '../../src/types';
 import {
 	DEFAULT_LOT_SIZE,
 	DEFAULT_TICK_SIZE,
@@ -60,7 +60,7 @@ describe('Interacting with the pool', () => {
 		const baseCoin = resp.data[0].coinObjectId;
 
 		const deepbook = new DeepBookClient(toolbox.client, accountCapId2);
-		const txb = await deepbook.deposit(pool.poolId, baseCoin, DEPOSIT_AMOUNT);
+		const txb = await deepbook.deposit(pool.poolId, baseCoin, 5n * DEPOSIT_AMOUNT);
 		await executeTransactionBlock(toolbox, txb);
 	});
 
@@ -113,14 +113,14 @@ describe('Interacting with the pool', () => {
 		expect(price.bestBidPrice).toBe(LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE);
 	});
 
-	it('test getting Level 2 Book status', async () => {
+	it('test getting Level 2 Book status, bid side', async () => {
 		const deepbook = new DeepBookClient(toolbox.client, accountCapId, toolbox.address());
-		const status = await deepbook.getLevel2BookStatus(
+		const status = (await deepbook.getLevel2BookStatus(
 			pool.poolId,
 			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
 			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
 			'bid',
-		);
+		)) as Level2BookStatusPoint[];
 		expect(status.length).toBe(1);
 		expect(status[0].price).toBe(LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE);
 		expect(status[0].depth).toBe(LIMIT_ORDER_QUANTITY);
@@ -208,5 +208,42 @@ describe('Interacting with the pool', () => {
 		const baseCoin = resp.data[0].coinObjectId;
 		const type = await deepbook.getCoinType(baseCoin);
 		expect(type).toBe(resp.data[0].coinType);
+	});
+
+	it('Test getting level 2 book status, both sides', async () => {
+		const deepbook1 = new DeepBookClient(toolbox.client, accountCapId);
+		const deepbook2 = new DeepBookClient(toolbox.client, accountCapId2);
+		const txb1 = await deepbook1.placeLimitOrder(
+			pool.poolId,
+			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+			LIMIT_ORDER_QUANTITY,
+			'bid',
+		);
+		await executeTransactionBlock(toolbox, txb1);
+		const txb2 = await deepbook2.placeLimitOrder(
+			pool.poolId,
+			2n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+			LIMIT_ORDER_QUANTITY,
+			'ask',
+		);
+		await executeTransactionBlock(toolbox, txb2);
+		const txb3 = await deepbook2.placeLimitOrder(
+			pool.poolId,
+			3n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+			LIMIT_ORDER_QUANTITY,
+			'ask',
+		);
+		await executeTransactionBlock(toolbox, txb3);
+		const status = (await deepbook2.getLevel2BookStatus(
+			pool.poolId,
+			LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+			3n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE,
+		)) as Level2BookStatusPoint[][];
+		expect(status.length).toBe(2);
+		expect(status[0].length).toBe(1);
+		expect(status[1].length).toBe(2);
+		expect(status[0][0].price).toBe(LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE);
+		expect(status[1][0].price).toBe(2n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE);
+		expect(status[1][1].price).toBe(3n * LIMIT_ORDER_PRICE * DEFAULT_TICK_SIZE);
 	});
 });


### PR DESCRIPTION
## Description 

This PR modifies the getLevel2BookStatus method of deepbook sdk so that both ask and bid side can be retrieved in a single PTB.   

## Test Plan 

Added a test function.
![Screenshot_1](https://github.com/MystenLabs/sui/assets/105368040/8eb641eb-1011-4dab-9cb1-f7573b08ab6f)

