### PR TITLE
Only enable Poseidon for devnet

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1362,6 +1362,7 @@
                 "disallow_change_struct_type_params_on_upgrade": false,
                 "enable_effects_v2": false,
                 "enable_jwk_consensus_updates": false,
+                "enable_poseidon": false,
                 "end_of_epoch_transaction_supported": false,
                 "hardened_otw_check": false,
                 "include_consensus_digest_in_prologue": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -367,6 +367,10 @@ struct FeatureFlags {
     // If true allow calling receiving_object_id function
     #[serde(skip_serializing_if = "is_false")]
     allow_receiving_object_id: bool,
+
+    // Enable the poseidon hash function
+    #[serde(skip_serializing_if = "is_false")]
+    enable_poseidon: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1085,6 +1089,10 @@ impl ProtocolConfig {
     pub fn hardened_otw_check(&self) -> bool {
         self.feature_flags.hardened_otw_check
     }
+
+    pub fn enable_poseidon(&self) -> bool {
+        self.feature_flags.enable_poseidon
+    }
 }
 
 #[cfg(not(msim))]
@@ -1735,8 +1743,11 @@ impl ProtocolConfig {
                 34 => {}
                 35 => {
                     // Add costs for poseidon::poseidon_bn254
-                    cfg.poseidon_bn254_cost_base = Some(260);
-                    cfg.poseidon_bn254_cost_per_block = Some(10);
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.enable_poseidon = true;
+                        cfg.poseidon_bn254_cost_base = Some(260);
+                        cfg.poseidon_bn254_cost_per_block = Some(10);
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_35.snap
@@ -196,8 +196,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 52
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
-poseidon_bn254_cost_per_block: 10
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_35.snap
@@ -198,8 +198,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 52
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
-poseidon_bn254_cost_per_block: 10
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_35.snap
@@ -42,6 +42,7 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Description 

Only enable Poseidon for devnet for now.

## Test Plan 

Unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [x] protocol change
- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
