### PR TITLE
[gql] objects_snapshot test for availableRange-aware object history lookup

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -9,7 +9,7 @@ use sui_config::Config;
 use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG};
 use sui_graphql_rpc::config::ConnectionConfig;
 use sui_graphql_rpc::test_infra::cluster::start_graphql_server;
-use sui_indexer::test_utils::{start_test_indexer, start_test_indexer_v2};
+use sui_indexer::test_utils::{start_test_indexer, start_test_indexer_v2, ReaderWriterConfig};
 use sui_indexer::IndexerConfig;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
@@ -228,8 +228,8 @@ impl Cluster for LocalNewCluster {
                 start_test_indexer_v2(
                     Some(pg_address.clone()),
                     fullnode_url.clone(),
-                    None,
                     options.use_indexer_experimental_methods,
+                    ReaderWriterConfig::writer_mode(None),
                 )
                 .await;
 
@@ -237,8 +237,8 @@ impl Cluster for LocalNewCluster {
                 start_test_indexer_v2(
                     Some(pg_address),
                     fullnode_url.clone(),
-                    Some(indexer_address.to_string()),
                     options.use_indexer_experimental_methods,
+                    ReaderWriterConfig::reader_mode(indexer_address.to_string()),
                 )
                 .await;
             } else {

--- a/crates/sui-graphql-e2e-tests/tests/objects/snapshot.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/snapshot.exp
@@ -1,0 +1,96 @@
+processed 17 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 11-37:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6171200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 39-39:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'create-checkpoint'. lines 41-41:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 43-56:
+Response: {
+  "data": {
+    "object": {
+      "status": "LIVE",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0xcf27391f83c42a323595be23151f6ede95a083f451a388ff2e3e25fbbf31a7c3",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 5 'run-graphql'. lines 59-73:
+Response: {
+  "data": {
+    "object": {
+      "status": "HISTORICAL",
+      "version": 3,
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0xcf27391f83c42a323595be23151f6ede95a083f451a388ff2e3e25fbbf31a7c3",
+            "value": "0"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 6 'run'. lines 75-75:
+created: object(6,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2553600,  storage_rebate: 1301652, non_refundable_storage_fee: 13148
+
+task 7 'create-checkpoint'. lines 77-77:
+Checkpoint created: 2
+
+task 9 'create-checkpoint'. lines 81-81:
+Checkpoint created: 3
+
+task 11 'create-checkpoint'. lines 85-85:
+Checkpoint created: 4
+
+task 13 'create-checkpoint'. lines 89-89:
+Checkpoint created: 5
+
+task 14 'run-graphql'. lines 91-105:
+Response: {
+  "data": {
+    "object": null
+  }
+}
+
+task 15 'run-graphql'. lines 108-123:
+Response: {
+  "data": {
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 4,
+      "asMoveObject": null
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 125-140:
+Response: {
+  "data": {
+    "object": null
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/snapshot.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/snapshot.move
@@ -1,0 +1,140 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Objects can continue to be found on the live objects table until they are WrappedOrDeleted. From
+// there, the object can be fetched on the objects_history table, until it gets snapshotted into
+// objects_snapshot table. This test checks that we correctly fetch data from both the
+// objects_snapshot and objects_history tables.
+
+//# init --addresses Test=0x0 --accounts A --simulator --object-snapshot-min-checkpoint-lag 0 --object-snapshot-max-checkpoint-lag 2
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        o: Object
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun wrap(o: Object, ctx: &mut TxContext) {
+        transfer::transfer(Wrapper { id: object::new(ctx), o }, tx_context::sender(ctx))
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# create-checkpoint 1
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 3
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run Test::M1::wrap --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# run-graphql
+# should not exist on live objects
+{
+  object(
+    address: "@{obj_2_0}"
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+
+//# run-graphql
+# fetched from objects_snapshot
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 4
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}
+
+//# run-graphql
+# should not exist in either objects_snapshot or objects_history
+{
+  object(
+    address: "@{obj_2_0}"
+    version: 3
+  ) {
+    status
+    version
+    asMoveObject {
+      contents {
+        json
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -326,6 +326,7 @@ pub mod tests {
                 connection_config,
                 DEFAULT_INTERNAL_DATA_SOURCE_PORT,
                 Arc::new(sim),
+                None,
             )
             .await,
         )

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -84,6 +84,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
         )
         .await;
 
@@ -115,6 +116,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
         )
         .await;
 
@@ -156,6 +158,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
         )
         .await;
 

--- a/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/sui-graphql-rpc/tests/examples_validation_tests.rs
@@ -113,6 +113,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
         )
         .await;
 
@@ -177,6 +178,7 @@ mod tests {
             connection_config,
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
         )
         .await;
 

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -13,16 +13,36 @@ use tracing::info;
 
 use crate::errors::IndexerError;
 use crate::indexer_v2::IndexerV2;
+use crate::processors_v2::objects_snapshot_processor::SnapshotLagConfig;
 use crate::store::{PgIndexerStore, PgIndexerStoreV2};
 use crate::utils::reset_database;
 use crate::{new_pg_connection_pool, Indexer, IndexerConfig};
 use crate::{new_pg_connection_pool_impl, IndexerMetrics};
 
+pub enum ReaderWriterConfig {
+    Reader { reader_mode_rpc_url: String },
+    Writer { snapshot_config: SnapshotLagConfig },
+}
+
+impl ReaderWriterConfig {
+    pub fn reader_mode(reader_mode_rpc_url: String) -> Self {
+        Self::Reader {
+            reader_mode_rpc_url,
+        }
+    }
+
+    pub fn writer_mode(snapshot_config: Option<SnapshotLagConfig>) -> Self {
+        Self::Writer {
+            snapshot_config: snapshot_config.unwrap_or_default(),
+        }
+    }
+}
+
 pub async fn start_test_indexer_v2(
     db_url: Option<String>,
     rpc_url: String,
-    reader_mode_rpc_url: Option<String>,
     use_indexer_experimental_methods: bool,
+    reader_writer_config: ReaderWriterConfig,
 ) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
@@ -54,36 +74,46 @@ pub async fn start_test_indexer_v2(
         ..Default::default()
     };
 
-    if let Some(reader_mode_rpc_url) = &reader_mode_rpc_url {
-        let reader_mode_rpc_url = reader_mode_rpc_url
-            .parse::<SocketAddr>()
-            .expect("Unable to parse fullnode address");
-        config.fullnode_sync_worker = false;
-        config.rpc_server_worker = true;
-        config.rpc_server_url = reader_mode_rpc_url.ip().to_string();
-        config.rpc_server_port = reader_mode_rpc_url.port();
-    }
-
-    let parsed_url = config.get_db_url().unwrap();
-    let blocking_pool = new_pg_connection_pool_impl(&parsed_url, Some(5)).unwrap();
-    if config.reset_db && reader_mode_rpc_url.is_none() {
-        reset_database(&mut blocking_pool.get().unwrap(), true, config.use_v2).unwrap();
-    }
-
     let registry = prometheus::Registry::default();
 
     init_metrics(&registry);
 
     let indexer_metrics = IndexerMetrics::new(&registry);
 
-    let store = PgIndexerStoreV2::new(blocking_pool, indexer_metrics.clone());
-    let store_clone = store.clone();
-    let handle = if reader_mode_rpc_url.is_some() {
-        tokio::spawn(async move { IndexerV2::start_reader(&config, &registry, db_url).await })
-    } else {
-        tokio::spawn(
-            async move { IndexerV2::start_writer(&config, store_clone, indexer_metrics).await },
-        )
+    let parsed_url = config.get_db_url().unwrap();
+    let blocking_pool = new_pg_connection_pool_impl(&parsed_url, Some(5)).unwrap();
+    let store = PgIndexerStoreV2::new(blocking_pool.clone(), indexer_metrics.clone());
+
+    let handle = match reader_writer_config {
+        ReaderWriterConfig::Reader {
+            reader_mode_rpc_url,
+        } => {
+            let reader_mode_rpc_url = reader_mode_rpc_url
+                .parse::<SocketAddr>()
+                .expect("Unable to parse fullnode address");
+            config.fullnode_sync_worker = false;
+            config.rpc_server_worker = true;
+            config.rpc_server_url = reader_mode_rpc_url.ip().to_string();
+            config.rpc_server_port = reader_mode_rpc_url.port();
+
+            tokio::spawn(async move { IndexerV2::start_reader(&config, &registry, db_url).await })
+        }
+        ReaderWriterConfig::Writer { snapshot_config } => {
+            if config.reset_db {
+                reset_database(&mut blocking_pool.get().unwrap(), true, config.use_v2).unwrap();
+            }
+            let store_clone = store.clone();
+
+            tokio::spawn(async move {
+                IndexerV2::start_writer_with_config(
+                    &config,
+                    store_clone,
+                    indexer_metrics,
+                    snapshot_config,
+                )
+                .await
+            })
+        }
     };
 
     (store, handle)

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -15,7 +15,7 @@ mod ingestion_tests {
     use sui_indexer::models_v2::transactions::StoredTransaction;
     use sui_indexer::schema_v2::transactions;
     use sui_indexer::store::{indexer_store_v2::IndexerStoreV2, PgIndexerStoreV2};
-    use sui_indexer::test_utils::start_test_indexer_v2;
+    use sui_indexer::test_utils::{start_test_indexer_v2, ReaderWriterConfig};
     use sui_types::base_types::SuiAddress;
     use sui_types::effects::TransactionEffectsAPI;
     use tokio::task::JoinHandle;
@@ -53,8 +53,8 @@ mod ingestion_tests {
         let (pg_store, pg_handle) = start_test_indexer_v2(
             Some(DEFAULT_DB_URL.to_owned()),
             format!("http://{}", server_url),
-            None,
             true,
+            ReaderWriterConfig::writer_mode(None),
         )
         .await;
         (server_handle, pg_store, pg_handle)

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -60,6 +60,10 @@ pub struct SuiInitArgs {
     pub reference_gas_price: Option<u64>,
     #[clap(long = "default-gas-price")]
     pub default_gas_price: Option<u64>,
+    #[clap(long = "object-snapshot-min-checkpoint-lag")]
+    pub object_snapshot_min_checkpoint_lag: Option<usize>,
+    #[clap(long = "object-snapshot-max-checkpoint-lag")]
+    pub object_snapshot_max_checkpoint_lag: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
## Description 

Expose a way to provide config values to ObjectsSnapshotProcessor to enable e2e tests around objects_snapshot. 
1. Adds a SnapshotLagConfig to ObjectsSnapshotProcessor struct
2. ReaderWriterConfig for start_test_indexer_v2, reorganizes some logic on instantiating a reader or writer indexer_v2
3. RunGraphqlCommand now waits for objects_snapshot catch up in addition to the existing checkpoint catch up.

snapshot.move to test querying against objects_snapshot and objects_history tables

## Test Plan 

snapshot.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
