### PR TITLE
[data ingestion] remote reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11604,6 +11604,7 @@ dependencies = [
  "futures",
  "mysten-metrics",
  "notify",
+ "object_store",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -11615,6 +11616,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
  "workspace-hack",
 ]
 

--- a/crates/sui-data-ingestion/Cargo.toml
+++ b/crates/sui-data-ingestion/Cargo.toml
@@ -18,6 +18,7 @@ bcs.workspace = true
 futures.workspace = true
 mysten-metrics.workspace = true
 notify.workspace = true
+object_store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
@@ -27,6 +28,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
+url.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-data-ingestion/src/executor.rs
+++ b/crates/sui-data-ingestion/src/executor.rs
@@ -58,11 +58,18 @@ impl<P: ProgressStore> IndexerExecutor<P> {
     pub async fn run(
         mut self,
         path: PathBuf,
+        remote_store_url: Option<String>,
+        remote_store_options: Vec<(String, String)>,
         mut exit_receiver: oneshot::Receiver<()>,
     ) -> Result<ExecutorProgress> {
         let mut reader_checkpoint_number = self.progress_store.min_watermark()?;
         let (checkpoint_reader, mut checkpoint_recv, gc_sender, _exit_sender) =
-            CheckpointReader::initialize(path, reader_checkpoint_number);
+            CheckpointReader::initialize(
+                path,
+                reader_checkpoint_number,
+                remote_store_url,
+                remote_store_options,
+            );
         spawn_monitored_task!(checkpoint_reader.run());
 
         for pool in std::mem::take(&mut self.pools) {

--- a/crates/sui-data-ingestion/src/main.rs
+++ b/crates/sui-data-ingestion/src/main.rs
@@ -42,6 +42,10 @@ struct IndexerConfig {
     path: PathBuf,
     tasks: Vec<TaskConfig>,
     progress_store: ProgressStoreConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_store_url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    remote_store_options: Vec<(String, String)>,
     #[serde(default = "default_metrics_host")]
     metrics_host: String,
     #[serde(default = "default_metrics_port")]
@@ -116,6 +120,13 @@ async fn main() -> Result<()> {
             }
         };
     }
-    executor.run(config.path, exit_receiver).await?;
+    executor
+        .run(
+            config.path,
+            config.remote_store_url,
+            config.remote_store_options,
+            exit_receiver,
+        )
+        .await?;
     Ok(())
 }

--- a/crates/sui-data-ingestion/src/tests.rs
+++ b/crates/sui-data-ingestion/src/tests.rs
@@ -42,10 +42,16 @@ async fn run(
     std::env::set_var(ENV_VAR_LOCAL_READ_TIMEOUT_MS, "10");
     let (sender, recv) = oneshot::channel();
     let result = match duration {
-        None => indexer.run(path.unwrap_or_else(temp_dir), recv).await,
+        None => {
+            indexer
+                .run(path.unwrap_or_else(temp_dir), None, vec![], recv)
+                .await
+        }
         Some(duration) => {
             let handle = tokio::task::spawn(async move {
-                indexer.run(path.unwrap_or_else(temp_dir), recv).await
+                indexer
+                    .run(path.unwrap_or_else(temp_dir), None, vec![], recv)
+                    .await
             });
             tokio::time::sleep(duration).await;
             drop(sender);


### PR DESCRIPTION
Adds the functionality of falling back to the remote store/bucket if data is not present in the local directory for the data ingestion daemon.
Example of a possible configuration:
```
path: checkpoints
remote_store_url: https://s3.us-west-2.amazonaws.com/mysten-mainnet-checkpoints
remote_store_options:
    - ["aws_access_key_id", "..."]
    - ["aws_secret_access_key", "..."]
....
```