### PR TITLE
[consensus] Add base committer tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,11 +2628,11 @@ dependencies = [
  "serde",
  "sui-protocol-config",
  "tap",
+ "telemetry-subscribers",
  "tempfile",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-test",
  "typed-store",
  "workspace-hack",
 ]
@@ -14982,29 +14982,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
-dependencies = [
- "lazy_static",
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
-dependencies = [
- "lazy_static",
- "quote 1.0.33",
- "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-test",
  "typed-store",
  "workspace-hack",
 ]
@@ -14981,6 +14982,29 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+dependencies = [
+ "lazy_static",
+ "quote 1.0.33",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -184,7 +184,12 @@ impl AuthorityIndex {
 
 impl Display for AuthorityIndex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0.to_string().as_str())
+        if self.value() < 26 {
+            let c = (b'A' + self.value() as u8) as char;
+            f.write_str(c.to_string().as_str())
+        } else {
+            write!(f, "[{:02}]", self.value())
+        }
     }
 }
 

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -182,6 +182,7 @@ impl AuthorityIndex {
     }
 }
 
+// TODO: re-evaluate formats for production debugging.
 impl Display for AuthorityIndex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if self.value() < 26 {

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -32,3 +32,4 @@ workspace-hack.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 tempfile.workspace = true
+tracing-test = "0.2.4"

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -32,4 +32,4 @@ workspace-hack.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 tempfile.workspace = true
-tracing-test = "0.2.4"
+telemetry-subscribers.workspace = true

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -185,13 +185,13 @@ impl BlockRef {
 
 impl fmt::Display for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}({};{})", self.round, self.author, self.digest)
+        write!(f, "{}{}({})", self.author, self.round, self.digest)
     }
 }
 
 impl fmt::Debug for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}({};{:?})", self.round, self.author, self.digest)
+        write!(f, "{}{}({:?})", self.author, self.round, self.digest)
     }
 }
 
@@ -273,7 +273,7 @@ impl From<BlockRef> for Slot {
 
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({})", self.round, self.authority)
+        write!(f, "{}{}", self.authority, self.round,)
     }
 }
 
@@ -409,7 +409,7 @@ impl fmt::Debug for VerifiedBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{:?}({};{:?};{}v)",
+            "{:?}({}ms;{:?};{}v)",
             self.reference(),
             self.timestamp_ms(),
             self.ancestors(),

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -183,6 +183,7 @@ impl BlockRef {
     }
 }
 
+// TODO: re-evaluate formats for production debugging.
 impl fmt::Display for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}{}({})", self.author, self.round, self.digest)
@@ -271,6 +272,7 @@ impl From<BlockRef> for Slot {
     }
 }
 
+// TODO: re-evaluate formats for production debugging.
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}", self.authority, self.round,)
@@ -405,6 +407,7 @@ impl fmt::Display for VerifiedBlock {
     }
 }
 
+// TODO: re-evaluate formats for production debugging.
 impl fmt::Debug for VerifiedBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -45,9 +45,11 @@ impl Context {
         }
     }
 
+    /// Create a test context with an optional committee of given size and even stake
     #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        let (committee, _) = Committee::new_for_test(0, vec![1, 1, 1, 1]);
+    pub(crate) fn new_for_test(committee_size: Option<usize>) -> Self {
+        let size = committee_size.unwrap_or(4);
+        let (committee, _) = Committee::new_for_test(0, vec![1; size]);
         let metrics = test_metrics();
         Context::new(
             AuthorityIndex::new_for_test(0),

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -45,7 +45,7 @@ impl Context {
         }
     }
 
-    /// Create a test context with an optional committee of given size and even stake
+    /// Create a test context with a committee of optional given size and even stake
     #[cfg(test)]
     pub(crate) fn new_for_test(committee_size: Option<usize>) -> Self {
         let size = committee_size.unwrap_or(4);

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -47,9 +47,8 @@ impl Context {
 
     /// Create a test context with a committee of optional given size and even stake
     #[cfg(test)]
-    pub(crate) fn new_for_test(committee_size: Option<usize>) -> Self {
-        let size = committee_size.unwrap_or(4);
-        let (committee, _) = Committee::new_for_test(0, vec![1; size]);
+    pub(crate) fn new_for_test(committee_size: usize) -> Self {
+        let (committee, _) = Committee::new_for_test(0, vec![1; committee_size]);
         let metrics = test_metrics();
         Context::new(
             AuthorityIndex::new_for_test(0),

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -400,7 +400,7 @@ mod test {
 
     #[tokio::test]
     async fn test_core_propose_after_genesis() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(4));
         let block_manager = BlockManager::new();
         let (transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
         let transactions_consumer = TransactionsConsumer::new(tx_receiver);
@@ -469,7 +469,7 @@ mod test {
 
     #[tokio::test]
     async fn test_core_propose_once_receiving_a_quorum() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(4));
         let block_manager = BlockManager::new();
         let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
         let transactions_consumer = TransactionsConsumer::new(tx_receiver);

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -159,7 +159,7 @@ mod test {
 
     #[tokio::test]
     async fn test_core_thread() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let block_manager = BlockManager::new();
         let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
         let transactions_consumer = TransactionsConsumer::new(tx_receiver);

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -159,7 +159,7 @@ mod test {
 
     #[tokio::test]
     async fn test_core_thread() {
-        let context = Arc::new(Context::new_for_test(None));
+        let context = Arc::new(Context::new_for_test(4));
         let block_manager = BlockManager::new();
         let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
         let transactions_consumer = TransactionsConsumer::new(tx_receiver);

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -85,7 +85,7 @@ impl DagState {
         let block_ref = block.reference();
         // Ensure we don't write multiple unique blocks per slot for our own index
         if block_ref.author == self.context.own_index {
-            let existing_blocks = self.get_blocks_at_slot(Slot::from(block_ref));
+            let existing_blocks = self.get_uncommitted_blocks_at_slot(block_ref.into());
             if let Some(existing_block) = existing_blocks.first() {
                 assert!(
                     existing_block.reference() == block.reference(),
@@ -215,7 +215,7 @@ mod test {
 
     #[test]
     fn get_unncommitted_blocks() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
@@ -303,7 +303,7 @@ mod test {
     #[test]
     fn ancestors_at_uncommitted_round() {
         // Initialize DagState.
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -83,15 +83,15 @@ impl DagState {
     /// Accepts a block into DagState and keeps it in memory.
     pub(crate) fn accept_block(&mut self, block: VerifiedBlock) {
         let block_ref = block.reference();
-        // Ensure we don't write multiple blocks per slot for our own index
+        // Ensure we don't write multiple unique blocks per slot for our own index
         if block_ref.author == self.context.own_index {
             let existing_blocks = self.get_blocks_at_slot(Slot::from(block_ref));
-            if !existing_blocks.is_empty() {
-                // TODO: should we panic?
-                tracing::error!(
-                    "Block Rejected! Attempted to add block {block} to own slot where block(s) {existing_blocks:#?} already exists."
+            if let Some(existing_block) = existing_blocks.first() {
+                assert!(
+                    existing_block.reference() == block.reference(),
+                    "Block Rejected! Attempted to add block {block} to own slot where \
+                block(s) {existing_block} already exists."
                 );
-                return;
             }
         }
         self.recent_blocks.insert(block_ref, block);

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -218,6 +218,7 @@ mod test {
         let context = Arc::new(Context::new_for_test(None));
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
+        let own_index = AuthorityIndex::new_for_test(0);
 
         // Populate test blocks for round 1 ~ 10, authorities 0 ~ 2.
         let num_rounds: u32 = 10;
@@ -237,6 +238,11 @@ mod test {
                     );
                     dag_state.accept_block(block.clone());
                     blocks.insert(block.reference(), block);
+
+                    // Only write one block per slot for own index
+                    if AuthorityIndex::new_for_test(author) == own_index {
+                        break;
+                    }
                 }
             }
         }
@@ -267,7 +273,14 @@ mod test {
                         .unwrap(),
                 );
                 let blocks = dag_state.get_uncommitted_blocks_at_slot(slot);
-                assert_eq!(blocks.len(), num_blocks_per_slot);
+
+                // We only write one block per slot for own index
+                if AuthorityIndex::new_for_test(author) == own_index {
+                    assert_eq!(blocks.len(), 1);
+                } else {
+                    assert_eq!(blocks.len(), num_blocks_per_slot);
+                }
+
                 for b in blocks {
                     assert_eq!(b.round(), round);
                     assert_eq!(
@@ -288,7 +301,12 @@ mod test {
         // Check rounds with uncommitted blocks.
         for round in 1..=num_rounds {
             let blocks = dag_state.get_uncommitted_blocks_at_round(round);
-            assert_eq!(blocks.len(), num_authorities as usize * num_blocks_per_slot);
+            // Expect 3 blocks per authority except for own authority which should
+            // have 1 block.
+            assert_eq!(
+                blocks.len(),
+                (num_authorities - 1) as usize * num_blocks_per_slot + 1
+            );
             for b in blocks {
                 assert_eq!(b.round(), round);
             }
@@ -400,7 +418,7 @@ mod test {
         ];
         let round_13 = vec![
             VerifiedBlock::new_for_test(
-                TestBlock::new(12, 0)
+                TestBlock::new(12, 1)
                     .set_timestamp_ms(1300)
                     .set_ancestors(ancestors_for_round_13.clone())
                     .build(),

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -83,11 +83,30 @@ impl DagState {
     /// Accepts a block into DagState and keeps it in memory.
     pub(crate) fn accept_block(&mut self, block: VerifiedBlock) {
         let block_ref = block.reference();
+        // Ensure we don't write multiple blocks per slot for our own index
+        if block_ref.author == self.context.own_index {
+            let existing_blocks = self.get_blocks_at_slot(Slot::from(block_ref));
+            if !existing_blocks.is_empty() {
+                // TODO: should we panic?
+                tracing::error!(
+                    "Block Rejected! Attempted to add block {block} to own slot where block(s) {existing_blocks:#?} already exists."
+                );
+                return;
+            }
+        }
         self.recent_blocks.insert(block_ref, block);
         self.cached_refs[block_ref.author].insert(block_ref);
     }
 
-    /// Gets an uncommitted block. Returns None if not found.
+    /// Accepts a blocks into DagState and keeps it in memory.
+    #[cfg(test)]
+    pub(crate) fn accept_blocks(&mut self, blocks: Vec<VerifiedBlock>) {
+        for block in blocks {
+            self.accept_block(block);
+        }
+    }
+
+    /// Gets a copy of an uncommitted block. Returns None if not found.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
         self.recent_blocks.get(reference).cloned()

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -20,4 +20,4 @@ mod threshold_clock;
 mod transactions_client;
 
 #[cfg(test)]
-mod test_utils;
+mod test_dag;

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -18,3 +18,6 @@ mod stake_aggregator;
 mod storage;
 mod threshold_clock;
 mod transactions_client;
+
+#[cfg(test)]
+mod test_utils;

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// A common interface for consensus storage.
-pub(crate) trait Store {
+pub(crate) trait Store: Send + Sync {
     /// Writes blocks and consensus commits to store.
     fn write(&self, blocks: Vec<VerifiedBlock>, commits: Vec<Commit>) -> ConsensusResult<()>;
 

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -13,9 +13,9 @@ use crate::{
 };
 
 /// Build a fully interconnected dag up to the specified round. This function
-/// starts building the dag from the specified [`start`] references or from
-/// genesis if none are specified. The round [`stop``] references is not inclusive
-/// to account for the rounds being zero indexed.
+/// starts building the dag from the specified [`start`] parameter or from
+/// genesis if none are specified up to and including the specified round [`stop`]
+/// parameter.
 pub fn build_dag(
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
@@ -49,7 +49,7 @@ pub fn build_dag(
     };
 
     let starting_round = ancestors.first().unwrap().round + 1;
-    for round in starting_round..stop {
+    for round in starting_round..=stop {
         let (references, blocks): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -1,29 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
-use consensus_config::{AuthorityIndex, Committee, Parameters};
+use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
-use sui_protocol_config::ProtocolConfig;
 
 use crate::{
     block::{BlockRef, Round, TestBlock, VerifiedBlock},
     context::Context,
     dag_state::DagState,
-    metrics::test_metrics,
 };
-
-/// A helper function to create a test context with a committee of given size
-/// and even stake
-pub fn context_for_test(committee_size: usize) -> Arc<Context> {
-    let committee = Committee::new_for_test(0, vec![1; committee_size]).0;
-    let metrics = test_metrics();
-    Arc::new(Context::new(
-        AuthorityIndex::new_for_test(0),
-        committee,
-        Parameters::default(),
-        ProtocolConfig::get_for_min_version(),
-        metrics,
-    ))
-}
 
 /// Build a fully interconnected dag up to the specified round. This function
 /// starts building the dag from the specified [`start`] references or from

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -32,6 +32,7 @@ pub fn build_dag(
             start
         }
         None => {
+            // TODO: use dedicated method for creating genesis block
             let (references, genesis): (Vec<_>, Vec<_>) = context
                 .committee
                 .authorities()
@@ -71,6 +72,7 @@ pub fn build_dag(
     ancestors
 }
 
+// TODO: Add layer_round as input parameter so ancestors can be from any round.
 pub fn build_dag_layer(
     // A list of (authority, parents) pairs. For each authority, we add a block
     // linking to the specified parents.

--- a/consensus/core/src/test_utils.rs
+++ b/consensus/core/src/test_utils.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use consensus_config::{AuthorityIndex, Committee, Parameters};
+use parking_lot::RwLock;
+use sui_protocol_config::ProtocolConfig;
+
+use crate::{
+    block::{BlockRef, Round, TestBlock, VerifiedBlock},
+    context::Context,
+    dag_state::DagState,
+    metrics::test_metrics,
+};
+
+/// A helper function to create a test context with a committee of given size
+/// and even stake
+pub fn context_for_test(committee_size: usize) -> Arc<Context> {
+    let committee = Committee::new_for_test(0, vec![1; committee_size]).0;
+    let metrics = test_metrics();
+    Arc::new(Context::new(
+        AuthorityIndex::new_for_test(0),
+        committee,
+        Parameters::default(),
+        ProtocolConfig::get_for_min_version(),
+        metrics,
+    ))
+}
+
+/// Build a fully interconnected dag up to the specified round. This function
+/// starts building the dag from the specified [`start`] references or from
+/// genesis if none are specified. The round [`stop``] references is not inclusive
+/// to account for the rounds being zero indexed.
+pub fn build_dag(
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    start: Option<Vec<BlockRef>>,
+    stop: Round,
+) -> Vec<BlockRef> {
+    let mut ancestors = match start {
+        Some(start) => {
+            assert!(!start.is_empty());
+            assert_eq!(
+                start.iter().map(|x| x.round).max(),
+                start.iter().map(|x| x.round).min()
+            );
+            start
+        }
+        None => {
+            let (references, genesis): (Vec<_>, Vec<_>) = context
+                .committee
+                .authorities()
+                .map(|index| {
+                    let author_idx = index.0.value() as u32;
+                    let block = TestBlock::new(0, author_idx).build();
+                    VerifiedBlock::new_for_test(block)
+                })
+                .map(|block| (block.reference(), block))
+                .unzip();
+            dag_state.write().accept_blocks(genesis);
+
+            references
+        }
+    };
+
+    let starting_round = ancestors.first().unwrap().round + 1;
+    for round in starting_round..stop {
+        let (references, blocks): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|authority| {
+                let author_idx = authority.0.value() as u32;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author_idx)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+
+                (block.reference(), block)
+            })
+            .unzip();
+        dag_state.write().accept_blocks(blocks);
+        ancestors = references;
+    }
+
+    ancestors
+}
+
+pub fn build_dag_layer(
+    // A list of (authority, parents) pairs. For each authority, we add a block
+    // linking to the specified parents.
+    connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+    dag_state: Arc<RwLock<DagState>>,
+) -> Vec<BlockRef> {
+    let mut references = Vec::new();
+    for (authority, ancestors) in connections {
+        let round = ancestors.first().unwrap().round + 1;
+        let author = authority.value() as u32;
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(round, author)
+                .set_ancestors(ancestors)
+                .build(),
+        );
+        references.push(block.reference());
+        dag_state.write().accept_block(block);
+    }
+    references
+}

--- a/consensus/core/src/tests/base_committer_tests.rs
+++ b/consensus/core/src/tests/base_committer_tests.rs
@@ -7,9 +7,10 @@ use crate::{
     base_committer::base_committer_builder::BaseCommitterBuilder,
     block::{BlockAPI, TestBlock, VerifiedBlock},
     commit::{LeaderStatus, DEFAULT_WAVE_LENGTH},
+    context::Context,
     dag_state::DagState,
     storage::mem_store::MemStore,
-    test_utils::{build_dag, build_dag_layer, context_for_test},
+    test_dag::{build_dag, build_dag_layer},
 };
 use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
@@ -19,7 +20,7 @@ use parking_lot::RwLock;
 #[tracing_test::traced_test]
 fn try_direct_commit() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -71,7 +72,7 @@ fn try_direct_commit() {
 #[tracing_test::traced_test]
 fn idempotence() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -113,7 +114,7 @@ fn idempotence() {
 #[tracing_test::traced_test]
 fn multiple_direct_commit() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -154,7 +155,7 @@ fn multiple_direct_commit() {
 #[tracing_test::traced_test]
 fn direct_skip() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -207,7 +208,7 @@ fn direct_skip() {
 #[tracing_test::traced_test]
 fn indirect_commit() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -351,7 +352,7 @@ fn indirect_commit() {
 #[tracing_test::traced_test]
 fn indirect_skip() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -484,7 +485,7 @@ fn indirect_skip() {
 #[tracing_test::traced_test]
 fn undecided() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -567,7 +568,7 @@ fn undecided() {
 #[tracing_test::traced_test]
 fn test_byzantine_validator() {
     // Commitee of 4 with even stake
-    let context = context_for_test(4);
+    let context = Arc::new(Context::new_for_test(Some(4)));
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),

--- a/consensus/core/src/tests/base_committer_tests.rs
+++ b/consensus/core/src/tests/base_committer_tests.rs
@@ -1,0 +1,743 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use crate::{
+    base_committer::base_committer_builder::BaseCommitterBuilder,
+    block::{BlockAPI, TestBlock, VerifiedBlock},
+    commit::{LeaderStatus, DEFAULT_WAVE_LENGTH},
+    dag_state::DagState,
+    storage::mem_store::MemStore,
+    test_utils::{build_dag, build_dag_layer, context_for_test},
+};
+use consensus_config::AuthorityIndex;
+use parking_lot::RwLock;
+
+/// Commit one leader.  
+#[test]
+#[tracing_test::traced_test]
+fn try_direct_commit() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Build fully connected dag with empty blocks. Adding 8 rounds to the dag
+    // so that we have 2 completed waves and one incomplete wave.
+    let num_rounds_in_dag = 8;
+    let wave_length = DEFAULT_WAVE_LENGTH;
+    let incomplete_wave_leader_round = 6;
+    build_dag(context, dag_state, None, num_rounds_in_dag);
+
+    // Leader rounds are the first rounds of each wave. In this case rounds 0, 3 & 6.
+    let leader_rounds = (0..num_rounds_in_dag)
+        .step_by(wave_length as usize)
+        .collect::<Vec<u32>>();
+
+    // Iterate from highest leader round first
+    for round in leader_rounds.into_iter().rev() {
+        let leader = committer
+            .elect_leader(round)
+            .expect("should have elected leader");
+        tracing::info!("Try direct commit for leader {leader}",);
+        let leader_status = committer.try_direct_decide(leader);
+        tracing::info!("Leader commit status: {leader_status}");
+
+        if round < incomplete_wave_leader_round {
+            if let LeaderStatus::Commit(ref committed_block) = leader_status {
+                assert_eq!(committed_block.author(), leader.authority)
+            } else {
+                panic!("Expected a committed leader")
+            };
+        } else {
+            // The base committer should mark the potential leader in r6 as undecided
+            // as there is no way to get enough certificates because we did not build
+            // the dag layer for the decision round of wave 3.
+            if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+                assert_eq!(undecided_slot, leader)
+            } else {
+                panic!("Expected an undecided leader")
+            };
+        }
+    }
+}
+
+/// Ensure idempotent replies.
+#[test]
+#[tracing_test::traced_test]
+fn idempotence() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Build fully connected dag with empty blocks. Adding 5 rounds to the dag.
+    build_dag(context, dag_state, None, 5);
+
+    // Commit one leader.
+    let leader_round = 0;
+    let leader = committer
+        .elect_leader(leader_round)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader}",);
+    let leader_status = committer.try_direct_decide(leader);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Commit(ref block) = leader_status {
+        assert_eq!(block.author(), leader.authority)
+    } else {
+        panic!("Expected a committed leader")
+    };
+
+    // Commit the same leader again on the same dag state and get the same result
+    tracing::info!("Try direct commit for leader {leader} again",);
+    let leader_status = committer.try_direct_decide(leader);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader.authority)
+    } else {
+        panic!("Expected a committed leader")
+    };
+}
+
+/// Commit one by one each leader as the dag progresses in ideal conditions.
+#[test]
+#[tracing_test::traced_test]
+fn multiple_direct_commit() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let wave_length = DEFAULT_WAVE_LENGTH;
+    let mut ancestors = None;
+
+    for n in 1..=10 {
+        let round_with_enough_blocks = wave_length * n;
+        ancestors = Some(build_dag(
+            context.clone(),
+            dag_state.clone(),
+            ancestors,
+            round_with_enough_blocks,
+        ));
+
+        // Leader round is the first round of each wave.
+        let leader_round = round_with_enough_blocks - wave_length;
+        let leader = committer
+            .elect_leader(leader_round)
+            .expect("should have elected leader");
+        tracing::info!("Try direct commit for leader {leader}",);
+        let leader_status = committer.try_direct_decide(leader);
+        tracing::info!("Leader commit status: {leader_status}");
+
+        if let LeaderStatus::Commit(ref committed_block) = leader_status {
+            assert_eq!(committed_block.author(), leader.authority)
+        } else {
+            panic!("Expected a committed leader")
+        };
+    }
+}
+
+/// We directly skip the leader if it has enough blame.
+#[test]
+#[tracing_test::traced_test]
+fn direct_skip() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let wave_length = DEFAULT_WAVE_LENGTH;
+
+    // Add enough blocks to reach the leader of wave 1.
+    let voting_round_wave_1 = wave_length + 1;
+    let references_round_2 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        voting_round_wave_1,
+    );
+
+    // Filter out that leader.
+    let leader_wave_1 = committer
+        .elect_leader(voting_round_wave_1 - 1)
+        .expect("should have elected leader");
+    let references_without_leader_wave_1: Vec<_> = references_round_2
+        .into_iter()
+        .filter(|x| x.author != leader_wave_1.authority)
+        .collect();
+
+    // Add enough blocks to reach the decision round of wave 1.
+    let leader_round_wave_2 = 2 * wave_length;
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_without_leader_wave_1),
+        leader_round_wave_2,
+    );
+
+    // Ensure no blocks are committed.
+    tracing::info!("Try direct commit for leader {leader_wave_1}",);
+    let leader_status = committer.try_direct_decide(leader_wave_1);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Skip(skipped_leader) = leader_status {
+        assert_eq!(skipped_leader, leader_wave_1);
+    } else {
+        panic!("Expected to directly skip the leader");
+    }
+}
+
+/// Indirect-commit the first leader.
+#[test]
+#[tracing_test::traced_test]
+fn indirect_commit() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let wave_length = DEFAULT_WAVE_LENGTH;
+
+    // Add enough blocks to reach the leader of wave 1.
+    let voting_round_wave_1 = wave_length + 1;
+    let references_leader_wave_1 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        voting_round_wave_1,
+    );
+
+    // Filter out that leader.
+    let leader_wave_1 = committer
+        .elect_leader(voting_round_wave_1 - 1)
+        .expect("should have elected leader");
+    let references_without_leader_wave_1: Vec<_> = references_leader_wave_1
+        .iter()
+        .cloned()
+        .filter(|x| x.author != leader_wave_1.authority)
+        .collect();
+
+    // Only 2f+1 validators vote for the leader of wave 1.
+    let connections_with_leader_wave_1 = context
+        .committee
+        .authorities()
+        .take(context.committee.quorum_threshold() as usize)
+        .map(|authority| (authority.0, references_leader_wave_1.clone()))
+        .collect();
+    let references_with_votes_for_leader_wave_1 =
+        build_dag_layer(connections_with_leader_wave_1, dag_state.clone());
+
+    // The validators not part of the 2f+1 above do not vote for the leader
+    // of wave 1
+    let connections_without_leader_wave_1 = context
+        .committee
+        .authorities()
+        .skip(context.committee.quorum_threshold() as usize)
+        .map(|authority| (authority.0, references_without_leader_wave_1.clone()))
+        .collect();
+    let references_without_votes_for_leader_wave_1 =
+        build_dag_layer(connections_without_leader_wave_1, dag_state.clone());
+
+    // Only f+1 validators certify the leader of wave 1.
+    let mut references_decision_round_wave_1 = Vec::new();
+
+    let connections_with_certs_for_leader_wave_1 = context
+        .committee
+        .authorities()
+        .take(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_with_votes_for_leader_wave_1.clone()))
+        .collect();
+    references_decision_round_wave_1.extend(build_dag_layer(
+        connections_with_certs_for_leader_wave_1,
+        dag_state.clone(),
+    ));
+
+    let references_voting_round_wave_1: Vec<_> = references_without_votes_for_leader_wave_1
+        .into_iter()
+        .chain(references_with_votes_for_leader_wave_1)
+        .take(context.committee.quorum_threshold() as usize)
+        .collect();
+
+    // The validators not part of the f+1 above will not certify the leader of wave 1.
+    let connections_without_votes_for_leader_1 = context
+        .committee
+        .authorities()
+        .skip(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_voting_round_wave_1.clone()))
+        .collect();
+    references_decision_round_wave_1.extend(build_dag_layer(
+        connections_without_votes_for_leader_1,
+        dag_state.clone(),
+    ));
+
+    // Add enough blocks to decide the leader of wave 2 connecting to the references
+    // manually constructed of the decision round of wave 1.
+    let leader_round_wave_3 = 3 * wave_length;
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_decision_round_wave_1),
+        leader_round_wave_3,
+    );
+
+    // Try direct commit leader from wave 2 which should result in Commit
+    let leader_wave_2 = committer
+        .elect_leader(2 * wave_length)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_2}");
+    let leader_status = committer.try_direct_decide(leader_wave_2);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    let mut decided_leaders = vec![];
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_2.authority);
+        decided_leaders.push(leader_status);
+    } else {
+        panic!("Expected a committed leader")
+    };
+
+    // Try direct commit leader from wave 1 which should result in Undecided
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
+    let leader_status = committer.try_direct_decide(leader_wave_1);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+        assert_eq!(undecided_slot, leader_wave_1)
+    } else {
+        panic!("Expected an undecided leader")
+    };
+
+    // Quick Summary:
+    // Leader of wave 2 or C6 has the necessary votes/certs to be directly commited.
+    // When we get to the leader of wave 1 or D3. We see that we cannot direct commit
+    // and it is marked as undecided. But this time we have a committed anchor so we
+    // check if there is a certified link from the anchor (c6) to the undecided leader
+    // (d3). There is a certified link through A5 with votes A4,B4,C4. So we can mark
+    // this leader as committed indirectly.
+
+    // Ensure we commit the leader of wave 1 indirectly with the committed leader
+    // of wave 2 as the anchor.
+    tracing::info!("Try indirect commit for leader {leader_wave_1}",);
+    let leader_status = committer.try_indirect_decide(leader_wave_1, decided_leaders.iter());
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_1.authority)
+    } else {
+        panic!("Expected a committed leader")
+    };
+}
+
+/// Commit the first leader, indirectly skip the 2nd, and commit the 3rd leader.
+#[test]
+#[tracing_test::traced_test]
+fn indirect_skip() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let wave_length = DEFAULT_WAVE_LENGTH;
+
+    // Add enough blocks to reach the leader of wave 2.
+    let leader_round_wave_2 = 2 * wave_length;
+    let voting_round_wave_2 = leader_round_wave_2 + 1;
+    let references_leader_round_wave_2 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        voting_round_wave_2,
+    );
+
+    // Filter out that leader.
+    let leader_wave_2 = committer
+        .elect_leader(leader_round_wave_2)
+        .expect("should have elected leader");
+    let references_without_leader_2: Vec<_> = references_leader_round_wave_2
+        .iter()
+        .cloned()
+        .filter(|x| x.author != leader_wave_2.authority)
+        .collect();
+
+    // Only f+1 validators connect to the leader of wave 2.
+    let mut references_voting_round_wave_2 = Vec::new();
+
+    let connections_with_vote_leader_wave_2 = context
+        .committee
+        .authorities()
+        .take(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_leader_round_wave_2.clone()))
+        .collect();
+
+    references_voting_round_wave_2.extend(build_dag_layer(
+        connections_with_vote_leader_wave_2,
+        dag_state.clone(),
+    ));
+
+    let connections_without_vote_leader_wave_2 = context
+        .committee
+        .authorities()
+        .skip(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_without_leader_2.clone()))
+        .collect();
+
+    references_voting_round_wave_2.extend(build_dag_layer(
+        connections_without_vote_leader_wave_2,
+        dag_state.clone(),
+    ));
+
+    // Add enough blocks to reach the decision round of the leader of wave 3.
+    let leader_round_wave_4 = 4 * wave_length;
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_voting_round_wave_2),
+        leader_round_wave_4,
+    );
+
+    // Ensure we commit the leaders of wave 1 and 3 and skip the leader of wave 2
+
+    // Ensure we commit the leader of wave 3.
+    let leader_round_wave_3 = 3 * wave_length;
+    let leader_wave_3 = committer
+        .elect_leader(leader_round_wave_3)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_3}");
+    let leader_status = committer.try_direct_decide(leader_wave_3);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    let mut decided_leaders = vec![];
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_3.authority);
+        decided_leaders.push(leader_status);
+    } else {
+        panic!("Expected a committed leader")
+    };
+
+    // Leader of wave 2 is undecided directly and then skipped indirectly because
+    // of lack of certified links.
+
+    // Ensure we directly mark leader of wave 2 undecided.
+    let leader_wave_2 = committer
+        .elect_leader(leader_round_wave_2)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_2}");
+    let leader_status = committer.try_direct_decide(leader_wave_2);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+        assert_eq!(undecided_slot, leader_wave_2)
+    } else {
+        panic!("Expected an undecided leader")
+    };
+
+    // Ensure we skip leader of wave 2 indirectly.
+    tracing::info!("Try indirect commit for leader {leader_wave_2}",);
+    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Skip(skipped_slot) = leader_status {
+        assert_eq!(skipped_slot, leader_wave_2)
+    } else {
+        panic!("Expected a skipped leader")
+    };
+
+    // Ensure we directly commit the leader of wave 1.
+    let leader_round_wave_1 = wave_length;
+    let leader_wave_1 = committer
+        .elect_leader(leader_round_wave_1)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
+    let leader_status = committer.try_direct_decide(leader_wave_1);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_1.authority);
+    } else {
+        panic!("Expected a committed leader")
+    };
+}
+
+/// If there is no leader with enough support nor blame, we commit nothing.
+#[test]
+#[tracing_test::traced_test]
+fn undecided() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let wave_length = DEFAULT_WAVE_LENGTH;
+
+    // Add enough blocks to reach the leader of wave 1.
+    let leader_round_wave_1 = wave_length;
+    let voting_round_wave_1 = leader_round_wave_1 + 1;
+    let references_leader_round_wave_1 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        voting_round_wave_1,
+    );
+
+    // Filter out that leader.
+    let leader_wave_1 = committer
+        .elect_leader(leader_round_wave_1)
+        .expect("should have elected leader");
+    let references_without_leader_wave_1: Vec<_> = references_leader_round_wave_1
+        .iter()
+        .cloned()
+        .filter(|x| x.author != leader_wave_1.authority)
+        .collect();
+
+    // Create a dag layer where only one authority votes for the leader of wave 1.
+    let mut authorities = context.committee.authorities();
+    let connections_leader_wave_1 = vec![(
+        authorities.next().unwrap().0,
+        references_leader_round_wave_1,
+    )];
+    let connections_without_leader_wave_1: Vec<_> = authorities
+        .take((context.committee.quorum_threshold() - 1) as usize)
+        .map(|authority| (authority.0, references_without_leader_wave_1.clone()))
+        .collect();
+
+    let connections_voting_round_wave_1 = connections_leader_wave_1
+        .into_iter()
+        .chain(connections_without_leader_wave_1)
+        .collect();
+    let references_voting_round_wave_1 =
+        build_dag_layer(connections_voting_round_wave_1, dag_state.clone());
+
+    // Add enough blocks to reach the decision round of the leader of wave 1.
+    let leader_round_wave_2 = 2 * wave_length;
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_voting_round_wave_1),
+        leader_round_wave_2,
+    );
+
+    // Ensure we directly mark leader of wave 1 undecided.
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
+    let leader_status = committer.try_direct_decide(leader_wave_1);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+        assert_eq!(undecided_slot, leader_wave_1)
+    } else {
+        panic!("Expected an undecided leader")
+    };
+
+    // Ensure we indirectly mark leader of wave 1 undecided.
+    tracing::info!("Try indirect commit for leader {leader_wave_1}");
+    let leader_status = committer.try_indirect_decide(leader_wave_1, [].iter());
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+        assert_eq!(undecided_slot, leader_wave_1)
+    } else {
+        panic!("Expected an undecided leader")
+    };
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn test_byzantine_validator() {
+    // Commitee of 4 with even stake
+    let context = context_for_test(4);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+    let wave_length = DEFAULT_WAVE_LENGTH;
+
+    // Add enough blocks to reach leader of wave 4
+    let leader_round_wave_4 = 4 * wave_length;
+    let voting_round_wave_4 = leader_round_wave_4 + 1;
+    let references_leader_round_wave_4 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        voting_round_wave_4,
+    );
+
+    let leader_round_wave_5 = 5 * wave_length;
+    // Add blocks to reach voting round of wave 4
+    // This includes a "good vote" from validator C which is acting as a byzantine validator
+    let good_references_voting_round_wave_4 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_leader_round_wave_4.clone()),
+        leader_round_wave_5 - 1,
+    );
+
+    // DagState:
+    // - A got a good vote from C above
+    // - A will then get a bad vote from C indirectly through the ancenstors of
+    //   the wave 4 decision blocks of B C D
+    // TODO: we should reject the any ancestors from C's decision round that do
+    //       not match what they sent in the voting round for that wave
+
+    // Add block layer for wave 4 decision round with no votes for leader A12
+    // from a byzantine validator C that sent different blocks to all validators.
+
+    // Filter out leader from wave 4.
+    let leader_wave_4 = committer
+        .elect_leader(leader_round_wave_4)
+        .expect("should have elected leader");
+
+    // B12 C12 D12
+    let references_without_leader_round_wave_4: Vec<_> = references_leader_round_wave_4
+        .into_iter()
+        .filter(|x| x.author != leader_wave_4.authority)
+        .collect();
+
+    // accept these references/blocks as ancestors from decision round blocks in dag state
+    // TODO: have to vary the ancestors for now or the block digests will be the same
+    //       revisit when transactions have been added to the block.
+    let byzantine_block_c13_1 = VerifiedBlock::new_for_test(
+        TestBlock::new(13, 2)
+            .set_ancestors(
+                references_without_leader_round_wave_4
+                    .clone()
+                    .into_iter()
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state
+        .write()
+        .accept_block(byzantine_block_c13_1.clone());
+
+    let byzantine_block_c13_2 = VerifiedBlock::new_for_test(
+        TestBlock::new(13, 2)
+            .set_ancestors(
+                references_without_leader_round_wave_4
+                    .clone()
+                    .into_iter()
+                    .skip(1)
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state
+        .write()
+        .accept_block(byzantine_block_c13_2.clone());
+
+    let byzantine_block_c13_3 = VerifiedBlock::new_for_test(
+        TestBlock::new(13, 2)
+            .set_ancestors(
+                references_without_leader_round_wave_4
+                    .clone()
+                    .into_iter()
+                    .skip(2)
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state
+        .write()
+        .accept_block(byzantine_block_c13_3.clone());
+
+    // ancestors of decision block round 14 should include multiple byzantine non-votes C13
+    // but there are enough good votes to prevent a skip. Additionally only one of the non-votes
+    // per authority should be counted so we should not skip leader A12.
+    let decison_block_a14 = VerifiedBlock::new_for_test(
+        TestBlock::new(14, 0)
+            .set_ancestors(good_references_voting_round_wave_4.clone())
+            .build(),
+    );
+    dag_state.write().accept_block(decison_block_a14.clone());
+
+    let good_references_voting_round_wave_4_without_c13 = good_references_voting_round_wave_4
+        .into_iter()
+        .filter(|r| r.author != AuthorityIndex::new_for_test(2))
+        .collect::<Vec<_>>();
+
+    let decison_block_b14 = VerifiedBlock::new_for_test(
+        TestBlock::new(14, 1)
+            .set_ancestors(
+                good_references_voting_round_wave_4_without_c13
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(byzantine_block_c13_1.reference()))
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state.write().accept_block(decison_block_b14.clone());
+
+    let decison_block_c14 = VerifiedBlock::new_for_test(
+        TestBlock::new(14, 2)
+            .set_ancestors(
+                good_references_voting_round_wave_4_without_c13
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(byzantine_block_c13_2.reference()))
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state.write().accept_block(decison_block_c14.clone());
+
+    let decison_block_d14 = VerifiedBlock::new_for_test(
+        TestBlock::new(14, 3)
+            .set_ancestors(
+                good_references_voting_round_wave_4_without_c13
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(byzantine_block_c13_3.reference()))
+                    .collect(),
+            )
+            .build(),
+    );
+    dag_state.write().accept_block(decison_block_d14.clone());
+
+    // DagState
+    // - We have A13, B13, D13, C13 as good votes in the voting round of wave 4
+    // - We have 3 byzantine C13 nonvotes that we received as ancestors from decision
+    //   round blocks from B C D.
+    // - We have  B14, C14, D14 that include this byzantine nonvote and A14 from the
+    //   decision round. But all of these blocks also have good votes from A B C D.
+    // Expect a successul direct commit.
+
+    tracing::info!("Try direct commit for leader {leader_wave_4}");
+    let leader_status = committer.try_direct_decide(leader_wave_4);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_4.authority);
+    } else {
+        panic!("Expected a committed leader")
+    };
+}
+
+// TODO: Add test for indirect commit with a certified link through a byzantine validator.
+
+// TODO: add basic tests for multi leader & pipeline. More tests will be added to
+// throughly test pipelining and multileader once universal committer lands so
+// these tests may not be necessary here.

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_block() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let mut aggregator = ThresholdClock::new(0, context);
 
         aggregator.add_block(BlockRef::new(
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_blocks() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_block() {
-        let context = Arc::new(Context::new_for_test(None));
+        let context = Arc::new(Context::new_for_test(4));
         let mut aggregator = ThresholdClock::new(0, context);
 
         aggregator.add_block(BlockRef::new(
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_blocks() {
-        let context = Arc::new(Context::new_for_test(None));
+        let context = Arc::new(Context::new_for_test(4));
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![

--- a/consensus/core/src/transactions_client.rs
+++ b/consensus/core/src/transactions_client.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_submit_and_consume() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test(None));
         let (client, tx_receiver) = TransactionsClient::new(context);
         let mut consumer = TransactionsConsumer::new(tx_receiver);
 

--- a/consensus/core/src/transactions_client.rs
+++ b/consensus/core/src/transactions_client.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_submit_and_consume() {
-        let context = Arc::new(Context::new_for_test(None));
+        let context = Arc::new(Context::new_for_test(4));
         let (client, tx_receiver) = TransactionsClient::new(context);
         let mut consumer = TransactionsConsumer::new(tx_receiver);
 


### PR DESCRIPTION
Additionally added prevention for writing multiple blocks per slot to own index in dag state. We should also consider preventing adding multiple blocks to slot from ancestor if received from the same index as the ancestor.