### PR TITLE
Fix clustering of transaction table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11188,6 +11188,8 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "sui-analytics-indexer-derive",
+ "sui-archival",
+ "sui-config",
  "sui-indexer",
  "sui-json-rpc-types",
  "sui-package-resolver",

--- a/crates/sui-analytics-indexer/Cargo.toml
+++ b/crates/sui-analytics-indexer/Cargo.toml
@@ -36,6 +36,8 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 mysten-metrics.workspace = true
 sui-analytics-indexer-derive.workspace = true
 sui-indexer.workspace = true
+sui-archival.workspace = true
+sui-config.workspace = true
 eyre.workspace = true
 rocksdb.workspace = true
 tempfile.workspace = true

--- a/crates/sui-analytics-indexer/src/archive_tailer.rs
+++ b/crates/sui-analytics-indexer/src/archive_tailer.rs
@@ -1,0 +1,156 @@
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use prometheus::Registry;
+use sui_archival::reader::{ArchiveReader, ArchiveReaderMetrics};
+use sui_config::node::ArchiveReaderConfig;
+use sui_indexer::framework::{Handler, IndexerBuilder};
+use sui_storage::object_store::ObjectStoreConfig;
+use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
+use sui_types::messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint, VerifiedCheckpointContents};
+use sui_types::storage::{CheckpointHandler, ObjectKey};
+
+pub struct ArchiveTailer {
+    archive_config: Option<ObjectStoreConfig>,
+    handlers: Vec<Box<dyn Handler>>,
+    last_downloaded_checkpoint: Option<CheckpointSequenceNumber>,
+    checkpoint_buffer_size: usize,
+}
+
+pub struct ArchiveCheckpointHandler {
+    inner: Arc<dyn Handler>,
+}
+
+impl CheckpointHandler for ArchiveCheckpointHandler {
+    fn handle_checkpoint(&mut self, verified_checkpoint: VerifiedCheckpoint, verified_checkpoint_contents: VerifiedCheckpointContents) -> Result<(), SuiError> {
+        let checkpoint_data = CheckpointData {
+            checkpoint_summary: verified_checkpoint.into(),
+            checkpoint_contents: verified_checkpoint_contents.into_checkpoint_contents(),
+            transactions: verified_checkpoint_contents.into_checkpoint_transactions(),
+        };
+    }
+    fn make_checkpoint_data(verified_checkpoint: VerifiedCheckpoint, verified_checkpoint_contents: VerifiedCheckpointContents) -> anyhow::Result<CheckpointData> {
+        let transaction_digests = verified_checkpoint_contents
+            .into_checkpoint_contents()
+            .iter()
+            .map(|execution_digests| execution_digests.transaction)
+            .collect::<Vec<_>>();
+
+        let transactions: Vec<_> = verified_checkpoint_contents.iter().map(|x| x.transaction.clone()).collect();
+        let effects: Vec<_> = verified_checkpoint_contents.iter().map(|x| x.effects.clone()).collect();
+        let event_digests = effects
+            .iter()
+            .flat_map(|fx| fx.events_digest().copied())
+            .collect::<Vec<_>>();
+
+        let mut full_transactions = Vec::with_capacity(transactions.len());
+        for (tx, fx) in transactions.into_iter().zip(effects) {
+            // Note unwrapped_then_deleted contains **updated** versions.
+            let unwrapped_then_deleted_obj_ids = fx
+                .unwrapped_then_deleted()
+                .into_iter()
+                .map(|k| k.0)
+                .collect::<HashSet<_>>();
+
+            let input_object_keys = fx
+                .input_shared_objects()
+                .into_iter()
+                .map(|kind| {
+                    let (id, version) = kind.id_and_version();
+                    ObjectKey(id, version)
+                })
+                .chain(
+                    fx.modified_at_versions()
+                        .into_iter()
+                        .map(|(object_id, version)| ObjectKey(object_id, version)),
+                )
+                .collect::<HashSet<_>>()
+                .into_iter()
+                // Unwrapped-then-deleted objects are not stored in state before the tx, so we have nothing to fetch.
+                .filter(|key| !unwrapped_then_deleted_obj_ids.contains(&key.0))
+                .collect::<Vec<_>>();
+
+
+            let output_object_keys = fx
+                .all_changed_objects()
+                .into_iter()
+                .map(|(object_ref, _owner, _kind)| ObjectKey::from(object_ref))
+                .collect::<Vec<_>>();
+
+            let output_objects = state
+                .multi_get_object_by_key(&output_object_keys)?
+                .into_iter()
+                .enumerate()
+                .map(|(idx, maybe_object)| {
+                    maybe_object.ok_or_else(|| {
+                        anyhow::anyhow!(
+                        "missing output object key {:?} from tx {}",
+                        output_object_keys[idx],
+                        tx.digest()
+                    )
+                    })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+        }
+
+
+
+
+
+
+
+
+        for execution_data in verified_checkpoint_contents.iter() {
+            let transaction = execution_data.transaction.clone();
+            let effect = execution_data.effects.clone();
+
+        }
+
+    }
+}
+impl ArchiveTailer {
+    const DEFAULT_CHECKPOINT_BUFFER_SIZE: usize = 1000;
+
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            archive_config: None,
+            handlers: Vec::new(),
+            last_downloaded_checkpoint: None,
+            checkpoint_buffer_size: Self::DEFAULT_CHECKPOINT_BUFFER_SIZE,
+        }
+    }
+
+    pub fn archive_config(mut self, object_store_config: ObjectStoreConfig) -> Self {
+        self.archive_config = Some(object_store_config);
+        self
+    }
+
+    pub fn handler<T: Handler + 'static>(mut self, handler: T) -> Self {
+        self.handlers.push(Box::new(handler));
+        self
+    }
+
+    pub fn last_downloaded_checkpoint(
+        mut self,
+        last_downloaded_checkpoint: Option<CheckpointSequenceNumber>,
+    ) -> Self {
+        self.last_downloaded_checkpoint = last_downloaded_checkpoint;
+        self
+    }
+
+    pub fn checkpoint_buffer_size(mut self, checkpoint_buffer_size: usize) -> Self {
+        self.checkpoint_buffer_size = checkpoint_buffer_size;
+        self
+    }
+
+    pub async fn run(self, registry: &Registry) {
+        let archive_reader_meteric = Arc::new(ArchiveReaderMetrics::new(registry));
+        let archive_reader_config = ArchiveReaderConfig {
+            remote_store_config: self.archive_config.unwrap(),
+            download_concurrency: NonZeroUsize::new(20).unwrap(),
+            use_for_pruning_watermark: false
+        };
+        let archive_reader = ArchiveReader::new(archive_reader_config, &archive_reader_meteric)?;
+        archive_reader.read(self.last_downloaded_checkpoint + 1, )

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -18,7 +18,7 @@ use sui_rest_api::CheckpointData;
 use sui_storage::object_store::util::{
     find_all_dirs_with_epoch_prefix, find_all_files_with_epoch_prefix,
 };
-use sui_storage::object_store::ObjectStoreConfig;
+use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
 use sui_types::base_types::EpochId;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
@@ -47,6 +47,7 @@ mod handlers;
 mod package_store;
 pub mod tables;
 mod writers;
+mod archive_tailer;
 
 const EPOCH_DIR_PREFIX: &str = "epoch_";
 const CHECKPOINT_DIR_PREFIX: &str = "checkpoints";
@@ -106,6 +107,12 @@ pub struct AnalyticsIndexerConfig {
         default_value = "/opt/sui/db/package_cache"
     )]
     pub package_cache_path: PathBuf,
+    // Remote object store where data gets written to
+    /// Archival bucket name. If not specified, defaults are
+    #[clap(long = "archive-bucket")]
+    archive_bucket: Option<String>,
+    #[clap(long = "archive-bucket-type", default_value = "s3")]
+    archive_bucket_type: ObjectStoreType,
 }
 
 #[derive(

--- a/crates/sui-analytics-indexer/src/store/bq/schemas/transaction.sql
+++ b/crates/sui-analytics-indexer/src/store/bq/schemas/transaction.sql
@@ -42,4 +42,4 @@ CREATE TABLE IF NOT EXISTS chaindata.TRANSACTION
     effects_json               JSON
 )
 PARTITION BY RANGE_BUCKET(epoch, GENERATE_ARRAY(0, 100000, 10))
-CLUSTER BY epoch, checkpoint, transaction_digest
+CLUSTER BY transaction_digest

--- a/crates/sui-indexer/src/framework/builder.rs
+++ b/crates/sui-indexer/src/framework/builder.rs
@@ -58,7 +58,6 @@ impl IndexerBuilder {
                     .channels
                     .with_label_values(&["checkpoint_tx_downloading"]),
             );
-
         // experimental rest api route is found at `/rest` on the same interface as the jsonrpc
         // service
         let rest_api_url = format!("{}/rest", self.rest_url.unwrap());

--- a/crates/sui-rest-api/src/lib.rs
+++ b/crates/sui-rest-api/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{HashMap, HashSet};
 use axum::{http::StatusCode, routing::get, Router};
 
 mod checkpoints;
@@ -11,7 +12,9 @@ mod objects;
 
 pub use client::Client;
 use node_state_getter::NodeStateGetter;
+use sui_types::error::{SuiError, SuiResult, UserInputError};
 pub use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
+use sui_types::storage::ObjectKey;
 
 async fn health_check() -> StatusCode {
     StatusCode::OK

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -30,6 +30,7 @@ use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 pub use write_store::WriteStore;
+use crate::messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint, VerifiedCheckpointContents};
 
 /// A potential input to a transaction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -514,4 +515,16 @@ pub trait GetSharedLocks: Send + Sync {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError>;
+}
+
+pub trait CheckpointHandler {
+    fn handle_checkpoint(&mut self, verified_checkpoint: VerifiedCheckpoint, verified_checkpoint_contents: VerifiedCheckpointContents) -> Result<(), SuiError>;
+}
+
+pub struct NoOpCheckpointHandler;
+
+impl CheckpointHandler for NoOpCheckpointHandler {
+    fn handle_checkpoint(&mut self, _verified_checkpoint: VerifiedCheckpoint, _verified_checkpoint_contents: VerifiedCheckpointContents) -> Result<(), SuiError> {
+        Ok(())
+    }
 }

--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -17,6 +17,7 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use tap::Pipe;
 use tracing::error;
+use crate::full_checkpoint_content::CheckpointData;
 
 #[derive(Clone, Debug, Default)]
 pub struct SharedInMemoryStore(Arc<std::sync::RwLock<InMemoryStore>>);


### PR DESCRIPTION
## Description 

The clustering of transaction table is currently inefficient as it is based on `epoch, checkpoint_seq_num, tx_digest` which leads to extra scan as most of our queries are based on digest almost always.

## Test Plan 

Existing tables are found doing a lot of scans, fixing it helped reduce it by a large margin