### PR TITLE
Fix Broken Documentation Link in Sui Move Concepts

### DIFF
--- a/docs/content/concepts/sui-move-concepts.mdx
+++ b/docs/content/concepts/sui-move-concepts.mdx
@@ -22,7 +22,7 @@ Where the Sui documentation refers to the Move language, the content is document
 In general, Move on Diem code written for other systems works in Sui with these exceptions:
 
 - [Global storage operators](https://move-language.github.io/move/global-storage-operators.html)
-- [Key abilities](https://github.com/move-language/move/blob/main/language/documentation/book/src/abilities.mdx)
+- [Key abilities](https://github.com/move-language/move/blob/main/language/documentation/book/src/abilities.md)
 
 ## Key differences {#differences}
 


### PR DESCRIPTION
## Description 

This PR corrects a broken link in the sui-move-concepts.mdx file, resolving a 404 error. The issue was a typographical error in the file extension of the hyperlink to the "Key abilities" section in the Move language documentation. The corrected link now properly redirects to the intended destination on GitHub.

## Test Plan 

Verified the updated link manually in sui-move-concepts.mdx. The link now successfully accesses the "Key abilities" page, confirming the resolution of the 404 error.
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A - Minor documentation fix with no significant impact on users, system components, or protocol.