### PR TITLE
[GraphQL/Data] Loosen restriction on Boxed Queries

### DIFF
--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -25,7 +25,6 @@ impl ChainIdentifier {
                     dsl::checkpoints
                         .select(dsl::checkpoint_digest)
                         .order_by(dsl::sequence_number.asc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -103,7 +103,6 @@ impl ProtocolConfigs {
                                 .single_value(),
                         ))
                         .order_by(e::epoch.desc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -187,9 +187,7 @@ impl TransactionBlock {
         let stored: Option<StoredTransaction> = db
             .execute(move |conn| {
                 conn.result(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq(digest.to_vec()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq(digest.to_vec()))
                 })
                 .optional()
             })
@@ -213,9 +211,7 @@ impl TransactionBlock {
         let stored: Vec<StoredTransaction> = db
             .execute(move |conn| {
                 conn.results(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq_any(digests.clone()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq_any(digests.clone()))
                 })
             })
             .await


### PR DESCRIPTION
## Description

Now the `DbConnection` (previously `QueryExecutor`) no longer needs to be given a boxed query.  This unblocks use of union queries, which we will likely need to support consistent object reads.

## Test Plan

Behaviour preserving refactor, passing all unit and E2E tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```


## Stack 

- #15661 
- #15695 