### PR TITLE
[data ingestion] perf tweaks

### DIFF
--- a/crates/sui-data-ingestion/src/executor.rs
+++ b/crates/sui-data-ingestion/src/executor.rs
@@ -16,7 +16,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
-pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 1000;
+pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 
 pub struct IndexerExecutor<P> {
     pools: Vec<Pin<Box<dyn Future<Output = ()> + Send>>>,


### PR DESCRIPTION
the PR includes the following changes:
* updated the task distribution method in the worker pool. Before, worker `i` used to process checkpoints with the `sequence number % number_of_workers = i`. We now track idle workers separately and assign new tasks to the first available one
* constructs the AWS ObjectStore with 0 retries (retries will be managed externally by the ingestion framework) and set an explicit timeout. The default timeout in the object store library is several minutes, and a single worker hanging during upload can sometimes paralyze overall progress
