### PR TITLE
[GraphQL/Cursor] Object::paginate for gas_payment

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -29,11 +29,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -196,11 +192,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -455,11 +447,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -850,11 +838,7 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": [
-                {
-                  "address": "0x8505f08fef00f4d24b84052c8da636814de039c600b7f3030b9a84dfe956bc5b"
-                }
-              ]
+              "nodes": []
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1014,7 +1014,7 @@ type GasInput {
 	"""
 	Objects used to pay for a transaction's execution and storage
 	"""
-	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
+	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection!
 	"""
 	An unsigned integer specifying the number of native tokens per gas unit this transaction
 	will pay (in MIST).

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -72,9 +72,6 @@ pub(crate) struct DeprecatedObjectFilter {
 
     /// Filter for live objects by their IDs.
     pub object_ids: Option<Vec<SuiAddress>>,
-
-    /// Filter for live or potentially historical objects by their ID and version.
-    pub object_keys: Option<Vec<ObjectKey>>,
 }
 
 /// Constrains the set of objects returned. All filters are optional, and the resulting set of
@@ -107,8 +104,8 @@ pub(crate) struct ObjectFilter {
 
 #[derive(InputObject, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectKey {
-    object_id: SuiAddress,
-    version: u64,
+    pub object_id: SuiAddress,
+    pub version: u64,
 }
 
 /// The object's owner type: Immutable, Shared, Parent, or Address.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1018,7 +1018,7 @@ type GasInput {
 	"""
 	Objects used to pay for a transaction's execution and storage
 	"""
-	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection
+	gasPayment(first: Int, after: String, last: Int, before: String): ObjectConnection!
 	"""
 	An unsigned integer specifying the number of native tokens per gas unit this transaction
 	will pay (in MIST).


### PR DESCRIPTION
## Description

Implement `GasInput.gasPayments` using the new `Object::paginate`. While here, also perform some clean-ups:

- Store the object *keys* instead of IDs for payment objects, so that we can see the version of the payment object that was input.

- Run the query using object keys, instead of object IDs, in preparation for object history support.

- Tweak the types used in the representation of gas types to favor the GraphQL equivalent types (e.g. `SuiAddress` instead of `ObjectID`).

- Remove an unused `From` impl that introduces a dependency on JSON-RPC.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

Note that the `programmable.move` test shows the gas payment connection returning an empty result now -- this should be fixed once object history support comes in.

## Stack

- #15661 
- #15695 
- #15698 
- #15699 
- #15701
- #15710 
- #15711 
- #15712
- #15713