### PR TITLE
[gql] refactor object and related types to leverage new Type::query framework

### DIFF
--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -11,7 +11,6 @@ use super::object::deserialize_move_struct;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
-use crate::context_data::db_data_provider::PgManager;
 use crate::context_data::package_cache::PackageCache;
 use crate::error::Error;
 use sui_types::object::Object as NativeObject;
@@ -90,9 +89,7 @@ impl DynamicField {
     /// in which case it is also accessible off-chain via its address.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         if self.df_kind == DynamicFieldType::DynamicObject {
-            let obj = ctx
-                .data_unchecked::<PgManager>()
-                .fetch_move_obj(self.df_object_id, None)
+            let obj = MoveObject::query(ctx.data_unchecked(), self.df_object_id, None)
                 .await
                 .extend()?;
             Ok(obj.map(DynamicFieldValue::MoveObject))

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -10,8 +10,6 @@ use sui_types::{parse_sui_struct_tag, TypeTag};
 
 use crate::error::Error;
 
-use crate::context_data::db_data_provider::PgManager;
-
 use super::digest::Digest;
 use super::{
     address::Address, base64::Base64, date_time::DateTime, move_module::MoveModule,
@@ -66,8 +64,7 @@ impl Event {
         let sending_package = SuiAddress::from_bytes(&self.stored.package)
             .map_err(|e| Error::Internal(e.to_string()))
             .extend()?;
-        ctx.data_unchecked::<PgManager>()
-            .fetch_move_module(sending_package, &self.stored.module)
+        MoveModule::query(ctx.data_unchecked(), sending_package, &self.stored.module)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -114,10 +114,13 @@ impl GasCostSummary {
 #[Object]
 impl GasEffects {
     async fn gas_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.object_id, Some(self.object_version))
-            .await
-            .extend()
+        Object::query(
+            ctx.data_unchecked(),
+            self.object_id,
+            Some(self.object_version),
+        )
+        .await
+        .extend()
     }
 
     async fn gas_summary(&self) -> Option<&GasCostSummary> {

--- a/crates/sui-graphql-rpc/src/types/move_struct.rs
+++ b/crates/sui-graphql-rpc/src/types/move_struct.rs
@@ -4,7 +4,6 @@
 use async_graphql::*;
 use sui_package_resolver::StructDef;
 
-use crate::context_data::db_data_provider::PgManager;
 use crate::error::Error;
 
 use super::{
@@ -41,9 +40,7 @@ pub(crate) struct MoveField {
 impl MoveStruct {
     /// The module this struct was originally defined in.
     async fn module(&self, ctx: &Context<'_>) -> Result<MoveModule> {
-        let Some(module) = ctx
-            .data_unchecked::<PgManager>()
-            .fetch_move_module(self.defining_id, &self.module)
+        let Some(module) = MoveModule::query(ctx.data_unchecked(), self.defining_id, &self.module)
             .await
             .extend()?
         else {

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -5,7 +5,6 @@ use async_graphql::*;
 use sui_types::effects::{IDOperation, ObjectChange as NativeObjectChange};
 
 use super::{object::Object, sui_address::SuiAddress};
-use crate::context_data::db_data_provider::PgManager;
 
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
@@ -25,10 +24,13 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.native.id.into(), Some(version.value()))
-            .await
-            .extend()
+        Object::query(
+            ctx.data_unchecked(),
+            self.native.id.into(),
+            Some(version.value()),
+        )
+        .await
+        .extend()
     }
 
     /// The contents of the object immediately after the transaction.
@@ -37,10 +39,13 @@ impl ObjectChange {
             return Ok(None);
         };
 
-        ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.native.id.into(), Some(version.value()))
-            .await
-            .extend()
+        Object::query(
+            ctx.data_unchecked(),
+            self.native.id.into(),
+            Some(version.value()),
+        )
+        .await
+        .extend()
     }
 
     /// Whether the ID was created in this transaction.

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -4,8 +4,6 @@
 use async_graphql::*;
 use sui_types::base_types::ObjectRef as NativeObjectRef;
 
-use crate::context_data::db_data_provider::PgManager;
-
 use super::{object::Object, sui_address::SuiAddress};
 
 // A helper type representing the read of a specific version of an object. Intended to be
@@ -33,10 +31,13 @@ impl ObjectRead {
 
     /// The object at this version.  May not be available due to pruning.
     async fn object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_obj(self.address_impl(), Some(self.version_impl()))
-            .await
-            .extend()
+        Object::query(
+            ctx.data_unchecked(),
+            self.address_impl(),
+            Some(self.version_impl()),
+        )
+        .await
+        .extend()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -73,8 +73,7 @@ impl Query {
         address: SuiAddress,
         version: Option<u64>,
     ) -> Result<Option<Object>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_obj(address, version)
+        Object::query(ctx.data_unchecked(), address, version)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -11,16 +11,13 @@ use sui_types::transaction::{
     ProgrammableTransaction as NativeProgrammableTransactionBlock,
 };
 
-use crate::{
-    context_data::db_data_provider::PgManager,
-    types::{
-        base64::Base64,
-        cursor::{Cursor, Page},
-        move_function::MoveFunction,
-        move_type::MoveType,
-        object_read::ObjectRead,
-        sui_address::SuiAddress,
-    },
+use crate::types::{
+    base64::Base64,
+    cursor::{Cursor, Page},
+    move_function::MoveFunction,
+    move_type::MoveType,
+    object_read::ObjectRead,
+    sui_address::SuiAddress,
 };
 
 #[derive(Clone, Eq, PartialEq)]
@@ -271,14 +268,14 @@ impl MoveCallTransaction {
 
     /// The function being called, resolved.
     async fn function(&self, ctx: &Context<'_>) -> Result<Option<MoveFunction>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_move_function(
-                self.0.package.into(),
-                self.0.module.as_str(),
-                self.0.function.as_str(),
-            )
-            .await
-            .extend()
+        MoveFunction::query(
+            ctx.data_unchecked(),
+            self.0.package.into(),
+            self.0.module.as_str(),
+            self.0.function.as_str(),
+        )
+        .await
+        .extend()
     }
 
     /// The actual type parameters passed in for this move call.

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -86,8 +86,7 @@ impl Validator {
     /// the operation ability to another address. The address holding this `Cap` object
     /// can then update the reference gas price and tallying rule on behalf of the validator.
     async fn operation_cap(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_move_obj(self.operation_cap_id(), None)
+        MoveObject::query(ctx.data_unchecked(), self.operation_cap_id(), None)
             .await
             .extend()
     }
@@ -95,8 +94,7 @@ impl Validator {
     /// The validator's current staking pool object, used to track the amount of stake
     /// and to compound staking rewards.
     async fn staking_pool(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_move_obj(self.staking_pool_id(), None)
+        MoveObject::query(ctx.data_unchecked(), self.staking_pool_id(), None)
             .await
             .extend()
     }
@@ -104,8 +102,7 @@ impl Validator {
     /// The validator's current exchange object. The exchange rate is used to determine
     /// the amount of SUI tokens that each past SUI staker can withdraw in the future.
     async fn exchange_rates(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_move_obj(self.exchange_rates_id(), None)
+        MoveObject::query(ctx.data_unchecked(), self.exchange_rates_id(), None)
             .await
             .extend()
     }


### PR DESCRIPTION
## Description 

Move Object and associated types to leverage new Type::query framework. This PR only touches the singleton gets. Remove its equivalent methods from db_data_provider as they are no longer used.

## Test Plan 

Existing tests should pass

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
