### PR TITLE
[GraphQL/Cursor] Generalise cursor type used by Page

### DIFF
--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -139,8 +139,8 @@ impl MoveModule {
         before: Option<CStruct>,
     ) -> Result<Option<Connection<String, MoveStruct>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(String::as_str);
-        let before = page.before().map(String::as_str);
+        let after = page.after().map(|a| (*a).as_str());
+        let before = page.before().map(|b| (*b).as_str());
         let struct_range = self.parsed.structs(after, before);
 
         let mut connection = Connection::new(false, false);
@@ -196,8 +196,8 @@ impl MoveModule {
         before: Option<CFunction>,
     ) -> Result<Option<Connection<String, MoveFunction>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(String::as_str);
-        let before = page.before().map(String::as_str);
+        let after = page.after().map(|a| (*a).as_str());
+        let before = page.before().map(|b| (*b).as_str());
         let function_range = self.parsed.functions(after, before);
 
         let mut connection = Connection::new(false, false);

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -79,8 +79,8 @@ impl MovePackage {
 
         let parsed = self.parsed_package()?;
         let module_range = parsed.modules().range::<String, _>((
-            page.after().map_or(B::Unbounded, B::Excluded),
-            page.before().map_or(B::Unbounded, B::Excluded),
+            page.after().map_or(B::Unbounded, |a| B::Excluded(&**a)),
+            page.before().map_or(B::Unbounded, |b| B::Excluded(&**b)),
         ));
 
         let mut connection = Connection::new(false, false);


### PR DESCRIPTION
## Description

`Page<C>` was originally designed to work with `Cursor<C>`. This change allows it to be used with any type that implements `CursorType`.

The motivation for this is the upcoming port of `Object` to the cursor and pagination framework: We need to be able to use `Page` to paginate Objects, but the representation of an object cursor in this form is very large, because it converts the hex-encoded string into a JSON array of numbers (bytes), stringifies that and Base64 encodes the result.

By decoupling `Page` and `Cursor`, we can define a new Cursor type for Object cursors (which will BCS-encode the underlying type before Base64 encoding it) with a more compact representation, and still take advantage of the pagination framework.

## Test Plan

Behaviour preserving refactor:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack

- #15661 
- #15695 
- #15698 
- #15699 
- #15701 
- #15710 