### PR TITLE
Laura/add logging to replay

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -64,7 +64,6 @@ fn main() {
 
     // Initialize logging
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
-        .with_target_prefix("sui_json_rpc")
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -17,6 +17,7 @@ mod checked {
     };
     use move_core_types::vm_status::StatusCode;
     use sui_protocol_config::*;
+    use tracing::trace;
 
     /// A bucket defines a range of units that will be priced the same.
     /// After execution a call to `GasStatus::bucketize` will round the computation
@@ -270,6 +271,13 @@ mod checked {
                 None,
                 SuiCostTable::unmetered(),
             )
+        }
+
+        pub fn log_for_replay(&self) {
+            #[skip_checked_arithmetic]
+            trace!(target:"replay", "Reference Gas Price: {}", self.reference_gas_price);
+
+            self.gas_status.log_for_replay();
         }
 
         // Check whether gas arguments are legit:

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -15,6 +15,7 @@ use move_vm_types::gas::{GasMeter, SimpleInstruction};
 use move_vm_types::loaded_data::runtime_types::Type;
 use move_vm_types::views::{TypeView, ValueView};
 use once_cell::sync::Lazy;
+use tracing::trace;
 
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
 
@@ -336,6 +337,12 @@ impl GasStatus {
         } else {
             val.abstract_memory_size()
         }
+    }
+
+    pub fn log_for_replay(&self) {
+        trace!(target: "replay", "Gas Price: {}", self.gas_price);
+        trace!(target: "replay", "Max Gas Stack Height: {}", self.stack_height_high_water_mark);
+        trace!(target: "replay", "Number of Bytecode Instructions Executed: {}", self.instructions_executed);
     }
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -66,7 +66,7 @@ use tabled::{
         Modify as TableModify, Panel as TablePanel, Style as TableStyle,
     },
 };
-use tracing::{info, trace};
+use tracing::info;
 
 use crate::key_identity::{get_identity_address, KeyIdentity};
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -66,7 +66,7 @@ use tabled::{
         Modify as TableModify, Panel as TablePanel, Style as TableStyle,
     },
 };
-use tracing::info;
+use tracing::{info, trace};
 
 use crate::key_identity::{get_identity_address, KeyIdentity};
 
@@ -615,6 +615,10 @@ pub enum SuiClientCommands {
         /// The digest of the transaction to replay
         #[arg(long, short)]
         tx_digest: String,
+
+        /// Log extra gas-related information
+        #[arg(long, short)]
+        gas_info: bool,
     },
 
     /// Replay transactions listed in a file.
@@ -652,7 +656,10 @@ impl SuiClientCommands {
         context: &mut WalletContext,
     ) -> Result<SuiClientCommandResult, anyhow::Error> {
         let ret = Ok(match self {
-            SuiClientCommands::ReplayTransaction { tx_digest } => {
+            SuiClientCommands::ReplayTransaction {
+                tx_digest,
+                gas_info: _,
+            } => {
                 let cmd = ReplayToolCommand::ReplayTransaction {
                     tx_digest,
                     show_effects: true,
@@ -660,6 +667,7 @@ impl SuiClientCommands {
                     executor_version_override: None,
                     protocol_version_override: None,
                 };
+
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -132,6 +132,7 @@ pub mod checked {
             if gas_coin_count == 1 {
                 return;
             }
+
             // sum the value of all gas coins
             let new_balance = self
                 .gas_coins
@@ -279,6 +280,16 @@ pub mod checked {
             // compute and collect storage charges
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
+
+            match &self.gas_status {
+                SuiGasStatus::V2(s) => {
+                    s.log_for_replay();
+                }
+            };
+            if self.smashed_gas_coin.is_some() {
+                #[skip_checked_arithmetic]
+                trace!(target: "replay", "Gas smashing has occurred for this transaction");
+            }
 
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
             // for storage, however they track storage values to check for conservation rules

--- a/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
@@ -280,6 +280,16 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
+            match &self.gas_status {
+                SuiGasStatus::V2(s) => {
+                    s.log_for_replay();
+                }
+            };
+            if self.smashed_gas_coin.is_some() {
+                #[skip_checked_arithmetic]
+                trace!(target: "replay", "Gas smashing has occurred for this transaction");
+            }
+
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
             // for storage, however they track storage values to check for conservation rules
             if let Some(gas_object_id) = self.smashed_gas_coin {

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -271,6 +271,16 @@ pub mod checked {
             temporary_store.ensure_gas_and_input_mutated(self);
             temporary_store.collect_storage_and_rebate(self);
 
+            match &self.gas_status {
+                SuiGasStatus::V2(s) => {
+                    s.log_for_replay();
+                }
+            };
+            if self.smashed_gas_coin.is_some() {
+                #[skip_checked_arithmetic]
+                trace!(target: "replay", "Gas smashing has occurred for this transaction");
+            }
+
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
             // for storage, however they track storage values to check for conservation rules
             if let Some(gas_object_id) = self.smashed_gas_coin {

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -280,6 +280,16 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
+            match &self.gas_status {
+                SuiGasStatus::V2(s) => {
+                    s.log_for_replay();
+                }
+            };
+            if self.smashed_gas_coin.is_some() {
+                #[skip_checked_arithmetic]
+                trace!(target: "replay", "Gas smashing has occurred for this transaction");
+            }
+
             // system transactions (None smashed_gas_coin)  do not have gas and so do not charge
             // for storage, however they track storage values to check for conservation rules
             if let Some(gas_object_id) = self.smashed_gas_coin {


### PR DESCRIPTION
## Description 

This adds a flag to the CLI replay command that when set will emit trace logs with the target "replay" to be output to the console. We output logs on reference gas price, gas price, Max Gas Stack Heigh, Number of Bytecode Instructions Executed, and occurrence of gas smashing. The gas cost summary (storage, computation cost, rebate, non-refundable storage fee) is included in the effects so it is not logged. 

I have also removed an unused field from the telemetry subscriber. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
