### PR TITLE
[cli][alias][easy] Add sort by alias in client addresses and keytool list

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -120,8 +120,11 @@ pub enum SuiClientCommands {
     ActiveEnv,
     /// Obtain the Addresses managed by the client.
     #[clap(name = "addresses")]
-    Addresses,
-
+    Addresses {
+        /// Sort by alias instead of address
+        #[clap(long, short = 's')]
+        sort_by_alias: bool,
+    },
     /// Call Move function
     #[clap(name = "call")]
     Call {
@@ -695,15 +698,18 @@ impl SuiClientCommands {
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
                 SuiClientCommandResult::ReplayCheckpoints
             }
-            SuiClientCommands::Addresses => {
+            SuiClientCommands::Addresses { sort_by_alias } => {
                 let active_address = context.active_address()?;
-                let addresses = context
+                let mut addresses: Vec<(String, SuiAddress)> = context
                     .config
                     .keystore
                     .addresses_with_alias()
                     .into_iter()
                     .map(|(address, alias)| (alias.alias.to_string(), *address))
                     .collect();
+                if sort_by_alias {
+                    addresses.sort();
+                }
 
                 let output = AddressesOutput {
                     active_address,

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -50,7 +50,12 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
     }
 
     // List all addresses with flag
-    KeyToolCommand::List.execute(&mut keystore).await.unwrap();
+    KeyToolCommand::List {
+        sort_by_alias: true,
+    }
+    .execute(&mut keystore)
+    .await
+    .unwrap();
     Ok(())
 }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -136,11 +136,13 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
     }
 
     // Print all addresses
-    SuiClientCommands::Addresses
-        .execute(&mut context)
-        .await
-        .unwrap()
-        .print(true);
+    SuiClientCommands::Addresses {
+        sort_by_alias: true,
+    }
+    .execute(&mut context)
+    .await
+    .unwrap()
+    .print(true);
 
     Ok(())
 }


### PR DESCRIPTION
## Description 

Add sort by alias in client addresses and keytool list

## Test Plan 

Existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added a `--sort-by-alias | -s` flag for the `sui client addresses` and `sui keytool list` to allow to sort by alias the list of addresses or keys. By default, the output is sorted by address.