### PR TITLE
[GraphQL/TransactionBlock] Checkpoint bound to Tx Seq Num bound

### DIFF
--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -25,7 +25,6 @@ impl ChainIdentifier {
                     dsl::checkpoints
                         .select(dsl::checkpoint_digest)
                         .order_by(dsl::sequence_number.asc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -103,7 +103,6 @@ impl ProtocolConfigs {
                                 .single_value(),
                         ))
                         .order_by(e::epoch.desc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -187,9 +187,7 @@ impl TransactionBlock {
         let stored: Option<StoredTransaction> = db
             .execute(move |conn| {
                 conn.result(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq(digest.to_vec()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq(digest.to_vec()))
                 })
                 .optional()
             })
@@ -213,9 +211,7 @@ impl TransactionBlock {
         let stored: Vec<StoredTransaction> = db
             .execute(move |conn| {
                 conn.results(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq_any(digests.clone()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq_any(digests.clone()))
                 })
             })
             .await


### PR DESCRIPTION
##  Description

Implement filtering transaction blocks above and below by checkpoints by first translating the checkpoint sequence number bound into a transaction sequence number bound.

This was an optimisation that existed prior to #15661, but was implemented by issuing three separate queries (three separate DB round-trips).  #15661, switched the query to a single DB round-trip, but experimentally, we found that querying for a max page size of transaction blocks was too slow -- and often it timed out at the DB.

This PR is hopefully the best of both worlds: One DB roundtrip and good use of indices.

## Test Plan

Tried the following query (querying the first 50 transactions in the last full epoch stored in the data-set for the GraphQL beta), in SQL:

```sql
SELECT
        *
FROM
        transactions
WHERE
        tx_sequence_number > (
        -- Last sequence number in the AFTER checkpoint
        SELECT
                tx_sequence_number
        FROM
                transactions
        WHERE
                checkpoint_sequence_number = 18783764
        ORDER BY
                tx_sequence_number DESC
        LIMIT
                1
)
AND     tx_sequence_number < (
        -- First sequence number in the BEFORE checkpoint
        SELECT
                tx_sequence_number
        FROM
                transactions
        WHERE
                checkpoint_sequence_number = 18870895
        ORDER BY
                tx_sequence_number ASC
        LIMIT
                1
)
ORDER BY
        tx_sequence_number
LIMIT
        50
```

And also in GraphQL:

```graphql
query {
  transactionBlocks(
    filter: {
        afterCheckpoint: 18783764,
        beforeCheckpoint: 18870895,
    }
  ) {
    pageInfo {
      hasNextPage
      endCursor
    }

    edges {
      cursor
      node {
        digest
      }
    }
  }
}
```

The GraphQL query now runs where previously it would time-out.  The SQL query also finishes in good time, compared to the old query which hangs forever:

```sql
SELECT
        *
FROM
        transactions
WHERE
        checkpoint_sequence_number > 18783764
AND     checkpoint_sequence_number < 18870895
ORDER BY
        tx_sequence_number
LIMIT
        50
```

## Stack 

- #15661 
- #15695 
- #15698 