### PR TITLE
do not panic on DB reset cmd

### DIFF
--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -99,8 +99,6 @@ async fn main() -> Result<(), IndexerError> {
         } else if indexer_config.analytical_worker {
             let store = PgIndexerAnalyticalStore::new(blocking_cp);
             return IndexerV2::start_analytical_worker(store, indexer_metrics.clone()).await;
-        } else {
-            panic!("No worker is specified");
         }
     }
 


### PR DESCRIPTION
## Description 

to run reset DB command only without panic

## Test Plan 

local run 
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --reset-db --use-v2
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
