### PR TITLE
return raw effects for dev inspect

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1050,8 +1050,8 @@ pub struct DevInspectArgs {
     pub gas_objects: Option<Vec<ObjectRef>>,
     /// Whether to skip transaction checks for the transaction.
     pub skip_checks: Option<bool>,
-    /// Whether to return the raw transaction data.
-    pub show_raw_txn_data: Option<bool>,
+    /// Whether to return the raw transaction data and effects.
+    pub show_raw_txn_data_and_effects: Option<bool>,
 }
 
 /// The response from processing a dev inspect transaction
@@ -1073,6 +1073,9 @@ pub struct DevInspectResults {
     /// The raw transaction data that was dev inspected.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub raw_txn_data: Vec<u8>,
+    /// The raw effects of the transaction that was dev inspected.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub raw_effects: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1098,6 +1101,7 @@ impl DevInspectResults {
         events: TransactionEvents,
         return_values: Result<Vec<ExecutionResult>, ExecutionError>,
         raw_txn_data: Vec<u8>,
+        raw_effects: Vec<u8>,
         resolver: &mut dyn LayoutResolver,
     ) -> SuiResult<Self> {
         let tx_digest = *effects.transaction_digest();
@@ -1133,6 +1137,7 @@ impl DevInspectResults {
             results,
             error,
             raw_txn_data,
+            raw_effects,
         })
     }
 }

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -127,7 +127,7 @@ pub trait StateRead: Send + Sync {
         gas_budget: Option<u64>,
         gas_sponsor: Option<SuiAddress>,
         gas_objects: Option<Vec<ObjectRef>>,
-        show_raw_txn_data: Option<bool>,
+        show_raw_txn_data_and_effects: Option<bool>,
         skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults>;
 
@@ -355,7 +355,7 @@ impl StateRead for AuthorityState {
         gas_budget: Option<u64>,
         gas_sponsor: Option<SuiAddress>,
         gas_objects: Option<Vec<ObjectRef>>,
-        show_raw_txn_data: Option<bool>,
+        show_raw_txn_data_and_effects: Option<bool>,
         skip_checks: Option<bool>,
     ) -> StateReadResult<DevInspectResults> {
         Ok(self
@@ -366,7 +366,7 @@ impl StateRead for AuthorityState {
                 gas_budget,
                 gas_sponsor,
                 gas_objects,
-                show_raw_txn_data,
+                show_raw_txn_data_and_effects,
                 skip_checks,
             )
             .await?)

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -301,7 +301,7 @@ impl WriteApiServer for TransactionExecutionApi {
                 gas_sponsor,
                 gas_budget,
                 gas_objects,
-                show_raw_txn_data,
+                show_raw_txn_data_and_effects,
                 skip_checks,
             } = additional_args.unwrap_or_default();
             let tx_kind: TransactionKind = self.convert_bytes(tx_bytes)?;
@@ -313,7 +313,7 @@ impl WriteApiServer for TransactionExecutionApi {
                     gas_budget.map(|i| *i),
                     gas_sponsor,
                     gas_objects,
-                    show_raw_txn_data,
+                    show_raw_txn_data_and_effects,
                     skip_checks,
                 )
                 .await

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5672,8 +5672,8 @@
               }
             ]
           },
-          "showRawTxnData": {
-            "description": "Whether to return the raw transaction data.",
+          "showRawTxnDataAndEffects": {
+            "description": "Whether to return the raw transaction data and effects.",
             "type": [
               "boolean",
               "null"
@@ -5716,6 +5716,15 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Event"
+            }
+          },
+          "rawEffects": {
+            "description": "The raw effects of the transaction that was dev inspected.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
             }
           },
           "rawTxnData": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -288,6 +288,7 @@ impl RpcExampleProvider {
             results: None,
             error: None,
             raw_txn_data: vec![],
+            raw_effects: vec![],
         };
 
         Examples::new(


### PR DESCRIPTION
## Description 

Similar to #15790, raw txn effects is also needed to implement dry run for graphql.

## Test Plan 

existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
