### PR TITLE
[GraphQL/Data] Query.resolveSuinsAddress

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -766,7 +766,7 @@
 ### Name Service
 
 ><pre>{
->  resolveNameServiceAddress(name: "example.sui") {
+>  resolveSuinsAddress(domain: "example.sui") {
 >    address
 >  }
 >  address(

--- a/crates/sui-graphql-rpc/examples/name_service/name_service.graphql
+++ b/crates/sui-graphql-rpc/examples/name_service/name_service.graphql
@@ -1,5 +1,5 @@
 {
-  resolveNameServiceAddress(name: "example.sui") {
+  resolveSuinsAddress(domain: "example.sui") {
     address
   }
   address(

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1381,6 +1381,10 @@ type MoveObject {
 	Attempts to convert the Move object into a `0x2::coin::CoinMetadata`.
 	"""
 	asCoinMetadata: CoinMetadata
+	"""
+	Attempts to convert the Move object into a `SuinsRegistration` object.
+	"""
+	asSuinsRegistration: SuinsRegistration
 }
 
 """
@@ -2207,9 +2211,9 @@ type Query {
 	"""
 	protocolConfig(protocolVersion: Int): ProtocolConfigs!
 	"""
-	Resolves the owner address of the provided domain name.
+	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
-	resolveNameServiceAddress(name: String!): Address
+	resolveSuinsAddress(domain: String!): Address
 	"""
 	The coin metadata associated with the given coin type.
 	"""

--- a/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/draft_target_schema.graphql
@@ -115,7 +115,7 @@ type Query {
     filter: ObjectFilter,
   ): ObjectConnection!
 
-  resolveNameServiceAddress(name: String!): Address
+  resolveSuinsAddress(name: String!): Address
 
   # NB. Will be moved into a private, explorer-specific extension.
   networkMetrics: NetworkMetrics
@@ -1119,6 +1119,7 @@ type MoveObject implements IOwner & IObject & IMoveObject {
   asCoin: Coin
   asStakedSui: StakedSui
   asCoinMetadata: CoinMetadata
+  asSuinsRegistration: SuinsRegistration
 }
 
 type MovePackage implements IOwner & IObject {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -33,7 +33,7 @@ use sui_indexer::{
 };
 use sui_json_rpc::{
     coin_api::{parse_to_struct_tag, parse_to_type_tag},
-    name_service::{Domain, NameRecord, NameServiceConfig},
+    name_service::{Domain, NameServiceConfig},
 };
 use sui_json_rpc_types::Stake as RpcStakedSui;
 use sui_types::{
@@ -372,30 +372,6 @@ impl PgManager {
         }
 
         Ok(Some(connection))
-    }
-
-    pub(crate) async fn resolve_name_service_address(
-        &self,
-        name_service_config: &NameServiceConfig,
-        name: String,
-    ) -> Result<Option<Address>, Error> {
-        let domain = name.parse::<Domain>()?;
-
-        let record_id = name_service_config.record_field_id(&domain);
-
-        let field_record_object = match self.inner.get_object_in_blocking_task(record_id).await? {
-            Some(o) => o,
-            None => return Ok(None),
-        };
-
-        let record = field_record_object
-            .to_rust::<Field<Domain, NameRecord>>()
-            .ok_or_else(|| Error::Internal(format!("Malformed Object {record_id}")))?
-            .value;
-
-        Ok(record.target_address.map(|address| Address {
-            address: SuiAddress::from_array(address.to_inner()),
-        }))
     }
 
     pub(crate) async fn available_range(&self) -> Result<(u64, u64), Error> {

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -91,7 +91,7 @@ fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), Functi
             (("Query", "moveCallMetrics"), G::Analytics),
             (("Query", "networkMetrics"), G::Analytics),
             (("Query", "protocolConfig"), G::SystemState),
-            (("Query", "resolveNameServiceAddress"), G::NameService),
+            (("Query", "resolveSuinsAddress"), G::NameService),
             (("Subscription", "events"), G::Subscriptions),
             (("Subscription", "transactions"), G::Subscriptions),
             (("SystemStateSummary", "safeMode"), G::SystemState),

--- a/crates/sui-graphql-rpc/src/types/sui_address.rs
+++ b/crates/sui-graphql-rpc/src/types/sui_address.rs
@@ -93,6 +93,12 @@ impl From<AccountAddress> for SuiAddress {
     }
 }
 
+impl From<SuiAddress> for AccountAddress {
+    fn from(value: SuiAddress) -> Self {
+        AccountAddress::new(value.0)
+    }
+}
+
 impl From<ObjectID> for SuiAddress {
     fn from(value: ObjectID) -> Self {
         SuiAddress(value.into_bytes())

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1385,6 +1385,10 @@ type MoveObject {
 	Attempts to convert the Move object into a `0x2::coin::CoinMetadata`.
 	"""
 	asCoinMetadata: CoinMetadata
+	"""
+	Attempts to convert the Move object into a `SuinsRegistration` object.
+	"""
+	asSuinsRegistration: SuinsRegistration
 }
 
 """
@@ -2211,9 +2215,9 @@ type Query {
 	"""
 	protocolConfig(protocolVersion: Int): ProtocolConfigs!
 	"""
-	Resolves the owner address of the provided domain name.
+	Resolves a SuiNS `domain` name to an address, if it has been bound.
 	"""
-	resolveNameServiceAddress(name: String!): Address
+	resolveSuinsAddress(domain: String!): Address
 	"""
 	The coin metadata associated with the given coin type.
 	"""


### PR DESCRIPTION
## Description

Implement `Query.resolveSuinsAddress` using the new data framework, and add a downcast operation to `MoveObject` to convert an arbitrary object into a `SuinsRegistration`.

This comes associated with the following changes:

- Rename the query from `resolveNameServiceAddress` to `resolveSuinsAddress` as per feedback from the dogfooding session.
- Make `Domain` a string scalar type.

## Test Plan

Manually tested with:

```
{
  resolveSuinsAddress(domain: "example.sui") {
    address
  }

  object(address: "0x55936857d1ca4d8a107b35e4d513bd0932da329389c976e8db6d52c58f16aefb") {
    asMoveObject {
      contents {
        json
      }

      asSuinsRegistration {
        domain
      }
    }
  }
}
```

![image](https://github.com/MystenLabs/sui/assets/332275/27a35e5b-c3ef-4660-b586-23f0d0a67c88)

## Stack

- #15749 