### PR TITLE
[wallet-ext] update Sui balance in coins list

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -5,9 +5,8 @@ import { useAppSelector } from '_hooks';
 import { API_ENV } from '_shared/api-env';
 import { Heading } from '_src/ui/app/shared/heading';
 import { Text } from '_src/ui/app/shared/text';
-import { useFormatCoin, useSuiCoinData } from '@mysten/core';
-import { SUI_DECIMALS } from '@mysten/sui.js/utils';
-import BigNumber from 'bignumber.js';
+import { useBalanceInUSD, useFormatCoin } from '@mysten/core';
+import { SUI_TYPE_ARG } from '@mysten/sui.js/utils';
 import { useMemo } from 'react';
 
 export type CoinProps = {
@@ -17,20 +16,16 @@ export type CoinProps = {
 
 function WalletBalanceUsd({ amount: walletBalance }: { amount: bigint }) {
 	const isDefiWalletEnabled = useIsWalletDefiEnabled();
-	const { data } = useSuiCoinData();
-	const { currentPrice } = data || {};
+	const formattedWalletBalance = useBalanceInUSD(SUI_TYPE_ARG, walletBalance);
 
 	const walletBalanceInUsd = useMemo(() => {
-		if (!currentPrice) return null;
-		const suiPriceInUsd = new BigNumber(currentPrice);
-		const walletBalanceInSui = new BigNumber(walletBalance.toString()).shiftedBy(-1 * SUI_DECIMALS);
-		const value = walletBalanceInSui.multipliedBy(suiPriceInUsd).toNumber();
+		if (!formattedWalletBalance) return null;
 
-		return `~${value.toLocaleString('en', {
+		return `~${formattedWalletBalance.toLocaleString('en', {
 			style: 'currency',
 			currency: 'USD',
 		})} USD`;
-	}, [currentPrice, walletBalance]);
+	}, [formattedWalletBalance]);
 
 	if (!walletBalanceInUsd) {
 		return null;


### PR DESCRIPTION
Fixes a bug were we were showing different amounts in USD for Sui

- Updates the recently-added hook `useTokenPrice` to use price info from CoinGecko for Sui, and updates the portfolio balance to use that hook





