### PR TITLE
Fix the serialize of proof_inputs_bytes

### DIFF
--- a/docs/content/guides/developer/cryptography/groth16.mdx
+++ b/docs/content/guides/developer/cryptography/groth16.mdx
@@ -94,7 +94,7 @@ To verify a proof, you also need two more inputs, `proof_inputs_bytes` and `proo
 
 ```rust
 let mut proof_inputs_bytes = Vec::new();
-inputs.serialize_compressed(&mut proof_inputs_bytes).unwrap();
+inputs[0].serialize_compressed(&mut proof_inputs_bytes).unwrap();
 
 let mut proof_points_bytes = Vec::new();
 proof.a.serialize_compressed(&mut proof_points_bytes).unwrap();


### PR DESCRIPTION
## Description 

I think there is some confusion here in the docs, when serializing proof inputs for the cases in the docs should serialize `inputs[0]`.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
