### PR TITLE
indexer: separate objects snapshot processing

### DIFF
--- a/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
+++ b/crates/sui-indexer/migrations_v2/2023-08-19-044023_objects/up.sql
@@ -55,7 +55,7 @@ CREATE TABLE objects_history (
     df_name                     bytea,
     df_object_type              text,
     df_object_id                bytea,
-    CONSTRAINT objects_history_pk PRIMARY KEY (object_id, object_version, checkpoint_sequence_number)
+    CONSTRAINT objects_history_pk PRIMARY KEY (checkpoint_sequence_number, object_id, object_version)
 ) PARTITION BY RANGE (checkpoint_sequence_number);
 CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 -- TODO(gegaowp): add corresponding indices for consistent reads of objects_history table

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -149,7 +149,6 @@ async fn commit_checkpoints<S>(
             state.persist_packages(packages_batch),
             state.persist_objects(object_changes_batch.clone()),
             state.persist_object_history(object_history_changes_batch.clone()),
-            state.persist_object_snapshot(),
         ];
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));

--- a/crates/sui-indexer/src/indexer_v2.rs
+++ b/crates/sui-indexer/src/indexer_v2.rs
@@ -21,6 +21,7 @@ use tracing::info;
 
 use crate::framework::fetcher::CheckpointFetcher;
 use crate::handlers::checkpoint_handler_v2::new_handlers;
+use crate::processors_v2::objects_snapshot_processor::ObjectsSnapshotProcessor;
 use crate::processors_v2::processor_orchestrator_v2::ProcessorOrchestratorV2;
 use crate::store::{IndexerStoreV2, PgIndexerAnalyticalStore};
 
@@ -61,6 +62,10 @@ impl IndexerV2 {
             downloaded_checkpoint_data_sender,
         );
         spawn_monitored_task!(fetcher.run());
+
+        let objects_snapshot_processor =
+            ObjectsSnapshotProcessor::new(store.clone(), metrics.clone());
+        spawn_monitored_task!(objects_snapshot_processor.start());
 
         let checkpoint_handler = new_handlers(store, metrics, config).await?;
 

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -58,6 +58,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_objects: Histogram,
     pub checkpoint_db_commit_latency_objects_history: Histogram,
     pub checkpoint_db_commit_latency_objects_chunks: Histogram,
+    pub checkpoint_db_commit_latency_objects_history_chunks: Histogram,
     pub checkpoint_db_commit_latency_events: Histogram,
     pub checkpoint_db_commit_latency_events_chunks: Histogram,
     pub checkpoint_db_commit_latency_packages: Histogram,
@@ -67,6 +68,7 @@ pub struct IndexerMetrics {
     pub checkpoint_db_commit_latency_epoch: Histogram,
     pub advance_epoch_latency: Histogram,
     pub update_object_snapshot_latency: Histogram,
+    pub tokio_blocking_task_wait_latency: Histogram,
     // average latency of committing 1000 transactions.
     // 1000 is not necessarily the batch size, it's to roughly map average tx commit latency to [0.1, 1] seconds,
     // which is well covered by DB_COMMIT_LATENCY_SEC_BUCKETS.
@@ -335,6 +337,12 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            checkpoint_db_commit_latency_objects_history_chunks: register_histogram_with_registry!(
+                "checkpoint_db_commit_latency_objects_history_chunks",
+                "Time spent commiting objects history chunks",
+                DB_COMMIT_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
             checkpoint_db_commit_latency_events: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency_events",
                 "Time spent commiting events",
@@ -394,6 +402,12 @@ impl IndexerMetrics {
             update_object_snapshot_latency: register_histogram_with_registry!(
                 "update_object_snapshot_latency",
                 "Time spent in updating object snapshot",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            tokio_blocking_task_wait_latency: register_histogram_with_registry!(
+                "tokio_blocking_task_wait_latency",
+                "Time spent to wait for tokio blocking task pool",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -31,6 +31,7 @@ pub struct IndexerMetrics {
     pub latest_fullnode_checkpoint_sequence_number: IntGauge,
     pub latest_tx_checkpoint_sequence_number: IntGauge,
     pub latest_indexer_object_checkpoint_sequence_number: IntGauge,
+    pub latest_object_snapshot_sequence_number: IntGauge,
     // analytical
     pub latest_move_call_metrics_tx_seq: IntGauge,
     pub latest_address_metrics_tx_seq: IntGauge,
@@ -178,6 +179,11 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            latest_object_snapshot_sequence_number: register_int_gauge_with_registry!(
+                "latest_object_snapshot_sequence_number",
+                "Latest object snapshot sequence number from the Indexer",
+                registry,
+            ).unwrap(),
             latest_move_call_metrics_tx_seq: register_int_gauge_with_registry!(
                 "latest_move_call_metrics_tx_seq",
                 "Latest move call metrics tx seq",

--- a/crates/sui-indexer/src/processors_v2/mod.rs
+++ b/crates/sui-indexer/src/processors_v2/mod.rs
@@ -4,4 +4,5 @@
 pub mod address_metrics_processor;
 pub mod move_call_metrics_processor;
 pub mod network_metrics_processor;
+pub mod objects_snapshot_processor;
 pub mod processor_orchestrator_v2;

--- a/crates/sui-indexer/src/processors_v2/objects_snapshot_processor.rs
+++ b/crates/sui-indexer/src/processors_v2/objects_snapshot_processor.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use tracing::info;
+
+use crate::types_v2::IndexerResult;
+use crate::{metrics::IndexerMetrics, store::IndexerStoreV2};
+
+const OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG: usize = 900;
+const OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG: usize = 300;
+
+pub struct ObjectsSnapshotProcessor<S> {
+    pub store: S,
+    metrics: IndexerMetrics,
+    pub snapshot_min_lag: usize,
+    pub snapshot_max_lag: usize,
+}
+
+impl<S> ObjectsSnapshotProcessor<S>
+where
+    S: IndexerStoreV2 + Clone + Sync + Send + 'static,
+{
+    pub fn new(store: S, metrics: IndexerMetrics) -> ObjectsSnapshotProcessor<S> {
+        let snapshot_min_lag = std::env::var("OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG")
+            .map(|s| {
+                s.parse::<usize>()
+                    .unwrap_or(OBJECTS_SNAPSHOT_MIN_CHECKPOINT_LAG)
+            })
+            .unwrap_or(0);
+        let snapshot_max_lag = std::env::var("OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG")
+            .map(|s| {
+                s.parse::<usize>()
+                    .unwrap_or(OBJECTS_SNAPSHOT_MAX_CHECKPOINT_LAG)
+            })
+            .unwrap_or(0);
+        Self {
+            store,
+            metrics,
+            snapshot_min_lag,
+            snapshot_max_lag,
+        }
+    }
+
+    // The `objects_snapshot` table maintains a delayed snapshot of the `objects` table,
+    // controlled by `object_snapshot_max_checkpoint_lag` (max lag) and
+    // `object_snapshot_min_checkpoint_lag` (min lag). For instance, with a max lag of 900
+    // and a min lag of 300 checkpoints, the `objects_snapshot` table will lag behind the
+    // `objects` table by 300 to 900 checkpoints. The snapshot is updated when the lag
+    // exceeds the max lag threshold, and updates continue until the lag is reduced to
+    // the min lag threshold. Then, we have a consistent read range between
+    // `latest_snapshot_cp` and `latest_cp` based on `objects_snapshot` and `objects_history`,
+    // where the size of this range varies between the min and max lag values.
+    pub async fn start(&self) -> IndexerResult<()> {
+        info!("Starting object snapshot processor...");
+        let latest_snapshot_cp = self
+            .store
+            .get_latest_object_snapshot_checkpoint_sequence_number()
+            .await?
+            .unwrap_or_default();
+        // make sure cp 0 is handled
+        let mut start_cp = if latest_snapshot_cp == 0 {
+            0
+        } else {
+            latest_snapshot_cp + 1
+        };
+        // with MAX and MIN, the CSR range will vary from MIN cps to MAX cps
+        let snapshot_window = self.snapshot_max_lag as u64 - self.snapshot_min_lag as u64;
+        let mut latest_cp = self
+            .store
+            .get_latest_tx_checkpoint_sequence_number()
+            .await?
+            .unwrap_or_default();
+
+        loop {
+            while latest_cp <= start_cp + self.snapshot_max_lag as u64 {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                latest_cp = self
+                    .store
+                    .get_latest_tx_checkpoint_sequence_number()
+                    .await?
+                    .unwrap_or_default();
+            }
+            self.store
+                .persist_object_snapshot(start_cp, start_cp + snapshot_window)
+                .await?;
+            start_cp += snapshot_window;
+            self.metrics
+                .latest_object_snapshot_sequence_number
+                .set(start_cp as i64);
+        }
+    }
+}

--- a/crates/sui-indexer/src/schema_v2.rs
+++ b/crates/sui-indexer/src/schema_v2.rs
@@ -153,7 +153,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    objects_history (object_id, object_version, checkpoint_sequence_number) {
+    objects_history (checkpoint_sequence_number, object_id, object_version) {
         object_id -> Bytea,
         object_version -> Int8,
         object_status -> Int2,
@@ -173,7 +173,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    objects_history_partition_0 (object_id, object_version, checkpoint_sequence_number) {
+    objects_history_partition_0 (checkpoint_sequence_number, object_id, object_version) {
         object_id -> Bytea,
         object_version -> Int8,
         object_status -> Int2,

--- a/crates/sui-indexer/src/store/indexer_store_v2.rs
+++ b/crates/sui-indexer/src/store/indexer_store_v2.rs
@@ -47,7 +47,8 @@ pub trait IndexerStoreV2 {
         object_changes: Vec<TransactionObjectChangesToCommit>,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_object_snapshot(&self) -> Result<(), IndexerError>;
+    async fn persist_object_snapshot(&self, start_cp: u64, end_cp: u64)
+        -> Result<(), IndexerError>;
 
     async fn persist_checkpoints(
         &self,


### PR DESCRIPTION
## Description 

- separate objects snapshot from batch cp commit, b/c on some heavy checkpoints, one cp would take >30s, which slowed down other data ingestion a lot
```
Persisted snapshot for checkpoints from 7798404 to 7798405 elapsed=57.556287846000004
```
Also snapshot is meant to be behind, so no need to stay in sync either.

- also some logging misc.

## Test Plan 

local run to make sure that both ingestion and snapshot can proceed independently

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
