### PR TITLE
support base64 exported keypairs

### DIFF
--- a/apps/wallet/src/background/accounts/ImportedAccount.ts
+++ b/apps/wallet/src/background/accounts/ImportedAccount.ts
@@ -127,7 +127,7 @@ export class ImportedAccount
 	async #getKeyPair() {
 		const ephemeralData = await this.getEphemeralValue();
 		if (ephemeralData) {
-			return fromExportedKeypair(ephemeralData.keyPair);
+			return fromExportedKeypair(ephemeralData.keyPair, true);
 		}
 		return null;
 	}

--- a/apps/wallet/src/background/legacy-accounts/LegacyVault.ts
+++ b/apps/wallet/src/background/legacy-accounts/LegacyVault.ts
@@ -53,7 +53,7 @@ export class LegacyVault {
 				mnemonicSeedHex: storedMnemonicSeedHex,
 			} = await decrypt<V2DecryptedDataType>(password, data.data);
 			entropy = toEntropy(entropySerialized);
-			keypairs = importedKeypairs.map(fromExportedKeypair);
+			keypairs = importedKeypairs.map((aKeyPair) => fromExportedKeypair(aKeyPair, true));
 			if (storedTokens) {
 				qredoTokens = new Map(Object.entries(storedTokens));
 			}

--- a/apps/wallet/src/shared/utils/from-exported-keypair.ts
+++ b/apps/wallet/src/shared/utils/from-exported-keypair.ts
@@ -10,14 +10,24 @@ import {
 import { Ed25519Keypair } from '@mysten/sui.js/keypairs/ed25519';
 import { Secp256k1Keypair } from '@mysten/sui.js/keypairs/secp256k1';
 import { Secp256r1Keypair } from '@mysten/sui.js/keypairs/secp256r1';
+import { fromB64 } from '@mysten/sui.js/utils';
 
 export function validateExportedKeypair(keypair: ExportedKeypair): ExportedKeypair {
 	const _kp = decodeSuiPrivateKey(keypair.privateKey);
 	return keypair;
 }
 
-export function fromExportedKeypair(keypair: ExportedKeypair): Keypair {
-	const { schema, secretKey } = decodeSuiPrivateKey(keypair.privateKey);
+export function fromExportedKeypair(keypair: ExportedKeypair, legacySupport = false): Keypair {
+	const { privateKey } = keypair;
+	let schema = keypair.schema;
+	let secretKey = null;
+	if (!legacySupport || privateKey.startsWith('suiprivkey')) {
+		const decoded = decodeSuiPrivateKey(keypair.privateKey);
+		schema = decoded?.schema;
+		secretKey = decoded.secretKey;
+	} else {
+		secretKey = fromB64(privateKey);
+	}
 
 	switch (schema) {
 		case 'ED25519':


### PR DESCRIPTION
## Description 

* this allows supporting keys that are stored in base64 format already in the wallet storage

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
