### PR TITLE
[consensus 2.0] adding application logic for block processing

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -372,3 +372,6 @@ impl TestBlock {
         Block::V1(self.block)
     }
 }
+
+// TODO: add basic verification for BlockRef and BlockDigest.
+// TODO: add tests for SignedBlock and VerifiedBlock conversion.

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -67,6 +67,23 @@ pub struct BlockV1 {
     ancestors: Vec<BlockRef>,
 }
 
+impl BlockV1 {
+    pub(crate) fn new(
+        round: Round,
+        author: AuthorityIndex,
+        timestamp_ms: BlockTimestampMs,
+        ancestors: Vec<BlockRef>,
+    ) -> BlockV1 {
+        Self {
+            round,
+            author,
+            timestamp_ms,
+            ancestors,
+            digest: OnceCell::new(),
+        }
+    }
+}
+
 impl BlockAPI for BlockV1 {
     fn round(&self) -> Round {
         self.round

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -240,7 +240,6 @@ pub(crate) struct VerifiedBlock {
 }
 
 impl VerifiedBlock {
-
     /// Creates VerifiedBlock from verified SignedBlock and its serialized bytes.
     pub fn new_verified(
         signed_block: SignedBlock,

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use enum_dispatch::enum_dispatch;
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -9,7 +10,6 @@ use std::{
 };
 
 use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
-use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +68,7 @@ pub struct BlockV1 {
 }
 
 impl BlockV1 {
+    #[allow(dead_code)]
     pub(crate) fn new(
         round: Round,
         author: AuthorityIndex,
@@ -79,7 +80,6 @@ impl BlockV1 {
             author,
             timestamp_ms,
             ancestors,
-            digest: OnceCell::new(),
         }
     }
 }
@@ -240,6 +240,7 @@ pub(crate) struct VerifiedBlock {
 }
 
 impl VerifiedBlock {
+
     /// Creates VerifiedBlock from verified SignedBlock and its serialized bytes.
     pub fn new_verified(
         signed_block: SignedBlock,
@@ -296,6 +297,7 @@ impl VerifiedBlock {
     }
 }
 
+/// Allow quick access on the underlying Block without having to always refer to the inner block ref.
 impl Deref for VerifiedBlock {
     type Target = Block;
 
@@ -371,6 +373,3 @@ impl TestBlock {
         Block::V1(self.block)
     }
 }
-
-// TODO: add basic verification for BlockRef and BlockDigest.
-// TODO: add tests for SignedBlock and VerifiedBlock conversion.

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,15 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::{Block, BlockRef};
+use crate::block::{BlockRef, VerifiedBlock};
 
 /// Block manager suspends incoming blocks until they are connected to the existing graph,
 /// returning newly connected blocks.
 /// TODO: As it is possible to have Byzantine validators who produce Blocks without valid causal
 /// history we need to make sure that BlockManager takes care of that and avoid OOM (Out Of Memory)
 /// situations.
+#[allow(dead_code)]
 pub(crate) struct BlockManager {}
 
+#[allow(dead_code)]
 impl BlockManager {
     pub(crate) fn new() -> Self {
         Self {}
@@ -18,7 +20,7 @@ impl BlockManager {
     /// Tries to accept the provided blocks assuming that all their causal history exists. The method
     /// returns all the blocks that have been successfully processed, that includes also previously
     /// suspended blocks that have now been able to get accepted.
-    pub(crate) fn add_blocks(&mut self, blocks: Vec<Block>) -> Vec<Block> {
+    pub(crate) fn add_blocks(&mut self, blocks: Vec<VerifiedBlock>) -> Vec<VerifiedBlock> {
         // TODO: add implementation - for now just return the blocks
         blocks
     }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::block::{Block, BlockRef};
+
+/// Block manager suspends incoming blocks until they are connected to the existing graph,
+/// returning newly connected blocks.
+/// TODO: As it is possible to have Byzantine validators who produce Blocks without valid causal
+/// history we need to make sure that BlockManager takes care of that and avoid OOM (Out Of Memory)
+/// situations.
+pub(crate) struct BlockManager {}
+
+impl BlockManager {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+
+    /// Tries to accept the provided blocks assuming that all their causal history exists. The method
+    /// returns all the blocks that have been successfully processed, that includes also previously
+    /// suspended blocks that have now been able to get accepted.
+    pub(crate) fn add_blocks(&mut self, blocks: Vec<Block>) -> Vec<Block> {
+        // TODO: add implementation - for now just return the blocks
+        blocks
+    }
+
+    /// Returns all the blocks that are currently missing and needed in order to accept suspended
+    /// blocks.
+    pub(crate) fn missing_blocks(&self) -> Vec<BlockRef> {
+        unimplemented!()
+    }
+
+    /// Returns all the suspended blocks whose causal history we miss hence we can't accept them yet.
+    pub(crate) fn suspended_blocks(&self) -> Vec<BlockRef> {
+        unimplemented!()
+    }
+}

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::block_manager::BlockManager;
+use crate::transactions_client::TransactionsConsumer;
+use std::collections::VecDeque;
 use std::sync::Arc;
+use tokio::sync::watch;
 
 use crate::{
-    block::{Block, BlockAPI, BlockRef, BlockV1, Round},
+    block::{Block, BlockAPI, BlockRef, BlockV1, Round, Transaction},
     context::Context,
     threshold_clock::ThresholdClock,
 };
@@ -14,13 +18,31 @@ use mysten_metrics::monitored_scope;
 #[allow(dead_code)]
 pub(crate) struct Core {
     context: Arc<Context>,
+    /// The threshold clock that is used to keep track of the current round
     threshold_clock: ThresholdClock,
+    /// The last produced block
     last_own_block: Block,
+    /// The consumer to use in order to pull transactions to be included for the next proposals
+    transactions_consumer: TransactionsConsumer,
+    /// The transactions that haven't been proposed yet and are to be included in the next proposal
+    pending_transactions: VecDeque<Transaction>,
+    /// The pending blocks refs to be included as ancestors to the next block
+    pending_ancestors: VecDeque<BlockRef>,
+    /// The block manager which is responsible for keeping track of the DAG dependencies when processing new blocks
+    /// and accept them or suspend if we are missing their causal history
+    block_manager: BlockManager,
+    /// Signals that the component emits
+    signals: CoreSignals,
 }
 
 #[allow(dead_code)]
 impl Core {
-    pub(crate) fn new(context: Arc<Context>) -> Self {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        transactions_consumer: TransactionsConsumer,
+        block_manager: BlockManager,
+        signals: CoreSignals,
+    ) -> Self {
         // TODO: restore the threshold clock round based on the last quorum data in storage when crash/recover
         let threshold_clock = ThresholdClock::new(0, context.clone());
 
@@ -28,14 +50,52 @@ impl Core {
             context,
             threshold_clock,
             last_own_block: Block::V1(BlockV1::default()), // TODO: restore on crash/recovery
+            transactions_consumer,
+            pending_transactions: VecDeque::new(),
+            pending_ancestors: VecDeque::new(),
+            block_manager,
+            signals,
         }
     }
 
     /// Processes the provided blocks and accepts them if possible when their causal history exists.
     /// The method returns the references of parents that are unknown and need to be fetched.
-    pub(crate) fn add_blocks(&mut self, _blocks: Vec<Block>) -> Vec<BlockRef> {
+    pub(crate) fn add_blocks(&mut self, blocks: Vec<Block>) -> Vec<BlockRef> {
         let _scope = monitored_scope("Core::add_blocks");
 
+        // Try to accept them via the block manager
+        let accepted_blocks = self.block_manager.add_blocks(blocks);
+
+        // Advance the threshold clock. If advanced to a new round then send a signal that a new quorum has been received.
+        if let Some(new_round) = self
+            .threshold_clock
+            .add_blocks(accepted_blocks.iter().map(|b| b.reference()).collect())
+        {
+            // notify that threshold clock advanced to new round
+            self.signals.new_round(new_round);
+        }
+
+        // Report the threshold clock round
+        self.context
+            .metrics
+            .node_metrics
+            .threshold_clock_round
+            .set(self.threshold_clock.get_round() as i64);
+
+        // Add the processed blocks to the list of pending
+        for block in accepted_blocks {
+            self.pending_ancestors.push_back(block.reference());
+        }
+
+        // Pull transactions to be proposed and append to the pending list
+        for transaction in self.transactions_consumer.next() {
+            self.pending_transactions.push_back(transaction);
+        }
+
+        // Attempt to create a new block
+        let _ = self.try_new_block(false);
+
+        // TODO: we don't deal for now with missed references, will address later.
         vec![]
     }
 
@@ -62,7 +122,18 @@ impl Core {
         // create a new block either because we want to "forcefully" propose a block due to a leader timeout,
         // or because we are actually ready to produce the block (leader exists)
         if force_new_block || self.ready_new_block() {
-            // TODO: produce the block for the clock_round
+            // TODO: produce the block for the clock_round. As the threshold clock can advance many rounds at once (ex
+            // because we synchronized a bulk of blocks) we can decide here whether we want to produce blocks per round
+            // or just the latest one. From earlier experiments I saw only benefit on proposing for the penultimate round
+            // only when the validator was supposed to be the leader of the round - so we bring down the missed leaders.
+            // Probably proposing for all the intermediate rounds might not make much sense.
+
+            // consume the next transactions to be included
+
+            // consume the next ancestors to be included
+
+            // create the block and insert to storage.
+            // TODO: take a decision on whether we want to flush to disk at this point the DagState.
         }
 
         None
@@ -79,28 +150,72 @@ impl Core {
     }
 }
 
+/// Signals support a series of signals that are sent from Core when various events happen (ex new block produced).
+pub(crate) struct CoreSignals {
+    new_round_sender: watch::Sender<Round>,
+    block_ready_sender: watch::Sender<Option<BlockRef>>,
+}
+
+impl CoreSignals {
+    pub(crate) fn new() -> (
+        Self,
+        watch::Receiver<Option<BlockRef>>,
+        watch::Receiver<Round>,
+    ) {
+        let (block_ready_sender, block_ready_receiver) = watch::channel(None);
+        let (new_round_sender, new_round_receiver) = watch::channel(0);
+
+        let me = Self {
+            block_ready_sender,
+            new_round_sender,
+        };
+
+        (me, block_ready_receiver, new_round_receiver)
+    }
+
+    /// Sends a signal to all the waiters that a new block has been produced.
+    fn new_block_ready(&mut self, block: BlockRef) {
+        self.block_ready_sender.send(Some(block)).ok();
+    }
+
+    /// Sends a signal that threshold clock has advanced to new round. The `round_number` is the round at which the
+    /// threshold clock has advanced to.
+    fn new_round(&mut self, round_number: Round) {
+        self.new_round_sender.send(round_number).ok();
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::metrics::test_metrics;
-    use consensus_config::Committee;
-    use consensus_config::{AuthorityIndex, Parameters};
-    use sui_protocol_config::ProtocolConfig;
+    use crate::transactions_client::TransactionsClient;
+    use consensus_config::AuthorityIndex;
 
-    #[test]
-    fn test_core() {
-        let (committee, _) = Committee::new_for_test(0, vec![1, 1, 1, 1]);
-        let metrics = test_metrics();
-        let context = Arc::new(Context::new(
-            AuthorityIndex::new_for_test(0),
-            committee,
-            Parameters::default(),
-            ProtocolConfig::get_for_min_version(),
-            metrics,
-        ));
+    #[tokio::test]
+    async fn test_core() {
+        let context = Arc::new(Context::new_for_test());
+        let block_manager = BlockManager::new();
+        let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
+        let transactions_consumer = TransactionsConsumer::new(tx_receiver);
+        let (signals, _new_block_receiver, mut new_round_receiver) = CoreSignals::new();
 
-        let core = Core::new(context);
+        let mut core = Core::new(context, transactions_consumer, block_manager, signals);
 
         assert_eq!(core.last_proposed_round(), 0);
+
+        // Add a few blocks which will get accepted
+        let block_1 = BlockV1::new(1, AuthorityIndex::new_for_test(0), 0, vec![]);
+        let block_2 = BlockV1::new(1, AuthorityIndex::new_for_test(1), 0, vec![]);
+        let block_3 = BlockV1::new(1, AuthorityIndex::new_for_test(2), 0, vec![]);
+
+        let blocks = vec![Block::V1(block_1), Block::V1(block_2), Block::V1(block_3)];
+
+        // Process them via Core
+        _ = core.add_blocks(blocks);
+
+        // Check that round has advanced
+        assert!(new_round_receiver.changed().await.is_ok());
+        let new_round = new_round_receiver.borrow_and_update();
+        assert_eq!(*new_round, 2);
     }
 }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::sync::watch;
 
 use crate::{
-    block::{Block, BlockAPI, BlockRef, BlockV1, Round, SignedBlock, Transaction, VerifiedBlock},
+    block::{Block, BlockAPI, BlockRef, BlockV1, Round, Transaction, VerifiedBlock},
     context::Context,
     threshold_clock::ThresholdClock,
 };
@@ -100,7 +100,7 @@ impl Core {
     }
 
     /// Force creating a new block for the dictated round. This is used when a leader timeout occurs.
-    pub fn force_new_block(&mut self, round: Round) -> Option<SignedBlock> {
+    pub fn force_new_block(&mut self, round: Round) -> Option<VerifiedBlock> {
         if self.last_proposed_round() < round {
             self.context.metrics.node_metrics.leader_timeout_total.inc();
             self.try_new_block(true)
@@ -111,7 +111,7 @@ impl Core {
 
     /// Attempts to propose a new block for the next round. If a block has already proposed for latest
     /// or earlier round, then no block is created and None is returned.
-    pub(crate) fn try_new_block(&mut self, force_new_block: bool) -> Option<SignedBlock> {
+    pub(crate) fn try_new_block(&mut self, force_new_block: bool) -> Option<VerifiedBlock> {
         let _scope = monitored_scope("Core::try_new_block");
 
         let clock_round = self.threshold_clock.get_round();

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod base_committer;
 mod block;
+mod block_manager;
 mod block_verifier;
 mod commit;
 mod context;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -39,6 +39,7 @@ pub(crate) struct NodeMetrics {
     pub core_lock_enqueued: IntCounter,
     pub core_lock_dequeued: IntCounter,
     pub leader_timeout_total: IntCounter,
+    pub threshold_clock_round: IntGauge,
 }
 
 impl NodeMetrics {
@@ -75,6 +76,11 @@ impl NodeMetrics {
                 registry,
             )
             .unwrap(),
+            threshold_clock_round: register_int_gauge_with_registry!(
+                "threshold_clock_round",
+                "The current threshold clock round. We only advance to a new round when a quorum of parents have been synced.",
+                registry,
+            ).unwrap(),
         }
     }
 }

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -41,10 +41,7 @@ impl ThresholdClock {
         for block_ref in blocks {
             self.add_block(block_ref);
         }
-        if self.round > previous_round {
-            return Some(self.round);
-        }
-        None
+        (self.round > previous_round).then_some(self.round)
     }
 
     pub fn add_block(&mut self, block: BlockRef) {
@@ -148,14 +145,14 @@ mod tests {
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![
-            BlockRef::new_test(AuthorityIndex::new_for_test(0), 0, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(1), 0, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(2), 0, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(0), 1, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(3), 1, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(1), 2, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(1), 1, BlockDigest::default()),
-            BlockRef::new_test(AuthorityIndex::new_for_test(2), 5, BlockDigest::default()),
+            BlockRef::new(0, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            BlockRef::new(0, AuthorityIndex::new_for_test(1), BlockDigest::default()),
+            BlockRef::new(0, AuthorityIndex::new_for_test(2), BlockDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(3), BlockDigest::default()),
+            BlockRef::new(2, AuthorityIndex::new_for_test(1), BlockDigest::default()),
+            BlockRef::new(1, AuthorityIndex::new_for_test(1), BlockDigest::default()),
+            BlockRef::new(5, AuthorityIndex::new_for_test(2), BlockDigest::default()),
         ];
 
         let result = aggregator.add_blocks(block_refs);


### PR DESCRIPTION
## Description 

Adding part of the application logic for the block processing. More specifically:
* accept the blocks via the `block_manager` (mock is used for now for the `block_manager`)
* advance the `threshold_clock` for the processed (accepted) blocks
* pull transactions via the `TransactionsConsumer` and add them to local queue
* send signals for `new round` advancement and `new block proposal` 
* switched to using the `VerifiedBlock` and `SignedBlock` structs

Next steps:
- [ ] add the propose block logic + clock/timestamp mechanics
- [ ] integrate the DagState logic
- [ ] integrate the commit rule logic
- [ ] use the real BlockManager
- [ ] implement the missing ancestors path

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
