### PR TITLE
change fullnode dev inspect interface to return raw txn data

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1607,7 +1607,7 @@ impl AuthorityState {
         gas_budget: Option<u64>,
         gas_sponsor: Option<SuiAddress>,
         gas_objects: Option<Vec<ObjectRef>>,
-        epoch: Option<u64>,
+        show_raw_txn_data: Option<bool>,
         skip_checks: Option<bool>,
     ) -> SuiResult<DevInspectResults> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
@@ -1623,6 +1623,8 @@ impl AuthorityState {
                 error: "system transactions are not supported".to_string(),
             });
         }
+
+        let show_raw_txn_data = show_raw_txn_data.unwrap_or(false);
         let skip_checks = skip_checks.unwrap_or(true);
         let reference_gas_price = epoch_store.reference_gas_price();
         let protocol_config = epoch_store.protocol_config();
@@ -1633,7 +1635,6 @@ impl AuthorityState {
         let owner = gas_sponsor.unwrap_or(sender);
         // Payment might be empty here, but it's fine we'll have to deal with it later after reading all the input objects.
         let payment = gas_objects.unwrap_or_default();
-        let expiration = epoch.map_or(TransactionExpiration::None, TransactionExpiration::Epoch);
         let transaction = TransactionData::V1(TransactionDataV1 {
             kind: transaction_kind.clone(),
             sender,
@@ -1643,8 +1644,16 @@ impl AuthorityState {
                 price,
                 budget,
             },
-            expiration,
+            expiration: TransactionExpiration::None,
         });
+
+        let raw_txn_data = if show_raw_txn_data {
+            bcs::to_bytes(&transaction).map_err(|_| SuiError::TransactionSerializationError {
+                error: "Failed to serialize transaction during dev inspect".to_string(),
+            })?
+        } else {
+            vec![]
+        };
 
         transaction.check_version_supported(protocol_config)?;
         transaction.validity_check_no_gas_check(protocol_config)?;
@@ -1773,6 +1782,7 @@ impl AuthorityState {
             effects,
             inner_temp_store.events.clone(),
             execution_result,
+            raw_txn_data,
             layout_resolver.as_mut(),
         )
     }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1050,6 +1050,8 @@ pub struct DevInspectArgs {
     pub gas_objects: Option<Vec<ObjectRef>>,
     /// Whether to skip transaction checks for the transaction.
     pub skip_checks: Option<bool>,
+    /// Whether to return the raw transaction data.
+    pub show_raw_txn_data: Option<bool>,
 }
 
 /// The response from processing a dev inspect transaction
@@ -1068,6 +1070,9 @@ pub struct DevInspectResults {
     /// Execution error from executing the transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// The raw transaction data that was dev inspected.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub raw_txn_data: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1092,6 +1097,7 @@ impl DevInspectResults {
         effects: TransactionEffects,
         events: TransactionEvents,
         return_values: Result<Vec<ExecutionResult>, ExecutionError>,
+        raw_txn_data: Vec<u8>,
         resolver: &mut dyn LayoutResolver,
     ) -> SuiResult<Self> {
         let tx_digest = *effects.transaction_digest();
@@ -1126,6 +1132,7 @@ impl DevInspectResults {
             events: SuiTransactionBlockEvents::try_from(events, tx_digest, None, resolver)?,
             results,
             error,
+            raw_txn_data,
         })
     }
 }

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -127,7 +127,7 @@ pub trait StateRead: Send + Sync {
         gas_budget: Option<u64>,
         gas_sponsor: Option<SuiAddress>,
         gas_objects: Option<Vec<ObjectRef>>,
-        epoch: Option<u64>,
+        show_raw_txn_data: Option<bool>,
         skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults>;
 
@@ -355,7 +355,7 @@ impl StateRead for AuthorityState {
         gas_budget: Option<u64>,
         gas_sponsor: Option<SuiAddress>,
         gas_objects: Option<Vec<ObjectRef>>,
-        epoch: Option<u64>,
+        show_raw_txn_data: Option<bool>,
         skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults> {
         Ok(self
@@ -366,7 +366,7 @@ impl StateRead for AuthorityState {
                 gas_budget,
                 gas_sponsor,
                 gas_objects,
-                epoch,
+                show_raw_txn_data,
                 skip_checks,
             )
             .await?)

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -293,7 +293,7 @@ impl WriteApiServer for TransactionExecutionApi {
         sender_address: SuiAddress,
         tx_bytes: Base64,
         gas_price: Option<BigInt<u64>>,
-        epoch: Option<BigInt<u64>>,
+        _epoch: Option<BigInt<u64>>,
         additional_args: Option<DevInspectArgs>,
     ) -> RpcResult<DevInspectResults> {
         with_tracing!(async move {
@@ -301,6 +301,7 @@ impl WriteApiServer for TransactionExecutionApi {
                 gas_sponsor,
                 gas_budget,
                 gas_objects,
+                show_raw_txn_data,
                 skip_checks,
             } = additional_args.unwrap_or_default();
             let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
@@ -312,7 +313,7 @@ impl WriteApiServer for TransactionExecutionApi {
                     gas_budget.map(|i| *i),
                     gas_sponsor,
                     gas_objects,
-                    epoch.map(|i| *i),
+                    show_raw_txn_data,
                     skip_checks,
                 )
                 .await

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5672,6 +5672,13 @@
               }
             ]
           },
+          "showRawTxnData": {
+            "description": "Whether to return the raw transaction data.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "skipChecks": {
             "description": "Whether to skip transaction checks for the transaction.",
             "type": [
@@ -5709,6 +5716,15 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Event"
+            }
+          },
+          "rawTxnData": {
+            "description": "The raw transaction data that was dev inspected.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
             }
           },
           "results": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -287,6 +287,7 @@ impl RpcExampleProvider {
             events: SuiTransactionBlockEvents { data: vec![] },
             results: None,
             error: None,
+            raw_txn_data: vec![],
         };
 
         Examples::new(


### PR DESCRIPTION
## Description 

This PR makes two changes:
- Added an option to dev inspect arguments to return the raw transaction data. This is needed to implement dry run from graphql side.
- In a previous PR #15679 , I started using the unused `epoch` parameter as transaction expiration epoch for dev inspect, which is apparently wrong. This `epoch` was supposed to be for running a txn in a previous epoch, which was never implemented. So this PR reverted that change and kept ignoring `epoch`.

## Test Plan 

Existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Added an option to return raw transaction data for dev inspect.
