### PR TITLE
Add bucket definition for size based histogram

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -22,6 +22,17 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1., 2.5, 5., 10., 20., 30., 60., 90.,
 ];
 
+const BYTES_BUCKETS: &[f64] = &[
+    1.,
+    10.,
+    100.,
+    1024., // 1k
+    1024. * 10.,
+    1024. * 100.,
+    1024. * 1024., // 1M
+    1024. * 1024. * 10.,
+];
+
 #[derive(Debug, Clone)]
 // A struct for sampling based on number of operations or duration.
 // Sampling happens if the duration expires and after number of operations
@@ -272,6 +283,7 @@ impl OperationMetrics {
                 "rocksdb_iter_bytes",
                 "Rocksdb iter size in bytes",
                 &["cf_name"],
+                BYTES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -294,6 +306,7 @@ impl OperationMetrics {
                 "rocksdb_get_bytes",
                 "Rocksdb get call returned data size in bytes",
                 &["cf_name"],
+                BYTES_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),
@@ -309,6 +322,7 @@ impl OperationMetrics {
                 "rocksdb_multiget_bytes",
                 "Rocksdb multiget call returned data size in bytes",
                 &["cf_name"],
+                BYTES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -324,6 +338,7 @@ impl OperationMetrics {
                 "rocksdb_put_bytes",
                 "Rocksdb put call puts data size in bytes",
                 &["cf_name"],
+                BYTES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -354,6 +369,7 @@ impl OperationMetrics {
                 "rocksdb_batch_commit_bytes",
                 "Rocksdb schema batch commit size in bytes",
                 &["db_name"],
+                BYTES_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

The default bucket

```
pub const DEFAULT_BUCKETS: &[f64; 11] = &[
    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
];
```

Is not very useful.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
