### PR TITLE
add more optional args to dev inspect on fullnode

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -54,7 +54,7 @@ pub use authority_store::{AuthorityStore, ResolverWrapper, UpdateType};
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 
 use once_cell::sync::OnceCell;
-use shared_crypto::intent::{Intent, IntentScope};
+use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::certificate_deny_config::CertificateDenyConfig;
 use sui_config::genesis::Genesis;
@@ -64,8 +64,8 @@ use sui_config::node::{
 use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_framework::{BuiltInFramework, SystemPackage};
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent, SuiMoveValue,
-    SuiObjectDataFilter, SuiTransactionBlockData, SuiTransactionBlockEffects,
+    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
+    SuiMoveValue, SuiObjectDataFilter, SuiTransactionBlockData, SuiTransactionBlockEffects,
     SuiTransactionBlockEvents, TransactionFilter,
 };
 use sui_macros::{fail_point, fail_point_async, fail_point_if};
@@ -90,8 +90,7 @@ use sui_types::event::{Event, EventID};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::inner_temporary_store::{
-    InnerTemporaryStore, ObjectMap, TemporaryModuleResolver, TemporaryPackageStore, TxCoins,
-    WrittenObjects,
+    InnerTemporaryStore, ObjectMap, TemporaryPackageStore, TxCoins, WrittenObjects,
 };
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
@@ -106,8 +105,8 @@ use sui_types::messages_grpc::{
     ObjectInfoResponse, TransactionInfoRequest, TransactionInfoResponse, TransactionStatus,
 };
 use sui_types::metrics::{BytecodeVerifierMetrics, LimitsMetrics};
-use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
 use sui_types::storage::{GetSharedLocks, ObjectKey, ObjectOrTombstone, ObjectStore, WriteKind};
+use sui_types::object::{Owner, PastObjectRead};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState};
@@ -270,6 +269,8 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 20.,
     30., 60., 90.,
 ];
+
+pub const DEV_INSPECT_GAS_COIN_VALUE: u64 = 1_000_000_000_000;
 
 impl AuthorityMetrics {
     pub fn new(registry: &prometheus::Registry) -> AuthorityMetrics {
@@ -1413,82 +1414,210 @@ impl AuthorityState {
     pub async fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
-        transaction_digest: TransactionDigest,
+        _transaction_digest: TransactionDigest,
     ) -> SuiResult<(
         DryRunTransactionBlockResponse,
         BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
         TransactionEffects,
         Option<ObjectID>,
     )> {
+        let (effects, results, written_objects, mock_gas) = self
+            .dev_inspect_transaction_impl(
+                DevInspectArgs::TransactionData(transaction.clone()),
+                /* skip_checks */ false,
+            )
+            .await?;
+
         let epoch_store = self.load_epoch_store_one_call_per_task();
+
+        // Returning empty vector here because we recalculate changes in the rpc layer.
+        let object_changes = Vec::new();
+
+        // Returning empty vector here because we recalculate changes in the rpc layer.
+        let balance_changes = Vec::new();
+
+        Ok((
+            DryRunTransactionBlockResponse {
+                // Using the module cache is fine because it is only used for resolving input object types, which are
+                // guaranteed to be in the module cache.
+                input: SuiTransactionBlockData::try_from(transaction, epoch_store.module_cache())
+                    .map_err(|e| SuiError::TransactionSerializationError {
+                    error: format!(
+                        "Failed to convert transaction to SuiTransactionBlockData: {}",
+                        e
+                    ),
+                })?, // TODO: replace the underlying try_from to SuiError. This one goes deep
+                effects: effects.clone().try_into()?,
+                events: results.events,
+                object_changes,
+                balance_changes,
+            },
+            written_objects,
+            effects,
+            mock_gas,
+        ))
+    }
+
+    /// The object ID for gas can be any object ID, even for an uncreated object
+    pub async fn dev_inspect_transaction_block(
+        &self,
+        sender: SuiAddress,
+        transaction_kind: TransactionKind,
+        gas_price: Option<u64>,
+    ) -> SuiResult<DevInspectResults> {
+        let (_, results, _, _) = self
+            .dev_inspect_transaction_impl(
+                DevInspectArgs::TransactionKindWithMeta {
+                    sender,
+                    kind: transaction_kind,
+                    gas_price,
+                    gas_sponsor: None,
+                    gas_objects: None,
+                    gas_budget: None,
+                    epoch: None,
+                },
+                /* skip_checks */ true,
+            )
+            .await?;
+        Ok(results)
+    }
+
+    #[allow(clippy::collapsible_else_if)]
+    pub async fn dev_inspect_transaction_impl(
+        &self,
+        txn_args: DevInspectArgs,
+        skip_checks: bool,
+    ) -> SuiResult<(
+        TransactionEffects,
+        DevInspectResults,
+        BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
+        Option<ObjectID>,
+    )> {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+        let reference_gas_price = epoch_store.reference_gas_price();
+
         if !self.is_fullnode(&epoch_store) {
             return Err(SuiError::UnsupportedFeatureError {
-                error: "dry-exec is only supported on fullnodes".to_string(),
+                error: "dev-inspect is only supported on fullnodes".to_string(),
             });
         }
+
+        let protocol_config = epoch_store.protocol_config();
+        let max_tx_gas = protocol_config.max_tx_gas();
+
+        // Create transaction data if it's not directly provided.
+        let transaction = match txn_args {
+            DevInspectArgs::TransactionData(data) => data,
+            DevInspectArgs::TransactionKindWithMeta {
+                kind,
+                sender,
+                gas_price,
+                gas_budget,
+                epoch,
+                gas_sponsor,
+                gas_objects,
+            } => {
+                let gas_price = gas_price.unwrap_or(reference_gas_price);
+                let gas_budget = gas_budget.unwrap_or(max_tx_gas);
+                let owner = gas_sponsor.unwrap_or(sender);
+                // Payment might be empty here, but it's fine we'll have to deal with it later after reading all the input objects.
+                let payment = gas_objects.unwrap_or_default();
+                let expiration = match epoch {
+                    None => TransactionExpiration::None,
+                    Some(epoch) => TransactionExpiration::Epoch(epoch),
+                };
+                TransactionData::V1(TransactionDataV1 {
+                    kind,
+                    sender,
+                    gas_data: GasData {
+                        payment,
+                        owner,
+                        price: gas_price,
+                        budget: gas_budget,
+                    },
+                    expiration,
+                })
+            }
+        };
+
+        transaction.check_version_supported(protocol_config)?;
+        transaction.validity_check_no_gas_check(protocol_config)?;
 
         if transaction.kind().is_system_tx() {
             return Err(SuiError::UnsupportedFeatureError {
-                error: "dry-exec does not support system transactions".to_string(),
+                error: "system transactions are not supported".to_string(),
             });
         }
-
-        // Cheap validity checks for a transaction, including input size limits.
-        transaction.check_version_supported(epoch_store.protocol_config())?;
-        transaction.validity_check_no_gas_check(epoch_store.protocol_config())?;
 
         let input_object_kinds = transaction.input_objects()?;
         let receiving_object_refs = transaction.receiving_objects();
 
-        sui_transaction_checks::deny::check_transaction_for_signing(
-            &transaction,
-            &[],
-            &input_object_kinds,
-            &receiving_object_refs,
-            &self.transaction_deny_config,
-            &self.database,
-        )?;
-
-        let (input_objects, receiving_objects) = self
-            .input_loader
-            .read_objects_for_dry_run_exec(
-                &transaction_digest,
+        if !skip_checks {
+            sui_transaction_checks::deny::check_transaction_for_signing(
+                &transaction,
+                &[],
                 &input_object_kinds,
                 &receiving_object_refs,
-                epoch_store.protocol_config(),
+                &self.transaction_deny_config,
+                &self.database,
+            )?;
+        }
+
+        let (mut input_objects, receiving_objects) = self
+            .input_loader
+            .read_objects_for_dev_inspect(
+                &input_object_kinds,
+                &receiving_object_refs,
+                protocol_config,
             )
             .await?;
 
-        // make a gas object if one was not provided
-        let mut gas_object_refs = transaction.gas().to_vec();
-        let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
-            let sender = transaction.sender();
-            // use a 1B sui coin
-            const MIST_TO_SUI: u64 = 1_000_000_000;
-            const DRY_RUN_SUI: u64 = 1_000_000_000;
-            let max_coin_value = MIST_TO_SUI * DRY_RUN_SUI;
-            let gas_object_id = ObjectID::random();
-            let gas_object = Object::new_move(
-                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_coin_value),
-                Owner::AddressOwner(sender),
-                TransactionDigest::genesis_marker(),
-            );
-            let gas_object_ref = gas_object.compute_object_reference();
-            gas_object_refs = vec![gas_object_ref];
-            (
+        // Create and use a dummy gas object if there is no gas object provided.
+        let dummy_gas_object = Object::new_gas_with_balance_and_owner_for_testing(
+            DEV_INSPECT_GAS_COIN_VALUE,
+            transaction.gas_owner(),
+        );
+
+        let (mock_gas, gas_objects) = if transaction.gas().is_empty() {
+            let gas_object_ref = dummy_gas_object.compute_object_reference();
+            (Some(gas_object_ref.0), vec![gas_object_ref])
+        } else {
+            (None, transaction.gas().to_vec())
+        };
+
+        let (gas_status, checked_input_objects) = if skip_checks {
+            if transaction.gas().is_empty() {
+                input_objects.push(ObjectReadResult::new(
+                    InputObjectKind::ImmOrOwnedMoveObject(gas_objects[0]),
+                    dummy_gas_object.into(),
+                ));
+            }
+            let checked_input_objects = sui_transaction_checks::check_dev_inspect_input(
+                protocol_config,
+                transaction.kind(),
+                input_objects,
+                receiving_objects,
+            )?;
+            let gas_status = SuiGasStatus::new(
+                max_tx_gas,
+                transaction.gas_price(),
+                reference_gas_price,
+                protocol_config,
+            )?;
+
+            (gas_status, checked_input_objects)
+        } else {
+            if transaction.gas().is_empty() {
                 sui_transaction_checks::check_transaction_input_with_given_gas(
                     epoch_store.protocol_config(),
                     epoch_store.reference_gas_price(),
                     &transaction,
                     input_objects,
                     receiving_objects,
-                    gas_object,
+                    dummy_gas_object,
                     &self.metrics.bytecode_verifier_metrics,
-                )?,
-                Some(gas_object_id),
-            )
-        } else {
-            (
+                )?
+            } else {
                 sui_transaction_checks::check_transaction_input(
                     epoch_store.protocol_config(),
                     epoch_store.reference_gas_price(),
@@ -1496,57 +1625,49 @@ impl AuthorityState {
                     input_objects,
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
-                )?,
-                None,
-            )
+                )?
+            }
         };
 
-        let protocol_config = epoch_store.protocol_config();
-        let (kind, signer, _) = transaction.execution_parts();
-
-        let silent = true;
-        let executor = sui_execution::executor(protocol_config, silent)
+        let (transaction_kind, signer, _) = transaction.execution_parts();
+        let executor = sui_execution::executor(protocol_config, /* silent */ true)
             .expect("Creating an executor should not fail here");
-
-        let expensive_checks = false;
-        let (inner_temp_store, effects, _execution_error) = executor
-            .execute_transaction_to_effects(
-                &self.database,
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                expensive_checks,
-                self.certificate_deny_config.certificate_deny_set(),
-                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-                epoch_store
-                    .epoch_start_config()
-                    .epoch_data()
-                    .epoch_start_timestamp(),
-                checked_input_objects,
-                gas_object_refs,
-                gas_status,
-                kind,
-                signer,
-                transaction_digest,
-            );
-        let tx_digest = *effects.transaction_digest();
-
-        let module_cache =
-            TemporaryModuleResolver::new(&inner_temp_store, epoch_store.module_cache().clone());
-
-        let mut layout_resolver =
+        let intent_msg = IntentMessage::new(
+            Intent {
+                version: IntentVersion::V0,
+                scope: IntentScope::TransactionData,
+                app_id: AppId::Sui,
+            },
+            transaction,
+        );
+        let transaction_digest = TransactionDigest::new(default_hash(&intent_msg.value));
+        let (inner_temp_store, effects, execution_result) = executor.dev_inspect_transaction(
+            &self.database,
+            protocol_config,
+            self.metrics.limits_metrics.clone(),
+            /* expensive checks */ false,
+            self.certificate_deny_config.certificate_deny_set(),
+            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
             epoch_store
-                .executor()
-                .type_layout_resolver(Box::new(TemporaryPackageStore::new(
-                    &inner_temp_store,
-                    self.database.clone(),
-                )));
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let object_changes = Vec::new();
+                .epoch_start_config()
+                .epoch_data()
+                .epoch_start_timestamp(),
+            checked_input_objects,
+            gas_objects,
+            gas_status,
+            transaction_kind,
+            signer,
+            transaction_digest,
+            skip_checks,
+        );
 
-        // Returning empty vector here because we recalculate changes in the rpc layer.
-        let balance_changes = Vec::new();
+        let package_store = TemporaryPackageStore::new(&inner_temp_store, self.database.clone());
 
-        let written_with_kind = effects
+        let mut layout_resolver = epoch_store
+            .executor()
+            .type_layout_resolver(Box::new(package_store));
+
+        let written_objects = effects
             .created()
             .into_iter()
             .map(|(oref, _)| (oref, WriteKind::Create))
@@ -1569,137 +1690,13 @@ impl AuthorityState {
             })
             .collect();
 
-        Ok((
-            DryRunTransactionBlockResponse {
-                input: SuiTransactionBlockData::try_from(transaction, &module_cache).map_err(
-                    |e| SuiError::TransactionSerializationError {
-                        error: format!(
-                            "Failed to convert transaction to SuiTransactionBlockData: {}",
-                            e
-                        ),
-                    },
-                )?, // TODO: replace the underlying try_from to SuiError. This one goes deep
-                effects: effects.clone().try_into()?,
-                events: SuiTransactionBlockEvents::try_from(
-                    inner_temp_store.events.clone(),
-                    tx_digest,
-                    None,
-                    layout_resolver.as_mut(),
-                )?,
-                object_changes,
-                balance_changes,
-            },
-            written_with_kind,
-            effects,
-            mock_gas,
-        ))
-    }
-
-    /// The object ID for gas can be any object ID, even for an uncreated object
-    pub async fn dev_inspect_transaction_block(
-        &self,
-        sender: SuiAddress,
-        transaction_kind: TransactionKind,
-        gas_price: Option<u64>,
-    ) -> SuiResult<DevInspectResults> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-        if !self.is_fullnode(&epoch_store) {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "dev-inspect is only supported on fullnodes".to_string(),
-            });
-        }
-
-        let protocol_config = epoch_store.protocol_config();
-        transaction_kind.check_version_supported(protocol_config)?;
-        transaction_kind.validity_check(protocol_config)?;
-
-        let max_tx_gas = protocol_config.max_tx_gas();
-        let reference_gas_price = epoch_store.reference_gas_price();
-        let gas_price = match gas_price {
-            None => reference_gas_price,
-            Some(gas) => {
-                if gas == 0 {
-                    reference_gas_price
-                } else {
-                    gas
-                }
-            }
-        };
-        let gas_status =
-            SuiGasStatus::new(max_tx_gas, gas_price, reference_gas_price, protocol_config)?;
-
-        let gas_object_id = ObjectID::random();
-        // give the gas object 2x the max gas to have coin balance to play with during execution
-        let gas_object = Object::new_move(
-            MoveObject::new_gas_coin(SequenceNumber::new(), gas_object_id, max_tx_gas * 2),
-            Owner::AddressOwner(sender),
-            TransactionDigest::genesis_marker(),
-        );
-
-        let input_object_kinds = transaction_kind.input_objects()?;
-        let receiving_object_refs = transaction_kind.receiving_objects();
-        let (input_objects, receiving_objects) = self
-            .input_loader
-            .read_objects_for_dev_inspect(
-                &input_object_kinds,
-                &receiving_object_refs,
-                protocol_config,
-            )
-            .await?;
-        let (gas_object_ref, checked_input_objects) =
-            sui_transaction_checks::check_dev_inspect_input(
-                protocol_config,
-                &transaction_kind,
-                input_objects,
-                receiving_objects,
-                gas_object,
-            )?;
-
-        let gas_budget = max_tx_gas;
-        let data = TransactionData::new(
-            transaction_kind,
-            sender,
-            gas_object_ref,
-            gas_price,
-            gas_budget,
-        );
-
-        let transaction_digest = TransactionDigest::new(default_hash(&data));
-        let transaction_kind = data.into_kind();
-        let silent = true;
-        let executor = sui_execution::executor(protocol_config, silent)
-            .expect("Creating an executor should not fail here");
-        let expensive_checks = false;
-        let (inner_temp_store, effects, execution_result) = executor.dev_inspect_transaction(
-            &self.database,
-            protocol_config,
-            self.metrics.limits_metrics.clone(),
-            expensive_checks,
-            self.certificate_deny_config.certificate_deny_set(),
-            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-            epoch_store
-                .epoch_start_config()
-                .epoch_data()
-                .epoch_start_timestamp(),
-            checked_input_objects,
-            vec![gas_object_ref],
-            gas_status,
-            transaction_kind,
-            sender,
-            transaction_digest,
-        );
-
-        let package_store = TemporaryPackageStore::new(&inner_temp_store, self.database.clone());
-        let mut layout_resolver = epoch_store
-            .executor()
-            .type_layout_resolver(Box::new(package_store));
-
-        DevInspectResults::new(
-            effects,
+        let results = DevInspectResults::new(
+            effects.clone(),
             inner_temp_store.events.clone(),
             execution_result,
             layout_resolver.as_mut(),
-        )
+        )?;
+        Ok((effects, results, written_objects, mock_gas))
     }
 
     // Only used for testing because of how epoch store is loaded.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -39,7 +39,7 @@ use sui_types::error::UserInputError;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages_consensus::{ConsensusCommitPrologue, ConsensusCommitPrologueV2};
-use sui_types::object::Data;
+use sui_types::object::{Data, MoveObject};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
 use sui_types::sui_system_state::SuiSystemStateWrapper;
@@ -831,7 +831,11 @@ async fn test_dev_inspect_gas_coin_argument() {
     assert_eq!(mutable_reference_outputs.len(), 1);
     let (arg, arg_value, arg_type) = &mutable_reference_outputs[0];
     assert_eq!(arg, &SuiArgument::GasCoin);
-    check_coin_value(arg_value, arg_type, protocol_config.max_tx_gas() - amount);
+    check_coin_value(
+        arg_value,
+        arg_type,
+        DEV_INSPECT_GAS_COIN_VALUE - protocol_config.max_tx_gas() - amount,
+    );
 
     assert_eq!(return_values.len(), 1);
     let (ret_value, ret_type) = &return_values[0];

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -39,7 +39,7 @@ use sui_types::error::UserInputError;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages_consensus::{ConsensusCommitPrologue, ConsensusCommitPrologueV2};
-use sui_types::object::{Data, MoveObject};
+use sui_types::object::Data;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
 use sui_types::sui_system_state::SuiSystemStateWrapper;
@@ -574,7 +574,7 @@ async fn test_dev_inspect_dynamic_field() {
     };
     let kind = TransactionKind::programmable(pt);
     let DevInspectResults { error, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, None)
+        .dev_inspect_transaction_block(sender, kind, None, None, None, None, None, None)
         .await
         .unwrap();
     // produces an error
@@ -816,7 +816,7 @@ async fn test_dev_inspect_gas_coin_argument() {
     };
     let kind = TransactionKind::programmable(pt);
     let results = fullnode
-        .dev_inspect_transaction_block(sender, kind, None)
+        .dev_inspect_transaction_block(sender, kind, None, None, None, None, None, None)
         .await
         .unwrap()
         .results
@@ -865,7 +865,7 @@ async fn test_dev_inspect_gas_price() {
     };
     let kind = TransactionKind::programmable(pt);
     let error = fullnode
-        .dev_inspect_transaction_block(sender, kind.clone(), Some(1))
+        .dev_inspect_transaction_block(sender, kind.clone(), Some(1), None, None, None, None, None)
         .await
         .unwrap_err();
     assert!(
@@ -879,7 +879,16 @@ async fn test_dev_inspect_gas_price() {
     let epoch_store = fullnode.epoch_store_for_testing();
     let protocol_config = epoch_store.protocol_config();
     let error = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(protocol_config.max_gas_price() + 1))
+        .dev_inspect_transaction_block(
+            sender,
+            kind,
+            Some(protocol_config.max_gas_price() + 1),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         .await
         .unwrap_err();
     assert!(
@@ -928,6 +937,11 @@ async fn test_dev_inspect_uses_unbound_object() {
             sender,
             kind,
             Some(fullnode.reference_gas_price_for_testing().unwrap()),
+            None,
+            None,
+            None,
+            None,
+            None,
         )
         .await;
     let Err(err) = result else { panic!() };
@@ -1069,7 +1083,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     // dev inspect
     let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(rgp))
+        .dev_inspect_transaction_block(sender, kind, Some(rgp), None, None, None, None, None)
         .await
         .unwrap();
     assert_eq!(effects.deleted().len(), 0);
@@ -1122,7 +1136,7 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     let kind = TransactionKind::programmable(pt.clone());
     // dev inspect
     let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(rgp + 100))
+        .dev_inspect_transaction_block(sender, kind, Some(rgp + 100), None, None, None, None, None)
         .await
         .unwrap();
     assert_eq!(effects.status(), &SuiExecutionStatus::Success);
@@ -4593,7 +4607,7 @@ pub async fn call_dev_inspect(
     let kind = TransactionKind::programmable(builder.finish());
     let rgp = authority.reference_gas_price_for_testing().unwrap();
     authority
-        .dev_inspect_transaction_block(*sender, kind, Some(rgp))
+        .dev_inspect_transaction_block(*sender, kind, Some(rgp), None, None, None, None, None)
         .await
 }
 
@@ -5265,6 +5279,11 @@ async fn test_for_inc_201_dev_inspect() {
             sender,
             kind,
             Some(fullnode.reference_gas_price_for_testing().unwrap() + 1000),
+            None,
+            None,
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -15,7 +15,7 @@ use sui_types::crypto::AccountKeyPair;
 use sui_types::effects::TransactionEvents;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
-use sui_types::object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION};
+use sui_types::object::GAS_VALUE_FOR_TESTING;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{base_types::dbg_addr, crypto::get_key_pair};

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -15,7 +15,7 @@ use sui_types::crypto::AccountKeyPair;
 use sui_types::effects::TransactionEvents;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
-use sui_types::object::GAS_VALUE_FOR_TESTING;
+use sui_types::object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{base_types::dbg_addr, crypto::get_key_pair};

--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -570,6 +570,7 @@ mod sim_only_tests {
                 Base64::from_bytes(&bcs::to_bytes(&txn).unwrap()),
                 /* gas_price */ None,
                 /* epoch_id */ None,
+                /* additional_args */ None,
             )
             .await
             .unwrap();

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -10,7 +10,7 @@ use jsonrpsee::RpcModule;
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_api::{WriteApiClient, WriteApiServer};
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
+    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc::Module;
@@ -60,9 +60,16 @@ impl WriteApiServer for WriteApi {
         tx_bytes: Base64,
         gas_price: Option<BigInt<u64>>,
         epoch: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults> {
         self.fullnode
-            .dev_inspect_transaction_block(sender_address, tx_bytes, gas_price, epoch)
+            .dev_inspect_transaction_block(
+                sender_address,
+                tx_bytes,
+                gas_price,
+                epoch,
+                additional_args,
+            )
             .await
     }
 

--- a/crates/sui-indexer/src/apis/write_api_v2.rs
+++ b/crates/sui-indexer/src/apis/write_api_v2.rs
@@ -14,7 +14,7 @@ use jsonrpsee::RpcModule;
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_api::WriteApiServer;
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
+    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc::Module;
@@ -50,6 +50,7 @@ impl WriteApiServer for WriteApiV2 {
         tx_bytes: Base64,
         gas_price: Option<BigInt<u64>>,
         epoch: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults> {
         unimplemented!()
     }

--- a/crates/sui-json-rpc-api/src/write.rs
+++ b/crates/sui-json-rpc-api/src/write.rs
@@ -6,7 +6,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
+    DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc_macros::open_rpc;
@@ -53,6 +53,8 @@ pub trait WriteApi {
         gas_price: Option<BigInt<u64>>,
         /// The epoch to perform the call. Will be set from the system state object if not provided
         epoch: Option<BigInt<u64>>,
+        /// Additional arguments including gas_budget, gas_objects, gas_sponsor and skip_checks.
+        additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults>;
 
     /// Return transaction execution effects including the gas cost summary,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1025,19 +1025,18 @@ impl Display for SuiTransactionBlockEvents {
 }
 
 // TODO: this file might not be the best place for this struct.
-/// Arguments supplied to dev inspect with toggles that will essentially simulate both the present day
-/// dry run and dev inspect.
-pub enum DevInspectArgs {
-    TransactionData(TransactionData),
-    TransactionKindWithMeta {
-        kind: TransactionKind,
-        sender: SuiAddress,
-        gas_sponsor: Option<SuiAddress>,
-        gas_price: Option<u64>,
-        gas_budget: Option<u64>,
-        epoch: Option<u64>,
-        gas_objects: Option<Vec<ObjectRef>>,
-    },
+/// Additional rguments supplied to dev inspect beyond what is allowed in today's API.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "DevInspectArgs", rename_all = "camelCase")]
+pub struct DevInspectArgs {
+    /// The sponsor of the gas for the transaction, might be different from the sender.
+    pub gas_sponsor: Option<SuiAddress>,
+    /// The gas budget for the transaction.
+    pub gas_budget: Option<BigInt<u64>>,
+    /// The gas objects used to pay for the transaction.
+    pub gas_objects: Option<Vec<ObjectRef>>,
+    /// Whether to skip transaction checks for the transaction.
+    pub skip_checks: Option<bool>,
 }
 
 /// The response from processing a dev inspect transaction

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1024,6 +1024,22 @@ impl Display for SuiTransactionBlockEvents {
     }
 }
 
+// TODO: this file might not be the best place for this struct.
+/// Arguments supplied to dev inspect with toggles that will essentially simulate both the present day
+/// dry run and dev inspect.
+pub enum DevInspectArgs {
+    TransactionData(TransactionData),
+    TransactionKindWithMeta {
+        kind: TransactionKind,
+        sender: SuiAddress,
+        gas_sponsor: Option<SuiAddress>,
+        gas_price: Option<u64>,
+        gas_budget: Option<u64>,
+        epoch: Option<u64>,
+        gas_objects: Option<Vec<ObjectRef>>,
+    },
+}
+
 /// The response from processing a dev inspect transaction
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "DevInspectResults", rename_all = "camelCase")]

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -124,6 +124,11 @@ pub trait StateRead: Send + Sync {
         sender: SuiAddress,
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
+        gas_budget: Option<u64>,
+        gas_sponsor: Option<SuiAddress>,
+        gas_objects: Option<Vec<ObjectRef>>,
+        epoch: Option<u64>,
+        skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults>;
 
     // indexer_api
@@ -347,9 +352,23 @@ impl StateRead for AuthorityState {
         sender: SuiAddress,
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
+        gas_budget: Option<u64>,
+        gas_sponsor: Option<SuiAddress>,
+        gas_objects: Option<Vec<ObjectRef>>,
+        epoch: Option<u64>,
+        skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults> {
         Ok(self
-            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .dev_inspect_transaction_block(
+                sender,
+                transaction_kind,
+                gas_price,
+                gas_budget,
+                gas_sponsor,
+                gas_objects,
+                epoch,
+                skip_checks,
+            )
             .await?)
     }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -52,6 +52,13 @@
           "schema": {
             "$ref": "#/components/schemas/BigInt_for_uint64"
           }
+        },
+        {
+          "name": "additional_args",
+          "description": "Additional arguments including gas_budget, gas_objects, gas_sponsor and skip_checks.",
+          "schema": {
+            "$ref": "#/components/schemas/DevInspectArgs"
+          }
         }
       ],
       "result": {
@@ -80,6 +87,10 @@
             {
               "name": "epoch",
               "value": 8888
+            },
+            {
+              "name": "additional_args",
+              "value": null
             }
           ],
           "result": {
@@ -5605,6 +5616,64 @@
               {
                 "$ref": "#/components/schemas/SuiAddress"
               }
+            ]
+          }
+        }
+      },
+      "DevInspectArgs": {
+        "description": "Additional rguments supplied to dev inspect beyond what is allowed in today's API.",
+        "type": "object",
+        "properties": {
+          "gasBudget": {
+            "description": "The gas budget for the transaction.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gasObjects": {
+            "description": "The gas objects used to pay for the transaction.",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/ObjectID"
+                },
+                {
+                  "$ref": "#/components/schemas/SequenceNumber"
+                },
+                {
+                  "$ref": "#/components/schemas/ObjectDigest"
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "gasSponsor": {
+            "description": "The sponsor of the gas for the transaction, might be different from the sender.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SuiAddress"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "skipChecks": {
+            "description": "Whether to skip transaction checks for the transaction.",
+            "type": [
+              "boolean",
+              "null"
             ]
           }
         }

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc::error::Error;
+use sui_json_rpc_types::DevInspectArgs;
 use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, CheckpointPage, Coin, CoinPage, DelegatedStake,
     DevInspectResults, DynamicFieldPage, EventFilter, EventPage, MoveCallParams,
@@ -297,6 +298,7 @@ impl RpcExampleProvider {
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
                     ("gas_price", json!(1000)),
                     ("epoch", json!(8888)),
+                    ("additional_args", json!(None::<DevInspectArgs>)),
                 ],
                 json!(dev_inspect_results),
             )],

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -273,9 +273,11 @@ pub async fn metadata(
             sender,
             coins: vec![],
             objects: objects.clone(),
-            total_coin_value: 10_000_000_000,
+            // Mock coin have 1B SUI
+            total_coin_value: 1_000_000_000 * 1_000_000_000,
             gas_price,
-            budget: 5_000_000_000,
+            // MAX BUDGET
+            budget: 50_000_000_000,
         })?;
 
     let dry_run = context

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -273,11 +273,9 @@ pub async fn metadata(
             sender,
             coins: vec![],
             objects: objects.clone(),
-            // Mock coin have 1B SUI
-            total_coin_value: 1_000_000_000 * 1_000_000_000,
+            total_coin_value: 10_000_000_000,
             gas_price,
-            // MAX BUDGET
-            budget: 50_000_000_000,
+            budget: 5_000_000_000,
         })?;
 
     let dry_run = context

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use std::future;
 use std::sync::Arc;
 use std::time::Instant;
+use sui_json_rpc_types::DevInspectArgs;
 
 use crate::error::{Error, SuiRpcResult};
 use crate::RpcClient;
@@ -651,6 +652,7 @@ impl ReadApi {
         tx: TransactionKind,
         gas_price: Option<BigInt<u64>>,
         epoch: Option<BigInt<u64>>,
+        additional_args: Option<DevInspectArgs>,
     ) -> SuiRpcResult<DevInspectResults> {
         Ok(self
             .api
@@ -660,6 +662,7 @@ impl ReadApi {
                 Base64::from_bytes(&bcs::to_bytes(&tx)?),
                 gas_price,
                 epoch,
+                additional_args,
             )
             .await?)
     }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -144,12 +144,10 @@ mod checked {
     pub fn check_dev_inspect_input(
         config: &ProtocolConfig,
         kind: &TransactionKind,
-        mut input_objects: InputObjects,
+        input_objects: InputObjects,
         // TODO: check ReceivingObjects for dev inspect?
         _receiving_objects: ReceivingObjects,
-        gas_object: Object,
-    ) -> SuiResult<(ObjectRef, CheckedInputObjects)> {
-        let gas_object_ref = gas_object.compute_object_reference();
+    ) -> SuiResult<CheckedInputObjects> {
         kind.validity_check(config)?;
         if kind.is_system_tx() {
             return Err(UserInputError::Unsupported(format!(
@@ -176,12 +174,7 @@ mod checked {
             }
         }
 
-        input_objects.push(ObjectReadResult::new(
-            InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref),
-            gas_object.into(),
-        ));
-
-        Ok((gas_object_ref, input_objects.into_checked()))
+        Ok(input_objects.into_checked())
     }
 
     // Common checks performed for transactions and certificates.

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -127,7 +127,16 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         gas_price: Option<u64>,
     ) -> SuiResult<DevInspectResults> {
         self.fullnode
-            .dev_inspect_transaction_block(sender, transaction_kind, gas_price)
+            .dev_inspect_transaction_block(
+                sender,
+                transaction_kind,
+                gas_price,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .await
     }
 

--- a/crates/sui-types/src/execution_mode.rs
+++ b/crates/sui-types/src/execution_mode.rs
@@ -199,27 +199,27 @@ impl ExecutionMode for System {
 /// WARNING! Using this mode will bypass all normal checks around Move entry functions! This
 /// includes the various rules for function arguments, meaning any object can be created just from
 /// BCS bytes!
-pub struct DevInspect;
+pub struct DevInspect<const SKIP_ALL_CHECKS: bool>;
 
 pub type ExecutionResult = (
     /*  mutable_reference_outputs */ Vec<(Argument, Vec<u8>, TypeTag)>,
     /*  return_values */ Vec<(Vec<u8>, TypeTag)>,
 );
 
-impl ExecutionMode for DevInspect {
+impl<const SKIP_ALL_CHECKS: bool> ExecutionMode for DevInspect<SKIP_ALL_CHECKS> {
     type ArgumentUpdates = Vec<(Argument, Vec<u8>, TypeTag)>;
     type ExecutionResults = Vec<ExecutionResult>;
 
     fn allow_arbitrary_function_calls() -> bool {
-        true
+        SKIP_ALL_CHECKS
     }
 
     fn allow_arbitrary_values() -> bool {
-        true
+        SKIP_ALL_CHECKS
     }
 
     fn skip_conservation_checks() -> bool {
-        true
+        SKIP_ALL_CHECKS
     }
 
     fn packages_are_predefined() -> bool {

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -67,6 +67,7 @@ pub trait Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
+        skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -123,27 +123,47 @@ impl executor::Executor for Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
+        skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        if skip_all_checks {
+            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        } else {
+            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        }
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/next_vm.rs
+++ b/sui-execution/src/next_vm.rs
@@ -125,27 +125,47 @@ impl executor::Executor for Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
+        skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        if skip_all_checks {
+            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        } else {
+            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        }
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -125,27 +125,47 @@ impl executor::Executor for Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
+        skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        if skip_all_checks {
+            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        } else {
+            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        }
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -125,27 +125,47 @@ impl executor::Executor for Executor {
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
         transaction_digest: TransactionDigest,
+        skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::DevInspect>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        if skip_all_checks {
+            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        } else {
+            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            )
+        }
     }
 
     fn update_genesis_state(


### PR DESCRIPTION
## Description 

For graphql we would like to combine dry run and dev inspect functionality, and any behavior difference between the two should be made toggleable via user provided options, which will look a lot like the newly added struct `DevInspectArgs` in this PR. This PR modifies the dev inspect code to make implementing new dev inspect easier. It also adds optional additional args to dev inspect APIs.

## Test Plan 

existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Add optional additional parameters to `dev_inspect_transaction_block` including gas_budget, gas_objects, gas_sponsor and skip_checks. 
