### PR TITLE
move: versioned compilation 2/n

### DIFF
--- a/crates/sui-framework/packages/deepbook/Move.lock
+++ b/crates/sui-framework/packages/deepbook/Move.lock
@@ -23,6 +23,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.16.0"
+compiler-version = "1.17.0"
 edition = "legacy"
 flavor = "sui"

--- a/crates/sui-framework/packages/move-stdlib/Move.lock
+++ b/crates/sui-framework/packages/move-stdlib/Move.lock
@@ -6,6 +6,6 @@ manifest_digest = "3FF3771B6F639B5D249A1D55EF826B1F6D5CC7C85A69CED739AF49E6B3CAA
 deps_digest = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
 
 [move.toolchain-version]
-compiler-version = "1.16.0"
+compiler-version = "1.17.0"
 edition = "legacy"
 flavor = "sui"

--- a/crates/sui-framework/packages/sui-framework/Move.lock
+++ b/crates/sui-framework/packages/sui-framework/Move.lock
@@ -14,6 +14,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.16.0"
+compiler-version = "1.17.0"
 edition = "legacy"
 flavor = "sui"

--- a/crates/sui-framework/packages/sui-system/Move.lock
+++ b/crates/sui-framework/packages/sui-system/Move.lock
@@ -23,6 +23,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.16.0"
+compiler-version = "1.17.0"
 edition = "legacy"
 flavor = "sui"


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/15598.

Previous PR https://github.com/MystenLabs/sui/pull/15598 basically ensures we can build successfully with prebuilt packages on prior compiler versions. This PR ensures prebuilt bytecode is exposed to the compiled package result, so that publishing succeeds.

See [main comment](https://github.com/MystenLabs/sui/pull/15622#discussion_r1446049112) for change.

## Test Plan 

Still local manual testing until I do e2e testing setup, this time with `sui client publish`. New behavior is guarded by env variable `VERIFIED_SOURCE_BUILD` so this has no chance of affecting current behavior.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
