### PR TITLE
Do not check deny list for sui coins

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4400,8 +4400,12 @@ impl AuthorityState {
             .chain(receiving_objects.iter_objects());
         let coin_types = all_objects
             .filter_map(|obj| {
-                obj.coin_type_maybe()
-                    .map(|type_tag| type_tag.to_canonical_string(false))
+                if obj.is_gas_coin() {
+                    None
+                } else {
+                    obj.coin_type_maybe()
+                        .map(|type_tag| type_tag.to_canonical_string(false))
+                }
             })
             .collect::<BTreeSet<_>>();
         DenyList::check_coin_deny_list(sender, coin_types, &self.database)?;


### PR DESCRIPTION
## Description 

A quick optimization before we implement something more complex.
The sui coin will never have deny list.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
