### PR TITLE
[cli][easy] Change log level to error for all commands

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -58,16 +58,19 @@ async fn main() {
         } => {
             if gas_info {
                 telemetry_subscribers::TelemetryConfig::new()
+                    .with_log_level("error")
                     .with_trace_target("replay")
                     .with_env()
                     .init()
             } else {
                 telemetry_subscribers::TelemetryConfig::new()
+                    .with_log_level("error")
                     .with_env()
                     .init()
             }
         }
         _ => telemetry_subscribers::TelemetryConfig::new()
+            .with_log_level("error")
             .with_env()
             .init(),
     };


### PR DESCRIPTION
## Description 

Change log level to error for all the CLI commands to avoid the output like this
<img width="1556" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/57652237-f1a9-42d0-a09c-ac14729ce05f">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
