### PR TITLE
Laura/per object gas

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -10,6 +10,7 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::{
     committee::{Committee, EpochId},
     effects::TransactionEffects,
+    gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::BytecodeVerifierMetrics,
     metrics::LimitsMetrics,
@@ -93,6 +94,7 @@ impl EpochState {
         transaction: &VerifiedTransaction,
     ) -> Result<(
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), sui_types::error::ExecutionError>,
     )> {

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -170,7 +170,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
         let transaction = transaction.verify(&VerifyParams::default())?;
 
-        let (inner_temporary_store, effects, execution_error_opt) = self
+        let (inner_temporary_store, _, effects, execution_error_opt) = self
             .epoch_state
             .execute_transaction(&self.store, &self.deny_config, &transaction)?;
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1386,7 +1386,7 @@ impl AuthorityState {
         let (kind, signer, gas) = transaction_data.execution_parts();
 
         #[allow(unused_mut)]
-        let (inner_temp_store, mut effects, execution_error_opt) =
+        let (inner_temp_store, _, mut effects, execution_error_opt) =
             epoch_store.executor().execute_transaction_to_effects(
                 &self.database,
                 protocol_config,
@@ -1516,7 +1516,7 @@ impl AuthorityState {
             .expect("Creating an executor should not fail here");
 
         let expensive_checks = false;
-        let (inner_temp_store, effects, _execution_error) = executor
+        let (inner_temp_store, _, effects, _execution_error) = executor
             .execute_transaction_to_effects(
                 &self.database,
                 protocol_config,
@@ -1757,7 +1757,7 @@ impl AuthorityState {
             transaction,
         );
         let transaction_digest = TransactionDigest::new(default_hash(&intent_msg.value));
-        let (inner_temp_store, effects, execution_result) = executor.dev_inspect_transaction(
+        let (inner_temp_store, _, effects, execution_result) = executor.dev_inspect_transaction(
             &self.database,
             protocol_config,
             self.metrics.limits_metrics.clone(),

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -855,7 +855,7 @@ fn create_genesis_transaction(
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, _) = transaction_data.execution_parts();
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
-        let (inner_temp_store, effects, _execution_error) = executor
+        let (inner_temp_store, _, effects, _execution_error) = executor
             .execute_transaction_to_effects(
                 &InMemoryStorage::new(Vec::new()),
                 protocol_config,

--- a/crates/sui-replay/src/displays/gas_status_displays.rs
+++ b/crates/sui-replay/src/displays/gas_status_displays.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::displays::Pretty;
+use std::fmt::{Display, Formatter};
+use sui_types::gas::SuiGasStatus;
+use sui_types::gas_model::gas_v2::SuiGasStatus as GasStatusV2;
+#[allow(unused)]
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{style::HorizontalLine, Style as TableStyle},
+};
+
+impl<'a> Display for Pretty<'a, SuiGasStatus> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(sui_gas_status) = self;
+        Ok(match sui_gas_status {
+            SuiGasStatus::V2(s) => {
+                display_info(f, &s)?;
+            }
+        })
+    }
+}
+
+#[allow(unused)]
+fn per_object_storage_table(f: &mut Formatter, _sui_gas_status: &GasStatusV2) -> String {
+    todo!();
+}
+
+fn display_info(f: &mut Formatter<'_>, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+    write!(
+        f,
+        "\nReference Gas Price: {}\n",
+        sui_gas_status.reference_gas_price()
+    )?;
+    write!(f, "Gas Price: {}\n", sui_gas_status.gas_status.gas_price())?;
+    write!(
+        f,
+        "Max Gas Stack Height: {}\n",
+        sui_gas_status.gas_status.stack_height_high_water_mark()
+    )?;
+    write!(
+        f,
+        "Number of Bytecode Instructions Executed: {}",
+        sui_gas_status.gas_status.instructions_executed()
+    )
+}

--- a/crates/sui-replay/src/displays/gas_status_displays.rs
+++ b/crates/sui-replay/src/displays/gas_status_displays.rs
@@ -5,7 +5,6 @@ use crate::displays::Pretty;
 use std::fmt::{Display, Formatter};
 use sui_types::gas::SuiGasStatus;
 use sui_types::gas_model::gas_v2::SuiGasStatus as GasStatusV2;
-#[allow(unused)]
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{style::HorizontalLine, Style as TableStyle},
@@ -14,39 +13,65 @@ use tabled::{
 impl<'a> Display for Pretty<'a, SuiGasStatus> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(sui_gas_status) = self;
-        Ok(match sui_gas_status {
+        match sui_gas_status {
             SuiGasStatus::V2(s) => {
-                display_info(f, &s)?;
+                display_info(f, s)?;
+                per_object_storage_table(f, s)?;
             }
-        })
+        };
+        Ok(())
     }
 }
 
-#[allow(unused)]
-fn per_object_storage_table(f: &mut Formatter, _sui_gas_status: &GasStatusV2) -> String {
-    todo!();
+fn per_object_storage_table(f: &mut Formatter, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
+    let mut builder = TableBuilder::default();
+    builder.push_record(vec!["Object ID", "Bytes", "Old Rebate", "New Rebate"]);
+    for (object_id, per_obj_storage) in sui_gas_status.per_object_storage() {
+        builder.push_record(vec![
+            object_id.to_string(),
+            per_obj_storage.new_size.to_string(),
+            per_obj_storage.storage_rebate.to_string(),
+            per_obj_storage.storage_cost.to_string(),
+        ]);
+    }
+    let mut table = builder.build();
+
+    table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+        1,
+        TableStyle::modern().get_horizontal(),
+    )]));
+    write!(f, "\n{}\n", table)
 }
 
 fn display_info(f: &mut Formatter<'_>, sui_gas_status: &GasStatusV2) -> std::fmt::Result {
-    write!(
-        f,
-        "\nReference Gas Price: {}\n",
+    let mut builder = TableBuilder::default();
+    builder.push_record(vec!["Gas Info".to_string()]);
+    builder.push_record(vec![format!(
+        "Reference Gas Price: {}",
         sui_gas_status.reference_gas_price()
-    )?;
-    write!(f, "Gas Price: {}\n", sui_gas_status.gas_status.gas_price())?;
-    write!(
-        f,
-        "Max Gas Stack Height: {}\n",
+    )]);
+    builder.push_record(vec![format!(
+        "Gas Price: {}",
+        sui_gas_status.gas_status.gas_price()
+    )]);
+
+    builder.push_record(vec![format!(
+        "Max Gas Stack Height: {}",
         sui_gas_status.gas_status.stack_height_high_water_mark()
-    )?;
-    write!(
-        f,
-        "Max Gas Stack Size: {}\n",
+    )]);
+
+    builder.push_record(vec![format!(
+        "Max Gas Stack Size: {}",
         sui_gas_status.gas_status.stack_size_high_water_mark()
-    )?;
-    write!(
-        f,
+    )]);
+
+    builder.push_record(vec![format!(
         "Number of Bytecode Instructions Executed: {}",
         sui_gas_status.gas_status.instructions_executed()
-    )
+    )]);
+
+    let mut table = builder.build();
+    table.with(TableStyle::rounded());
+
+    write!(f, "\n{}\n", table)
 }

--- a/crates/sui-replay/src/displays/gas_status_displays.rs
+++ b/crates/sui-replay/src/displays/gas_status_displays.rs
@@ -41,6 +41,11 @@ fn display_info(f: &mut Formatter<'_>, sui_gas_status: &GasStatusV2) -> std::fmt
     )?;
     write!(
         f,
+        "Max Gas Stack Size: {}\n",
+        sui_gas_status.gas_status.stack_size_high_water_mark()
+    )?;
+    write!(
+        f,
         "Number of Bytecode Instructions Executed: {}",
         sui_gas_status.gas_status.instructions_executed()
     )

--- a/crates/sui-replay/src/displays/mod.rs
+++ b/crates/sui-replay/src/displays/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod gas_status_displays;
 mod transaction_displays;
 
 pub struct Pretty<'a, T>(pub &'a T);

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -26,6 +26,7 @@ use sui_types::digests::TransactionDigest;
 use tracing::{error, info};
 pub mod config;
 mod data_fetcher;
+mod displays;
 pub mod fuzz;
 pub mod fuzz_mutations;
 mod replay;
@@ -35,7 +36,6 @@ pub mod types;
 static DEFAULT_SANDBOX_BASE_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/tests/sandbox_snapshots");
 
-mod displays;
 #[cfg(test)]
 mod tests;
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chain_from_chain_id;
-use crate::displays::Pretty;
 use crate::{
     config::ReplayableNetworkConfigSet,
     data_fetcher::{
         extract_epoch_and_version, DataFetcher, Fetchers, NodeStateDumpFetcher, RemoteFetcher,
     },
+    displays::Pretty,
     types::*,
 };
 use futures::executor::block_on;
@@ -739,7 +739,7 @@ impl LocalExec {
         let expensive_checks = true;
         let transaction_kind = override_transaction_kind.unwrap_or(tx_info.kind.clone());
         let certificate_deny_set = HashSet::new();
-        let (inner_store, _gas_status, effects, result) = if let Ok(gas_status) =
+        let (inner_store, gas_status, effects, result) = if let Ok(gas_status) =
             SuiGasStatus::new(tx_info.gas_budget, tx_info.gas_price, rgp, protocol_config)
         {
             executor.execute_transaction_to_effects(
@@ -760,6 +760,8 @@ impl LocalExec {
         } else {
             unreachable!("Transaction was valid so gas status must be valid");
         };
+
+        trace!(target: "replay_gas_info", "{}", Pretty(&gas_status));
 
         if let ProgrammableTransaction(pt) = transaction_kind {
             trace!(target: "replay_ptb_info", "{}", Pretty(&pt));

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -739,7 +739,7 @@ impl LocalExec {
         let expensive_checks = true;
         let transaction_kind = override_transaction_kind.unwrap_or(tx_info.kind.clone());
         let certificate_deny_set = HashSet::new();
-        let res = if let Ok(gas_status) =
+        let (inner_store, _gas_status, effects, result) = if let Ok(gas_status) =
             SuiGasStatus::new(tx_info.gas_budget, tx_info.gas_price, rgp, protocol_config)
         {
             executor.execute_transaction_to_effects(
@@ -767,14 +767,14 @@ impl LocalExec {
 
         let all_required_objects = self.storage.all_objects();
         let effects =
-            SuiTransactionBlockEffects::try_from(res.1).map_err(ReplayEngineError::from)?;
+            SuiTransactionBlockEffects::try_from(effects).map_err(ReplayEngineError::from)?;
 
         Ok(ExecutionSandboxState {
             transaction_info: tx_info.clone(),
             required_objects: all_required_objects,
-            local_exec_temporary_store: Some(res.0),
+            local_exec_temporary_store: Some(inner_store),
             local_exec_effects: effects,
-            local_exec_status: Some(res.2),
+            local_exec_status: Some(result),
             pre_exec_diag: self.diag.clone(),
         })
     }

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -202,7 +202,7 @@ impl SingleValidator {
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();
-        let (_, effects, _) = self.epoch_store.executor().execute_transaction_to_effects(
+        let (_, _, effects, _) = self.epoch_store.executor().execute_transaction_to_effects(
             &store,
             self.epoch_store.protocol_config(),
             self.get_validator().metrics.limits_metrics.clone(),

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -493,7 +493,7 @@ mod test {
         let (kind, signer, _) = transaction_data.execution_parts();
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
 
-        let (_inner_temp_store, effects, _execution_error) = executor
+        let (_inner_temp_store, _, effects, _execution_error) = executor
             .execute_transaction_to_effects(
                 &InMemoryStorage::new(Vec::new()),
                 &protocol_config,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -15,6 +15,7 @@ pub mod checked {
         object::Object,
         sui_serde::{BigInt, Readable},
         transaction::ObjectReadResult,
+        ObjectID,
     };
     use enum_dispatch::enum_dispatch;
     use itertools::MultiUnzip;
@@ -38,7 +39,12 @@ pub mod checked {
         fn reset_storage_cost_and_rebate(&mut self);
         fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError>;
         fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError>;
-        fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64;
+        fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64;
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
     }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -150,12 +150,14 @@ mod checked {
         /// at the end of execution while determining storage charges.
         /// It tracks `storage_bytes * obj_data_cost_refundable` as
         /// described in `storage_gas_price`
-        /// It has been multiplied by the storage gas price
-        storage_cost: u64,
+        /// It has been multiplied by the storage gas price. This is the new storage rebate.
+        pub storage_cost: u64,
         /// storage_rebate is the storage rebate (in Sui) for in this object.
         /// This is computed at the end of execution while determining storage charges.
         /// The value is in Sui.
-        storage_rebate: u64,
+        pub storage_rebate: u64,
+        /// The object size post-transaction in bytes
+        pub new_size: u64,
     }
 
     #[allow(dead_code)]
@@ -341,6 +343,10 @@ mod checked {
         fn storage_cost(&self) -> u64 {
             self.storage_gas_units()
         }
+
+        pub fn per_object_storage(&self) -> &Vec<(ObjectID, PerObjectStorage)> {
+            &self.per_object_storage
+        }
     }
 
     impl SuiGasStatusAPI for SuiGasStatus {
@@ -471,6 +477,7 @@ mod checked {
                 PerObjectStorage {
                     storage_cost,
                     storage_rebate,
+                    new_size,
                 },
             ));
             // return the new object rebate (object storage cost)

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -150,7 +150,7 @@ mod checked {
         /// at the end of execution while determining storage charges.
         /// It tracks `storage_bytes * obj_data_cost_refundable` as
         /// described in `storage_gas_price`
-        /// It will be multiplied by the storage gas price.
+        /// It has been multiplied by the storage gas price
         storage_cost: u64,
         /// storage_rebate is the storage rebate (in Sui) for in this object.
         /// This is computed at the end of execution while determining storage charges.
@@ -337,6 +337,7 @@ mod checked {
                 Ok(())
             }
         }
+
         fn storage_cost(&self) -> u64 {
             self.storage_gas_units()
         }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -18,7 +18,6 @@ mod checked {
     };
     use move_core_types::vm_status::StatusCode;
     use sui_protocol_config::*;
-    use tracing::trace;
 
     /// A bucket defines a range of units that will be priced the same.
     /// After execution a call to `GasStatus::bucketize` will round the computation
@@ -279,11 +278,8 @@ mod checked {
             )
         }
 
-        pub fn log_for_replay(&self) {
-            #[skip_checked_arithmetic]
-            trace!(target:"replay", "Reference Gas Price: {}", self.reference_gas_price);
-
-            self.gas_status.log_for_replay();
+        pub fn reference_gas_price(&self) -> u64 {
+            self.reference_gas_price
         }
 
         // Check whether gas arguments are legit:

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -14,6 +14,7 @@ mod checked {
     use crate::{
         error::{ExecutionError, ExecutionErrorKind},
         gas_model::tables::{GasStatus, ZERO_COST_SCHEDULE},
+        ObjectID,
     };
     use move_core_types::vm_status::StatusCode;
     use sui_protocol_config::*;
@@ -144,6 +145,20 @@ mod checked {
         }
     }
 
+    #[derive(Debug)]
+    pub struct PerObjectStorage {
+        /// storage_cost is the total storage gas to charge. This is computed
+        /// at the end of execution while determining storage charges.
+        /// It tracks `storage_bytes * obj_data_cost_refundable` as
+        /// described in `storage_gas_price`
+        /// It will be multiplied by the storage gas price.
+        storage_cost: u64,
+        /// storage_rebate is the storage rebate (in Sui) for in this object.
+        /// This is computed at the end of execution while determining storage charges.
+        /// The value is in Sui.
+        storage_rebate: u64,
+    }
+
     #[allow(dead_code)]
     #[derive(Debug)]
     pub struct SuiGasStatus {
@@ -176,17 +191,9 @@ mod checked {
         // `total_storage_cost = storage_bytes * obj_data_cost_refundable`
         // `final_storage_cost = total_storage_cost * storage_gas_price`
         storage_gas_price: u64,
-        /// storage_cost is the total storage gas to charge. This is an accumulator computed
-        /// at the end of execution while determining storage charges.
-        /// It tracks `total_storage_cost = storage_bytes * obj_data_cost_refundable` as
-        /// described in `storage_gas_price`
-        /// It will be multiplied by the storage gas price.
-        storage_cost: u64,
-        /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
-        /// This is an accumulator computed at the end of execution while determining storage charges.
-        /// It is the sum of all `storage_rebate` of all objects mutated or deleted during
-        /// execution. The value is in Sui.
-        storage_rebate: u64,
+        /// Per Object Storage Cost and Storage Rebate, used to get accumulated values at the
+        /// end of execution to determine storage charges and rebates.
+        per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
         // storage rebate rate as defined in the ProtocolConfig
         rebate_rate: u64,
         /// Amount of storage rebate accumulated when we are running in unmetered mode (i.e. system transaction).
@@ -217,8 +224,7 @@ mod checked {
                 gas_price,
                 reference_gas_price,
                 storage_gas_price,
-                storage_cost: 0,
-                storage_rebate: 0,
+                per_object_storage: Vec::new(),
                 rebate_rate,
                 unmetered_storage_rebate: 0,
                 gas_rounding_step,
@@ -335,6 +341,9 @@ mod checked {
                 Ok(())
             }
         }
+        fn storage_cost(&self) -> u64 {
+            self.storage_gas_units()
+        }
     }
 
     impl SuiGasStatusAPI for SuiGasStatus {
@@ -378,12 +387,13 @@ mod checked {
         /// computation cost.
         fn summary(&self) -> GasCostSummary {
             // compute storage rebate, both rebate and non refundable fee
-            let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
-            assert!(sender_rebate <= self.storage_rebate);
-            let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
+            let storage_rebate = self.storage_rebate();
+            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+            assert!(sender_rebate <= storage_rebate);
+            let non_refundable_storage_fee = storage_rebate - sender_rebate;
             GasCostSummary {
                 computation_cost: self.computation_cost,
-                storage_cost: self.storage_cost,
+                storage_cost: self.storage_cost(),
                 storage_rebate: sender_rebate,
                 non_refundable_storage_fee,
             }
@@ -394,11 +404,17 @@ mod checked {
         }
 
         fn storage_gas_units(&self) -> u64 {
-            self.storage_cost
+            self.per_object_storage
+                .iter()
+                .map(|(_, per_object)| per_object.storage_cost)
+                .sum()
         }
 
         fn storage_rebate(&self) -> u64 {
-            self.storage_rebate
+            self.per_object_storage
+                .iter()
+                .map(|(_, per_object)| per_object.storage_rebate)
+                .sum()
         }
 
         fn unmetered_storage_rebate(&self) -> u64 {
@@ -410,8 +426,7 @@ mod checked {
         }
 
         fn reset_storage_cost_and_rebate(&mut self) {
-            self.storage_cost = 0;
-            self.storage_rebate = 0;
+            self.per_object_storage = Vec::new();
             self.unmetered_storage_rebate = 0;
         }
 
@@ -437,33 +452,47 @@ mod checked {
         /// There is no charge in this function. Charges will all be applied together at the end
         /// (`track_storage_mutation`).
         /// Return the new storage rebate (cost of object storage) according to `new_size`.
-        fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64 {
             if self.is_unmetered() {
                 self.unmetered_storage_rebate += storage_rebate;
                 return 0;
             }
-            self.storage_rebate += storage_rebate;
+
             // compute and track cost (based on size)
             let new_size = new_size as u64;
             let storage_cost =
                 new_size * self.cost_table.storage_per_byte_cost * self.storage_gas_price;
             // track rebate
-            self.storage_cost += storage_cost;
+
+            self.per_object_storage.push((
+                object_id,
+                PerObjectStorage {
+                    storage_cost,
+                    storage_rebate,
+                },
+            ));
             // return the new object rebate (object storage cost)
             storage_cost
         }
 
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
-            let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
-            assert!(sender_rebate <= self.storage_rebate);
-            if sender_rebate >= self.storage_cost {
+            let storage_rebate = self.storage_rebate();
+            let storage_cost = self.storage_cost();
+            let sender_rebate = sender_rebate(storage_rebate, self.rebate_rate);
+            assert!(sender_rebate <= storage_rebate);
+            if sender_rebate >= storage_cost {
                 // there is more rebate than cost, when deducting gas we are adding
                 // to whatever is the current amount charged so we are `Ok`
                 Ok(())
             } else {
                 let gas_left = self.gas_budget - self.computation_cost;
                 // we have to charge for storage and may go out of gas, check
-                if gas_left < self.storage_cost - sender_rebate {
+                if gas_left < storage_cost - sender_rebate {
                     // Running out of gas would cause the temporary store to reset
                     // and zero storage and rebate.
                     // The remaining_gas will be 0 and we will charge all in computation
@@ -475,8 +504,7 @@ mod checked {
         }
 
         fn adjust_computation_on_out_of_gas(&mut self) {
-            self.storage_rebate = 0;
-            self.storage_cost = 0;
+            self.per_object_storage = Vec::new();
             self.computation_cost = self.gas_budget;
         }
     }

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -15,7 +15,6 @@ use move_vm_types::gas::{GasMeter, SimpleInstruction};
 use move_vm_types::loaded_data::runtime_types::Type;
 use move_vm_types::views::{TypeView, ValueView};
 use once_cell::sync::Lazy;
-use tracing::trace;
 
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
 
@@ -339,10 +338,16 @@ impl GasStatus {
         }
     }
 
-    pub fn log_for_replay(&self) {
-        trace!(target: "replay_gas_info", "Gas Price: {}", self.gas_price);
-        trace!(target: "replay_gas_info", "Max Gas Stack Height: {}", self.stack_height_high_water_mark);
-        trace!(target: "replay_gas_info", "Number of Bytecode Instructions Executed: {}", self.instructions_executed);
+    pub fn gas_price(&self) -> u64 {
+        self.gas_price
+    }
+
+    pub fn stack_height_high_water_mark(&self) -> u64 {
+        self.stack_height_high_water_mark
+    }
+
+    pub fn instructions_executed(&self) -> u64 {
+        self.instructions_executed
     }
 }
 

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -346,6 +346,10 @@ impl GasStatus {
         self.stack_height_high_water_mark
     }
 
+    pub fn stack_size_high_water_mark(&self) -> u64 {
+        self.stack_size_high_water_mark
+    }
+
     pub fn instructions_executed(&self) -> u64 {
         self.instructions_executed
     }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -208,8 +208,13 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        
-        (inner, gas_charger.consume(), effects, execution_result)
+
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -81,6 +81,7 @@ mod checked {
         certificate_deny_set: &HashSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
@@ -207,7 +208,8 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, effects, execution_result)
+        
+        (inner, gas_charger.consume(), effects, execution_result)
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -196,9 +196,14 @@ pub mod checked {
         // Gas charging operations
         //
 
-        pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        pub fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64 {
             self.gas_status
-                .track_storage_mutation(new_size, storage_rebate)
+                .track_storage_mutation(object_id, new_size, storage_rebate)
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -290,11 +290,6 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
-            match &self.gas_status {
-                SuiGasStatus::V2(s) => {
-                    s.log_for_replay();
-                }
-            };
             if self.smashed_gas_coin.is_some() {
                 #[skip_checked_arithmetic]
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -108,7 +108,7 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
-        pub fn consume(self) -> SuiGasStatus {
+        pub fn into_gas_status(self) -> SuiGasStatus {
             self.gas_status
         }
 

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -108,6 +108,10 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
+        pub fn consume(self) -> SuiGasStatus {
+            self.gas_status
+        }
+
         pub fn summary(&self) -> GasCostSummary {
             self.gas_status.summary()
         }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -800,7 +800,7 @@ impl<'backing> TemporaryStore<'backing> {
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate = gas_charger.track_storage_mutation(
-                (*object.id()).into(),
+                object.id(),
                 new_object_size,
                 old_storage_rebate,
             );

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -799,8 +799,11 @@ impl<'backing> TemporaryStore<'backing> {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
-            let new_storage_rebate =
-                gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
+            let new_storage_rebate = gas_charger.track_storage_mutation(
+                (*object.id()).into(),
+                new_object_size,
+                old_storage_rebate,
+            );
             object.storage_rebate = new_storage_rebate;
         }
 
@@ -822,7 +825,7 @@ impl<'backing> TemporaryStore<'backing> {
                 // Unwrap is safe because this loop iterates through all modified objects.
                 .unwrap()
                 .storage_rebate;
-            gas_charger.track_storage_mutation(0, storage_rebate);
+            gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
         }
     }
 

--- a/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
@@ -196,7 +196,12 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, gas_charger.consume(), effects, execution_result)
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/next-vm/sui-adapter/src/execution_engine.rs
@@ -81,6 +81,7 @@ mod checked {
         certificate_deny_set: &HashSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
@@ -195,7 +196,7 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, effects, execution_result)
+        (inner, gas_charger.consume(), effects, execution_result)
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
@@ -108,7 +108,7 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
-        pub fn consume(self) -> SuiGasStatus {
+        pub fn into_gas_status(self) -> SuiGasStatus {
             self.gas_status
         }
 

--- a/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
@@ -195,9 +195,14 @@ pub mod checked {
         // Gas charging operations
         //
 
-        pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        pub fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64 {
             self.gas_status
-                .track_storage_mutation(new_size, storage_rebate)
+                .track_storage_mutation(object_id, new_size, storage_rebate)
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
@@ -108,6 +108,10 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
+        pub fn consume(self) -> SuiGasStatus {
+            self.gas_status
+        }
+
         pub fn summary(&self) -> GasCostSummary {
             self.gas_status.summary()
         }

--- a/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/next-vm/sui-adapter/src/gas_charger.rs
@@ -289,11 +289,6 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
-            match &self.gas_status {
-                SuiGasStatus::V2(s) => {
-                    s.log_for_replay();
-                }
-            };
             if self.smashed_gas_coin.is_some() {
                 #[skip_checked_arithmetic]
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");

--- a/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
@@ -747,8 +747,11 @@ impl<'backing> TemporaryStore<'backing> {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
-            let new_storage_rebate =
-                gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
+            let new_storage_rebate = gas_charger.track_storage_mutation(
+                (*object.id()).into(),
+                new_object_size,
+                old_storage_rebate,
+            );
             object.storage_rebate = new_storage_rebate;
         }
 
@@ -770,7 +773,7 @@ impl<'backing> TemporaryStore<'backing> {
                 // Unwrap is safe because this loop iterates through all modified objects.
                 .unwrap()
                 .storage_rebate;
-            gas_charger.track_storage_mutation(0, storage_rebate);
+            gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
         }
     }
 

--- a/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/next-vm/sui-adapter/src/temporary_store.rs
@@ -748,7 +748,7 @@ impl<'backing> TemporaryStore<'backing> {
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate = gas_charger.track_storage_mutation(
-                (*object.id()).into(),
+                object.id(),
                 new_object_size,
                 old_storage_rebate,
             );

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -43,6 +43,7 @@ pub trait Executor {
         transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
     );
@@ -70,6 +71,7 @@ pub trait Executor {
         skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     );

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -87,6 +87,7 @@ impl executor::Executor for Executor {
         transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
@@ -126,6 +127,7 @@ impl executor::Executor for Executor {
         skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {

--- a/sui-execution/src/next_vm.rs
+++ b/sui-execution/src/next_vm.rs
@@ -89,6 +89,7 @@ impl executor::Executor for Executor {
         transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
@@ -128,6 +129,7 @@ impl executor::Executor for Executor {
         skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -89,6 +89,7 @@ impl executor::Executor for Executor {
         transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
@@ -128,6 +129,7 @@ impl executor::Executor for Executor {
         skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -89,6 +89,7 @@ impl executor::Executor for Executor {
         transaction_digest: TransactionDigest,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<(), ExecutionError>,
     ) {
@@ -128,6 +129,7 @@ impl executor::Executor for Executor {
         skip_all_checks: bool,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -70,6 +70,7 @@ mod checked {
         certificate_deny_set: &HashSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
@@ -175,7 +176,7 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, effects, execution_result)
+        (inner, gas_charger.consume(), effects, execution_result)
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -176,7 +176,12 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, gas_charger.consume(), effects, execution_result)
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -107,7 +107,7 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
-        pub fn consume(self) -> SuiGasStatus {
+        pub fn into_gas_status(self) -> SuiGasStatus {
             self.gas_status
         }
 

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -280,11 +280,6 @@ pub mod checked {
             temporary_store.ensure_gas_and_input_mutated(self);
             temporary_store.collect_storage_and_rebate(self);
 
-            match &self.gas_status {
-                SuiGasStatus::V2(s) => {
-                    s.log_for_replay();
-                }
-            };
             if self.smashed_gas_coin.is_some() {
                 #[skip_checked_arithmetic]
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -194,9 +194,14 @@ pub mod checked {
         // Gas charging operations
         //
 
-        pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        pub fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64 {
             self.gas_status
-                .track_storage_mutation(new_size, storage_rebate)
+                .track_storage_mutation(object_id, new_size, storage_rebate)
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -107,6 +107,10 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
+        pub fn consume(self) -> SuiGasStatus {
+            self.gas_status
+        }
+
         pub fn summary(&self) -> GasCostSummary {
             self.gas_status.summary()
         }

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -705,7 +705,7 @@ impl<'backing> TemporaryStore<'backing> {
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate =
-                gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
+                gas_charger.track_storage_mutation(*object_id, new_object_size, old_storage_rebate);
             object.storage_rebate = new_storage_rebate;
             if !object.is_immutable() {
                 objects_to_update.push((object.clone(), *write_kind));
@@ -728,7 +728,7 @@ impl<'backing> TemporaryStore<'backing> {
                 | DeleteKindWithOldVersion::Normal(version) => {
                     // get and track the deleted object `storage_rebate`
                     let storage_rebate = self.get_input_storage_rebate(object_id, *version);
-                    gas_charger.track_storage_mutation(0, storage_rebate);
+                    gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
                 }
                 DeleteKindWithOldVersion::UnwrapThenDelete
                 | DeleteKindWithOldVersion::UnwrapThenDeleteDEPRECATED(_) => {

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -190,7 +190,12 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, gas_charger.consume(), effects, execution_result)
+        (
+            inner,
+            gas_charger.into_gas_status(),
+            effects,
+            execution_result,
+        )
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -75,6 +75,7 @@ mod checked {
         certificate_deny_set: &HashSet<TransactionDigest>,
     ) -> (
         InnerTemporaryStore,
+        SuiGasStatus,
         TransactionEffects,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
@@ -189,7 +190,7 @@ mod checked {
             &mut gas_charger,
             *epoch_id,
         );
-        (inner, effects, execution_result)
+        (inner, gas_charger.consume(), effects, execution_result)
     }
 
     pub fn execute_genesis_state_update(

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -108,7 +108,7 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
-        pub fn consume(self) -> SuiGasStatus {
+        pub fn into_gas_status(self) -> SuiGasStatus {
             self.gas_status
         }
 

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -195,9 +195,14 @@ pub mod checked {
         // Gas charging operations
         //
 
-        pub fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        pub fn track_storage_mutation(
+            &mut self,
+            object_id: ObjectID,
+            new_size: usize,
+            storage_rebate: u64,
+        ) -> u64 {
             self.gas_status
-                .track_storage_mutation(new_size, storage_rebate)
+                .track_storage_mutation(object_id, new_size, storage_rebate)
         }
 
         pub fn reset_storage_cost_and_rebate(&mut self) {

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -108,6 +108,10 @@ pub mod checked {
             self.gas_status.move_gas_status_mut()
         }
 
+        pub fn consume(self) -> SuiGasStatus {
+            self.gas_status
+        }
+
         pub fn summary(&self) -> GasCostSummary {
             self.gas_status.summary()
         }

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -289,11 +289,6 @@ pub mod checked {
             temporary_store.ensure_active_inputs_mutated();
             temporary_store.collect_storage_and_rebate(self);
 
-            match &self.gas_status {
-                SuiGasStatus::V2(s) => {
-                    s.log_for_replay();
-                }
-            };
             if self.smashed_gas_coin.is_some() {
                 #[skip_checked_arithmetic]
                 trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -747,8 +747,11 @@ impl<'backing> TemporaryStore<'backing> {
             // new object size
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
-            let new_storage_rebate =
-                gas_charger.track_storage_mutation(new_object_size, old_storage_rebate);
+            let new_storage_rebate = gas_charger.track_storage_mutation(
+                (*object.id()).into(),
+                new_object_size,
+                old_storage_rebate,
+            );
             object.storage_rebate = new_storage_rebate;
         }
 
@@ -770,7 +773,7 @@ impl<'backing> TemporaryStore<'backing> {
                 // Unwrap is safe because this loop iterates through all modified objects.
                 .unwrap()
                 .storage_rebate;
-            gas_charger.track_storage_mutation(0, storage_rebate);
+            gas_charger.track_storage_mutation(*object_id, 0, storage_rebate);
         }
     }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -748,7 +748,7 @@ impl<'backing> TemporaryStore<'backing> {
             let new_object_size = object.object_size_for_gas_metering();
             // track changes and compute the new object `storage_rebate`
             let new_storage_rebate = gas_charger.track_storage_mutation(
-                (*object.id()).into(),
+                object.id(),
                 new_object_size,
                 old_storage_rebate,
             );


### PR DESCRIPTION
## Description 

Alternate approach for displaying Gas Info in replay:

- Refactors GasCharger to store per-object info
- Refactors trait member execute_tracsaction_to_effects to return the SuiGasStatus
- Removes targeted trace statements from execution path and into the replay crate, but keeps the functionality available for use as a convenience to avoid dependency injection within sui cli and replay crates
- Creates a Display directory in replay that will house Pretty() formatters used specifically for formatting replay output

This is PR is meant to demonstrate a general approach and get buy in, if we like this we can keep adding to the Display, and change the formatting however we like. The only additions to the main codepath in the realm of `Gas Info` would be to add public getters on the SuiGasStatus struct. 

Then we can add other Display files for displaying the ptb info and error info. More investigation is needed to see what refactors may be necessary there to keep as much logging contained to replay as possible.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
