### PR TITLE
[GraphQL/Objects] receivedTransactionBlocks

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/objects/received.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.exp
@@ -1,0 +1,35 @@
+processed 5 tasks
+
+task 1 'run-graphql'. lines 6-15:
+Response: {
+  "data": {
+    "object": {
+      "receivedTransactionBlocks": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 2 'publish'. lines 17-31:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6353600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 33-33:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 35-44:
+Response: {
+  "data": {
+    "object": {
+      "receivedTransactionBlocks": {
+        "nodes": [
+          {
+            "digest": "B7XWWojtQYLco5HTokGZNpeFQZso3F3ddoU9JYB5iR15"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/received.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 --simulator
+
+//# run-graphql
+{
+    object(address: "0x2") {
+        receivedTransactionBlocks {
+            nodes {
+                digest
+            }
+        }
+    }
+}
+
+//# publish
+module P0::m {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+
+    struct Obj has key {
+        id: UID
+    }
+
+    fun init(ctx: &mut TxContext) {
+        let obj = Obj { id: object::new(ctx) };
+        transfer::transfer(obj, @0x2)
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+    object(address: "0x2") {
+        receivedTransactionBlocks {
+            nodes {
+                digest
+            }
+        }
+    }
+}

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -1718,6 +1718,10 @@ type Object implements IOwner {
 	"""
 	owner: ObjectOwner
 	"""
+	The transaction blocks that sent objects to this object.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection!
+	"""
 	Attempts to convert the object into a MoveObject
 	"""
 	asMoveObject: MoveObject

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -24,7 +24,6 @@ use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::gas_coin::GAS;
 use sui_types::TypeTag;
 
-use super::balance;
 use super::big_int::BigInt;
 use super::cursor::{self, Page, Target};
 use super::display::{get_rendered_fields, DisplayEntry};
@@ -32,7 +31,9 @@ use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::suins_registration::SuinsRegistration;
+use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
+use super::{balance, transaction_block};
 use super::{
     balance::Balance, coin::Coin, owner::Owner, stake::StakedSui, sui_address::SuiAddress,
     transaction_block::TransactionBlock,
@@ -312,6 +313,33 @@ impl Object {
                 initial_shared_version: initial_shared_version.value(),
             })),
         }
+    }
+
+    /// The transaction blocks that sent objects to this object.
+    async fn received_transaction_blocks(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<transaction_block::Cursor>,
+        last: Option<u64>,
+        before: Option<transaction_block::Cursor>,
+        filter: Option<TransactionBlockFilter>,
+    ) -> Result<Connection<String, TransactionBlock>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+
+        let Some(filter) = filter
+            .unwrap_or_default()
+            .intersect(TransactionBlockFilter {
+                recv_address: Some(self.address),
+                ..Default::default()
+            })
+        else {
+            return Ok(Connection::new(false, false));
+        };
+
+        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
+            .await
+            .extend()
     }
 
     /// Attempts to convert the object into a MoveObject

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1722,6 +1722,10 @@ type Object implements IOwner {
 	"""
 	owner: ObjectOwner
 	"""
+	The transaction blocks that sent objects to this object.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter): TransactionBlockConnection!
+	"""
 	Attempts to convert the object into a MoveObject
 	"""
 	asMoveObject: MoveObject


### PR DESCRIPTION
##  Description

This function seems to have gone missing (it's in the draft schema, but doesn't show up in the current schema).  It is a specialisation of `Address.transactionBlocks` for `Object`s which can't send transactions, but can receive them.

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- objects/received.move
```

## Stack

- #15804 