### PR TITLE
[GraphQL/Data] Specialise Object::paginate to OwnerType::Address

### DIFF
--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -97,7 +97,7 @@ impl Address {
             return Ok(Connection::new(false, false));
         };
 
-        Object::paginate(ctx.data_unchecked(), page, None, filter)
+        Object::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -65,7 +65,7 @@ impl GasInput {
             ..Default::default()
         };
 
-        Object::paginate(ctx.data_unchecked(), page, None, filter)
+        Object::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -146,7 +146,7 @@ impl Owner {
             return Ok(Connection::new(false, false));
         };
 
-        Object::paginate(ctx.data_unchecked(), page, None, filter)
+        Object::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -203,7 +203,7 @@ impl Query {
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Object::paginate(ctx.data_unchecked(), page, None, filter.unwrap_or_default())
+        Object::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -12,7 +12,6 @@ use super::{
 use async_graphql::connection::Connection;
 use async_graphql::*;
 use move_core_types::language_storage::StructTag;
-use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc_types::{Stake as RpcStakedSui, StakeStatus as RpcStakeStatus};
 use sui_types::base_types::MoveObjectType;
 use sui_types::governance::StakedSui as NativeStakedSui;
@@ -114,7 +113,7 @@ impl StakedSui {
             ..Default::default()
         };
 
-        Object::paginate_subtype(db, page, Some(OwnerType::Address), filter, |object| {
+        Object::paginate_subtype(db, page, filter, |object| {
             let address = object.address;
             let move_object = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -14,7 +14,6 @@ use crate::{data::Db, error::Error};
 use async_graphql::{connection::Connection, *};
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
-use sui_indexer::types_v2::OwnerType;
 use sui_json_rpc::name_service::{Domain as NativeDomain, NameRecord, NameServiceConfig};
 use sui_types::{base_types::SuiAddress as NativeSuiAddress, dynamic_field::Field, id::UID};
 
@@ -121,7 +120,7 @@ impl SuinsRegistration {
             ..Default::default()
         };
 
-        Object::paginate_subtype(db, page, Some(OwnerType::Address), filter, |object| {
+        Object::paginate_subtype(db, page, filter, |object| {
             let address = object.address;
             let move_object = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(


### PR DESCRIPTION
## Description

While implementing pagination for dynamic fields, I realised it would be easier for it to implement its own query, rather than go through `Object::paginate` which means we no longer need to be aware of `OwnerType::Object` in the Object querying paths.

## Test Plan

Behaviour preserving refactor -- run all tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack
- #15749 
- #15760 
- #15761 
- #15764
- #15777
- #15778