### PR TITLE
[GraphQL/Cursor] Balance pagination

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
@@ -11,7 +11,7 @@ gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate:
 task 2 'create-checkpoint'. lines 38-38:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 40-71:
+task 3 'run-graphql'. lines 40-90:
 Response: {
   "data": {
     "suiCoins": {
@@ -115,6 +115,44 @@ Response: {
                 }
               }
             }
+          }
+        ]
+      },
+      "allBalances": {
+        "edges": [
+          {
+            "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki",
+            "node": {
+              "coinType": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+              },
+              "coinObjectCount": 1,
+              "totalBalance": "299999983336400"
+            }
+          },
+          {
+            "cursor": "IjB4MTZhMjc2NDdkYmVhMmY1MTEyMzc5MGI3OTJkNDY4OGUyMWFhMGZjNzE2NDA1MjEwY2VlYmIwYTJkYzcwZDlmMDo6ZmFrZTo6RkFLRSI",
+            "node": {
+              "coinType": {
+                "repr": "0x16a27647dbea2f51123790b792d4688e21aa0fc716405210ceebb0a2dc70d9f0::fake::FAKE"
+              },
+              "coinObjectCount": 3,
+              "totalBalance": "6"
+            }
+          }
+        ]
+      },
+      "firstBalance": {
+        "edges": [
+          {
+            "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+          }
+        ]
+      },
+      "lastBalance": {
+        "edges": [
+          {
+            "cursor": "IjB4MTZhMjc2NDdkYmVhMmY1MTEyMzc5MGI3OTJkNDY4OGUyMWFhMGZjNzE2NDA1MjEwY2VlYmIwYTJkYzcwZDlmMDo6ZmFrZTo6RkFLRSI"
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.move
@@ -67,5 +67,24 @@ fragment C on Coin {
         node { ...C }
       }
     }
+
+    allBalances: balances {
+      edges {
+        cursor
+        node {
+          coinType { repr }
+          coinObjectCount
+          totalBalance
+        }
+      }
+    }
+
+    firstBalance: balances(first: 1) {
+      edges { cursor }
+    }
+
+    lastBalance: balances(last: 1) {
+      edges { cursor }
+    }
   }
 }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -158,7 +158,7 @@
 >      coinObjectCount
 >      totalBalance
 >    }
->    balanceConnection {
+>    balances {
 >      nodes {
 >        coinType {
 >          repr

--- a/crates/sui-graphql-rpc/examples/balance_connection/balance_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/balance_connection/balance_connection.graphql
@@ -10,7 +10,7 @@
       coinObjectCount
       totalBalance
     }
-    balanceConnection {
+    balances {
       nodes {
         coinType {
           repr

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -77,9 +77,10 @@ type Address implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balance objects for this address.
+	The balances of all coin types owned by this address. Coins of the same type are grouped
+	together into one Balance.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for this address.
 	
@@ -192,7 +193,7 @@ type Balance {
 	"""
 	Coin type for the balance, such as 0x2::sui::SUI
 	"""
-	coinType: MoveType
+	coinType: MoveType!
 	"""
 	How many coins of this type constitute the balance
 	"""
@@ -1045,7 +1046,7 @@ interface IOwner {
 	address: SuiAddress!
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultSuinsName: String
@@ -1695,10 +1696,10 @@ type Object implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balances of all coin types owned by the object. Coins of the same type are grouped
+	The balances of all coin types owned by this object. Coins of the same type are grouped
 	together into one Balance.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for this object.
 	
@@ -1948,9 +1949,9 @@ type Owner implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balances of all coin types owned by this Owner.
+	The balances of all coin types owned by this owner.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for the given address or object.
 	

--- a/crates/sui-graphql-rpc/src/context_data/db_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_backend.rs
@@ -4,27 +4,11 @@
 use diesel::backend::Backend;
 use sui_indexer::schema_v2::{display, objects};
 
-use diesel::{
-    query_builder::{BoxedSelectStatement, FromClause, QueryId},
-    sql_types::Text,
-};
-
-pub(crate) type BalanceQuery<'a, DB> = BoxedSelectStatement<
-    'a,
-    (
-        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
-        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
-        diesel::sql_types::Nullable<diesel::sql_types::Text>,
-    ),
-    FromClause<objects::table>,
-    DB,
-    objects::dsl::coin_type,
->;
+use diesel::{query_builder::QueryId, sql_types::Text};
 
 pub(crate) trait GenericQueryBuilder<DB: Backend> {
     fn get_obj_by_type(object_type: String) -> objects::BoxedQuery<'static, DB>;
     fn get_display_by_obj_type(object_type: String) -> display::BoxedQuery<'static, DB>;
-    fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, DB>;
 }
 
 /// The struct returned for query.explain()

--- a/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
+++ b/crates/sui-graphql-rpc/src/context_data/pg_backend.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::db_backend::{BalanceQuery, Explain, Explained, GenericQueryBuilder};
+use super::db_backend::{Explain, Explained, GenericQueryBuilder};
 use crate::{context_data::db_data_provider::PgManager, error::Error};
 use async_trait::async_trait;
 use diesel::{
@@ -9,10 +9,7 @@ use diesel::{
     query_builder::{AstPass, QueryFragment},
     ExpressionMethods, PgConnection, QueryDsl, QueryResult, RunQueryDsl,
 };
-use sui_indexer::{
-    schema_v2::{display, objects},
-    types_v2::OwnerType,
-};
+use sui_indexer::schema_v2::{display, objects};
 use tap::TapFallible;
 use tracing::{info, warn};
 
@@ -33,26 +30,6 @@ impl GenericQueryBuilder<Pg> for PgQueryBuilder {
             .filter(display::dsl::object_type.eq(object_type))
             .limit(1)
             .into_boxed()
-    }
-
-    fn multi_get_balances(address: Vec<u8>) -> BalanceQuery<'static, Pg> {
-        let query = objects::dsl::objects
-            .group_by(objects::dsl::coin_type)
-            .select((
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "CAST(SUM(coin_balance) AS BIGINT)",
-                ),
-                diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
-                    "COUNT(*)",
-                ),
-                objects::dsl::coin_type,
-            ))
-            .filter(objects::dsl::owner_id.eq(address))
-            .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
-            .filter(objects::dsl::coin_type.is_not_null())
-            .into_boxed();
-
-        query
     }
 }
 

--- a/crates/sui-graphql-rpc/src/functional_group.rs
+++ b/crates/sui-graphql-rpc/src/functional_group.rs
@@ -66,7 +66,7 @@ fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), Functi
     static GROUPS: Lazy<BTreeMap<(&str, &str), FunctionalGroup>> = Lazy::new(|| {
         BTreeMap::from_iter([
             (("Address", "balance"), G::Coins),
-            (("Address", "balanceConnection"), G::Coins),
+            (("Address", "balances"), G::Coins),
             (("Address", "coins"), G::Coins),
             (("Address", "defaultSuinsName"), G::NameService),
             (("Address", "dynamicField"), G::DynamicFields),
@@ -79,7 +79,7 @@ fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), Functi
             (("Epoch", "referenceGasPrice"), G::SystemState),
             (("Epoch", "validatorSet"), G::SystemState),
             (("Object", "balance"), G::Coins),
-            (("Object", "balanceConnection"), G::Coins),
+            (("Object", "balances"), G::Coins),
             (("Object", "coins"), G::Coins),
             (("Object", "defaultSuinsName"), G::NameService),
             (("Object", "dynamicField"), G::DynamicFields),
@@ -87,7 +87,7 @@ fn functional_groups() -> &'static BTreeMap<(&'static str, &'static str), Functi
             (("Object", "dynamicFields"), G::DynamicFields),
             (("Object", "suinsRegistrations"), G::NameService),
             (("Owner", "balance"), G::Coins),
-            (("Owner", "balanceConnection"), G::Coins),
+            (("Owner", "balances"), G::Coins),
             (("Owner", "coins"), G::Coins),
             (("Owner", "defaultSuinsName"), G::NameService),
             (("Owner", "dynamicField"), G::DynamicFields),

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,15 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::cursor::{self, Page, Target};
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
+use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
+use diesel::NullableExpressionMethods;
 use diesel::{
     dsl::sql,
-    sql_types::{BigInt as SqlBigInt, Nullable},
+    sql_types::{BigInt as SqlBigInt, Nullable, Text},
     ExpressionMethods, OptionalExtension, QueryDsl,
 };
+use std::str::FromStr;
 use sui_indexer::{schema_v2::objects, types_v2::OwnerType};
 use sui_types::{parse_sui_type_tag, TypeTag};
 
@@ -17,18 +21,23 @@ use sui_types::{parse_sui_type_tag, TypeTag};
 #[derive(Clone, Debug, SimpleObject)]
 pub(crate) struct Balance {
     /// Coin type for the balance, such as 0x2::sui::SUI
-    pub(crate) coin_type: Option<MoveType>,
+    pub(crate) coin_type: MoveType,
     /// How many coins of this type constitute the balance
     pub(crate) coin_object_count: Option<u64>,
     /// Total balance across all coin objects of the coin type
     pub(crate) total_balance: Option<BigInt>,
 }
 
+/// Representation of a row of balance information from the DB. We read the balance as a `String` to
+/// deal with the large (bigger than 2^63 - 1) balances.
 type StoredBalance = (
-    /* balance */ Option<i64>,
+    /* balance */ Option<String>,
     /* count */ Option<i64>,
-    /* type */ Option<String>,
+    /* type */ String,
 );
+
+pub(crate) type Cursor = cursor::JsonCursor<String>;
+type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 
 impl Balance {
     /// Query for the balance of coins owned by `address`, of coins with type `coin_type`. Note that
@@ -46,9 +55,9 @@ impl Balance {
                 conn.first(move || {
                     dsl::objects
                         .select((
-                            sql::<Nullable<SqlBigInt>>("CAST(SUM(coin_balance) AS BIGINT)"),
+                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
                             sql::<Nullable<SqlBigInt>>("COUNT(*)"),
-                            dsl::coin_type,
+                            dsl::coin_type.assume_not_null(),
                         ))
                         .filter(dsl::owner_id.eq(address.into_vec()))
                         .filter(dsl::owner_type.eq(OwnerType::Address as i16))
@@ -64,20 +73,85 @@ impl Balance {
 
         stored.map(Balance::try_from).transpose()
     }
+
+    /// Query the database for a `page` of coin balances. Each balance represents the total balance
+    /// for a particular coin type, owned by `address`.
+    pub(crate) async fn paginate(
+        db: &Db,
+        page: Page<Cursor>,
+        address: SuiAddress,
+    ) -> Result<Connection<String, Balance>, Error> {
+        let (prev, next, results) = db
+            .execute(move |conn| {
+                page.paginate_query::<StoredBalance, _, _, _>(conn, move || {
+                    use objects::dsl;
+                    dsl::objects
+                        .select((
+                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
+                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
+                            dsl::coin_type.assume_not_null(),
+                        ))
+                        .filter(dsl::owner_id.eq(address.into_vec()))
+                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
+                        .filter(dsl::coin_type.is_not_null())
+                        .group_by(dsl::coin_type)
+                        .into_boxed()
+                })
+            })
+            .await?;
+
+        let mut conn = Connection::new(prev, next);
+
+        for stored in results {
+            let cursor = stored.cursor().encode_cursor();
+            let balance = Balance::try_from(stored)?;
+            conn.edges.push(Edge::new(cursor, balance));
+        }
+
+        Ok(conn)
+    }
+}
+
+impl Target<Cursor> for StoredBalance {
+    type Source = objects::table;
+
+    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(objects::dsl::coin_type.ge((**cursor).clone()))
+    }
+
+    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
+        query.filter(objects::dsl::coin_type.le((**cursor).clone()))
+    }
+
+    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
+        use objects::dsl;
+        if asc {
+            query.order_by(dsl::coin_type.asc())
+        } else {
+            query.order_by(dsl::coin_type.desc())
+        }
+    }
+
+    fn cursor(&self) -> Cursor {
+        Cursor::new(self.2.clone())
+    }
 }
 
 impl TryFrom<StoredBalance> for Balance {
     type Error = Error;
 
     fn try_from((balance, count, coin_type): StoredBalance) -> Result<Self, Error> {
-        let total_balance = balance.map(BigInt::from);
-        let coin_object_count = count.map(|c| c as u64);
-        let coin_type = coin_type
-            .as_deref()
-            .map(parse_sui_type_tag)
+        let total_balance = balance
+            .map(|b| BigInt::from_str(&b))
             .transpose()
-            .map_err(|e| Error::Internal(format!("Failed to parse coin type: {e}")))?
-            .map(MoveType::new);
+            .map_err(|_| Error::Internal("Failed to read balance.".to_string()))?;
+
+        let coin_object_count = count.map(|c| c as u64);
+
+        let coin_type = MoveType::new(
+            parse_sui_type_tag(&coin_type)
+                .map_err(|e| Error::Internal(format!("Failed to parse coin type: {e}")))?,
+        );
 
         Ok(Balance {
             coin_type,

--- a/crates/sui-graphql-rpc/src/types/move_type.rs
+++ b/crates/sui-graphql-rpc/src/types/move_type.rs
@@ -14,7 +14,7 @@ use super::open_move_type::MoveAbility;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct MoveType {
-    native: TypeTag,
+    pub native: TypeTag,
 }
 
 scalar!(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -21,6 +21,7 @@ use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::gas_coin::GAS;
 use sui_types::TypeTag;
 
+use super::balance;
 use super::big_int::BigInt;
 use super::cursor::{self, Page, Target};
 use super::display::{get_rendered_fields, DisplayEntry};
@@ -305,18 +306,18 @@ impl Object {
             .extend()
     }
 
-    /// The balances of all coin types owned by the object. Coins of the same type are grouped
+    /// The balances of all coin types owned by this object. Coins of the same type are grouped
     /// together into one Balance.
-    pub async fn balance_connection(
+    pub async fn balances(
         &self,
         ctx: &Context<'_>,
         first: Option<u64>,
-        after: Option<String>,
+        after: Option<balance::Cursor>,
         last: Option<u64>,
-        before: Option<String>,
-    ) -> Result<Option<Connection<String, Balance>>> {
-        ctx.data_unchecked::<PgManager>()
-            .fetch_balances(self.address, first, after, last, before)
+        before: Option<balance::Cursor>,
+    ) -> Result<Connection<String, Balance>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        Balance::paginate(ctx.data_unchecked(), page, self.address)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -81,9 +81,10 @@ type Address implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balance objects for this address.
+	The balances of all coin types owned by this address. Coins of the same type are grouped
+	together into one Balance.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for this address.
 	
@@ -196,7 +197,7 @@ type Balance {
 	"""
 	Coin type for the balance, such as 0x2::sui::SUI
 	"""
-	coinType: MoveType
+	coinType: MoveType!
 	"""
 	How many coins of this type constitute the balance
 	"""
@@ -1049,7 +1050,7 @@ interface IOwner {
 	address: SuiAddress!
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
 	balance(type: String): Balance
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
 	stakedSuis(first: Int, after: String, last: Int, before: String): StakedSuiConnection
 	defaultSuinsName: String
@@ -1699,10 +1700,10 @@ type Object implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balances of all coin types owned by the object. Coins of the same type are grouped
+	The balances of all coin types owned by this object. Coins of the same type are grouped
 	together into one Balance.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for this object.
 	
@@ -1952,9 +1953,9 @@ type Owner implements IOwner {
 	"""
 	balance(type: String): Balance
 	"""
-	The balances of all coin types owned by this Owner.
+	The balances of all coin types owned by this owner.
 	"""
-	balanceConnection(first: Int, after: String, last: Int, before: String): BalanceConnection
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
 	"""
 	The coin objects for the given address or object.
 	


### PR DESCRIPTION
## Description

Port paginated Balance queries to the new cursor/data/pagination framework. The earlier implementation asked whether it was even worth paginating balances, because we needed to compute all the balances up-front before we limit them. This is in fact not true, because we have an index on `coin_type`, so the database can avoid work by knowing that we only need to produce `N < COUNT(coin_type)` balances.

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- objects/coin.move
```

## Stack
- #15749 
- #15760 
- #15761 
- #15764
- #15777
- #15778
- #15779
- #15780
- #15781
