### PR TITLE
Add support for downloading latest epoch snapshot in sui-tool

### DIFF
--- a/crates/sui-storage/src/object_store/util.rs
+++ b/crates/sui-storage/src/object_store/util.rs
@@ -29,7 +29,7 @@ pub const MANIFEST_FILENAME: &str = "MANIFEST";
 #[derive(Serialize, Deserialize)]
 
 pub struct Manifest {
-    available_epochs: Vec<u64>,
+    pub available_epochs: Vec<u64>,
 }
 
 impl Manifest {


### PR DESCRIPTION
## Description 

This PR adds the support for user to pass in `--latest` while downloading snapshots. This is going to be super useful for first time users trying to run a testnet or mainnet sui fullnode locally (where they don't want to fist find out the latest epoch somehow first) and make running a fullnode for the first time a more convenient process
## Test Plan 

```
(base) sadhansood@Sadhans-Laptop sui % cargo run -p sui-tool download-db-snapshot --genesis ~/Downloads/genesis.blob --formal --network mainnet  --path /opt/sui/db/authorities_db --num-parallel-downloads 50 --no-sign-request --snapshot-bucket-type=s3 --verbose --latest
    Finished dev [unoptimized + debuginfo] target(s) in 0.81s
     Running `target/debug/sui-tool download-db-snapshot --genesis /Users/sadhansood/Downloads/genesis.blob --formal --network mainnet --path /opt/sui/db/authorities_db --num-parallel-downloads 50 --no-sign-request --snapshot-bucket-type=s3 --verbose --latest`
Warning: download-db-snapshot --formal is deprecated. Please use download-formal-snapshot.
Beginning formal snapshot restore to end of epoch 279, network: Mainnet
2024-01-17T23:50:31.015392Z  INFO sui_tool: Starting summary sync
```
