### PR TITLE
[GraphQL/Owner] Implement asObject

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/owner/downcasts.exp
+++ b/crates/sui-graphql-e2e-tests/tests/owner/downcasts.exp
@@ -1,0 +1,26 @@
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1 'programmable'. lines 7-9:
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 11-11:
+Checkpoint created: 1
+
+task 3 'run-graphql'. lines 13-22:
+Response: {
+  "data": {
+    "sender": {
+      "asObject": null
+    },
+    "coin": {
+      "asObject": {
+        "digest": "Bg8AMye7tTRW5p5RC36XkDMxNvezbowJa3P7fR36jSHy"
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/owner/downcasts.move
+++ b/crates/sui-graphql-e2e-tests/tests/owner/downcasts.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses P0=0x0 --accounts A --simulator
+
+// Split off a gas coin, so we have an object to query
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  sender: owner(address: "@{A}") {
+    asObject { digest }
+  }
+
+  coin: owner(address: "@{obj_1_0}") {
+    asObject { digest }
+  }
+}

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -7,6 +7,7 @@ use super::cursor::Page;
 use super::dynamic_field::DynamicField;
 use super::dynamic_field::DynamicFieldName;
 use super::move_package::MovePackage;
+use super::object::ObjectVersionKey;
 use super::stake::StakedSui;
 use super::suins_registration::SuinsRegistration;
 use crate::data::Db;
@@ -220,10 +221,11 @@ impl Owner {
         })
     }
 
-    async fn as_object(&self) -> Option<Object> {
-        // TODO: extend when send to object imnplementation is done
-        // For now only addresses can be owners
-        None
+    async fn as_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
+        // TODO: Make consistent
+        Object::query(ctx.data_unchecked(), self.address, ObjectVersionKey::Latest)
+            .await
+            .extend()
     }
 
     /// Access a dynamic field on an object using its name. Names are arbitrary Move values whose


### PR DESCRIPTION
## Description

Implemented by querying for the object with that address. Note that this needs to be revised once we have consistent reads, to read the latest object for the checkpoint that the owner was queried at.

## Test Plan

New E2E test:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- owner/downcasts.move
```

## Stack
- #15804 
- #15823 
- #15824 
- #15825 