### PR TITLE
[sui cli] remove panic when git revision cannot be found

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -16,14 +16,17 @@ const GIT_REVISION: &str = {
             args = ["--always", "--dirty", "--exclude", "*"],
             fallback = ""
         );
-
-        if version.is_empty() {
-            panic!("unable to query git revision");
-        }
         version
     }
 };
-const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+
+const VERSION: &str = {
+    if GIT_REVISION.is_empty() {
+        env!("CARGO_PKG_VERSION")
+    } else {
+        const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+    }
+};
 
 #[derive(Parser)]
 #[clap(


### PR DESCRIPTION
## Description
Part of adding sui to homebrew core. For the native install we run `cargo install --path crates/sui` on a tar'd release. The problem is that github's tar'd source bundles (ie. https://github.com/MystenLabs/sui/archive/refs/tags/mainnet-v1.15.1.tar.gz) don't have any git history:

```
   Compiling sui v1.15.1 (/Users/johnmartin/Downloads/sui-mainnet-v1.15.1/crates/sui)
error[E0080]: evaluation of constant value failed
  --> crates/sui/src/main.rs:20:13
   |
20 |             panic!("unable to query git revision");
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'unable to query git revision', crates/sui/src/main.rs:20:13
   ```

## Test Plan 

```
$ rm -fr .git/
$ cargo install --path crates/sui  
$ target/release/sui -V                                                             
sui 1.17.0
```
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
