### PR TITLE
[graphql] implement executeTransactionBlock

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.exp
@@ -26,93 +26,99 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 5 'create-checkpoint'. lines 36-36:
 Checkpoint created: 1
 
-task 6 'run-graphql'. lines 38-55:
+task 6 'run-graphql'. lines 38-57:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
         {
-          "events": {
-            "edges": [
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "1"
-                  },
-                  "bcs": "AQAAAAAAAAA="
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "1"
+                    },
+                    "bcs": "AQAAAAAAAAA="
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         },
         {
-          "events": {
-            "edges": [
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "10"
-                  },
-                  "bcs": "CgAAAAAAAAA="
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "10"
+                    },
+                    "bcs": "CgAAAAAAAAA="
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "11"
+                    },
+                    "bcs": "CwAAAAAAAAA="
+                  }
                 }
-              },
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "11"
-                  },
-                  "bcs": "CwAAAAAAAAA="
-                }
-              }
-            ]
+              ]
+            }
           }
         },
         {
-          "events": {
-            "edges": [
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "100"
-                  },
-                  "bcs": "ZAAAAAAAAAA="
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "100"
+                    },
+                    "bcs": "ZAAAAAAAAAA="
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "101"
+                    },
+                    "bcs": "ZQAAAAAAAAA="
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "102"
+                    },
+                    "bcs": "ZgAAAAAAAAA="
+                  }
                 }
-              },
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "101"
-                  },
-                  "bcs": "ZQAAAAAAAAA="
-                }
-              },
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "102"
-                  },
-                  "bcs": "ZgAAAAAAAAA="
-                }
-              }
-            ]
+              ]
+            }
           }
         }
       ]
@@ -120,7 +126,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 57-68:
+task 7 'run-graphql'. lines 59-70:
 Response: {
   "data": {
     "events": {
@@ -184,26 +190,28 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 70-87:
+task 8 'run-graphql'. lines 72-91:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
         {
-          "events": {
-            "edges": [
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "1"
-                  },
-                  "bcs": "AQAAAAAAAAA="
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "1"
+                    },
+                    "bcs": "AQAAAAAAAAA="
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       ]
@@ -211,37 +219,39 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 89-106:
+task 9 'run-graphql'. lines 93-112:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
         {
-          "events": {
-            "edges": [
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "101"
-                  },
-                  "bcs": "ZQAAAAAAAAA="
+          "effects": {
+            "events": {
+              "edges": [
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "101"
+                    },
+                    "bcs": "ZQAAAAAAAAA="
+                  }
+                },
+                {
+                  "node": {
+                    "sendingModule": {
+                      "name": "M1"
+                    },
+                    "json": {
+                      "new_value": "102"
+                    },
+                    "bcs": "ZgAAAAAAAAA="
+                  }
                 }
-              },
-              {
-                "node": {
-                  "sendingModule": {
-                    "name": "M1"
-                  },
-                  "json": {
-                    "new_value": "102"
-                  },
-                  "bcs": "ZgAAAAAAAAA="
-                }
-              }
-            ]
+              ]
+            }
           }
         }
       ]

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
@@ -39,14 +39,16 @@ module Test::M1 {
 {
   transactionBlocks(filter: { signAddress: "@{A}" }) {
     nodes {
-      events {
-        edges {
-          node {
-            sendingModule {
-              name
+      effects{
+        events {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+              json
+              bcs
             }
-            json
-            bcs
           }
         }
       }
@@ -71,14 +73,16 @@ module Test::M1 {
 {
   transactionBlocks(first: 1, filter: { signAddress: "@{A}" }) {
     nodes {
-      events(last: 1) {
-        edges {
-          node {
-            sendingModule {
-              name
+      effects {
+        events(last: 1) {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+              json
+              bcs
             }
-            json
-            bcs
           }
         }
       }
@@ -90,14 +94,16 @@ module Test::M1 {
 {
   transactionBlocks(last: 1, filter: { signAddress: "@{A}" }) {
     nodes {
-      events(first: 2, after: "@{cursor_0}") {
-        edges {
-          node {
-            sendingModule {
-              name
+      effects {
+        events(first: 2, after: "@{cursor_0}") {
+          edges {
+            node {
+              sendingModule {
+                name
+              }
+              json
+              bcs
             }
-            json
-            bcs
           }
         }
       }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -912,7 +912,9 @@ type ExecutionResult {
 	"""
 	errors: [String!]
 	"""
-	The effects of the executed transaction.
+	The effects of the executed transaction. Since the transaction was just executed
+	and not indexed yet, fields including `balance_changes`, `timestamp` and `checkpoint`
+	are not available.
 	"""
 	effects: TransactionBlockEffects!
 }
@@ -2701,7 +2703,7 @@ type TransactionBlock {
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain.
 	"""
-	digest: String!
+	digest: String
 	"""
 	The address corresponding to the public key that signed this transaction. System
 	transactions do not have senders.
@@ -2729,10 +2731,6 @@ type TransactionBlock {
 	The effects field captures the results to the chain of executing this transaction.
 	"""
 	effects: TransactionBlockEffects
-	"""
-	Events emitted by this transaction block.
-	"""
-	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,
@@ -2816,6 +2814,10 @@ type TransactionBlockEffects {
 	addresses and objects.
 	"""
 	balanceChanges(first: Int, after: String, last: Int, before: String): BalanceChangeConnection!
+	"""
+	Events emitted by this transaction block.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -912,9 +912,9 @@ type ExecutionResult {
 	"""
 	errors: [String!]
 	"""
-	The digest field captures the digest of the transaction block
+	The effects of the executed transaction.
 	"""
-	digest: String!
+	effects: TransactionBlockEffects!
 }
 
 """

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -780,7 +780,7 @@ type Checkpoint {
 }
 
 type TransactionBlock {
-  digest: String!
+  digest: String
 
   sender: Address
   gasInput: GasInput

--- a/crates/sui-graphql-rpc/src/mutation.rs
+++ b/crates/sui-graphql-rpc/src/mutation.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::execution_result::ExecutedTransaction;
 use crate::{
-    error::Error, types::event::Event, types::execution_result::ExecutionResult,
+    error::Error, types::execution_result::ExecutionResult,
     types::transaction_block_effects::TransactionBlockEffects,
 };
 use async_graphql::*;
-use either::Either;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::{encoding::Base64, traits::ToFromBytes};
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
@@ -81,7 +79,6 @@ impl Mutation {
         let transaction = Transaction::from_generic_sig_data(tx_data, sigs);
         let options = SuiTransactionBlockResponseOptions::new()
             .with_events()
-            .with_balance_changes()
             .with_raw_input()
             .with_raw_effects();
 
@@ -90,9 +87,7 @@ impl Mutation {
             .execute_transaction_block(
                 transaction,
                 options,
-                // This needs to be WaitForLocalExecution because we need the transaction effects.
-                // TODO: make it possible to execute without waiting for local execution?
-                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+                Some(ExecuteTransactionRequestType::WaitForEffectsCert),
             )
             .await
             // TODO: use proper error type as this could be a client error or internal error
@@ -100,35 +95,28 @@ impl Mutation {
             .map_err(|e| Error::Internal(format!("Unable to execute transaction: {e}")))
             .extend()?;
 
-        let raw_effects: NativeTransactionEffects = bcs::from_bytes(&result.raw_effects)
+        let native: NativeTransactionEffects = bcs::from_bytes(&result.raw_effects)
             .map_err(|e| Error::Internal(format!("Unable to deserialize transaction effects: {e}")))
             .extend()?;
-        let sender_signed_data: SenderSignedData = bcs::from_bytes(&result.raw_transaction)
+        let tx_data: SenderSignedData = bcs::from_bytes(&result.raw_transaction)
             .map_err(|e| Error::Internal(format!("Unable to deserialize transaction data: {e}")))
             .extend()?;
 
         let events = result
             .events
-            .ok_or(Error::Internal(
-                "No events are returned from tranasction execution".to_string(),
-            ))?
+            .ok_or_else(|| {
+                Error::Internal("No events are returned from transaction execution".to_string())
+            })?
             .data
             .into_iter()
-            .map(|e| Event {
-                stored: None,
-                native: NativeEvent {
-                    package_id: e.package_id,
-                    transaction_module: e.transaction_module,
-                    sender: e.sender,
-                    type_: e.type_,
-                    contents: e.bcs,
-                },
+            .map(|e| NativeEvent {
+                package_id: e.package_id,
+                transaction_module: e.transaction_module,
+                sender: e.sender,
+                type_: e.type_,
+                contents: e.bcs,
             })
             .collect();
-
-        let balance_changes = result.balance_changes.ok_or(Error::Internal(
-            "No balance changes are returned from tranasction execution".to_string(),
-        ))?;
 
         Ok(ExecutionResult {
             errors: if result.errors.is_empty() {
@@ -136,14 +124,10 @@ impl Mutation {
             } else {
                 Some(result.errors)
             },
-            effects: TransactionBlockEffects {
-                tx_data: Either::Right(ExecutedTransaction {
-                    sender_signed_data,
-                    raw_effects: raw_effects.clone(),
-                    balance_changes,
-                    events,
-                }),
-                native: raw_effects,
+            effects: TransactionBlockEffects::Executed {
+                tx_data,
+                native,
+                events,
             },
         })
     }

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -41,10 +41,6 @@ impl BalanceChange {
 }
 
 impl BalanceChange {
-    pub(crate) fn new(stored: StoredBalanceChange) -> Self {
-        Self { stored }
-    }
-
     pub(crate) fn read(bytes: &[u8]) -> Result<Self, Error> {
         let stored = bcs::from_bytes(bytes)
             .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -41,6 +41,10 @@ impl BalanceChange {
 }
 
 impl BalanceChange {
+    pub(crate) fn new(stored: StoredBalanceChange) -> Self {
+        Self { stored }
+    }
+
     pub(crate) fn read(bytes: &[u8]) -> Result<Self, Error> {
         let stored = bcs::from_bytes(bytes)
             .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -114,7 +114,7 @@ impl Event {
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
         if let Some(stored) = &self.stored {
-            Ok(DateTime::from_ms(stored.timestamp_ms).ok())
+            Ok(Some(DateTime::from_ms(stored.timestamp_ms)?))
         } else {
             Ok(None)
         }
@@ -184,33 +184,7 @@ impl Event {
 
         for stored in results {
             let cursor = stored.cursor().encode_cursor();
-            let sender_bytes = stored
-                .senders
-                .first()
-                .ok_or(Error::Internal("No senders found for event".to_string()))?
-                .clone()
-                .ok_or(Error::Internal("No senders found for event".to_string()))?;
-            let package_id = ObjectID::from_bytes(&stored.package)
-                .map_err(|e| Error::Internal(e.to_string()))?;
-            let type_ = parse_sui_struct_tag(&stored.event_type)
-                .map_err(|e| Error::Internal(e.to_string()))?;
-            let transaction_module =
-                Identifier::from_str(&stored.module).map_err(|e| Error::Internal(e.to_string()))?;
-            let contents = stored.bcs.clone();
-            conn.edges.push(Edge::new(
-                cursor,
-                Event {
-                    stored: Some(stored),
-                    native: NativeEvent {
-                        sender: NativeSuiAddress::from_bytes(&sender_bytes)
-                            .map_err(|e| Error::Internal(e.to_string()))?,
-                        package_id,
-                        transaction_module,
-                        type_,
-                        contents,
-                    },
-                },
-            ));
+            conn.edges.push(Edge::new(cursor, stored.try_into()?));
         }
 
         Ok(conn)
@@ -252,6 +226,36 @@ impl Event {
         Ok(Self {
             stored: Some(stored_event),
             native: native_event,
+        })
+    }
+}
+
+impl TryFrom<StoredEvent> for Event {
+    type Error = Error;
+
+    fn try_from(stored: StoredEvent) -> Result<Self, Self::Error> {
+        let Some(Some(sender_bytes)) = stored.senders.first() else {
+            return Err(Error::Internal("No senders found for event".to_string()));
+        };
+        let sender = NativeSuiAddress::from_bytes(sender_bytes)
+            .map_err(|e| Error::Internal(e.to_string()))?;
+
+        let package_id =
+            ObjectID::from_bytes(&stored.package).map_err(|e| Error::Internal(e.to_string()))?;
+        let type_ =
+            parse_sui_struct_tag(&stored.event_type).map_err(|e| Error::Internal(e.to_string()))?;
+        let transaction_module =
+            Identifier::from_str(&stored.module).map_err(|e| Error::Internal(e.to_string()))?;
+        let contents = stored.bcs.clone();
+        Ok(Event {
+            stored: Some(stored),
+            native: NativeEvent {
+                sender,
+                package_id,
+                transaction_module,
+                type_,
+                contents,
+            },
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use super::cursor::{self, Page, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
@@ -16,9 +18,10 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use serde::{Deserialize, Serialize};
 use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
 use sui_indexer::schema_v2::{events, transactions, tx_senders};
+use sui_types::base_types::ObjectID;
+use sui_types::Identifier;
 use sui_types::{
     base_types::SuiAddress as NativeSuiAddress, event::Event as NativeEvent, parse_sui_struct_tag,
-    TypeTag,
 };
 
 /// A Sui node emits one of the following events:
@@ -28,8 +31,10 @@ use sui_types::{
 /// Delete object event
 /// New object event
 /// Epoch change event
+#[derive(Clone, Debug)]
 pub(crate) struct Event {
-    pub stored: StoredEvent,
+    pub stored: Option<StoredEvent>,
+    pub native: NativeEvent,
 }
 
 /// Contents of an Event's cursor.
@@ -86,44 +91,41 @@ impl Event {
     /// calls A::m2::emit_event to emit an event,
     /// the sending module would be A::m1.
     async fn sending_module(&self, ctx: &Context<'_>) -> Result<Option<MoveModule>> {
-        let sending_package = SuiAddress::from_bytes(&self.stored.package)
-            .map_err(|e| Error::Internal(e.to_string()))
-            .extend()?;
-        MoveModule::query(ctx.data_unchecked(), sending_package, &self.stored.module)
-            .await
-            .extend()
+        MoveModule::query(
+            ctx.data_unchecked(),
+            self.native.package_id.into(),
+            &self.native.transaction_module.to_string(),
+        )
+        .await
+        .extend()
     }
 
     /// Address of the sender of the event
     async fn sender(&self) -> Result<Option<Address>> {
-        let Some(Some(sender)) = self.stored.senders.first() else {
-            return Ok(None);
-        };
-
-        let address = SuiAddress::from_bytes(sender)
-            .map_err(|e| Error::Internal(format!("Failed to deserialize address: {e}")))
-            .extend()?;
-
-        if address.as_slice() == NativeSuiAddress::ZERO.as_ref() {
+        if self.native.sender == NativeSuiAddress::ZERO {
             return Ok(None);
         }
 
-        Ok(Some(Address { address }))
+        Ok(Some(Address {
+            address: self.native.sender.into(),
+        }))
     }
 
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        Ok(DateTime::from_ms(self.stored.timestamp_ms).ok())
+        if let Some(stored) = &self.stored {
+            Ok(DateTime::from_ms(stored.timestamp_ms).ok())
+        } else {
+            Ok(None)
+        }
     }
 
     #[graphql(flatten)]
     async fn move_value(&self) -> Result<MoveValue> {
-        let type_ = TypeTag::from(
-            parse_sui_struct_tag(&self.stored.event_type)
-                .map_err(|e| Error::Internal(e.to_string()))
-                .extend()?,
-        );
-        Ok(MoveValue::new(type_, Base64::from(self.stored.bcs.clone())))
+        Ok(MoveValue::new(
+            self.native.type_.clone().into(),
+            Base64::from(self.native.contents.clone()),
+        ))
     }
 }
 
@@ -182,7 +184,33 @@ impl Event {
 
         for stored in results {
             let cursor = stored.cursor().encode_cursor();
-            conn.edges.push(Edge::new(cursor, Event { stored }));
+            let sender_bytes = stored
+                .senders
+                .first()
+                .ok_or(Error::Internal("No senders found for event".to_string()))?
+                .clone()
+                .ok_or(Error::Internal("No senders found for event".to_string()))?;
+            let package_id = ObjectID::from_bytes(&stored.package)
+                .map_err(|e| Error::Internal(e.to_string()))?;
+            let type_ = parse_sui_struct_tag(&stored.event_type)
+                .map_err(|e| Error::Internal(e.to_string()))?;
+            let transaction_module =
+                Identifier::from_str(&stored.module).map_err(|e| Error::Internal(e.to_string()))?;
+            let contents = stored.bcs.clone();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event {
+                    stored: Some(stored),
+                    native: NativeEvent {
+                        sender: NativeSuiAddress::from_bytes(&sender_bytes)
+                            .map_err(|e| Error::Internal(e.to_string()))?,
+                        package_id,
+                        transaction_module,
+                        type_,
+                        contents,
+                    },
+                },
+            ));
         }
 
         Ok(conn)
@@ -217,12 +245,13 @@ impl Event {
             event_type: native_event
                 .type_
                 .to_canonical_string(/* with_prefix */ true),
-            bcs: native_event.contents,
+            bcs: native_event.contents.clone(),
             timestamp_ms: stored_tx.timestamp_ms,
         };
 
         Ok(Self {
-            stored: stored_event,
+            stored: Some(stored_event),
+            native: native_event,
         })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/execution_result.rs
+++ b/crates/sui-graphql-rpc/src/types/execution_result.rs
@@ -1,7 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::event::Event;
+use super::transaction_block_effects::TransactionBlockEffects;
 use async_graphql::*;
+use sui_json_rpc_types::BalanceChange as NativeBalanceChange;
+use sui_types::{
+    effects::TransactionEffects as NativeTransactionEffects,
+    transaction::SenderSignedData as NativeSenderSignedData,
+};
 
 /// The result of an execution, including errors that occurred during said execution.
 #[derive(SimpleObject, Clone)]
@@ -9,7 +16,14 @@ pub(crate) struct ExecutionResult {
     /// The errors field captures any errors that occurred during execution
     pub errors: Option<Vec<String>>,
 
-    /// The digest field captures the digest of the transaction block
-    pub digest: String,
-    // TODO: add support for `TransactionBlockEffects` field
+    /// The effects of the executed transaction.
+    pub effects: TransactionBlockEffects,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExecutedTransaction {
+    pub sender_signed_data: NativeSenderSignedData,
+    pub raw_effects: NativeTransactionEffects,
+    pub balance_changes: Vec<NativeBalanceChange>,
+    pub events: Vec<Event>,
 }

--- a/crates/sui-graphql-rpc/src/types/execution_result.rs
+++ b/crates/sui-graphql-rpc/src/types/execution_result.rs
@@ -1,14 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::event::Event;
 use super::transaction_block_effects::TransactionBlockEffects;
 use async_graphql::*;
-use sui_json_rpc_types::BalanceChange as NativeBalanceChange;
-use sui_types::{
-    effects::TransactionEffects as NativeTransactionEffects,
-    transaction::SenderSignedData as NativeSenderSignedData,
-};
 
 /// The result of an execution, including errors that occurred during said execution.
 #[derive(SimpleObject, Clone)]
@@ -16,14 +10,8 @@ pub(crate) struct ExecutionResult {
     /// The errors field captures any errors that occurred during execution
     pub errors: Option<Vec<String>>,
 
-    /// The effects of the executed transaction.
+    /// The effects of the executed transaction. Since the transaction was just executed
+    /// and not indexed yet, fields including `balance_changes`, `timestamp` and `checkpoint`
+    /// are not available.
     pub effects: TransactionBlockEffects,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ExecutedTransaction {
-    pub sender_signed_data: NativeSenderSignedData,
-    pub raw_effects: NativeTransactionEffects,
-    pub balance_changes: Vec<NativeBalanceChange>,
-    pub events: Vec<Event>,
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -7,6 +7,7 @@ use async_graphql::{
     *,
 };
 use diesel::{alias, ExpressionMethods, NullableExpressionMethods, OptionalExtension, QueryDsl};
+use either::Either;
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_indexer::{
     models_v2::transactions::StoredTransaction,
@@ -16,6 +17,7 @@ use sui_indexer::{
 };
 use sui_types::{
     base_types::SuiAddress as NativeSuiAddress,
+    message_envelope::Message,
     transaction::{
         SenderSignedData as NativeSenderSignedData, TransactionDataAPI, TransactionExpiration,
     },
@@ -34,6 +36,7 @@ use super::{
     digest::Digest,
     epoch::Epoch,
     event::Event,
+    execution_result::ExecutedTransaction,
     gas::GasInput,
     sui_address::SuiAddress,
     transaction_block_effects::TransactionBlockEffects,
@@ -43,9 +46,8 @@ use super::{
 
 #[derive(Clone)]
 pub(crate) struct TransactionBlock {
-    /// Representation of transaction data in the Indexer's Store. The indexer stores the
-    /// transaction data and its effects together, in one table.
-    pub stored: StoredTransaction,
+    /// Representation of transaction data either in the Indexer's Store, or coming from an execution result.
+    pub tx_data: Either<StoredTransaction, ExecutedTransaction>,
 
     /// Deserialized representation of `stored.raw_transaction`.
     pub native: NativeSenderSignedData,
@@ -89,7 +91,7 @@ impl TransactionBlock {
     /// A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
     /// This serves as a unique id for the block on chain.
     async fn digest(&self) -> String {
-        Base58::encode(&self.stored.transaction_digest)
+        Base58::encode(self.native.digest())
     }
 
     /// The address corresponding to the public key that signed this transaction. System
@@ -133,7 +135,7 @@ impl TransactionBlock {
     /// The effects field captures the results to the chain of executing this transaction.
     async fn effects(&self) -> Result<Option<TransactionBlockEffects>> {
         Ok(Some(
-            TransactionBlockEffects::try_from(self.stored.clone()).extend()?,
+            TransactionBlockEffects::try_from(self.clone()).extend()?,
         ))
     }
 
@@ -148,7 +150,11 @@ impl TransactionBlock {
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.stored.events.len()) else {
+        let len = match &self.tx_data {
+            Either::Left(stored) => stored.events.len(),
+            Either::Right(executed) => executed.events.len(),
+        };
+        let Some((prev, next, cs)) = page.paginate_indices(len) else {
             return Ok(connection);
         };
 
@@ -156,7 +162,12 @@ impl TransactionBlock {
         connection.has_next_page = next;
 
         for c in cs {
-            let event = Event::try_from_stored_transaction(&self.stored, *c).extend()?;
+            let event = match self.tx_data {
+                Either::Left(ref stored) => {
+                    Event::try_from_stored_transaction(stored, *c).extend()?
+                }
+                Either::Right(ref executed) => executed.events[*c].clone(),
+            };
             connection.edges.push(Edge::new(c.encode_cursor(), event));
         }
 
@@ -176,7 +187,12 @@ impl TransactionBlock {
 
     /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
     async fn bcs(&self) -> Option<Base64> {
-        Some(Base64::from(&self.stored.raw_transaction))
+        match &self.tx_data {
+            Either::Left(stored) => Some(Base64::from(&stored.raw_transaction)),
+            Either::Right(executed) => bcs::to_bytes(&executed.sender_signed_data)
+                .ok()
+                .map(Base64::from),
+        }
     }
 }
 
@@ -418,6 +434,9 @@ impl TryFrom<StoredTransaction> for TransactionBlock {
         let native = bcs::from_bytes(&stored.raw_transaction)
             .map_err(|e| Error::Internal(format!("Error deserializing transaction block: {e}")))?;
 
-        Ok(TransactionBlock { stored, native })
+        Ok(TransactionBlock {
+            tx_data: Either::Left(stored),
+            native,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -18,7 +18,6 @@ mod tests {
     use sui_types::DEEPBOOK_ADDRESS;
     use sui_types::SUI_FRAMEWORK_ADDRESS;
     use tokio::time::sleep;
-    use tracing::error;
 
     #[tokio::test]
     #[serial]
@@ -345,7 +344,6 @@ mod tests {
             .execute_mutation_to_graphql(mutation.to_string(), variables)
             .await
             .unwrap();
-        error!("{:?}", res);
         let binding = res.response_body().data.clone().into_json().unwrap();
         let res = binding.get("executeTransactionBlock").unwrap();
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -916,7 +916,9 @@ type ExecutionResult {
 	"""
 	errors: [String!]
 	"""
-	The effects of the executed transaction.
+	The effects of the executed transaction. Since the transaction was just executed
+	and not indexed yet, fields including `balance_changes`, `timestamp` and `checkpoint`
+	are not available.
 	"""
 	effects: TransactionBlockEffects!
 }
@@ -2705,7 +2707,7 @@ type TransactionBlock {
 	A 32-byte hash that uniquely identifies the transaction block contents, encoded in Base58.
 	This serves as a unique id for the block on chain.
 	"""
-	digest: String!
+	digest: String
 	"""
 	The address corresponding to the public key that signed this transaction. System
 	transactions do not have senders.
@@ -2733,10 +2735,6 @@ type TransactionBlock {
 	The effects field captures the results to the chain of executing this transaction.
 	"""
 	effects: TransactionBlockEffects
-	"""
-	Events emitted by this transaction block.
-	"""
-	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a
 	deadline after which validators will no longer consider the transaction valid. By default,
@@ -2820,6 +2818,10 @@ type TransactionBlockEffects {
 	addresses and objects.
 	"""
 	balanceChanges(first: Int, after: String, last: Int, before: String): BalanceChangeConnection!
+	"""
+	Events emitted by this transaction block.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection!
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
 	"""

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -916,9 +916,9 @@ type ExecutionResult {
 	"""
 	errors: [String!]
 	"""
-	The digest field captures the digest of the transaction block
+	The effects of the executed transaction.
 	"""
-	digest: String!
+	effects: TransactionBlockEffects!
 }
 
 """


### PR DESCRIPTION
## Description 

This PR does a few things to implement transaction execution in graphql:
- Extend in a number of graphql places to take in either the stored or native version of some information, now that a transaction can be either indexed or just executed
- Actually finish implementing executeTransactionBlock

## Test Plan 

Existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

