### PR TITLE
[consensus 2.0] adding propose logic in Core

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -31,7 +31,7 @@ impl AuthorityNode {
         protocol_config: ProtocolConfig,
         // To avoid accidentally leaking the private key, the key pair should only be
         // stored in the Block signer.
-        _signer: ProtocolKeyPair,
+        signer: ProtocolKeyPair,
         _block_verifier: impl BlockVerifier,
         registry: Registry,
     ) -> Self {

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use crate::block_verifier::BlockVerifier;
 use crate::context::Context;
-use crate::core::{Core, CoreSignals};
+use crate::core::{Core, CoreOptions, CoreSignals};
 use crate::metrics::initialise_metrics;
 use crate::transactions_client::{TransactionsClient, TransactionsConsumer};
 
@@ -52,7 +52,13 @@ impl AuthorityNode {
         // Construct Core
         let (core_signals, _signals_receivers) = CoreSignals::new();
         let block_manager = BlockManager::new();
-        let _core = Core::new(context.clone(), tx_consumer, block_manager, core_signals);
+        let _core = Core::new(
+            context.clone(),
+            tx_consumer,
+            block_manager,
+            core_signals,
+            CoreOptions::default(),
+        );
 
         Self {
             context,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -31,7 +31,7 @@ impl AuthorityNode {
         protocol_config: ProtocolConfig,
         // To avoid accidentally leaking the private key, the key pair should only be
         // stored in the Block signer.
-        signer: ProtocolKeyPair,
+        _signer: ProtocolKeyPair,
         _block_verifier: impl BlockVerifier,
         registry: Registry,
     ) -> Self {

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -121,7 +121,7 @@ impl BlockAPI for BlockV1 {
 }
 
 /// BlockRef is the minimum info that uniquely identify a block.
-#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BlockRef {
     pub round: Round,
     pub author: AuthorityIndex,
@@ -261,7 +261,7 @@ impl SignedBlock {
     /// Serialises the block using the bcs serializer
     pub(crate) fn serialize(&self) -> Result<bytes::Bytes, bcs::Error> {
         let bytes = bcs::to_bytes(self)?;
-        bytes.into()
+        Ok(bytes.into())
     }
 }
 

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -36,7 +36,7 @@ pub fn timestamp_utc_ms() -> BlockTimestampMs {
 /// The transaction serialised bytes
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Default, Debug)]
 pub struct Transaction {
-    data: bytes::Bytes,
+    data: Bytes,
 }
 
 #[allow(dead_code)]
@@ -86,34 +86,34 @@ impl Block {
 
 #[enum_dispatch]
 pub trait BlockAPI {
+    fn epoch(&self) -> Epoch;
     fn round(&self) -> Round;
     fn author(&self) -> AuthorityIndex;
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn ancestors(&self) -> &[BlockRef];
     fn transactions(&self) -> &[Transaction];
-    fn epoch(&self) -> Epoch;
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct BlockV1 {
+    epoch: Epoch,
     round: Round,
     author: AuthorityIndex,
     // TODO: during verification ensure that timestamp_ms >= ancestors.timestamp
     timestamp_ms: BlockTimestampMs,
     ancestors: Vec<BlockRef>,
-    transactions: Vec<Transaction>,
-    epoch: Epoch,
+    transactions: Vec<Transaction>
 }
 
 impl BlockV1 {
     #[allow(dead_code)]
     pub(crate) fn new(
+        epoch: Epoch,
         round: Round,
         author: AuthorityIndex,
         timestamp_ms: BlockTimestampMs,
         ancestors: Vec<BlockRef>,
         transactions: Vec<Transaction>,
-        epoch: Epoch,
     ) -> BlockV1 {
         Self {
             round,
@@ -288,7 +288,7 @@ impl fmt::Debug for Slot {
 #[derive(Deserialize, Serialize)]
 pub(crate) struct SignedBlock {
     inner: Block,
-    signature: bytes::Bytes,
+    signature: Bytes,
 }
 
 impl SignedBlock {
@@ -303,7 +303,7 @@ impl SignedBlock {
     }
 
     /// Serialises the block using the bcs serializer
-    pub(crate) fn serialize(&self) -> Result<bytes::Bytes, bcs::Error> {
+    pub(crate) fn serialize(&self) -> Result<Bytes, bcs::Error> {
         let bytes = bcs::to_bytes(self)?;
         Ok(bytes.into())
     }
@@ -317,15 +317,12 @@ pub(crate) struct VerifiedBlock {
 
     // Cached Block digest and serialized SignedBlock, to avoid re-computing these values.
     digest: BlockDigest,
-    serialized: bytes::Bytes,
+    serialized: Bytes,
 }
 
 impl VerifiedBlock {
     /// Creates VerifiedBlock from verified SignedBlock and its serialized bytes.
-    pub fn new_verified(
-        signed_block: SignedBlock,
-        serialized: bytes::Bytes,
-    ) -> Result<Self, bcs::Error> {
+    pub fn new_verified(signed_block: SignedBlock, serialized: Bytes) -> Result<Self, bcs::Error> {
         let digest = Self::compute_digest(&signed_block.inner)?;
         Ok(VerifiedBlock {
             block: Arc::new(signed_block),
@@ -349,7 +346,7 @@ impl VerifiedBlock {
             inner: block,
             signature: Default::default(),
         };
-        let serialized: bytes::Bytes = bcs::to_bytes(&signed_block)
+        let serialized: Bytes = bcs::to_bytes(&signed_block)
             .expect("Serialization should not fail")
             .into();
         VerifiedBlock {
@@ -373,7 +370,7 @@ impl VerifiedBlock {
     }
 
     /// Returns the serialized block with signature.
-    pub fn serialized(&self) -> &bytes::Bytes {
+    pub fn serialized(&self) -> &Bytes {
         &self.serialized
     }
 

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -10,10 +10,14 @@ use std::{
 };
 
 use bytes::Bytes;
-use consensus_config::{AuthorityIndex, DefaultHashFunction, DIGEST_LENGTH};
+use consensus_config::{AuthorityIndex, DefaultHashFunction, Epoch, DIGEST_LENGTH};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
 use serde::{Deserialize, Serialize};
+
+use crate::context::Context;
+
+const GENESIS_ROUND: Round = 0;
 
 /// Round number of a block.
 pub type Round = u32;
@@ -60,6 +64,26 @@ pub enum Block {
     V1(BlockV1),
 }
 
+impl Block {
+    /// Generate the genesis blocks for the latest Block version. The tuple contains (my_genesis_block, others_genesis_blocks).
+    /// The blocks are returned in authority index order.
+    pub(crate) fn genesis(context: Arc<Context>) -> (VerifiedBlock, Vec<VerifiedBlock>) {
+        let (my_block, others_block): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|(authority_index, _)| {
+                let signed = SignedBlock::new(Block::V1(BlockV1::genesis(
+                    authority_index,
+                    context.committee.epoch(),
+                )));
+                VerifiedBlock::new_verified_unserialized(signed)
+                    .expect("Shouldn't fail when creating verified block for genesis")
+            })
+            .partition(|block| block.author() == context.own_index);
+        (my_block[0].clone(), others_block)
+    }
+}
+
 #[enum_dispatch]
 pub trait BlockAPI {
     fn round(&self) -> Round;
@@ -67,6 +91,7 @@ pub trait BlockAPI {
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn ancestors(&self) -> &[BlockRef];
     fn transactions(&self) -> &[Transaction];
+    fn epoch(&self) -> Epoch;
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
@@ -77,6 +102,7 @@ pub struct BlockV1 {
     timestamp_ms: BlockTimestampMs,
     ancestors: Vec<BlockRef>,
     transactions: Vec<Transaction>,
+    epoch: Epoch,
 }
 
 impl BlockV1 {
@@ -87,6 +113,7 @@ impl BlockV1 {
         timestamp_ms: BlockTimestampMs,
         ancestors: Vec<BlockRef>,
         transactions: Vec<Transaction>,
+        epoch: Epoch,
     ) -> BlockV1 {
         Self {
             round,
@@ -94,6 +121,19 @@ impl BlockV1 {
             timestamp_ms,
             ancestors,
             transactions,
+            epoch,
+        }
+    }
+
+    /// Generate the block that is meant to be used for genesis
+    pub(crate) fn genesis(author: AuthorityIndex, epoch: Epoch) -> BlockV1 {
+        Self {
+            round: GENESIS_ROUND,
+            author,
+            timestamp_ms: 0,
+            ancestors: vec![],
+            transactions: vec![],
+            epoch,
         }
     }
 }
@@ -117,6 +157,10 @@ impl BlockAPI for BlockV1 {
 
     fn transactions(&self) -> &[Transaction] {
         &self.transactions
+    }
+
+    fn epoch(&self) -> Epoch {
+        self.epoch
     }
 }
 
@@ -414,6 +458,10 @@ impl TestBlock {
 
     pub(crate) fn set_transactions(mut self, transactions: Vec<Transaction>) -> Self {
         self.block.transactions = transactions;
+    }
+
+    pub(crate) fn set_epoch(mut self, epoch: Epoch) -> Self {
+        self.block.epoch = epoch;
         self
     }
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::{BlockRef, VerifiedBlock};
+use crate::block::{BlockAPI, BlockRef, VerifiedBlock};
+use std::collections::HashSet;
 
 /// Block manager suspends incoming blocks until they are connected to the existing graph,
 /// returning newly connected blocks.
@@ -9,20 +10,34 @@ use crate::block::{BlockRef, VerifiedBlock};
 /// history we need to make sure that BlockManager takes care of that and avoid OOM (Out Of Memory)
 /// situations.
 #[allow(dead_code)]
-pub(crate) struct BlockManager {}
+pub(crate) struct BlockManager {
+    // TODO: dummy implementation, just
+    accepted_blocks: HashSet<BlockRef>,
+}
 
 #[allow(dead_code)]
 impl BlockManager {
     pub(crate) fn new() -> Self {
-        Self {}
+        Self {
+            accepted_blocks: HashSet::new(),
+        }
     }
 
     /// Tries to accept the provided blocks assuming that all their causal history exists. The method
-    /// returns all the blocks that have been successfully processed, that includes also previously
+    /// returns all the blocks that have been successfully processed in round ascending order, that includes also previously
     /// suspended blocks that have now been able to get accepted.
-    pub(crate) fn add_blocks(&mut self, blocks: Vec<VerifiedBlock>) -> Vec<VerifiedBlock> {
-        // TODO: add implementation - for now just return the blocks
+    pub(crate) fn add_blocks(&mut self, mut blocks: Vec<VerifiedBlock>) -> Vec<VerifiedBlock> {
+        // TODO: add implementation - for now just dummy/test. Accept everything assuming history exists and cache them
+        // to ensure that they are not returned if they already processed.
+        blocks.sort_by_key(|b1| b1.round());
         blocks
+            .into_iter()
+            .flat_map(|block| {
+                self.accepted_blocks
+                    .insert(block.reference())
+                    .then_some(block)
+            })
+            .collect()
     }
 
     /// Returns all the blocks that are currently missing and needed in order to accept suspended

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 /// situations.
 #[allow(dead_code)]
 pub(crate) struct BlockManager {
-    // TODO: dummy implementation, just
+    // TODO: dummy implementation, just keep all the block references
     accepted_blocks: HashSet<BlockRef>,
 }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -61,7 +61,10 @@ impl Core {
         Self {
             context,
             threshold_clock,
-            last_own_block: VerifiedBlock::new(SignedBlock::new(Block::V1(BlockV1::default()))), // TODO: restore on crash/recovery
+            last_own_block: VerifiedBlock::new_verified_unserialized(SignedBlock::new(Block::V1(
+                BlockV1::default(),
+            )))
+            .unwrap(), // TODO: restore on crash/recovery
             transactions_consumer,
             pending_transactions: Vec::new(),
             pending_ancestors: VecDeque::new(),
@@ -167,7 +170,7 @@ impl Core {
             self.threshold_clock.add_block(verified_block.reference());
             self.last_own_block = verified_block.clone();
 
-            tracing::debug!("New block created for round {}", verified_block.round());
+            tracing::debug!("New block created {}", verified_block);
 
             //5. emit an event that a new block is ready
             self.signals.new_block_ready(verified_block.reference());

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -154,7 +154,7 @@ mod test {
     use super::*;
     use crate::block_manager::BlockManager;
     use crate::context::Context;
-    use crate::core::CoreSignals;
+    use crate::core::{CoreOptions, CoreSignals};
     use crate::transactions_client::{TransactionsClient, TransactionsConsumer};
 
     #[tokio::test]
@@ -169,6 +169,7 @@ mod test {
             transactions_consumer,
             block_manager,
             signals,
+            CoreOptions::default(),
         );
 
         let (core_dispatcher, handle) = CoreThreadDispatcher::start(core, context);

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -51,8 +51,8 @@ impl CoreThread {
                     let missing_blocks = self.core.add_blocks(blocks);
                     sender.send(missing_blocks).ok();
                 }
-                CoreThreadCommand::NewBlockLeaderTimeout(round, sender) => {
-                    self.core.try_new_block_leader_timeout(round);
+                CoreThreadCommand::ForceNewBlock(round, sender) => {
+                    self.core.force_new_block(round);
                     sender.send(()).ok();
                 }
                 CoreThreadCommand::GetMissing(sender) => {
@@ -75,7 +75,7 @@ enum CoreThreadCommand {
     /// Add blocks to be processed and accepted
     AddBlocks(Vec<VerifiedBlock>, oneshot::Sender<Vec<BlockRef>>),
     /// Called when a leader timeout occurs and a block should be produced
-    NewBlockLeaderTimeout(Round, oneshot::Sender<()>),
+    ForceNewBlock(Round, oneshot::Sender<()>),
     /// Request missing blocks that need to be synced.
     GetMissing(oneshot::Sender<Vec<HashSet<BlockRef>>>),
 }
@@ -123,9 +123,9 @@ impl CoreThreadDispatcher {
         receiver.await.map_err(Shutdown)
     }
 
-    pub async fn new_block_leader_timeout(&self, round: Round) -> Result<(), CoreError> {
+    pub async fn force_new_block(&self, round: Round) -> Result<(), CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::NewBlockLeaderTimeout(round, sender))
+        self.send(CoreThreadCommand::ForceNewBlock(round, sender))
             .await;
         receiver.await.map_err(Shutdown)
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -8,13 +8,13 @@ use std::{
     sync::Arc,
 };
 
-use consensus_config::AuthorityIndex;
 use crate::{
     block::{Block, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
     commit::Commit,
     context::Context,
     storage::Store,
 };
+use consensus_config::AuthorityIndex;
 
 /// Rounds of recently committed blocks cached in memory, per authority.
 #[allow(unused)]
@@ -142,7 +142,8 @@ impl DagState {
 
     /// Gets all ancestors in the history of a block at a certain round.
     /// The round must be higher than the last committed round.
-    pub(crate) fn ancestors_at_uncommitted_round(&self,
+    pub(crate) fn ancestors_at_uncommitted_round(
+        &self,
         later_block: &VerifiedBlock,
         earlier_round: Round,
     ) -> Vec<VerifiedBlock> {

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -9,9 +9,8 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-
 use crate::{
-    block::{BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
+    block::{Block, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
     commit::Commit,
     context::Context,
     storage::Store,
@@ -59,7 +58,7 @@ impl DagState {
         };
 
         let mut state = Self {
-            context,
+            context: context.clone(),
             recent_blocks: BTreeMap::new(),
             cached_refs: vec![BTreeSet::new(); num_authorities],
             last_commit,
@@ -73,6 +72,22 @@ impl DagState {
                 .scan_blocks_by_author(authority_index, round.saturating_sub(CACHED_ROUNDS))
                 .unwrap();
             for block in blocks {
+                state.accept_block(block);
+            }
+        }
+
+        // If nothing exists in state yet, then we know that this is a fresh start system. Populate the genesis blocks both
+        // in store and the state. We can probably find a better place for this (ex when the storage gets initiliased etc) but
+        // maybe for now is ok.
+        if state.cached_refs.is_empty() {
+            let (genesis_my, mut genesis_others) = Block::genesis(context);
+            genesis_others.push(genesis_my);
+
+            state
+                .store
+                .write(genesis_others.clone(), vec![])
+                .expect("Failed to write genesis blocks in storage.");
+            for block in genesis_others {
                 state.accept_block(block);
             }
         }
@@ -127,8 +142,7 @@ impl DagState {
 
     /// Gets all ancestors in the history of a block at a certain round.
     /// The round must be higher than the last committed round.
-    pub(crate) fn ancestors_at_uncommitted_round(
-        &self,
+    pub(crate) fn ancestors_at_uncommitted_round(&self,
         later_block: &VerifiedBlock,
         earlier_round: Round,
     ) -> Vec<VerifiedBlock> {
@@ -171,6 +185,27 @@ impl DagState {
                     .get(r)
                     .unwrap_or_else(|| panic!("Block {:?} should be available in memory!", r))
                     .clone()
+            })
+            .collect()
+    }
+
+    /// It will return the latest proposed block refs for every author whose round is < before_round the provided round.
+    /// The method is guaranteed to return a block per author even if that is its genesis block.
+    /// Note: if equivocating blocks have been received per round for an authority then the last accepted is returned.
+    pub(crate) fn get_latest_authors_block_refs(&self, before_round: Round) -> Vec<&BlockRef> {
+        assert!(
+            before_round > 0,
+            "The method should never be called with a before_round = 0"
+        );
+
+        self.cached_refs
+            .iter()
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .rev()
+                    .find(|block_ref| block_ref.round < before_round)
+                    .expect("At least one block should be found")
             })
             .collect()
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -8,13 +8,14 @@ use std::{
     sync::Arc,
 };
 
+use consensus_config::AuthorityIndex;
+
 use crate::{
     block::{BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
     commit::Commit,
     context::Context,
     storage::Store,
 };
-use consensus_config::AuthorityIndex;
 
 /// Rounds of recently committed blocks cached in memory, per authority.
 #[allow(unused)]
@@ -422,12 +423,13 @@ mod test {
         let ancestors = dag_state.ancestors_at_uncommitted_round(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
-        let expected_refs = vec![
+        let mut expected_refs = vec![
             round_11[0].reference(),
             round_11[1].reference(),
             round_11[2].reference(),
             round_11[5].reference(),
         ];
+        expected_refs.sort(); // we need to sort as blocks with same author and round of round 11 (position 1 & 2) might not be in right lexicographical order.
         assert_eq!(
             ancestors_refs, expected_refs,
             "Expected round 11 ancestors: {:?}. Got: {:?}",


### PR DESCRIPTION
## Description 

Adding the block propose logic in Core. The implementation is not finished as there are things missing (ex using the DagState to query for blocks, write state, recover state, signing blocks etc) but it should still capture the core logic. 

More tests will be added on follow up PR.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
