### PR TITLE
Rename get_sui_system_state_object to make it less error prone

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2793,16 +2793,9 @@ impl AuthorityState {
             .compute_object_reference())
     }
 
-    /// This function should be called once and exactly once during reconfiguration.
-    /// Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
-    /// besides when we are reading fields for the current epoch
-    pub fn get_sui_system_state_object_during_reconfig(&self) -> SuiResult<SuiSystemState> {
-        self.database.get_sui_system_state_object()
-    }
-
     // This function is only used for testing.
     pub fn get_sui_system_state_object_for_testing(&self) -> SuiResult<SuiSystemState> {
-        self.database.get_sui_system_state_object()
+        self.database.get_sui_system_state_object_unsafe()
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -628,7 +628,10 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: AuthAggMetrics,
     ) -> anyhow::Result<Self> {
-        let sui_system_state = store.get_sui_system_state_object()?;
+        // TODO: We should get the committee from the epoch store instead to ensure consistency.
+        // Instead of this function use AuthorityEpochStore::epoch_start_configuration() to access this object everywhere
+        // besides when we are reading fields for the current epoch
+        let sui_system_state = store.get_sui_system_state_object_unsafe()?;
         let committee = sui_system_state.get_current_epoch_committee();
         let validator_display_names = sui_system_state
             .into_sui_system_state_summary()

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -591,7 +591,7 @@ impl Validator for ValidatorService {
         &self,
         _request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<SuiSystemState>, tonic::Status> {
-        let response = self.state.database.get_sui_system_state_object()?;
+        let response = self.state.database.get_sui_system_state_object_unsafe()?;
 
         return Ok(tonic::Response::new(response));
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1532,7 +1532,7 @@ async fn diagnose_split_brain(
 
     let sui_system_state = state
         .database
-        .get_sui_system_state_object()
+        .get_sui_system_state_object_unsafe()
         .expect("Failed to get system state object");
     let committee = sui_system_state.get_current_epoch_committee();
     let network_config = default_mysten_network_config();
@@ -1639,10 +1639,10 @@ async fn diagnose_split_brain(
                 .unzip();
             let summary_patch = create_patch(&local_summary_text, &other_summary_text);
             let contents_patch = create_patch(&local_contents_text, &other_contents_text);
-            let local_transcations_text = format!("{local_transactions:#?}");
+            let local_transactions_text = format!("{local_transactions:#?}");
             let other_transactions_text = format!("{other_transactions:#?}");
             let transactions_patch =
-                create_patch(&local_transcations_text, &other_transactions_text);
+                create_patch(&local_transactions_text, &other_transactions_text);
             let local_effects_text = format!("{local_effects:#?}");
             let other_effects_text = format!("{other_effects:#?}");
             let effects_patch = create_patch(&local_effects_text, &other_effects_text);

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -123,7 +123,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         _request: SystemStateRequest,
     ) -> Result<SuiSystemState, SuiError> {
-        Ok(self.state.database.get_sui_system_state_object()?)
+        self.state.get_sui_system_state_object_for_testing()
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3263,8 +3263,7 @@ async fn test_genesis_sui_system_state_object() {
         bcs::from_bytes::<SuiSystemStateWrapper>(move_object.contents()).unwrap();
     assert!(move_object.type_().is(&SuiSystemStateWrapper::type_()));
     let sui_system_state = authority_state
-        .database
-        .get_sui_system_state_object()
+        .get_sui_system_state_object_for_testing()
         .unwrap();
     assert_eq!(
         &sui_system_state.get_current_epoch_committee().committee,

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -396,7 +396,7 @@ impl StateRead for AuthorityState {
             .await?)
     }
     fn get_system_state(&self) -> StateReadResult<SuiSystemState> {
-        Ok(self.database.get_sui_system_state_object()?)
+        Ok(self.database.get_sui_system_state_object_unsafe()?)
     }
     fn get_or_latest_committee(&self, epoch: Option<BigInt<u64>>) -> StateReadResult<Committee> {
         Ok(self

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1392,9 +1392,11 @@ impl SuiNode {
                 return Ok(());
             }
 
+            // Safe to call because we are in the middle of reconfiguration.
             let latest_system_state = self
                 .state
-                .get_sui_system_state_object_during_reconfig()
+                .database
+                .get_sui_system_state_object_unsafe()
                 .expect("Read Sui System State object cannot fail");
 
             #[cfg(msim)]


### PR DESCRIPTION
## Description 

Suffix it with unsafe to avoid accidental calls.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
