### PR TITLE
Convert iter_with_bounds to safe_iter_with_bounds

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -122,7 +122,7 @@ use sui_types::{
     SUI_SYSTEM_ADDRESS,
 };
 use sui_types::{is_system_package, TypeTag};
-use typed_store::Map;
+use typed_store::{Map, TypedStoreError};
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
@@ -3102,7 +3102,7 @@ impl AuthorityState {
         Ok(self
             .get_dynamic_fields_iterator(owner, cursor)?
             .take(limit)
-            .collect())
+            .collect::<Result<Vec<_>, _>>()?)
     }
 
     fn get_dynamic_fields_iterator(
@@ -3110,7 +3110,8 @@ impl AuthorityState {
         owner: ObjectID,
         // If `Some`, the query will start from the next item after the specified cursor
         cursor: Option<ObjectID>,
-    ) -> SuiResult<impl Iterator<Item = (ObjectID, DynamicFieldInfo)> + '_> {
+    ) -> SuiResult<impl Iterator<Item = Result<(ObjectID, DynamicFieldInfo), TypedStoreError>> + '_>
+    {
         if let Some(indexes) = &self.indexes {
             indexes.get_dynamic_fields_iterator(owner, cursor)
         } else {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2059,11 +2059,12 @@ impl AuthorityStore {
     pub fn count_object_versions(&self, object_id: ObjectID) -> usize {
         self.perpetual_tables
             .objects
-            .iter_with_bounds(
+            .safe_iter_with_bounds(
                 Some(ObjectKey(object_id, VersionNumber::MIN)),
                 Some(ObjectKey(object_id, VersionNumber::MAX)),
             )
-            .collect::<Vec<_>>()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
             .len()
     }
 }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -195,10 +195,11 @@ impl AuthorityStorePruner {
         if !object_tombstones_to_prune.is_empty() {
             let mut object_keys_to_delete = vec![];
             for ObjectKey(object_id, seq_number) in object_tombstones_to_prune {
-                for (object_key, _object_value) in perpetual_db.objects.iter_with_bounds(
+                for result in perpetual_db.objects.safe_iter_with_bounds(
                     Some(ObjectKey(object_id, VersionNumber::MIN)),
                     Some(ObjectKey(object_id, seq_number.next())),
                 ) {
+                    let (object_key, _) = result?;
                     assert_eq!(object_key.0, object_id);
                     object_keys_to_delete.push(object_key);
                 }

--- a/crates/sui-tool/src/db_tool/index_search.rs
+++ b/crates/sui-tool/src/db_tool/index_search.rs
@@ -225,17 +225,19 @@ where
     let mut entries = Vec::new();
     match termination {
         SearchRange::ExclusiveLastKey(exclusive_last_key) => {
-            let iter = db_map.iter_with_bounds(Some(start), Some(exclusive_last_key));
+            let iter = db_map.safe_iter_with_bounds(Some(start), Some(exclusive_last_key));
 
-            for (key, value) in iter {
+            for result in iter {
+                let (key, value) = result?;
                 entries.push((key.clone(), value.clone()));
             }
         }
         SearchRange::Count(mut count) => {
-            let mut iter = db_map.iter_with_bounds(Some(start), None);
+            let mut iter = db_map.safe_iter_with_bounds(Some(start), None);
 
             while count > 0 {
-                if let Some((key, value)) = iter.next() {
+                if let Some(result) = iter.next() {
+                    let (key, value) = result?;
                     entries.push((key.clone(), value.clone()));
                 } else {
                     break;

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -379,7 +379,7 @@ pub fn remove_transaction(path: &Path, opt: RemoveTransactionOptions) -> anyhow:
 pub fn remove_object_lock(path: &Path, opt: RemoveObjectLockOptions) -> anyhow::Result<()> {
     let perpetual_db = AuthorityPerpetualTables::open(&path.join("store"), None);
     let key = ObjectKey(opt.id, SequenceNumber::from_u64(opt.version));
-    if !opt.confirm && !perpetual_db.has_object_lock(&key) {
+    if !opt.confirm && !perpetual_db.has_object_lock(&key)? {
         bail!("Owned object lock for {:?} is not found!", key);
     };
     println!("Removing owned object lock for {:?}", key);

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1183,7 +1183,28 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
-    // Creates an RocksDB read option with lower and upper bounds set corresponding to `range`.
+    // Creates a RocksDB read option with specified lower and upper bounds.
+    fn create_read_options_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+        if let Some(lower_bound) = lower_bound {
+            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
+            readopts.set_iterate_lower_bound(key_buf);
+        }
+        if let Some(upper_bound) = upper_bound {
+            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
+            readopts.set_iterate_upper_bound(key_buf);
+        }
+        readopts
+    }
+
+    // Creates a RocksDB read option with lower and upper bounds set corresponding to `range`.
     fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
     where
         K: Serialize,
@@ -1952,15 +1973,7 @@ where
         lower_bound: Option<K>,
         upper_bound: Option<K>,
     ) -> Self::Iterator {
-        let mut readopts = self.opts.readopts();
-        if let Some(lower_bound) = lower_bound {
-            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
-            readopts.set_iterate_lower_bound(key_buf);
-        }
-        if let Some(upper_bound) = upper_bound {
-            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
-            readopts.set_iterate_upper_bound(key_buf);
-        }
+        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
         let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         Iter::new(
@@ -1995,6 +2008,25 @@ where
         let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         SafeIter::new(
             self.cf.clone(),

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1184,6 +1184,7 @@ impl<K, V> DBMap<K, V> {
     }
 
     // Creates a RocksDB read option with specified lower and upper bounds.
+    /// Lower bound is inclusive, and upper bound is exclusive.
     fn create_read_options_with_bounds(
         &self,
         lower_bound: Option<K>,

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -302,6 +302,14 @@ where
         .build()
     }
 
+    fn safe_iter_with_bounds(
+        &'a self,
+        _lower_bound: Option<K>,
+        _upper_bound: Option<K>,
+    ) -> Self::SafeIterator {
+        unimplemented!("unimplemented API");
+    }
+
     fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
         unimplemented!("unimplemented API");
     }

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -58,7 +58,7 @@ where
     /// This is potentially unsafe as it can perform a full table scan
     fn unbounded_iter(&'a self) -> Self::Iterator;
 
-    /// Returns an iterator visiting each key-value pair in the map.
+    /// Returns an iterator visiting each key-value pair within the specified bounds in the map.
     fn iter_with_bounds(&'a self, lower_bound: Option<K>, upper_bound: Option<K>)
         -> Self::Iterator;
 
@@ -68,6 +68,13 @@ where
 
     /// Same as `iter` but performs status check.
     fn safe_iter(&'a self) -> Self::SafeIterator;
+
+    // Same as `iter_with_bounds` but performs status check.
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator;
 
     // Same as `range_iter` but performs status check.
     fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;


### PR DESCRIPTION
## Description 

Replacing iter_with_bounds with safe_iter_with_bounds. Appreciate if the reviewers can spot check each call site and see if returning error makes sense.

## Test Plan 

More test cases added in unit test.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
