### PR TITLE
move package: use original root pkg name in resolution graph error me…

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -66,6 +66,8 @@ pub struct DependencyGraph {
     /// Path to the root package and its name (according to its manifest)
     pub root_path: PathBuf,
     pub root_package: PM::PackageName,
+    /// Root package name as defined in its manifest (can be different from the resolved name).
+    pub root_package_orig_name: PM::PackageName,
 
     /// Transitive dependency graph, with dependency edges `P -> Q` labelled according to whether Q
     /// is always a dependency of P or only in dev-mode.
@@ -270,6 +272,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         let mut combined_graph = DependencyGraph {
             root_path,
             root_package: root_pkg_name,
+            root_package_orig_name: root_pkg_orig_name,
             package_graph: DiGraphMap::new(),
             package_table: BTreeMap::new(),
             always_deps: BTreeSet::new(),
@@ -1108,6 +1111,7 @@ impl DependencyGraph {
         let mut graph = DependencyGraph {
             root_path,
             root_package,
+            root_package_orig_name: root_package,
             package_graph,
             package_table,
             always_deps: BTreeSet::new(),

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -193,7 +193,7 @@ impl ResolvedGraph {
                          Dev addresses cannot introduce new named addresses",
                         name,
                         addr.short_str_lossless(),
-                        graph.root_package,
+                        graph.root_package_orig_name,
                     );
                 }
 
@@ -203,7 +203,7 @@ impl ResolvedGraph {
                         format!(
                             "Unable to resolve named address '{}' in package '{}' when resolving \
                              dependencies in dev mode",
-                            name, graph.root_package,
+                            name, graph.root_package_orig_name,
                         )
                     })?;
 
@@ -216,7 +216,7 @@ impl ResolvedGraph {
                          Assignment conflicts with previous assignments: {conflicts} = 0x{addr}",
                         name = name,
                         addr = addr.short_str_lossless(),
-                        pkg = graph.root_package,
+                        pkg = graph.root_package_orig_name,
                         conflicts = conflicts
                             .iter()
                             .map(NamedAddress::as_str)

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps_address_assigned",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_invalid_dev_address_assignment_name_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_invalid_dev_address_assignment_name_resolution/Move.resolved
@@ -1,0 +1,1 @@
+Found unbound dev address assignment 'B = 0x1' in root package 'test-rename'. Dev addresses cannot introduce new named addresses

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_invalid_dev_address_assignment_name_resolution/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_invalid_dev_address_assignment_name_resolution/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-rename"
+
+[addresses]
+A = "_"
+
+[dev-addresses]
+B = "0x1"

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/dep_dev_dep_diamond",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/dep_good_digest",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_backflow_resolution",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_dev_override_with_reg",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_no_conflict",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_override_root",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_nested_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_transitive_nested_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_two_nested_overrides",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_with_deps",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dual_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_no_conflict",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_with_and_without_override_v1",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_with_and_without_override_v2",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/direct_and_indirect_dep",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external_dev_dep",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external_overlap",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_from_lock",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_from_lock_no_manifest",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_rename",
         root_package: "test",
+        root_package_orig_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_deps_git_local",
         root_package: "NestedDeps",
+        root_package_orig_name: "NestedDeps",
         package_graph: {
             "NestedDeps": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_deps_shared_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_pruned_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_assigned_address",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_multiple_of_same_name",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_override",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_reassigned_address",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_unification_across_local_renamings",
         root_package: "Root",
+        root_package_orig_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_edition_2024_alpha",
         root_package: "name",
+        root_package_orig_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_edition_legacy",
         root_package: "name",
+        root_package_orig_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_flavor_global_storage",
         root_package: "name",
+        root_package_orig_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_flavor_sui",
         root_package: "name",
+        root_package_orig_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_invalid_identifier_package_name",
         root_package: "®´∑œ",
+        root_package_orig_name: "®´∑œ",
         package_graph: {
             "®´∑œ": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_minimal_manifest",
         root_package: "name",
+        root_package_orig_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_pkg_name",
         root_package: "Root-resolved",
+        root_package_orig_name: "Root-rename",
         package_graph: {
             "Root-resolved": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -2,6 +2,7 @@ ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_pkg_name_override",
         root_package: "Root-resolved",
+        root_package_orig_name: "Root-rename",
         package_graph: {
             "Root-resolved": [
                 (


### PR DESCRIPTION
…ssages

## Description 

Store original name of the root package in the `DependencyGraph` so that it can be used for displaying error messages in the resolution graph. This commit only affects the printed error messages and not functionality of the toolchain.

This is part of the work to enable compiling against on-chain
dependencies https://github.com/MystenLabs/sui/pull/14178.

cc @rvantonder @amnn 

## Test Plan 

Added a unit test

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
