### PR TITLE
[gql] introduce HistoricalContext for Address and Owner

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -17,6 +17,7 @@ use crate::{
         move_object::MoveObject,
         move_type::MoveType,
         object::{Object, ObjectFilter},
+        owner::HistoricalContext,
         stake::StakedSui,
         sui_address::SuiAddress,
         suins_registration::SuinsRegistration,
@@ -883,6 +884,7 @@ impl PgManager {
 
         Ok(record.target_address.map(|address| Address {
             address: SuiAddress::from_array(address.to_inner()),
+            historical_context: HistoricalContext::default(),
         }))
     }
 
@@ -1306,6 +1308,8 @@ pub(crate) fn convert_to_validators(
     validators: Vec<SuiValidatorSummary>,
     system_state: Option<NativeSuiSystemStateSummary>,
 ) -> Vec<Validator> {
+    let historical_context = HistoricalContext::with_epoch(system_state.as_ref().map(|s| s.epoch));
+
     let (at_risk, reports) = if let Some(NativeSuiSystemStateSummary {
         at_risk_validators,
         validator_report_records,
@@ -1330,6 +1334,7 @@ pub(crate) fn convert_to_validators(
                     .cloned()
                     .map(|a| Address {
                         address: SuiAddress::from(a),
+                        historical_context,
                     })
                     .collect()
             });
@@ -1338,6 +1343,7 @@ pub(crate) fn convert_to_validators(
                 validator_summary,
                 at_risk,
                 report_records,
+                historical_context,
             }
         })
         .collect()

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -11,6 +11,7 @@ use super::{
     coin::Coin,
     dynamic_field::{DynamicField, DynamicFieldName},
     object::{Object, ObjectFilter},
+    owner::HistoricalContext,
     stake::StakedSui,
     sui_address::SuiAddress,
     suins_registration::SuinsRegistration,
@@ -20,6 +21,7 @@ use super::{
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub(crate) struct Address {
     pub address: SuiAddress,
+    pub historical_context: HistoricalContext,
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -57,7 +57,7 @@ impl BalanceChange {
 
         Ok(Self {
             stored,
-            historical_context: historical_context.unwrap_or_else(HistoricalContext::default),
+            historical_context: historical_context.unwrap_or_default(),
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -11,6 +11,7 @@ use sui_types::{parse_sui_struct_tag, TypeTag};
 use crate::error::Error;
 
 use super::digest::Digest;
+use super::owner::HistoricalContext;
 use super::{
     address::Address, base64::Base64, date_time::DateTime, move_module::MoveModule,
     move_value::MoveValue, sui_address::SuiAddress,
@@ -83,7 +84,12 @@ impl Event {
             return Ok(None);
         }
 
-        Ok(Some(Address { address }))
+        Ok(Some(Address {
+            address,
+            historical_context: HistoricalContext::with_checkpoint(Some(
+                self.stored.checkpoint_sequence_number as u64,
+            )),
+        }))
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -153,11 +153,7 @@ impl From<&TransactionBlock> for GasInput {
             owner: gas_data.owner,
             price: gas_data.price,
             budget: gas_data.budget,
-            payment_obj_ids: gas_data
-                .payment
-                .iter()
-                .map(|o| ObjectRead(o.clone()))
-                .collect(),
+            payment_obj_ids: gas_data.payment.iter().map(|o| ObjectRead(*o)).collect(),
             historical_context,
         }
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -98,6 +98,13 @@ pub(crate) enum IOwner {
 #[derive(Clone, Debug)]
 pub(crate) struct Owner {
     pub address: SuiAddress,
+    pub historical_context: HistoricalContext,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct HistoricalContext {
+    pub epoch: Option<u64>,
+    pub checkpoint: Option<u64>,
 }
 
 #[Object]
@@ -106,6 +113,7 @@ impl Owner {
         // For now only addresses can be owners
         Some(Address {
             address: self.address,
+            historical_context: self.historical_context,
         })
     }
 
@@ -270,5 +278,25 @@ impl Owner {
             .fetch_dynamic_fields(first, after, last, before, self.address)
             .await
             .extend()
+    }
+}
+
+impl HistoricalContext {
+    pub fn new(epoch: Option<u64>, checkpoint: Option<u64>) -> Self {
+        Self { epoch, checkpoint }
+    }
+
+    pub fn with_epoch(epoch: Option<u64>) -> Self {
+        Self {
+            epoch,
+            checkpoint: None,
+        }
+    }
+
+    pub fn with_checkpoint(checkpoint: Option<u64>) -> Self {
+        Self {
+            epoch: None,
+            checkpoint,
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -20,7 +20,7 @@ use super::{
     event::{Event, EventFilter},
     move_type::MoveType,
     object::{Object, ObjectFilter},
-    owner::Owner,
+    owner::{HistoricalContext, Owner},
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
     transaction_block::{TransactionBlock, TransactionBlockFilter},
@@ -64,7 +64,10 @@ impl Query {
     // coinMetadata
 
     async fn owner(&self, address: SuiAddress) -> Option<Owner> {
-        Some(Owner { address })
+        Some(Owner {
+            address,
+            historical_context: HistoricalContext::default(),
+        })
     }
 
     async fn object(
@@ -79,7 +82,10 @@ impl Query {
     }
 
     async fn address(&self, address: SuiAddress) -> Option<Address> {
-        Some(Address { address })
+        Some(Address {
+            address,
+            historical_context: HistoricalContext::default(),
+        })
     }
 
     /// Fetch a structured representation of a concrete type, including its layout information.

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -23,6 +23,7 @@ use super::{
     epoch::Epoch,
     event::Event,
     gas::GasInput,
+    owner::HistoricalContext,
     sui_address::SuiAddress,
     transaction_block_effects::TransactionBlockEffects,
     transaction_block_kind::TransactionBlockKind,
@@ -82,6 +83,9 @@ impl TransactionBlock {
         let sender = self.native.transaction_data().sender();
         (sender != NativeSuiAddress::ZERO).then(|| Address {
             address: SuiAddress::from(sender),
+            historical_context: HistoricalContext::with_checkpoint(Some(
+                self.stored.checkpoint_sequence_number as u64,
+            )),
         })
     }
 
@@ -91,7 +95,7 @@ impl TransactionBlock {
     /// If the owner of the gas object(s) is not the same as the sender, the transaction block is a
     /// sponsored transaction block.
     async fn gas_input(&self) -> Option<GasInput> {
-        Some(GasInput::from(self.native.transaction_data().gas_data()))
+        Some(GasInput::from(self))
     }
 
     /// The type of this transaction as well as the commands and/or parameters comprising the

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -5,6 +5,7 @@ use crate::context_data::db_data_provider::PgManager;
 
 use super::big_int::BigInt;
 use super::move_object::MoveObject;
+use super::owner::HistoricalContext;
 use super::sui_address::SuiAddress;
 use super::validator_credentials::ValidatorCredentials;
 use super::{address::Address, base64::Base64};
@@ -16,6 +17,7 @@ pub(crate) struct Validator {
     pub validator_summary: NativeSuiValidatorSummary,
     pub at_risk: Option<u64>,
     pub report_records: Option<Vec<Address>>,
+    pub historical_context: HistoricalContext,
 }
 
 #[Object]
@@ -24,6 +26,7 @@ impl Validator {
     async fn address(&self) -> Address {
         Address {
             address: SuiAddress::from(self.validator_summary.sui_address),
+            historical_context: self.historical_context,
         }
     }
 


### PR DESCRIPTION
## Description 

Today, when we issue a request like
```
{
  transactionBlock(digest:"Hi"){
    sender {
      coinConnection {
        nodes {
          balance
        }
      }
    }
  }
}
```
where the transaction block is temporally at some checkpoint 100, the information fetched for sender and its coinConnection is retrieved today from the live objects table. This is incorrect as one would expect the respective information to also reflect the state at checkpoint 100, if that's within the available range of the graphql service.

To correctly fetch information about the sender and its coins at the state at checkpoint 100, we need to persist that context to the Address and Owner type, and then use it to resolve their fields.

Subsequently, the db query for coins owned by sender changes from, "select * from objects where owner_id = address and coin_type is not null" to "(select * from objects_snapshot where owner_id = address and coin_type is not null) union (select * from objects_history where owner_id = address and coin_type is not null and checkpoint_sequence_number = 100)". We need a union query as objects that exist at checkpoint 100 but were not modified will not show up in objects_history, but will have been snapshotted in the objects_snapshot table.

This PR just sets up the needed context to support object history queries, to be used in a subsequent PR (in the constructed query and the encoded cursor)

## Test Plan 

This just sets up the needed context to support object history queries, so existing tests should pass.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
