### PR TITLE
Update sui-full-node.mdx to add libpq-dev

### DIFF
--- a/docs/content/guides/operator/sui-full-node.mdx
+++ b/docs/content/guides/operator/sui-full-node.mdx
@@ -69,6 +69,7 @@ ca-certificates \
 build-essential \
 libssl-dev \
 libclang-dev \
+libpq-dev \
 pkg-config \
 openssl \
 protobuf-compiler \


### PR DESCRIPTION
## Description 

Compiling sui-node requires `libpq-dev` installed.

## Test Plan 

N/A

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
