### PR TITLE
[cli] Update description of keytool update-alias to include allowing dot as a character

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -66,7 +66,7 @@ pub enum KeyToolCommand {
     #[clap(name = "update-alias")]
     Alias {
         old_alias: String,
-        /// The alias must start with a letter and can contain only letters, digits, hyphens (-), or underscores (_).
+        /// The alias must start with a letter and can contain only letters, digits, dots, hyphens (-), or underscores (_).
         new_alias: Option<String>,
     },
     /// Convert private key from wallet format (hex of 32 byte private key) to sui.keystore format


### PR DESCRIPTION
## Description 

Update description of keytool update-alias to include allowing dot as a character

## Test Plan 

Just docs, no tests needed.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The `keytool update-alias` command's description was updated to match the latest changes that allow aliases to contain the dot character in their names.