### PR TITLE
[graphql/telemetry] 2/n Add query UUID and revisit some error logging

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -53,6 +53,7 @@ use sui_types::{
     },
     TypeTag,
 };
+use tracing::error;
 
 #[cfg(feature = "pg_backend")]
 use super::pg_backend::{PgQueryExecutor, QueryBuilder};
@@ -188,9 +189,18 @@ impl PgManager {
         let after = after
             .map(|cursor| self.parse_obj_cursor(&cursor))
             .transpose()?;
-        let coin_type = parse_to_type_tag(Some(coin_type))
-            .map_err(|e| Error::InvalidCoinType(e.to_string()))?
-            .to_canonical_string(/* with_prefix */ true);
+        let parsed_coin_type = parse_to_type_tag(Some(coin_type.clone()))
+            .map_err(|e| Error::InvalidCoinType(e.to_string()));
+
+        if parsed_coin_type.is_err() {
+            // TODO once we merge use the new PgManager
+            // self.metrics
+            // .request_metrics
+            // .request_client_input_error
+            // .inc();
+            error!("Invalid coin type: {coin_type}");
+        }
+        let coin_type = parsed_coin_type?.to_canonical_string(/* with_prefix */ true);
         let result: Option<Vec<StoredObject>> = self
             .run_query_async_with_cost(
                 move || {
@@ -697,6 +707,7 @@ impl PgManager {
         let mut connection = Connection::new(false, false);
         for (balance, count, coin_type) in balances {
             let (Some(balance), Some(count), Some(coin_type)) = (balance, count, coin_type) else {
+                error!("Expected fields are missing on balance calculation");
                 return Err(Error::Internal(
                     "Expected fields are missing on balance calculation".to_string(),
                 ));

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -14,8 +14,6 @@ use diesel::{
 };
 use sui_indexer::indexer_reader::IndexerReader;
 
-use tracing::{error, info};
-
 pub(crate) struct PgManager_ {
     pub inner: IndexerReader,
     pub limits: Limits,

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -59,9 +59,6 @@ impl QueryExecutor for PgManager_ {
         if let Some(metrics) = &self.metrics {
             metrics.observe_db_data(elapsed.as_secs_f64(), result.is_ok());
         }
-        if result.is_err() {
-            info!(target: "async-graphql", "DB query error: {:?}", result.as_ref().err());
-        }
         result
     }
 
@@ -89,9 +86,6 @@ impl QueryExecutor for PgManager_ {
         if let Some(metrics) = &self.metrics {
             metrics.observe_db_data(elapsed.as_secs_f64(), result.is_ok());
         }
-        if result.is_err() {
-            info!(target: "async-graphql", "DB query error: {:?}", result.as_ref().err());
-        }
         result
     }
 
@@ -117,9 +111,6 @@ impl QueryExecutor for PgManager_ {
         let elapsed = instant.elapsed();
         if let Some(metrics) = &self.metrics {
             metrics.observe_db_data(elapsed.as_secs_f64(), result.is_ok());
-        }
-        if result.is_err() {
-            error!(target: "async-graphql", "DB query error: {:?}", result.as_ref().err());
         }
         result
     }

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -164,9 +164,19 @@ mod query_cost {
         };
 
         if cost > max_db_query_cost as f64 {
-            warn!(cost, max_db_query_cost, exceeds = true, "Estimated cost");
+            warn!(
+                cost,
+                max_db_query_cost,
+                exceeds = true,
+                "[Cost] Estimated cost"
+            );
         } else {
-            info!(cost, max_db_query_cost, exceeds = false, "Estimated cost");
+            info!(
+                cost,
+                max_db_query_cost,
+                exceeds = false,
+                "[Cost] Estimated cost"
+            );
         }
     }
 

--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -140,7 +140,6 @@ impl Extension for LoggerExtension {
                             }
                         }
                     }
-
                     error!(
                         target: "async-graphql",
                         "[Response] path={} message={}", path, err.message,

--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -178,26 +178,25 @@ impl Extension for LoggerExtension {
                     }
                     if let Some(ext) = &err.extensions {
                         if let Some(code) = ext.get("code") {
-                            match code.clone().into_value() {
-                                async_graphql_value::Value::String(val) => {
-                                    if val == code::INTERNAL_SERVER_ERROR {
-                                        let query = self.query().await.clone();
-                                        error!(
-                                            query_id = query_uuid,
-                                            query = format!("{query}"),
-                                            "[Response] path={} message={}",
-                                            path,
-                                            err.message,
-                                        );
-                                    }
-                                    if val == code::BAD_USER_INPUT {
-                                        warn!(
-                                            query_id = query_uuid,
-                                            "[Response] path={} message={}", path, err.message,
-                                        );
-                                    }
+                            if let async_graphql_value::Value::String(val) =
+                                code.clone().into_value()
+                            {
+                                if val == code::INTERNAL_SERVER_ERROR {
+                                    let query = self.query().await.clone();
+                                    error!(
+                                        query_id = query_uuid,
+                                        query = format!("{query}"),
+                                        "[Response] path={} message={}",
+                                        path,
+                                        err.message,
+                                    );
                                 }
-                                _ => (),
+                                if val == code::BAD_USER_INPUT {
+                                    warn!(
+                                        query_id = query_uuid,
+                                        "[Response] path={} message={}", path, err.message,
+                                    );
+                                }
                             }
                         }
                     } else {

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -1,15 +1,210 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{register_histogram_with_registry, Histogram, Registry};
+use std::sync::Arc;
 
-#[derive(Clone, Debug)]
-pub struct RequestMetrics {
-    pub(crate) input_nodes: Histogram,
-    pub(crate) output_nodes: Histogram,
-    pub(crate) query_depth: Histogram,
-    pub(crate) query_payload_size: Histogram,
-    pub(crate) _db_query_cost: Histogram,
+use async_graphql::{PathSegment, ServerError};
+use prometheus::{
+    register_histogram_vec_with_registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, Histogram, HistogramVec, IntCounterVec, Registry,
+};
+use std::fmt::Write;
+
+use crate::error::code;
+
+#[derive(Clone)]
+pub(crate) struct Metrics {
+    pub db_metrics: Arc<DBMetrics>,
+    pub request_metrics: Arc<RequestMetrics>,
+}
+
+impl Metrics {
+    pub(crate) fn new(db_metrics: DBMetrics, request_metrics: RequestMetrics) -> Self {
+        Self {
+            db_metrics: Arc::new(db_metrics),
+            request_metrics: Arc::new(request_metrics),
+        }
+    }
+
+    /// Updates the DB related metrics (latency, error, success)
+    pub(crate) fn observe_db_data(&self, db_latency: f64, succeeded: bool) {
+        self.db_metrics
+            .db_fetch_latency
+            .with_label_values(&["latency", "db"])
+            .observe(db_latency);
+        if succeeded {
+            self.db_metrics
+                .db_fetch_success_rate
+                .with_label_values(&["success_rate", "db"])
+                .inc();
+        } else {
+            self.db_metrics
+                .db_fetch_error_rate
+                .with_label_values(&["error_rate", "db"])
+                .inc();
+        }
+    }
+
+    /// Use this function to increment the number of errors due to bad input
+    pub(crate) fn inc_num_bad_input_errors(&self, label: &str) {
+        self.request_metrics
+            .num_bad_input_errors_by_path
+            // TODO when measuring cost related errors, there's no path
+            // not 100% how to label such an error?
+            .with_label_values(&[label])
+            .inc();
+    }
+
+    /// Use this function to increment the number of errors per path, and labels
+    /// them as either internal server error, bad user input, or any other error.
+    /// The path is the same as the path that the user sees.
+    pub(crate) fn inc_errors(&self, errors: Vec<ServerError>) {
+        for err in errors {
+            if let Some(ext) = err.extensions {
+                if let Some(code) = ext.get("code") {
+                    match code.clone().into_value() {
+                        async_graphql_value::Value::String(val) => {
+                            if val == code::INTERNAL_SERVER_ERROR {
+                                self.request_metrics
+                                    .num_internal_errors_by_path
+                                    .with_label_values(&[&self.get_query_path(err.path)])
+                                    .inc();
+                            } else if val == code::BAD_USER_INPUT {
+                                self.request_metrics
+                                    .num_bad_input_errors_by_path
+                                    .with_label_values(&[&self.get_query_path(err.path)])
+                                    .inc();
+                            } else {
+                                self.request_metrics
+                                    .num_query_errors_by_path
+                                    .with_label_values(&[&self.get_query_path(err.path)])
+                                    .inc();
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Use this function to increment the number of request error.
+    /// If you need to increase error rate due to bad input, use both
+    /// this function and `inc_error_bad_input`
+    pub(crate) fn inc_num_query_success(&self) {
+        self.request_metrics
+            .num_query_success
+            .with_label_values(&["path"])
+            .inc();
+    }
+
+    /// When an error occurs, GraphQL returns a vector of PathSegments,
+    /// that we can use to construct a simplified path to the actual error.
+    pub(crate) fn get_query_path(&self, query: Vec<PathSegment>) -> String {
+        let mut path = String::new();
+        for (idx, s) in query.iter().enumerate() {
+            if idx > 0 {
+                path.push('.');
+            }
+            match s {
+                PathSegment::Index(idx) => {
+                    let _ = write!(&mut path, "{}", idx);
+                }
+                PathSegment::Field(name) => {
+                    let _ = write!(&mut path, "{}", name);
+                }
+            }
+        }
+        path
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DBMetrics {
+    pub db_fetch_success_rate: IntCounterVec,
+    pub db_fetch_error_rate: IntCounterVec,
+    pub db_fetch_latency: HistogramVec,
+    // TODO determine if we want this metric, and implement it
+    pub _db_fetch_batch_size: HistogramVec,
+}
+
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1., 2.5, 5., 10., 20., 30., 60., 90.,
+];
+
+const BATCH_SIZE_BUCKETS: &[f64] = &[
+    1., 2., 4., 8., 12., 16., 24., 32., 48., 64., 96., 128., 256., 512., 1024.,
+];
+
+impl DBMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        Self {
+            db_fetch_error_rate: register_int_counter_vec_with_registry!(
+                "db_fetch_error_rate",
+                "The total number of DB requests that returned an error",
+                &["error_rate", "type"],
+                registry
+            )
+            .unwrap(),
+
+            db_fetch_success_rate: register_int_counter_vec_with_registry!(
+                "db_fetch_success_rate",
+                "The total number of DB requests that were successful",
+                &["success_rate", "type"],
+                registry
+            )
+            .unwrap(),
+            db_fetch_latency: register_histogram_vec_with_registry!(
+                "db_fetch_latency",
+                "Latency of DB requests",
+                &["latency", "type"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+
+            _db_fetch_batch_size: register_histogram_vec_with_registry!(
+                "db_fetch_batch_size",
+                "Number of ids fetched per batch",
+                &["batch_size", "type"],
+                BATCH_SIZE_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RequestMetrics {
+    /// The number of nodes for the input query that passed the query limits check
+    pub input_nodes: Histogram,
+    /// The number of nodes in the result
+    pub output_nodes: Histogram,
+    /// The query depth
+    pub query_depth: Histogram,
+    /// The size (in bytes) of the payload
+    pub query_payload_size: Histogram,
+    /// An error due to too high payload size
+    pub query_payload_error: IntCounterVec,
+    pub _db_query_cost: Histogram,
+    /// The time it takes to validate the query
+    pub query_validation_latency: Histogram,
+    /// The time it takes to validate the query
+    pub query_validation_latency_by_path: HistogramVec,
+    /// The time it takes for the GraphQL service to execute the request
+    pub query_latency: Histogram,
+    // TODO figure out how to get the path for a
+    /// The time it takes for the GraphQL service to execute the request by path
+    pub _query_latency_by_path: HistogramVec,
+    /// Number of query errors by path, which are not bad input or internal
+    pub num_query_errors_by_path: IntCounterVec,
+    /// Number of query successes by path
+    pub num_query_success: IntCounterVec,
+    /// Bad input errors by path
+    pub num_bad_input_errors_by_path: IntCounterVec,
+    /// Internal errors by path
+    pub num_internal_errors_by_path: IntCounterVec,
 }
 
 // TODO: finetune buckets as we learn more about the distribution of queries
@@ -31,8 +226,13 @@ const DB_QUERY_COST_BUCKETS: &[f64] = &[
     1., 2., 4., 8., 12., 16., 24., 32., 48., 64., 96., 128., 256., 512., 1024.,
 ];
 
+// const REQUEST_NUM_ERRORS_BUCKETS: &[f64] = &[
+//     100., 200., 400., 800., 1200., 1600., 2400., 3200., 4800., 6400., 9600., 12800., 25600.,
+//     51200., 102400.,
+// ];
+
 impl RequestMetrics {
-    pub fn new(registry: &Registry) -> Self {
+    pub(crate) fn new(registry: &Registry) -> Self {
         Self {
             input_nodes: register_histogram_with_registry!(
                 "input_nodes",
@@ -62,10 +262,75 @@ impl RequestMetrics {
                 registry,
             )
             .unwrap(),
+            query_payload_error: register_int_counter_vec_with_registry!(
+                "query_payload_error",
+                "The total number of client input errors due to too large payload size",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
             _db_query_cost: register_histogram_with_registry!(
                 "db_query_cost",
                 "Cost of a DB query",
                 DB_QUERY_COST_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            query_validation_latency_by_path: register_histogram_vec_with_registry!(
+                "query_validation_latency_by_path",
+                "The time to validate the query for each path",
+                &["path"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            query_validation_latency: register_histogram_with_registry!(
+                "query_validation_latency",
+                "The time to validate the query",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            query_latency: register_histogram_with_registry!(
+                "query_latency",
+                "The time needed to resolve and get the result for the request",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            _query_latency_by_path: register_histogram_vec_with_registry!(
+                "query_latency_by_path",
+                "The time needed to resolve and get the result for the request for this path",
+                &["path"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            num_query_errors_by_path: register_int_counter_vec_with_registry!(
+                "num_query_errors",
+                "The number of queries that resulted in an error",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
+            num_query_success: register_int_counter_vec_with_registry!(
+                "num_query_success",
+                "The number of queries that were successful",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
+            num_bad_input_errors_by_path: register_int_counter_vec_with_registry!(
+                "num_bad_input_errors",
+                "The number of requests that resulted in an error due to bad input from the client",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
+            num_internal_errors_by_path: register_int_counter_vec_with_registry!(
+                "num_internal_errors_by_path",
+                "The number of requests that resulted in an error due to internal error",
+                &["path"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -41,6 +41,7 @@ use sui_sdk::SuiClientBuilder;
 use tokio::sync::OnceCell;
 use tower::{Layer, Service};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 pub struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
@@ -267,6 +268,18 @@ impl ServerBuilder {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct QueryUuid {
+    pub uuid: String,
+}
+impl QueryUuid {
+    pub(crate) fn new() -> Self {
+        Self {
+            uuid: format!("{}", Uuid::new_v4()),
+        }
+    }
+}
+
 async fn graphql_handler(
     State(metrics): State<Option<Metrics>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -284,6 +297,7 @@ async fn graphql_handler(
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);
+    req.data.insert(QueryUuid::new());
     let result = schema.execute(req).await;
     if let Some(timer) = timer {
         timer.observe_duration();

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -4,6 +4,7 @@
 use crate::config::{MAX_CONCURRENT_REQUESTS, RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD};
 use crate::context_data::package_cache::DbPackageStore;
 use crate::data::Db;
+use crate::metrics::{DBMetrics, Metrics, RequestMetrics};
 use crate::mutation::Mutation;
 use crate::{
     config::ServerConfig,
@@ -15,7 +16,6 @@ use crate::{
         query_limits_checker::{QueryLimitsChecker, ShowUsage},
         timeout::Timeout,
     },
-    metrics::RequestMetrics,
     server::version::{check_version_middleware, set_version_middleware},
     types::query::{Query, SuiGraphQLSchema},
 };
@@ -24,25 +24,23 @@ use async_graphql::extensions::Tracing;
 use async_graphql::EmptySubscription;
 use async_graphql::{extensions::ExtensionFactory, Schema, SchemaBuilder};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo, State};
 use axum::http::HeaderMap;
+use axum::middleware::{self};
 use axum::response::IntoResponse;
 use axum::routing::{post, MethodRouter, Route};
-use axum::{
-    extract::{connect_info::IntoMakeServiceWithConnectInfo, ConnectInfo},
-    middleware,
-};
 use axum::{headers::Header, Router};
 use http::Request;
 use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
 use hyper::Body;
 use hyper::Server as HyperServer;
 use std::convert::Infallible;
-use std::{any::Any, net::SocketAddr, sync::Arc, time::Instant};
+use std::{any::Any, net::SocketAddr, time::Instant};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use sui_sdk::SuiClientBuilder;
 use tokio::sync::OnceCell;
 use tower::{Layer, Service};
-use tracing::warn;
+use tracing::{info, warn};
 
 pub struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
@@ -63,15 +61,17 @@ pub(crate) struct ServerBuilder {
 
     schema: SchemaBuilder<Query, Mutation, EmptySubscription>,
     router: Option<Router>,
+    metrics: Option<Metrics>,
 }
 
 impl ServerBuilder {
-    pub fn new(port: u16, host: String) -> Self {
+    pub fn new(port: u16, host: String, metrics: Option<Metrics>) -> Self {
         Self {
             port,
             host,
             schema: async_graphql::Schema::build(Query, Mutation, EmptySubscription),
             router: None,
+            metrics,
         }
     }
 
@@ -109,7 +109,12 @@ impl ServerBuilder {
                 .route("/", post(graphql_handler))
                 .route("/graphql", post(graphql_handler))
                 .route("/health", axum::routing::get(health_checks))
-                .layer(middleware::from_fn(check_version_middleware))
+                .with_state(self.metrics.clone())
+                .route_layer(middleware::from_fn_with_state(
+                    self.metrics.clone(),
+                    check_version_middleware,
+                ))
+                // .layer(middleware::from_fn(check_version_middleware))
                 .layer(middleware::from_fn(set_version_middleware));
             self.router = Some(router);
         }
@@ -157,8 +162,32 @@ impl ServerBuilder {
     }
 
     pub async fn from_config(config: &ServerConfig) -> Result<Self, Error> {
-        let mut builder =
-            ServerBuilder::new(config.connection.port, config.connection.host.clone());
+        // PROMETHEUS
+        let prom_addr: SocketAddr = format!(
+            "{}:{}",
+            config.connection.prom_url, config.connection.prom_port
+        )
+        .parse()
+        .map_err(|_| {
+            Error::Internal(format!(
+                "Failed to parse url {}, port {} into socket address",
+                config.connection.prom_url, config.connection.prom_port
+            ))
+        })?;
+        let registry_service = mysten_metrics::start_prometheus_server(prom_addr);
+        info!("Starting Prometheus HTTP endpoint at {}", prom_addr);
+        let registry = registry_service.default_registry();
+
+        // METRICS
+        let request_metrics = RequestMetrics::new(&registry);
+        let db_metrics = DBMetrics::new(&registry);
+        let metrics = Metrics::new(db_metrics, request_metrics);
+
+        let mut builder = ServerBuilder::new(
+            config.connection.port,
+            config.connection.host.clone(),
+            Some(metrics.clone()),
+        );
 
         let name_service_config = config.name_service.clone();
         let reader = PgManager::reader_with_config(
@@ -166,7 +195,9 @@ impl ServerBuilder {
             config.connection.db_pool_size,
         )
         .map_err(|e| Error::Internal(format!("Failed to create pg connection pool: {}", e)))?;
-        let db = Db::new(reader.clone(), config.service.limits);
+
+        // DB
+        let db = Db::new(reader.clone(), config.service.limits, Some(metrics.clone()));
         let pg_conn_pool = PgManager::new(reader.clone(), config.service.limits);
         let package_store = DbPackageStore(reader);
         let package_cache = PackageStoreWithLruCache::new(package_store);
@@ -187,23 +218,6 @@ impl ServerBuilder {
             None
         };
 
-        let prom_addr: SocketAddr = format!(
-            "{}:{}",
-            config.connection.prom_url, config.connection.prom_port
-        )
-        .parse()
-        .map_err(|_| {
-            Error::Internal(format!(
-                "Failed to parse url {}, port {} into socket address",
-                config.connection.prom_url, config.connection.prom_port
-            ))
-        })?;
-        let registry_service = mysten_metrics::start_prometheus_server(prom_addr);
-        println!("Starting Prometheus HTTP endpoint at {}", prom_addr);
-        let registry = registry_service.default_registry();
-
-        let metrics = RequestMetrics::new(&registry);
-
         builder = builder
             .context_data(config.service.clone())
             .context_data(db)
@@ -214,7 +228,7 @@ impl ServerBuilder {
             ))
             .context_data(sui_sdk_client)
             .context_data(name_service_config)
-            .context_data(Arc::new(metrics))
+            .context_data(metrics.clone())
             .context_data(config.clone());
 
         if config.internal_features.feature_gate {
@@ -238,7 +252,14 @@ impl ServerBuilder {
 
         // TODO: uncomment once impl
         // if config.internal_features.open_telemetry {
-        //     let tracer;
+        //     let config = opentelemetry::sdk::trace::config()
+        //         .with_resource(Resource::new(vec![opentelemetry::KeyValue::new(
+        //             "service.name",
+        //             "sui-graphql-rpc",
+        //         )]))
+        //         .with_sampler(Sampler::ParentBased(Box::new(sampler.clone())));
+
+        //     let sampler = SamplingFilter::new(config.sample_rate);
         //     builder = builder.extension(OpenTelemetry::new(tracer));
         // }
 
@@ -247,11 +268,15 @@ impl ServerBuilder {
 }
 
 async fn graphql_handler(
+    State(metrics): State<Option<Metrics>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     schema: axum::Extension<SuiGraphQLSchema>,
     headers: HeaderMap,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
+    let timer = metrics
+        .clone()
+        .map(|m| m.request_metrics.query_latency.start_timer());
     let mut req = req.into_inner();
     if headers.contains_key(ShowUsage::name()) {
         req.data.insert(ShowUsage)
@@ -259,7 +284,18 @@ async fn graphql_handler(
     // Capture the IP address of the client
     // Note: if a load balancer is used it must be configured to forward the client IP address
     req.data.insert(addr);
-    schema.execute(req).await.into()
+    let result = schema.execute(req).await;
+    if let Some(timer) = timer {
+        timer.observe_duration();
+    }
+    if let Some(m) = metrics {
+        if result.is_ok() {
+            m.inc_num_query_success();
+        } else {
+            m.inc_errors(result.errors.clone());
+        }
+    }
+    result.into()
 }
 
 async fn health_checks(
@@ -369,9 +405,9 @@ pub mod tests {
             let mut cfg = ServiceConfig::default();
             cfg.limits.request_timeout_ms = timeout.as_millis() as u64;
 
-            let db = Db::new(reader.clone(), cfg.limits);
+            let db = Db::new(reader.clone(), cfg.limits, None);
             let pg_conn_pool = PgManager::new(reader, cfg.limits);
-            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(cfg)
@@ -380,6 +416,7 @@ pub mod tests {
                 })
                 .extension(Timeout)
                 .build_schema();
+
             schema.execute("{ chainIdentifier }").await
         }
 
@@ -419,9 +456,9 @@ pub mod tests {
                 },
                 ..Default::default()
             };
-            let db = Db::new(reader.clone(), service_config.limits);
+            let db = Db::new(reader.clone(), service_config.limits, None);
             let pg_conn_pool = PgManager::new(reader, service_config.limits);
-            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(service_config)
@@ -488,9 +525,9 @@ pub mod tests {
                 },
                 ..Default::default()
             };
-            let db = Db::new(reader.clone(), service_config.limits);
+            let db = Db::new(reader.clone(), service_config.limits, None);
             let pg_conn_pool = PgManager::new(reader, service_config.limits);
-            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+            let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(service_config)
@@ -557,9 +594,9 @@ pub mod tests {
         };
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-        let db = Db::new(reader.clone(), service_config.limits);
+        let db = Db::new(reader.clone(), service_config.limits, None);
         let pg_conn_pool = PgManager::new(reader, service_config.limits);
-        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(service_config)
@@ -606,7 +643,7 @@ pub mod tests {
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
         let pg_conn_pool = PgManager::new(reader, Limits::default());
-        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
             .context_data(pg_conn_pool)
             .build_schema();
 
@@ -644,9 +681,9 @@ pub mod tests {
 
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-        let db = Db::new(reader.clone(), service_config.limits);
+        let db = Db::new(reader.clone(), service_config.limits, None);
         let pg_conn_pool = PgManager::new(reader, service_config.limits);
-        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string())
+        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), None)
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(service_config)


### PR DESCRIPTION
## Description 

Adds a query uuid that can be used throughout the request to identify a unique query. The underlying idea is to log problematic queries and to be able to refer to them.

## Test Plan 

<img width="1723" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/34de0527-2494-4f6e-9f43-a490ec7b29c8">---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
