### PR TITLE
move [EASY]: add function to read lock header with file handle

### DIFF
--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -132,6 +132,17 @@ impl ToolchainVersion {
     }
 }
 
+impl Header {
+    pub fn read(lock: &mut impl Read) -> Result<Header> {
+        let contents = {
+            let mut buf = String::new();
+            lock.read_to_string(&mut buf).context("Reading lock file")?;
+            buf
+        };
+        read_header(&contents)
+    }
+}
+
 /// Read lock file header after verifying that the version of the lock is not newer than the version
 /// supported by this library.
 #[allow(clippy::ptr_arg)] // Allowed to avoid interface changes.


### PR DESCRIPTION
## Description 

Adds a helper we need to check Move.lock versions.

Context: https://github.com/MystenLabs/sui/pull/15731#discussion_r1456080903

## Test Plan 

Unused currently. When used will be part of tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
