### PR TITLE
add missing typescript client api tryMultiGetPastObjects

### DIFF
--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -86,6 +86,7 @@ import type {
 	SuiTransactionBlockResponseQuery,
 	TransactionEffects,
 	TryGetPastObjectParams,
+	TryMultiGetPastObjectsParams,
 	Unsubscribe,
 	ValidatorsApy,
 } from './types/index.js';
@@ -332,6 +333,20 @@ export class SuiClient {
 		return await this.transport.request({
 			method: 'sui_tryGetPastObject',
 			params: [input.id, input.version, input.options],
+		});
+	}
+
+	async tryMultiGetPastObjects(input: TryMultiGetPastObjectsParams): Promise<ObjectRead[]> {
+		const objectIds = input.pastObjects.map((pastObject) => pastObject.objectId);
+		objectIds.forEach((id) => {
+			if (!id || !isValidSuiObjectId(normalizeSuiObjectId(id))) {
+				throw new Error(`Invalid Sui Object id ${id}`);
+			}
+		});
+
+		return await this.transport.request({
+			method: 'sui_tryMultiGetPastObjects',
+			params: [input.pastObjects, input.options],
 		});
 	}
 

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -36,6 +36,14 @@ describe('Object id/Address/Transaction digest validation', () => {
 		expect(toolbox.client.multiGetObjects({ ids: objectIds })).rejects.toThrowError(
 			/Invalid Sui Object id 0xWRONG/,
 		);
+
+		const pastObjects = objectIds.map((objectId) => ({
+			objectId: objectId,
+			version: '1',
+		}));
+		expect(toolbox.client.tryMultiGetPastObjects({ pastObjects })).rejects.toThrowError(
+			/Invalid Sui Object id 0xWRONG/,
+		);
 	});
 
 	it('Test all functions with invalid Transaction Digest', async () => {

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -132,4 +132,38 @@ describe('Object Reading API', () => {
 
 		expect(res.status).toBe('VersionFound');
 	});
+
+	it('Try Get Past Objects', async () => {
+		const { data } = await toolbox.client.getCoins({
+			owner: toolbox.address(),
+			coinType: SUI_TYPE_ARG,
+		});
+
+		const tx = new TransactionBlock();
+		// Transfer the entire gas object:
+		tx.transferObjects([tx.gas], tx.pure(normalizeSuiAddress('0x2')));
+
+		await toolbox.client.signAndExecuteTransactionBlock({
+			signer: toolbox.keypair,
+			transactionBlock: tx,
+		});
+
+		const pastGasObjects = [
+			{ objectId: normalizeSuiAddress('0x9999'), version: '0' }, // object not exists
+			{ objectId: data[0].coinObjectId, version: data[0].version }, // object found
+			{ objectId: data[0].coinObjectId, version: (Number(data[0].version) - 1).toString() }, // object version not found
+		];
+
+		const pastObjectInfos = await toolbox.client.tryMultiGetPastObjects({
+			pastObjects: pastGasObjects,
+			options: {
+				showType: true,
+			},
+		});
+
+		expect(pastGasObjects.length).to.equal(pastObjectInfos.length);
+		expect(pastObjectInfos[0].status).to.equal('ObjectNotExists');
+		expect(pastObjectInfos[1].status).to.equal('VersionFound');
+		expect(pastObjectInfos[2].status).to.equal('VersionNotFound');
+	});
 });


### PR DESCRIPTION
## Description 

add missing typescript SDK client api: tryMultiGetPastObjects

## Test Plan 

two e2e test under: test/e2e/

1. Test all functions with invalid Object Id in (test/e2e/invalid-ids.test.ts)
2. Try Get Past Objects in (test/e2e/objects.test.ts)
