### PR TITLE
update h2 to 0.3.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,9 +4929,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -4939,7 +4939,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
  "tokio-util 0.7.4",


### PR DESCRIPTION
## Description 

```
cargo deny check advisories
error[vulnerability]: Resource exhaustion vulnerability in h2 may lead to Denial of Service (DoS)
    ┌─ /Users/luzhang/Workplaces/sui/Cargo.lock:415:1
    │
415 │ h2 0.3.18 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0003
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0003
    = An attacker with an HTTP/2 connection to an affected endpoint can send a steady stream of invalid frames to force the
      generation of reset frames on the victim endpoint.
      By closing their recv window, the attacker could then force these resets to be queued in an unbounded fashion,
      resulting in Out Of Memory (OOM) and high CPU usage.

      This fix is corrected in [hyperium/h2#737](https://github.com/hyperium/h2/pull/737), which limits the total number of
      internal error resets emitted by default before the connection is closed.
    = Solution: Upgrade to ^0.3.24 OR >=0.4.2 (try `cargo update -p h2`)
    = h2 v0.3.18

```

## Test Plan 

cargo deny check advisories


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
