### PR TITLE
[GraphQL/Type Filter] Intersection for TypeFilter

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
@@ -1,39 +1,39 @@
 processed 11 tasks
 
-task 1 'publish'. lines 15-37:
+task 1 'publish'. lines 22-44:
 created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run-graphql'. lines 39-57:
+task 2 'run-graphql'. lines 46-64:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": []
       }
     }
   }
 }
 
-task 3 'run'. lines 59-59:
+task 3 'run'. lines 66-66:
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4 'view-object'. lines 61-61:
+task 4 'view-object'. lines 68-68:
 Owner: Account Address ( A )
 Version: 3
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, value: 0u64}
 
-task 5 'create-checkpoint'. lines 63-63:
+task 5 'create-checkpoint'. lines 70-70:
 Checkpoint created: 1
 
-task 6 'run-graphql'. lines 65-83:
+task 6 'run-graphql'. lines 72-90:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {
@@ -51,11 +51,11 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 85-103:
+task 7 'run-graphql'. lines 92-110:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {
@@ -73,33 +73,22 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 105-123:
+task 8 'run-graphql'. lines 112-130:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
-        "edges": [
-          {
-            "node": {
-              "owner": {
-                "__typename": "AddressOwner",
-                "owner": {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
-                }
-              }
-            }
-          }
-        ]
+      "objects": {
+        "edges": []
       }
     }
   }
 }
 
-task 9 'run-graphql'. lines 125-143:
+task 9 'run-graphql'. lines 132-150:
 Response: {
   "data": {
     "owner": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {
@@ -117,7 +106,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 145-163:
+task 10 'run-graphql'. lines 152-170:
 Response: {
   "data": {
     "object": null

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -1,16 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Tests objectConnection on address, object, and owner
-// The initial query for objectConnection under address should yield no objects
-// After object creation, the same query for address.objectConnection should now have one object
-// The address of the parent field takes precedence when querying an address's objects with a filter
-// So if a different owner address is provided, it is overwritten
-// The same query on the address as an owner should return the same result
-// The same query on the address as an object should return a null result, since the address is not an object
-
-
 //# init --addresses Test=0x0 A=0x42 --simulator
+
+// Tests objects on address, object, and owner.
+//
+// - The initial query for objects under address should yield no
+//   objects.
+// - After object creation, the same query for address.objects should
+//   now have one object
+// - A query for transactions belonging to an address that also
+//   supplies an address filter will combine the two filters.
+// - If the two filters suggest two different addresses, they will
+//   combine to form an inconsistent query, which will yield no
+//   results.
+// - The same query on the address as an owner should return the same
+//   result
+// - The same query on the address as an object should return a null
+//   result, since the address is not an object
 
 //# publish
 module Test::M1 {
@@ -39,7 +46,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "0x42") {
-    objectConnection{
+    objects {
       edges {
         node {
           owner {
@@ -65,7 +72,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "0x42") {
-    objectConnection{
+    objects {
       edges {
         node {
           owner {
@@ -85,7 +92,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "0x42") {
-    objectConnection(filter: {owner: "0x42"}) {
+    objects(filter: {owner: "0x42"}) {
       edges {
         node {
           owner {
@@ -105,7 +112,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "0x42") {
-    objectConnection(filter: {owner: "0x888"}) {
+    objects(filter: {owner: "0x888"}) {
       edges {
         node {
           owner {
@@ -125,7 +132,7 @@ module Test::M1 {
 //# run-graphql
 {
   owner(address: "0x42") {
-    objectConnection{
+    objects {
       edges {
         node {
           owner {
@@ -145,7 +152,7 @@ module Test::M1 {
 //# run-graphql
 {
   object(address: "0x42") {
-    objectConnection{
+    objects {
       edges {
         node {
           owner {

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -108,7 +108,7 @@ task 18 'run-graphql'. lines 80-95:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {
@@ -129,12 +129,12 @@ task 19 'run-graphql'. lines 97-152:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": []
       }
     },
     "second": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {
@@ -149,7 +149,7 @@ Response: {
       }
     },
     "val_objs": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
             "node": {

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -80,7 +80,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection{
+    objects {
       edges {
         node {
           address
@@ -97,7 +97,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "@{Test}") {
-    objectConnection{
+    objects {
       edges {
         node {
           address
@@ -110,7 +110,7 @@ module Test::M1 {
     }
   }
   second: address(address: "@{A}") {
-    objectConnection{
+    objects {
       edges {
         node {
           address
@@ -124,7 +124,7 @@ module Test::M1 {
   }
 
   val_objs: address(address: "@{validator_0}") {
-    objectConnection{
+    objects {
       edges {
         node {
           address

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.exp
@@ -37,7 +37,7 @@ task 8 'run-graphql'. lines 148-161:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "nodes": [
           {
             "display": [
@@ -80,7 +80,7 @@ task 12 'run-graphql'. lines 169-182:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "nodes": [
           {
             "display": [
@@ -128,7 +128,7 @@ task 16 'run-graphql'. lines 190-203:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "nodes": [
           {
             "display": [

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -148,7 +148,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
+    objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key
@@ -169,7 +169,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
+    objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key
@@ -190,7 +190,7 @@ module Test::boars {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection(filter: {type: "@{Test}::boars::Boar"}) {
+    objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
         display {
           key

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.exp
@@ -30,7 +30,7 @@ Epoch advanced: 1
 task 7 'run-graphql'. lines 22-37:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": [
         {
           "node": {
@@ -73,7 +73,7 @@ Response: {
 task 8 'run-graphql'. lines 39-54:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": [
         {
           "node": {
@@ -259,7 +259,7 @@ Response: {
 task 9 'run-graphql'. lines 56-71:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": [
         {
           "node": {
@@ -313,7 +313,7 @@ Response: {
 task 10 'run-graphql'. lines 73-88:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": [
         {
           "node": {
@@ -356,7 +356,7 @@ Response: {
 task 11 'run-graphql'. lines 90-106:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": [
         {
           "node": {
@@ -401,19 +401,16 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid struct type: 0x2::coin::Coin<ye>. Got error: expected token ::, got >",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"ObjectFilter\")",
       "locations": [
         {
           "line": 3,
-          "column": 3
+          "column": 19
         }
       ],
       "path": [
-        "objectConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "objects"
+      ]
     }
   ]
 }
@@ -423,19 +420,16 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid struct type: 0x2::coin::Coin<. Got error: unexpected end of tokens",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"ObjectFilter\")",
       "locations": [
         {
           "line": 3,
-          "column": 3
+          "column": 19
         }
       ],
       "path": [
-        "objectConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "objects"
+      ]
     }
   ]
 }
@@ -445,19 +439,16 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid struct type: 0x2::a%::B&. Got error: unrecognized token: %::B&",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"ObjectFilter\")",
       "locations": [
         {
           "line": 3,
-          "column": 3
+          "column": 19
         }
       ],
       "path": [
-        "objectConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "objects"
+      ]
     }
   ]
 }
@@ -467,19 +458,16 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Invalid type provided as filter: Invalid format in '::::' - if '::' is present, there must be a non-empty string on both sides. Expected format like 'package[::module[::type[<type_params>]]]'",
+      "message": "Failed to parse \"String\": Invalid filter, expected: package[::module[::type[<type_params>]]] or primitive type (occurred while parsing \"ObjectFilter\")",
       "locations": [
         {
           "line": 3,
-          "column": 3
+          "column": 19
         }
       ],
       "path": [
-        "objectConnection"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
+        "objects"
+      ]
     }
   ]
 }
@@ -487,7 +475,7 @@ Response: {
 task 16 'run-graphql'. lines 180-196:
 Response: {
   "data": {
-    "objectConnection": {
+    "objects": {
       "edges": []
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
@@ -21,7 +21,7 @@
 
 //# run-graphql
 {
-  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+  objects(filter: {type: "0x3::staking_pool::StakedSui"}) {
     edges {
       node {
         asMoveObject {
@@ -38,7 +38,7 @@
 
 //# run-graphql
 {
-  objectConnection(filter: {type: "0x2"}) {
+  objects(filter: {type: "0x2"}) {
     edges {
       node {
         asMoveObject {
@@ -55,7 +55,7 @@
 
 //# run-graphql
 {
-  objectConnection(filter: {type: "0x2::coin"}) {
+  objects(filter: {type: "0x2::coin"}) {
     edges {
       node {
         asMoveObject {
@@ -72,7 +72,7 @@
 
 //# run-graphql
 {
-  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+  objects(filter: {type: "0x2::coin::Coin"}) {
     edges {
       node {
         asMoveObject {
@@ -90,7 +90,7 @@
 //# run-graphql
 # Fetch coins of 0x2::sui::SUI inner type
 {
-  objectConnection(filter: {type: "0x2::coin::Coin<0x2::sui::SUI>"}) {
+  objects(filter: {type: "0x2::coin::Coin<0x2::sui::SUI>"}) {
     edges {
       node {
         asMoveObject {
@@ -108,7 +108,7 @@
 //# run-graphql
 # Inner type should be fully qualified
 {
-  objectConnection(filter: {type: "0x2::coin::Coin<ye>"}) {
+  objects(filter: {type: "0x2::coin::Coin<ye>"}) {
     edges {
       node {
         asMoveObject {
@@ -126,7 +126,7 @@
 //# run-graphql
 # If caller provides angle brackets, they must be balanced and wrap a valid type
 {
-  objectConnection(filter: {type: "0x2::coin::Coin<"}) {
+  objects(filter: {type: "0x2::coin::Coin<"}) {
     edges {
       node {
         asMoveObject {
@@ -144,7 +144,7 @@
 //# run-graphql
 # Package, module, and name must be valid addresses and identifiers
 {
-  objectConnection(filter: {type: "0x2::a%::B&"}) {
+  objects(filter: {type: "0x2::a%::B&"}) {
     edges {
       node {
         asMoveObject {
@@ -162,7 +162,7 @@
 //# run-graphql
 # Empty strings are invalid inputs
 {
-  objectConnection(filter: {type: "::::"}) {
+  objects(filter: {type: "::::"}) {
     edges {
       node {
         asMoveObject {
@@ -180,7 +180,7 @@
 //# run-graphql
 # Should run successfully but return an empty result
 {
-  objectConnection(filter: {type: "u64"}) {
+  objects(filter: {type: "u64"}) {
     edges {
       node {
         asMoveObject {

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -37,22 +37,22 @@ task 8 'run-graphql'. lines 37-47:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
-            "cursor": "0x12c9486e45e705b85abc9dee0ece401b9e3f69e0287185c92e442210d1a5f0df"
+            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDf"
           },
           {
-            "cursor": "0x52ca6a82406f3bc1b840368752f8311ccfb800cddbb0d34dbad003031a11397b"
+            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7"
           },
           {
-            "cursor": "0x894edad69269658ba1acf4601e77441eeaee84a233efd62006a4a1a57586d80e"
+            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgO"
           },
           {
-            "cursor": "0xe92e3023cd035b3963bf453474b5eda40b8c9964c01e9ab6c04522efdb0d5fa0"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
           },
           {
-            "cursor": "0xfa5a6bd6d2a740a1829f36715f13a6805090bae7f5a7f2ac66d70b63105e7c5a"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
           }
         ]
       }
@@ -64,13 +64,13 @@ task 9 'run-graphql'. lines 49-59:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
-            "cursor": "0x12c9486e45e705b85abc9dee0ece401b9e3f69e0287185c92e442210d1a5f0df"
+            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDf"
           },
           {
-            "cursor": "0x52ca6a82406f3bc1b840368752f8311ccfb800cddbb0d34dbad003031a11397b"
+            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7"
           }
         ]
       }
@@ -82,10 +82,10 @@ task 10 'run-graphql'. lines 61-73:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
-            "cursor": "0xfa5a6bd6d2a740a1829f36715f13a6805090bae7f5a7f2ac66d70b63105e7c5a"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
           }
         ]
       }
@@ -97,13 +97,13 @@ task 11 'run-graphql'. lines 75-85:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
-            "cursor": "0x894edad69269658ba1acf4601e77441eeaee84a233efd62006a4a1a57586d80e"
+            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgO"
           },
           {
-            "cursor": "0xe92e3023cd035b3963bf453474b5eda40b8c9964c01e9ab6c04522efdb0d5fa0"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
           }
         ]
       }
@@ -115,7 +115,7 @@ task 12 'run-graphql'. lines 87-97:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": []
       }
     }
@@ -126,13 +126,13 @@ task 13 'run-graphql'. lines 99-108:
 Response: {
   "data": {
     "address": {
-      "objectConnection": {
+      "objects": {
         "edges": [
           {
-            "cursor": "0xe92e3023cd035b3963bf453474b5eda40b8c9964c01e9ab6c04522efdb0d5fa0"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
           },
           {
-            "cursor": "0xfa5a6bd6d2a740a1829f36715f13a6805090bae7f5a7f2ac66d70b63105e7c5a"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -38,7 +38,7 @@ module Test::M1 {
 {
   # select all objects owned by A
   address(address: "@{A}") {
-    objectConnection {
+    objects {
       edges {
         cursor
       }
@@ -50,7 +50,7 @@ module Test::M1 {
 {
   # select the first 2 objects owned by A
   address(address: "@{A}") {
-    objectConnection(first: 2) {
+    objects(first: 2) {
       edges {
         cursor
       }
@@ -64,7 +64,7 @@ module Test::M1 {
     # select the 2nd and 3rd objects
     # note that order does not correspond
     # to order in which objects were created
-    objectConnection(first: 2 after: "@{obj_5_0}") {
+    objects(first: 2 after: "@{obj_5_0_cursor}") {
       edges {
         cursor
       }
@@ -76,7 +76,7 @@ module Test::M1 {
 {
   address(address: "@{A}") {
     # select 4th and last object
-    objectConnection(first: 2 after: "@{obj_4_0}") {
+    objects(first: 2 after: "@{obj_4_0_cursor}") {
       edges {
         cursor
       }
@@ -88,7 +88,7 @@ module Test::M1 {
 {
   address(address: "@{A}") {
     # select 3rd and 4th object
-    objectConnection(last: 2 before: "@{obj_3_0}") {
+    objects(last: 2 before: "@{obj_3_0_cursor}") {
       edges {
         cursor
       }
@@ -99,7 +99,7 @@ module Test::M1 {
 //# run-graphql
 {
   address(address: "@{A}") {
-    objectConnection(last: 2) {
+    objects(last: 2) {
       edges {
         cursor
       }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -29,11 +29,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -196,11 +192,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -455,11 +447,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -850,11 +838,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -828,13 +828,9 @@
 ####  Filter on objectIds
 
 ><pre>{
->  objectConnection(
->    filter: {
->      objectIds: [
->        "0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"
->      ]
->    }
->  ) {
+>  objects(filter: { objectIds: [
+>    "0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"
+>  ]}) {
 >    edges {
 >      node {
 >        storageRebate
@@ -865,7 +861,7 @@
 ### Filter On Generic Type
 
 ><pre>{
->  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+>  objects(filter: {type: "0x2::coin::Coin"}) {
 >    edges {
 >      node {
 >        asMoveObject {
@@ -884,7 +880,7 @@
 ### Filter On Type
 
 ><pre>{
->  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+>  objects(filter: {type: "0x3::staking_pool::StakedSui"}) {
 >    edges {
 >      node {
 >        asMoveObject {
@@ -904,11 +900,9 @@
 ####  Filter on owner
 
 ><pre>{
->  objectConnection(
->    filter: {
->      owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
->    }
->  ) {
+>  objects(filter: {
+>    owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
+>  }) {
 >    edges {
 >      node {
 >        storageRebate
@@ -939,7 +933,7 @@
 ### Object Connection
 
 ><pre>{
->  objectConnection {
+>  objects {
 >    nodes {
 >      version
 >      digest

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_object_ids.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_object_ids.graphql
@@ -1,12 +1,8 @@
 # Filter on objectIds
 {
-  objectConnection(
-    filter: {
-      objectIds: [
-        "0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"
-      ]
-    }
-  ) {
+  objects(filter: { objectIds: [
+    "0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"
+  ]}) {
     edges {
       node {
         storageRebate

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_on_generic_type.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_on_generic_type.graphql
@@ -1,5 +1,5 @@
 {
-  objectConnection(filter: {type: "0x2::coin::Coin"}) {
+  objects(filter: {type: "0x2::coin::Coin"}) {
     edges {
       node {
         asMoveObject {

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_on_type.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_on_type.graphql
@@ -1,5 +1,5 @@
 {
-  objectConnection(filter: {type: "0x3::staking_pool::StakedSui"}) {
+  objects(filter: {type: "0x3::staking_pool::StakedSui"}) {
     edges {
       node {
         asMoveObject {

--- a/crates/sui-graphql-rpc/examples/object_connection/filter_owner.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/filter_owner.graphql
@@ -1,10 +1,8 @@
 # Filter on owner
 {
-  objectConnection(
-    filter: {
-      owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
-    }
-  ) {
+  objects(filter: {
+    owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
+  }) {
     edges {
       node {
         storageRebate

--- a/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/object_connection/object_connection.graphql
@@ -1,5 +1,5 @@
 {
-  objectConnection {
+  objects {
     nodes {
       version
       digest

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1014,7 +1014,7 @@ type GasInput {
 	"""
 	Objects used to pay for a transaction's execution and storage
 	"""
-	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
+	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection!
 	"""
 	An unsigned integer specifying the number of native tokens per gas unit this transaction
 	will pay (in MIST).

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -71,7 +71,7 @@ type Address implements IOwner {
 	"""
 	The objects that are owned by this address.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	The balance that this address holds.
 	"""
@@ -1039,7 +1039,7 @@ type GenesisTransaction {
 
 interface IOwner {
 	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
@@ -1681,7 +1681,7 @@ type Object implements IOwner {
 	"""
 	The objects owned by this object
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	The balance of coin objects of a particular coin type owned by the object.
 	"""
@@ -1817,6 +1817,14 @@ type ObjectEdge {
 	cursor: String!
 }
 
+"""
+Constrains the set of objects returned. All filters are optional, and the resulting set of
+objects are ones whose
+
+- Type matches the `type` filter,
+- AND, whose owner matches the `owner` filter,
+- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+"""
 input ObjectFilter {
 	"""
 	This field is used to specify the type of objects that should be included in the query
@@ -1925,7 +1933,7 @@ type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	Total balance of all coins with marker type owned by this Owner. If type is not supplied,
 	it defaults to 0x2::sui::SUI.
@@ -2191,7 +2199,7 @@ type Query {
 	"""
 	The objects that exist in the network.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -7,7 +7,7 @@ use sui_indexer::{
     types_v2::OwnerType,
 };
 
-use crate::{error::Error, types::object::ObjectFilter};
+use crate::{error::Error, types::object::DeprecatedObjectFilter};
 use diesel::{
     query_builder::{BoxedSelectStatement, FromClause, QueryId},
     sql_types::Text,
@@ -42,7 +42,7 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
         limit: PageLimit,
-        filter: Option<ObjectFilter>,
+        filter: Option<DeprecatedObjectFilter>,
         owner_type: Option<OwnerType>,
     ) -> Result<objects::BoxedQuery<'static, DB>, Error>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     context_data::db_data_provider::PgManager,
     error::Error,
-    types::{object::ObjectFilter, sui_address::SuiAddress},
+    types::{object::DeprecatedObjectFilter, sui_address::SuiAddress},
 };
 use async_trait::async_trait;
 use diesel::{
@@ -78,7 +78,7 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
         before: Option<Vec<u8>>,
         after: Option<Vec<u8>>,
         limit: PageLimit,
-        filter: Option<ObjectFilter>,
+        filter: Option<DeprecatedObjectFilter>,
         owner_type: Option<OwnerType>,
     ) -> Result<objects::BoxedQuery<'static, Pg>, Error> {
         let mut query = order_objs(before, after, &limit);

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -37,7 +37,7 @@ pub(crate) struct Checkpoint {
     pub stored: StoredCheckpoint,
 }
 
-pub(crate) type Cursor = cursor::Cursor<u64>;
+pub(crate) type Cursor = cursor::JsonCursor<u64>;
 type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
 
 /// Checkpoints contain finalized transactions and are used for node synchronization

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -42,7 +42,7 @@ pub(crate) struct EventKey {
     e: u64,
 }
 
-pub(crate) type Cursor = cursor::Cursor<EventKey>;
+pub(crate) type Cursor = cursor::JsonCursor<EventKey>;
 type Query<ST, GB> = data::Query<ST, events::table, GB>;
 
 #[derive(InputObject, Clone, Default)]

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -13,7 +13,7 @@ use sui_types::{
     transaction::GasData,
 };
 
-use super::object::ObjectFilter;
+use super::object::DeprecatedObjectFilter;
 use super::{address::Address, big_int::BigInt, sui_address::SuiAddress};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,7 +58,7 @@ impl GasInput {
         last: Option<u64>,
         before: Option<String>,
     ) -> Result<Option<Connection<String, Object>>> {
-        let filter = ObjectFilter {
+        let filter = DeprecatedObjectFilter {
             object_ids: Some(
                 self.payment_obj_ids
                     .iter()

--- a/crates/sui-graphql-rpc/src/types/intersect.rs
+++ b/crates/sui-graphql-rpc/src/types/intersect.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Merges two filter fields. If both values exist, `merge` is used to combine them, which returns
+/// some combined value if there is some consistent combination, and `None` otherwise. The overall
+/// function returns `Some(None)`, if the filters combined to no filter, `Some(Some(f))` if the
+/// filters combined to `f`, and `None` if the filters couldn't be combined.
+pub(crate) fn field<T>(
+    this: Option<T>,
+    that: Option<T>,
+    merge: impl FnOnce(T, T) -> Option<T>,
+) -> Option<Option<T>> {
+    match (this, that) {
+        (None, None) => Some(None),
+        (Some(this), None) => Some(Some(this)),
+        (None, Some(that)) => Some(Some(that)),
+        (Some(this), Some(that)) => merge(this, that).map(Some),
+    }
+}
+
+/// Merge options by equality check (equal values get merged, everything else is inconsistent).
+pub(crate) fn by_eq<T: Eq>(a: T, b: T) -> Option<T> {
+    (a == b).then_some(a)
+}
+
+/// Merge options by taking the max.
+pub(crate) fn by_max<T: Ord>(a: T, b: T) -> Option<T> {
+    Some(a.max(b))
+}
+
+/// Merge options by taking the min.
+pub(crate) fn by_min<T: Ord>(a: T, b: T) -> Option<T> {
+    Some(a.min(b))
+}

--- a/crates/sui-graphql-rpc/src/types/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod epoch;
 pub(crate) mod event;
 pub(crate) mod execution_result;
 pub(crate) mod gas;
+pub(crate) mod intersect;
 pub(crate) mod json;
 pub(crate) mod move_function;
 pub(crate) mod move_module;

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -12,7 +12,7 @@ use crate::data::Db;
 use crate::error::Error;
 use sui_package_resolver::Module as ParsedMoveModule;
 
-use super::cursor::{Cursor, Page};
+use super::cursor::{JsonCursor, Page};
 use super::move_function::MoveFunction;
 use super::move_struct::MoveStruct;
 use super::{base64::Base64, move_package::MovePackage, sui_address::SuiAddress};
@@ -24,9 +24,9 @@ pub(crate) struct MoveModule {
     pub parsed: ParsedMoveModule,
 }
 
-pub(crate) type CFriend = Cursor<usize>;
-pub(crate) type CStruct = Cursor<String>;
-pub(crate) type CFunction = Cursor<String>;
+pub(crate) type CFriend = JsonCursor<usize>;
+pub(crate) type CStruct = JsonCursor<String>;
+pub(crate) type CFunction = JsonCursor<String>;
 
 /// Represents a module in Move, a library that defines struct types
 /// and functions that operate on these types.
@@ -170,7 +170,7 @@ impl MoveModule {
                 .extend();
             };
 
-            let cursor = Cursor::new(name.to_string()).encode_cursor();
+            let cursor = JsonCursor::new(name.to_string()).encode_cursor();
             connection.edges.push(Edge::new(cursor, struct_));
         }
 
@@ -227,7 +227,7 @@ impl MoveModule {
                 .extend();
             };
 
-            let cursor = Cursor::new(name.to_string()).encode_cursor();
+            let cursor = JsonCursor::new(name.to_string()).encode_cursor();
             connection.edges.push(Edge::new(cursor, function));
         }
 

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -139,8 +139,8 @@ impl MoveModule {
         before: Option<CStruct>,
     ) -> Result<Option<Connection<String, MoveStruct>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(String::as_str);
-        let before = page.before().map(String::as_str);
+        let after = page.after().map(|a| (*a).as_str());
+        let before = page.before().map(|b| (*b).as_str());
         let struct_range = self.parsed.structs(after, before);
 
         let mut connection = Connection::new(false, false);
@@ -196,8 +196,8 @@ impl MoveModule {
         before: Option<CFunction>,
     ) -> Result<Option<Connection<String, MoveFunction>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(String::as_str);
-        let before = page.before().map(String::as_str);
+        let after = page.after().map(|a| (*a).as_str());
+        let before = page.before().map(|b| (*b).as_str());
         let function_range = self.parsed.functions(after, before);
 
         let mut connection = Connection::new(false, false);

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::base64::Base64;
-use super::cursor::{Cursor, Page};
+use super::cursor::{JsonCursor, Page};
 use super::move_module::MoveModule;
 use super::object::Object;
 use super::sui_address::SuiAddress;
@@ -52,7 +52,7 @@ struct TypeOrigin {
 
 pub(crate) struct MovePackageDowncastError;
 
-pub(crate) type CModule = Cursor<String>;
+pub(crate) type CModule = JsonCursor<String>;
 
 /// A MovePackage is a kind of Move object that represents code that has been published on chain.
 /// It exposes information about its modules, type definitions, functions, and dependencies.
@@ -116,7 +116,7 @@ impl MovePackage {
                 .extend());
             };
 
-            let cursor = Cursor::new(name.clone()).encode_cursor();
+            let cursor = JsonCursor::new(name.clone()).encode_cursor();
             connection.edges.push(Edge::new(
                 cursor,
                 MoveModule {

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -79,8 +79,8 @@ impl MovePackage {
 
         let parsed = self.parsed_package()?;
         let module_range = parsed.modules().range::<String, _>((
-            page.after().map_or(B::Unbounded, B::Excluded),
-            page.before().map_or(B::Unbounded, B::Excluded),
+            page.after().map_or(B::Unbounded, |a| B::Excluded(&**a)),
+            page.before().map_or(B::Unbounded, |b| B::Excluded(&**b)),
         ));
 
         let mut connection = Connection::new(false, false);

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -72,9 +72,6 @@ pub(crate) struct DeprecatedObjectFilter {
 
     /// Filter for live objects by their IDs.
     pub object_ids: Option<Vec<SuiAddress>>,
-
-    /// Filter for live or potentially historical objects by their ID and version.
-    pub object_keys: Option<Vec<ObjectKey>>,
 }
 
 /// Constrains the set of objects returned. All filters are optional, and the resulting set of
@@ -107,8 +104,8 @@ pub(crate) struct ObjectFilter {
 
 #[derive(InputObject, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectKey {
-    object_id: SuiAddress,
-    version: u64,
+    pub object_id: SuiAddress,
+    pub version: u64,
 }
 
 /// The object's owner type: Immutable, Shared, Parent, or Address.

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1,33 +1,43 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
+use async_graphql::connection::{CursorType, Edge};
 use async_graphql::{connection::Connection, *};
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel::{
+    BoolExpressionMethods, ExpressionMethods, NullableExpressionMethods, OptionalExtension,
+    QueryDsl,
+};
 use fastcrypto::encoding::{Base58, Encoding};
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
 use sui_indexer::models_v2::objects::StoredObject;
 use sui_indexer::schema_v2::objects;
+use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc::name_service::NameServiceConfig;
 use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::TypeTag;
 
 use super::big_int::BigInt;
+use super::cursor::{self, Page, Target};
 use super::display::{get_rendered_fields, DisplayEntry};
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::suins_registration::SuinsRegistration;
+use super::type_filter::TypeFilter;
 use super::{
     balance::Balance, coin::Coin, owner::Owner, stake::StakedSui, sui_address::SuiAddress,
     transaction_block::TransactionBlock,
 };
 use crate::context_data::db_data_provider::PgManager;
 use crate::context_data::package_cache::PackageCache;
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::types::base64::Base64;
+use crate::types::intersect;
 use sui_types::object::{
     MoveObject as NativeMoveObject, Object as NativeObject, Owner as NativeOwner,
 };
@@ -43,8 +53,10 @@ pub(crate) struct Object {
     pub native: NativeObject,
 }
 
-#[derive(InputObject, Default, Clone)]
-pub(crate) struct ObjectFilter {
+/// Previous implementation of `ObjectFilter`, kept around to use in the legacy DB provider APIs,
+/// while we are in the process of migrating over to the DB APIs.
+#[derive(Default, Clone)]
+pub(crate) struct DeprecatedObjectFilter {
     /// This field is used to specify the type of objects that should be included in the query
     /// results.
     ///
@@ -65,7 +77,35 @@ pub(crate) struct ObjectFilter {
     pub object_keys: Option<Vec<ObjectKey>>,
 }
 
-#[derive(InputObject, Clone)]
+/// Constrains the set of objects returned. All filters are optional, and the resulting set of
+/// objects are ones whose
+///
+/// - Type matches the `type` filter,
+/// - AND, whose owner matches the `owner` filter,
+/// - AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+#[derive(InputObject, Default, Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ObjectFilter {
+    /// This field is used to specify the type of objects that should be included in the query
+    /// results.
+    ///
+    /// Objects can be filtered by their type's package, package::module, or their fully qualified
+    /// type name.
+    ///
+    /// Generic types can be queried by either the generic type name, e.g. `0x2::coin::Coin`, or by
+    /// the full type name, such as `0x2::coin::Coin<0x2::sui::SUI>`.
+    pub type_: Option<TypeFilter>,
+
+    /// Filter for live objects by their current owners.
+    pub owner: Option<SuiAddress>,
+
+    /// Filter for live objects by their IDs.
+    pub object_ids: Option<Vec<SuiAddress>>,
+
+    /// Filter for live or potentially historical objects by their ID and version.
+    pub object_keys: Option<Vec<ObjectKey>>,
+}
+
+#[derive(InputObject, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectKey {
     object_id: SuiAddress,
     version: u64,
@@ -110,6 +150,9 @@ pub struct Parent {
 pub struct AddressOwner {
     owner: Option<Owner>,
 }
+
+pub(crate) type Cursor = cursor::BcsCursor<Vec<u8>>;
+type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 
 /// An object in Sui is a package (set of Move bytecode modules) or object (typed data structure
 /// with fields) with additional metadata detailing its id, version, transaction digest, owner
@@ -250,17 +293,25 @@ impl Object {
     }
 
     /// The objects owned by this object
-    pub async fn object_connection(
+    pub async fn objects(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<self::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<self::Cursor>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Option<Connection<String, Object>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_owned_objs(first, after, last, before, filter, self.address)
+    ) -> Result<Connection<String, Object>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+
+        let Some(filter) = filter.unwrap_or_default().intersect(ObjectFilter {
+            owner: Some(self.address),
+            ..Default::default()
+        }) else {
+            return Ok(Connection::new(false, false));
+        };
+
+        Object::paginate(ctx.data_unchecked(), page, None, filter)
             .await
             .extend()
     }
@@ -448,6 +499,187 @@ impl Object {
 
         stored_obj.map(Self::try_from).transpose()
     }
+
+    /// Query the database for a `page` of objects. The page uses the bytes of an Object ID as the
+    /// cursor, and can optionally be further `filter`-ed. The `owner_type` is an optional
+    /// additional filter, to constrain the objects to be those whose owner is of a particular kind
+    /// (address-owned, object-owned, shared, immutable). This kind of filter is not exposed
+    /// directly in the GraphQL API, but we can take advantage of it when constructing DB queries to
+    /// serve certain other queries (e.g. dynamic field queries).
+    pub(crate) async fn paginate(
+        db: &Db,
+        page: Page<Cursor>,
+        owner_type: Option<OwnerType>,
+        filter: ObjectFilter,
+    ) -> Result<Connection<String, Object>, Error> {
+        let (prev, next, results) = db
+            .execute(move |conn| {
+                page.paginate_query::<StoredObject, _, _, _>(conn, move || {
+                    use objects::dsl;
+                    let mut query = dsl::objects.into_boxed();
+
+                    // Start by applying the filters on IDs and/or keys because they are combined as
+                    // a disjunction, while the remaining queries are conjunctions.
+                    if let Some(object_ids) = &filter.object_ids {
+                        query = query.or_filter(
+                            dsl::object_id.eq_any(object_ids.iter().map(|a| a.into_vec())),
+                        );
+                    }
+
+                    for ObjectKey { object_id, version } in filter.object_keys.iter().flatten() {
+                        query = query.or_filter(
+                            dsl::object_id
+                                .eq(object_id.into_vec())
+                                .and(dsl::object_version.eq(*version as i64)),
+                        );
+                    }
+
+                    if let Some(owner_type) = &owner_type {
+                        query = query.filter(dsl::owner_type.eq(*owner_type as i16));
+                    }
+
+                    if let Some(type_) = &filter.type_ {
+                        query = query.filter(dsl::object_type.is_not_null());
+                        query = type_.apply(query, dsl::object_type.assume_not_null());
+                    }
+
+                    if let Some(owner) = &filter.owner {
+                        query = query.filter(dsl::owner_id.eq(owner.into_vec()));
+
+                        // If we are supplying an address as the owner, we know that the object must
+                        // be owned by an address, or by an object.
+                        query = query.filter(
+                            dsl::owner_type
+                                .eq_any([OwnerType::Address as i16, OwnerType::Object as i16]),
+                        );
+                    }
+
+                    query
+                })
+            })
+            .await?;
+
+        let mut conn = Connection::new(prev, next);
+
+        for stored in results {
+            let cursor = stored.cursor().encode_cursor();
+            let object = Object::try_from(stored)?;
+            conn.edges.push(Edge::new(cursor, object));
+        }
+
+        Ok(conn)
+    }
+}
+
+impl ObjectFilter {
+    /// Try to create a filter whose results are the intersection of objects in `self`'s results and
+    /// objects in `other`'s results. This may not be possible if the resulting filter is
+    /// inconsistent in some way (e.g. a filter that requires one field to be two different values
+    /// simultaneously).
+    pub(crate) fn intersect(self, other: ObjectFilter) -> Option<Self> {
+        macro_rules! intersect {
+            ($field:ident, $body:expr) => {
+                intersect::field(self.$field, other.$field, $body)
+            };
+        }
+
+        // Treat `object_ids` and `object_keys` as a single filter on IDs, and optionally versions,
+        // and compute the intersection of that.
+        let keys = intersect::field(self.keys(), other.keys(), |k, l| {
+            let mut combined = BTreeMap::new();
+
+            for (id, v) in k {
+                if let Some(w) = l.get(&id).copied() {
+                    combined.insert(id, intersect::field(v, w, intersect::by_eq)?);
+                }
+            }
+
+            // If the intersection is empty, it means, there were some ID or Key filters in both
+            // `self` and `other`, but they don't overlap, so the final result is inconsistent.
+            (!combined.is_empty()).then_some(combined)
+        })?;
+
+        // Extract the ID and Key filters back out. At this point, we know that if there were ID/Key
+        // filters in both `self` and `other`, then they intersected to form a consistent set of
+        // constraints, so it is safe to interpret the lack of any ID/Key filters respectively as a
+        // lack of that kind of constraint, rather than a constraint on the empty set.
+
+        let object_ids = {
+            let partition: Vec<_> = keys
+                .iter()
+                .flatten()
+                .filter_map(|(id, v)| v.is_none().then_some(*id))
+                .collect();
+
+            (!partition.is_empty()).then_some(partition)
+        };
+
+        let object_keys = {
+            let partition: Vec<_> = keys
+                .iter()
+                .flatten()
+                .filter_map(|(id, v)| {
+                    Some(ObjectKey {
+                        object_id: *id,
+                        version: (*v)?,
+                    })
+                })
+                .collect();
+
+            (!partition.is_empty()).then_some(partition)
+        };
+
+        Some(Self {
+            type_: intersect!(type_, TypeFilter::intersect)?,
+            owner: intersect!(owner, intersect::by_eq)?,
+            object_ids,
+            object_keys,
+        })
+    }
+
+    /// Extract the Object ID and Key filters into one combined map from Object IDs in this filter,
+    /// to the versions they should have (or None if the filter mentions the ID but no version for
+    /// it).
+    fn keys(&self) -> Option<BTreeMap<SuiAddress, Option<u64>>> {
+        if self.object_keys.is_none() && self.object_ids.is_none() {
+            return None;
+        }
+
+        Some(BTreeMap::from_iter(
+            self.object_keys
+                .iter()
+                .flatten()
+                .map(|key| (key.object_id, Some(key.version)))
+                // Chain ID filters after Key filters so if there is overlap, we overwrite the key
+                // filter with the ID filter.
+                .chain(self.object_ids.iter().flatten().map(|id| (*id, None))),
+        ))
+    }
+}
+
+impl Target<Cursor> for StoredObject {
+    type Source = objects::table;
+
+    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(objects::dsl::object_id.ge((**cursor).clone()))
+    }
+
+    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(objects::dsl::object_id.le((**cursor).clone()))
+    }
+
+    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
+        use objects::dsl;
+        if asc {
+            query.order_by(dsl::object_id.asc())
+        } else {
+            query.order_by(dsl::object_id.desc())
+        }
+    }
+
+    fn cursor(&self) -> Cursor {
+        Cursor::new(self.object_id.clone())
+    }
 }
 
 impl TryFrom<StoredObject> for Object {
@@ -503,4 +735,126 @@ pub(crate) async fn deserialize_move_struct(
     })?;
 
     Ok((struct_tag, move_struct))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_owner_filter_intersection() {
+        let f0 = ObjectFilter {
+            owner: Some(SuiAddress::from_str("0x1").unwrap()),
+            ..Default::default()
+        };
+
+        let f1 = ObjectFilter {
+            owner: Some(SuiAddress::from_str("0x2").unwrap()),
+            ..Default::default()
+        };
+
+        assert_eq!(f0.clone().intersect(f0.clone()), Some(f0.clone()));
+        assert_eq!(f0.clone().intersect(f1.clone()), None);
+    }
+
+    #[test]
+    fn test_key_filter_intersection() {
+        let i1 = SuiAddress::from_str("0x1").unwrap();
+        let i2 = SuiAddress::from_str("0x2").unwrap();
+        let i3 = SuiAddress::from_str("0x3").unwrap();
+        let i4 = SuiAddress::from_str("0x4").unwrap();
+
+        let f0 = ObjectFilter {
+            object_ids: Some(vec![i1, i3]),
+            object_keys: Some(vec![
+                ObjectKey {
+                    object_id: i2,
+                    version: 1,
+                },
+                ObjectKey {
+                    object_id: i4,
+                    version: 2,
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let f1 = ObjectFilter {
+            object_ids: Some(vec![i1, i2]),
+            object_keys: Some(vec![ObjectKey {
+                object_id: i4,
+                version: 2,
+            }]),
+            ..Default::default()
+        };
+
+        let f2 = ObjectFilter {
+            object_ids: Some(vec![i1, i3]),
+            ..Default::default()
+        };
+
+        let f3 = ObjectFilter {
+            object_keys: Some(vec![
+                ObjectKey {
+                    object_id: i2,
+                    version: 2,
+                },
+                ObjectKey {
+                    object_id: i4,
+                    version: 2,
+                },
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            f0.clone().intersect(f1.clone()),
+            Some(ObjectFilter {
+                object_ids: Some(vec![i1]),
+                object_keys: Some(vec![
+                    ObjectKey {
+                        object_id: i2,
+                        version: 1
+                    },
+                    ObjectKey {
+                        object_id: i4,
+                        version: 2
+                    },
+                ]),
+                ..Default::default()
+            })
+        );
+
+        assert_eq!(
+            f1.clone().intersect(f2.clone()),
+            Some(ObjectFilter {
+                object_ids: Some(vec![i1]),
+                ..Default::default()
+            })
+        );
+
+        assert_eq!(
+            f1.clone().intersect(f3.clone()),
+            Some(ObjectFilter {
+                object_keys: Some(vec![
+                    ObjectKey {
+                        object_id: i2,
+                        version: 2
+                    },
+                    ObjectKey {
+                        object_id: i4,
+                        version: 2
+                    },
+                ]),
+                ..Default::default()
+            })
+        );
+
+        // i2 got a conflicting version assignment
+        assert_eq!(f0.clone().intersect(f3.clone()), None);
+
+        // No overlap between these two.
+        assert_eq!(f2.clone().intersect(f3.clone()), None);
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -19,7 +19,7 @@ use super::{
     epoch::Epoch,
     event::{self, Event, EventFilter},
     move_type::MoveType,
-    object::{Object, ObjectFilter},
+    object::{self, Object, ObjectFilter},
     owner::Owner,
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
@@ -190,17 +190,17 @@ impl Query {
     }
 
     /// The objects that exist in the network.
-    async fn object_connection(
+    async fn objects(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<object::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
+        before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Option<Connection<String, Object>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_objs(first, after, last, before, filter)
+    ) -> Result<Connection<String, Object>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        Object::paginate(ctx.data_unchecked(), page, None, filter.unwrap_or_default())
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -18,7 +18,7 @@ use super::{
     balance_change::BalanceChange,
     base64::Base64,
     checkpoint::{Checkpoint, CheckpointId},
-    cursor::{Cursor, Page},
+    cursor::{JsonCursor, Page},
     date_time::DateTime,
     digest::Digest,
     epoch::Epoch,
@@ -51,10 +51,10 @@ pub enum ExecutionStatus {
 /// therefore must be a different types to the default `TransactionBlockConnection`).
 struct DependencyConnectionNames;
 
-pub(crate) type CDependencies = Cursor<usize>;
-pub(crate) type CUnchangedSharedObject = Cursor<usize>;
-pub(crate) type CObjectChange = Cursor<usize>;
-pub(crate) type CBalanceChange = Cursor<usize>;
+pub(crate) type CDependencies = JsonCursor<usize>;
+pub(crate) type CUnchangedSharedObject = JsonCursor<usize>;
+pub(crate) type CObjectChange = JsonCursor<usize>;
+pub(crate) type CBalanceChange = JsonCursor<usize>;
 
 /// The effects representing the result of executing a transaction block.
 #[Object]

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -12,7 +12,7 @@ use sui_types::{
 };
 
 use crate::types::{
-    cursor::{Cursor, Page},
+    cursor::{JsonCursor, Page},
     epoch::Epoch,
 };
 
@@ -21,7 +21,7 @@ pub(crate) struct AuthenticatorStateUpdateTransaction(
     pub NativeAuthenticatorStateUpdateTransaction,
 );
 
-pub(crate) type CActiveJwk = Cursor<usize>;
+pub(crate) type CActiveJwk = JsonCursor<usize>;
 
 /// The active JSON Web Key representing a set of public keys for an OpenID provider
 struct ActiveJwk(NativeActiveJwk);

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -15,7 +15,7 @@ use sui_types::{
     },
 };
 
-use crate::types::cursor::{Cursor, Page};
+use crate::types::cursor::{JsonCursor, Page};
 use crate::types::sui_address::SuiAddress;
 use crate::{
     error::Error,
@@ -67,8 +67,8 @@ pub(crate) struct CoinDenyListStateCreateTransaction {
     dummy: Option<bool>,
 }
 
-pub(crate) type CTxn = Cursor<usize>;
-pub(crate) type CPackage = Cursor<usize>;
+pub(crate) type CTxn = JsonCursor<usize>;
+pub(crate) type CPackage = JsonCursor<usize>;
 
 /// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions
 /// at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -12,7 +12,7 @@ use sui_types::{
 };
 
 use crate::types::{
-    cursor::{Cursor, Page},
+    cursor::{JsonCursor, Page},
     object::Object,
     sui_address::SuiAddress,
 };
@@ -20,7 +20,7 @@ use crate::types::{
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct GenesisTransaction(pub NativeGenesisTransaction);
 
-pub(crate) type CObject = Cursor<usize>;
+pub(crate) type CObject = JsonCursor<usize>;
 
 /// System transaction that initializes the network and writes the initial set of objects on-chain.
 #[Object]

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -13,7 +13,7 @@ use sui_types::transaction::{
 
 use crate::types::{
     base64::Base64,
-    cursor::{Cursor, Page},
+    cursor::{JsonCursor, Page},
     move_function::MoveFunction,
     move_type::MoveType,
     object_read::ObjectRead,
@@ -23,8 +23,8 @@ use crate::types::{
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct ProgrammableTransactionBlock(pub NativeProgrammableTransactionBlock);
 
-pub(crate) type CInput = Cursor<usize>;
-pub(crate) type CTxn = Cursor<usize>;
+pub(crate) type CInput = JsonCursor<usize>;
+pub(crate) type CTxn = JsonCursor<usize>;
 
 #[derive(Union, Clone, Eq, PartialEq)]
 enum TransactionInput {

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -103,7 +103,6 @@ impl TypeFilter {
     /// filters (`self` and `other`). This may not be possible if the resulting filter is
     /// inconsistent (e.g. a filter that requires the module member's package to be at two different
     /// addresses simultaneously), in which case `None` is returned.
-    #[allow(dead_code)]
     pub(crate) fn intersect(self, other: Self) -> Option<Self> {
         use ModuleFilter as M;
         use TypeFilter as T;

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -75,7 +75,7 @@ type Address implements IOwner {
 	"""
 	The objects that are owned by this address.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	The balance that this address holds.
 	"""
@@ -1043,7 +1043,7 @@ type GenesisTransaction {
 
 interface IOwner {
 	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coinConnection(first: Int, after: String, last: Int, before: String, type: String): CoinConnection
@@ -1685,7 +1685,7 @@ type Object implements IOwner {
 	"""
 	The objects owned by this object
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	The balance of coin objects of a particular coin type owned by the object.
 	"""
@@ -1821,6 +1821,14 @@ type ObjectEdge {
 	cursor: String!
 }
 
+"""
+Constrains the set of objects returned. All filters are optional, and the resulting set of
+objects are ones whose
+
+- Type matches the `type` filter,
+- AND, whose owner matches the `owner` filter,
+- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+"""
 input ObjectFilter {
 	"""
 	This field is used to specify the type of objects that should be included in the query
@@ -1929,7 +1937,7 @@ type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	Total balance of all coins with marker type owned by this Owner. If type is not supplied,
 	it defaults to 0x2::sui::SUI.
@@ -2195,7 +2203,7 @@ type Query {
 	"""
 	The objects that exist in the network.
 	"""
-	objectConnection(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	"""
 	Fetch the protocol config by protocol version (defaults to the latest protocol
 	version known to the GraphQL service).

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1018,7 +1018,7 @@ type GasInput {
 	"""
 	Objects used to pay for a transaction's execution and storage
 	"""
-	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
+	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection!
 	"""
 	An unsigned integer specifying the number of native tokens per gas unit this transaction
 	will pay (in MIST).

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1028,9 +1028,16 @@ impl<'a> SuiTestAdapter<'a> {
         let objects = self
             .object_enumeration
             .iter()
-            .filter_map(|(oid, fid)| match fid {
-                FakeID::Known(_) => None,
-                FakeID::Enumerated(x, y) => Some((format!("obj_{x}_{y}"), oid.to_string())),
+            .flat_map(|(oid, fid)| match fid {
+                FakeID::Known(_) => vec![],
+                FakeID::Enumerated(x, y) => vec![
+                    (format!("obj_{x}_{y}"), oid.to_string()),
+                    // Add a binding to treat this object as a cursor
+                    (
+                        format!("obj_{x}_{y}_cursor"),
+                        Base64::encode(bcs::to_bytes(&oid.to_vec()).unwrap_or_default()),
+                    ),
+                ],
             });
 
         let cursors = cursors


### PR DESCRIPTION
## Description

Implement filter intersection for `TypeFilter`. This is not used yet, but will become necessary for implementing filter intersection for `ObjectFilter` in a follow-up PR (at which point the `#[allow(dead_code)]` annotation can be removed from the implementation).

## Test Plan

New unit tests for `TypeFilter::intersect`:

```
sui-graphql-rpc$ cargo nextest run
```

## Stack

- #15661 
- #15695 
- #15698 
- #15699 
- #15701 