### PR TITLE
[move-compiler] Report tmp lvalue errors in locals analysis

### DIFF
--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -219,24 +219,38 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                             LocalState::MaybeUnavailable { .. } => "might contain",
                         };
                         let available = *available;
-                        let vstr = match display_var(v.value()) {
-                            DisplayVar::Tmp => panic!("ICE invalid assign tmp local"),
-                            DisplayVar::Orig(s) => s,
+                        match display_var(v.value()) {
+                            DisplayVar::Tmp => {
+                                let msg = format!(
+                                    "This term {} a value without the '{}' ability and must be used",
+                                    verb,
+                                    Ability_::Drop,
+                                );
+                                let mut diag = diag!(
+                                    MoveSafety::UnusedUndroppable,
+                                    (*loc, "Invalid usage of undroppable value".to_string()),
+                                    (available, msg),
+                                );
+                                add_drop_ability_tip(context, &mut diag, ty.clone());
+                                context.add_diag(diag)
+                            }
+                            DisplayVar::Orig(s) => {
+                                let msg = format!(
+                                    "The variable {} a value due to this assignment. The value \
+                                    does not have the '{}' ability and must be used before you \
+                                    assign to this variable again",
+                                    verb,
+                                    Ability_::Drop,
+                                );
+                                let mut diag = diag!(
+                                    MoveSafety::UnusedUndroppable,
+                                    (*loc, format!("Invalid assignment to variable '{}'", s)),
+                                    (available, msg),
+                                );
+                                add_drop_ability_tip(context, &mut diag, ty.clone());
+                                context.add_diag(diag)
+                            }
                         };
-                        let msg = format!(
-                            "The variable {} a value due to this assignment. The value does not \
-                             have the '{}' ability and must be used before you assign to this \
-                             variable again",
-                            verb,
-                            Ability_::Drop,
-                        );
-                        let mut diag = diag!(
-                            MoveSafety::UnusedUndroppable,
-                            (*loc, format!("Invalid assignment to variable '{}'", vstr)),
-                            (available, msg),
-                        );
-                        add_drop_ability_tip(context, &mut diag, ty.clone());
-                        context.add_diag(diag)
                     }
                 }
             }

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -222,9 +222,7 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                         match display_var(v.value()) {
                             DisplayVar::Tmp => {
                                 let msg = format!(
-                                    "This expression {} a value without the '{}' ability \
-                                    which must be used",
-                                    verb,
+                                    "This expression without the '{}' ability must be used",
                                     Ability_::Drop,
                                 );
                                 let mut diag = diag!(

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -222,7 +222,8 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                         match display_var(v.value()) {
                             DisplayVar::Tmp => {
                                 let msg = format!(
-                                    "This term {} a value without the '{}' ability and must be used",
+                                    "This expression {} a value without the '{}' ability \
+                                    which must be used",
                                     verb,
                                     Ability_::Drop,
                                 );

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
@@ -1,0 +1,43 @@
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_check/liveness/vector_loop.move:23:60
+   │
+14 │     struct User has key, store { id: ID }
+   │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+23 │             user_delete(table::remove(&mut table, user_id(&vector::pop_back(users))));
+   │                                                            ^^^^^^^^^^^^^^^^^^^^^^^
+   │                                                            │
+   │                                                            Invalid usage of undroppable value
+   │                                                            The type 'a::m::User' does not have the ability 'drop'
+   │                                                            This term might contain a value without the 'drop' ability and must be used
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_check/liveness/vector_loop.move:25:9
+   │
+14 │     struct User has key, store { id: ID }
+   │            ---- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+23 │             user_delete(table::remove(&mut table, user_id(&vector::pop_back(users))));
+   │                                                            -----------------------
+   │                                                            │
+   │                                                            The value is created but not used. The value does not have the 'drop' ability and must be consumed before the function returns
+   │                                                            The type 'a::m::User' does not have the ability 'drop'
+24 │         };
+25 │         table::destroy<ID, User>(table)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_check/liveness/vector_loop.move:28:41
+   │  
+14 │       struct User has key, store { id: ID }
+   │              ---- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·  
+28 │       public fun user_delete(_user: User) {
+   │                              -----  ---- The type 'a::m::User' does not have the ability 'drop'
+   │                              │       
+   │                              The parameter '_user' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+   │ ╭─────────────────────────────────────────^
+29 │ │ 
+30 │ │     }
+   │ ╰─────^ Invalid return
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
@@ -9,7 +9,7 @@ error[E06001]: unused value without 'drop'
    │                                                            │
    │                                                            Invalid usage of undroppable value
    │                                                            The type 'a::m::User' does not have the ability 'drop'
-   │                                                            This expression might contain a value without the 'drop' ability which must be used
+   │                                                            This expression without the 'drop' ability must be used
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/liveness/vector_loop.move:25:9

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.exp
@@ -9,7 +9,7 @@ error[E06001]: unused value without 'drop'
    │                                                            │
    │                                                            Invalid usage of undroppable value
    │                                                            The type 'a::m::User' does not have the ability 'drop'
-   │                                                            This term might contain a value without the 'drop' ability and must be used
+   │                                                            This expression might contain a value without the 'drop' ability which must be used
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/liveness/vector_loop.move:25:9

--- a/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/liveness/vector_loop.move
@@ -1,0 +1,85 @@
+module a::m {
+
+    use std::vector;
+    use sui::table;
+
+    struct ID has store, copy, drop {
+        bytes: address,
+    }
+
+    struct UID has store {
+        id: ID,
+    }
+
+    struct User has key, store { id: ID }
+
+    struct Org {
+        table: table::Table<ID, User>,
+    }
+
+    public fun delete(self: Org, users: &mut vector<User>) {
+        let Org { table } = self;
+        while (!table::is_empty(&table)) {
+            user_delete(table::remove(&mut table, user_id(&vector::pop_back(users))));
+        };
+        table::destroy<ID, User>(table)
+    }
+
+    public fun user_delete(_user: User) {
+
+    }
+
+    public fun user_id(user: &User): ID {
+        let User { id } = user;
+        *id
+    }
+
+    public fun id_delete(id: UID) {
+        let UID { id: ID { bytes } } = id;
+        delete_impl(bytes)
+    }
+
+    /// Get the underlying `ID` of `obj`
+    public fun id<T: key>(obj: &T): ID {
+        borrow_uid(obj).id
+    }
+
+    /// Borrow the underlying `ID` of `obj`
+    public fun borrow_id<T: key>(obj: &T): &ID {
+        &borrow_uid(obj).id
+    }
+
+    native fun borrow_uid<T: key>(obj: &T): &UID;
+
+    native fun delete_impl(id: address);
+
+}
+
+#[defines_primitive(vector)]
+module std::vector {
+    #[bytecode_instruction]
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+}
+
+module sui::table {
+    struct Table<phantom K: copy + drop + store, phantom V: store> {
+        size: u64,
+    }
+
+    public fun new<K: copy + drop + store, V: store>(): Table<K, V> {
+        abort 0
+    }
+
+    public fun destroy<K: copy + drop + store, V: store>(table: Table<K, V>) {
+        let Table { size: _size } = table;
+    }
+
+    public fun remove<K: copy + drop + store, V: store>(_table: &mut Table<K, V>, _k: K): V {
+        abort 0
+    }
+
+    public fun is_empty<K: copy + drop + store, V: store>(_table: &Table<K, V>): bool {
+        false
+    }
+
+}


### PR DESCRIPTION
## Description 

This fixes a situation where locals analysis bails when it finds weird temp usages.

## Test Plan 

New test (thanks to @tedks)


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
