### PR TITLE
More updates to bridge move code 

### DIFF
--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -213,8 +213,11 @@ module bridge::bridge {
         let target_chain = message::token_target_chain(&token_payload);
         // ensure target chain is matches self.chain_id
         assert!(target_chain == inner.chain_id, EUnexpectedChainID);
+
         // Ensure route is valid
+        // TODO: add unit tests
         assert!(chain_ids::is_valid_route(source_chain, target_chain), EInvalidBridgeRoute);
+
         // get owner address
         let owner = address::from_bytes(message::token_target_address(&token_payload));
         // check token type

--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -68,7 +68,26 @@ module bridge::bridge {
     const EUnexpectedOperation: u64 = 11;
     const EInvalidBridgeRoute: u64 = 12;
 
+    const EInvariantSuiInitializedTokenTransferShouldNotBeClaimed: u64 = 13;
+    const EMessageNotFoundInRecords: u64 = 14;
+
     const CURRENT_VERSION: u64 = 1;
+
+    struct TokenTransferApproved has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferClaimed has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferAlreadyApproved has copy, drop {
+        message_key: BridgeMessageKey,
+    }
+
+    struct TokenTransferAlreadyClaimed has copy, drop {
+        message_key: BridgeMessageKey,
+    }
 
     // this method is called once in end of epoch tx to create the bridge
     #[allow(unused_function)]
@@ -155,6 +174,7 @@ module bridge::bridge {
     }
 
     // Record bridge message approvals in Sui, called by the bridge client
+    // If already approved, return early instead of aborting.
     public fun approve_bridge_message(
         self: &mut Bridge,
         message: BridgeMessage,
@@ -163,39 +183,59 @@ module bridge::bridge {
         let inner = load_inner_mut(self);
         let key = message::key(&message);
 
+        // TODO: use borrow mut
+
         // retrieve pending message if source chain is Sui, the initial message must exist on chain.
-        if (message::message_type(&message) == message_types::token()) {
-            if (message::source_chain(&message) == inner.chain_id) {
-                let record = linked_table::remove(&mut inner.bridge_records, key);
-                assert!(record.message == message, EMalformedMessageError);
-                // The message should be in pending state (no approval and not claimed)
-                assert!(option::is_none(&record.verified_signatures), ERecordAlreadyExists);
-                assert!(!record.claimed, EAlreadyClaimed)
+        if (message::message_type(&message) == message_types::token() && message::source_chain(&message) == inner.chain_id) {
+            let record = linked_table::remove(&mut inner.bridge_records, key);
+            assert!(record.message == message, EMalformedMessageError);
+            assert!(!record.claimed, EInvariantSuiInitializedTokenTransferShouldNotBeClaimed);
+
+            // If record already has verified signatures, it means the message has been approved.
+            // Then we push this message back to bridge_records and exit early.
+            if (option::is_some(&record.verified_signatures)) {
+                emit(TokenTransferAlreadyApproved { message_key: key });
+                linked_table::push_back(&mut inner.bridge_records, key, record);
+                return
             }
         };
 
-        // ensure bridge massage not exist
-        assert!(!linked_table::contains(&inner.bridge_records, key), ERecordAlreadyExists);
+        // At this point, if this message is in bridge_records, we know it's already approved
+        // because we only add a message to bridge_records after verifying the signatures.
+        if (linked_table::contains(&inner.bridge_records, key)) {
+            emit(TokenTransferAlreadyApproved { message_key: key });
+            return
+        };
 
+        // At this point, we know the message has not been approved, hence has not been claimed.
         // verify signatures
         committee::verify_signatures(&inner.committee, message, signatures);
+
+        // Critical: here we set `claimed` as false. It's vitally important to make sure
+        // the token transfer has not been claimed already.
         // Store approval
         linked_table::push_back(&mut inner.bridge_records, key, BridgeRecord {
             message,
             verified_signatures: some(signatures),
             claimed: false
-        })
+        });
+        emit(TokenTransferApproved { message_key: key });
     }
 
     // Claim token from approved bridge message
+    // Returns Some(Coin) if coin can be claimed. If already claimed, return None
     fun claim_token_internal<T>(
         self: &mut Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
         ctx: &mut TxContext
-    ): (Coin<T>, address) {
+    ): (Option<Coin<T>>, address) {
         let inner = load_inner_mut(self);
         let key = message::create_key(source_chain, message_types::token(), bridge_seq_num);
+        if (!linked_table::contains(&inner.bridge_records, key)) {
+            abort EMessageNotFoundInRecords
+        };
+        // TODO: use borrow mut
         // retrieve approved bridge message
         let BridgeRecord {
             message,
@@ -206,13 +246,28 @@ module bridge::bridge {
         assert!(message::message_type(&message) == message_types::token(), EUnexpectedMessageType);
         // Ensure it's signed
         assert!(option::is_some(&signatures), EUnauthorisedClaim);
-        // Ensure it is not claimed already
-        assert!(!claimed, EAlreadyClaimed);
+
         // extract token message
         let token_payload = message::extract_token_bridge_payload(&message);
+        // get owner address
+        let owner = address::from_bytes(message::token_target_address(&token_payload));
+
+        // If already claimed, exit early
+        if (claimed) {
+            emit(TokenTransferAlreadyClaimed { message_key: key });
+            linked_table::push_back(&mut inner.bridge_records, key, BridgeRecord {
+                message,
+                verified_signatures: signatures,
+                claimed: true // <-- this is important
+            });
+            return (option::none(), owner)
+        };
+
         let target_chain = message::token_target_chain(&token_payload);
-        // ensure target chain is matches self.chain_id
+        // ensure target chain matches self.chain_id
         assert!(target_chain == inner.chain_id, EUnexpectedChainID);
+
+        // TODO: why do we check validity of the route here? what if inconsistency?
 
         // Ensure route is valid
         // TODO: add unit tests
@@ -230,11 +285,13 @@ module bridge::bridge {
             verified_signatures: signatures,
             claimed: true
         });
-        (token, owner)
+        emit(TokenTransferClaimed { message_key: key });
+        (option::some(token), owner)
     }
 
     // This function can only be called by the token recipient
-    public fun claim_token<T>(self: &mut Bridge, source_chain: u8, bridge_seq_num: u64, ctx: &mut TxContext): Coin<T> {
+    // Returns None if the token has already been claimed.
+    public fun claim_token<T>(self: &mut Bridge, source_chain: u8, bridge_seq_num: u64, ctx: &mut TxContext): Option<Coin<T>> {
         let (token, owner) = claim_token_internal<T>(self, source_chain, bridge_seq_num, ctx);
         // Only token owner can claim the token
         assert!(tx_context::sender(ctx) == owner, EUnauthorisedClaim);
@@ -242,6 +299,7 @@ module bridge::bridge {
     }
 
     // This function can be called by anyone to claim and transfer the token to the recipient
+    // If the token has already been claimed, it will return instead of aborting.
     public fun claim_and_transfer_token<T>(
         self: &mut Bridge,
         source_chain: u8,
@@ -249,7 +307,11 @@ module bridge::bridge {
         ctx: &mut TxContext
     ) {
         let (token, owner) = claim_token_internal<T>(self, source_chain, bridge_seq_num, ctx);
-        transfer::public_transfer(token, owner)
+        if (option::is_none(&token)) {
+            option::destroy_none(token);
+            return
+        };
+        transfer::public_transfer(option::destroy_some(token), owner)
     }
 
     public fun execute_emergency_op(

--- a/crates/sui-framework/packages/bridge/sources/committee.move
+++ b/crates/sui-framework/packages/bridge/sources/committee.move
@@ -38,6 +38,9 @@ module bridge::committee {
         bridge_pubkey_bytes: vector<u8>,
         /// Voting power
         voting_power: u64,
+        /// The HTTP REST URL the member's node listens to
+        /// it looks like b'https://127.0.0.1:9191'
+        http_rest_url: vector<u8>,
         /// If this member is blocklisted
         blocklisted: bool,
     }
@@ -53,6 +56,7 @@ module bridge::committee {
             sui_address: address::from_u256(1),
             bridge_pubkey_bytes,
             voting_power: 10,
+            http_rest_url: b"https://127.0.0.1:9191",
             blocklisted: false
         });
 
@@ -61,6 +65,7 @@ module bridge::committee {
             sui_address: address::from_u256(2),
             bridge_pubkey_bytes,
             voting_power: 10,
+            http_rest_url: b"https://127.0.0.1:9192",
             blocklisted: false
         });
 
@@ -186,6 +191,7 @@ module bridge::committee {
             sui_address: address::from_u256(1),
             bridge_pubkey_bytes,
             voting_power: 100,
+            http_rest_url: b"https://127.0.0.1:9191",
             blocklisted: false
         });
 
@@ -194,6 +200,7 @@ module bridge::committee {
             sui_address: address::from_u256(2),
             bridge_pubkey_bytes,
             voting_power: 100,
+            http_rest_url: b"https://127.0.0.1:9192",
             blocklisted: false
         });
 

--- a/crates/sui-framework/packages/bridge/sources/message.move
+++ b/crates/sui-framework/packages/bridge/sources/message.move
@@ -170,13 +170,7 @@ module bridge::message {
     }
 
     public fun key(self: &BridgeMessage): BridgeMessageKey {
-        let source_chain = if (self.message_type == message_types::token()) {
-            let bcs = bcs::new(self.payload);
-            bcs::peel_u8(&mut bcs)
-        } else {
-            0
-        };
-        create_key(source_chain, self.message_type, self.seq_num)
+        create_key(self.source_chain, self.message_type, self.seq_num)
     }
 
     // BridgeMessage getters


### PR DESCRIPTION
## Description 

This PR changes the a few things:
1. when message is already processed/claimed, return Ok instead of panic. This is to make bridge client's life easier such that whenever they see a successful execution status, they consider the action is done
2. emit events for approval/claiming
3. fix message::key function

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
