### PR TITLE
[GraphQL/Type Filter] Intersection algorithm

### DIFF
--- a/crates/sui-graphql-rpc/src/types/chain_identifier.rs
+++ b/crates/sui-graphql-rpc/src/types/chain_identifier.rs
@@ -25,7 +25,6 @@ impl ChainIdentifier {
                     dsl::checkpoints
                         .select(dsl::checkpoint_digest)
                         .order_by(dsl::sequence_number.asc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/protocol_config.rs
+++ b/crates/sui-graphql-rpc/src/types/protocol_config.rs
@@ -103,7 +103,6 @@ impl ProtocolConfigs {
                                 .single_value(),
                         ))
                         .order_by(e::epoch.desc())
-                        .into_boxed()
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -187,9 +187,7 @@ impl TransactionBlock {
         let stored: Option<StoredTransaction> = db
             .execute(move |conn| {
                 conn.result(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq(digest.to_vec()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq(digest.to_vec()))
                 })
                 .optional()
             })
@@ -213,9 +211,7 @@ impl TransactionBlock {
         let stored: Vec<StoredTransaction> = db
             .execute(move |conn| {
                 conn.results(move || {
-                    dsl::transactions
-                        .filter(dsl::transaction_digest.eq_any(digests.clone()))
-                        .into_boxed()
+                    dsl::transactions.filter(dsl::transaction_digest.eq_any(digests.clone()))
                 })
             })
             .await

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -376,7 +376,7 @@ impl TransactionBlockFilter {
         }
 
         Some(Self {
-            function: merge!(function, by_eq)?,
+            function: merge!(function, FqNameFilter::intersect)?,
             kind: merge!(kind, by_eq)?,
 
             after_checkpoint: merge!(after_checkpoint, by_max)?,


### PR DESCRIPTION
## Description

Adds a way to intersect two module or fully-qualified name filters, to correct the behaviour of transaction block filtering (which previously implemented intersection of its function filter by simple equality test).

## Test Plan

New unit tests:

```
sui-graphql-rpc$ cargo nextest run -- type_filter
```

## Stack 

- #15661 
- #15695 
- #15698 
- #15699 