### PR TITLE
[GraphQL/Data] Balance point query

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -25,7 +25,6 @@ pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_obj_by_type(object_type: String) -> objects::BoxedQuery<'static, DB>;
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
     fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
-    fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, DB>;
 }
 
 /// The struct returned for query.explain()

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -54,10 +54,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
 
         query
     }
-    fn get_balance(address: Vec<u8>, coin_type: String) -> BalanceQuery<'static, Pg> {
-        let query = PgQueryBuilder::multi_get_balances(address);
-        query.filter(objects::dsl::coin_type.eq(coin_type))
-    }
 }
 
 /// Allows methods like load(), get_result(), etc. on an Explained query

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -106,10 +106,10 @@ impl Address {
     pub async fn balance(
         &self,
         ctx: &Context<'_>,
-        type_: Option<String>,
+        type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_balance(self.address, type_)
+        let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
+        Balance::query(ctx.data_unchecked(), self.address, coin)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,8 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{big_int::BigInt, move_type::MoveType};
+use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
+use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::error::Error;
 use async_graphql::*;
+use diesel::{
+    dsl::sql,
+    sql_types::{BigInt as SqlBigInt, Nullable},
+    ExpressionMethods, OptionalExtension, QueryDsl,
+};
+use sui_indexer::{schema_v2::objects, types_v2::OwnerType};
+use sui_types::{parse_sui_type_tag, TypeTag};
 
 /// The total balance for a particular coin type.
 #[derive(Clone, Debug, SimpleObject)]
@@ -13,4 +22,67 @@ pub(crate) struct Balance {
     pub(crate) coin_object_count: Option<u64>,
     /// Total balance across all coin objects of the coin type
     pub(crate) total_balance: Option<BigInt>,
+}
+
+type StoredBalance = (
+    /* balance */ Option<i64>,
+    /* count */ Option<i64>,
+    /* type */ Option<String>,
+);
+
+impl Balance {
+    /// Query for the balance of coins owned by `address`, of coins with type `coin_type`. Note that
+    /// `coin_type` is the type of `0x2::coin::Coin`'s type parameter, not the full type of the coin
+    /// object.
+    pub(crate) async fn query(
+        db: &Db,
+        address: SuiAddress,
+        coin_type: TypeTag,
+    ) -> Result<Option<Balance>, Error> {
+        use objects::dsl;
+
+        let stored: Option<StoredBalance> = db
+            .execute(move |conn| {
+                conn.first(move || {
+                    dsl::objects
+                        .select((
+                            sql::<Nullable<SqlBigInt>>("CAST(SUM(coin_balance) AS BIGINT)"),
+                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
+                            dsl::coin_type,
+                        ))
+                        .filter(dsl::owner_id.eq(address.into_vec()))
+                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
+                        .filter(
+                            dsl::coin_type
+                                .eq(coin_type.to_canonical_string(/* with_prefix */ true)),
+                        )
+                        .group_by(dsl::coin_type)
+                })
+                .optional()
+            })
+            .await?;
+
+        stored.map(Balance::try_from).transpose()
+    }
+}
+
+impl TryFrom<StoredBalance> for Balance {
+    type Error = Error;
+
+    fn try_from((balance, count, coin_type): StoredBalance) -> Result<Self, Error> {
+        let total_balance = balance.map(BigInt::from);
+        let coin_object_count = count.map(|c| c as u64);
+        let coin_type = coin_type
+            .as_deref()
+            .map(parse_sui_type_tag)
+            .transpose()
+            .map_err(|e| Error::Internal(format!("Failed to parse coin type: {e}")))?
+            .map(MoveType::new);
+
+        Ok(Balance {
+            coin_type,
+            coin_object_count,
+            total_balance,
+        })
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -297,10 +297,10 @@ impl Object {
     pub async fn balance(
         &self,
         ctx: &Context<'_>,
-        type_: Option<String>,
+        type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_balance(self.address, type_)
+        let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
+        Balance::query(ctx.data_unchecked(), self.address, coin)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -36,7 +36,7 @@ use sui_types::gas_coin::GAS;
     field(
         name = "balance",
         ty = "Option<Balance>",
-        arg(name = "type", ty = "Option<String>")
+        arg(name = "type", ty = "Option<ExactTypeFilter>")
     ),
     field(
         name = "balance_connection",
@@ -156,10 +156,10 @@ impl Owner {
     pub async fn balance(
         &self,
         ctx: &Context<'_>,
-        type_: Option<String>,
+        type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_balance(self.address, type_)
+        let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
+        Balance::query(ctx.data_unchecked(), self.address, coin)
             .await
             .extend()
     }


### PR DESCRIPTION
## Description

Ported to new data framework -- this introduces a slight behaviour change that a failure to parse a coin type in the data layer is now treated as an internal error, not a user error, because the user error is handled by `ExactTypeFilter`.

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```

## Stack
- #15749 
- #15760 
- #15761 
- #15764
- #15777
- #15778
- #15779
- #15780