### PR TITLE
[transactional-test-runner][gql][easy] extend InitCommand to set env vars

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -230,6 +230,7 @@ impl Cluster for LocalNewCluster {
                     fullnode_url.clone(),
                     None,
                     options.use_indexer_experimental_methods,
+                    None,
                 )
                 .await;
 
@@ -239,6 +240,7 @@ impl Cluster for LocalNewCluster {
                     fullnode_url.clone(),
                     Some(indexer_address.to_string()),
                     options.use_indexer_experimental_methods,
+                    None,
                 )
                 .await;
             } else {

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -309,8 +309,8 @@ pub mod tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
     use simulacrum::Simulacrum;
-    use std::sync::Arc;
     use std::time::Duration;
+    use std::{collections::BTreeMap, sync::Arc};
 
     async fn prep_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
@@ -326,6 +326,7 @@ pub mod tests {
                 connection_config,
                 DEFAULT_INTERNAL_DATA_SOURCE_PORT,
                 Arc::new(sim),
+                BTreeMap::new(),
             )
             .await,
         )

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -309,8 +309,8 @@ pub mod tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
     use simulacrum::Simulacrum;
+    use std::sync::Arc;
     use std::time::Duration;
-    use std::{collections::BTreeMap, sync::Arc};
 
     async fn prep_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
@@ -326,7 +326,7 @@ pub mod tests {
                 connection_config,
                 DEFAULT_INTERNAL_DATA_SOURCE_PORT,
                 Arc::new(sim),
-                BTreeMap::new(),
+                None,
             )
             .await,
         )

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -80,7 +80,7 @@ pub async fn start_cluster(
     }
 }
 
-// TODO (wlmyng) what's the diff between this and start_cluster? This yields an executor to do e2e tests, start_cluster only creates
+/// Spins up a cluster and executor, typically for tests that require simulating transaction executions.
 pub async fn serve_executor(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: u16,
@@ -100,8 +100,6 @@ pub async fn serve_executor(
     let executor_server_handle = tokio::spawn(async move {
         sui_rest_api::start_service(executor_server_url, executor, Some("/rest".to_owned())).await;
     });
-
-    // set the env variables
 
     let (pg_store, pg_handle) = start_test_indexer_v2(
         Some(db_url),

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -6,7 +6,6 @@ use crate::config::Limits;
 use crate::config::ServerConfig;
 use crate::config::ServiceConfig;
 use crate::server::graphiql_server::start_graphiql_server;
-use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,7 +47,7 @@ pub struct Cluster {
 pub async fn start_cluster(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: Option<u16>,
-    store_config: PgIndexerStoreV2Config,
+    store_config: Option<PgIndexerStoreV2Config>,
 ) -> Cluster {
     let db_url = graphql_connection_config.db_url.clone();
     // Starts validator+fullnode
@@ -92,13 +91,8 @@ pub async fn serve_executor(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: u16,
     executor: Arc<dyn NodeStateGetter>,
-    env_vars: BTreeMap<String, String>,
-    store_config: PgIndexerStoreV2Config,
+    store_config: Option<PgIndexerStoreV2Config>,
 ) -> ExecutorCluster {
-    for (k, v) in env_vars {
-        std::env::set_var(k, v);
-    }
-
     let db_url = graphql_connection_config.db_url.clone();
 
     let executor_server_url: SocketAddr = format!("127.0.0.1:{}", internal_data_source_rpc_port)

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -14,7 +14,6 @@ mod tests {
     use sui_graphql_rpc::client::ClientError;
     use sui_graphql_rpc::config::ConnectionConfig;
     use sui_graphql_rpc::test_infra::cluster::DEFAULT_INTERNAL_DATA_SOURCE_PORT;
-    use sui_indexer::store::PgIndexerStoreV2Config;
     use sui_types::digests::ChainIdentifier;
     use sui_types::DEEPBOOK_ADDRESS;
     use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -85,7 +84,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
-            PgIndexerStoreV2Config::default(),
+            None,
         )
         .await;
 
@@ -117,7 +116,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
-            PgIndexerStoreV2Config::default(),
+            None,
         )
         .await;
 
@@ -159,7 +158,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
-            PgIndexerStoreV2Config::default(),
+            None,
         )
         .await;
 

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -14,6 +14,7 @@ mod tests {
     use sui_graphql_rpc::client::ClientError;
     use sui_graphql_rpc::config::ConnectionConfig;
     use sui_graphql_rpc::test_infra::cluster::DEFAULT_INTERNAL_DATA_SOURCE_PORT;
+    use sui_indexer::store::PgIndexerStoreV2Config;
     use sui_types::digests::ChainIdentifier;
     use sui_types::DEEPBOOK_ADDRESS;
     use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -84,6 +85,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            PgIndexerStoreV2Config::default(),
         )
         .await;
 
@@ -115,6 +117,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            PgIndexerStoreV2Config::default(),
         )
         .await;
 
@@ -156,6 +159,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            PgIndexerStoreV2Config::default(),
         )
         .await;
 

--- a/crates/sui-indexer/src/main.rs
+++ b/crates/sui-indexer/src/main.rs
@@ -8,9 +8,7 @@ use sui_indexer::errors::IndexerError;
 use sui_indexer::indexer_v2::IndexerV2;
 use sui_indexer::metrics::IndexerMetrics;
 use sui_indexer::start_prometheus_server;
-use sui_indexer::store::PgIndexerAnalyticalStore;
-use sui_indexer::store::PgIndexerStore;
-use sui_indexer::store::PgIndexerStoreV2;
+use sui_indexer::store::{PgIndexerAnalyticalStore, PgIndexerStore, PgIndexerStoreV2};
 use sui_indexer::utils::reset_database;
 use sui_indexer::{get_pg_pool_connection, new_pg_connection_pool, Indexer, IndexerConfig};
 

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -6,7 +6,7 @@ pub use indexer_store::*;
 pub(crate) use indexer_store_v2::*;
 pub use pg_indexer_analytical_store::PgIndexerAnalyticalStore;
 pub use pg_indexer_store::PgIndexerStore;
-pub use pg_indexer_store_v2::PgIndexerStoreV2;
+pub use pg_indexer_store_v2::{PgIndexerStoreV2, PgIndexerStoreV2Config};
 
 mod indexer_analytical_store;
 mod indexer_store;

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -23,7 +23,7 @@ pub async fn start_test_indexer_v2(
     rpc_url: String,
     reader_mode_rpc_url: Option<String>,
     use_indexer_experimental_methods: bool,
-    store_config: PgIndexerStoreV2Config,
+    store_config: Option<PgIndexerStoreV2Config>,
 ) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
@@ -42,6 +42,8 @@ pub async fn start_test_indexer_v2(
     } else {
         vec![]
     };
+
+    let store_config = store_config.unwrap_or_else(|| PgIndexerStoreV2Config::default());
 
     // Default writer mode
     let mut config = IndexerConfig {

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use crate::errors::IndexerError;
 use crate::indexer_v2::IndexerV2;
-use crate::store::{PgIndexerStore, PgIndexerStoreV2};
+use crate::store::{PgIndexerStore, PgIndexerStoreV2, PgIndexerStoreV2Config};
 use crate::utils::reset_database;
 use crate::{new_pg_connection_pool, Indexer, IndexerConfig};
 use crate::{new_pg_connection_pool_impl, IndexerMetrics};
@@ -23,6 +23,7 @@ pub async fn start_test_indexer_v2(
     rpc_url: String,
     reader_mode_rpc_url: Option<String>,
     use_indexer_experimental_methods: bool,
+    store_config: PgIndexerStoreV2Config,
 ) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
@@ -76,7 +77,8 @@ pub async fn start_test_indexer_v2(
 
     let indexer_metrics = IndexerMetrics::new(&registry);
 
-    let store = PgIndexerStoreV2::new(blocking_pool, indexer_metrics.clone());
+    let store =
+        PgIndexerStoreV2::new_with_config(blocking_pool, indexer_metrics.clone(), store_config);
     let store_clone = store.clone();
     let handle = if reader_mode_rpc_url.is_some() {
         tokio::spawn(async move { IndexerV2::start_reader(&config, &registry, db_url).await })

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -60,6 +60,8 @@ pub struct SuiInitArgs {
     pub reference_gas_price: Option<u64>,
     #[clap(long = "default-gas-price")]
     pub default_gas_price: Option<u64>,
+    #[clap(long = "env-vars", num_args(1..))]
+    pub env_vars: Option<Vec<String>>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -60,8 +60,6 @@ pub struct SuiInitArgs {
     pub reference_gas_price: Option<u64>,
     #[clap(long = "default-gas-price")]
     pub default_gas_price: Option<u64>,
-    #[clap(long = "env-vars", num_args(1..))]
-    pub env_vars: Option<Vec<String>>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -204,7 +204,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             custom_validator_account,
             reference_gas_price,
             default_gas_price,
-            env_vars,
         ) = match task_opt.map(|t| t.command) {
             Some((
                 InitCommand { named_addresses },
@@ -217,7 +216,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     custom_validator_account,
                     reference_gas_price,
                     default_gas_price,
-                    env_vars,
                 },
             )) => {
                 let map = verify_and_create_named_address_mapping(named_addresses).unwrap();
@@ -245,19 +243,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 if reference_gas_price.is_some() && !simulator {
                     panic!("Can only set reference gas price in simulator mode");
                 }
-
-                let mut env_vars_map = BTreeMap::new();
-
-                if let Some(env_vars) = env_vars {
-                    for kv in env_vars {
-                        let parts: Vec<&str> = kv.splitn(2, '=').collect();
-                        if parts.len() == 2 {
-                            env_vars_map.insert(parts[0].to_string(), parts[1].to_string());
-                        } else {
-                            panic!("Invalid key-value pair: {}", kv);
-                        }
-                    }
-                }
                 (
                     map,
                     accounts,
@@ -266,7 +251,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     custom_validator_account,
                     reference_gas_price,
                     default_gas_price,
-                    env_vars_map,
                 )
             }
             None => {
@@ -279,7 +263,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     false,
                     None,
                     None,
-                    BTreeMap::new(),
                 )
             }
         };
@@ -302,7 +285,6 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 &protocol_config,
                 custom_validator_account,
                 reference_gas_price,
-                env_vars,
             )
             .await
         } else {
@@ -1825,7 +1807,6 @@ async fn init_sim_executor(
     protocol_config: &ProtocolConfig,
     custom_validator_account: bool,
     reference_gas_price: Option<u64>,
-    env_vars: BTreeMap<String, String>,
 ) -> (
     Box<dyn TransactionalAdapter>,
     AccountSetup,
@@ -1895,7 +1876,7 @@ async fn init_sim_executor(
         ConnectionConfig::ci_integration_test_cfg(),
         DEFAULT_INTERNAL_DATA_SOURCE_PORT,
         Arc::new(read_replica),
-        env_vars,
+        None,
     )
     .await;
 


### PR DESCRIPTION
## Description 

To enable testing the objects_snapshot and objects_history behavior w.r.t the graphql-rpc + indexer setup, I'd like to extend InitCommand to also set env vars before spinning up the cluster.

## Test Plan 

existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
