### PR TITLE
[graphql] Add more context about a parent's object

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1482,8 +1482,7 @@ type Object implements IOwner {
 	"""
 	previousTransactionBlock: TransactionBlock
 	"""
-	The owner type of this Object.
-	The owner can be one of the following types: Immutable, Shared, Parent, Address
+	The owner type of this object: Immutable, Shared, Parent, Address
 	Immutable and Shared Objects do not have owners.
 	"""
 	owner: ObjectOwner
@@ -1805,7 +1804,8 @@ type PageInfo {
 }
 
 """
-The parent of this object
+The parent of this object.
+If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
 """
 type Parent {
 	parent: Object
@@ -2147,10 +2147,9 @@ type ServiceConfig {
 
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
-and is accessible to everyone.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
-unless it is made immutable. An example of immutable shared objects are all published packages
-and modules on Sui.
+and is accessible to everyone. There are two types of shared objects: mutable and immutable.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+An example of immutable shared objects are all published packages and modules on Sui.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1804,8 +1804,9 @@ type PageInfo {
 }
 
 """
-The parent of this object.
-If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
+If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
+the dynamic field, or the intermediate Field object itself). Also note that if the owner
+is a parent, then it's guaranteed to be an object.
 """
 type Parent {
 	parent: Object
@@ -2146,10 +2147,8 @@ type ServiceConfig {
 }
 
 """
-A shared object is an object that is shared using the 0x2::transfer::share_object function
-and is accessible to everyone. There are two types of shared objects: mutable and immutable.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-An example of immutable shared objects are all published packages and modules on Sui.
+A shared object is an object that is shared using the 0x2::transfer::share_object function.
+Unlike owned objects, once an object is shared, it stays mutable and is accesssible by anyone.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -86,16 +86,16 @@ pub struct Immutable {
 }
 
 /// A shared object is an object that is shared using the 0x2::transfer::share_object function
-/// and is accessible to everyone.
-/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
-/// unless it is made immutable. An example of immutable shared objects are all published packages
-/// and modules on Sui.
+/// and is accessible to everyone. There are two types of shared objects: mutable and immutable.
+/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+/// An example of immutable shared objects are all published packages and modules on Sui.
 #[derive(SimpleObject, Clone)]
 pub struct Shared {
     initial_shared_version: u64,
 }
 
-/// The parent of this object
+/// The parent of this object.
+/// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
 #[derive(SimpleObject, Clone)]
 pub struct Parent {
     parent: Option<Object>,
@@ -199,8 +199,7 @@ impl Object {
             .extend()
     }
 
-    /// The owner type of this Object.
-    /// The owner can be one of the following types: Immutable, Shared, Parent, Address
+    /// The owner type of this object: Immutable, Shared, Parent, Address
     /// Immutable and Shared Objects do not have owners.
     async fn owner(&self, ctx: &Context<'_>) -> Option<ObjectOwner> {
         use NativeOwner as O;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -85,17 +85,16 @@ pub struct Immutable {
     dummy: Option<bool>,
 }
 
-/// A shared object is an object that is shared using the 0x2::transfer::share_object function
-/// and is accessible to everyone. There are two types of shared objects: mutable and immutable.
-/// Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-/// An example of immutable shared objects are all published packages and modules on Sui.
+/// A shared object is an object that is shared using the 0x2::transfer::share_object function.
+/// Unlike owned objects, once an object is shared, it stays mutable and is accesssible by anyone.
 #[derive(SimpleObject, Clone)]
 pub struct Shared {
     initial_shared_version: u64,
 }
 
-/// The parent of this object.
-/// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
+/// If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
+/// the dynamic field, or the intermediate Field object itself). Also note that if the owner
+/// is a parent, then it's guaranteed to be an object.
 #[derive(SimpleObject, Clone)]
 pub struct Parent {
     parent: Option<Object>,

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1808,8 +1808,9 @@ type PageInfo {
 }
 
 """
-The parent of this object.
-If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
+If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
+the dynamic field, or the intermediate Field object itself). Also note that if the owner
+is a parent, then it's guaranteed to be an object.
 """
 type Parent {
 	parent: Object
@@ -2150,10 +2151,8 @@ type ServiceConfig {
 }
 
 """
-A shared object is an object that is shared using the 0x2::transfer::share_object function
-and is accessible to everyone. There are two types of shared objects: mutable and immutable.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
-An example of immutable shared objects are all published packages and modules on Sui.
+A shared object is an object that is shared using the 0x2::transfer::share_object function.
+Unlike owned objects, once an object is shared, it stays mutable and is accesssible by anyone.
 """
 type Shared {
 	initialSharedVersion: Int!

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1486,8 +1486,7 @@ type Object implements IOwner {
 	"""
 	previousTransactionBlock: TransactionBlock
 	"""
-	The owner type of this Object.
-	The owner can be one of the following types: Immutable, Shared, Parent, Address
+	The owner type of this object: Immutable, Shared, Parent, Address
 	Immutable and Shared Objects do not have owners.
 	"""
 	owner: ObjectOwner
@@ -1809,7 +1808,8 @@ type PageInfo {
 }
 
 """
-The parent of this object
+The parent of this object.
+If the object's owner is a Parent, this object is part of a dynamic field (it is the value of the dynamic field, or the intermediate Field object itself).
 """
 type Parent {
 	parent: Object
@@ -2151,10 +2151,9 @@ type ServiceConfig {
 
 """
 A shared object is an object that is shared using the 0x2::transfer::share_object function
-and is accessible to everyone.
-Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone,
-unless it is made immutable. An example of immutable shared objects are all published packages
-and modules on Sui.
+and is accessible to everyone. There are two types of shared objects: mutable and immutable.
+Unlike owned objects, once an object is shared, it stays mutable and can be accessed by anyone.
+An example of immutable shared objects are all published packages and modules on Sui.
 """
 type Shared {
 	initialSharedVersion: Int!


### PR DESCRIPTION
## Description 

Follow up on PR #15569 to fix the wrong description on shared mutable objects - they can never become immutable (this can be done only when they're created).

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
