### PR TITLE
[Consensus] rename Validator to AuthorityNode

### DIFF
--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -148,7 +148,7 @@ pub struct Authority {
     pub stake: Stake,
     /// Network address for communicating with the authority.
     pub address: Multiaddr,
-    /// The validator's hostname, for metrics and logging.
+    /// The authority's hostname, for metrics and logging.
     pub hostname: String,
     /// The authority's ed25519 publicKey for signing network messages and blocks.
     pub network_key: NetworkPublicKey,

--- a/consensus/core/src/authority.rs
+++ b/consensus/core/src/authority.rs
@@ -16,13 +16,13 @@ use crate::core::{Core, CoreSignals};
 use crate::metrics::initialise_metrics;
 use crate::transactions_client::{TransactionsClient, TransactionsConsumer};
 
-pub struct Validator {
+pub struct Authority {
     context: Arc<Context>,
     start_time: Instant,
     transactions_client: Arc<TransactionsClient>,
 }
 
-impl Validator {
+impl Authority {
     #[allow(unused)]
     async fn start(
         own_index: AuthorityIndex,
@@ -35,7 +35,7 @@ impl Validator {
         _block_verifier: impl BlockVerifier,
         registry: Registry,
     ) -> Self {
-        info!("Boot validator with authority index {}", own_index);
+        info!("Boot authority with index {}", own_index);
         let context = Arc::new(Context::new(
             own_index,
             committee,
@@ -64,7 +64,7 @@ impl Validator {
     #[allow(unused)]
     async fn stop(self) {
         info!(
-            "Stopping validator. Total run time: {:?}",
+            "Stopping authority. Total run time: {:?}",
             self.start_time.elapsed()
         );
         self.context
@@ -82,15 +82,16 @@ impl Validator {
 
 #[cfg(test)]
 mod tests {
-    use crate::block_verifier::TestBlockVerifier;
-    use crate::validator::Validator;
     use consensus_config::{Committee, Parameters, ProtocolKeyPair};
     use fastcrypto::traits::ToFromBytes;
     use prometheus::Registry;
     use sui_protocol_config::ProtocolConfig;
 
+    use crate::authority::Authority;
+    use crate::block_verifier::TestBlockVerifier;
+
     #[tokio::test]
-    async fn validator_start_and_stop() {
+    async fn start_and_stop() {
         let (committee, keypairs) = Committee::new_for_test(0, vec![1]);
         let registry = Registry::new();
         let parameters = Parameters::default();
@@ -99,7 +100,7 @@ mod tests {
         let (own_index, _) = committee.authorities().last().unwrap();
         let signer = ProtocolKeyPair::from_bytes(keypairs[0].1.as_bytes()).unwrap();
 
-        let validator = Validator::start(
+        let authority = Authority::start(
             own_index,
             committee,
             parameters,
@@ -110,10 +111,10 @@ mod tests {
         )
         .await;
 
-        assert_eq!(validator.context.own_index, own_index);
-        assert_eq!(validator.context.committee.epoch(), 0);
-        assert_eq!(validator.context.committee.size(), 1);
+        assert_eq!(authority.context.own_index, own_index);
+        assert_eq!(authority.context.committee.epoch(), 0);
+        assert_eq!(authority.context.committee.size(), 1);
 
-        validator.stop().await;
+        authority.stop().await;
     }
 }

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -16,13 +16,13 @@ use crate::core::{Core, CoreSignals};
 use crate::metrics::initialise_metrics;
 use crate::transactions_client::{TransactionsClient, TransactionsConsumer};
 
-pub struct Authority {
+pub struct AuthorityNode {
     context: Arc<Context>,
     start_time: Instant,
     transactions_client: Arc<TransactionsClient>,
 }
 
-impl Authority {
+impl AuthorityNode {
     #[allow(unused)]
     async fn start(
         own_index: AuthorityIndex,
@@ -35,7 +35,7 @@ impl Authority {
         _block_verifier: impl BlockVerifier,
         registry: Registry,
     ) -> Self {
-        info!("Boot authority with index {}", own_index);
+        info!("Starting authority with index {}", own_index);
         let context = Arc::new(Context::new(
             own_index,
             committee,
@@ -87,7 +87,7 @@ mod tests {
     use prometheus::Registry;
     use sui_protocol_config::ProtocolConfig;
 
-    use crate::authority::Authority;
+    use crate::authority_node::AuthorityNode;
     use crate::block_verifier::TestBlockVerifier;
 
     #[tokio::test]
@@ -100,7 +100,7 @@ mod tests {
         let (own_index, _) = committee.authorities().last().unwrap();
         let signer = ProtocolKeyPair::from_bytes(keypairs[0].1.as_bytes()).unwrap();
 
-        let authority = Authority::start(
+        let authority = AuthorityNode::start(
             own_index,
             committee,
             parameters,

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -230,7 +230,6 @@ impl SignedBlock {
 
 /// VerifiedBlock allows full access to its content.
 /// It should be relatively cheap to copy.
-#[allow(unused)]
 #[derive(Clone)]
 pub(crate) struct VerifiedBlock {
     block: Arc<SignedBlock>,

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use enum_dispatch::enum_dispatch;
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -9,7 +8,9 @@ use std::{
     sync::Arc,
 };
 
+use bytes::Bytes;
 use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
+use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +23,7 @@ pub type Round = u32;
 /// The transaction serialised bytes
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
 pub(crate) struct Transaction {
-    data: bytes::Bytes,
+    data: Bytes,
 }
 
 #[allow(dead_code)]
@@ -35,14 +36,14 @@ impl Transaction {
         &self.data
     }
 
-    pub fn into_data(self) -> Vec<u8> {
-        self.data.to_vec()
+    pub fn into_data(self) -> Bytes {
+        self.data
     }
 }
 
-/// A block includes references to previous round blocks and transactions that the validator
+/// A block includes references to previous round blocks and transactions that the authority
 /// considers valid.
-/// Well behaved validators produce at most one block per round, but malicious validators can
+/// Well behaved authorities produce at most one block per round, but malicious authorities can
 /// equivocate.
 #[derive(Clone, Deserialize, Serialize)]
 #[enum_dispatch(BlockAPI)]

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod authority;
 mod base_committer;
 mod block;
 mod block_manager;
@@ -17,4 +18,3 @@ mod stake_aggregator;
 mod storage;
 mod threshold_clock;
 mod transactions_client;
-mod validator;

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod authority;
+mod authority_node;
 mod base_committer;
 mod block;
 mod block_manager;


### PR DESCRIPTION
## Description 

Use `Authority` consistently across type names.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
