### PR TITLE
[mysten-service] 5/n add boilerplate instantiation from suiop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13680,6 +13680,7 @@ dependencies = [
  "colored",
  "docker-api",
  "field_names",
+ "include_dir",
  "inquire",
  "prettytable-rs",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,7 +277,7 @@ bimap = "0.6.2"
 bincode = "1.3.3"
 bip32 = "0.4.0"
 byteorder = "1.4.3"
-bytes = { version = "1.5.0", features = ["serde"] } 
+bytes = { version = "1.5.0", features = ["serde"] }
 cached = "0.43.0"
 camino = "1.1.1"
 cfg-if = "1.0.0"
@@ -665,6 +665,7 @@ docker-api = "0.12.2"
 field_names = "0.2.0"
 semver = "1.0.16"
 spinners = "4.1.0"
+include_dir = "0.7.3"
 
 
 # Using the workspace-hack via this patch directive means that it only applies

--- a/crates/mysten-service-boilerplate/Cargo-sui.toml
+++ b/crates/mysten-service-boilerplate/Cargo-sui.toml
@@ -1,0 +1,15 @@
+[package]
+name = "service-boilerplate"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+workspace.anyhow = true
+workspace.axum = true
+workspace.mysten-service = true
+workspace.prometheus = true
+workspace.serde = true
+workspace.tokio = true
+workspace.tracing = true

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { workspace = true, features = [
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 workspace-hack.workspace = true
+include_dir.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/suiop-cli/boilerplate
+++ b/crates/suiop-cli/boilerplate
@@ -1,0 +1,1 @@
+../mysten-service-boilerplate

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -3,6 +3,8 @@
 
 mod incidents;
 pub mod pulumi;
+mod service;
 
 pub use incidents::{incidents_cmd, IncidentsArgs};
 pub use pulumi::{pulumi_cmd, PulumiArgs};
+pub use service::{service_cmd, ServiceArgs};

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use clap::ValueEnum;
+use include_dir::{include_dir, Dir};
+use std::fs::create_dir_all;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+use tracing::info;
+
+// include the boilerplate code in this binary
+static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/boilerplate");
+
+#[derive(ValueEnum, Parser, Debug, Clone)]
+pub enum ServiceLanguage {
+    Rust,
+    Typescript,
+}
+
+pub fn bootstrap_service(lang: &ServiceLanguage, path: &Path) -> Result<()> {
+    match lang {
+        ServiceLanguage::Rust => create_rust_service(path),
+        ServiceLanguage::Typescript => todo!(),
+    }
+}
+
+fn create_rust_service(path: &Path) -> Result<()> {
+    info!("creating rust service in {}", path.to_string_lossy());
+    let cargo_toml_path = if path.to_string_lossy().contains("sui/crates") {
+        "Cargo-sui.toml"
+    } else {
+        "Cargo.toml"
+    };
+    let cargo_toml = PROJECT_DIR.get_file(cargo_toml_path).unwrap();
+    let main_rs = PROJECT_DIR.get_file("src/main.rs").unwrap();
+    let main_body = main_rs.contents();
+    let cargo_body = cargo_toml.contents();
+    create_dir_all(path.join("src"))?;
+    let mut main_file = File::create(path.join("src/main.rs"))?;
+    main_file.write_all(main_body)?;
+    let mut cargo_file = File::create(path.join("Cargo.toml"))?;
+    cargo_file.write_all(cargo_body)?;
+    Ok(())
+}

--- a/crates/suiop-cli/src/cli/service/mod.rs
+++ b/crates/suiop-cli/src/cli/service/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod init;
+
+use anyhow::Result;
+use clap::Parser;
+pub use init::bootstrap_service;
+use init::ServiceLanguage;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug, Clone)]
+pub struct ServiceArgs {
+    #[command(subcommand)]
+    action: ServiceAction,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum ServiceAction {
+    /// initialize new service boilerplate
+    #[command(name = "init", aliases=["i"])]
+    InitService {
+        /// service boilerplate language
+        #[arg(value_enum, short, long, default_value_t = ServiceLanguage::Rust)]
+        lang: ServiceLanguage,
+
+        /// directory to create service boilerplate in
+        #[arg(short, long)]
+        path: PathBuf,
+    },
+}
+
+pub async fn service_cmd(args: &ServiceArgs) -> Result<()> {
+    match &args.action {
+        ServiceAction::InitService { lang, path } => bootstrap_service(lang, path),
+    }
+}

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -3,7 +3,9 @@
 
 use anyhow::Result;
 use clap::Parser;
-use suioplib::cli::{incidents_cmd, pulumi_cmd, IncidentsArgs, PulumiArgs};
+use suioplib::cli::{
+    incidents_cmd, pulumi_cmd, service_cmd, IncidentsArgs, PulumiArgs, ServiceArgs,
+};
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
     FmtSubscriber,
@@ -23,6 +25,8 @@ pub(crate) enum Resource {
     Incidents(IncidentsArgs),
     #[clap(aliases = ["p"])]
     Pulumi(PulumiArgs),
+    #[clap(aliases = ["s", "svc"])]
+    Service(ServiceArgs),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -44,6 +48,9 @@ async fn main() -> Result<()> {
         }
         Resource::Pulumi(args) => {
             pulumi_cmd(&args).await?;
+        }
+        Resource::Service(args) => {
+            service_cmd(&args).await?;
         }
     }
 


### PR DESCRIPTION
## Description 

Duplicate of the work originally in https://github.com/MystenLabs/sui-operations/pull/3072/files

## Test Plan 

 ```
» cargo r -- s i --path ../my-service
    Finished dev [unoptimized + debuginfo] target(s) in 0.99s
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop s i --path ../my-service`
```

```
» tree ../my-service 
../my-service
├── Cargo.toml
└── src
    └── main.rs

```

Added to the main cargo.toml then

```

» cargo r 
    Updating crates.io index
   Compiling prometheus-closure-metric v0.1.0 (/Users/jkjensen/mysten/sui/crates/prometheus-closure-metric)
   Compiling telemetry-subscribers v0.2.0 (/Users/jkjensen/mysten/sui/crates/telemetry-subscribers)
   Compiling mysten-metrics v0.7.0 (/Users/jkjensen/mysten/sui/crates/mysten-metrics)
   Compiling mysten-service v0.0.1 (/Users/jkjensen/mysten/sui/crates/mysten-service)
   Compiling my-service v0.0.1 (/Users/jkjensen/mysten/sui/crates/my-service)
    Finished dev [unoptimized + debuginfo] target(s) in 7.73s
     Running `/Users/jkjensen/mysten/sui/target/debug/my-service`
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
