### PR TITLE
Fix clustering of transaction table

### DIFF
--- a/crates/sui-analytics-indexer/src/store/bq/schemas/transaction.sql
+++ b/crates/sui-analytics-indexer/src/store/bq/schemas/transaction.sql
@@ -42,4 +42,4 @@ CREATE TABLE IF NOT EXISTS chaindata.TRANSACTION
     effects_json               JSON
 )
 PARTITION BY RANGE_BUCKET(epoch, GENERATE_ARRAY(0, 100000, 10))
-CLUSTER BY epoch, checkpoint, transaction_digest
+CLUSTER BY transaction_digest


### PR DESCRIPTION
## Description 

Fix clustering of transaction table as most of the queries don't query by epoch and checkpoint which leads to inefficient scans.
## Test Plan 

Changing clustering reduced bytes scanned and billing
