### PR TITLE
[Bridge 24/n] only use events that are emitted/declared from specific contracts/packages

### DIFF
--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -15,6 +15,10 @@ pub enum BridgeError {
     TxNotFinalized,
     // No recognized bridge event in specified transaction and event position
     NoBridgeEventsInTxPosition,
+    // Found a bridge event but not in a recognized Eth bridge contract
+    BridgeEventInUnrecognizedEthContract,
+    // Found a bridge event but not in a recognized Sui bridge package
+    BridgeEventInUnrecognizedSuiPackage,
     // Found BridgeEvent but not BridgeAction
     BridgeEventNotActionable,
     // Failure to serialize

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -117,7 +117,8 @@ where
         Ok(number.as_u64())
     }
 
-    // TODO: this needs some pagination if the range is too big
+    // Note: query may fail if range is too big. Callsite is responsible
+    // for chunking the query.
     pub async fn get_events_in_range(
         &self,
         address: ethers::types::Address,

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -1,35 +1,34 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO remove when integrated
-#![allow(unused)]
-
-use std::sync::Arc;
+use std::collections::HashSet;
 
 use crate::abi::EthBridgeEvent;
 use crate::error::{BridgeError, BridgeResult};
 use crate::types::{BridgeAction, EthLog};
-use ethers::providers::{Http, JsonRpcClient, Middleware, Provider, ProviderError};
+use ethers::providers::{Http, JsonRpcClient, Middleware, Provider};
 use ethers::types::TxHash;
-use ethers::types::{Block, BlockId, Filter, H256};
-use std::str::FromStr;
-use tap::{Tap, TapFallible};
+use ethers::types::{Block, Filter};
+use tap::TapFallible;
 
 #[cfg(test)]
 use crate::eth_mock_provider::EthMockProvider;
-use ethers::{
-    providers::MockProvider,
-    types::{U256, U64},
-};
-
+use ethers::types::Address as EthAddress;
 pub struct EthClient<P> {
     provider: Provider<P>,
+    contract_addresses: HashSet<EthAddress>,
 }
 
 impl EthClient<Http> {
-    pub async fn new(provider_url: &str) -> anyhow::Result<Self> {
+    pub async fn new(
+        provider_url: &str,
+        contract_addresses: HashSet<EthAddress>,
+    ) -> anyhow::Result<Self> {
         let provider = Provider::try_from(provider_url)?;
-        let self_ = Self { provider };
+        let self_ = Self {
+            provider,
+            contract_addresses,
+        };
         self_.describe().await?;
         Ok(self_)
     }
@@ -37,9 +36,12 @@ impl EthClient<Http> {
 
 #[cfg(test)]
 impl EthClient<EthMockProvider> {
-    pub fn new_mocked(provider: EthMockProvider) -> Self {
+    pub fn new_mocked(provider: EthMockProvider, contract_addresses: HashSet<EthAddress>) -> Self {
         let provider = Provider::new(provider);
-        Self { provider }
+        Self {
+            provider,
+            contract_addresses,
+        }
     }
 }
 
@@ -57,7 +59,9 @@ where
         Ok(())
     }
 
-    // TODO: need to fix this to assert address that emits the events
+    /// Returns BridgeAction from an Eth Transaction with transaction hash
+    /// and the event index. If event is declared in an unrecognized
+    /// contract, return error.
     pub async fn get_finalized_bridge_action_maybe(
         &self,
         tx_hash: TxHash,
@@ -80,6 +84,12 @@ where
             .logs
             .get(event_idx as usize)
             .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
+
+        // Ignore events emitted from unrecognized contracts
+        if !self.contract_addresses.contains(&log.address) {
+            return Err(BridgeError::BridgeEventInUnrecognizedEthContract);
+        }
+
         let eth_log = EthLog {
             block_number: receipt_block_num.as_u64(),
             tx_hash,
@@ -133,6 +143,9 @@ where
         if logs.is_empty() {
             return Ok(vec![]);
         }
+        // Safeguard check that all events are emitted from requested contract address
+        assert!(logs.iter().all(|log| log.address == address));
+
         let tasks = logs.into_iter().map(|log| self.get_log_tx_details(log));
         let results = futures::future::join_all(tasks)
             .await
@@ -214,17 +227,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::{Address as EthAddress, Log, TransactionReceipt};
+    use ethers::types::{Address as EthAddress, Log, TransactionReceipt, U64};
     use prometheus::Registry;
 
     use super::*;
-    use crate::test_utils::mock_get_logs;
-    use crate::test_utils::{
-        get_test_authority_and_key, get_test_log_and_action, get_test_sui_to_eth_bridge_action,
-        mock_last_finalized_block,
-    };
-    use crate::types::BridgeAction;
-    use crate::types::SignedBridgeAction;
+    use crate::test_utils::{get_test_log_and_action, mock_last_finalized_block};
 
     #[tokio::test]
     async fn test_get_finalized_bridge_action_maybe() {
@@ -233,7 +240,11 @@ mod tests {
         mysten_metrics::init_metrics(&registry);
         let mock_provider = EthMockProvider::new();
         mock_last_finalized_block(&mock_provider, 777);
-        let client = EthClient::new_mocked(mock_provider.clone());
+
+        let client = EthClient::new_mocked(
+            mock_provider.clone(),
+            HashSet::from_iter(vec![EthAddress::zero()]),
+        );
         let result = client.get_last_finalized_block_id().await.unwrap();
         assert_eq!(result, 777);
 
@@ -291,6 +302,71 @@ mod tests {
 
         let action = client
             .get_finalized_bridge_action_maybe(eth_tx_hash, 1)
+            .await
+            .unwrap();
+        assert_eq!(action, bridge_action);
+    }
+
+    #[tokio::test]
+    async fn test_get_finalized_bridge_action_maybe_unrecognized_contract() {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let mock_provider = EthMockProvider::new();
+        mock_last_finalized_block(&mock_provider, 777);
+
+        let client = EthClient::new_mocked(
+            mock_provider.clone(),
+            HashSet::from_iter(vec![
+                EthAddress::repeat_byte(5),
+                EthAddress::repeat_byte(6),
+                EthAddress::repeat_byte(7),
+            ]),
+        );
+        let result = client.get_last_finalized_block_id().await.unwrap();
+        assert_eq!(result, 777);
+
+        let eth_tx_hash = TxHash::random();
+        // Event emitted from a different contract address
+        let (log, _bridge_action) =
+            get_test_log_and_action(EthAddress::repeat_byte(4), eth_tx_hash, 0);
+        mock_provider
+            .add_response::<[TxHash; 1], TransactionReceipt, TransactionReceipt>(
+                "eth_getTransactionReceipt",
+                [log.transaction_hash.unwrap()],
+                TransactionReceipt {
+                    block_number: log.block_number,
+                    logs: vec![log],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let error = client
+            .get_finalized_bridge_action_maybe(eth_tx_hash, 0)
+            .await
+            .unwrap_err();
+        match error {
+            BridgeError::BridgeEventInUnrecognizedEthContract => {}
+            _ => panic!("expected TxNotFinalized"),
+        };
+
+        // Ok if emitted from the right contract
+        let (log, bridge_action) =
+            get_test_log_and_action(EthAddress::repeat_byte(6), eth_tx_hash, 0);
+        mock_provider
+            .add_response::<[TxHash; 1], TransactionReceipt, TransactionReceipt>(
+                "eth_getTransactionReceipt",
+                [log.transaction_hash.unwrap()],
+                TransactionReceipt {
+                    block_number: log.block_number,
+                    logs: vec![log],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let action = client
+            .get_finalized_bridge_action_maybe(eth_tx_hash, 0)
             .await
             .unwrap();
         assert_eq!(action, bridge_action);

--- a/crates/sui-bridge/src/eth_syncer.rs
+++ b/crates/sui-bridge/src/eth_syncer.rs
@@ -21,6 +21,7 @@ use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 use tracing::error;
 
+const ETH_LOG_QUERY_MAX_BLOCK_RANGE: u64 = 1000;
 const ETH_EVENTS_CHANNEL_SIZE: usize = 1000;
 const FINALIZED_BLOCK_QUERY_INTERVAL: Duration = Duration::from_secs(2);
 
@@ -122,11 +123,15 @@ where
         eth_client: Arc<EthClient<P>>,
     ) {
         tracing::info!(contract_address=?contract_address, "Starting eth events listening task from block {start_block}");
+        let mut more_blocks = false;
         loop {
-            last_finalized_block_receiver
-                .changed()
-                .await
-                .expect("last_finalized_block channel sender is closed");
+            // If no more known blocks, wait for the next finalized block.
+            if !more_blocks {
+                last_finalized_block_receiver
+                    .changed()
+                    .await
+                    .expect("last_finalized_block channel sender is closed");
+            }
             let new_finalized_block = *last_finalized_block_receiver.borrow();
             if new_finalized_block < start_block {
                 tracing::info!(
@@ -137,15 +142,20 @@ where
                 );
                 continue;
             }
+            // Each query does at most ETH_LOG_QUERY_MAX_BLOCK_RANGE blocks.
+            let end_block = std::cmp::min(
+                start_block + ETH_LOG_QUERY_MAX_BLOCK_RANGE - 1,
+                new_finalized_block,
+            );
+            more_blocks = end_block < new_finalized_block;
             let Ok(events) = retry_with_max_delay!(
-                eth_client.get_events_in_range(contract_address, start_block, new_finalized_block),
+                eth_client.get_events_in_range(contract_address, start_block, end_block),
                 Duration::from_secs(600)
             ) else {
                 error!("Failed to get events from eth client after retry");
                 continue;
             };
             let len = events.len();
-            // TODO: convert Log to a custom Log struct that contains block number, tx hash and log index in tx.
             if !events.is_empty() {
                 // Note: it's extremely critical to make sure the Logs we send via this channel
                 // are complete per block height. Namely, we should never send a partial list
@@ -156,7 +166,7 @@ where
                     .expect("All Eth event channel receivers are closed");
                 tracing::info!(?contract_address, "Observed {len} new Eth events",);
             }
-            start_block = new_finalized_block + 1;
+            start_block = end_block + 1;
         }
     }
 }
@@ -370,6 +380,85 @@ mod tests {
         );
         // No more finalized block change, no more logs.
         assert_eq!(logs_rx.try_recv().unwrap_err(), TryRecvError::Empty);
+        Ok(())
+    }
+
+    /// Test that the syncer will query for logs in multiple queries if the range is too big.
+    #[tokio::test]
+    async fn test_paginated_eth_log_query() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let mock_provider = EthMockProvider::new();
+        let start_block = 100;
+        // range too big, we need two queries
+        let last_finalized_block = start_block + ETH_LOG_QUERY_MAX_BLOCK_RANGE + 1;
+        mock_last_finalized_block(&mock_provider, last_finalized_block);
+        let client = EthClient::new_mocked(
+            mock_provider.clone(),
+            HashSet::from_iter(vec![EthAddress::zero()]),
+        );
+        let result = client.get_last_finalized_block_id().await.unwrap();
+        assert_eq!(result, last_finalized_block);
+
+        let addresses = HashMap::from_iter(vec![(EthAddress::zero(), start_block)]);
+        let log = Log {
+            address: EthAddress::zero(),
+            transaction_hash: Some(TxHash::random()),
+            block_number: Some(U64::from(start_block)),
+            log_index: Some(U256::from(3)),
+            ..Default::default()
+        };
+        let log2 = Log {
+            address: EthAddress::zero(),
+            transaction_hash: Some(TxHash::random()),
+            block_number: Some(U64::from(last_finalized_block)),
+            log_index: Some(U256::from(3)),
+            ..Default::default()
+        };
+        let eth_log = EthLog {
+            block_number: start_block,
+            tx_hash: log.transaction_hash.unwrap(),
+            log_index_in_tx: 0,
+            log: log.clone(),
+        };
+        let eth_log2 = EthLog {
+            block_number: last_finalized_block,
+            tx_hash: log2.transaction_hash.unwrap(),
+            log_index_in_tx: 0,
+            log: log2.clone(),
+        };
+        // First query handles [start, start + ETH_LOG_QUERY_MAX_BLOCK_RANGE - 1]
+        mock_get_logs(
+            &mock_provider,
+            EthAddress::zero(),
+            start_block,
+            start_block + ETH_LOG_QUERY_MAX_BLOCK_RANGE - 1,
+            vec![log.clone()],
+        );
+        // Second query handles [start + ETH_LOG_QUERY_MAX_BLOCK_RANGE, last_finalized_block]
+        mock_get_logs(
+            &mock_provider,
+            EthAddress::zero(),
+            start_block + ETH_LOG_QUERY_MAX_BLOCK_RANGE,
+            last_finalized_block,
+            vec![log2.clone()],
+        );
+
+        let (_handles, mut logs_rx, mut finalized_block_rx) =
+            EthSyncer::new(Arc::new(client), addresses)
+                .run()
+                .await
+                .unwrap();
+
+        finalized_block_rx.changed().await.unwrap();
+        assert_eq!(*finalized_block_rx.borrow(), last_finalized_block);
+        let (contract_address, received_logs) = logs_rx.recv().await.unwrap();
+        assert_eq!(contract_address, EthAddress::zero());
+        assert_eq!(received_logs, vec![eth_log.clone()]);
+        let (contract_address, received_logs) = logs_rx.recv().await.unwrap();
+        assert_eq!(contract_address, EthAddress::zero());
+        assert_eq!(received_logs, vec![eth_log2.clone()]);
         Ok(())
     }
 }

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -35,7 +35,7 @@ pub struct EmittedSuiToEthTokenBridgeV1 {
 }
 
 const EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG: &str =
-    "0x01::SuiToEthTokenBridge::SuiToEthTokenBridge";
+    "0x0b::SuiToEthTokenBridge::SuiToEthTokenBridge";
 
 crate::declare_events!(
     // TODO: Placeholder, use right struct tag

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -92,7 +92,7 @@ impl BridgeRequestHandlerTrait for BridgeRequestHandler {
             .map_err(|_e| BridgeError::InvalidTxHash)?;
         let bridge_action = self
             .sui_client
-            .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, event_idx)
+            .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, event_idx)
             .await?;
         info!(action_digest=?bridge_action.digest(), "Retrieved matched Bridge Action: {:?}", bridge_action);
         let sig = BridgeAuthoritySignInfo::new(&bridge_action, &self.signer);

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -41,6 +41,7 @@ use tracing::warn;
 use crate::crypto::BridgeAuthorityPublicKey;
 use crate::error::{BridgeError, BridgeResult};
 use crate::events::SuiBridgeEvent;
+use crate::sui_transaction_builder::get_bridge_package_id;
 use crate::types::{
     BridgeAction, BridgeAuthority, BridgeCommittee, MoveTypeBridgeCommittee, MoveTypeBridgeInner,
     MoveTypeCommitteeMember,
@@ -108,7 +109,10 @@ where
         // meaning it is intersted in events in transactions after A, globally ordering wise.
         cursor: TransactionDigest,
     ) -> BridgeResult<Page<SuiEvent, TransactionDigest>> {
-        let filter = EventFilter::MoveEventModule { package, module };
+        let filter = EventFilter::MoveEventModule {
+            package,
+            module: module.clone(),
+        };
         let initial_cursor = EventID {
             tx_digest: cursor,
             // Cursor is exclusive, so we use a reasonably large number
@@ -128,6 +132,13 @@ where
                     has_next_page: false,
                 });
             }
+
+            // Safeguard check that all events are emitted from requested package and module
+            assert!(events
+                .data
+                .iter()
+                .all(|event| event.type_.address.as_ref() == package.as_ref()
+                    && event.type_.module == module));
 
             // unwrap safe: we just checked data is not empty
             let new_cursor = events.data.last().unwrap().id;
@@ -178,8 +189,10 @@ where
         }
     }
 
-    // TODO: needs to fix this to match emitted package id
-    pub async fn get_bridge_action_by_tx_digest_and_event_idx(
+    /// Returns BridgeAction from a Sui Transaction with transaction hash
+    /// and the event index. If event is declared in an unrecognized
+    /// package, return error.
+    pub async fn get_bridge_action_by_tx_digest_and_event_idx_maybe(
         &self,
         tx_digest: &TransactionDigest,
         event_idx: u16,
@@ -188,6 +201,9 @@ where
         let event = events
             .get(event_idx as usize)
             .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
+        if event.type_.address.as_ref() != get_bridge_package_id().as_ref() {
+            return Err(BridgeError::BridgeEventInUnrecognizedSuiPackage);
+        }
         let bridge_event = SuiBridgeEvent::try_from_sui_event(event)?
             .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
 
@@ -391,6 +407,7 @@ mod tests {
     use ethers::types::{
         Address, Block, BlockNumber, Filter, FilterBlockOption, Log, ValueOrArray, U64,
     };
+    use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
     use std::{collections::HashSet, str::FromStr};
 
@@ -399,9 +416,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_query_events_by_module() {
-        // Note: for random events generated in this test, we only care about
-        // tx_digest and event_seq, so it's ok that package and module does
-        // not match the query parameters.
         telemetry_subscribers::init_for_testing();
         let mock_client = SuiMockClient::default();
         let sui_client = SuiClient::new_for_testing(mock_client.clone());
@@ -452,7 +466,9 @@ mod tests {
         assert_eq!(mock_client.pop_front_past_event_query_params(), None);
 
         // Case 2, only one page (has_next_page = false)
-        let event = SuiEvent::random_for_testing();
+        let mut event = SuiEvent::random_for_testing();
+        event.type_.address = package.into();
+        event.type_.module = module.clone();
         let events = EventPage {
             data: vec![event.clone()],
             next_cursor: None,
@@ -495,7 +511,9 @@ mod tests {
 
         // Case 3, more than one pages, one tx has several events across pages
         // page 1 (event 1)
-        let event_1 = SuiEvent::random_for_testing();
+        let mut event_1 = SuiEvent::random_for_testing();
+        event_1.type_.address = package.into();
+        event_1.type_.module = module.clone();
         let events_page_1 = EventPage {
             data: vec![event_1.clone()],
             next_cursor: Some(event_1.id),
@@ -512,6 +530,8 @@ mod tests {
         );
         // page 2 (event 1, event 2, same tx_digest)
         let mut event_2 = SuiEvent::random_for_testing();
+        event_2.type_.address = package.into();
+        event_2.type_.module = module.clone();
         event_2.id.tx_digest = event_1.id.tx_digest;
         event_2.id.event_seq = event_1.id.event_seq + 1;
         let events_page_2 = EventPage {
@@ -522,9 +542,13 @@ mod tests {
         mock_client.add_event_response(package, module.clone(), event_1.id, events_page_2);
         // page 3 (event 3, event 4, different tx_digest)
         let mut event_3 = SuiEvent::random_for_testing();
+        event_3.type_.address = package.into();
+        event_3.type_.module = module.clone();
         event_3.id.tx_digest = event_2.id.tx_digest;
         event_3.id.event_seq = event_2.id.event_seq + 1;
-        let event_4 = SuiEvent::random_for_testing();
+        let mut event_4 = SuiEvent::random_for_testing();
+        event_4.type_.address = package.into();
+        event_4.type_.module = module.clone();
         assert_ne!(event_3.id.tx_digest, event_4.id.tx_digest);
         let events_page_3 = EventPage {
             data: vec![event_3.clone(), event_4.clone()],
@@ -655,7 +679,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_bridge_action_by_tx_digest_and_event_idx() {
+    async fn get_bridge_action_by_tx_digest_and_event_idx_maybe() {
         // Note: for random events generated in this test, we only care about
         // tx_digest and event_seq, so it's ok that package and module does
         // not match the query parameters.
@@ -675,6 +699,12 @@ mod tests {
             token_id: TokenId::Sui,
             amount: 100,
         };
+
+        // TODO: remove once we don't rely on env var to get object id
+        // Before that happens, the value needs to match address of
+        // `EMITTED_SUI_TO_ETH_TOKEN_BRIDGE_V1_STUCT_TAG`
+        std::env::set_var("BRIDGE_PACKAGE_ID", "0x0b");
+
         let mut sui_event_1 = SuiEvent::random_for_testing();
         sui_event_1.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
         sui_event_1.bcs = bcs::to_bytes(&event_1).unwrap();
@@ -685,7 +715,13 @@ mod tests {
         let event_2: RandomStruct = RandomStruct {};
         // undeclared struct tag
         let mut sui_event_2 = SuiEvent::random_for_testing();
+        sui_event_2.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
+        sui_event_2.type_.module = Identifier::from_str("unrecognized_module").unwrap();
         sui_event_2.bcs = bcs::to_bytes(&event_2).unwrap();
+
+        // Event 3 is defined in non-bridge package
+        let mut sui_event_3 = sui_event_1.clone();
+        sui_event_3.type_.address = AccountAddress::random();
 
         mock_client.add_events_by_tx_digest(
             tx_digest,
@@ -693,6 +729,7 @@ mod tests {
                 sui_event_1.clone(),
                 sui_event_2.clone(),
                 sui_event_1.clone(),
+                sui_event_3.clone(),
             ],
         );
         let mut expected_action_1 = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
@@ -702,7 +739,7 @@ mod tests {
         });
         assert_eq!(
             sui_client
-                .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, 0)
+                .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 0)
                 .await
                 .unwrap(),
             expected_action_1,
@@ -714,21 +751,28 @@ mod tests {
         });
         assert_eq!(
             sui_client
-                .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, 2)
+                .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 2)
                 .await
                 .unwrap(),
             expected_action_2,
         );
         assert!(matches!(
             sui_client
-                .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, 1)
+                .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 1)
                 .await
                 .unwrap_err(),
             BridgeError::NoBridgeEventsInTxPosition
         ),);
         assert!(matches!(
             sui_client
-                .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, 3)
+                .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 3)
+                .await
+                .unwrap_err(),
+            BridgeError::BridgeEventInUnrecognizedSuiPackage
+        ),);
+        assert!(matches!(
+            sui_client
+                .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 4)
                 .await
                 .unwrap_err(),
             BridgeError::NoBridgeEventsInTxPosition
@@ -738,7 +782,7 @@ mod tests {
         sui_event_2.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
         mock_client.add_events_by_tx_digest(tx_digest, vec![sui_event_2]);
         sui_client
-            .get_bridge_action_by_tx_digest_and_event_idx(&tx_digest, 2)
+            .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, 2)
             .await
             .unwrap_err();
     }

--- a/crates/sui-bridge/src/sui_syncer.rs
+++ b/crates/sui-bridge/src/sui_syncer.rs
@@ -163,7 +163,9 @@ mod tests {
         assert_no_more_events(interval, &mut events_rx).await;
 
         // Module Foo has new events
-        let event_1: SuiEvent = SuiEvent::random_for_testing();
+        let mut event_1: SuiEvent = SuiEvent::random_for_testing();
+        event_1.type_.address = PACKAGE_ID.into();
+        event_1.type_.module = module_foo.clone();
         let module_foo_events_1: sui_json_rpc_types::Page<SuiEvent, EventID> = EventPage {
             data: vec![event_1.clone(), event_1.clone()],
             next_cursor: None,
@@ -191,7 +193,9 @@ mod tests {
         assert_no_more_events(interval, &mut events_rx).await;
 
         // Module Bar has new events
-        let event_2: SuiEvent = SuiEvent::random_for_testing();
+        let mut event_2: SuiEvent = SuiEvent::random_for_testing();
+        event_2.type_.address = PACKAGE_ID.into();
+        event_2.type_.module = module_bar.clone();
         let module_bar_events_1 = EventPage {
             data: vec![event_2.clone()],
             next_cursor: None,

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 // TODO: once we have bridge package on sui framework, we can hardcode the actual package id.
-fn get_bridge_package_id() -> &'static ObjectID {
+pub fn get_bridge_package_id() -> &'static ObjectID {
     static BRIDGE_PACKAGE_ID: OnceCell<ObjectID> = OnceCell::new();
     BRIDGE_PACKAGE_ID.get_or_init(|| match std::env::var("BRIDGE_PACKAGE_ID") {
         Ok(id) => {


### PR DESCRIPTION
## Description 

The meat of this PR is in `eth_client.rs` and `sui_client.rs`. Basically, they only care about events that are defined in corresponding packages/contracts. This is critical to make sure no other random events will be considered as legit bridge actions.


## Test Plan 

unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
