### PR TITLE
[CheckpointExecutor] Make scheduling more robust

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1673,11 +1673,6 @@ async fn diagnose_split_brain(
     debug!("{}", fork_logs_text);
 
     fail_point!("split_brain_reached");
-
-    // There is no option to never restart the node, so choosing longer than should
-    // be needed for any testcase
-    // #[cfg(msim)]
-    // sui_simulator::task::kill_current_node(Some(Duration::from_secs(100)));
 }
 
 pub trait CheckpointServiceNotify {


### PR DESCRIPTION
## Description 

In case we, for whatever reason, do not receive a notification about newly synced checkpoints after some amount of time, this change will cause us to exit the `tokio::select!` statement and re-loop, which will in turn re-invoke `schedule_synced_checkpoints`. Note that `schedule_synced_checkpoints` always checks the db directly and attempts to schedule everything it can, so this is a failsafe. 

## Test Plan 

Existing simtests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
