### PR TITLE
[GraphQL/Cursor] StakedSui pagination

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
@@ -1,0 +1,99 @@
+processed 7 tasks
+
+init:
+C: object(0,0)
+
+task 1 'run-graphql'. lines 6-31:
+Response: {
+  "data": {
+    "objects": {
+      "edges": [
+        {
+          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdM",
+          "node": {
+            "asMoveObject": {
+              "asStakedSui": {
+                "principal": "20000000000000000"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "address": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 2 'programmable'. lines 33-35:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 37-37:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [104, 17, 175, 77, 18, 32, 226, 121, 113, 180, 229, 78, 138, 243, 228, 253, 21, 20, 34, 255, 110, 134, 76, 151, 87, 168, 59, 129, 115, 99, 39, 78, 218, 131, 22, 109, 1, 175, 215, 221, 207, 138, 245, 248, 68, 244, 90, 170, 83, 244, 133, 72, 229, 17, 124, 35, 245, 162, 151, 140, 253, 66, 34, 68, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(3,0), object(3,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(_), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4 'create-checkpoint'. lines 39-39:
+Checkpoint created: 1
+
+task 5 'advance-epoch'. lines 41-41:
+Epoch advanced: 0
+
+task 6 'run-graphql'. lines 43-68:
+Response: {
+  "data": {
+    "objects": {
+      "edges": [
+        {
+          "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOu",
+          "node": {
+            "asMoveObject": {
+              "asStakedSui": {
+                "principal": "10000000000"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdM",
+          "node": {
+            "asMoveObject": {
+              "asStakedSui": {
+                "principal": "20000000000000000"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "IIHMnvkeALMPjTeJ/OOC5YxcRUCNj2lhNJxXlLo4Bhnu",
+          "node": {
+            "asMoveObject": {
+              "asStakedSui": {
+                "principal": "40000"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "address": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOu",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator --accounts C
+
+//# run-graphql
+{ # Initial query yields only the validator's stake
+  objects(filter: { type: "0x3::staking_pool::StakedSui" }) {
+    edges {
+      cursor
+      node {
+        asMoveObject {
+          asStakedSui {
+            principal
+          }
+        }
+      }
+    }
+  }
+
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(2,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{ # This query should pick up the recently Staked SUI as well.
+  objects(filter: { type: "0x3::staking_pool::StakedSui" }) {
+    edges {
+      cursor
+      node {
+        asMoveObject {
+          asStakedSui {
+            principal
+          }
+        }
+      }
+    }
+  }
+
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -1220,7 +1220,7 @@
 >      }
 >      totalBalance
 >    }
->    stakedSuiConnection {
+>    stakedSuis {
 >      nodes {
 >        status
 >        principal

--- a/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -10,7 +10,7 @@
       }
       totalBalance
     }
-    stakedSuiConnection {
+    stakedSuis {
       nodes {
         status
         principal

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -88,9 +88,9 @@ type Address implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given address.
+	The `0x3::staking_pool::StakedSui` objects owned by this address.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""
@@ -1047,7 +1047,7 @@ interface IOwner {
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultSuinsName: String
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
 	dynamicField(name: DynamicFieldName!): DynamicField
@@ -1707,9 +1707,9 @@ type Object implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given object.
+	The `0x3::staking_pool::StakedSui` objects owned by this object.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""
@@ -1959,9 +1959,9 @@ type Owner implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given object.
+	The `0x3::staking_pool::StakedSui` objects owned by this address or object.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -149,17 +149,17 @@ impl Address {
             .extend()
     }
 
-    /// The `0x3::staking_pool::StakedSui` objects owned by the given address.
-    pub async fn staked_sui_connection(
+    /// The `0x3::staking_pool::StakedSui` objects owned by this address.
+    pub async fn staked_suis(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<object::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<Connection<String, StakedSui>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_staked_sui(self.address, first, after, last, before)
+        before: Option<object::Cursor>,
+    ) -> Result<Connection<String, StakedSui>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        StakedSui::paginate(ctx.data_unchecked(), page, self.address)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -56,12 +56,12 @@ use sui_types::gas_coin::GAS;
         arg(name = "type", ty = "Option<ExactTypeFilter>")
     ),
     field(
-        name = "staked_sui_connection",
+        name = "staked_suis",
         ty = "Option<Connection<String, StakedSui>>",
         arg(name = "first", ty = "Option<u64>"),
-        arg(name = "after", ty = "Option<String>"),
+        arg(name = "after", ty = "Option<object::Cursor>"),
         arg(name = "last", ty = "Option<u64>"),
-        arg(name = "before", ty = "Option<String>")
+        arg(name = "before", ty = "Option<object::Cursor>")
     ),
     field(name = "default_suins_name", ty = "Option<String>"),
     field(
@@ -199,17 +199,17 @@ impl Owner {
             .extend()
     }
 
-    /// The `0x3::staking_pool::StakedSui` objects owned by the given object.
-    pub async fn staked_sui_connection(
+    /// The `0x3::staking_pool::StakedSui` objects owned by this address or object.
+    pub async fn staked_suis(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<object::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<Connection<String, StakedSui>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_staked_sui(self.address, first, after, last, before)
+        before: Option<object::Cursor>,
+    ) -> Result<Connection<String, StakedSui>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        StakedSui::paginate(ctx.data_unchecked(), page, self.address)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -92,9 +92,9 @@ type Address implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given address.
+	The `0x3::staking_pool::StakedSui` objects owned by this address.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""
@@ -1051,7 +1051,7 @@ interface IOwner {
 	balance(type: String): Balance
 	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultSuinsName: String
 	suinsRegistrations(first: Int, after: String, last: Int, before: String): SuinsRegistrationConnection
 	dynamicField(name: DynamicFieldName!): DynamicField
@@ -1711,9 +1711,9 @@ type Object implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given object.
+	The `0x3::staking_pool::StakedSui` objects owned by this object.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""
@@ -1963,9 +1963,9 @@ type Owner implements IOwner {
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	"""
-	The `0x3::staking_pool::StakedSui` objects owned by the given object.
+	The `0x3::staking_pool::StakedSui` objects owned by this address or object.
 	"""
-	stakedSuiConnection(first: Int, after: String, last: Int, before: String): StakedSuiConnection
+	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection!
 	"""
 	The domain that a user address has explicitly configured as their default domain.
 	"""


### PR DESCRIPTION
## Description

Port StakedSui to the cursor/data/pagination framework.

Also extracts the logic for paginating a sub-type of Object into a reusable helper function: `Object::paginate_subtype`.

## Test Plan

New E2E test:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- objects/staked_sui.move
```

## Stack
- #15749 
- #15760 
- #15761 
- #15764