### PR TITLE
[GraphQL/Cursor] SuinsRegistration pagination

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -96,10 +96,10 @@ type Address implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
+	manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	This resolver is not supported on the Address type.
 	"""
@@ -1715,10 +1715,10 @@ type Object implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
+	manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Access a dynamic field on an object using its name.
 	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
@@ -1967,10 +1967,10 @@ type Owner implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this address or object. These grant the owner the
+	capability to manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Access a dynamic field on an object using its name.
 	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -176,27 +176,25 @@ impl Address {
         .map(|d| d.to_string()))
     }
 
-    /// The SuinsRegistration NFTs owned by the given object. These grant the owner
-    /// the capability to manage the associated domain.
+    /// The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
+    /// manage the associated domain.
     pub async fn suins_registrations(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<object::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<Connection<String, SuinsRegistration>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_suins_registrations(
-                first,
-                after,
-                last,
-                before,
-                ctx.data_unchecked::<NameServiceConfig>(),
-                self.address,
-            )
-            .await
-            .extend()
+        before: Option<object::Cursor>,
+    ) -> Result<Connection<String, SuinsRegistration>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        SuinsRegistration::paginate(
+            ctx.data_unchecked::<Db>(),
+            ctx.data_unchecked::<NameServiceConfig>(),
+            page,
+            self.address,
+        )
+        .await
+        .extend()
     }
 
     /// This resolver is not supported on the Address type.

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -389,27 +389,25 @@ impl Object {
         .map(|d| d.to_string()))
     }
 
-    /// The SuinsRegistration NFTs owned by the given object. These grant the owner
-    /// the capability to manage the associated domain.
+    /// The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
+    /// manage the associated domain.
     pub async fn suins_registrations(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<Cursor>,
         last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<Connection<String, SuinsRegistration>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_suins_registrations(
-                first,
-                after,
-                last,
-                before,
-                ctx.data_unchecked::<NameServiceConfig>(),
-                self.address,
-            )
-            .await
-            .extend()
+        before: Option<Cursor>,
+    ) -> Result<Connection<String, SuinsRegistration>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        SuinsRegistration::paginate(
+            ctx.data_unchecked::<Db>(),
+            ctx.data_unchecked::<NameServiceConfig>(),
+            page,
+            self.address,
+        )
+        .await
+        .extend()
     }
 
     /// Access a dynamic field on an object using its name.

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -11,6 +11,7 @@ use diesel::{
     AppearsOnTable, BoolExpressionMethods, Expression, ExpressionMethods, QueryDsl, QuerySource,
     TextExpressionMethods,
 };
+use move_core_types::language_storage::StructTag;
 use std::{fmt, result::Result, str::FromStr};
 use sui_types::{
     parse_sui_address, parse_sui_fq_name, parse_sui_module_id, parse_sui_type_tag, TypeTag,
@@ -355,6 +356,18 @@ impl fmt::Display for TypeFilter {
 impl fmt::Display for ExactTypeFilter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.to_canonical_display(/* with_prefix */ true))
+    }
+}
+
+impl From<TypeTag> for TypeFilter {
+    fn from(tag: TypeTag) -> Self {
+        TypeFilter::ByType(tag)
+    }
+}
+
+impl From<StructTag> for TypeFilter {
+    fn from(tag: StructTag) -> Self {
+        TypeFilter::ByType(tag.into())
     }
 }
 

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -100,10 +100,10 @@ type Address implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
+	manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	This resolver is not supported on the Address type.
 	"""
@@ -1719,10 +1719,10 @@ type Object implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
+	manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Access a dynamic field on an object using its name.
 	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified
@@ -1971,10 +1971,10 @@ type Owner implements IOwner {
 	"""
 	defaultSuinsName: String
 	"""
-	The SuinsRegistration NFTs owned by the given object. These grant the owner
-	the capability to manage the associated domain.
+	The SuinsRegistration NFTs owned by this address or object. These grant the owner the
+	capability to manage the associated domain.
 	"""
-	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
+	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection!
 	"""
 	Access a dynamic field on an object using its name.
 	Names are arbitrary Move values whose type have `copy`, `drop`, and `store`, and are specified


### PR DESCRIPTION
## Description

Port `IOwner.suinsRegistrations` to the new cursor and data framework and clarify some of the related doc comments.

## Test Plan

Manually tested with:

```
{
  address(address: "0x0b86be5d779fac217b41d484b8040ad5145dc9ba0cba099d083c6cbda50d983e") {
    suinsRegistrations {
      nodes {
        domain
      }
    }
  }
}
```

![image](https://github.com/MystenLabs/sui/assets/332275/ad993389-8bcc-46f5-9a3c-98477dc3c4e6)

## Stack
- #15749 
- #15760 
- #15761 