### PR TITLE
[GraphQL/Data] Consistent Reads API

### DIFF
--- a/crates/sui-graphql-rpc/src/data.rs
+++ b/crates/sui-graphql-rpc/src/data.rs
@@ -7,85 +7,98 @@ use async_trait::async_trait;
 use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryFragment},
     query_dsl::{methods::LimitDsl, LoadQuery},
-    Connection, QuerySource,
+    QueryResult, QuerySource,
 };
 
 use crate::error::Error;
 
 /// Database Backend in use -- abstracting a specific implementation.
-pub(crate) type Db = pg::PgManager_;
+pub(crate) type Db = pg::PgExecutor;
 
 /// Helper types to access associated types on `Db`.
-pub(crate) type DbConnection = <Db as QueryExecutor>::Connection;
-pub(crate) type DbBackend = <DbConnection as Connection>::Backend;
+pub(crate) type Conn<'c> = <Db as QueryExecutor>::DbConnection<'c>;
+pub(crate) type DieselConn = <Db as QueryExecutor>::Connection;
+pub(crate) type DieselBackend = <Db as QueryExecutor>::Backend;
 
 /// A generic boxed query (compatible with the return type of `into_boxed` on diesel's table DSL).
 ///
 /// - ST is the SqlType of the rows selected.
 /// - QS is the QuerySource (the table(s) being selected from).
-/// - QE is an instance of `QueryExecutor`, wrapping a particular diesel `Connection` and `Backend`.
 /// - GB is the GroupBy clause.
 ///
 /// These type parameters should usually be inferred by context.
-pub(crate) type BoxedQuery<ST, QS, QE, GB> = BoxedSelectStatement<
-    'static,
-    ST,
-    FromClause<QS>,
-    <<QE as QueryExecutor>::Connection as Connection>::Backend,
-    GB,
->;
+pub(crate) type Query<ST, QS, GB> = Query_<ST, QS, DieselBackend, GB>;
+
+/// Generic boxed query type that is also generic over the database backend. Used in the signatures
+/// of `QueryExecutor` and `DbConnection` and their implementations. (Clients can use the `Query`
+/// type above, which is specialised to the DB Backend in use.)
+pub(crate) type Query_<ST, QS, DB, GB> = BoxedSelectStatement<'static, ST, FromClause<QS>, DB, GB>;
 
 /// Interface for accessing relational data written by the Indexer, agnostic of the database
 /// back-end being used.
 #[async_trait]
 pub(crate) trait QueryExecutor {
-    type Connection: Connection;
+    type Backend: diesel::backend::Backend;
+    type Connection: diesel::Connection;
+
+    type DbConnection<'c>: DbConnection<Connection = Self::Connection, Backend = Self::Backend>
+    where
+        Self: 'c;
+
+    /// Execute `txn` with read committed isolation. `txn` is supplied a database connection to
+    /// issue queries over.
+    async fn execute<T, U, E>(&self, txn: T) -> Result<U, Error>
+    where
+        T: FnOnce(&mut Self::DbConnection<'_>) -> Result<U, E>,
+        E: From<diesel::result::Error> + std::error::Error,
+        T: Send + 'static,
+        U: Send + 'static,
+        E: Send + 'static;
+
+    /// Execute `txn` with repeatable reads and no phantom reads -- multiple calls to the same query
+    /// should produce the same results. `txn` is supplied a database connection to issue queries
+    /// over.
+    async fn execute_repeatable<T, U, E>(&self, txn: T) -> Result<U, Error>
+    where
+        T: FnOnce(&mut Self::DbConnection<'_>) -> Result<U, E>,
+        E: From<diesel::result::Error> + std::error::Error,
+        T: Send + 'static,
+        U: Send + 'static,
+        E: Send + 'static;
+}
+
+pub(crate) trait DbConnection {
+    type Backend: diesel::backend::Backend;
+    type Connection: diesel::Connection<Backend = Self::Backend>;
 
     /// Run a query that fetches a single value. `query` is a thunk that returns a boxed query when
     /// called.
-    async fn result<Q, ST, QS, GB, U>(&self, query: Q) -> Result<U, Error>
+    fn result<Q, ST, QS, GB, U>(&mut self, query: Q) -> QueryResult<U>
     where
-        Q: Fn() -> BoxedQuery<ST, QS, Self, GB>,
-        BoxedQuery<ST, QS, Self, GB>: LoadQuery<'static, Self::Connection, U>,
-        BoxedQuery<ST, QS, Self, GB>: QueryFragment<<Self::Connection as Connection>::Backend>,
-        QS: QuerySource,
-        Q: Send + 'static,
-        U: Send + 'static;
+        Q: Fn() -> Query_<ST, QS, Self::Backend, GB>,
+        Query_<ST, QS, Self::Backend, GB>: LoadQuery<'static, Self::Connection, U>,
+        Query_<ST, QS, Self::Backend, GB>: QueryFragment<Self::Backend>,
+        QS: QuerySource;
 
     /// Run a query that fetches multiple values. `query` is a thunk that returns a boxed query when
     /// called.
-    async fn results<Q, ST, QS, GB, U>(&self, query: Q) -> Result<Vec<U>, Error>
+    fn results<Q, ST, QS, GB, U>(&mut self, query: Q) -> QueryResult<Vec<U>>
     where
-        Q: Fn() -> BoxedQuery<ST, QS, Self, GB>,
-        BoxedQuery<ST, QS, Self, GB>: LoadQuery<'static, Self::Connection, U>,
-        BoxedQuery<ST, QS, Self, GB>: QueryFragment<<Self::Connection as Connection>::Backend>,
-        QS: QuerySource,
-        Q: Send + 'static,
-        U: Send + 'static;
-
-    /// Run a query that fetches a single value that might not exist. `query` is a thunk that
-    /// returns a boxed query when called.
-    async fn optional<Q, ST, QS, GB, U>(&self, query: Q) -> Result<Option<U>, Error>
-    where
-        Q: Fn() -> BoxedQuery<ST, QS, Self, GB>,
-        BoxedQuery<ST, QS, Self, GB>: LoadQuery<'static, Self::Connection, U>,
-        BoxedQuery<ST, QS, Self, GB>: QueryFragment<<Self::Connection as Connection>::Backend>,
-        QS: QuerySource,
-        Q: Send + 'static,
-        U: Send + 'static;
+        Q: Fn() -> Query_<ST, QS, Self::Backend, GB>,
+        Query_<ST, QS, Self::Backend, GB>: LoadQuery<'static, Self::Connection, U>,
+        Query_<ST, QS, Self::Backend, GB>: QueryFragment<Self::Backend>,
+        QS: QuerySource;
 
     /// Helper to limit a query that fetches multiple values to return only its first value. `query`
     /// is a thunk that returns a boxed query when called.
-    async fn first<Q, ST, QS, GB, U>(&self, query: Q) -> Result<U, Error>
+    fn first<Q, ST, QS, GB, U>(&mut self, query: Q) -> QueryResult<U>
     where
-        Q: Fn() -> BoxedQuery<ST, QS, Self, GB>,
-        BoxedQuery<ST, QS, Self, GB>: LoadQuery<'static, Self::Connection, U>,
-        BoxedQuery<ST, QS, Self, GB>: QueryFragment<<Self::Connection as Connection>::Backend>,
-        BoxedQuery<ST, QS, Self, GB>: LimitDsl<Output = BoxedQuery<ST, QS, Self, GB>>,
+        Q: Fn() -> Query_<ST, QS, Self::Backend, GB>,
+        Query_<ST, QS, Self::Backend, GB>: LoadQuery<'static, Self::Connection, U>,
+        Query_<ST, QS, Self::Backend, GB>: QueryFragment<Self::Backend>,
+        Query_<ST, QS, Self::Backend, GB>: LimitDsl<Output = Query_<ST, QS, Self::Backend, GB>>,
         QS: QuerySource,
-        Q: Send + 'static,
-        U: Send + 'static,
     {
-        self.result(move || query().limit(1i64)).await
+        self.result(move || query().limit(1i64))
     }
 }

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{string_input::impl_string_input, sui_address::SuiAddress};
-use crate::data::{BoxedQuery, Db, DbBackend};
+use crate::data::{DieselBackend, Query};
 use async_graphql::*;
 use diesel::{
     expression::{is_aggregate::No, ValidGrouping},
@@ -62,13 +62,13 @@ impl TypeFilter {
     /// Modify `query` to apply this filter to `field`, returning the new query.
     pub(crate) fn apply<E, QS, ST, GB>(
         &self,
-        query: BoxedQuery<ST, QS, Db, GB>,
+        query: Query<ST, QS, GB>,
         field: E,
-    ) -> BoxedQuery<ST, QS, Db, GB>
+    ) -> Query<ST, QS, GB>
     where
-        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
+        Query<ST, QS, GB>: QueryDsl,
         E: ExpressionMethods + TextExpressionMethods,
-        E: Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        E: Expression<SqlType = Text> + QueryFragment<DieselBackend>,
         E: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
         E: Clone + Send + 'static,
         QS: QuerySource,
@@ -106,16 +106,16 @@ impl FqNameFilter {
     /// containing the module member name.
     pub(crate) fn apply<P, M, N, QS, ST, GB>(
         &self,
-        query: BoxedQuery<ST, QS, Db, GB>,
+        query: Query<ST, QS, GB>,
         package: P,
         module: M,
         name: N,
-    ) -> BoxedQuery<ST, QS, Db, GB>
+    ) -> Query<ST, QS, GB>
     where
-        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
-        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DbBackend>,
-        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DbBackend>,
-        N: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        Query<ST, QS, GB>: QueryDsl,
+        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DieselBackend>,
+        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DieselBackend>,
+        N: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DieselBackend>,
         P: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
         M: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
         N: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
@@ -139,14 +139,14 @@ impl ModuleFilter {
     /// address and `module` as the module containing the module name.
     pub(crate) fn apply<P, M, QS, ST, GB>(
         &self,
-        query: BoxedQuery<ST, QS, Db, GB>,
+        query: Query<ST, QS, GB>,
         package: P,
         module: M,
-    ) -> BoxedQuery<ST, QS, Db, GB>
+    ) -> Query<ST, QS, GB>
     where
-        BoxedQuery<ST, QS, Db, GB>: QueryDsl,
-        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DbBackend>,
-        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DbBackend>,
+        Query<ST, QS, GB>: QueryDsl,
+        P: ExpressionMethods + Expression<SqlType = Binary> + QueryFragment<DieselBackend>,
+        M: ExpressionMethods + Expression<SqlType = Text> + QueryFragment<DieselBackend>,
         P: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
         M: AppearsOnTable<QS> + ValidGrouping<(), IsAggregate = No>,
         P: Send + 'static,


### PR DESCRIPTION
## Description

Adapt the `QueryExecutor` interface, to allow multiple queries to be issued within one transaction that sees a consistent snapshot of the database.

The previous API required that a query executor offer a way to run a query that produced a single result, multiple results, and an optional result (and provided a helper that produced one result), asynchronously.

The new API splits this functionality into two parts:

- `QueryExecutor` which offers an asynchronous API for executing transactions.
- `DbConnection` which offers a way to run a query that produces one or more results.

When `QueryExecutor` executes a transaction, it passes it an instance of `DbConnection`, which can then be used to run queries.

This change also gets rid of the `optional` helper, because it's no longer required -- we can rely on Diesel's own `OptionalExtension` to convert the output from a `result` or `first` query into an optional query.

Finally, we also adapt all the re-usable query building components (pagination, type filtering, etc) to accept a `DbConnection`, instead of the `Db` to allow them to be called within a transaction that contains other queries.

## Test Plan

This is a behaviour preserving refactor, confirmed by running all unit and E2E tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack 

- #15661 