### PR TITLE
[gql] sql_query for consistent paginated object queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13797,6 +13797,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rocksdb",
+ "serde",
  "serde_json",
  "simulacrum",
  "sui-config",

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
@@ -103,14 +103,75 @@ gas summary: computation_cost: 1000000, storage_cost: 2485200,  storage_rebate: 
 task 8 'create-checkpoint'. lines 91-91:
 Checkpoint created: 2
 
-task 9 'run-graphql'. lines 93-116:
+task 9 'run-graphql'. lines 93-117:
 Response: {
   "data": {
-    "object": null
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveObject"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "bool"
+              },
+              "data": {
+                "Bool": false
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "u64"
+              },
+              "data": {
+                "Number": "0"
+              },
+              "bcs": "AAAAAAAAAAA="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          },
+          {
+            "name": {
+              "type": {
+                "repr": "vector<u8>"
+              },
+              "data": {
+                "Vector": []
+              },
+              "bcs": "AA=="
+            },
+            "value": {
+              "__typename": "MoveValue"
+            }
+          }
+        ]
+      }
+    }
   }
 }
 
-task 10 'run-graphql'. lines 118-143:
+task 10 'run-graphql'. lines 119-144:
 Response: {
   "data": {
     "owner": {
@@ -190,7 +251,7 @@ Response: {
   }
 }
 
-task 11 'run-graphql'. lines 145-165:
+task 11 'run-graphql'. lines 146-166:
 Response: {
   "data": {
     "owner": {
@@ -216,7 +277,7 @@ Response: {
   }
 }
 
-task 12 'run-graphql'. lines 167-178:
+task 12 'run-graphql'. lines 168-179:
 Response: {
   "data": {
     "owner": {

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -91,6 +91,7 @@ module Test::m {
 //# create-checkpoint
 
 //# run-graphql
+# Wrapped objects can now be viewed!
 {
   object(address: "@{obj_2_0}") {
     dynamicFields {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects.exp
@@ -1,0 +1,363 @@
+processed 19 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 6-23:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 25-25:
+created: object(2,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 27-27:
+created: object(3,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'create-checkpoint'. lines 29-29:
+Checkpoint created: 1
+
+task 5 'run-graphql'. lines 31-46:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x964986e511889b779fd982e23fd10671d0307eab2dbc7bfcab0509822eddffe7",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 6 'run'. lines 48-48:
+created: object(6,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'run'. lines 50-50:
+created: object(7,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'create-checkpoint'. lines 52-52:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 54-70:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 72-88:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 90-106:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x2e20433b1c867b6836cd76229df094d9b328c7aee83fa0da3257849081d5905e",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x410558e2e0608f10512dbce681da4bbb9421b4c8b89a4e20f2e7605df3df8d0e",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x964986e511889b779fd982e23fd10671d0307eab2dbc7bfcab0509822eddffe7",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 108-134:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x2e20433b1c867b6836cd76229df094d9b328c7aee83fa0da3257849081d5905e",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x410558e2e0608f10512dbce681da4bbb9421b4c8b89a4e20f2e7605df3df8d0e",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x964986e511889b779fd982e23fd10671d0307eab2dbc7bfcab0509822eddffe7",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'programmable'. lines 136-137:
+mutated: object(0,0), object(2,0), object(3,0), object(6,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 5206608, non_refundable_storage_fee: 52592
+
+task 14 'create-checkpoint'. lines 139-139:
+Checkpoint created: 3
+
+task 15 'run-graphql'. lines 141-157:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x410558e2e0608f10512dbce681da4bbb9421b4c8b89a4e20f2e7605df3df8d0e",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x964986e511889b779fd982e23fd10671d0307eab2dbc7bfcab0509822eddffe7",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 159-175:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 17 'run-graphql'. lines 177-203:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 18 'run-graphql'. lines 205-221:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x2e20433b1c867b6836cd76229df094d9b328c7aee83fa0da3257849081d5905e",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x410558e2e0608f10512dbce681da4bbb9421b4c8b89a4e20f2e7605df3df8d0e",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0x964986e511889b779fd982e23fd10671d0307eab2dbc7bfcab0509822eddffe7",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x2527295454532ba1451cc18e054585413393127281c56de07f9f0bf5b66c4959::M1::Object"
+              },
+              "json": {
+                "id": "0xaff3bdb6dbd73f5807e79a5fa60405005dc4c0f0902d67bac5772f71ccbf9021",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects.move
@@ -1,0 +1,221 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::create --args 1 @A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::create --args 2 @A
+
+//# run Test::M1::create --args 3 @A
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_2_0,1}
+# We should see one or no objects, depending on how the object_ids are ordered
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_0,1}
+# Thus we also make this query - if the previous query yielded no results, this should yield one
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# The query for live objects should show 4 objects
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Selecting objects at version should also yield results
+{
+  address(address: "@{A}") {
+    objects(
+      filter: {
+        type: "@{Test}",
+        objectKeys: [
+            {objectId: "@{obj_2_0}", version: 3},
+            {objectId: "@{obj_3_0}", version: 4},
+            {objectId: "@{obj_6_0}", version: 5},
+            {objectId: "@{obj_7_0}", version: 6}
+            ]
+      }
+    ) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_6_0,2}
+# We should still see objects at this cursor
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Should not have any objects on the live objects table
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This one should also yield no results, since there are more recent versions of the object at the checkpo
+{
+  address(address: "@{A}") {
+    objects(
+      filter: {
+        type: "@{Test}",
+        objectKeys: [
+            {objectId: "@{obj_2_0}", version: 3},
+            {objectId: "@{obj_3_0}", version: 4},
+            {objectId: "@{obj_6_0}", version: 5},
+            {objectId: "@{obj_7_0}", version: 6}
+            ]
+      }
+    ) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Should have all the objects
+{
+  address(address: "@{B}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
@@ -17,7 +17,7 @@ Response: {
     "suiCoins": {
       "edges": [
         {
-          "cursor": "IC/ODiKvEk37J2+SHdOXOh0tj3+kKyMTQRJIm4g7eZSB",
+          "cursor": "IC/ODiKvEk37J2+SHdOXOh0tj3+kKyMTQRJIm4g7eZSBAAAAAAAAAAA=",
           "node": {
             "coinBalance": "300000000000000",
             "contents": {
@@ -28,7 +28,7 @@ Response: {
           }
         },
         {
-          "cursor": "IIUF8I/vAPTSS4QFLI2mNoFN4DnGALfzAwuahN/pVrxb",
+          "cursor": "IIUF8I/vAPTSS4QFLI2mNoFN4DnGALfzAwuahN/pVrxbAQAAAAAAAAA=",
           "node": {
             "coinBalance": "299999983336400",
             "contents": {
@@ -39,7 +39,7 @@ Response: {
           }
         },
         {
-          "cursor": "IMuoUJrAqPQolyrJOQDQP8MtinwxMmIaikWg2Um7ZZSU",
+          "cursor": "IMuoUJrAqPQolyrJOQDQP8MtinwxMmIaikWg2Um7ZZSUAAAAAAAAAAA=",
           "node": {
             "coinBalance": "30000000000000000",
             "contents": {
@@ -54,7 +54,7 @@ Response: {
     "fakeCoins": {
       "edges": [
         {
-          "cursor": "IF1ymdLegVciBXLBI6Y6HdJ/5hQguKpAgAKnTCcgbvhv",
+          "cursor": "IF1ymdLegVciBXLBI6Y6HdJ/5hQguKpAgAKnTCcgbvhvAQAAAAAAAAA=",
           "node": {
             "coinBalance": "2",
             "contents": {
@@ -65,7 +65,7 @@ Response: {
           }
         },
         {
-          "cursor": "IIoI4sKegbEz05/HKKtUr5Jh5xsjZNdTBMhXLyAvY0x8",
+          "cursor": "IIoI4sKegbEz05/HKKtUr5Jh5xsjZNdTBMhXLyAvY0x8AQAAAAAAAAA=",
           "node": {
             "coinBalance": "1",
             "contents": {
@@ -76,7 +76,7 @@ Response: {
           }
         },
         {
-          "cursor": "IP3OtufdP1lIpko4Gdw3YAOc+hhMq2YIBWFuGKP3luxj",
+          "cursor": "IP3OtufdP1lIpko4Gdw3YAOc+hhMq2YIBWFuGKP3luxjAQAAAAAAAAA=",
           "node": {
             "coinBalance": "3",
             "contents": {
@@ -92,7 +92,7 @@ Response: {
       "coins": {
         "edges": [
           {
-            "cursor": "IIUF8I/vAPTSS4QFLI2mNoFN4DnGALfzAwuahN/pVrxb",
+            "cursor": "IIUF8I/vAPTSS4QFLI2mNoFN4DnGALfzAwuahN/pVrxbAQAAAAAAAAA=",
             "node": {
               "coinBalance": "299999983336400",
               "contents": {

--- a/crates/sui-graphql-e2e-tests/tests/objects/historical.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/historical.exp
@@ -20,7 +20,7 @@ task 4 'run-graphql'. lines 60-73:
 Response: {
   "data": {
     "object": {
-      "status": "LIVE",
+      "status": "HISTORICAL",
       "version": 3,
       "asMoveObject": {
         "contents": {
@@ -45,7 +45,7 @@ task 7 'run-graphql'. lines 79-92:
 Response: {
   "data": {
     "object": {
-      "status": "LIVE",
+      "status": "HISTORICAL",
       "version": 4,
       "asMoveObject": {
         "contents": {
@@ -89,7 +89,11 @@ Checkpoint created: 3
 task 11 'run-graphql'. lines 114-127:
 Response: {
   "data": {
-    "object": null
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 5,
+      "asMoveObject": null
+    }
   }
 }
 
@@ -142,7 +146,7 @@ task 16 'run-graphql'. lines 166-179:
 Response: {
   "data": {
     "object": {
-      "status": "LIVE",
+      "status": "HISTORICAL",
       "version": 6,
       "asMoveObject": {
         "contents": {
@@ -214,7 +218,11 @@ Checkpoint created: 5
 task 22 'run-graphql'. lines 233-246:
 Response: {
   "data": {
-    "object": null
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 7,
+      "asMoveObject": null
+    }
   }
 }
 

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -40,19 +40,19 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDf"
+            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDfAQAAAAAAAAA="
           },
           {
-            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7"
+            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7AQAAAAAAAAA="
           },
           {
-            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgO"
+            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgOAQAAAAAAAAA="
           },
           {
-            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+gAQAAAAAAAAA="
           },
           {
-            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxaAQAAAAAAAAA="
           }
         ]
       }
@@ -67,10 +67,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDf"
+            "cursor": "IBLJSG5F5wW4Wryd7g7OQBueP2ngKHGFyS5EIhDRpfDfAQAAAAAAAAA="
           },
           {
-            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7"
+            "cursor": "IFLKaoJAbzvBuEA2h1L4MRzPuADN27DTTbrQAwMaETl7AQAAAAAAAAA="
           }
         ]
       }
@@ -85,7 +85,7 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxaAQAAAAAAAAA="
           }
         ]
       }
@@ -100,10 +100,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgO"
+            "cursor": "IIlO2taSaWWLoaz0YB53RB7q7oSiM+/WIAakoaV1htgOAQAAAAAAAAA="
           },
           {
-            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+gAQAAAAAAAAA="
           }
         ]
       }
@@ -129,10 +129,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+g"
+            "cursor": "IOkuMCPNA1s5Y79FNHS17aQLjJlkwB6atsBFIu/bDV+gAQAAAAAAAAA="
           },
           {
-            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxa"
+            "cursor": "IPpaa9bSp0Chgp82cV8TpoBQkLrn9afyrGbXC2MQXnxaAQAAAAAAAAA="
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -58,13 +58,13 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_5_0}
 {
   address(address: "@{A}") {
     # select the 2nd and 3rd objects
     # note that order does not correspond
     # to order in which objects were created
-    objects(first: 2 after: "@{obj_5_0_cursor}") {
+    objects(first: 2 after: "@{cursor_0}") {
       edges {
         cursor
       }
@@ -72,11 +72,11 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_4_0,1}
 {
   address(address: "@{A}") {
     # select 4th and last object
-    objects(first: 2 after: "@{obj_4_0_cursor}") {
+    objects(first: 2 after: "@{cursor_0}") {
       edges {
         cursor
       }
@@ -84,11 +84,11 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_3_0,1}
 {
   address(address: "@{A}") {
     # select 3rd and 4th object
-    objects(last: 2 before: "@{obj_3_0_cursor}") {
+    objects(last: 2 before: "@{cursor_0}") {
       edges {
         cursor
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/snapshot.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/snapshot.exp
@@ -20,7 +20,7 @@ task 4 'run-graphql'. lines 43-56:
 Response: {
   "data": {
     "object": {
-      "status": "LIVE",
+      "status": "HISTORICAL",
       "version": 3,
       "asMoveObject": {
         "contents": {
@@ -70,14 +70,7 @@ Checkpoint created: 4
 task 13 'create-checkpoint'. lines 89-89:
 Checkpoint created: 5
 
-task 14 'run-graphql'. lines 91-105:
-Response: {
-  "data": {
-    "object": null
-  }
-}
-
-task 15 'run-graphql'. lines 108-123:
+task 14 'run-graphql'. lines 91-104:
 Response: {
   "data": {
     "object": {
@@ -88,7 +81,18 @@ Response: {
   }
 }
 
-task 16 'run-graphql'. lines 125-140:
+task 15 'run-graphql'. lines 107-122:
+Response: {
+  "data": {
+    "object": {
+      "status": "WRAPPED_OR_DELETED",
+      "version": 4,
+      "asMoveObject": null
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 124-139:
 Response: {
   "data": {
     "object": null

--- a/crates/sui-graphql-e2e-tests/tests/objects/snapshot.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/snapshot.move
@@ -89,7 +89,6 @@ module Test::M1 {
 //# create-checkpoint
 
 //# run-graphql
-# should not exist on live objects
 {
   object(
     address: "@{obj_2_0}"

--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
@@ -9,7 +9,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdM",
+          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdMAAAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -52,7 +52,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOu",
+          "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOuAQAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -62,7 +62,7 @@ Response: {
           }
         },
         {
-          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdM",
+          "cursor": "IGIUg8rFWqWwFn/Sv3WtoBagCn0xIsmfBiP0J7fl2CdMAAAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -72,7 +72,7 @@ Response: {
           }
         },
         {
-          "cursor": "IIHMnvkeALMPjTeJ/OOC5YxcRUCNj2lhNJxXlLo4Bhnu",
+          "cursor": "IIHMnvkeALMPjTeJ/OOC5YxcRUCNj2lhNJxXlLo4BhnuAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -87,7 +87,7 @@ Response: {
       "stakedSuis": {
         "edges": [
           {
-            "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOu",
+            "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOuAQAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/sui-graphql-rpc/src/data.rs
+++ b/crates/sui-graphql-rpc/src/data.rs
@@ -5,8 +5,13 @@ pub(crate) mod pg;
 
 use async_trait::async_trait;
 use diesel::{
-    query_builder::{BoxedSelectStatement, FromClause, QueryFragment, QueryId},
+    deserialize::FromSqlRow,
+    query_builder::{
+        BoxedSelectStatement, BoxedSqlQuery, FromClause, QueryFragment, QueryId, SqlQuery,
+    },
     query_dsl::{methods::LimitDsl, LoadQuery},
+    serialize::ToSql,
+    sql_types::{HasSqlType, Untyped},
     QueryResult,
 };
 
@@ -29,6 +34,14 @@ pub(crate) type DieselBackend = <Db as QueryExecutor>::Backend;
 /// These type parameters should usually be inferred by context.
 pub(crate) type Query<ST, QS, GB> =
     BoxedSelectStatement<'static, ST, FromClause<QS>, DieselBackend, GB>;
+
+pub(crate) type RawQuery = BoxedSqlQuery<'static, DieselBackend, SqlQuery>;
+
+pub(crate) struct RawQueryWrapper {
+    pub boxed: RawQuery,
+    pub has_where_clause: bool,
+    pub num_binds: u64,
+}
 
 /// Interface for accessing relational data written by the Indexer, agnostic of the database
 /// back-end being used.
@@ -83,6 +96,14 @@ pub(crate) trait DbConnection {
         Q: LoadQuery<'static, Self::Connection, U>,
         Q: QueryId + QueryFragment<Self::Backend>;
 
+    fn result_from_raw<U>(&mut self, query: impl Fn() -> RawQueryWrapper) -> QueryResult<U>
+    where
+        U: FromSqlRow<Untyped, Self::Backend> + 'static;
+
+    fn results_from_raw<U>(&mut self, query: impl Fn() -> RawQueryWrapper) -> QueryResult<Vec<U>>
+    where
+        U: FromSqlRow<Untyped, Self::Backend> + 'static;
+
     /// Helper to limit a query that fetches multiple values to return only its first value. `query`
     /// is a thunk that returns a query when called.
     fn first<Q: LimitDsl, U>(&mut self, query: impl Fn() -> Q) -> QueryResult<U>
@@ -92,5 +113,58 @@ pub(crate) trait DbConnection {
         <Q as LimitDsl>::Output: QueryId + QueryFragment<Self::Backend>,
     {
         self.result(move || query().limit(1i64))
+    }
+}
+
+impl RawQueryWrapper {
+    pub(crate) fn new(boxed: RawQuery) -> Self {
+        Self {
+            boxed,
+            has_where_clause: false,
+            num_binds: 0,
+        }
+    }
+
+    pub(crate) fn build_condition<T: AsRef<str>>(&mut self, condition: T) -> String {
+        let mut statement = match self.has_where_clause {
+            true => " AND (".to_string(),
+            false => {
+                self.has_where_clause = true;
+                " WHERE (".to_string()
+            }
+        };
+
+        statement += condition.as_ref();
+        statement += ")";
+
+        statement
+    }
+
+    pub(crate) fn get_bind_idx(&mut self) -> String {
+        // TODO (wlmyng): this is postgres-specific
+        self.num_binds += 1;
+        format!("${}", self.num_binds)
+    }
+
+    pub(crate) fn sql<T: AsRef<str>>(self, statement: T) -> Self {
+        let new_query = self.boxed.sql(statement);
+        Self {
+            boxed: new_query,
+            ..self
+        }
+    }
+
+    pub(crate) fn bind<BindSt, Value>(self, b: Value) -> Self
+    where
+        DieselBackend: HasSqlType<BindSt>,
+        Value: ToSql<BindSt, DieselBackend> + Send + 'static,
+        BindSt: Send + 'static,
+    {
+        let new_query = self.boxed.bind(b);
+
+        Self {
+            boxed: new_query,
+            ..self
+        }
     }
 }

--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -3,9 +3,11 @@
 
 use std::time::Instant;
 
-use super::QueryExecutor;
+use super::{QueryExecutor, RawQueryWrapper};
 use crate::{config::Limits, error::Error, metrics::Metrics};
 use async_trait::async_trait;
+use diesel::deserialize::FromSqlRow;
+use diesel::sql_types::Untyped;
 use diesel::{
     pg::Pg,
     query_builder::{Query, QueryFragment, QueryId},
@@ -112,6 +114,22 @@ impl<'c> super::DbConnection for PgConnection<'c> {
     {
         query_cost::log(self.conn, self.max_cost, query());
         query().get_results(self.conn)
+    }
+
+    fn result_from_raw<U>(&mut self, query: impl Fn() -> RawQueryWrapper) -> QueryResult<U>
+    where
+        U: FromSqlRow<Untyped, Self::Backend> + 'static,
+    {
+        query_cost::log(self.conn, self.max_cost, query().boxed);
+        query().boxed.get_result::<U>(self.conn)
+    }
+
+    fn results_from_raw<U>(&mut self, query: impl Fn() -> RawQueryWrapper) -> QueryResult<Vec<U>>
+    where
+        U: FromSqlRow<Untyped, Self::Backend> + 'static,
+    {
+        query_cost::log(self.conn, self.max_cost, query().boxed);
+        query().boxed.load::<U>(self.conn)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,20 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::cursor::{self, Page, Target};
+use super::cursor::{self, BoxedPaginated, Page, Target};
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
-use crate::data::{self, Db, DbConnection, QueryExecutor};
+use crate::data::{Db, DbConnection, DieselBackend, QueryExecutor, RawQueryWrapper};
 use crate::error::Error;
+use crate::types::object::Object;
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
-use diesel::NullableExpressionMethods;
+use diesel::{sql_query, CombineDsl};
 use diesel::{
-    dsl::sql,
     sql_types::{BigInt as SqlBigInt, Nullable, Text},
-    ExpressionMethods, OptionalExtension, QueryDsl,
+    ExpressionMethods, OptionalExtension, QueryDsl, QueryableByName,
 };
 use std::str::FromStr;
-use sui_indexer::{schema_v2::objects, types_v2::OwnerType};
+use sui_indexer::schema_v2::{checkpoints, objects_snapshot};
 use sui_types::{parse_sui_type_tag, TypeTag};
 
 /// The total balance for a particular coin type.
@@ -30,14 +30,17 @@ pub(crate) struct Balance {
 
 /// Representation of a row of balance information from the DB. We read the balance as a `String` to
 /// deal with the large (bigger than 2^63 - 1) balances.
-type StoredBalance = (
-    /* balance */ Option<String>,
-    /* count */ Option<i64>,
-    /* type */ String,
-);
+#[derive(QueryableByName)]
+pub struct StoredBalance {
+    #[diesel(sql_type = Nullable<Text>)]
+    pub balance: Option<String>,
+    #[diesel(sql_type = Nullable<SqlBigInt>)]
+    pub count: Option<i64>,
+    #[diesel(sql_type = Text)]
+    pub coin_type: String,
+}
 
 pub(crate) type Cursor = cursor::JsonCursor<String>;
-type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 
 impl Balance {
     /// Query for the balance of coins owned by `address`, of coins with type `coin_type`. Note that
@@ -46,28 +49,102 @@ impl Balance {
     pub(crate) async fn query(
         db: &Db,
         address: SuiAddress,
+        checkpoint_sequence_number: Option<u64>,
         coin_type: TypeTag,
     ) -> Result<Option<Balance>, Error> {
-        use objects::dsl;
+        use checkpoints::dsl as checkpoints;
+        use objects_snapshot::dsl as snapshot;
 
         let stored: Option<StoredBalance> = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    dsl::objects
-                        .select((
-                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
-                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
-                            dsl::coin_type.assume_not_null(),
-                        ))
-                        .filter(dsl::owner_id.eq(address.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
-                        .filter(
-                            dsl::coin_type
-                                .eq(coin_type.to_canonical_string(/* with_prefix */ true)),
-                        )
-                        .group_by(dsl::coin_type)
+            .execute_repeatable(move |conn| {
+                // If the checkpoint_sequence_number among cursor(s) and input is consistent, it
+                // still needs to be within the graphql's availableRange
+                let checkpoint_range: Vec<i64> = conn.results(move || {
+                    let rhs = checkpoints::checkpoints
+                        .select(checkpoints::sequence_number)
+                        .order(checkpoints::sequence_number.desc()).limit(1);
+
+                    let lhs = snapshot::objects_snapshot
+                        .select(snapshot::checkpoint_sequence_number)
+                        .order(snapshot::checkpoint_sequence_number.desc()).limit(1);
+
+                    lhs.union(rhs)
+                })?;
+
+                let (lhs, mut rhs) = match checkpoint_range.as_slice() {
+                    [] => (0, 0),
+                    [single_value] => (0, *single_value),
+                    values => {
+                        let min_value = *values.iter().min().unwrap();
+                        let max_value = *values.iter().max().unwrap();
+                        (min_value, max_value)
+                    }
+                };
+
+                if let Some(checkpoint_sequence_number) = checkpoint_sequence_number {
+                    // no-op as we've exceeded the upper bound of the available range
+                    if checkpoint_sequence_number > rhs as u64
+                    {
+                        return Ok::<_, diesel::result::Error>(None);
+                    }
+                    // Even if the input is less than the availble range, it may still be valid
+                    // since the chkpt may have come from an active object in the objects_snapshot
+                    // table. However, it will not yield a result on objects_history since the query
+                    // would be bounded by [lhs, rhs=C] where lhs > rhs = C
+                    rhs = checkpoint_sequence_number as i64;
+                }
+
+                conn.result_from_raw(move || {
+                    let top_level_select = sql_query(r#"
+                    SELECT CAST(SUM(candidates.coin_balance) AS TEXT) as balance, COUNT(*) as count, candidates.coin_type as coin_type FROM (
+                        SELECT DISTINCT ON (object_id) * FROM (
+                            SELECT * FROM objects_snapshot"#).into_boxed::<DieselBackend>();
+                    let mut helper = RawQueryWrapper::new(top_level_select);
+
+                    let bind_rhs = helper.get_bind_idx();
+                    let statement = helper.build_condition(format!(r#"checkpoint_sequence_number <= {}"#, bind_rhs));
+                    helper = helper.sql(statement)
+                        .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                    helper = Object::raw_coin_filter(helper, Some(coin_type.clone()), address);
+
+                    helper = helper.sql(r#"
+                    UNION
+                    SELECT * FROM objects_history"#);
+
+                    // history_query where clause -> WHERE (...)
+                    helper.has_where_clause = false; // reset where clause
+                    let bind_lhs = helper.get_bind_idx();
+                    let bind_rhs = helper.get_bind_idx();
+                    let statement = helper.build_condition(format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, bind_lhs, bind_rhs));
+                    helper = helper.sql(statement)
+                        .bind::<diesel::sql_types::BigInt, _>(lhs)
+                        .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                    helper = Object::raw_coin_filter(helper, Some(coin_type.clone()), address);
+
+                    let bind_lhs = helper.get_bind_idx();
+                    let bind_rhs = helper.get_bind_idx();
+
+                    helper = helper.sql(format!(r#"
+                        ) o
+                        ORDER BY object_id, object_version DESC) candidates
+                    LEFT JOIN (
+                        SELECT object_id, object_version
+                        FROM objects_history
+                        WHERE checkpoint_sequence_number BETWEEN {} AND {}
+                    ) newer
+                    ON ( candidates.object_id = newer.object_id AND candidates.object_version < newer.object_version )
+                    WHERE newer.object_version IS NULL
+                    GROUP BY candidates.coin_type;
+                    "#, bind_lhs, bind_rhs))
+                    .bind::<diesel::sql_types::BigInt, _>(lhs)
+                    .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                     helper
                 })
                 .optional()
+
             })
             .await?;
 
@@ -80,27 +157,110 @@ impl Balance {
         db: &Db,
         page: Page<Cursor>,
         address: SuiAddress,
+        checkpoint_sequence_number: Option<u64>,
     ) -> Result<Connection<String, Balance>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredBalance, _, _, _>(conn, move || {
-                    use objects::dsl;
-                    dsl::objects
-                        .select((
-                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
-                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
-                            dsl::coin_type.assume_not_null(),
-                        ))
-                        .filter(dsl::owner_id.eq(address.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
-                        .filter(dsl::coin_type.is_not_null())
-                        .group_by(dsl::coin_type)
-                        .into_boxed()
-                })
-            })
-            .await?;
+        use checkpoints::dsl as checkpoints;
+        use objects_snapshot::dsl as snapshot;
+        let response= db
+        .execute_repeatable(move |conn| {
+            // If the checkpoint_sequence_number among cursor(s) and input is consistent, it
+            // still needs to be within the graphql's availableRange
+            let checkpoint_range: Vec<i64> = conn.results(move || {
+                let rhs = checkpoints::checkpoints
+                    .select(checkpoints::sequence_number)
+                    .order(checkpoints::sequence_number.desc()).limit(1);
 
-        let mut conn = Connection::new(prev, next);
+                let lhs = snapshot::objects_snapshot
+                    .select(snapshot::checkpoint_sequence_number)
+                    .order(snapshot::checkpoint_sequence_number.desc()).limit(1);
+
+                lhs.union(rhs)
+            })?;
+
+            let (lhs, mut rhs) = match checkpoint_range.as_slice() {
+                [] => (0, 0),
+                [single_value] => (0, *single_value),
+                values => {
+                    let min_value = *values.iter().min().unwrap();
+                    let max_value = *values.iter().max().unwrap();
+                    (min_value, max_value)
+                }
+            };
+
+            if let Some(checkpoint_sequence_number) = checkpoint_sequence_number {
+                if checkpoint_sequence_number > rhs as u64
+                {
+                    return Ok::<_, diesel::result::Error>(None);
+                }
+                rhs = checkpoint_sequence_number as i64;
+            }
+
+            let result = page.paginate_raw_query::<StoredBalance, _>(conn,
+                move |element| element.map(|balance_struct| balance_struct.cursor()),
+                                move || {
+                let top_level_select = sql_query(r#"
+                SELECT CAST(SUM(candidates.coin_balance) AS TEXT) as balance, COUNT(*) as count, candidates.coin_type as coin_type FROM (
+                    SELECT DISTINCT ON (object_id) * FROM (
+                        SELECT * FROM objects_snapshot"#).into_boxed::<DieselBackend>();
+                let mut helper = RawQueryWrapper::new(top_level_select);
+
+                let bind_rhs = helper.get_bind_idx();
+                let statement = helper.build_condition(format!(r#"checkpoint_sequence_number <= {}"#, bind_rhs));
+                helper = helper.sql(statement)
+                    .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                helper = Object::raw_coin_filter(helper, None, address);
+
+                helper = helper.sql(r#"
+                UNION
+                SELECT * FROM objects_history"#);
+
+                // history_query where clause -> WHERE (...)
+                helper.has_where_clause = false; // reset where clause
+                let bind_lhs = helper.get_bind_idx();
+                let bind_rhs = helper.get_bind_idx();
+                let statement = helper.build_condition(format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, bind_lhs, bind_rhs));
+                helper = helper.sql(statement)
+                    .bind::<diesel::sql_types::BigInt, _>(lhs)
+                    .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                helper = Object::raw_coin_filter(helper, None, address);
+
+                let bind_lhs = helper.get_bind_idx();
+                let bind_rhs = helper.get_bind_idx();
+
+                helper = helper.sql(format!(r#"
+                    ) o
+                    ORDER BY object_id, object_version DESC
+                ) candidates
+                LEFT JOIN (
+                    SELECT object_id, object_version
+                    FROM objects_history
+                    WHERE checkpoint_sequence_number BETWEEN {} AND {}
+                ) newer
+                ON ( candidates.object_id = newer.object_id AND candidates.object_version < newer.object_version )
+                WHERE newer.object_version IS NULL
+                GROUP BY candidates.coin_type
+                "#, bind_lhs, bind_rhs))
+                .bind::<diesel::sql_types::BigInt, _>(lhs)
+                .bind::<diesel::sql_types::BigInt, _>(rhs);
+
+                 helper
+            })?;
+
+            Ok::<_, diesel::result::Error>(Some(result))
+
+        })
+        .await?;
+
+        let mut conn = Connection::new(false, false);
+
+        let Some((prev, next, results)) = response else {
+            return Ok(conn);
+        };
+
+        conn.has_previous_page = prev;
+        conn.has_next_page = next;
 
         for stored in results {
             let cursor = stored.cursor().encode_cursor();
@@ -112,35 +272,46 @@ impl Balance {
     }
 }
 
-impl Target<Cursor> for StoredBalance {
-    type Source = objects::table;
-
-    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::coin_type.ge((**cursor).clone()))
+impl BoxedPaginated<Cursor> for StoredBalance {
+    fn filter_ge(cursor: &Cursor, mut helper: RawQueryWrapper) -> RawQueryWrapper {
+        let bind_idx = helper.get_bind_idx();
+        let statement = helper.build_condition(format!("candidates.coin_type >= {}", bind_idx));
+        helper
+            .sql(statement)
+            .bind::<diesel::sql_types::Text, _>((**cursor).clone())
     }
 
-    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::coin_type.le((**cursor).clone()))
+    fn filter_le(cursor: &Cursor, mut helper: RawQueryWrapper) -> RawQueryWrapper {
+        let bind_idx = helper.get_bind_idx();
+        let statement = helper.build_condition(format!("candidates.coin_type <= {}", bind_idx));
+        helper
+            .sql(statement)
+            .bind::<diesel::sql_types::Text, _>((**cursor).clone())
     }
 
-    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
-        use objects::dsl;
-        if asc {
-            query.order_by(dsl::coin_type.asc())
-        } else {
-            query.order_by(dsl::coin_type.desc())
+    fn order(asc: bool, helper: RawQueryWrapper) -> RawQueryWrapper {
+        match asc {
+            true => helper.sql(" ORDER BY candidates.coin_type ASC"),
+            false => helper.sql(" ORDER BY candidates.coin_type DESC"),
         }
     }
+}
 
+impl Target<Cursor> for StoredBalance {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.2.clone())
+        Cursor::new(self.coin_type.clone())
     }
 }
 
 impl TryFrom<StoredBalance> for Balance {
     type Error = Error;
 
-    fn try_from((balance, count, coin_type): StoredBalance) -> Result<Self, Error> {
+    fn try_from(s: StoredBalance) -> Result<Self, Error> {
+        let StoredBalance {
+            balance,
+            count,
+            coin_type,
+        } = s;
         let total_balance = balance
             .map(|b| BigInt::from_str(&b))
             .transpose()

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -3,7 +3,7 @@
 
 use super::{
     base64::Base64,
-    cursor::{self, Page, Target},
+    cursor::{self, Page, Paginated, Target},
     date_time::DateTime,
     digest::Digest,
     epoch::Epoch,
@@ -231,7 +231,7 @@ impl Checkpoint {
     }
 }
 
-impl Target<Cursor> for StoredCheckpoint {
+impl Paginated<Cursor> for StoredCheckpoint {
     type Source = checkpoints::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -250,7 +250,9 @@ impl Target<Cursor> for StoredCheckpoint {
             query.order(dsl::sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredCheckpoint {
     fn cursor(&self) -> Cursor {
         Cursor::new(self.sequence_number as u64)
     }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -1,18 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::data::{Db, QueryExecutor};
+use crate::data::Db;
 use crate::error::Error;
 
 use super::balance::{self, Balance};
 use super::base64::Base64;
 use super::big_int::BigInt;
-use super::cursor::{Page, Target};
+use super::cursor::Page;
 use super::display::DisplayEntry;
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::{MoveObject, MoveObjectImpl};
 use super::move_value::MoveValue;
-use super::object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus};
+use super::object::{
+    self, Object, ObjectFilter, ObjectFilterWrapper, ObjectImpl, ObjectOwner, ObjectStatus,
+};
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
@@ -21,11 +23,7 @@ use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use async_graphql::*;
 
-use async_graphql::connection::{Connection, CursorType, Edge};
-use diesel::{ExpressionMethods, QueryDsl};
-use sui_indexer::models_v2::objects::StoredObject;
-use sui_indexer::schema_v2::objects;
-use sui_indexer::types_v2::OwnerType;
+use async_graphql::connection::Connection;
 use sui_types::coin::Coin as NativeCoin;
 use sui_types::TypeTag;
 
@@ -290,49 +288,32 @@ impl Coin {
         page: Page<object::Cursor>,
         coin_type: TypeTag,
         owner: Option<SuiAddress>,
+        checkpoint_sequence_number: Option<u64>,
     ) -> Result<Connection<String, Coin>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredObject, _, _, _>(conn, move || {
-                    use objects::dsl;
-                    let mut query = dsl::objects.into_boxed();
+        let filter = ObjectFilter {
+            owner,
+            ..Default::default()
+        };
 
-                    query = query.filter(
-                        dsl::coin_type.eq(coin_type.to_canonical_string(/* with_prefix */ true)),
-                    );
+        Object::paginate_subtype(
+            db,
+            page,
+            checkpoint_sequence_number,
+            ObjectFilterWrapper::Coin(filter, coin_type),
+            |object| {
+                let address = object.address;
+                let move_object = MoveObject::try_from(&object).map_err(|_| {
+                    Error::Internal(format!(
+                        "Expected {address} to be a Coin, but it's not a Move Object.",
+                    ))
+                })?;
 
-                    if let Some(owner) = &owner {
-                        // Leverage index on objects table
-                        query = query.filter(dsl::owner_type.eq(OwnerType::Address as i16));
-                        query = query.filter(dsl::owner_id.eq(owner.into_vec()));
-                    }
-
-                    query
+                Coin::try_from(&move_object).map_err(|_| {
+                    Error::Internal(format!("Expected {address} to be a Coin, but it is not."))
                 })
-            })
-            .await?;
-
-        let mut conn = Connection::new(prev, next);
-
-        for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            let object = Object::try_from(stored)?;
-
-            let move_ = MoveObject::try_from(&object).map_err(|_| {
-                Error::Internal(format!(
-                    "Failed to deserialize as Move object: {}",
-                    object.address
-                ))
-            })?;
-
-            let coin = Coin::try_from(&move_).map_err(|_| {
-                Error::Internal(format!("Faild to deserialize as Coin: {}", object.address))
-            })?;
-
-            conn.edges.push(Edge::new(cursor, coin));
-        }
-
-        Ok(conn)
+            },
+        )
+        .await
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -8,14 +8,15 @@ use async_graphql::{
     *,
 };
 use diesel::{
-    query_builder::QueryFragment, query_dsl::LoadQuery, QueryDsl, QueryResult, QuerySource,
+    deserialize::FromSqlRow, query_builder::QueryFragment, query_dsl::LoadQuery,
+    sql_types::Untyped, QueryDsl, QueryResult, QuerySource,
 };
 use fastcrypto::encoding::{Base64, Encoding};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     config::ServiceConfig,
-    data::{Conn, DbConnection, DieselBackend, DieselConn, Query},
+    data::{Conn, DbConnection, DieselBackend, DieselConn, Query, RawQueryWrapper},
     error::Error,
 };
 
@@ -53,7 +54,7 @@ enum End {
 }
 
 /// Results from the database that are pointed to by cursors.
-pub(crate) trait Target<C: CursorType> {
+pub(crate) trait Paginated<C: CursorType>: Target<C> {
     type Source: QuerySource;
 
     /// Adds a filter to `query` to bound its result to be greater than or equal to `cursor`
@@ -74,7 +75,17 @@ pub(crate) trait Target<C: CursorType> {
     /// (returning the new query). The `asc` parameter controls whether the ordering is ASCending
     /// (`true`) or descending (`false`).
     fn order<ST, GB>(asc: bool, query: Query<ST, Self::Source, GB>) -> Query<ST, Self::Source, GB>;
+}
 
+pub(crate) trait BoxedPaginated<C: CursorType>: Target<C> {
+    fn filter_ge(cursor: &C, helper: RawQueryWrapper) -> RawQueryWrapper;
+
+    fn filter_le(cursor: &C, helper: RawQueryWrapper) -> RawQueryWrapper;
+
+    fn order(asc: bool, helper: RawQueryWrapper) -> RawQueryWrapper;
+}
+
+pub(crate) trait Target<C: CursorType> {
     /// The cursor pointing at this target value.
     fn cursor(&self) -> C;
 }
@@ -194,10 +205,10 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         Q: Fn() -> Query<ST, T::Source, GB>,
         Query<ST, T::Source, GB>: LoadQuery<'static, DieselConn, T>,
         Query<ST, T::Source, GB>: QueryFragment<DieselBackend>,
-        <T as Target<C>>::Source: Send + 'static,
-        <<T as Target<C>>::Source as QuerySource>::FromClause: Send + 'static,
+        <T as Paginated<C>>::Source: Send + 'static,
+        <<T as Paginated<C>>::Source as QuerySource>::FromClause: Send + 'static,
         Q: Send + 'static,
-        T: Send + Target<C> + 'static,
+        T: Send + Paginated<C> + 'static,
         ST: Send + 'static,
         GB: Send + 'static,
     {
@@ -228,69 +239,122 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
             results
         };
 
-        // Detect whether the results imply the existence of a previous or next page.
-        let (prev, next, prefix, suffix) = match (
-            self.after(),
-            results.first(),
-            results.last(),
-            self.before(),
-            self.end,
-        ) {
-            // Results came back empty, despite supposedly including the `after` and `before`
-            // cursors, so the bounds must have been invalid, no matter which end the page was
-            // drawn from.
-            (_, None, _, _, _) | (_, _, None, _, _) => {
-                return Ok((false, false, vec![].into_iter()));
+        Ok(self.paginate_results(
+            results.first().map(|f| f.cursor()),
+            results.last().map(|l| l.cursor()),
+            results,
+        ))
+    }
+
+    pub(crate) fn paginate_raw_query<T, F>(
+        &self,
+        conn: &mut Conn<'_>,
+        cursor_fn: F,
+        query_fn: impl Fn() -> RawQueryWrapper,
+    ) -> QueryResult<(bool, bool, impl Iterator<Item = T>)>
+    where
+        T: Send + BoxedPaginated<C> + FromSqlRow<Untyped, DieselBackend> + 'static,
+        F: Fn(Option<&T>) -> Option<C>,
+    {
+        let new_query = move || {
+            let mut helper = query_fn();
+            if let Some(after) = self.after() {
+                helper = T::filter_ge(after, helper);
             }
 
-            // Page drawn from the front, and the cursor for the first element does not match
-            // `after`. This implies the bound was invalid, so we return an empty result.
-            (Some(a), Some(f), _, _, End::Front) if f.cursor() != *a => {
-                return Ok((false, false, vec![].into_iter()));
+            if let Some(before) = self.before() {
+                helper = T::filter_le(before, helper);
             }
 
-            // Similar to above case, but for back of results.
-            (_, _, Some(l), Some(b), End::Back) if l.cursor() != *b => {
-                return Ok((false, false, vec![].into_iter()));
-            }
+            helper = T::order(self.is_from_front(), helper);
 
-            // From here onwards, we know that the results are non-empty and if a cursor was
-            // supplied on the end the page is being drawn from, it was found in the results
-            // (implying a page follows in that direction).
-
-            // If both cursors are provided, and match both edges of the results, then we are in a
-            // special case where the limit, or the end of the page being drawn from do not matter,
-            // because the subsequence defined by the cursors is smaller than the limit.
-            (Some(a), Some(f), Some(l), Some(b), _) if f.cursor() == *a && l.cursor() == *b => {
-                (true, true, 1, 1)
-            }
-
-            // From here onwards, to detect whether there is a page on the other side than the page
-            // is being drawn from, it is enough to check the length of the results.
-            (after, _, _, _, End::Front) => {
-                let has_previous_page = after.is_some();
-                let prefix = has_previous_page as usize;
-                let suffix = results.len() - results.len().min(self.limit() + prefix);
-                let has_next_page = suffix > 0;
-
-                (has_previous_page, has_next_page, prefix, suffix)
-            }
-
-            (_, _, _, before, End::Back) => {
-                let has_next_page = before.is_some();
-                let suffix = has_next_page as usize;
-                let prefix = results.len() - results.len().min(self.limit() + suffix);
-                let has_previous_page = prefix > 0;
-
-                (has_previous_page, has_next_page, prefix, suffix)
-            }
+            helper = helper.sql(format!(" LIMIT {};", self.limit() as i64 + 2));
+            helper
         };
+
+        let results: Vec<T> = if self.limit() == 0 {
+            // Avoid the database roundtrip in the degenerate case.
+            vec![]
+        } else {
+            let mut results: Vec<T> = conn.results_from_raw(new_query)?;
+            if !self.is_from_front() {
+                results.reverse();
+            }
+            results
+        };
+
+        Ok(self.paginate_results(
+            cursor_fn(results.first()),
+            cursor_fn(results.last()),
+            results,
+        ))
+    }
+
+    pub(crate) fn paginate_results<T>(
+        &self,
+        f_cursor: Option<C>,
+        l_cursor: Option<C>,
+        results: Vec<T>,
+    ) -> (bool, bool, impl Iterator<Item = T>)
+    where
+        T: Send + 'static,
+    {
+        // Detect whether the results imply the existence of a previous or next page.
+        let (prev, next, prefix, suffix) =
+            match (self.after(), f_cursor, l_cursor, self.before(), self.end) {
+                // Results came back empty, despite supposedly including the `after` and `before`
+                // cursors, so the bounds must have been invalid, no matter which end the page was
+                // drawn from.
+                (_, None, _, _, _) | (_, _, None, _, _) => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // Page drawn from the front, and the cursor for the first element does not match
+                // `after`. This implies the bound was invalid, so we return an empty result.
+                (Some(a), Some(f), _, _, End::Front) if f != *a => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // Similar to above case, but for back of results.
+                (_, _, Some(l), Some(b), End::Back) if l != *b => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // From here onwards, we know that the results are non-empty and if a cursor was
+                // supplied on the end the page is being drawn from, it was found in the results
+                // (implying a page follows in that direction).
+
+                // If both cursors are provided, and match both edges of the results, then we are in a
+                // special case where the limit, or the end of the page being drawn from do not matter,
+                // because the subsequence defined by the cursors is smaller than the limit.
+                (Some(a), Some(f), Some(l), Some(b), _) if f == *a && l == *b => (true, true, 1, 1),
+
+                // From here onwards, to detect whether there is a page on the other side than the page
+                // is being drawn from, it is enough to check the length of the results.
+                (after, _, _, _, End::Front) => {
+                    let has_previous_page = after.is_some();
+                    let prefix = has_previous_page as usize;
+                    let suffix = results.len() - results.len().min(self.limit() + prefix);
+                    let has_next_page = suffix > 0;
+
+                    (has_previous_page, has_next_page, prefix, suffix)
+                }
+
+                (_, _, _, before, End::Back) => {
+                    let has_next_page = before.is_some();
+                    let suffix = has_next_page as usize;
+                    let prefix = results.len() - results.len().min(self.limit() + suffix);
+                    let has_previous_page = prefix > 0;
+
+                    (has_previous_page, has_next_page, prefix, suffix)
+                }
+            };
 
         // If after trimming, we're going to return no elements, then forget whether there's a
         // previous or next page, because there will be no start or end cursor for this page to
         // anchor on.
         if results.len() == prefix + suffix {
-            return Ok((false, false, vec![].into_iter()));
+            return (false, false, vec![].into_iter());
         }
 
         // We finally made it -- trim the prefix and suffix rows from the result and send it!
@@ -302,7 +366,7 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
             results.nth_back(suffix - 1);
         }
 
-        Ok((prev, next, results))
+        (prev, next, results)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -1,29 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::connection::{Connection, CursorType, Edge};
-use async_graphql::*;
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
-use move_core_types::annotated_value::{self as A, MoveStruct};
-use sui_indexer::models_v2::objects::StoredObject;
-use sui_indexer::schema_v2::objects;
-use sui_indexer::types_v2::OwnerType;
-use sui_package_resolver::Resolver;
-use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
-
-use super::cursor::{Page, Target};
-use super::object::{self, deserialize_move_struct, ObjectVersionKey};
+use super::cursor::Page;
+use super::object::{self, deserialize_move_struct, Object, ObjectFilterWrapper, ObjectVersionKey};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
 use crate::context_data::package_cache::PackageCache;
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::Db;
 use crate::error::Error;
-use sui_types::object::Object as NativeObject;
+use async_graphql::connection::Connection;
+use async_graphql::*;
+use move_core_types::annotated_value::{self as A, MoveStruct};
+use sui_package_resolver::Resolver;
+use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 pub(crate) struct DynamicField {
-    pub stored: StoredObject,
+    pub super_: MoveObject,
     pub df_object_id: SuiAddress,
     pub df_kind: DynamicFieldType,
 }
@@ -62,15 +56,7 @@ impl DynamicField {
             .data()
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
-        let native_object: NativeObject = bcs::from_bytes(&self.stored.serialized_object)
-            .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?;
-        let move_object = native_object
-            .data
-            .try_as_move()
-            .ok_or_else(|| Error::Internal("Failed to convert object into MoveObject".to_string()))
-            .extend()?;
-
-        let (struct_tag, move_struct) = deserialize_move_struct(move_object, resolver)
+        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
             .await
             .extend()?;
 
@@ -109,7 +95,7 @@ impl DynamicField {
             let obj = MoveObject::query(
                 ctx.data_unchecked(),
                 self.df_object_id,
-                ObjectVersionKey::Latest,
+                ObjectVersionKey::LatestAt(None),
             )
             .await
             .extend()?;
@@ -119,17 +105,7 @@ impl DynamicField {
                 .data()
                 .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
                 .extend()?;
-            let native_object: NativeObject = bcs::from_bytes(&self.stored.serialized_object)
-                .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?;
-            let move_object = native_object
-                .data
-                .try_as_move()
-                .ok_or_else(|| {
-                    Error::Internal("Failed to convert object into MoveObject".to_string())
-                })
-                .extend()?;
-
-            let (struct_tag, move_struct) = deserialize_move_struct(move_object, resolver)
+            let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
                 .await
                 .extend()?;
 
@@ -162,8 +138,6 @@ impl DynamicField {
         name: DynamicFieldName,
         kind: DynamicFieldType,
     ) -> Result<Option<DynamicField>, Error> {
-        use objects::dsl;
-
         let type_ = match kind {
             DynamicFieldType::DynamicField => name.type_.0,
             DynamicFieldType::DynamicObject => {
@@ -172,18 +146,27 @@ impl DynamicField {
         };
 
         let field_id = derive_dynamic_field_id(parent, &type_, &name.bcs.0)
-            .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?
-            .to_vec();
+            .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?;
 
-        let stored: Option<StoredObject> = db
-            .execute(move |conn| {
-                conn.first(move || dsl::objects.filter(dsl::object_id.eq(field_id.clone())))
-                    .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch object: {e}")))?;
+        let Some(super_) = MoveObject::query(
+            db,
+            SuiAddress::from(field_id),
+            ObjectVersionKey::LatestAt(None),
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
 
-        stored.map(Self::try_from).transpose()
+        let Some((df_object_id, df_kind)) = super_.super_.dynamic_field_info()? else {
+            return Ok(None);
+        };
+
+        Ok(Some(DynamicField {
+            super_,
+            df_object_id,
+            df_kind,
+        }))
     }
 
     /// Query the `db` for a `page` of dynamic fields attached to object with ID `parent`.
@@ -191,62 +174,33 @@ impl DynamicField {
         db: &Db,
         page: Page<object::Cursor>,
         parent: SuiAddress,
+        checkpoint_sequence_number: Option<u64>,
     ) -> Result<Connection<String, DynamicField>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredObject, _, _, _>(conn, move || {
-                    use objects::dsl;
-                    dsl::objects
-                        .filter(dsl::owner_id.eq(parent.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Object as i16))
-                        .filter(dsl::df_kind.is_not_null())
-                        .into_boxed()
+        Object::paginate_subtype(
+            db,
+            page,
+            checkpoint_sequence_number,
+            ObjectFilterWrapper::DynamicField(parent),
+            |object| {
+                let Some((df_object_id, df_kind)) = object.dynamic_field_info()? else {
+                    return Err(Error::Internal("Missing dynamic field info".to_string()));
+                };
+
+                let address = object.address;
+                let super_ = MoveObject::try_from(&object).map_err(|_| {
+                    Error::Internal(format!(
+                        "Expected {address} to be a Dynamic Field, but it's not a Move Object.",
+                    ))
+                })?;
+
+                Ok(DynamicField {
+                    super_,
+                    df_object_id,
+                    df_kind,
                 })
-            })
-            .await?;
-
-        let mut conn = Connection::new(prev, next);
-
-        for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            let field = DynamicField::try_from(stored)?;
-            conn.edges.push(Edge::new(cursor, field));
-        }
-
-        Ok(conn)
-    }
-}
-
-impl TryFrom<StoredObject> for DynamicField {
-    type Error = Error;
-
-    fn try_from(stored: StoredObject) -> Result<Self, Error> {
-        let Some(df_object_id) = stored.df_object_id.as_ref() else {
-            return Err(Error::Internal(
-                "Object is not a dynamic field.".to_string(),
-            ));
-        };
-
-        let df_object_id = SuiAddress::from_bytes(df_object_id).map_err(|e| {
-            Error::Internal(format!("Failed to deserialize dynamic field ID: {e}."))
-        })?;
-
-        let df_kind = match stored.df_kind {
-            Some(0) => DynamicFieldType::DynamicField,
-            Some(1) => DynamicFieldType::DynamicObject,
-            Some(k) => {
-                return Err(Error::Internal(format!(
-                    "Unrecognized dynamic field kind: {k}."
-                )))
-            }
-            None => return Err(Error::Internal("No dynamic field kind.".to_string())),
-        };
-
-        Ok(DynamicField {
-            stored,
-            df_object_id,
-            df_kind,
-        })
+            },
+        )
+        .await
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 
-use super::cursor::{self, Page, Target};
+use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
@@ -277,7 +277,7 @@ impl TryFrom<StoredEvent> for Event {
     }
 }
 
-impl Target<Cursor> for StoredEvent {
+impl Paginated<Cursor> for StoredEvent {
     type Source = events::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -308,7 +308,9 @@ impl Target<Cursor> for StoredEvent {
                 .then_order_by(dsl::event_sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredEvent {
     fn cursor(&self) -> Cursor {
         Cursor::new(EventKey {
             tx: self.tx_sequence_number as u64,

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -65,9 +65,14 @@ impl GasInput {
             ..Default::default()
         };
 
-        Object::paginate(ctx.data_unchecked(), page, filter)
-            .await
-            .extend()
+        Object::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            /* checkpoint_sequence_number */ None,
+        )
+        .await
+        .extend()
     }
 
     /// An unsigned integer specifying the number of native tokens per gas unit this transaction

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -38,7 +38,7 @@ impl MoveModule {
         MovePackage::query(
             ctx.data_unchecked(),
             self.storage_id,
-            ObjectVersionKey::Latest,
+            ObjectVersionKey::LatestAt(None),
         )
         .await
         .extend()?
@@ -87,7 +87,7 @@ impl MoveModule {
         let Some(package) = MovePackage::query(
             ctx.data_unchecked(),
             self.storage_id,
-            ObjectVersionKey::Latest,
+            ObjectVersionKey::LatestAt(None),
         )
         .await
         .extend()?
@@ -301,7 +301,9 @@ impl MoveModule {
         address: SuiAddress,
         name: &str,
     ) -> Result<Option<Self>, Error> {
-        let Some(package) = MovePackage::query(db, address, ObjectVersionKey::Latest).await? else {
+        let Some(package) =
+            MovePackage::query(db, address, ObjectVersionKey::LatestAt(None)).await?
+        else {
             return Ok(None);
         };
 

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -223,9 +223,13 @@ impl Owner {
 
     async fn as_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
         // TODO: Make consistent
-        Object::query(ctx.data_unchecked(), self.address, ObjectVersionKey::Latest)
-            .await
-            .extend()
+        Object::query(
+            ctx.data_unchecked(),
+            self.address,
+            ObjectVersionKey::LatestAt(None),
+        )
+        .await
+        .extend()
     }
 
     /// Access a dynamic field on an object using its name. Names are arbitrary Move values whose
@@ -297,9 +301,14 @@ impl OwnerImpl {
             return Ok(Connection::new(false, false));
         };
 
-        MoveObject::paginate(ctx.data_unchecked(), page, filter)
-            .await
-            .extend()
+        MoveObject::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            /* checkpoint_sequence_number */ None,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn balance(
@@ -308,7 +317,7 @@ impl OwnerImpl {
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Balance::query(ctx.data_unchecked(), self.0, coin)
+        Balance::query(ctx.data_unchecked(), self.0, None, coin)
             .await
             .extend()
     }
@@ -322,7 +331,7 @@ impl OwnerImpl {
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Balance::paginate(ctx.data_unchecked(), page, self.0)
+        Balance::paginate(ctx.data_unchecked(), page, self.0, None)
             .await
             .extend()
     }
@@ -338,7 +347,7 @@ impl OwnerImpl {
     ) -> Result<Connection<String, Coin>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Coin::paginate(ctx.data_unchecked(), page, coin, Some(self.0))
+        Coin::paginate(ctx.data_unchecked(), page, coin, Some(self.0), None)
             .await
             .extend()
     }
@@ -352,9 +361,14 @@ impl OwnerImpl {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        StakedSui::paginate(ctx.data_unchecked(), page, self.0)
-            .await
-            .extend()
+        StakedSui::paginate(
+            ctx.data_unchecked(),
+            page,
+            self.0,
+            /* checkpoint_sequence_number */ None,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
@@ -382,6 +396,7 @@ impl OwnerImpl {
             ctx.data_unchecked::<NameServiceConfig>(),
             page,
             self.0,
+            None,
         )
         .await
         .extend()
@@ -421,7 +436,7 @@ impl OwnerImpl {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        DynamicField::paginate(ctx.data_unchecked(), page, self.0)
+        DynamicField::paginate(ctx.data_unchecked(), page, self.0, None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -194,9 +194,13 @@ impl Query {
             )
             .await
             .extend(),
-            None => Object::query(ctx.data_unchecked(), address, ObjectVersionKey::Latest)
-                .await
-                .extend(),
+            None => Object::query(
+                ctx.data_unchecked(),
+                address,
+                ObjectVersionKey::LatestAt(None),
+            )
+            .await
+            .extend(),
         }
     }
 
@@ -258,9 +262,15 @@ impl Query {
     ) -> Result<Connection<String, Coin>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Coin::paginate(ctx.data_unchecked(), page, coin, /* owner */ None)
-            .await
-            .extend()
+        Coin::paginate(
+            ctx.data_unchecked(),
+            page,
+            coin,
+            /* owner */ None,
+            /* checkpoint_sequence_number */ None,
+        )
+        .await
+        .extend()
     }
 
     /// The checkpoints that exist in the network.
@@ -321,9 +331,14 @@ impl Query {
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, Object>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Object::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
-            .await
-            .extend()
+        Object::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter.unwrap_or_default(),
+            /* checkpoint_sequence_number */ None,
+        )
+        .await
+        .extend()
     }
 
     /// Fetch the protocol config by protocol version (defaults to the latest protocol

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -13,7 +13,10 @@ use super::{
     dynamic_field::{DynamicField, DynamicFieldName},
     move_object::{MoveObject, MoveObjectImpl},
     move_value::MoveValue,
-    object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus, ObjectVersionKey},
+    object::{
+        self, Object, ObjectFilter, ObjectFilterWrapper, ObjectImpl, ObjectOwner, ObjectStatus,
+        ObjectVersionKey,
+    },
     owner::OwnerImpl,
     stake::StakedSui,
     string_input::impl_string_input,
@@ -307,7 +310,7 @@ impl SuinsRegistration {
         let record_id = config.record_field_id(&domain.0);
 
         let Some(object) =
-            MoveObject::query(db, record_id.into(), ObjectVersionKey::Latest).await?
+            MoveObject::query(db, record_id.into(), ObjectVersionKey::LatestAt(None)).await?
         else {
             return Ok(None);
         };
@@ -329,8 +332,12 @@ impl SuinsRegistration {
     ) -> Result<Option<NativeDomain>, Error> {
         let reverse_record_id = config.reverse_record_field_id(address.as_slice());
 
-        let Some(object) =
-            MoveObject::query(db, reverse_record_id.into(), ObjectVersionKey::Latest).await?
+        let Some(object) = MoveObject::query(
+            db,
+            reverse_record_id.into(),
+            ObjectVersionKey::LatestAt(None),
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -351,6 +358,7 @@ impl SuinsRegistration {
         config: &NameServiceConfig,
         page: Page<object::Cursor>,
         owner: SuiAddress,
+        checkpoint_sequence_number: Option<u64>,
     ) -> Result<Connection<String, SuinsRegistration>, Error> {
         let type_ = SuinsRegistration::type_(config.package_address.into());
 
@@ -360,20 +368,26 @@ impl SuinsRegistration {
             ..Default::default()
         };
 
-        Object::paginate_subtype(db, page, filter, |object| {
-            let address = object.address;
-            let move_object = MoveObject::try_from(&object).map_err(|_| {
-                Error::Internal(format!(
-                    "Expected {address} to be a SuinsRegistration, but it's not a Move Object.",
-                ))
-            })?;
+        Object::paginate_subtype(
+            db,
+            page,
+            checkpoint_sequence_number,
+            ObjectFilterWrapper::Object(filter),
+            |object| {
+                let address = object.address;
+                let move_object = MoveObject::try_from(&object).map_err(|_| {
+                    Error::Internal(format!(
+                        "Expected {address} to be a SuinsRegistration, but it's not a Move Object.",
+                    ))
+                })?;
 
-            SuinsRegistration::try_from(&move_object, &type_).map_err(|_| {
-                Error::Internal(format!(
-                    "Expected {address} to be a SuinsRegistration, but it is not."
-                ))
-            })
-        })
+                SuinsRegistration::try_from(&move_object, &type_).map_err(|_| {
+                    Error::Internal(format!(
+                        "Expected {address} to be a SuinsRegistration, but it is not."
+                    ))
+                })
+            },
+        )
         .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -34,7 +34,7 @@ use crate::{
 use super::{
     address::Address,
     base64::Base64,
-    cursor::{self, Page, Target},
+    cursor::{self, Page, Paginated, Target},
     digest::Digest,
     epoch::Epoch,
     gas::GasInput,
@@ -397,7 +397,7 @@ impl TransactionBlockFilter {
     }
 }
 
-impl Target<Cursor> for StoredTransaction {
+impl Paginated<Cursor> for StoredTransaction {
     type Source = transactions::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -416,7 +416,9 @@ impl Target<Cursor> for StoredTransaction {
             query.order_by(dsl::tx_sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredTransaction {
     fn cursor(&self) -> Cursor {
         Cursor::new(self.tx_sequence_number as u64)
     }

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -90,7 +90,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.operation_cap_id(),
-            ObjectVersionKey::Latest,
+            ObjectVersionKey::LatestAt(None),
         )
         .await
         .extend()
@@ -102,7 +102,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.staking_pool_id(),
-            ObjectVersionKey::Latest,
+            ObjectVersionKey::LatestAt(None),
         )
         .await
         .extend()
@@ -114,7 +114,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.exchange_rates_id(),
-            ObjectVersionKey::Latest,
+            ObjectVersionKey::LatestAt(None),
         )
         .await
         .extend()

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -19,6 +19,7 @@ regex.workspace = true
 tempfile.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 fastcrypto.workspace = true

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -557,7 +557,8 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     .wait_for_objects_snapshot_catchup(Duration::from_secs(30))
                     .await;
 
-                let interpolated = self.interpolate_query(&contents, &cursors)?;
+                let interpolated =
+                    self.interpolate_query(&contents, &cursors, highest_checkpoint)?;
                 let resp = cluster
                     .graphql_client
                     .execute_to_graphql(interpolated.trim().to_owned(), show_usage, vec![], vec![])
@@ -1055,7 +1056,18 @@ impl<'a> SuiTestAdapter<'a> {
         self.executor
     }
 
-    fn named_variables(&self, cursors: &[String]) -> BTreeMap<String, String> {
+    fn named_variables(
+        &self,
+        cursors: &[String],
+        highest_checkpoint: u64,
+    ) -> BTreeMap<String, String> {
+        use serde::{Deserialize, Serialize};
+        #[derive(Serialize, Deserialize)]
+        struct HistoricalObjectCursor {
+            object_id: Vec<u8>,
+            checkpoint_sequence_number: u64,
+        }
+
         let mut variables = BTreeMap::new();
         let named_addrs = self
             .compiled_state
@@ -1063,27 +1075,28 @@ impl<'a> SuiTestAdapter<'a> {
             .iter()
             .map(|(name, addr)| (name.clone(), format!("{:#02x}", addr)));
 
+        let mut objects_mapping: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+
         let objects = self
             .object_enumeration
             .iter()
             .flat_map(|(oid, fid)| match fid {
                 FakeID::Known(_) => vec![],
-                FakeID::Enumerated(x, y) => vec![
-                    (format!("obj_{x}_{y}"), oid.to_string()),
-                    // Add a binding to treat this object as a cursor
-                    (
-                        format!("obj_{x}_{y}_cursor"),
-                        Base64::encode(bcs::to_bytes(&oid.to_vec()).unwrap_or_default()),
-                    ),
-                ],
+                FakeID::Enumerated(x, y) => {
+                    objects_mapping.insert(format!("obj_{x}_{y}"), oid.to_vec());
+
+                    vec![
+                        (format!("obj_{x}_{y}"), oid.to_string()),
+                        // Add a binding to treat this object as a cursor
+                        (
+                            format!("obj_{x}_{y}_cursor"),
+                            Base64::encode(bcs::to_bytes(&oid.to_vec()).unwrap_or_default()),
+                        ),
+                    ]
+                }
             });
 
-        let cursors = cursors
-            .iter()
-            .enumerate()
-            .map(|(idx, c)| (format!("cursor_{idx}"), Base64::encode(c)));
-
-        for (name, addr) in named_addrs.chain(objects).chain(cursors) {
+        for (name, addr) in named_addrs.chain(objects) {
             let addr = addr.to_string();
 
             // Required variant
@@ -1092,11 +1105,51 @@ impl<'a> SuiTestAdapter<'a> {
             let name = name.to_string() + "_opt";
             variables.insert(name.clone(), addr.clone());
         }
+
+        for (idx, s) in cursors.iter().enumerate() {
+            // an object cursor may be either @{obj_x_y} or @{obj_x_y,n}
+            // if the former, then use highest_checkpoint
+            if s.starts_with("@{obj_") && s.ends_with('}') {
+                let end_of_key = s.find(',').unwrap_or(s.len() - 1);
+                let obj_lookup = s[2..end_of_key].to_string();
+
+                let obj_id = objects_mapping.get(&obj_lookup).unwrap_or_else(|| {
+                    panic!(
+                        "Unknown object lookup: {}\nAllowed variable mappings are {:#?}",
+                        obj_lookup, variables
+                    )
+                });
+
+                let checkpoint = if end_of_key == s.len() - 1 {
+                    highest_checkpoint
+                } else {
+                    s[end_of_key + 1..s.len() - 1].parse::<u64>().unwrap()
+                };
+
+                let cursor = HistoricalObjectCursor {
+                    object_id: obj_id.clone(),
+                    checkpoint_sequence_number: checkpoint,
+                };
+
+                let bcsd = bcs::to_bytes(&cursor).unwrap_or_default();
+                let base64d = Base64::encode(bcsd);
+
+                variables.insert(format!("cursor_{idx}"), base64d);
+            } else {
+                variables.insert(format!("cursor_{idx}"), Base64::encode(s));
+            }
+        }
+
         variables
     }
 
-    fn interpolate_query(&self, contents: &str, cursors: &[String]) -> anyhow::Result<String> {
-        let variables = self.named_variables(cursors);
+    fn interpolate_query(
+        &self,
+        contents: &str,
+        cursors: &[String],
+        highest_checkpoint: u64,
+    ) -> anyhow::Result<String> {
+        let variables = self.named_variables(cursors, highest_checkpoint);
         let mut interpolated_query = contents.to_string();
 
         let re = regex::Regex::new(r"@\{([^\}]+)\}").unwrap();


### PR DESCRIPTION
## Description 

Introduce query against objects_snapshot and objects_history tables for consistent reads bounded by available range. The query applies the given set of filters on both the objects_snapshot and objects_history table and left joins against the objects_history table again to filter out any objects that matched the filtering criteria but have a more recent version bounded by the available range.

This query is not straightforward to implement in Diesel dsl, so introduce RawQueryWrapper that wraps diesel's BoxedSqlQuery with some helper fns, namely around incrementing binds across parts of a query.

With the exception of CoinMetadata and TreasuryCap, all objects will be read off the historical tables. This allows us to query fields off WrappedOrDeleted objects.



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
