### PR TITLE
Update base64 handling

### DIFF
--- a/.changeset/fast-bikes-arrive.md
+++ b/.changeset/fast-bikes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mysten/bcs': minor
+---
+
+Update base64 encoding to use global atob and btoa functions.

--- a/sdk/bcs/src/b64.ts
+++ b/sdk/bcs/src/b64.ts
@@ -1,84 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/*\
-|*|  Base64 / binary data / UTF-8 strings utilities
-|*|  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Base64_encoding_and_decoding
-\*/
-
-/* Array of bytes to Base64 string decoding */
-
-function b64ToUint6(nChr: number) {
-	return nChr > 64 && nChr < 91
-		? nChr - 65
-		: nChr > 96 && nChr < 123
-		? nChr - 71
-		: nChr > 47 && nChr < 58
-		? nChr + 4
-		: nChr === 43
-		? 62
-		: nChr === 47
-		? 63
-		: 0;
-}
-
-export function fromB64(sBase64: string, nBlocksSize?: number): Uint8Array {
-	var sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, ''),
-		nInLen = sB64Enc.length,
-		nOutLen = nBlocksSize
-			? Math.ceil(((nInLen * 3 + 1) >> 2) / nBlocksSize) * nBlocksSize
-			: (nInLen * 3 + 1) >> 2,
-		taBytes = new Uint8Array(nOutLen);
-
-	for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
-		nMod4 = nInIdx & 3;
-		nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << (6 * (3 - nMod4));
-		if (nMod4 === 3 || nInLen - nInIdx === 1) {
-			for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
-				taBytes[nOutIdx] = (nUint24 >>> ((16 >>> nMod3) & 24)) & 255;
-			}
-			nUint24 = 0;
-		}
-	}
-
-	return taBytes;
-}
-
-/* Base64 string to array encoding */
-
-function uint6ToB64(nUint6: number) {
-	return nUint6 < 26
-		? nUint6 + 65
-		: nUint6 < 52
-		? nUint6 + 71
-		: nUint6 < 62
-		? nUint6 - 4
-		: nUint6 === 62
-		? 43
-		: nUint6 === 63
-		? 47
-		: 65;
+export function fromB64(sBase64: string): Uint8Array {
+	return Uint8Array.from(atob(sBase64), (char) => char.charCodeAt(0));
 }
 
 export function toB64(aBytes: Uint8Array): string {
-	var nMod3 = 2,
-		sB64Enc = '';
-
-	for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
-		nMod3 = nIdx % 3;
-		nUint24 |= aBytes[nIdx] << ((16 >>> nMod3) & 24);
-		if (nMod3 === 2 || aBytes.length - nIdx === 1) {
-			sB64Enc += String.fromCodePoint(
-				uint6ToB64((nUint24 >>> 18) & 63),
-				uint6ToB64((nUint24 >>> 12) & 63),
-				uint6ToB64((nUint24 >>> 6) & 63),
-				uint6ToB64(nUint24 & 63),
-			);
-			nUint24 = 0;
-		}
+	const output = [];
+	for (let i = 0; i < aBytes.length; i++) {
+		output.push(String.fromCharCode(aBytes[i]));
 	}
-
-	return (
-		sB64Enc.slice(0, sB64Enc.length - 2 + nMod3) + (nMod3 === 2 ? '' : nMod3 === 1 ? '=' : '==')
-	);
+	return btoa(output.join(''));
 }

--- a/sdk/typescript/test/unit/cryptography/multisig.test.ts
+++ b/sdk/typescript/test/unit/cryptography/multisig.test.ts
@@ -233,9 +233,7 @@ describe('Multisig scenarios', () => {
 		expect(isValidSig2).toBe(true);
 
 		// publickey.ts
-		expect(() => multiSigPublicKey.combinePartialSignatures([sig3.signature])).toThrow(
-			new Error(`Unsupported signature scheme`),
-		);
+		expect(() => multiSigPublicKey.combinePartialSignatures([sig3.signature])).toThrowError();
 	});
 
 	it('providing signatures with invalid order', async () => {

--- a/sdk/typescript/test/unit/cryptography/signature.test.ts
+++ b/sdk/typescript/test/unit/cryptography/signature.test.ts
@@ -186,8 +186,6 @@ describe('Signature', () => {
 		bytes[0] = 0x06;
 		const invalidSignature = toB64(bytes);
 
-		expect(() => parseSerializedSignature(invalidSignature)).toThrowError(
-			new Error('Unsupported signature scheme'),
-		);
+		expect(() => parseSerializedSignature(invalidSignature)).toThrowError();
 	});
 });


### PR DESCRIPTION
## Description 

This updates the base64 code in the bcs library to use the `atob` and `btoa` built-ins, which should be faster, and are available in nearly every JS environment. In places these aren't available, they're trivial to polyfill, and can be part of our standard list of globals we expect folks to polyfill (`fetch`, `TextEncoder`, `crypto`, etc.)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
