### PR TITLE
[GraphQL/Upcast] IOwner.objects returns MoveObjects

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.exp
@@ -5,7 +5,7 @@ created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run-graphql'. lines 46-64:
+task 2 'run-graphql'. lines 46-66:
 Response: {
   "data": {
     "address": {
@@ -16,20 +16,20 @@ Response: {
   }
 }
 
-task 3 'run'. lines 66-66:
+task 3 'run'. lines 68-68:
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4 'view-object'. lines 68-68:
+task 4 'view-object'. lines 70-70:
 Owner: Account Address ( A )
 Version: 3
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,0)}}, value: 0u64}
 
-task 5 'create-checkpoint'. lines 70-70:
+task 5 'create-checkpoint'. lines 72-72:
 Checkpoint created: 1
 
-task 6 'run-graphql'. lines 72-90:
+task 6 'run-graphql'. lines 74-94:
 Response: {
   "data": {
     "address": {
@@ -37,10 +37,12 @@ Response: {
         "edges": [
           {
             "node": {
-              "owner": {
-                "__typename": "AddressOwner",
+              "asObject": {
                 "owner": {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  "__typename": "AddressOwner",
+                  "owner": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  }
                 }
               }
             }
@@ -51,7 +53,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 92-110:
+task 7 'run-graphql'. lines 96-116:
 Response: {
   "data": {
     "address": {
@@ -59,10 +61,12 @@ Response: {
         "edges": [
           {
             "node": {
-              "owner": {
-                "__typename": "AddressOwner",
+              "asObject": {
                 "owner": {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  "__typename": "AddressOwner",
+                  "owner": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  }
                 }
               }
             }
@@ -73,7 +77,7 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 112-130:
+task 8 'run-graphql'. lines 118-138:
 Response: {
   "data": {
     "address": {
@@ -84,7 +88,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 132-150:
+task 9 'run-graphql'. lines 140-160:
 Response: {
   "data": {
     "owner": {
@@ -92,10 +96,12 @@ Response: {
         "edges": [
           {
             "node": {
-              "owner": {
-                "__typename": "AddressOwner",
+              "asObject": {
                 "owner": {
-                  "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  "__typename": "AddressOwner",
+                  "owner": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000042"
+                  }
                 }
               }
             }
@@ -106,7 +112,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 152-170:
+task 10 'run-graphql'. lines 162-182:
 Response: {
   "data": {
     "object": null

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -49,11 +49,13 @@ module Test::M1 {
     objects {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+                __typename
+                ... on AddressOwner {
+                owner {
+                    address
+                }
               }
             }
           }
@@ -75,11 +77,13 @@ module Test::M1 {
     objects {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+              __typename
+              ... on AddressOwner {
+                owner {
+                  address
+                }
               }
             }
           }
@@ -95,11 +99,13 @@ module Test::M1 {
     objects(filter: {owner: "0x42"}) {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+                __typename
+                ... on AddressOwner {
+                owner {
+                    address
+                }
               }
             }
           }
@@ -115,11 +121,13 @@ module Test::M1 {
     objects(filter: {owner: "0x888"}) {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+                __typename
+                ... on AddressOwner {
+                owner {
+                    address
+                }
               }
             }
           }
@@ -135,11 +143,13 @@ module Test::M1 {
     objects {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+                __typename
+                ... on AddressOwner {
+                owner {
+                    address
+                }
               }
             }
           }
@@ -155,11 +165,13 @@ module Test::M1 {
     objects {
       edges {
         node {
-          owner {
-            __typename
-            ... on AddressOwner {
-              owner {
-                address
+          asObject {
+            owner {
+                __typename
+                ... on AddressOwner {
+                owner {
+                    address
+                }
               }
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -104,7 +104,7 @@ CheckpointSummary { epoch: 6, seq: 11, content_digest: D3oWLCcqoa1D15gxzvMaDemNN
 task 17 'advance-epoch'. lines 75-78:
 Epoch advanced: 6
 
-task 18 'run-graphql'. lines 80-95:
+task 18 'run-graphql'. lines 80-97:
 Response: {
   "data": {
     "address": {
@@ -112,10 +112,12 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0xa32a93f14493e55245984b369444cf47ecba1ea7d07d47ea12e24e9c138f8ebe",
-              "digest": "6XvjcDQkAXZ1GGfr4zHXu3E3xxMzg8fxarQ35UUVShhf",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0xa32a93f14493e55245984b369444cf47ecba1ea7d07d47ea12e24e9c138f8ebe",
+                "digest": "6XvjcDQkAXZ1GGfr4zHXu3E3xxMzg8fxarQ35UUVShhf",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           }
@@ -125,7 +127,7 @@ Response: {
   }
 }
 
-task 19 'run-graphql'. lines 97-152:
+task 19 'run-graphql'. lines 99-160:
 Response: {
   "data": {
     "address": {
@@ -138,10 +140,12 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0xa32a93f14493e55245984b369444cf47ecba1ea7d07d47ea12e24e9c138f8ebe",
-              "digest": "6XvjcDQkAXZ1GGfr4zHXu3E3xxMzg8fxarQ35UUVShhf",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0xa32a93f14493e55245984b369444cf47ecba1ea7d07d47ea12e24e9c138f8ebe",
+                "digest": "6XvjcDQkAXZ1GGfr4zHXu3E3xxMzg8fxarQ35UUVShhf",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           }
@@ -153,55 +157,67 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0x1e1139f952d75bf56e0a0a826e37dba541c8153c73ff74365123ff540381808f",
-              "digest": "DjRtgypRNspFeqoStwsJrq9DCLJh8PMs1Wmj4n13kSXj",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0x1e1139f952d75bf56e0a0a826e37dba541c8153c73ff74365123ff540381808f",
+                "digest": "DjRtgypRNspFeqoStwsJrq9DCLJh8PMs1Wmj4n13kSXj",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           },
           {
             "node": {
-              "address": "0x240476962fc4e20d8be733d7664a48697d3e6c62620649ee647458995dfa5480",
-              "digest": "Bir8CH5vVHLr6MY6EeJijANL3WUZ3KdDsXGMi5hgJD5m",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0x240476962fc4e20d8be733d7664a48697d3e6c62620649ee647458995dfa5480",
+                "digest": "Bir8CH5vVHLr6MY6EeJijANL3WUZ3KdDsXGMi5hgJD5m",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           },
           {
             "node": {
-              "address": "0x3d0bae92b4a225cad2580b9e23f27ddae8e1990f82f47fab62f05c9927699b73",
-              "digest": "833ydMhC3jXfrH7mZjBuTGbFNFqfvDm19j9vCBSWh5xG",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0x3d0bae92b4a225cad2580b9e23f27ddae8e1990f82f47fab62f05c9927699b73",
+                "digest": "833ydMhC3jXfrH7mZjBuTGbFNFqfvDm19j9vCBSWh5xG",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           },
           {
             "node": {
-              "address": "0x649aa4df7bcd7420ee73c34aff56b01e9fe07f1f6975c5d6d90b36afe271e7fa",
-              "digest": "HPNaS95Tnynhw9d3AZpjyafaBMH6J7NRnzYx6tQ7iiz3",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0x649aa4df7bcd7420ee73c34aff56b01e9fe07f1f6975c5d6d90b36afe271e7fa",
+                "digest": "HPNaS95Tnynhw9d3AZpjyafaBMH6J7NRnzYx6tQ7iiz3",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           },
           {
             "node": {
-              "address": "0xbe721dbf695e3e460c8578135108654b81e9b6cb6fe109df692518ed533e0263",
-              "digest": "7NDbogGsD1R9EUsTVaV5j4gqUNMi8Yb56KSn8QJRbfSn",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0xbe721dbf695e3e460c8578135108654b81e9b6cb6fe109df692518ed533e0263",
+                "digest": "7NDbogGsD1R9EUsTVaV5j4gqUNMi8Yb56KSn8QJRbfSn",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           },
           {
             "node": {
-              "address": "0xfeaa81cf669e0de385b8a1baa4f1b47b9abfefe04d972b60bb51b4d852f199e1",
-              "digest": "5uD5qjqHyoJEb2GvTwrndYuPBQJvihVa1P8fNHMo6MJm",
-              "owner": {
-                "__typename": "AddressOwner"
+              "asObject": {
+                "address": "0xfeaa81cf669e0de385b8a1baa4f1b47b9abfefe04d972b60bb51b4d852f199e1",
+                "digest": "5uD5qjqHyoJEb2GvTwrndYuPBQJvihVa1P8fNHMo6MJm",
+                "owner": {
+                  "__typename": "AddressOwner"
+                }
               }
             }
           }
@@ -220,7 +236,7 @@ Response: {
   }
 }
 
-task 20 'run-graphql'. lines 154-168:
+task 20 'run-graphql'. lines 162-176:
 Response: {
   "data": {
     "epoch": {
@@ -240,7 +256,7 @@ Response: {
   }
 }
 
-task 21 'run-graphql'. lines 170-176:
+task 21 'run-graphql'. lines 178-184:
 Response: {
   "data": {
     "epoch": {
@@ -249,17 +265,17 @@ Response: {
   }
 }
 
-task 22 'run'. lines 178-178:
+task 22 'run'. lines 186-186:
 created: object(22,0)
 mutated: object(0,1)
 gas summary: computation_cost: 999000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 23 'run'. lines 180-180:
+task 23 'run'. lines 188-188:
 created: object(23,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 182-182:
+task 24 'run'. lines 190-190:
 created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -83,10 +83,12 @@ module Test::M1 {
     objects {
       edges {
         node {
-          address
-          digest
-          owner {
-            __typename
+          asObject {
+            address
+            digest
+            owner {
+                __typename
+            }
           }
         }
       }
@@ -100,10 +102,12 @@ module Test::M1 {
     objects {
       edges {
         node {
-          address
-          digest
-          owner {
-            __typename
+          asObject {
+            address
+            digest
+            owner {
+                __typename
+            }
           }
         }
       }
@@ -113,10 +117,12 @@ module Test::M1 {
     objects {
       edges {
         node {
-          address
-          digest
-          owner {
-            __typename
+          asObject {
+            address
+            digest
+            owner {
+                __typename
+            }
           }
         }
       }
@@ -127,10 +133,12 @@ module Test::M1 {
     objects {
       edges {
         node {
-          address
-          digest
-          owner {
-            __typename
+          asObject {
+            address
+            digest
+            owner {
+                __typename
+            }
           }
         }
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.exp
@@ -33,30 +33,32 @@ task 7 'view-checkpoint'. lines 146-146:
 CheckpointSummary { epoch: 0, seq: 2, content_digest: AyLXQ2Wu8NyosPPTuTiafRXU5pQANwSGawiXj5HRRtFb,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, storage_cost: 27968000, storage_rebate: 3603996, non_refundable_storage_fee: 36404 }}
 
-task 8 'run-graphql'. lines 148-161:
+task 8 'run-graphql'. lines 148-163:
 Response: {
   "data": {
     "address": {
       "objects": {
         "nodes": [
           {
-            "display": [
-              {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
-              },
-              {
-                "key": "idd",
-                "value": null,
-                "error": "Field 'idd' not found"
-              },
-              {
-                "key": "namee",
-                "value": null,
-                "error": "Field 'namee' not found"
-              }
-            ]
+            "asObject": {
+              "display": [
+                {
+                  "key": "vectors",
+                  "value": null,
+                  "error": "Vector of name vec is not supported as a Display value"
+                },
+                {
+                  "key": "idd",
+                  "value": null,
+                  "error": "Field 'idd' not found"
+                },
+                {
+                  "key": "namee",
+                  "value": null,
+                  "error": "Field 'namee' not found"
+                }
+              ]
+            }
           }
         ]
       }
@@ -64,47 +66,49 @@ Response: {
   }
 }
 
-task 9 'run'. lines 163-163:
+task 9 'run'. lines 165-165:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [114, 217, 251, 191, 109, 185, 13, 48, 213, 233, 192, 59, 34, 196, 255, 174, 50, 222, 94, 241, 231, 252, 97, 68, 85, 134, 93, 244, 228, 232, 119, 246, 2, 0, 4, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 3032400,  storage_rebate: 2911788, non_refundable_storage_fee: 29412
 
-task 10 'create-checkpoint'. lines 165-165:
+task 10 'create-checkpoint'. lines 167-167:
 Checkpoint created: 3
 
-task 11 'view-checkpoint'. lines 167-167:
+task 11 'view-checkpoint'. lines 169-169:
 CheckpointSummary { epoch: 0, seq: 3, content_digest: 6SYbNxmXZoub3LDs7BH4JdXv42dcz4Ey9DG3pZzUbJV4,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, storage_cost: 31000400, storage_rebate: 6515784, non_refundable_storage_fee: 65816 }}
 
-task 12 'run-graphql'. lines 169-182:
+task 12 'run-graphql'. lines 171-186:
 Response: {
   "data": {
     "address": {
       "objects": {
         "nodes": [
           {
-            "display": [
-              {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
-              },
-              {
-                "key": "idd",
-                "value": null,
-                "error": "Field 'idd' not found"
-              },
-              {
-                "key": "namee",
-                "value": null,
-                "error": "Field 'namee' not found"
-              },
-              {
-                "key": "nums",
-                "value": "420",
-                "error": null
-              }
-            ]
+            "asObject": {
+              "display": [
+                {
+                  "key": "vectors",
+                  "value": null,
+                  "error": "Vector of name vec is not supported as a Display value"
+                },
+                {
+                  "key": "idd",
+                  "value": null,
+                  "error": "Field 'idd' not found"
+                },
+                {
+                  "key": "namee",
+                  "value": null,
+                  "error": "Field 'namee' not found"
+                },
+                {
+                  "key": "nums",
+                  "value": "420",
+                  "error": null
+                }
+              ]
+            }
           }
         ]
       }
@@ -112,102 +116,104 @@ Response: {
   }
 }
 
-task 13 'run'. lines 184-184:
+task 13 'run'. lines 188-188:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [114, 217, 251, 191, 109, 185, 13, 48, 213, 233, 192, 59, 34, 196, 255, 174, 50, 222, 94, 241, 231, 252, 97, 68, 85, 134, 93, 244, 228, 232, 119, 246, 3, 0, 15, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125, 5, 98, 111, 111, 108, 115, 7, 123, 98, 111, 111, 108, 115, 125, 5, 98, 117, 121, 101, 114, 7, 123, 98, 117, 121, 101, 114, 125, 4, 110, 97, 109, 101, 6, 123, 110, 97, 109, 101, 125, 7, 99, 114, 101, 97, 116, 111, 114, 9, 123, 99, 114, 101, 97, 116, 111, 114, 125, 5, 112, 114, 105, 99, 101, 7, 123, 112, 114, 105, 99, 101, 125, 11, 112, 114, 111, 106, 101, 99, 116, 95, 117, 114, 108, 58, 85, 110, 105, 113, 117, 101, 32, 66, 111, 97, 114, 32, 102, 114, 111, 109, 32, 116, 104, 101, 32, 66, 111, 97, 114, 115, 32, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 32, 119, 105, 116, 104, 32, 123, 110, 97, 109, 101, 125, 32, 97, 110, 100, 32, 123, 105, 100, 125, 8, 98, 97, 115, 101, 95, 117, 114, 108, 32, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 123, 105, 109, 103, 95, 117, 114, 108, 125, 11, 110, 111, 95, 116, 101, 109, 112, 108, 97, 116, 101, 23, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 3, 97, 103, 101, 21, 123, 109, 101, 116, 97, 100, 97, 116, 97, 46, 110, 101, 115, 116, 101, 100, 46, 97, 103, 101, 125, 8, 102, 117, 108, 108, 95, 117, 114, 108, 10, 123, 102, 117, 108, 108, 95, 117, 114, 108, 125, 13, 101, 115, 99, 97, 112, 101, 95, 115, 121, 110, 116, 97, 120, 8, 92, 123, 110, 97, 109, 101, 92, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5236400,  storage_rebate: 3002076, non_refundable_storage_fee: 30324
 
-task 14 'create-checkpoint'. lines 186-186:
+task 14 'create-checkpoint'. lines 190-190:
 Checkpoint created: 4
 
-task 15 'view-checkpoint'. lines 188-188:
+task 15 'view-checkpoint'. lines 192-192:
 CheckpointSummary { epoch: 0, seq: 4, content_digest: FKzpZ8kPHbKYxtmASaUcpULZdEMjYKe8pDshAVynqVCX,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, storage_cost: 36236800, storage_rebate: 9517860, non_refundable_storage_fee: 96140 }}
 
-task 16 'run-graphql'. lines 190-203:
+task 16 'run-graphql'. lines 194-209:
 Response: {
   "data": {
     "address": {
       "objects": {
         "nodes": [
           {
-            "display": [
-              {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
-              },
-              {
-                "key": "idd",
-                "value": null,
-                "error": "Field 'idd' not found"
-              },
-              {
-                "key": "namee",
-                "value": null,
-                "error": "Field 'namee' not found"
-              },
-              {
-                "key": "nums",
-                "value": "420",
-                "error": null
-              },
-              {
-                "key": "bools",
-                "value": "true",
-                "error": null
-              },
-              {
-                "key": "buyer",
-                "value": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e",
-                "error": null
-              },
-              {
-                "key": "name",
-                "value": "First Boar",
-                "error": null
-              },
-              {
-                "key": "creator",
-                "value": "Will",
-                "error": null
-              },
-              {
-                "key": "price",
-                "value": "",
-                "error": null
-              },
-              {
-                "key": "project_url",
-                "value": "Unique Boar from the Boars collection with First Boar and 0x73414a77fe9ef7c0b5d4c80e473f1143d4a83ac1402636fb19e2b846ddafd0e0",
-                "error": null
-              },
-              {
-                "key": "base_url",
-                "value": "https://get-a-boar.com/first.png",
-                "error": null
-              },
-              {
-                "key": "no_template",
-                "value": "https://get-a-boar.com/",
-                "error": null
-              },
-              {
-                "key": "age",
-                "value": "10",
-                "error": null
-              },
-              {
-                "key": "full_url",
-                "value": "https://get-a-boar.fullurl.com/",
-                "error": null
-              },
-              {
-                "key": "escape_syntax",
-                "value": "{name}",
-                "error": null
-              }
-            ]
+            "asObject": {
+              "display": [
+                {
+                  "key": "vectors",
+                  "value": null,
+                  "error": "Vector of name vec is not supported as a Display value"
+                },
+                {
+                  "key": "idd",
+                  "value": null,
+                  "error": "Field 'idd' not found"
+                },
+                {
+                  "key": "namee",
+                  "value": null,
+                  "error": "Field 'namee' not found"
+                },
+                {
+                  "key": "nums",
+                  "value": "420",
+                  "error": null
+                },
+                {
+                  "key": "bools",
+                  "value": "true",
+                  "error": null
+                },
+                {
+                  "key": "buyer",
+                  "value": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e",
+                  "error": null
+                },
+                {
+                  "key": "name",
+                  "value": "First Boar",
+                  "error": null
+                },
+                {
+                  "key": "creator",
+                  "value": "Will",
+                  "error": null
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "error": null
+                },
+                {
+                  "key": "project_url",
+                  "value": "Unique Boar from the Boars collection with First Boar and 0x73414a77fe9ef7c0b5d4c80e473f1143d4a83ac1402636fb19e2b846ddafd0e0",
+                  "error": null
+                },
+                {
+                  "key": "base_url",
+                  "value": "https://get-a-boar.com/first.png",
+                  "error": null
+                },
+                {
+                  "key": "no_template",
+                  "value": "https://get-a-boar.com/",
+                  "error": null
+                },
+                {
+                  "key": "age",
+                  "value": "10",
+                  "error": null
+                },
+                {
+                  "key": "full_url",
+                  "value": "https://get-a-boar.fullurl.com/",
+                  "error": null
+                },
+                {
+                  "key": "escape_syntax",
+                  "value": "{name}",
+                  "error": null
+                }
+              ]
+            }
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -150,10 +150,12 @@ module Test::boars {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
-        display {
-          key
-          value
-          error
+        asObject {
+            display {
+            key
+            value
+            error
+          }
         }
       }
     }
@@ -171,10 +173,12 @@ module Test::boars {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
-        display {
-          key
-          value
-          error
+        asObject {
+            display {
+            key
+            value
+            error
+          }
         }
       }
     }
@@ -192,10 +196,12 @@ module Test::boars {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}::boars::Boar"}) {
       nodes {
-        display {
-          key
-          value
-          error
+        asObject {
+            display {
+            key
+            value
+            error
+          }
         }
       }
     }

--- a/crates/sui-graphql-e2e-tests/tests/objects/received.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.exp
@@ -1,0 +1,35 @@
+processed 5 tasks
+
+task 1 'run-graphql'. lines 6-15:
+Response: {
+  "data": {
+    "object": {
+      "receivedTransactionBlocks": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 2 'publish'. lines 17-31:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6353600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 33-33:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 35-44:
+Response: {
+  "data": {
+    "object": {
+      "receivedTransactionBlocks": {
+        "nodes": [
+          {
+            "digest": "B7XWWojtQYLco5HTokGZNpeFQZso3F3ddoU9JYB5iR15"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/received.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 --simulator
+
+//# run-graphql
+{
+    object(address: "0x2") {
+        receivedTransactionBlocks {
+            nodes {
+                digest
+            }
+        }
+    }
+}
+
+//# publish
+module P0::m {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+
+    struct Obj has key {
+        id: UID
+    }
+
+    fun init(ctx: &mut TxContext) {
+        let obj = Obj { id: object::new(ctx) };
+        transfer::transfer(obj, @0x2)
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    object(address: "0x2") {
+        receivedTransactionBlocks {
+            nodes {
+                digest
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1718,6 +1718,10 @@ type Object implements IOwner {
 	"""
 	owner: ObjectOwner
 	"""
+	The transaction blocks that sent objects to this object.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection!
+	"""
 	Attempts to convert the object into a MoveObject
 	"""
 	asMoveObject: MoveObject

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -71,7 +71,7 @@ type Address implements IOwner {
 	"""
 	The objects that are owned by this address.
 	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	The balance that this address holds.
 	"""
@@ -1046,7 +1046,7 @@ type GenesisTransaction {
 
 interface IOwner {
 	address: SuiAddress!
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	balance(type: String): Balance
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
@@ -1393,6 +1393,35 @@ type MoveObject {
 	asSuinsRegistration: SuinsRegistration
 }
 
+type MoveObjectConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [MoveObjectEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveObject!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveObjectEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveObject!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 A MovePackage is a kind of Move object that represents code that has been published on chain.
 It exposes information about its modules, type definitions, functions, and dependencies.
@@ -1703,7 +1732,7 @@ type Object implements IOwner {
 	"""
 	The objects owned by this object
 	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	The balance of coin objects of a particular coin type owned by the object.
 	"""
@@ -1976,7 +2005,7 @@ type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	Total balance of all coins with marker type owned by this Owner. If type is not supplied,
 	it defaults to 0x2::sui::SUI.

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -15,16 +15,3 @@ mod mutation;
 pub mod server;
 pub mod test_infra;
 mod types;
-
-use async_graphql::*;
-use mutation::Mutation;
-use types::owner::IOwner;
-
-use crate::types::query::Query;
-
-pub fn schema_sdl_export() -> String {
-    let schema = Schema::build(Query, Mutation, EmptySubscription)
-        .register_output_type::<IOwner>()
-        .finish();
-    schema.sdl()
-}

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use sui_graphql_rpc::commands::Command;
 use sui_graphql_rpc::config::{ConnectionConfig, ServerConfig, ServiceConfig};
 use sui_graphql_rpc::config::{Ide, TxExecFullNodeConfig};
-use sui_graphql_rpc::schema_sdl_export;
+use sui_graphql_rpc::server::builder::export_schema;
 use sui_graphql_rpc::server::graphiql_server::{
     start_graphiql_server, start_graphiql_server_from_cfg_path,
 };
@@ -32,7 +32,7 @@ async fn main() {
             }
         }
         Command::GenerateSchema { file } => {
-            let out = schema_sdl_export();
+            let out = export_schema();
             if let Some(file) = file {
                 println!("Write schema to file: {:?}", file);
                 std::fs::write(file, &out).unwrap();

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -6,6 +6,7 @@ use crate::context_data::package_cache::DbPackageStore;
 use crate::data::Db;
 use crate::metrics::Metrics;
 use crate::mutation::Mutation;
+use crate::types::owner::IOwner;
 use crate::{
     config::ServerConfig,
     context_data::db_data_provider::PgManager,
@@ -70,7 +71,8 @@ impl ServerBuilder {
         Self {
             port,
             host,
-            schema: async_graphql::Schema::build(Query, Mutation, EmptySubscription),
+            schema: async_graphql::Schema::build(Query, Mutation, EmptySubscription)
+                .register_output_type::<IOwner>(),
             router: None,
             metrics,
         }
@@ -253,6 +255,16 @@ impl ServerBuilder {
 
         Ok(builder)
     }
+}
+
+fn schema_builder() -> SchemaBuilder<Query, Mutation, EmptySubscription> {
+    async_graphql::Schema::build(Query, Mutation, EmptySubscription)
+        .register_output_type::<IOwner>()
+}
+
+/// Return the string representation of the schema used by this server.
+pub fn export_schema() -> String {
+    schema_builder().finish().sdl()
 }
 
 async fn graphql_handler(

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -12,7 +12,8 @@ use super::{
     coin::Coin,
     cursor::Page,
     dynamic_field::{DynamicField, DynamicFieldName},
-    object::{self, Object, ObjectFilter},
+    move_object::MoveObject,
+    object::{self, ObjectFilter},
     stake::StakedSui,
     sui_address::SuiAddress,
     suins_registration::SuinsRegistration,
@@ -87,7 +88,7 @@ impl Address {
         last: Option<u64>,
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, MoveObject>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let Some(filter) = filter.unwrap_or_default().intersect(ObjectFilter {
@@ -97,7 +98,7 @@ impl Address {
             return Ok(Connection::new(false, false));
         };
 
-        Object::paginate(ctx.data_unchecked(), page, filter)
+        MoveObject::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -24,7 +24,6 @@ use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::gas_coin::GAS;
 use sui_types::TypeTag;
 
-use super::balance;
 use super::big_int::BigInt;
 use super::cursor::{self, Page, Target};
 use super::display::{get_rendered_fields, DisplayEntry};
@@ -32,7 +31,9 @@ use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::suins_registration::SuinsRegistration;
+use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
+use super::{balance, transaction_block};
 use super::{
     balance::Balance, coin::Coin, owner::Owner, stake::StakedSui, sui_address::SuiAddress,
     transaction_block::TransactionBlock,
@@ -312,6 +313,33 @@ impl Object {
                 initial_shared_version: initial_shared_version.value(),
             })),
         }
+    }
+
+    /// The transaction blocks that sent objects to this object.
+    async fn received_transaction_blocks(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<transaction_block::Cursor>,
+        last: Option<u64>,
+        before: Option<transaction_block::Cursor>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Connection<String, TransactionBlock>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+
+        let Some(filter) = filter
+            .unwrap_or_default()
+            .intersect(TransactionBlockFilter {
+                recv_address: Some(self.address),
+                ..Default::default()
+            })
+        else {
+            return Ok(Connection::new(false, false));
+        };
+
+        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
+            .await
+            .extend()
     }
 
     /// Attempts to convert the object into a MoveObject

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -340,7 +340,7 @@ impl Object {
         last: Option<u64>,
         before: Option<self::Cursor>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, MoveObject>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let Some(filter) = filter.unwrap_or_default().intersect(ObjectFilter {
@@ -350,7 +350,7 @@ impl Object {
             return Ok(Connection::new(false, false));
         };
 
-        Object::paginate(ctx.data_unchecked(), page, filter)
+        MoveObject::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -8,9 +8,10 @@ use super::dynamic_field::DynamicFieldName;
 use super::stake::StakedSui;
 use super::suins_registration::SuinsRegistration;
 use crate::data::Db;
-use crate::types::balance::{self, *};
-use crate::types::coin::*;
-use crate::types::object::{self, *};
+use crate::types::balance::{self, Balance};
+use crate::types::coin::Coin;
+use crate::types::move_object::MoveObject;
+use crate::types::object::{self, Object, ObjectFilter};
 use crate::types::sui_address::SuiAddress;
 use crate::types::type_filter::ExactTypeFilter;
 
@@ -25,7 +26,7 @@ use sui_types::gas_coin::GAS;
     field(name = "address", ty = "SuiAddress"),
     field(
         name = "objects",
-        ty = "Connection<String, Object>",
+        ty = "Connection<String, MoveObject>",
         arg(name = "first", ty = "Option<u64>"),
         arg(name = "after", ty = "Option<object::Cursor>"),
         arg(name = "last", ty = "Option<u64>"),
@@ -135,7 +136,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
-    ) -> Result<Connection<String, Object>> {
+    ) -> Result<Connection<String, MoveObject>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let Some(filter) = filter.unwrap_or_default().intersect(ObjectFilter {
@@ -145,7 +146,7 @@ impl Owner {
             return Ok(Connection::new(false, false));
         };
 
-        Object::paginate(ctx.data_unchecked(), page, filter)
+        MoveObject::paginate(ctx.data_unchecked(), page, filter)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/tests/snapshot_tests.rs
+++ b/crates/sui-graphql-rpc/tests/snapshot_tests.rs
@@ -4,10 +4,11 @@
 use insta::assert_snapshot;
 use std::fs::write;
 use std::path::PathBuf;
+use sui_graphql_rpc::server::builder::export_schema;
 
 #[test]
 fn test_schema_sdl_export() {
-    let sdl = sui_graphql_rpc::schema_sdl_export();
+    let sdl = export_schema();
 
     // update the current schema file
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -75,7 +75,7 @@ type Address implements IOwner {
 	"""
 	The objects that are owned by this address.
 	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	The balance that this address holds.
 	"""
@@ -1050,7 +1050,7 @@ type GenesisTransaction {
 
 interface IOwner {
 	address: SuiAddress!
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	balance(type: String): Balance
 	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
@@ -1397,6 +1397,35 @@ type MoveObject {
 	asSuinsRegistration: SuinsRegistration
 }
 
+type MoveObjectConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [MoveObjectEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveObject!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveObjectEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveObject!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 A MovePackage is a kind of Move object that represents code that has been published on chain.
 It exposes information about its modules, type definitions, functions, and dependencies.
@@ -1707,7 +1736,7 @@ type Object implements IOwner {
 	"""
 	The objects owned by this object
 	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	The balance of coin objects of a particular coin type owned by the object.
 	"""
@@ -1980,7 +2009,7 @@ type Owner implements IOwner {
 	asAddress: Address
 	asObject: Object
 	address: SuiAddress!
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): ObjectConnection!
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
 	"""
 	Total balance of all coins with marker type owned by this Owner. If type is not supplied,
 	it defaults to 0x2::sui::SUI.

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1722,6 +1722,10 @@ type Object implements IOwner {
 	"""
 	owner: ObjectOwner
 	"""
+	The transaction blocks that sent objects to this object.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection!
+	"""
 	Attempts to convert the object into a MoveObject
 	"""
 	asMoveObject: MoveObject


### PR DESCRIPTION
## Description

Part of the feedback to address from 1.5 -- return a `MoveObject` from te `objects` connection on owners, because it's impossible for an object that is owned by another object or an address to be a package.

At the moment, this makes certain queries more annoying (if you want to access fields on `Object` from this endpoint), but this inconvenience will disappear soon, when the explicit upcasts are replaced by interfaces (in a PR to come).

## Test Plan

Existing E2E and unit tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration
```