### PR TITLE
introduce a general purpose storage error and convert ObjectStore to use it

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -23,7 +23,6 @@ use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::base_types::{AuthorityName, ObjectID, VersionNumber};
 use sui_types::crypto::AuthoritySignature;
 use sui_types::digests::ConsensusCommitDigest;
-use sui_types::error::SuiError;
 use sui_types::object::Object;
 use sui_types::storage::ObjectStore;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
@@ -391,7 +390,10 @@ impl ValidatorKeypairProvider for CommitteeWithKeys<'_> {
 }
 
 impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(store::SimulatorStore::get_object(&self.store, object_id))
     }
 
@@ -399,7 +401,7 @@ impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.store.get_object_by_key(object_id, version)
     }
 }

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -308,7 +308,7 @@ impl ObjectStore for InMemoryStore {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self.get_object(object_id).cloned())
     }
 
@@ -316,7 +316,7 @@ impl ObjectStore for InMemoryStore {
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self.get_object_at_version(object_id, version).cloned())
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2885,7 +2885,7 @@ impl AuthorityState {
 
     #[instrument(level = "trace", skip_all)]
     pub async fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
-        self.database.get_object(object_id)
+        self.database.get_object(object_id).map_err(Into::into)
     }
 
     pub async fn get_sui_system_package_object_ref(&self) -> SuiResult<ObjectRef> {
@@ -4678,7 +4678,9 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         object_id: ObjectID,
         version: VersionNumber,
     ) -> SuiResult<Option<Object>> {
-        self.database.get_object_by_key(&object_id, version)
+        self.database
+            .get_object_by_key(&object_id, version)
+            .map_err(Into::into)
     }
 
     async fn multi_get_transaction_checkpoint(

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1081,7 +1081,7 @@ impl AuthorityPerEpochStore {
             .state_hash_by_checkpoint
             .safe_range_iter(from_checkpoint..=to_checkpoint)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(SuiError::StorageError)
+            .map_err(Into::into)
     }
 
     /// Returns future containing the state digest for the given epoch

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2043,7 +2043,10 @@ impl BackingPackageStore for AuthorityStore {
 
 impl ObjectStore for AuthorityStore {
     /// Read an object and return it, or Ok(None) if the object was not found.
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.perpetual_tables.as_ref().get_object(object_id)
     }
 
@@ -2051,7 +2054,7 @@ impl ObjectStore for AuthorityStore {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.perpetual_tables.get_object_by_key(object_id, version)
     }
 }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1359,8 +1359,7 @@ impl AuthorityStore {
             if let Some(lock_info) = self
                 .perpetual_tables
                 .owned_object_transaction_locks
-                .get(&obj_ref)
-                .map_err(SuiError::StorageError)?
+                .get(&obj_ref)?
             {
                 match lock_info {
                     Some(lock_info) => {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -451,7 +451,7 @@ impl AuthorityPerpetualTables {
         // This checkpoints the entire db and not just objects table
         self.objects
             .checkpoint_db(path)
-            .map_err(SuiError::StorageError)
+            .map_err(Into::into)
     }
 
     pub fn reset_db_for_execution_since_genesis(&self) -> SuiResult {
@@ -470,8 +470,7 @@ impl AuthorityPerpetualTables {
         self.object_per_epoch_marker_table.unsafe_clear()?;
         self.objects
             .rocksdb
-            .flush()
-            .map_err(SuiError::StorageError)?;
+            .flush()?;
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -268,8 +268,8 @@ pub(crate) fn try_construct_object(
             )?)
         },
         _ => {
-            return Err(SuiError::StorageCorruptedFieldError(
-                "inconsistent object representation".to_string(),
+            return Err(SuiError::StorageError(
+                "corrupted field: inconsistent object representation".to_string(),
             ))
         }
     };

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -268,7 +268,7 @@ pub(crate) fn try_construct_object(
             )?)
         },
         _ => {
-            return Err(SuiError::StorageError(
+            return Err(SuiError::Storage(
                 "corrupted field: inconsistent object representation".to_string(),
             ))
         }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -46,7 +46,7 @@ use sui_types::committee::StakeUnit;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::error::{SuiResult};
+use sui_types::error::SuiResult;
 use sui_types::gas::GasCostSummary;
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
@@ -647,9 +647,7 @@ impl CheckpointStore {
 
     pub fn reset_db_for_execution_since_genesis(&self) -> SuiResult {
         self.delete_highest_executed_checkpoint_test_only()?;
-        self.watermarks
-            .rocksdb
-            .flush()?;
+        self.watermarks.rocksdb.flush()?;
         Ok(())
     }
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -46,7 +46,7 @@ use sui_types::committee::StakeUnit;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::error::{SuiError, SuiResult};
+use sui_types::error::{SuiResult};
 use sui_types::gas::GasCostSummary;
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
@@ -632,7 +632,7 @@ impl CheckpointStore {
         // This checkpoints the entire db and not one column family
         self.checkpoint_content
             .checkpoint_db(path)
-            .map_err(SuiError::StorageError)
+            .map_err(Into::into)
     }
 
     pub fn delete_highest_executed_checkpoint_test_only(&self) -> Result<(), TypedStoreError> {
@@ -649,8 +649,7 @@ impl CheckpointStore {
         self.delete_highest_executed_checkpoint_test_only()?;
         self.watermarks
             .rocksdb
-            .flush()
-            .map_err(SuiError::StorageError)?;
+            .flush()?;
         Ok(())
     }
 }

--- a/crates/sui-core/src/epoch/committee_store.rs
+++ b/crates/sui-core/src/epoch/committee_store.rs
@@ -122,7 +122,7 @@ impl CommitteeStore {
         self.tables
             .committee_map
             .checkpoint_db(path)
-            .map_err(SuiError::StorageError)
+            .map_err(Into::into)
     }
 
     fn database_is_empty(&self) -> bool {

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -219,7 +219,7 @@ impl<'a> sui_types::storage::ObjectStore for CheckpointDataObjectStore<'a> {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         Ok(self
             .objects
             .iter()
@@ -232,7 +232,7 @@ impl<'a> sui_types::storage::ObjectStore for CheckpointDataObjectStore<'a> {
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         Ok(self
             .objects
             .iter()

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -291,7 +291,7 @@ impl<'a> sui_types::storage::ObjectStore for EpochEndIndexingObjectStore<'a> {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self
             .objects
             .iter()
@@ -304,7 +304,7 @@ impl<'a> sui_types::storage::ObjectStore for EpochEndIndexingObjectStore<'a> {
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self
             .objects
             .iter()

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1752,18 +1752,18 @@ impl sui_types::storage::ObjectStore for IndexerReader {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         self.get_object(object_id, None)
-            .map_err(|e| sui_types::error::SuiError::StorageError(e.to_string()))
+            .map_err(sui_types::storage::error::Error::custom)
     }
 
     fn get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         self.get_object(object_id, Some(version))
-            .map_err(|e| sui_types::error::SuiError::StorageError(e.to_string()))
+            .map_err(sui_types::storage::error::Error::custom)
     }
 }
 

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1754,7 +1754,7 @@ impl sui_types::storage::ObjectStore for IndexerReader {
         object_id: &ObjectID,
     ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
         self.get_object(object_id, None)
-            .map_err(|e| sui_types::error::SuiError::GenericStorageError(e.to_string()))
+            .map_err(|e| sui_types::error::SuiError::StorageError(e.to_string()))
     }
 
     fn get_object_by_key(
@@ -1763,7 +1763,7 @@ impl sui_types::storage::ObjectStore for IndexerReader {
         version: sui_types::base_types::VersionNumber,
     ) -> Result<Option<sui_types::object::Object>, sui_types::error::SuiError> {
         self.get_object(object_id, Some(version))
-            .map_err(|e| sui_types::error::SuiError::GenericStorageError(e.to_string()))
+            .map_err(|e| sui_types::error::SuiError::StorageError(e.to_string()))
     }
 }
 

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -14,7 +14,6 @@ use sui_json_rpc_types::{
 };
 use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, SuiAddress, VersionNumber};
 use sui_types::digests::{CheckpointDigest, TransactionDigest};
-use sui_types::error::SuiError;
 use sui_types::event::EventID;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::ObjectRead;
@@ -316,7 +315,7 @@ impl ObjectStore for CheckpointTxData {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<sui_types::object::Object>, SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         Ok(self
             .system_state_objects
             .iter()
@@ -328,7 +327,7 @@ impl ObjectStore for CheckpointTxData {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<sui_types::object::Object>, SuiError> {
+    ) -> Result<Option<sui_types::object::Object>, sui_types::storage::error::Error> {
         Ok(self
             .system_state_objects
             .iter()

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -803,7 +803,7 @@ mod tests {
                 error_object.code(),
                 jsonrpsee::types::error::INTERNAL_ERROR_CODE
             );
-            let expected = expect!["Storage error"];
+            let expected = expect!["Storage error: mock rocksdb error"];
             expected.assert_eq(error_object.message());
         }
     }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -425,7 +425,6 @@ mod tests {
     use sui_types::object::Object;
     use sui_types::utils::create_fake_transaction;
     use sui_types::{parse_sui_struct_tag, TypeTag};
-    use typed_store_error::TypedStoreError;
 
     mock! {
         pub KeyValueStore {}
@@ -790,10 +789,7 @@ mod tests {
             mock_state
                 .expect_get_owned_coins()
                 .returning(move |_, _, _, _| {
-                    Err(SuiError::StorageError(TypedStoreError::RocksDBError(
-                        "mock rocksdb error".to_string(),
-                    ))
-                    .into())
+                    Err(SuiError::StorageError("mock rocksdb error".to_string()).into())
                 });
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
             let response = coin_read_api

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -789,7 +789,7 @@ mod tests {
             mock_state
                 .expect_get_owned_coins()
                 .returning(move |_, _, _, _| {
-                    Err(SuiError::StorageError("mock rocksdb error".to_string()).into())
+                    Err(SuiError::Storage("mock rocksdb error".to_string()).into())
                 });
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
             let response = coin_read_api

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1725,7 +1725,7 @@ impl BackingPackageStore for LocalExec {
             // If package not present fetch it from the network
             self_
                 .get_or_download_object(package_id, true /* we expect a Move package*/)
-                .map_err(|e| SuiError::StorageError(e.to_string()))
+                .map_err(|e| SuiError::Storage(e.to_string()))
         }
 
         let res = inner(self, package_id);

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1725,7 +1725,7 @@ impl BackingPackageStore for LocalExec {
             // If package not present fetch it from the network
             self_
                 .get_or_download_object(package_id, true /* we expect a Move package*/)
-                .map_err(|e| SuiError::GenericStorageError(e.to_string()))
+                .map_err(|e| SuiError::StorageError(e.to_string()))
         }
 
         let res = inner(self, package_id);

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1948,16 +1948,19 @@ impl ModuleResolver for &mut LocalExec {
 impl ObjectStore for LocalExec {
     /// The object must be present in store by normal process we used to backfill store in init
     /// We dont download if not present
-    fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
-        let res = Ok(self.storage.live_objects_store.get(object_id).cloned());
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> sui_types::storage::error::Result<Option<Object>> {
+        let res = self.storage.live_objects_store.get(object_id).cloned();
         self.exec_store_events
             .lock()
             .expect("Unable to lock events list")
             .push(ExecutionStoreEvent::ObjectStoreGetObject {
                 object_id: *object_id,
-                result: res.clone(),
+                result: Ok(res.clone()),
             });
-        res
+        Ok(res)
     }
 
     /// The object must be present in store by normal process we used to backfill store in init
@@ -1966,8 +1969,8 @@ impl ObjectStore for LocalExec {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> SuiResult<Option<Object>> {
-        let res = Ok(self
+    ) -> sui_types::storage::error::Result<Option<Object>> {
+        let res = self
             .storage
             .live_objects_store
             .get(object_id)
@@ -1977,7 +1980,7 @@ impl ObjectStore for LocalExec {
                 } else {
                     None
                 }
-            }));
+            });
 
         self.exec_store_events
             .lock()
@@ -1985,15 +1988,18 @@ impl ObjectStore for LocalExec {
             .push(ExecutionStoreEvent::ObjectStoreGetObjectByKey {
                 object_id: *object_id,
                 version,
-                result: res.clone(),
+                result: Ok(res.clone()),
             });
 
-        res
+        Ok(res)
     }
 }
 
 impl ObjectStore for &mut LocalExec {
-    fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> sui_types::storage::error::Result<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in the get_module fn
         (**self).get_object(object_id)
     }
@@ -2002,7 +2008,7 @@ impl ObjectStore for &mut LocalExec {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> SuiResult<Option<Object>> {
+    ) -> sui_types::storage::error::Result<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in the get_module fn
         (**self).get_object_by_key(object_id, version)
     }

--- a/crates/sui-rest-api/src/node_state_getter.rs
+++ b/crates/sui-rest-api/src/node_state_getter.rs
@@ -250,11 +250,13 @@ impl NodeStateGetter for AuthorityState {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        self.database.get_object_by_key(object_id, version)
+        self.database
+            .get_object_by_key(object_id, version)
+            .map_err(Into::into)
     }
 
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.database.get_object(object_id)
+        self.database.get_object(object_id).map_err(Into::into)
     }
 }
 
@@ -327,7 +329,11 @@ impl<T: Sync + Send, W: simulacrum::SimulatorStore + Sync + Send> NodeStateGette
     ) -> Result<Vec<Option<Object>>, SuiError> {
         object_keys
             .iter()
-            .map(|key| self.store().get_object_by_key(&key.0, key.1))
+            .map(|key| {
+                self.store()
+                    .get_object_by_key(&key.0, key.1)
+                    .map_err(SuiError::from)
+            })
             .collect::<Result<Vec<_>, SuiError>>()
     }
 

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -113,7 +113,10 @@ impl InMemoryObjectStore {
 }
 
 impl ObjectStore for InMemoryObjectStore {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.num_object_reads.inc_by(1);
         Ok(self.objects.get(object_id).cloned())
     }
@@ -122,7 +125,7 @@ impl ObjectStore for InMemoryObjectStore {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self.get_object(object_id).unwrap().and_then(|o| {
             if o.version() == version {
                 Some(o.clone())

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -68,7 +68,7 @@ where
     E: std::error::Error,
 {
     fn into_sui_result(self) -> SuiResult<T> {
-        self.map_err(|e| SuiError::GenericStorageError(e.to_string()))
+        self.map_err(|e| SuiError::StorageError(e.to_string()))
     }
 }
 

--- a/crates/sui-storage/src/http_key_value_store.rs
+++ b/crates/sui-storage/src/http_key_value_store.rs
@@ -68,7 +68,7 @@ where
     E: std::error::Error,
 {
     fn into_sui_result(self) -> SuiResult<T> {
-        self.map_err(|e| SuiError::StorageError(e.to_string()))
+        self.map_err(|e| SuiError::Storage(e.to_string()))
     }
 }
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -1322,7 +1322,7 @@ impl IndexStore {
         self.tables
             .transactions_from_addr
             .checkpoint_db(path)
-            .map_err(SuiError::StorageError)
+            .map_err(Into::into)
     }
 
     /// This method first gets the balance from `per_coin_type_balance` cache. On a cache miss, it

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -260,12 +260,18 @@ impl NodeStateGetter for ValidatorWithFullnode {
     }
 
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.validator.database.get_object(object_id)
+        self.validator
+            .database
+            .get_object(object_id)
+            .map_err(Into::into)
     }
 }
 
 impl ObjectStore for ValidatorWithFullnode {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.validator.database.get_object(object_id)
     }
 
@@ -273,7 +279,7 @@ impl ObjectStore for ValidatorWithFullnode {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.validator
             .database
             .get_object_by_key(object_id, version)

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -512,7 +512,7 @@ impl ObjectStore for PersistedStore {
     fn get_object(
         &self,
         object_id: &ObjectID,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(SimulatorStore::get_object(self, object_id))
     }
 
@@ -520,7 +520,7 @@ impl ObjectStore for PersistedStore {
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<Object>, sui_types::error::SuiError> {
+    ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         Ok(self.get_object_at_version(object_id, version))
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -2064,10 +2064,10 @@ impl NodeStateGetter for SuiTestAdapter<'_> {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        ObjectStore::get_object_by_key(&*self.executor, object_id, version)
+        ObjectStore::get_object_by_key(&*self.executor, object_id, version).map_err(Into::into)
     }
 
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        ObjectStore::get_object(&*self.executor, object_id)
+        ObjectStore::get_object(&*self.executor, object_id).map_err(Into::into)
     }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -467,10 +467,8 @@ pub enum SuiError {
         authority: AuthorityName,
         reason: String,
     },
-    #[error("Storage error")]
-    StorageError(#[from] TypedStoreError),
-    #[error("Non-RocksDB Storage error: {0}")]
-    GenericStorageError(String),
+    #[error("Storage error: {0}")]
+    StorageError(String),
     #[error(
         "Attempted to access {object} through parent {given_parent}, \
         but it's actual parent is {actual_owner}"
@@ -480,11 +478,6 @@ pub enum SuiError {
         given_parent: ObjectID,
         actual_owner: Owner,
     },
-
-    #[error("Missing fields/data in storage error: {0}")]
-    StorageMissingFieldError(String),
-    #[error("Corrupted fields/data in storage error: {0}")]
-    StorageCorruptedFieldError(String),
 
     #[error("Authority Error: {error:?}")]
     GenericAuthorityError { error: String },
@@ -654,6 +647,18 @@ impl From<Status> for SuiError {
                 status.code().description().to_owned(),
             )
         }
+    }
+}
+
+impl From<TypedStoreError> for SuiError {
+    fn from(e: TypedStoreError) -> Self {
+        Self::StorageError(e.to_string())
+    }
+}
+
+impl From<crate::storage::error::Error> for SuiError {
+    fn from(e: crate::storage::error::Error) -> Self {
+        Self::StorageError(e.to_string())
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -467,8 +467,14 @@ pub enum SuiError {
         authority: AuthorityName,
         reason: String,
     },
-    #[error("Storage error: {0}")]
-    StorageError(String),
+    #[allow(non_camel_case_types)]
+    #[serde(rename = "StorageError")]
+    #[error("DEPRECATED")]
+    DEPRECATED_StorageError,
+    #[allow(non_camel_case_types)]
+    #[serde(rename = "GenericStorageError")]
+    #[error("DEPRECATED")]
+    DEPRECATED_GenericStorageError,
     #[error(
         "Attempted to access {object} through parent {given_parent}, \
         but it's actual parent is {actual_owner}"
@@ -478,6 +484,15 @@ pub enum SuiError {
         given_parent: ObjectID,
         actual_owner: Owner,
     },
+
+    #[allow(non_camel_case_types)]
+    #[serde(rename = "StorageMissingFieldError")]
+    #[error("DEPRECATED")]
+    DEPRECATED_StorageMissingFieldError,
+    #[allow(non_camel_case_types)]
+    #[serde(rename = "StorageCorruptedFieldError")]
+    #[error("DEPRECATED")]
+    DEPRECATED_StorageCorruptedFieldError,
 
     #[error("Authority Error: {error:?}")]
     GenericAuthorityError { error: String },
@@ -594,6 +609,9 @@ pub enum SuiError {
 
     #[error("Failed to get JWK")]
     JWKRetrievalError,
+
+    #[error("Storage error: {0}")]
+    Storage(String),
 }
 
 #[repr(u64)]
@@ -652,13 +670,13 @@ impl From<Status> for SuiError {
 
 impl From<TypedStoreError> for SuiError {
     fn from(e: TypedStoreError) -> Self {
-        Self::StorageError(e.to_string())
+        Self::Storage(e.to_string())
     }
 }
 
 impl From<crate::storage::error::Error> for SuiError {
     fn from(e: crate::storage::error::Error) -> Self {
-        Self::StorageError(e.to_string())
+        Self::Storage(e.to_string())
     }
 }
 

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -107,7 +107,7 @@ impl ModuleResolver for &mut InMemoryStorage {
 }
 
 impl ObjectStore for InMemoryStorage {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> crate::storage::error::Result<Option<Object>> {
         Ok(self.persistent.get(object_id).cloned())
     }
 
@@ -115,7 +115,7 @@ impl ObjectStore for InMemoryStorage {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> crate::storage::error::Result<Option<Object>> {
         Ok(self
             .persistent
             .get(object_id)
@@ -131,7 +131,7 @@ impl ObjectStore for InMemoryStorage {
 }
 
 impl ObjectStore for &mut InMemoryStorage {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> crate::storage::error::Result<Option<Object>> {
         Ok(self.persistent.get(object_id).cloned())
     }
 
@@ -139,7 +139,7 @@ impl ObjectStore for &mut InMemoryStorage {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> crate::storage::error::Result<Option<Object>> {
         Ok(self
             .persistent
             .get(object_id)

--- a/crates/sui-types/src/storage/error.rs
+++ b/crates/sui-types/src/storage/error.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub type Result<T, E = Error> = ::std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Error {
+    inner: Box<Inner>,
+}
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Debug)]
+struct Inner {
+    kind: Kind,
+    source: Option<BoxError>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Kind {
+    Serialization,
+    Missing,
+    Custom,
+}
+
+impl Error {
+    fn new<E: Into<BoxError>>(kind: Kind, source: Option<E>) -> Self {
+        Self {
+            inner: Box::new(Inner {
+                kind,
+                source: source.map(Into::into),
+            }),
+        }
+    }
+
+    pub fn serialization<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::Serialization, Some(e))
+    }
+
+    pub fn missing<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::Missing, Some(e))
+    }
+
+    pub fn custom<E: Into<BoxError>>(e: E) -> Self {
+        Self::new(Kind::Custom, Some(e))
+    }
+
+    pub fn kind(&self) -> Kind {
+        self.inner.kind
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source.as_ref().map(|e| &**e as _)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: change output based on kind?
+        write!(f, "{:?}", self)
+    }
+}

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -5,6 +5,7 @@ mod object_store_trait;
 mod read_store;
 mod shared_in_memory_store;
 mod write_store;
+pub mod error;
 
 use crate::base_types::{TransactionDigest, VersionNumber};
 use crate::committee::EpochId;

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod error;
 mod object_store_trait;
 mod read_store;
 mod shared_in_memory_store;
 mod write_store;
-pub mod error;
 
 use crate::base_types::{TransactionDigest, VersionNumber};
 use crate::committee::EpochId;

--- a/crates/sui-types/src/storage/object_store_trait.rs
+++ b/crates/sui-types/src/storage/object_store_trait.rs
@@ -1,24 +1,106 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::error::Result;
+use super::ObjectKey;
 use crate::base_types::{ObjectID, ObjectRef, VersionNumber};
-use crate::error::SuiError;
 use crate::object::Object;
 use crate::storage::WriteKind;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub trait ObjectStore {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError>;
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>>;
+
     fn get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError>;
+    ) -> Result<Option<Object>>;
+
+    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        object_ids
+            .iter()
+            .map(|digest| self.get_object(digest))
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
+        object_keys
+            .iter()
+            .map(|k| self.get_object_by_key(&k.0, k.1))
+            .collect::<Result<Vec<_>, _>>()
+    }
+}
+
+impl<T: ObjectStore + ?Sized> ObjectStore for &T {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (*self).get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>> {
+        (*self).get_object_by_key(object_id, version)
+    }
+
+    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (*self).multi_get_objects(object_ids)
+    }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
+        (*self).multi_get_objects_by_key(object_keys)
+    }
+}
+
+impl<T: ObjectStore + ?Sized> ObjectStore for Box<T> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (**self).get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>> {
+        (**self).get_object_by_key(object_id, version)
+    }
+
+    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (**self).multi_get_objects(object_ids)
+    }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
+        (**self).multi_get_objects_by_key(object_keys)
+    }
+}
+
+impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (**self).get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>> {
+        (**self).get_object_by_key(object_id, version)
+    }
+
+    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (**self).multi_get_objects(object_ids)
+    }
+
+    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
+        (**self).multi_get_objects_by_key(object_keys)
+    }
 }
 
 impl ObjectStore for &[Object] {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.iter().find(|o| o.id() == *object_id).cloned())
     }
 
@@ -26,7 +108,7 @@ impl ObjectStore for &[Object] {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>> {
         Ok(self
             .iter()
             .find(|o| o.id() == *object_id && o.version() == version)
@@ -35,7 +117,7 @@ impl ObjectStore for &[Object] {
 }
 
 impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.get(object_id).map(|(_, obj, _)| obj).cloned())
     }
 
@@ -43,7 +125,7 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>> {
         Ok(self
             .get(object_id)
             .and_then(|(_, obj, _)| {
@@ -58,7 +140,7 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
 }
 
 impl ObjectStore for BTreeMap<ObjectID, Object> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.get(object_id).cloned())
     }
 
@@ -66,7 +148,7 @@ impl ObjectStore for BTreeMap<ObjectID, Object> {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> Result<Option<Object>> {
         Ok(self.get(object_id).and_then(|o| {
             if o.version() == version {
                 Some(o.clone())
@@ -74,33 +156,5 @@ impl ObjectStore for BTreeMap<ObjectID, Object> {
                 None
             }
         }))
-    }
-}
-
-impl<T: ObjectStore> ObjectStore for Arc<T> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.as_ref().get_object(object_id)
-    }
-
-    fn get_object_by_key(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
-        self.as_ref().get_object_by_key(object_id, version)
-    }
-}
-
-impl<T: ObjectStore> ObjectStore for &T {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        ObjectStore::get_object(*self, object_id)
-    }
-
-    fn get_object_by_key(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
-        ObjectStore::get_object_by_key(*self, object_id, version)
     }
 }


### PR DESCRIPTION
## Description 

This PR does some work to create a general purpose storage error, and then converting ObjectStore to use it, in an effort to reduce the reliance on the SuiError type (which is sort of a kitchen sink of errors across our repo).

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
