### PR TITLE
Add deny list transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -39,4 +39,4 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(5,1)}}}
 
 task 8 'run'. lines 93-93:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(4,0)], parent_id: [object(5,0)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(4,0), parent_id: object(5,0) }

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -39,4 +39,4 @@ Version: 3
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(5,1)}}}
 
 task 8 'run'. lines 93-93:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0x466fb7f9c3c2c8e5e958e3597f5b22b28656f86aa5d8092810cde4edc79d7b39, parent_id: 0x8ef41369eee2379bf085587cea4e384d7d00a6e8f975b51abd1bf014b394a87c }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(4,0)], parent_id: [object(5,0)] }

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.exp
@@ -47,10 +47,10 @@ mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000
 gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
 
 task 10 'transfer-object'. lines 59-61:
-Error: Error checking transaction input objects: AddressDeniedForCoin { address: [B], coin_type: "[object(1,0)]::regulated_coin::REGULATED_COIN" }
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: @B, coin_type: "object(1,0)::regulated_coin::REGULATED_COIN" }
 
 task 11 'run'. lines 62-64:
-Error: Error checking transaction input objects: AddressDeniedForCoin { address: [B], coin_type: "[object(1,0)]::regulated_coin::REGULATED_COIN" }
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: @B, coin_type: "object(1,0)::regulated_coin::REGULATED_COIN" }
 
 task 12 'run'. lines 65-67:
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(9,1)

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 12-38:
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 18316000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'view-object'. lines 40-40:
+1,0::regulated_coin
+
+task 3 'view-object'. lines 42-42:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,1)}}, balance: sui::balance::Balance<test::regulated_coin::REGULATED_COIN> {value: 10000u64}}
+
+task 4 'view-object'. lines 44-44:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::CoinMetadata<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,2)}}, decimals: 9u8, name: std::string::String {bytes: vector[82u8, 69u8, 71u8, 85u8, 76u8, 65u8, 84u8, 69u8, 68u8, 95u8, 67u8, 79u8, 73u8, 78u8]}, symbol: std::ascii::String {bytes: vector[82u8, 67u8]}, description: std::string::String {bytes: vector[65u8, 32u8, 110u8, 101u8, 119u8, 32u8, 114u8, 101u8, 103u8, 117u8, 108u8, 97u8, 116u8, 101u8, 100u8, 32u8, 99u8, 111u8, 105u8, 110u8]}, icon_url: std::option::Option<sui::url::Url> {vec: vector[]}}
+
+task 5 'view-object'. lines 46-46:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::DenyCap<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,3)}}}
+
+task 6 'view-object'. lines 48-48:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::RegulatedCoinMetadata<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,4)}}, coin_metadata_object: sui::object::ID {bytes: fake(1,2)}, deny_cap_object: sui::object::ID {bytes: fake(1,3)}}
+
+task 7 'view-object'. lines 50-52:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::TreasuryCap<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,5)}}, total_supply: sui::balance::Supply<test::regulated_coin::REGULATED_COIN> {value: 10000u64}}
+
+task 8 'run'. lines 53-55:
+created: object(8,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 3936800,  storage_rebate: 2437776, non_refundable_storage_fee: 24624
+
+task 9 'run'. lines 56-58:
+created: object(9,0), object(9,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
+
+task 10 'transfer-object'. lines 59-61:
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: [B], coin_type: "[object(1,0)]::regulated_coin::REGULATED_COIN" }
+
+task 11 'run'. lines 62-64:
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: [B], coin_type: "[object(1,0)]::regulated_coin::REGULATED_COIN" }
+
+task 12 'run'. lines 65-67:
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(9,1)
+deleted: object(9,0)
+gas summary: computation_cost: 1000000, storage_cost: 9522800,  storage_rebate: 11301048, non_refundable_storage_fee: 114152
+
+task 13 'transfer-object'. lines 68-68:
+mutated: object(0,1), object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 2462400,  storage_rebate: 1459656, non_refundable_storage_fee: 14744

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test verifies the basic e2e work flow of coin deny list.
+// A newly created regulated coin type should come with the deny cap object.
+// Coin isser can use the deny cap to deny addresses, which will no longer be able to
+// transfer the coin or use it in Move calls.
+// Undeny the address will restore the original behavior.
+
+//# init --accounts A B --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    struct REGULATED_COIN has drop {}
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# view-object 1,0
+
+//# view-object 1,1
+
+//# view-object 1,2
+
+//# view-object 1,3
+
+//# view-object 1,4
+
+//# view-object 1,5
+
+// Transfer away the newly minted coin works normally.
+//# run sui::pay::split_and_transfer --args object(1,1) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Deny account B.
+//# run sui::coin::deny_list_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Try transfer the coin from B. This should now be denied.
+//# transfer-object 8,0 --sender B --recipient A
+
+// Try using the coin in a Move call. This should also be denied.
+//# run sui::pay::split_and_transfer --args object(8,0) 1 @A --type-args test::regulated_coin::REGULATED_COIN --sender B
+
+// Undeny account B.
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// This time the transfer should work.
+//# transfer-object 8,0 --sender B --recipient A

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.exp
@@ -67,7 +67,7 @@ mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000
 gas summary: computation_cost: 1000000, storage_cost: 11293600,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
 task 14 'transfer-object'. lines 90-92:
-Error: Error checking transaction input objects: AddressDeniedForCoin { address: [A], coin_type: "[object(1,0)]::first_coin::FIRST_COIN" }
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: @A, coin_type: "object(1,0)::first_coin::FIRST_COIN" }
 
 task 15 'transfer-object'. lines 93-93:
 mutated: object(0,0), object(1,2)

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.exp
@@ -1,0 +1,74 @@
+processed 16 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 9-62:
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 33082800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'view-object'. lines 64-64:
+1,0::{first_coin, second_coin}
+
+task 3 'view-object'. lines 66-66:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<test::first_coin::FIRST_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,1)}}, balance: sui::balance::Balance<test::first_coin::FIRST_COIN> {value: 10000u64}}
+
+task 4 'view-object'. lines 68-68:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<test::second_coin::SECOND_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,2)}}, balance: sui::balance::Balance<test::second_coin::SECOND_COIN> {value: 10000u64}}
+
+task 5 'view-object'. lines 70-70:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::CoinMetadata<test::first_coin::FIRST_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,3)}}, decimals: 9u8, name: std::string::String {bytes: vector[82u8, 69u8, 71u8, 85u8, 76u8, 65u8, 84u8, 69u8, 68u8, 95u8, 67u8, 79u8, 73u8, 78u8]}, symbol: std::ascii::String {bytes: vector[82u8, 67u8]}, description: std::string::String {bytes: vector[65u8, 32u8, 110u8, 101u8, 119u8, 32u8, 114u8, 101u8, 103u8, 117u8, 108u8, 97u8, 116u8, 101u8, 100u8, 32u8, 99u8, 111u8, 105u8, 110u8]}, icon_url: std::option::Option<sui::url::Url> {vec: vector[]}}
+
+task 6 'view-object'. lines 72-72:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::CoinMetadata<test::second_coin::SECOND_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,4)}}, decimals: 9u8, name: std::string::String {bytes: vector[82u8, 69u8, 71u8, 85u8, 76u8, 65u8, 84u8, 69u8, 68u8, 95u8, 67u8, 79u8, 73u8, 78u8]}, symbol: std::ascii::String {bytes: vector[82u8, 67u8]}, description: std::string::String {bytes: vector[65u8, 32u8, 110u8, 101u8, 119u8, 32u8, 114u8, 101u8, 103u8, 117u8, 108u8, 97u8, 116u8, 101u8, 100u8, 32u8, 99u8, 111u8, 105u8, 110u8]}, icon_url: std::option::Option<sui::url::Url> {vec: vector[]}}
+
+task 7 'view-object'. lines 74-74:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::DenyCap<test::first_coin::FIRST_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,5)}}}
+
+task 8 'view-object'. lines 76-76:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::DenyCap<test::second_coin::SECOND_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,6)}}}
+
+task 9 'view-object'. lines 78-78:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::RegulatedCoinMetadata<test::first_coin::FIRST_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,7)}}, coin_metadata_object: sui::object::ID {bytes: fake(1,3)}, deny_cap_object: sui::object::ID {bytes: fake(1,5)}}
+
+task 10 'view-object'. lines 80-80:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::RegulatedCoinMetadata<test::second_coin::SECOND_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,8)}}, coin_metadata_object: sui::object::ID {bytes: fake(1,4)}, deny_cap_object: sui::object::ID {bytes: fake(1,6)}}
+
+task 11 'view-object'. lines 82-82:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::TreasuryCap<test::first_coin::FIRST_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,9)}}, total_supply: sui::balance::Supply<test::first_coin::FIRST_COIN> {value: 10000u64}}
+
+task 12 'view-object'. lines 84-86:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::TreasuryCap<test::second_coin::SECOND_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,10)}}, total_supply: sui::balance::Supply<test::second_coin::SECOND_COIN> {value: 10000u64}}
+
+task 13 'run'. lines 87-89:
+created: object(13,0), object(13,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,5)
+gas summary: computation_cost: 1000000, storage_cost: 11293600,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
+
+task 14 'transfer-object'. lines 90-92:
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: [A], coin_type: "[object(1,0)]::first_coin::FIRST_COIN" }
+
+task 15 'transfer-object'. lines 93-93:
+mutated: object(0,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 2416800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.move
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test creates multiple coin types in the same module, and show that deny actions on one type does not affect
+// the other type.
+
+//# init --accounts A --addresses test=0x0
+
+//# publish --sender A
+module test::first_coin {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    struct FIRST_COIN has drop {}
+
+    fun init(otw: FIRST_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+module test::second_coin {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    struct SECOND_COIN has drop {}
+
+    fun init(otw: SECOND_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+}
+
+//# view-object 1,0
+
+//# view-object 1,1
+
+//# view-object 1,2
+
+//# view-object 1,3
+
+//# view-object 1,4
+
+//# view-object 1,5
+
+//# view-object 1,6
+
+//# view-object 1,7
+
+//# view-object 1,8
+
+//# view-object 1,9
+
+//# view-object 1,10
+
+// Deny account A for FIRST_COIN.
+//# run sui::coin::deny_list_add --args object(0x403) object(1,5) @A --type-args test::first_coin::FIRST_COIN --sender A
+
+// Sending away first coin from A should fail.
+//# transfer-object 1,1 --sender A --recipient A
+
+// Sending away second coin from A should not be affected, and hence will succeed.
+//# transfer-object 1,2 --sender A --recipient A

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.exp
@@ -1,0 +1,59 @@
+processed 13 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-52:
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 21766400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'view-object'. lines 54-54:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::regulated_coin::Wallet {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,0)}}}
+
+task 3 'view-object'. lines 56-56:
+1,1::regulated_coin
+
+task 4 'view-object'. lines 58-58:
+Owner: Account Address ( fake(1,0) )
+Version: 2
+Contents: sui::coin::Coin<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,2)}}, balance: sui::balance::Balance<test::regulated_coin::REGULATED_COIN> {value: 10000u64}}
+
+task 5 'view-object'. lines 60-60:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::CoinMetadata<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,3)}}, decimals: 9u8, name: std::string::String {bytes: vector[82u8, 69u8, 71u8, 85u8, 76u8, 65u8, 84u8, 69u8, 68u8, 95u8, 67u8, 79u8, 73u8, 78u8]}, symbol: std::ascii::String {bytes: vector[82u8, 67u8]}, description: std::string::String {bytes: vector[65u8, 32u8, 110u8, 101u8, 119u8, 32u8, 114u8, 101u8, 103u8, 117u8, 108u8, 97u8, 116u8, 101u8, 100u8, 32u8, 99u8, 111u8, 105u8, 110u8]}, icon_url: std::option::Option<sui::url::Url> {vec: vector[]}}
+
+task 6 'view-object'. lines 62-62:
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::DenyCap<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,4)}}}
+
+task 7 'view-object'. lines 64-64:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::RegulatedCoinMetadata<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,5)}}, coin_metadata_object: sui::object::ID {bytes: fake(1,3)}, deny_cap_object: sui::object::ID {bytes: fake(1,4)}}
+
+task 8 'view-object'. lines 66-68:
+Owner: Immutable
+Version: 2
+Contents: sui::coin::TreasuryCap<test::regulated_coin::REGULATED_COIN> {id: sui::object::UID {id: sui::object::ID {bytes: fake(1,6)}}, total_supply: sui::balance::Supply<test::regulated_coin::REGULATED_COIN> {value: 10000u64}}
+
+task 9 'run'. lines 69-71:
+created: object(9,0), object(9,1)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,4)
+gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
+
+task 10 'run'. lines 72-74:
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: [A], coin_type: "[object(1,1)]::regulated_coin::REGULATED_COIN" }
+
+task 11 'run'. lines 75-77:
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,4), object(9,1)
+deleted: object(9,0)
+gas summary: computation_cost: 1000000, storage_cost: 9522800,  storage_rebate: 11301048, non_refundable_storage_fee: 114152
+
+task 12 'run'. lines 78-78:
+mutated: object(0,0), object(1,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 3807600,  storage_rebate: 3769524, non_refundable_storage_fee: 38076

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.exp
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.exp
@@ -47,7 +47,7 @@ mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000
 gas summary: computation_cost: 1000000, storage_cost: 11415200,  storage_rebate: 2723688, non_refundable_storage_fee: 27512
 
 task 10 'run'. lines 72-74:
-Error: Error checking transaction input objects: AddressDeniedForCoin { address: [A], coin_type: "[object(1,1)]::regulated_coin::REGULATED_COIN" }
+Error: Error checking transaction input objects: AddressDeniedForCoin { address: @A, coin_type: "object(1,1)::regulated_coin::REGULATED_COIN" }
 
 task 11 'run'. lines 75-77:
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,4), object(9,1)

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.move
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test verifies the deny list also applies to receiving coin objects.
+
+//# init --accounts A --addresses test=0x0
+
+//# publish --sender A
+module test::regulated_coin {
+    use std::option;
+    use sui::coin;
+    use sui::coin::Coin;
+    use sui::object;
+    use sui::object::UID;
+    use sui::transfer;
+    use sui::transfer::Receiving;
+    use sui::tx_context;
+    use sui::tx_context::TxContext;
+
+    struct REGULATED_COIN has drop {}
+
+    struct Wallet has key {
+        id: UID,
+    }
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        let wallet = Wallet {
+            id: object::new(ctx),
+        };
+        transfer::public_transfer(coin, object::id_address(&wallet));
+        transfer::transfer(wallet, tx_context::sender(ctx));
+
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+
+    public fun receive_coin(wallet: &mut Wallet, coin: Receiving<Coin<REGULATED_COIN>>, ctx: &TxContext) {
+        let coin = transfer::public_receive(&mut wallet.id, coin);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+    }
+}
+
+//# view-object 1,0
+
+//# view-object 1,1
+
+//# view-object 1,2
+
+//# view-object 1,3
+
+//# view-object 1,4
+
+//# view-object 1,5
+
+//# view-object 1,6
+
+// Deny account A.
+//# run sui::coin::deny_list_add --args object(0x403) object(1,4) @A --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Try to receive coin in Wallet. This should now fail.
+//# run test::regulated_coin::receive_coin --args object(1,0) receiving(1,2) --sender A
+
+// Undeny account A.
+//# run sui::coin::deny_list_remove --args object(0x403) object(1,4) @A --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Try to receive coin in Wallet. This should now succeed.
+//# run test::regulated_coin::receive_coin --args object(1,0) receiving(1,2) --sender A

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -33,7 +33,7 @@ mutated: object(0,0), object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
 
 task 7 'run'. lines 132-136:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(6,0)], parent_id: [object(6,1)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(6,0), parent_id: object(6,1) }
 
 task 8 'run'. lines 138-138:
 created: object(8,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -33,7 +33,7 @@ mutated: object(0,0), object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
 
 task 7 'run'. lines 132-136:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0x2a3551a605e9b22e289b35067b1aaa934c563a6bc2de5cc049658ce8ce89b3c7, parent_id: 0x692d988f96ea464e0f265006c68ec4a81831402dde7a75cae73197e07768a461 }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(6,0)], parent_id: [object(6,1)] }
 
 task 8 'run'. lines 138-138:
 created: object(8,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -29,7 +29,7 @@ mutated: object(0,0), object(4,0)
 gas summary: computation_cost: 1000000, storage_cost: 6665200,  storage_rebate: 2573208, non_refundable_storage_fee: 25992
 
 task 6 'run'. lines 129-133:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0xc7f065f57e819836de7be3316b9106fb484b971ea18fdbd5034904850342d3ca, parent_id: 0xffddb920cb12e53ca4fb828fb0ecad515e6e889d3f183889a4e10908cb39b2e0 }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(5,0)], parent_id: [object(5,1)] }
 
 task 7 'run'. lines 135-135:
 created: object(7,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -29,7 +29,7 @@ mutated: object(0,0), object(4,0)
 gas summary: computation_cost: 1000000, storage_cost: 6665200,  storage_rebate: 2573208, non_refundable_storage_fee: 25992
 
 task 6 'run'. lines 129-133:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(5,0)], parent_id: [object(5,1)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(5,0), parent_id: object(5,1) }
 
 task 7 'run'. lines 135-135:
 created: object(7,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.exp
@@ -29,7 +29,7 @@ mutated: object(0,0), object(4,0)
 gas summary: computation_cost: 1000000, storage_cost: 6665200,  storage_rebate: 2573208, non_refundable_storage_fee: 25992
 
 task 6 'run'. lines 129-133:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0xc7f065f57e819836de7be3316b9106fb484b971ea18fdbd5034904850342d3ca, parent_id: 0xffddb920cb12e53ca4fb828fb0ecad515e6e889d3f183889a4e10908cb39b2e0 }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(5,0)], parent_id: [object(5,1)] }
 
 task 7 'run'. lines 135-135:
 created: object(7,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.exp
@@ -29,7 +29,7 @@ mutated: object(0,0), object(4,0)
 gas summary: computation_cost: 1000000, storage_cost: 6665200,  storage_rebate: 2573208, non_refundable_storage_fee: 25992
 
 task 6 'run'. lines 129-133:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(5,0)], parent_id: [object(5,1)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(5,0), parent_id: object(5,1) }
 
 task 7 'run'. lines 135-135:
 created: object(7,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.exp
@@ -33,7 +33,7 @@ mutated: object(0,0), object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
 
 task 7 'run'. lines 132-136:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(6,0)], parent_id: [object(6,1)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(6,0), parent_id: object(6,1) }
 
 task 8 'run'. lines 138-138:
 created: object(8,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.exp
@@ -33,7 +33,7 @@ mutated: object(0,0), object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 2249676, non_refundable_storage_fee: 22724
 
 task 7 'run'. lines 132-136:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0x2a3551a605e9b22e289b35067b1aaa934c563a6bc2de5cc049658ce8ce89b3c7, parent_id: 0x692d988f96ea464e0f265006c68ec4a81831402dde7a75cae73197e07768a461 }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(6,0)], parent_id: [object(6,1)] }
 
 task 8 'run'. lines 138-138:
 created: object(8,0)

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.exp
@@ -18,4 +18,4 @@ task 4 'programmable'. lines 41-44:
 Error: Error checking transaction input objects: DuplicateObjectRefInput
 
 task 5 'programmable'. lines 45-46:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object 0x6b7c4000d7f46a0cf15aeab3134157cbdecc6d25aa828d74c8bd36f91314a17e is owned by account address 0xacc3895100e62eddf620872c5c762488afac12c37c4e1141ca0a88052738a9e1, but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(2,1)] is owned by account address [object(2,0)], but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.exp
@@ -18,4 +18,4 @@ task 4 'programmable'. lines 41-44:
 Error: Error checking transaction input objects: DuplicateObjectRefInput
 
 task 5 'programmable'. lines 45-46:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(2,1)] is owned by account address [object(2,0)], but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object object(2,1) is owned by account address object(2,0), but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.exp
@@ -41,7 +41,7 @@ Error: Transaction Effects Status: Invalid command argument at 0. The type of th
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
 
 task 10 'run'. lines 61-61:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(2,1)] is owned by account address [object(2,0)], but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object object(2,1) is owned by account address object(2,0), but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
 
 task 11 'run'. lines 63-63:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.exp
@@ -41,7 +41,7 @@ Error: Transaction Effects Status: Invalid command argument at 0. The type of th
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
 
 task 10 'run'. lines 61-61:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object 0xd38c9db0c1935b185ec59bacb9e6ce2e736579cedabb791fce9a8165cef6c319 is owned by account address 0xa0027b0c13d66e2958feb9c56af104ea20ddfcb46a3ea93b9ba5d3c2d9b94d42, but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(2,1)] is owned by account address [object(2,0)], but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
 
 task 11 'run'. lines 63-63:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.exp
@@ -29,7 +29,7 @@ Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 6 'run'. lines 41-43:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(2,1)], parent_id: [object(2,0)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(2,1), parent_id: object(2,0) }
 
 task 7 'run'. lines 44-44:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(2,0)], parent_id: [object(2,2)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(2,0), parent_id: object(2,2) }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.exp
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.exp
@@ -29,7 +29,7 @@ Version: 2
 Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 6 'run'. lines 41-43:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0xc8a6ab1286d28dc445a92bd8852fbbf41a97d17f0ff8fe74f44d5ca31bc5ac6e, parent_id: 0xc8182c524f27fa3e1e79ef9f3e478d5b27637f94e5c7664eee82881e2381ed93 }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(2,1)], parent_id: [object(2,0)] }
 
 task 7 'run'. lines 44-44:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0xc8182c524f27fa3e1e79ef9f3e478d5b27637f94e5c7664eee82881e2381ed93, parent_id: 0xf6a5bb079609c3cac5d9283028659a9a1ffc1cfcf05d4e220d795383f1f02d1b }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(2,0)], parent_id: [object(2,2)] }

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -29,7 +29,7 @@ Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 10u64}}
 
 task 6 'run'. lines 20-20:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(1,0)] is owned by account address [B], but given owner/signer address is [A]" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object object(1,0) is owned by account address @B, but given owner/signer address is @A" }
 
 task 7 'view-object'. lines 22-22:
 Owner: Account Address ( B )

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -29,7 +29,7 @@ Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 10u64}}
 
 task 6 'run'. lines 20-20:
-Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object 0x16497d6ad2ad4c226bedea1c03921a110bad4769f30ae0e80b3e208d41c90ddd is owned by account address 0xd31b7b5068b139941cedc52b036f55c894fd394a170e2ba34245a324f1d16c8b, but given owner/signer address is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e" }
+Error: Error checking transaction input objects: IncorrectUserSignature { error: "Object [object(1,0)] is owned by account address [B], but given owner/signer address is [A]" }
 
 task 7 'view-object'. lines 22-22:
 Owner: Account Address ( B )

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -12,7 +12,7 @@ task 2 'view-object'. lines 13-13:
 1,0::m
 
 task 3 'transfer-object'. lines 15-15:
-Error: Error checking transaction input objects: MovePackageAsObject { object_id: 0xea71cafce0431a127076a7884cb66612bdc9bb2ff442c4d3afbbc73dbc18f660 }
+Error: Error checking transaction input objects: MovePackageAsObject { object_id: [object(1,0)] }
 
 task 4 'view-object'. lines 17-17:
 1,0::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -12,7 +12,7 @@ task 2 'view-object'. lines 13-13:
 1,0::m
 
 task 3 'transfer-object'. lines 15-15:
-Error: Error checking transaction input objects: MovePackageAsObject { object_id: [object(1,0)] }
+Error: Error checking transaction input objects: MovePackageAsObject { object_id: object(1,0) }
 
 task 4 'view-object'. lines 17-17:
 1,0::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -24,7 +24,7 @@ Version: 4
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(3,1)}}
 
 task 5 'transfer-object'. lines 35-35:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(3,0)], parent_id: [object(2,0)] }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: object(3,0), parent_id: object(2,0) }
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(2,0) )

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -24,7 +24,7 @@ Version: 4
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(3,1)}}
 
 task 5 'transfer-object'. lines 35-35:
-Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: 0x88fe67d0d1d038fbea0dc20116688bf67b6290914b3f85bc2b8822a3746cd51f, parent_id: 0xab53a8a3065f7b7a657ea9399e7ef2443dfa87a78fde5962a0742842710586ca }
+Error: Error checking transaction input objects: InvalidChildObjectArgument { child_id: [object(3,0)], parent_id: [object(2,0)] }
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(2,0) )

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
@@ -61,4 +61,4 @@ task 13 'view-object'. lines 65-67:
 No object at id 1,1
 
 task 14 'upgrade'. lines 68-71:
-Error: INVALID TEST. Could not load object argument 0xf12c31c3d61d79fc968525b7de593500d3f5b386308affb08c292abecafda6ef
+Error: INVALID TEST. Could not load object argument [object(1,1)]

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
@@ -61,4 +61,4 @@ task 13 'view-object'. lines 65-67:
 No object at id 1,1
 
 task 14 'upgrade'. lines 68-71:
-Error: INVALID TEST. Could not load object argument [object(1,1)]
+Error: INVALID TEST. Could not load object argument object(1,1)

--- a/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
@@ -1,29 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::ident_str;
-use move_core_types::language_storage::TypeTag;
 use std::path::PathBuf;
 use sui_core::authority::epoch_start_configuration::EpochStartConfigTrait;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_json_rpc_types::SuiTransactionBlockKind;
 use sui_json_rpc_types::{SuiTransactionBlockDataAPI, SuiTransactionBlockResponseOptions};
-use sui_json_rpc_types::{SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse};
 use sui_macros::sim_test;
-use sui_types::base_types::{ObjectID, SuiAddress};
-use sui_types::coin::COIN_MODULE_NAME;
 use sui_types::deny_list::RegulatedCoinMetadata;
 use sui_types::deny_list::{
     get_coin_deny_list, get_deny_list_obj_initial_shared_version, get_deny_list_root_object,
     CoinDenyCap, DenyList,
 };
-use sui_types::error::UserInputError;
 use sui_types::id::UID;
-use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::storage::ObjectStore;
-use sui_types::transaction::{CallArg, ObjectArg};
-use sui_types::{SUI_DENY_LIST_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID};
-use test_cluster::{TestCluster, TestClusterBuilder};
-use tracing::debug;
+use sui_types::SUI_DENY_LIST_OBJECT_ID;
+use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn test_coin_deny_list_creation() {
@@ -109,401 +101,63 @@ async fn test_coin_deny_list_creation() {
 }
 
 #[sim_test]
-async fn test_coin_deny_transfer() {
-    // This test creates a new coin and denies the sender address for the coin.
-    // A transfer transaction is subsequently denied.
-    // The sender address is then undenied and the transfer transaction is allowed.
-
-    let mut test_context = TestContext::new().await;
-    // Deny the sender address for the new coin.
-    test_context
-        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Deny)
-        .await;
-    // After the address is denied, sending the coin should fail to sign.
-    let transfer_result = test_context
-        .transfer_new_coin(test_context.test_cluster.get_address_2())
-        .await;
-    let expected_error = UserInputError::AddressDeniedForCoin {
-        address: test_context.new_coin_owner,
-        coin_type: test_context
-            .get_new_coin_type()
-            .await
-            .to_canonical_string(false),
-    };
-    assert!(transfer_result
-        .unwrap_err()
-        .to_string()
-        .contains(&expected_error.to_string()));
-
-    // Sending SUI coin should still work.
-    let tx_data = test_context
-        .test_cluster
-        .test_transaction_builder_with_sender(test_context.new_coin_owner)
+async fn test_regulated_coin_creation() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/move_test_code");
+    let tx_data = test_cluster
+        .test_transaction_builder()
         .await
-        .transfer_sui(Some(1), test_context.test_cluster.get_address_2())
+        .publish(path)
         .build();
-    test_context
-        .test_cluster
-        .sign_and_execute_transaction(&tx_data)
-        .await;
-
-    // Undeny the address.
-    test_context
-        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Undeny)
-        .await;
-
-    // After the address is undenied, sending the coin should work now.
-    assert!(test_context
-        .transfer_new_coin(test_context.test_cluster.get_address_2())
-        .await
-        .is_ok_and(|r| r.effects.unwrap().status().is_ok()));
-}
-
-#[sim_test]
-async fn test_coin_deny_move_call() {
-    // This test creates a new coin and denies the sender address for the coin.
-    // A Move call transaction that uses the new coin from the denied address is subsequently denied.
-    // The sender address is then undenied and the Move call transaction is allowed.
-
-    let test_context = TestContext::new().await;
-    // Deny the sender address for the new coin.
-    test_context
-        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Deny)
-        .await;
-
-    // After the address is denied, using the coin in a Move call should fail to sign.
-    let mut pt = ProgrammableTransactionBuilder::new();
-    let object_arg = pt
-        .obj(ObjectArg::ImmOrOwnedObject(
-            test_context
-                .test_cluster
-                .get_latest_object_ref(&test_context.new_coin_id)
-                .await,
-        ))
-        .unwrap();
-    let pure_arg = pt.pure(1u64).unwrap();
-    let split_result = pt.programmable_move_call(
-        SUI_FRAMEWORK_PACKAGE_ID,
-        ident_str!("coin").to_owned(),
-        ident_str!("split").to_owned(),
-        vec![test_context.get_new_coin_type().await],
-        vec![object_arg, pure_arg],
-    );
-    pt.transfer_arg(test_context.test_cluster.get_address_2(), split_result);
-    let tx_data = test_context
-        .test_cluster
-        .test_transaction_builder_with_sender(test_context.new_coin_owner)
-        .await
-        .programmable(pt.finish())
-        .build();
-    let tx = test_context.test_cluster.sign_transaction(&tx_data);
-    let result = test_context
-        .test_cluster
-        .wallet
-        .execute_transaction_may_fail(tx.clone())
-        .await;
-    let expected_error = UserInputError::AddressDeniedForCoin {
-        address: test_context.new_coin_owner,
-        coin_type: test_context
-            .get_new_coin_type()
-            .await
-            .to_canonical_string(false),
-    };
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains(&expected_error.to_string()));
-
-    // Undeny the address.
-    test_context
-        .call_deny_list_api(test_context.new_coin_owner, DenyAction::Undeny)
-        .await;
-
-    // After the address is undenied, the same transaction should work now.
-    test_context.test_cluster.execute_transaction(tx).await;
-}
-
-#[sim_test]
-async fn test_coin_deny_tto_receiving() {
-    // This test creates a new coin and denies the sender address for the coin.
-    // A transaction that attempts to receive the new coin from the denied address is subsequently denied.
-    // The sender address is then undenied and the transaction is allowed.
-
-    let mut test_context = TestContext::new().await;
-    let new_sender = test_context.test_cluster.get_address_2();
-    // Deny this new address for the new coin.
-    test_context
-        .call_deny_list_api(new_sender, DenyAction::Deny)
-        .await;
-
-    // Even though the new address is denied, it can still call the contract of the coin package to do other things.
-    let package_id = test_context.get_new_coin_package_id().await;
-    let tx_data = test_context
-        .test_cluster
-        .test_transaction_builder_with_sender(new_sender)
-        .await
-        .move_call(package_id, "regulated_coin", "new_wallet", vec![])
-        .build();
-    let wallet_oref = test_context
-        .test_cluster
+    let effects = test_cluster
         .sign_and_execute_transaction(&tx_data)
         .await
         .effects
-        .unwrap()
-        .created()[0]
-        .reference
-        .to_object_ref();
-    test_context
-        .transfer_new_coin(wallet_oref.0.into())
-        .await
         .unwrap();
-
-    // After the address is denied, trying to receive the coin in a Move call should fail to sign.
-    let mut pt = ProgrammableTransactionBuilder::new();
-    pt.move_call(
-        package_id,
-        ident_str!("regulated_coin").to_owned(),
-        ident_str!("receive_coin").to_owned(),
-        vec![],
-        vec![
-            CallArg::Object(ObjectArg::ImmOrOwnedObject(wallet_oref)),
-            CallArg::Object(ObjectArg::Receiving(
-                test_context
-                    .test_cluster
-                    .get_latest_object_ref(&test_context.new_coin_id)
-                    .await,
-            )),
-        ],
-    )
-    .unwrap();
-    let tx_data = test_context
-        .test_cluster
-        .test_transaction_builder_with_sender(new_sender)
-        .await
-        .programmable(pt.finish())
-        .build();
-    let tx = test_context.test_cluster.sign_transaction(&tx_data);
-    let result = test_context
-        .test_cluster
-        .wallet
-        .execute_transaction_may_fail(tx.clone())
-        .await;
-    let expected_error = UserInputError::AddressDeniedForCoin {
-        address: new_sender,
-        coin_type: test_context
-            .get_new_coin_type()
+    let mut deny_cap_object = None;
+    let mut metadata_object = None;
+    let mut regulated_metadata_object = None;
+    for created in effects.created() {
+        let object = test_cluster
+            .get_object_from_fullnode_store(&created.object_id())
             .await
-            .to_canonical_string(false),
-    };
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains(&expected_error.to_string()));
-
-    // Undeny the address.
-    test_context
-        .call_deny_list_api(new_sender, DenyAction::Undeny)
-        .await;
-
-    // After the address is undenied, the same transaction should work now.
-    test_context.test_cluster.execute_transaction(tx).await;
-}
-
-struct TestContext {
-    test_cluster: TestCluster,
-    new_coin_id: ObjectID,
-    new_coin_owner: SuiAddress,
-    deny_cap_object_id: ObjectID,
-    deny_cap_object_owner: SuiAddress,
-}
-
-#[derive(Debug)]
-enum DenyAction {
-    Deny,
-    Undeny,
-}
-
-impl TestContext {
-    // Returns the test cluster and the deny cap.
-    async fn new() -> Self {
-        let test_cluster = TestClusterBuilder::new().build().await;
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("tests/move_test_code");
-        let tx_data = test_cluster
-            .test_transaction_builder()
-            .await
-            .publish(path)
-            .build();
-        let effects = test_cluster
-            .sign_and_execute_transaction(&tx_data)
-            .await
-            .effects
             .unwrap();
-        let mut new_coin_object = None;
-        let mut deny_cap_object = None;
-        let mut metadata_object = None;
-        let mut regulated_metadata_object = None;
-        for created in effects.created() {
-            let object = test_cluster
-                .get_object_from_fullnode_store(&created.object_id())
-                .await
-                .unwrap();
-            if object.is_package() {
-                continue;
-            }
-            let t = object.type_().unwrap();
-            if t.is_coin() {
-                assert!(new_coin_object.is_none());
-                new_coin_object = Some(object);
-            } else if t.is_coin_deny_cap() {
-                assert!(deny_cap_object.is_none());
-                deny_cap_object = Some(object);
-            } else if t.is_regulated_coin_metadata() {
-                assert!(regulated_metadata_object.is_none());
-                regulated_metadata_object = Some(object);
-            } else if t.is_coin_metadata() {
-                assert!(metadata_object.is_none());
-                metadata_object = Some(object);
-            }
+        if object.is_package() {
+            continue;
         }
-        // Check that publishing the package minted the new coin, along with
-        // the metadata, deny cap, and regulated metadata.
-        // Check that all their fields are consistent.
-        let new_coin_object = new_coin_object.unwrap();
-        let metadata_object = metadata_object.unwrap();
-        let deny_cap_object = deny_cap_object.unwrap();
-        let deny_cap: CoinDenyCap = deny_cap_object.to_rust().unwrap();
-        assert_eq!(deny_cap.id.id.bytes, deny_cap_object.id());
-
-        let regulated_metadata_object = regulated_metadata_object.unwrap();
-        let regulated_metadata: RegulatedCoinMetadata =
-            regulated_metadata_object.to_rust().unwrap();
-        assert_eq!(
-            regulated_metadata.id.id.bytes,
-            regulated_metadata_object.id()
-        );
-        assert_eq!(
-            regulated_metadata.deny_cap_object.bytes,
-            deny_cap_object.id()
-        );
-        assert_eq!(
-            regulated_metadata.coin_metadata_object.bytes,
-            metadata_object.id()
-        );
-
-        let mut test_context = Self {
-            test_cluster,
-            new_coin_id: new_coin_object.id(),
-            new_coin_owner: new_coin_object.owner.get_address_owner_address().unwrap(),
-            deny_cap_object_id: deny_cap_object.id(),
-            deny_cap_object_owner: deny_cap_object.owner.get_address_owner_address().unwrap(),
-        };
-        // Transfer the new coin to a new address just so that it's different from the deny cap owner.
-        // This helps make sure we don't have bugs like always denying the deny cap owner.
-        let receiver = test_context.test_cluster.get_address_1();
-        assert_ne!(test_context.new_coin_owner, receiver);
-        test_context.transfer_new_coin(receiver).await.unwrap();
-
-        test_context
-    }
-
-    async fn transfer_new_coin(
-        &mut self,
-        receiver: SuiAddress,
-    ) -> anyhow::Result<SuiTransactionBlockResponse> {
-        let tx_data = self
-            .test_cluster
-            .test_transaction_builder_with_sender(self.new_coin_owner)
-            .await
-            .transfer(
-                self.test_cluster
-                    .get_latest_object_ref(&self.new_coin_id)
-                    .await,
-                receiver,
-            )
-            .build();
-        let tx = self.test_cluster.sign_transaction(&tx_data);
-        let result = self
-            .test_cluster
-            .wallet
-            .execute_transaction_may_fail(tx)
-            .await;
-        if result
-            .as_ref()
-            .is_ok_and(|r| r.effects.as_ref().unwrap().status().is_ok())
-        {
-            self.new_coin_owner = receiver;
-        }
-        result
-    }
-
-    async fn call_deny_list_api(&self, address: SuiAddress, action: DenyAction) {
-        let function = match action {
-            DenyAction::Deny => "deny_list_add",
-            DenyAction::Undeny => "deny_list_remove",
-        };
-        let tx_data = self
-            .test_cluster
-            .test_transaction_builder_with_sender(self.deny_cap_object_owner)
-            .await
-            .move_call(
-                SUI_FRAMEWORK_PACKAGE_ID,
-                COIN_MODULE_NAME.as_str(),
-                function,
-                vec![
-                    CallArg::Object(self.get_deny_list_object_arg().await),
-                    CallArg::Object(ObjectArg::ImmOrOwnedObject(
-                        self.test_cluster
-                            .get_latest_object_ref(&self.deny_cap_object_id)
-                            .await,
-                    )),
-                    CallArg::Pure(bcs::to_bytes(&address).unwrap()),
-                ],
-            )
-            .with_type_args(vec![self.get_new_coin_type().await])
-            .build();
-        let effects = self
-            .test_cluster
-            .sign_and_execute_transaction(&tx_data)
-            .await
-            .effects
-            .unwrap();
-        debug!(
-            "call_deny_list_api with action {:?} effects: {:?}",
-            action, effects
-        );
-    }
-
-    async fn get_deny_list_object_arg(&self) -> ObjectArg {
-        let coin_deny_list_object_init_version = self
-            .test_cluster
-            .fullnode_handle
-            .sui_node
-            .state()
-            .epoch_store_for_testing()
-            .epoch_start_config()
-            .coin_deny_list_obj_initial_shared_version()
-            .unwrap();
-        ObjectArg::SharedObject {
-            id: SUI_DENY_LIST_OBJECT_ID,
-            initial_shared_version: coin_deny_list_object_init_version,
-            mutable: true,
+        let t = object.type_().unwrap();
+        if t.is_coin_deny_cap() {
+            assert!(deny_cap_object.is_none());
+            deny_cap_object = Some(object);
+        } else if t.is_regulated_coin_metadata() {
+            assert!(regulated_metadata_object.is_none());
+            regulated_metadata_object = Some(object);
+        } else if t.is_coin_metadata() {
+            assert!(metadata_object.is_none());
+            metadata_object = Some(object);
         }
     }
+    // Check that publishing the package created
+    // the metadata, deny cap, and regulated metadata.
+    // Check that all their fields are consistent.
+    let metadata_object = metadata_object.unwrap();
+    let deny_cap_object = deny_cap_object.unwrap();
+    let deny_cap: CoinDenyCap = deny_cap_object.to_rust().unwrap();
+    assert_eq!(deny_cap.id.id.bytes, deny_cap_object.id());
 
-    async fn get_new_coin_type(&self) -> TypeTag {
-        self.test_cluster
-            .get_object_from_fullnode_store(&self.new_coin_id)
-            .await
-            .unwrap()
-            .coin_type_maybe()
-            .unwrap()
-    }
-
-    async fn get_new_coin_package_id(&self) -> ObjectID {
-        match self.get_new_coin_type().await {
-            TypeTag::Struct(struct_tag) => ObjectID::from(struct_tag.address),
-            _ => panic!("Expected Struct TypeTag"),
-        }
-    }
+    let regulated_metadata_object = regulated_metadata_object.unwrap();
+    let regulated_metadata: RegulatedCoinMetadata = regulated_metadata_object.to_rust().unwrap();
+    assert_eq!(
+        regulated_metadata.id.id.bytes,
+        regulated_metadata_object.id()
+    );
+    assert_eq!(
+        regulated_metadata.deny_cap_object.bytes,
+        deny_cap_object.id()
+    );
+    assert_eq!(
+        regulated_metadata.coin_metadata_object.bytes,
+        metadata_object.id()
+    );
 }

--- a/crates/sui-e2e-tests/tests/move_test_code/sources/regulated_coin.move
+++ b/crates/sui-e2e-tests/tests/move_test_code/sources/regulated_coin.move
@@ -4,11 +4,8 @@
 module move_test_code::regulated_coin {
     use std::option;
     use sui::coin;
-    use sui::coin::Coin;
-    use sui::object;
     use sui::object::UID;
     use sui::transfer;
-    use sui::transfer::Receiving;
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
@@ -28,22 +25,8 @@ module move_test_code::regulated_coin {
             option::none(),
             ctx
         );
-        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
-        transfer::public_transfer(coin, tx_context::sender(ctx));
         transfer::public_transfer(deny_cap, tx_context::sender(ctx));
         transfer::public_freeze_object(treasury_cap);
         transfer::public_freeze_object(metadata);
-    }
-
-    public fun new_wallet(ctx: &mut TxContext) {
-        let wallet = Wallet {
-            id: object::new(ctx),
-        };
-        transfer::transfer(wallet, tx_context::sender(ctx));
-    }
-
-    public fun receive_coin(wallet: &mut Wallet, coin: Receiving<Coin<REGULATED_COIN>>, ctx: &TxContext) {
-        let coin = transfer::public_receive(&mut wallet.id, coin);
-        transfer::public_transfer(coin, tx_context::sender(ctx));
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -70,7 +70,6 @@ use sui_types::messages_checkpoint::{
 use sui_types::storage::{ObjectKey, ObjectStore};
 use sui_types::transaction::Command;
 use sui_types::transaction::ProgrammableTransaction;
-use sui_types::DEEPBOOK_ADDRESS;
 use sui_types::DEEPBOOK_PACKAGE_ID;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
 use sui_types::SUI_SYSTEM_ADDRESS;
@@ -92,6 +91,7 @@ use sui_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder, SUI_FRAMEWORK_PACKAGE_ID,
 };
 use sui_types::{utils::to_sender_signed_transaction, SUI_SYSTEM_PACKAGE_ID};
+use sui_types::{DEEPBOOK_ADDRESS, SUI_DENY_LIST_OBJECT_ID};
 use tempfile::NamedTempFile;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -109,6 +109,7 @@ const WELL_KNOWN_OBJECTS: &[ObjectID] = &[
     SUI_SYSTEM_PACKAGE_ID,
     SUI_SYSTEM_STATE_OBJECT_ID,
     SUI_CLOCK_OBJECT_ID,
+    SUI_DENY_LIST_OBJECT_ID,
 ];
 // TODO use the file name as a seed
 const RNG_SEED: [u8; 32] = [
@@ -990,6 +991,28 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 Ok(None)
             }
         }
+    }
+
+    /// Process the error string such that it's less dependent on specific addresses or object IDs. Instead, they are
+    /// replaced by the account names or fake IDs as much as possible. This reduces the effort of updating tests
+    /// when something changed.
+    async fn process_error(&self, error: anyhow::Error) -> anyhow::Error {
+        let mut err = error.to_string();
+        for (name, account) in &self.accounts {
+            let addr = account.address.to_string();
+            let replace = format!("[{}]", name);
+            err = err.replace(&addr, &replace);
+            // Also match without 0x since different error messages may use different format.
+            err = err.replace(&addr[2..], &replace);
+        }
+        for (id, fake_id) in &self.object_enumeration {
+            let id = id.to_string();
+            let replace = format!("[object({})]", fake_id);
+            err = err.replace(&id, &replace);
+            // Also match without 0x since different error messages may use different format.
+            err = err.replace(&id[2..], &replace);
+        }
+        anyhow!(err)
     }
 }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1000,14 +1000,14 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let mut err = error.to_string();
         for (name, account) in &self.accounts {
             let addr = account.address.to_string();
-            let replace = format!("[{}]", name);
+            let replace = format!("@{}", name);
             err = err.replace(&addr, &replace);
             // Also match without 0x since different error messages may use different format.
             err = err.replace(&addr[2..], &replace);
         }
         for (id, fake_id) in &self.object_enumeration {
             let id = id.to_string();
-            let replace = format!("[object({})]", fake_id);
+            let replace = format!("object({})", fake_id);
             err = err.replace(&id, &replace);
             // Also match without 0x since different error messages may use different format.
             err = err.replace(&id[2..], &replace);

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -143,6 +143,8 @@ pub trait MoveTestAdapter<'a>: Sized + Send {
         subcommand: TaskInput<Self::Subcommand>,
     ) -> Result<Option<String>>;
 
+    async fn process_error(&self, error: anyhow::Error) -> anyhow::Error;
+
     async fn handle_command(
         &mut self,
         task: TaskInput<
@@ -771,7 +773,7 @@ async fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
     let result_string = match result {
         Ok(None) => return,
         Ok(Some(s)) => s,
-        Err(e) => format!("Error: {}", e),
+        Err(e) => format!("Error: {}", adapter.process_error(e).await),
     };
     assert!(!result_string.is_empty());
 

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -8,7 +8,7 @@ use crate::{
     framework::{run_test_impl, CompiledState, MaybeNamedCompiledModule, MoveTestAdapter},
     tasks::{EmptyCommand, InitCommand, SyntaxChoice, TaskInput},
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use move_binary_format::{
@@ -222,6 +222,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         _: TaskInput<Self::Subcommand>,
     ) -> Result<Option<String>> {
         unimplemented!()
+    }
+
+    async fn process_error(&self, err: Error) -> Error {
+        err
     }
 }
 


### PR DESCRIPTION
## Description 

This PR replaces the deny list simtest with transactional tests, which are much easier to inspect and validate.
To make errors easier to visualize and update, this PR also introduces a new function in the test adapter that can replace known addresses and IDs with names/fake ids in the error string.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
