### PR TITLE
[move] Refactor use fun scopes

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -51,7 +51,7 @@ pub enum UseFunKind {
     // From a function declaration in the module
     FunctionDeclaration,
     // From a normal, non 'use fun' use declaration,
-    UseAlias { used: bool },
+    UseAlias,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -63,6 +63,10 @@ pub struct UseFun {
     // If None, disregard any use/unused information.
     // If Some, we track whether or not the associated function alias was used prior to receiver
     pub kind: UseFunKind,
+    // Set to true on usage during typing on usage.
+    // For UseAlias implicit use funs, this might already be set to true if it was used in a
+    // non method syntax case
+    pub used: bool,
 }
 
 // Mapping from type to their possible "methods"
@@ -762,6 +766,7 @@ impl AstDebug for UseFun {
             is_public,
             target_function: (target_m, target_f),
             kind,
+            used,
         } = self;
         attributes.ast_debug(w);
         w.new_line();
@@ -769,12 +774,12 @@ impl AstDebug for UseFun {
             w.write("public ")
         }
         let kind_str = match kind {
-            UseFunKind::Explicit => "",
-            UseFunKind::UseAlias { used: true } => "#used",
-            UseFunKind::UseAlias { used: false } => "#unused",
+            UseFunKind::Explicit => "#explicit",
+            UseFunKind::UseAlias => "#use-alias",
             UseFunKind::FunctionDeclaration => "#fundecl",
         };
-        w.write(&format!("use{kind_str} {target_m}::{target_f}"));
+        let usage = if *used { "#used" } else { "#unused" };
+        w.write(&format!("use{kind_str}{usage} {target_m}::{target_f}"));
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -196,11 +196,14 @@ fn use_funs(context: &mut Context, uf: &mut N::UseFuns) {
             }
             continue;
         };
-        let kind = match ekind {
-            E::ImplicitUseFunKind::FunctionDeclaration => N::UseFunKind::FunctionDeclaration,
+        let (kind, used) = match ekind {
+            E::ImplicitUseFunKind::FunctionDeclaration => (
+                N::UseFunKind::FunctionDeclaration,
+                /* silences unused warning */ true,
+            ),
             E::ImplicitUseFunKind::UseAlias { used } => {
                 assert!(is_public.is_none());
-                N::UseFunKind::UseAlias { used }
+                (N::UseFunKind::UseAlias, used)
             }
         };
         let nuf = N::UseFun {
@@ -209,6 +212,7 @@ fn use_funs(context: &mut Context, uf: &mut N::UseFuns) {
             is_public,
             target_function: (target_m, target_f),
             kind,
+            used,
         };
         let nuf_loc = nuf.loc;
         let methods = resolved.entry(tn.clone()).or_insert_with(UniqueMap::new);

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -751,6 +751,7 @@ fn explicit_use_fun(
         is_public,
         target_function,
         kind: N::UseFunKind::Explicit,
+        used: is_public.is_some(), // suppress unused warning for public use funs
     };
     Some((tn, method, use_fun))
 }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -27,7 +27,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 struct UseFunsScope {
     count: usize,
-    unused: BTreeMap<(TypeName, Name), (Loc, UseFunKind, /* depth */ usize)>,
     use_funs: ResolvedUseFuns,
 }
 
@@ -82,7 +81,6 @@ pub struct Context<'env> {
 impl UseFunsScope {
     pub fn global(info: &NamingProgramInfo) -> Self {
         let count = 1;
-        let unused = BTreeMap::new();
         let mut use_funs = BTreeMap::new();
         for (_, _, minfo) in &info.modules {
             for (tn, methods) in &minfo.use_funs {
@@ -109,11 +107,7 @@ impl UseFunsScope {
                 use_funs.insert(tn.clone(), public_methods);
             }
         }
-        UseFunsScope {
-            count,
-            unused,
-            use_funs,
-        }
+        UseFunsScope { count, use_funs }
     }
 }
 
@@ -150,34 +144,14 @@ impl<'env> Context<'env> {
             implicit_candidates.is_empty(),
             "ICE use fun candidates should have been resolved"
         );
-        let depth = self.use_funs.len();
         let cur = self.use_funs.last_mut().unwrap();
         if new_scope.is_empty() {
             cur.count += 1;
             return;
         }
-        let mut unused = cur.unused.clone();
-        let mut use_funs = cur.use_funs.clone();
-        for (tn, additional_methods) in new_scope {
-            for (method, nuf) in additional_methods {
-                match nuf.kind {
-                    UseFunKind::Explicit if nuf.is_public.is_none() => {
-                        unused.insert((tn.clone(), method), (nuf.loc, nuf.kind, depth));
-                    }
-                    UseFunKind::UseAlias { used: false } => {
-                        unused.insert((tn.clone(), method), (nuf.loc, nuf.kind, depth));
-                    }
-                    _ => (),
-                }
-                let cur_methods = use_funs.entry(tn.clone()).or_default();
-                cur_methods.remove(&method);
-                cur_methods.add(method, nuf).unwrap();
-            }
-        }
         self.use_funs.push(UseFunsScope {
             count: 1,
-            unused,
-            use_funs,
+            use_funs: new_scope,
         })
     }
 
@@ -187,31 +161,44 @@ impl<'env> Context<'env> {
             cur.count -= 1;
             return;
         }
-        let UseFunsScope { unused, .. } = self.use_funs.pop().unwrap();
-        let cur_depth = self.use_funs.len();
-        let mut new_unused = BTreeMap::new();
-        for ((tn, method), (loc, kind, depth)) in unused {
-            if depth != cur_depth {
-                // the unused was added in a scope above
-                assert!(depth < cur_depth);
-                new_unused.insert((tn, method), (loc, kind, depth));
-                continue;
+        let UseFunsScope { use_funs, .. } = self.use_funs.pop().unwrap();
+        for (tn, methods) in use_funs {
+            let unused = methods.iter().filter(|(_, _, uf)| !uf.used);
+            for (_, method, use_fun) in unused {
+                let N::UseFun {
+                    loc,
+                    kind,
+                    attributes: _,
+                    is_public: _,
+                    target_function: _,
+                    used: _,
+                } = use_fun;
+                let msg = match kind {
+                    UseFunKind::Explicit => {
+                        format!("Unused 'use fun' of '{tn}.{method}'. Consider removing it")
+                    }
+                    UseFunKind::UseAlias => {
+                        format!("Unused 'use' of alias '{method}'. Consider removing it")
+                    }
+                    UseFunKind::FunctionDeclaration => {
+                        panic!("ICE function declaration use funs should never be added to use fun")
+                    }
+                };
+                self.env.add_diag(diag!(UnusedItem::Alias, (*loc, msg)))
             }
-            let msg = match kind {
-                UseFunKind::Explicit => {
-                    format!("Unused 'use fun' of '{tn}.{method}'. Consider removing it")
-                }
-                UseFunKind::UseAlias { used } => {
-                    assert!(!used);
-                    format!("Unused 'use' of alias '{method}'. Consider removing it")
-                }
-                UseFunKind::FunctionDeclaration => {
-                    panic!("ICE function declaration use funs should never be added to use fun")
-                }
-            };
-            self.env.add_diag(diag!(UnusedItem::Alias, (loc, msg)))
         }
-        self.use_funs.last_mut().unwrap().unused = new_unused;
+    }
+
+    pub fn find_method_and_mark_used(
+        &mut self,
+        tn: &TypeName,
+        method: Name,
+    ) -> Option<(ModuleIdent, FunctionName)> {
+        self.use_funs.iter_mut().rev().find_map(|scope| {
+            let use_fun = scope.use_funs.get_mut(tn)?.get_mut(&method)?;
+            use_fun.used = true;
+            Some(use_fun.target_function)
+        })
     }
 
     pub fn reset_for_module_item(&mut self) {
@@ -804,13 +791,7 @@ pub fn make_method_call_type(
     Vec<(Var, Type)>,
     Type,
 )> {
-    let target_function_opt = context
-        .use_funs
-        .last()
-        .unwrap()
-        .use_funs
-        .get(tn)
-        .and_then(|methods| Some(methods.get(&method)?.target_function));
+    let target_function_opt = context.find_method_and_mark_used(tn, method);
     // try to find a function in the defining module for errors
     let Some((target_m, target_f)) = target_function_opt else {
         let lhs_ty_str = error_format_nested(lhs_ty, &Subst::empty());
@@ -876,13 +857,6 @@ pub fn make_method_call_type(
         }
         return None;
     };
-    // mark the method as used
-    context
-        .use_funs
-        .last_mut()
-        .unwrap()
-        .unused
-        .remove(&(tn.clone(), method));
 
     let (defined_loc, ty_args, params, return_ty) =
         make_function_type(context, loc, &target_m, &target_f, ty_args_opt);


### PR DESCRIPTION
## Description 

- Refactor use fun scopes to reduce O(n) clones in favor of O(n) lookups

## Test Plan 

- non functional change, ran tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
