### PR TITLE
add option to return raw txn effects on fullnode

### DIFF
--- a/crates/sui-indexer/src/models_v2/transactions.rs
+++ b/crates/sui-indexer/src/models_v2/transactions.rs
@@ -217,6 +217,7 @@ impl StoredTransaction {
             checkpoint: Some(self.checkpoint_sequence_number as u64),
             confirmed_local_execution: None,
             errors: vec![],
+            raw_effects: self.raw_effects,
         })
     }
 

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -581,6 +581,7 @@ impl PgIndexerStore {
             object_changes,
             balance_changes,
             errors: vec![],
+            raw_effects: vec![],
         })
     }
 

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -58,6 +58,7 @@ impl TryFrom<SuiTransactionBlockResponse> for CheckpointTransactionBlockResponse
             confirmed_local_execution,
             checkpoint,
             errors,
+            raw_effects: _,
         } = response;
 
         let transaction = transaction.ok_or_else(|| {
@@ -344,6 +345,10 @@ impl From<SuiTransactionBlockResponseWithOptions> for SuiTransactionBlockRespons
             confirmed_local_execution: response.confirmed_local_execution,
             checkpoint: response.checkpoint,
             errors: vec![],
+            raw_effects: options
+                .show_raw_effects
+                .then_some(response.raw_effects)
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -122,7 +122,9 @@ impl SuiTransactionBlockResponseOptions {
             show_events: true,
             show_object_changes: true,
             show_balance_changes: true,
-            show_raw_effects: true,
+            // This field is added for graphql execution. We keep it false here
+            // so current users of `full_content` will not get raw effects unexpectedly.
+            show_raw_effects: false,
         }
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -105,6 +105,8 @@ pub struct SuiTransactionBlockResponseOptions {
     pub show_object_changes: bool,
     /// Whether to show balance_changes. Default to be False
     pub show_balance_changes: bool,
+    /// Whether to show raw transaction effects. Default to be False
+    pub show_raw_effects: bool,
 }
 
 impl SuiTransactionBlockResponseOptions {
@@ -120,6 +122,7 @@ impl SuiTransactionBlockResponseOptions {
             show_events: true,
             show_object_changes: true,
             show_balance_changes: true,
+            show_raw_effects: true,
         }
     }
 
@@ -153,6 +156,11 @@ impl SuiTransactionBlockResponseOptions {
         self
     }
 
+    pub fn with_raw_effects(mut self) -> Self {
+        self.show_raw_effects = true;
+        self
+    }
+
     /// default to return `WaitForEffectsCert` unless some options require
     /// local execution
     pub fn default_execution_request_type(&self) -> ExecuteTransactionRequestType {
@@ -177,6 +185,7 @@ impl SuiTransactionBlockResponseOptions {
             || self.show_events
             || self.show_balance_changes
             || self.show_object_changes
+            || self.show_raw_effects
     }
 
     pub fn only_digest(&self) -> bool {
@@ -220,6 +229,8 @@ pub struct SuiTransactionBlockResponse {
     pub checkpoint: Option<CheckpointSequenceNumber>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub errors: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub raw_effects: Vec<u8>,
 }
 
 impl SuiTransactionBlockResponse {

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -193,6 +193,12 @@ impl TransactionExecutionApi {
             None
         };
 
+        let raw_effects = if opts.show_raw_effects {
+            bcs::to_bytes(&effects.effects)?
+        } else {
+            vec![]
+        };
+
         Ok(SuiTransactionBlockResponse {
             digest,
             transaction,
@@ -205,6 +211,7 @@ impl TransactionExecutionApi {
             confirmed_local_execution: Some(is_executed_locally),
             checkpoint: None,
             errors: vec![],
+            raw_effects,
         })
     }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -376,7 +376,8 @@
                 "showEffects": true,
                 "showEvents": true,
                 "showObjectChanges": true,
-                "showBalanceChanges": true
+                "showBalanceChanges": true,
+                "showRawEffects": true
               }
             },
             {
@@ -1973,7 +1974,8 @@
                 "showEffects": true,
                 "showEvents": true,
                 "showObjectChanges": false,
-                "showBalanceChanges": false
+                "showBalanceChanges": false,
+                "showRawEffects": false
               }
             }
           ],
@@ -2350,7 +2352,8 @@
                 "showEffects": true,
                 "showEvents": true,
                 "showObjectChanges": false,
-                "showBalanceChanges": false
+                "showBalanceChanges": false,
+                "showRawEffects": false
               }
             }
           ],
@@ -10414,6 +10417,14 @@
               "$ref": "#/components/schemas/ObjectChange"
             }
           },
+          "rawEffects": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
           "rawTransaction": {
             "description": "BCS encoded [SenderSignedData] that includes input object references returns empty array if `show_raw_transaction` is false",
             "allOf": [
@@ -10470,6 +10481,11 @@
           },
           "showObjectChanges": {
             "description": "Whether to show object_changes. Default to be False",
+            "default": false,
+            "type": "boolean"
+          },
+          "showRawEffects": {
+            "description": "Whether to show raw transaction effects. Default to be False",
             "default": false,
             "type": "boolean"
           },

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -377,7 +377,7 @@
                 "showEvents": true,
                 "showObjectChanges": true,
                 "showBalanceChanges": true,
-                "showRawEffects": true
+                "showRawEffects": false
               }
             },
             {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -766,6 +766,7 @@ impl RpcExampleProvider {
             confirmed_local_execution: None,
             checkpoint: None,
             errors: vec![],
+            raw_effects: vec![],
         };
 
         (data2, signatures, recipient, obj_id, result)

--- a/crates/sui-sdk/examples/read_api.rs
+++ b/crates/sui-sdk/examples/read_api.rs
@@ -125,6 +125,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 show_events: true,
                 show_object_changes: true,
                 show_balance_changes: true,
+                show_raw_effects: true,
             },
         )
         .await?;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -942,6 +942,7 @@ impl SuiClientCommands {
                             show_events: true,
                             show_object_changes: true,
                             show_balance_changes: false,
+                            show_raw_effects: false,
                         },
                     )
                     .await?;


### PR DESCRIPTION
## Description 

Add an option to return raw transaction effects via transaction execution api on fullnode so that graphql can use it. See discussion on the gql PR #15717.

## Test Plan 

Existing tests
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Add an option to SuiTransactionBlockResponseOptions to return the raw transaction effects.