### PR TITLE
[gql] provide historical context for entities that otherwise lack it

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.exp
@@ -3,30 +3,30 @@ processed 13 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 13-54:
+task 1 'publish'. lines 12-53:
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 8329600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'run'. lines 56-56:
+task 2 'run'. lines 55-55:
 created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3 'run'. lines 58-58:
+task 3 'run'. lines 57-57:
 created: object(3,0), object(3,1), object(3,2)
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 6536000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
 
-task 4 'run'. lines 60-60:
+task 4 'run'. lines 59-59:
 created: object(4,0), object(4,1)
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
 
-task 5 'create-checkpoint'. lines 62-62:
+task 5 'create-checkpoint'. lines 61-61:
 Checkpoint created: 1
 
-task 6 'run-graphql'. lines 64-87:
+task 6 'run-graphql'. lines 63-86:
 Response: {
   "data": {
     "object": {
@@ -94,16 +94,16 @@ Response: {
   }
 }
 
-task 7 'run'. lines 89-89:
+task 7 'run'. lines 88-88:
 created: object(7,0)
 mutated: object(0,0)
 wrapped: object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2485200,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
 
-task 8 'create-checkpoint'. lines 91-91:
+task 8 'create-checkpoint'. lines 90-90:
 Checkpoint created: 2
 
-task 9 'run-graphql'. lines 93-117:
+task 9 'run-graphql'. lines 92-118:
 Response: {
   "data": {
     "object": {
@@ -134,6 +134,10 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
+              "bcs": "AgAAAAAAAAA=",
+              "data": {
+                "Number": "2"
+              },
               "__typename": "MoveValue"
             }
           },
@@ -148,6 +152,10 @@ Response: {
               "bcs": "AAAAAAAAAAA="
             },
             "value": {
+              "bcs": "AAAAAAAAAAA=",
+              "data": {
+                "Number": "0"
+              },
               "__typename": "MoveValue"
             }
           },
@@ -162,6 +170,10 @@ Response: {
               "bcs": "AA=="
             },
             "value": {
+              "bcs": "AQAAAAAAAAA=",
+              "data": {
+                "Number": "1"
+              },
               "__typename": "MoveValue"
             }
           }
@@ -171,7 +183,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 119-144:
+task 10 'run-graphql'. lines 120-145:
 Response: {
   "data": {
     "owner": {
@@ -251,7 +263,7 @@ Response: {
   }
 }
 
-task 11 'run-graphql'. lines 146-166:
+task 11 'run-graphql'. lines 147-167:
 Response: {
   "data": {
     "owner": {
@@ -277,7 +289,7 @@ Response: {
   }
 }
 
-task 12 'run-graphql'. lines 168-179:
+task 12 'run-graphql'. lines 169-180:
 Response: {
   "data": {
     "owner": {

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Create some dynamic fields on an object, and then try to query them.
-// There should be 1 dynamic object field (MoveObject) and 3 dynamic fields.
-// When the object is wrapped, we expect that making the query through Object will return null.
-// But it should still be visible through the Owner type.
-// This test also demonstrates why we need separate dynamicField and dynamicObjectField APIs.
+// Create some dynamic fields on an object, and then try to query them. There should be 1 dynamic
+// object field (MoveObject) and 3 dynamic fields. When the object is wrapped, we can still view
+// some information such as its dynamic fields. But it should still be visible through the Owner
+// type. This test also demonstrates why we need separate dynamicField and dynamicObjectField APIs.
 // It is possible for a dynamic field and a dynamic object field to share the same name lookup.
 
 //# init --addresses Test=0x0 --accounts A --simulator
@@ -108,6 +107,8 @@ module Test::m {
             __typename
           }
           ... on MoveValue {
+            bcs
+            data
             __typename
           }
         }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
@@ -1,0 +1,988 @@
+processed 26 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 12-42:
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 44-44:
+Checkpoint created: 1
+
+task 3 'programmable'. lines 46-48:
+mutated: object(0,0), object(1,1), object(1,5)
+gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 3972672, non_refundable_storage_fee: 40128
+
+task 4 'create-checkpoint'. lines 50-50:
+Checkpoint created: 2
+
+task 5 'transfer-object'. lines 52-52:
+mutated: object(0,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 6 'create-checkpoint'. lines 54-54:
+Checkpoint created: 3
+
+task 7 'transfer-object'. lines 56-56:
+mutated: object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 9 'create-checkpoint'. lines 60-60:
+Checkpoint created: 4
+
+task 11 'create-checkpoint'. lines 64-64:
+Checkpoint created: 5
+
+task 13 'create-checkpoint'. lines 68-68:
+Checkpoint created: 6
+
+task 15 'create-checkpoint'. lines 72-72:
+Checkpoint created: 7
+
+task 16 'run-graphql'. lines 74-106:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "300"
+                },
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999983336400"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18 'run-graphql'. lines 111-143:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "300"
+                },
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999983336400"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 20 'run-graphql'. lines 147-179:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "300"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "100"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 22 'run-graphql'. lines 183-215:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "200"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                },
+                {
+                  "coinBalance": "200"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "600"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 24 'run-graphql'. lines 220-253:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "coins": {
+              "nodes": []
+            },
+            "allBalances": {
+              "nodes": []
+            },
+            "firstBalance": {
+              "edges": []
+            },
+            "lastBalance": {
+              "edges": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "coins": {
+              "nodes": [
+                {
+                  "coinBalance": "400"
+                }
+              ]
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            },
+            "firstBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+                }
+              ]
+            },
+            "lastBalance": {
+              "edges": [
+                {
+                  "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 25 'run-graphql'. lines 255-283:
+Response: {
+  "data": {
+    "address": {
+      "coins": {
+        "nodes": [
+          {
+            "coinBalance": "100"
+          },
+          {
+            "coinBalance": "200"
+          }
+        ]
+      },
+      "allBalances": {
+        "nodes": [
+          {
+            "coinType": {
+              "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            },
+            "coinObjectCount": 1,
+            "totalBalance": "300000000000000"
+          },
+          {
+            "coinType": {
+              "repr": "0x3f7ced265e17fe806f71e83d5f33c8baa58ccb482cb7f71e655d924226a3660d::fake::FAKE"
+            },
+            "coinObjectCount": 2,
+            "totalBalance": "300"
+          }
+        ]
+      },
+      "firstBalance": {
+        "edges": [
+          {
+            "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+          }
+        ]
+      },
+      "lastBalance": {
+        "edges": [
+          {
+            "cursor": "IjB4M2Y3Y2VkMjY1ZTE3ZmU4MDZmNzFlODNkNWYzM2M4YmFhNThjY2I0ODJjYjdmNzFlNjU1ZDkyNDIyNmEzNjYwZDo6ZmFrZTo6RkFLRSI"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -1,0 +1,284 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Create three coins of a fake currency. Merge the first one with another coin, and hold on to that
+// coin. Transfer the rest out to another address B. Validate that we get the expected balances
+// across each of 4 transaction blocks. Increment objects_snapshot, verifying that less and less
+// data is returned once the data lies beyond the available range. The coin with value 400 should
+// continue to show up, even as we move beyond checkpoint 4. Finally, verify that the data is not
+// actually gone - the transferred coins should show up under address B.
+
+//# init --addresses P0=0x0 --accounts A B --simulator
+
+//# publish --sender A
+module P0::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (treasury_cap, metadata) = coin::create_currency(
+            witness,
+            2,
+            b"FAKE",
+            b"",
+            b"",
+            option::none(),
+            ctx,
+        );
+
+        let c1 = coin::mint(&mut treasury_cap, 100, ctx);
+        let c2 = coin::mint(&mut treasury_cap, 200, ctx);
+        let c3 = coin::mint(&mut treasury_cap, 300, ctx);
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+        transfer::public_transfer(c1, tx_context::sender(ctx));
+        transfer::public_transfer(c2, tx_context::sender(ctx));
+        transfer::public_transfer(c3, tx_context::sender(ctx));
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,5) 100 object(1,1)
+//> 0: sui::coin::mint<P0::fake::FAKE>(Input(0), Input(1));
+//> MergeCoins(Input(2), [Result(0)]);
+
+//# create-checkpoint
+
+//# transfer-object 1,2 --sender A --recipient B
+
+//# create-checkpoint
+
+//# transfer-object 1,3 --sender A --recipient B
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        coins(type:"@{P0}::fake::FAKE") {
+          nodes {
+            coinBalance
+          }
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+        firstBalance: balances(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        lastBalance: balances(last: 1) {
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 2
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        coins(type:"@{P0}::fake::FAKE") {
+          nodes {
+            coinBalance
+          }
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+        firstBalance: balances(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        lastBalance: balances(last: 1) {
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 3
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        coins(type:"@{P0}::fake::FAKE") {
+          nodes {
+            coinBalance
+          }
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+        firstBalance: balances(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        lastBalance: balances(last: 1) {
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 4
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        coins(type:"@{P0}::fake::FAKE") {
+          nodes {
+            coinBalance
+          }
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+        firstBalance: balances(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        lastBalance: balances(last: 1) {
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 6
+
+//# run-graphql
+# We should still see the fake coin with value 400.
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        coins(type:"@{P0}::fake::FAKE") {
+          nodes {
+            coinBalance
+          }
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+        firstBalance: balances(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        lastBalance: balances(last: 1) {
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  address(address: "@{B}") {
+    coins(type: "@{P0}::fake::FAKE") {
+      nodes {
+        coinBalance
+      }
+    }
+    allBalances: balances {
+      nodes {
+        coinType {
+          repr
+        }
+        coinObjectCount
+        totalBalance
+      }
+    }
+    firstBalance: balances(first: 1) {
+      edges {
+        cursor
+      }
+    }
+    lastBalance: balances(last: 1) {
+      edges {
+        cursor
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields.exp
@@ -1,0 +1,102 @@
+processed 12 tasks
+
+init:
+A: object(0,0), validator_0: object(0,1)
+
+task 1 'publish'. lines 6-56:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 8390400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 58-60:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3549200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 62-62:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6004000,  storage_rebate: 3513708, non_refundable_storage_fee: 35492
+
+task 4 'create-checkpoint'. lines 64-64:
+Checkpoint created: 1
+
+task 5 'run'. lines 66-66:
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 3549200,  storage_rebate: 3513708, non_refundable_storage_fee: 35492
+
+task 6 'create-checkpoint'. lines 68-68:
+Checkpoint created: 2
+
+task 7 'run-graphql'. lines 70-89:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "value": {
+              "contents": {
+                "json": {
+                  "id": "0x4509ef25b4f830aa2167220cfb53774f1d3beca9ac00ed95d8471b5c5de76159",
+                  "count": "1"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 8 'run'. lines 91-91:
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 3549200,  storage_rebate: 3513708, non_refundable_storage_fee: 35492
+
+task 9 'create-checkpoint'. lines 93-93:
+Checkpoint created: 3
+
+task 10 'run-graphql'. lines 95-114:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "value": {
+              "contents": {
+                "json": {
+                  "id": "0x4509ef25b4f830aa2167220cfb53774f1d3beca9ac00ed95d8471b5c5de76159",
+                  "count": "2"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 116-135:
+Response: {
+  "data": {
+    "object": {
+      "dynamicFields": {
+        "nodes": [
+          {
+            "value": {
+              "contents": {
+                "json": {
+                  "id": "0x4509ef25b4f830aa2167220cfb53774f1d3beca9ac00ed95d8471b5c5de76159",
+                  "count": "1"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields.move
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Parent has key, store {
+        id: UID,
+    }
+
+    struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx) },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun mutate_child(child: &mut Child) {
+        child.count = child.count + 1;
+    }
+
+    public fun mutate_child_via_parent(parent: &mut Parent, name: u64) {
+        mutate_child(ofield::borrow_mut(&mut parent.id, name))
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun delete_child(parent: &mut Parent, name: u64) {
+        let Child { id, count: _ } = reclaim_child(parent, name);
+        object::delete(id);
+    }
+}
+
+//# programmable --sender A --inputs @A 42
+//> 0: Test::M1::parent(Input(0));
+//> 1: Test::M1::child(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 1
+
+//# create-checkpoint
+
+//# run Test::M1::mutate_child_via_parent --sender A --args object(2,1) 1
+
+//# create-checkpoint
+
+//# run-graphql
+# Child should have value of 1
+{
+  object(address: "@{obj_2_1}") {
+    dynamicFields {
+      nodes {
+        value {
+          ... on MoveObject {
+            contents {
+              json
+            }
+          }
+          ... on MoveValue {
+            json
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::mutate_child_via_parent --sender A --args object(2,1) 1
+
+//# create-checkpoint
+
+//# run-graphql
+# Child should have value of 2
+{
+  object(address: "@{obj_2_1}") {
+    dynamicFields {
+      nodes {
+        value {
+          ... on MoveObject {
+            contents {
+              json
+            }
+          }
+          ... on MoveValue {
+            json
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# View the parent at the previous version, which should be a child with a value of 1
+{
+  object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields {
+      nodes {
+        value {
+          ... on MoveObject {
+            contents {
+              json
+            }
+          }
+          ... on MoveValue {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects.move
@@ -139,7 +139,7 @@ module Test::M1 {
 //# create-checkpoint
 
 //# run-graphql --cursors @{obj_6_0,2}
-# We should still see objects at this cursor
+# We should see objects - the cursor should still be valid.
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
@@ -1,0 +1,149 @@
+processed 17 tasks
+
+init:
+C: object(0,0)
+
+task 1 'run-graphql'. lines 6-18:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 2 'programmable'. lines 20-22:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 24-24:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [104, 17, 175, 77, 18, 32, 226, 121, 113, 180, 229, 78, 138, 243, 228, 253, 21, 20, 34, 255, 110, 134, 76, 151, 87, 168, 59, 129, 115, 99, 39, 78, 218, 131, 22, 109, 1, 175, 215, 221, 207, 138, 245, 248, 68, 244, 90, 170, 83, 244, 133, 72, 229, 17, 124, 35, 245, 162, 151, 140, 253, 66, 34, 68, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(3,0), object(3,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(_), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4 'create-checkpoint'. lines 26-26:
+Checkpoint created: 1
+
+task 5 'advance-epoch'. lines 28-28:
+Epoch advanced: 0
+
+task 6 'programmable'. lines 30-32:
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'run'. lines 34-34:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [104, 17, 175, 77, 18, 32, 226, 121, 113, 180, 229, 78, 138, 243, 228, 253, 21, 20, 34, 255, 110, 134, 76, 151, 87, 168, 59, 129, 115, 99, 39, 78, 218, 131, 22, 109, 1, 175, 215, 221, 207, 138, 245, 248, 68, 244, 90, 170, 83, 244, 133, 72, 229, 17, 124, 35, 245, 162, 151, 140, 253, 66, 34, 68, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(7,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0), object(3,0)
+deleted: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 14626656, non_refundable_storage_fee: 147744
+
+task 8 'create-checkpoint'. lines 36-36:
+Checkpoint created: 3
+
+task 9 'advance-epoch'. lines 38-38:
+Epoch advanced: 1
+
+task 10 'view-object'. lines 40-40:
+Owner: Account Address ( C )
+Version: 3
+Contents: sui_system::staking_pool::StakedSui {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,1)}}, pool_id: sui::object::ID {bytes: _}, stake_activation_epoch: 1u64, principal: sui::balance::Balance<sui::sui::SUI> {value: 10000000000u64}}
+
+task 11 'view-object'. lines 42-42:
+Owner: Account Address ( C )
+Version: 5
+Contents: sui_system::staking_pool::StakedSui {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, pool_id: sui::object::ID {bytes: _}, stake_activation_epoch: 2u64, principal: sui::balance::Balance<sui::sui::SUI> {value: 10000000000u64}}
+
+task 12 'run-graphql'. lines 44-56:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOuAQAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          },
+          {
+            "cursor": "IKhFEBw99dcc4jqIDHTZSqOJBhE+UqUPCTg9+BgMsJhZAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 58-72:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 74-87:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 89-102:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "IKhFEBw99dcc4jqIDHTZSqOJBhE+UqUPCTg9+BgMsJhZAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 16 'run-graphql'. lines 104-117:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "ICWp4ehjW4WR6h2xCIHZMmodpaSn8u/5R1UICUd7ZCOuAQAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          },
+          {
+            "cursor": "IKhFEBw99dcc4jqIDHTZSqOJBhE+UqUPCTg9+BgMsJhZAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator --accounts C
+
+//# run-graphql
+{
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(2,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(6,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# view-object 3,1
+
+//# view-object 7,0
+
+//# run-graphql
+{
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_1,1}
+# Even though there is a stake created after the initial one, the cursor locks the upper bound to
+# checkpoint 1 - at that point in time, we did not have any additional stakes.
+{
+  address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_7_0,1}
+# Similarly, the second stake did not exist at checkpoint 1, so this should yield a null result.
+{
+  address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_1,3}
+# The second stake was created at checkpoint 3, and thus will be visible.
+{
+  address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_7_0,3}
+# The first stake should now appear.
+{
+  address(address: "@{C}") {
+    stakedSuis(before: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1,0 +1,433 @@
+processed 15 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 11-32:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5479600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 34-35:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 37-37:
+Checkpoint created: 1
+
+task 4 'programmable'. lines 39-42:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 4932400,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'create-checkpoint'. lines 44-44:
+Checkpoint created: 2
+
+task 6 'programmable'. lines 46-50:
+created: object(6,0), object(6,1), object(6,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7 'create-checkpoint'. lines 52-52:
+Checkpoint created: 3
+
+task 8 'run-graphql'. lines 54-73:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x03d1d56149b2b8ccd67f3d04170778b8a5981c0a3e0b30d40f090d3e5c5706ee",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x6ddd2e700f62d8bbf0f99cc4ba01333506f52e15709c9f3c5b8b0f5219d9cd85",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x89222b50150f07213db64abfe033dadae32d64498e5e11919eee60181ffc0abe",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xa00c48eb3867ff637b140ceecee465d0e87d92c1ed927cfd329451236b624c7a",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xf083d223f2de9cfc9108829164005c788228bc8527d25c14fd48d9f092c9fcd6",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 75-90:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "contents": {
+              "json": {
+                "id": "0x03d1d56149b2b8ccd67f3d04170778b8a5981c0a3e0b30d40f090d3e5c5706ee",
+                "value": "3"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                "value": "200"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x6ddd2e700f62d8bbf0f99cc4ba01333506f52e15709c9f3c5b8b0f5219d9cd85",
+                "value": "2"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x89222b50150f07213db64abfe033dadae32d64498e5e11919eee60181ffc0abe",
+                "value": "4"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0xa00c48eb3867ff637b140ceecee465d0e87d92c1ed927cfd329451236b624c7a",
+                "value": "5"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0xf083d223f2de9cfc9108829164005c788228bc8527d25c14fd48d9f092c9fcd6",
+                "value": "6"
+              },
+              "type": {
+                "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 92-113:
+Response: {
+  "data": {
+    "object": {
+      "owner": {
+        "owner": {
+          "objects": {
+            "nodes": [
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x03d1d56149b2b8ccd67f3d04170778b8a5981c0a3e0b30d40f090d3e5c5706ee",
+                    "value": "3"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                    "value": "200"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x6ddd2e700f62d8bbf0f99cc4ba01333506f52e15709c9f3c5b8b0f5219d9cd85",
+                    "value": "2"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x89222b50150f07213db64abfe033dadae32d64498e5e11919eee60181ffc0abe",
+                    "value": "4"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0xa00c48eb3867ff637b140ceecee465d0e87d92c1ed927cfd329451236b624c7a",
+                    "value": "5"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0xf083d223f2de9cfc9108829164005c788228bc8527d25c14fd48d9f092c9fcd6",
+                    "value": "6"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 115-134:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x03d1d56149b2b8ccd67f3d04170778b8a5981c0a3e0b30d40f090d3e5c5706ee",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                      "value": "100"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x6ddd2e700f62d8bbf0f99cc4ba01333506f52e15709c9f3c5b8b0f5219d9cd85",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 136-157:
+Response: {
+  "data": {
+    "object": {
+      "owner": {
+        "owner": {
+          "objects": {
+            "nodes": [
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x03d1d56149b2b8ccd67f3d04170778b8a5981c0a3e0b30d40f090d3e5c5706ee",
+                    "value": "3"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                    "value": "100"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x6ddd2e700f62d8bbf0f99cc4ba01333506f52e15709c9f3c5b8b0f5219d9cd85",
+                    "value": "2"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 159-178:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                      "value": "0"
+                    },
+                    "type": {
+                      "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 180-201:
+Response: {
+  "data": {
+    "object": {
+      "owner": {
+        "owner": {
+          "objects": {
+            "nodes": [
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x5ae5812f2881a335781f339960172d9f87c915cd53d4e662c251d0a0466b5d0d",
+                    "value": "0"
+                  },
+                  "type": {
+                    "repr": "0xd0eed746299c20e74e40e3aca3431f31eebfb8775e422eece0be4eeade2d98ee::M1::Object"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
@@ -1,0 +1,201 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The first PTB creates a single object that will be modified in subsequent txs. The second creates
+// 2, and the third creates 3. Query for the last transaction signed by A, then the second last, and
+// the first one. Validate that these return the same set of objects as a query for object(version)
+// { address { objects } }.
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun set_value(o: &mut Object, value: u64) {
+        o.value = value;
+    }
+}
+
+//# programmable --sender A --inputs 0 1 @A
+//> 0: Test::M1::create(Input(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(2,0) 100 2 3 @A
+//> Test::M1::set_value(Input(0), Input(1));
+//> Test::M1::create(Input(2), Input(4));
+//> Test::M1::create(Input(3), Input(4));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(2,0) 200 4 5 6 @A
+//> Test::M1::set_value(Input(0), Input(1));
+//> Test::M1::create(Input(2), Input(5));
+//> Test::M1::create(Input(3), Input(5));
+//> Test::M1::create(Input(4), Input(5));
+
+//# create-checkpoint
+
+//# run-graphql
+# There should be 6 objects under sender at the latest checkpoint.
+{
+  transactionBlocks(last: 1, filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# This query should yield the same result.
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Do the same thing from the object's point of view, starting from the latest version.
+{
+  object(address: "@{obj_2_0}") {
+    owner {
+      ... on AddressOwner {
+        owner {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors 4
+# View the second PTB, which resulted in a total of 3 objects owned by sender.
+{
+  transactionBlocks(last: 1, before: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Using the object that has been modified at every checkpoint, view the state at the second-to-last mutation.
+{
+  object(address: "@{obj_2_0}", version: 3) {
+    owner {
+      ... on AddressOwner {
+        owner {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors 3
+# View the first PTB, which created 1 object.
+{
+  transactionBlocks(last: 1, before: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Using the object that has been modified at every checkpoint, view the state at its first version.
+{
+  object(address: "@{obj_2_0}", version: 2) {
+    owner {
+      ... on AddressOwner {
+        owner {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -118,6 +118,7 @@ impl PgManager {
 }
 
 pub(crate) fn convert_to_validators(
+    checkpoint_sequence_number: Option<u64>,
     validators: Vec<SuiValidatorSummary>,
     system_state: Option<NativeSuiSystemStateSummary>,
 ) -> Vec<Validator> {
@@ -145,6 +146,7 @@ pub(crate) fn convert_to_validators(
                     .cloned()
                     .map(|a| Address {
                         address: SuiAddress::from(a),
+                        checkpoint_sequence_number,
                     })
                     .collect()
             });
@@ -153,6 +155,7 @@ pub(crate) fn convert_to_validators(
                 validator_summary,
                 at_risk,
                 report_records,
+                checkpoint_sequence_number,
             }
         })
         .collect()

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -240,4 +240,11 @@ impl ExecutorCluster {
         .await
         .expect("Timeout waiting for indexer to update objects snapshot");
     }
+
+    pub async fn force_objects_snapshot_catchup(&self, start_cp: u64, end_cp: u64) {
+        self.indexer_store
+            .persist_object_snapshot(start_cp, end_cp)
+            .await
+            .unwrap();
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -19,6 +19,7 @@ use async_graphql::{connection::Connection, *};
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub(crate) struct Address {
     pub address: SuiAddress,
+    pub checkpoint_sequence_number: Option<u64>,
 }
 
 /// The possible relationship types for a transaction block: sign, sent, received, or paid.
@@ -34,7 +35,7 @@ pub(crate) enum AddressTransactionBlockRelationship {
 #[Object]
 impl Address {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.address).address().await
+        OwnerImpl::from(self).address().await
     }
 
     /// Objects owned by this address, optionally `filter`-ed.
@@ -47,7 +48,7 @@ impl Address {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -59,7 +60,7 @@ impl Address {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.address).balance(ctx, type_).await
+        OwnerImpl::from(self).balance(ctx, type_).await
     }
 
     /// The balances of all coin types owned by this address.
@@ -71,7 +72,7 @@ impl Address {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -88,7 +89,7 @@ impl Address {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -102,14 +103,14 @@ impl Address {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this address.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.address).default_suins_name(ctx).await
+        OwnerImpl::from(self).default_suins_name(ctx).await
     }
 
     /// The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
@@ -122,7 +123,7 @@ impl Address {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -45,7 +45,7 @@ pub(crate) enum CoinDowncastError {
 #[Object]
 impl Coin {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.super_.address).address().await
+        OwnerImpl::from(&self.super_.super_).address().await
     }
 
     /// Objects owned by this object, optionally `filter`-ed.
@@ -58,7 +58,7 @@ impl Coin {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -70,7 +70,7 @@ impl Coin {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balance(ctx, type_)
             .await
     }
@@ -84,7 +84,7 @@ impl Coin {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -101,7 +101,7 @@ impl Coin {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -115,14 +115,14 @@ impl Coin {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .default_suins_name(ctx)
             .await
     }
@@ -137,7 +137,7 @@ impl Coin {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -235,7 +235,7 @@ impl Coin {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_field(ctx, name)
             .await
     }
@@ -252,7 +252,7 @@ impl Coin {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_object_field(ctx, name)
             .await
     }
@@ -269,7 +269,7 @@ impl Coin {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -38,7 +38,7 @@ pub(crate) enum CoinMetadataDowncastError {
 #[Object]
 impl CoinMetadata {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.super_.address).address().await
+        OwnerImpl::from(&self.super_.super_).address().await
     }
 
     /// Objects owned by this object, optionally `filter`-ed.
@@ -51,7 +51,7 @@ impl CoinMetadata {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -63,7 +63,7 @@ impl CoinMetadata {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balance(ctx, type_)
             .await
     }
@@ -77,7 +77,7 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -94,7 +94,7 @@ impl CoinMetadata {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -108,14 +108,14 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .default_suins_name(ctx)
             .await
     }
@@ -130,7 +130,7 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -228,7 +228,7 @@ impl CoinMetadata {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_field(ctx, name)
             .await
     }
@@ -245,7 +245,7 @@ impl CoinMetadata {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_object_field(ctx, name)
             .await
     }
@@ -262,7 +262,7 @@ impl CoinMetadata {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -49,7 +49,11 @@ impl Epoch {
             .fetch_sui_system_state(Some(self.stored.epoch as u64))
             .await?;
 
-        let active_validators = convert_to_validators(system_state.active_validators, None);
+        let active_validators = convert_to_validators(
+            self.stored.last_checkpoint_id.map(|id| id as u64),
+            system_state.active_validators,
+            None,
+        );
         let validator_set = ValidatorSet {
             total_stake: Some(BigInt::from(self.stored.total_stake)),
             active_validators: Some(active_validators),

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -109,6 +109,7 @@ impl Event {
 
         Ok(Some(Address {
             address: self.native.sender.into(),
+            checkpoint_sequence_number: self.checkpoint_sequence_number_impl(),
         }))
     }
 
@@ -228,6 +229,12 @@ impl Event {
             stored: Some(stored_event),
             native: native_event,
         })
+    }
+
+    pub(crate) fn checkpoint_sequence_number_impl(&self) -> Option<u64> {
+        self.stored
+            .as_ref()
+            .map(|stored| stored.checkpoint_sequence_number as u64)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -22,6 +22,7 @@ pub(crate) struct GasInput {
     pub price: u64,
     pub budget: u64,
     pub payment_obj_keys: Vec<ObjectKey>,
+    pub checkpoint_sequence_number: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,6 +47,7 @@ impl GasInput {
     async fn gas_sponsor(&self) -> Option<Address> {
         Some(Address {
             address: self.owner,
+            checkpoint_sequence_number: self.checkpoint_sequence_number,
         })
     }
 
@@ -69,7 +71,7 @@ impl GasInput {
             ctx.data_unchecked(),
             page,
             filter,
-            /* checkpoint_sequence_number */ None,
+            self.checkpoint_sequence_number,
         )
         .await
         .extend()
@@ -143,8 +145,8 @@ impl GasEffects {
     }
 }
 
-impl From<&GasData> for GasInput {
-    fn from(s: &GasData) -> Self {
+impl GasInput {
+    pub(crate) fn from(s: &GasData, checkpoint_sequence_number: Option<u64>) -> Self {
         Self {
             owner: s.owner.into(),
             price: s.price,
@@ -157,6 +159,7 @@ impl From<&GasData> for GasInput {
                     version: o.1.value(),
                 })
                 .collect(),
+            checkpoint_sequence_number,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -119,7 +119,7 @@ pub(crate) enum IMoveObject {
 #[Object]
 impl MoveObject {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.address).address().await
+        OwnerImpl::from(&self.super_).address().await
     }
 
     /// Objects owned by this object, optionally `filter`-ed.
@@ -132,7 +132,7 @@ impl MoveObject {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -144,7 +144,7 @@ impl MoveObject {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.address).balance(ctx, type_).await
+        OwnerImpl::from(&self.super_).balance(ctx, type_).await
     }
 
     /// The balances of all coin types owned by this object.
@@ -156,7 +156,7 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -173,7 +173,7 @@ impl MoveObject {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -187,14 +187,14 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.address).default_suins_name(ctx).await
+        OwnerImpl::from(&self.super_).default_suins_name(ctx).await
     }
 
     /// The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
@@ -207,7 +207,7 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -305,9 +305,7 @@ impl MoveObject {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.address)
-            .dynamic_field(ctx, name)
-            .await
+        OwnerImpl::from(&self.super_).dynamic_field(ctx, name).await
     }
 
     /// Access a dynamic object field on an object using its name. Names are arbitrary Move values
@@ -322,7 +320,7 @@ impl MoveObject {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .dynamic_object_field(ctx, name)
             .await
     }
@@ -339,7 +337,7 @@ impl MoveObject {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -70,7 +70,7 @@ pub(crate) type CModule = JsonCursor<String>;
 #[Object]
 impl MovePackage {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.address).address().await
+        OwnerImpl::from(&self.super_).address().await
     }
 
     /// Objects owned by this package, optionally `filter`-ed.
@@ -86,7 +86,7 @@ impl MovePackage {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -101,7 +101,7 @@ impl MovePackage {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.address).balance(ctx, type_).await
+        OwnerImpl::from(&self.super_).balance(ctx, type_).await
     }
 
     /// The balances of all coin types owned by this package.
@@ -116,7 +116,7 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -136,7 +136,7 @@ impl MovePackage {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -153,14 +153,14 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.address).default_suins_name(ctx).await
+        OwnerImpl::from(&self.super_).default_suins_name(ctx).await
     }
 
     /// The SuinsRegistration NFTs owned by this package. These grant the owner the capability to
@@ -176,7 +176,7 @@ impl MovePackage {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.address)
+        OwnerImpl::from(&self.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -27,10 +27,11 @@ use sui_types::gas_coin::GAS;
 #[derive(Clone, Debug)]
 pub(crate) struct Owner {
     pub address: SuiAddress,
+    pub checkpoint_sequence_number: Option<u64>,
 }
 
 /// Type to implement GraphQL fields that are shared by all Owners.
-pub(crate) struct OwnerImpl(pub SuiAddress);
+pub(crate) struct OwnerImpl(pub Owner);
 
 /// Interface implemented by GraphQL types representing entities that can own objects. Object owners
 /// are identified by an address which can represent either the public key of an account or another
@@ -121,7 +122,7 @@ pub(crate) enum IOwner {
 #[Object]
 impl Owner {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.address).address().await
+        OwnerImpl::from(self).address().await
     }
 
     /// Objects owned by this object or address, optionally `filter`-ed.
@@ -134,7 +135,7 @@ impl Owner {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -146,7 +147,7 @@ impl Owner {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.address).balance(ctx, type_).await
+        OwnerImpl::from(self).balance(ctx, type_).await
     }
 
     /// The balances of all coin types owned by this object or address.
@@ -158,7 +159,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -175,7 +176,7 @@ impl Owner {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -189,14 +190,14 @@ impl Owner {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object or address.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.address).default_suins_name(ctx).await
+        OwnerImpl::from(self).default_suins_name(ctx).await
     }
 
     /// The SuinsRegistration NFTs owned by this object or address. These grant the owner the
@@ -209,7 +210,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -218,15 +219,15 @@ impl Owner {
         // For now only addresses can be owners
         Some(Address {
             address: self.address,
+            checkpoint_sequence_number: self.checkpoint_sequence_number,
         })
     }
 
     async fn as_object(&self, ctx: &Context<'_>) -> Result<Option<Object>> {
-        // TODO: Make consistent
         Object::query(
             ctx.data_unchecked(),
             self.address,
-            ObjectVersionKey::LatestAt(None),
+            ObjectVersionKey::LatestAt(self.checkpoint_sequence_number),
         )
         .await
         .extend()
@@ -242,7 +243,7 @@ impl Owner {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.address).dynamic_field(ctx, name).await
+        OwnerImpl::from(self).dynamic_field(ctx, name).await
     }
 
     /// Access a dynamic object field on an object using its name. Names are arbitrary Move values
@@ -256,9 +257,7 @@ impl Owner {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.address)
-            .dynamic_object_field(ctx, name)
-            .await
+        OwnerImpl::from(self).dynamic_object_field(ctx, name).await
     }
 
     /// The dynamic fields and dynamic object fields on an object.
@@ -272,7 +271,7 @@ impl Owner {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.address)
+        OwnerImpl::from(self)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }
@@ -280,7 +279,7 @@ impl Owner {
 
 impl OwnerImpl {
     pub(crate) async fn address(&self) -> SuiAddress {
-        self.0
+        self.0.address
     }
 
     pub(crate) async fn objects(
@@ -295,7 +294,7 @@ impl OwnerImpl {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let Some(filter) = filter.unwrap_or_default().intersect(ObjectFilter {
-            owner: Some(self.0),
+            owner: Some(self.0.address),
             ..Default::default()
         }) else {
             return Ok(Connection::new(false, false));
@@ -305,7 +304,7 @@ impl OwnerImpl {
             ctx.data_unchecked(),
             page,
             filter,
-            /* checkpoint_sequence_number */ None,
+            self.0.checkpoint_sequence_number,
         )
         .await
         .extend()
@@ -317,9 +316,14 @@ impl OwnerImpl {
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Balance::query(ctx.data_unchecked(), self.0, None, coin)
-            .await
-            .extend()
+        Balance::query(
+            ctx.data_unchecked(),
+            self.0.address,
+            self.0.checkpoint_sequence_number,
+            coin,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn balances(
@@ -331,9 +335,14 @@ impl OwnerImpl {
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Balance::paginate(ctx.data_unchecked(), page, self.0, None)
-            .await
-            .extend()
+        Balance::paginate(
+            ctx.data_unchecked(),
+            page,
+            self.0.address,
+            self.0.checkpoint_sequence_number,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn coins(
@@ -347,9 +356,16 @@ impl OwnerImpl {
     ) -> Result<Connection<String, Coin>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Coin::paginate(ctx.data_unchecked(), page, coin, Some(self.0), None)
-            .await
-            .extend()
+
+        Coin::paginate(
+            ctx.data_unchecked(),
+            page,
+            coin,
+            Some(self.0.address),
+            self.0.checkpoint_sequence_number,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn staked_suis(
@@ -364,8 +380,8 @@ impl OwnerImpl {
         StakedSui::paginate(
             ctx.data_unchecked(),
             page,
-            self.0,
-            /* checkpoint_sequence_number */ None,
+            self.0.address,
+            self.0.checkpoint_sequence_number,
         )
         .await
         .extend()
@@ -375,7 +391,7 @@ impl OwnerImpl {
         Ok(SuinsRegistration::reverse_resolve_to_name(
             ctx.data_unchecked::<Db>(),
             ctx.data_unchecked::<NameServiceConfig>(),
-            self.0,
+            self.0.address,
         )
         .await
         .extend()?
@@ -395,8 +411,8 @@ impl OwnerImpl {
             ctx.data_unchecked::<Db>(),
             ctx.data_unchecked::<NameServiceConfig>(),
             page,
-            self.0,
-            None,
+            self.0.address,
+            self.0.checkpoint_sequence_number,
         )
         .await
         .extend()
@@ -411,9 +427,15 @@ impl OwnerImpl {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         use DynamicFieldType as T;
-        DynamicField::query(ctx.data_unchecked(), self.0, name, T::DynamicField)
-            .await
-            .extend()
+        DynamicField::query(
+            ctx.data_unchecked(),
+            self.0.address,
+            self.0.checkpoint_sequence_number,
+            name,
+            T::DynamicField,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn dynamic_object_field(
@@ -422,9 +444,15 @@ impl OwnerImpl {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         use DynamicFieldType as T;
-        DynamicField::query(ctx.data_unchecked(), self.0, name, T::DynamicObject)
-            .await
-            .extend()
+        DynamicField::query(
+            ctx.data_unchecked(),
+            self.0.address,
+            self.0.checkpoint_sequence_number,
+            name,
+            T::DynamicObject,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn dynamic_fields(
@@ -436,8 +464,37 @@ impl OwnerImpl {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        DynamicField::paginate(ctx.data_unchecked(), page, self.0, None)
-            .await
-            .extend()
+        DynamicField::paginate(
+            ctx.data_unchecked(),
+            page,
+            self.0.address,
+            self.0.checkpoint_sequence_number,
+        )
+        .await
+        .extend()
+    }
+}
+
+impl From<&Address> for OwnerImpl {
+    fn from(address: &Address) -> Self {
+        OwnerImpl(Owner {
+            address: address.address,
+            checkpoint_sequence_number: address.checkpoint_sequence_number,
+        })
+    }
+}
+
+impl From<&Owner> for OwnerImpl {
+    fn from(owner: &Owner) -> Self {
+        OwnerImpl(owner.clone())
+    }
+}
+
+impl From<&Object> for OwnerImpl {
+    fn from(object: &Object) -> Self {
+        OwnerImpl(Owner {
+            address: object.address,
+            checkpoint_sequence_number: object.checkpoint_sequence_number,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -175,7 +175,10 @@ impl Query {
     }
 
     async fn owner(&self, address: SuiAddress) -> Option<Owner> {
-        Some(Owner { address })
+        Some(Owner {
+            address,
+            checkpoint_sequence_number: None,
+        })
     }
 
     /// The object corresponding to the given address at the (optionally) given version.
@@ -206,7 +209,10 @@ impl Query {
 
     /// Look-up an Account by its SuiAddress.
     async fn address(&self, address: SuiAddress) -> Option<Address> {
-        Some(Address { address })
+        Some(Address {
+            address,
+            checkpoint_sequence_number: None,
+        })
     }
 
     /// Fetch a structured representation of a concrete type, including its layout information.
@@ -367,7 +373,10 @@ impl Query {
         .await
         .extend()?
         .and_then(|r| r.target_address)
-        .map(|a| Address { address: a.into() }))
+        .map(|a| Address {
+            address: a.into(),
+            checkpoint_sequence_number: None,
+        }))
     }
 
     /// The coin metadata associated with the given coin type.

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -59,7 +59,7 @@ pub(crate) struct StakedSui {
 #[Object]
 impl StakedSui {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.super_.address).address().await
+        OwnerImpl::from(&self.super_.super_).address().await
     }
 
     /// Objects owned by this object, optionally `filter`-ed.
@@ -72,7 +72,7 @@ impl StakedSui {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -84,7 +84,7 @@ impl StakedSui {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balance(ctx, type_)
             .await
     }
@@ -98,7 +98,7 @@ impl StakedSui {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -115,7 +115,7 @@ impl StakedSui {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -129,14 +129,14 @@ impl StakedSui {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .default_suins_name(ctx)
             .await
     }
@@ -151,7 +151,7 @@ impl StakedSui {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -249,7 +249,7 @@ impl StakedSui {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_field(ctx, name)
             .await
     }
@@ -266,7 +266,7 @@ impl StakedSui {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_object_field(ctx, name)
             .await
     }
@@ -283,7 +283,7 @@ impl StakedSui {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -64,7 +64,7 @@ pub(crate) enum SuinsRegistrationDowncastError {
 #[Object]
 impl SuinsRegistration {
     pub(crate) async fn address(&self) -> SuiAddress {
-        OwnerImpl(self.super_.super_.address).address().await
+        OwnerImpl::from(&self.super_.super_).address().await
     }
 
     /// Objects owned by this object, optionally `filter`-ed.
@@ -77,7 +77,7 @@ impl SuinsRegistration {
         before: Option<object::Cursor>,
         filter: Option<ObjectFilter>,
     ) -> Result<Connection<String, MoveObject>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -89,7 +89,7 @@ impl SuinsRegistration {
         ctx: &Context<'_>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balance(ctx, type_)
             .await
     }
@@ -103,7 +103,7 @@ impl SuinsRegistration {
         last: Option<u64>,
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .balances(ctx, first, after, last, before)
             .await
     }
@@ -120,7 +120,7 @@ impl SuinsRegistration {
         before: Option<object::Cursor>,
         type_: Option<ExactTypeFilter>,
     ) -> Result<Connection<String, Coin>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .coins(ctx, first, after, last, before, type_)
             .await
     }
@@ -134,14 +134,14 @@ impl SuinsRegistration {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, StakedSui>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .staked_suis(ctx, first, after, last, before)
             .await
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .default_suins_name(ctx)
             .await
     }
@@ -156,7 +156,7 @@ impl SuinsRegistration {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, SuinsRegistration>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .suins_registrations(ctx, first, after, last, before)
             .await
     }
@@ -254,7 +254,7 @@ impl SuinsRegistration {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_field(ctx, name)
             .await
     }
@@ -271,7 +271,7 @@ impl SuinsRegistration {
         ctx: &Context<'_>,
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_object_field(ctx, name)
             .await
     }
@@ -288,7 +288,7 @@ impl SuinsRegistration {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
-        OwnerImpl(self.super_.super_.address)
+        OwnerImpl::from(&self.super_.super_)
             .dynamic_fields(ctx, first, after, last, before)
             .await
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -288,7 +288,11 @@ impl TransactionBlockEffects {
                 continue;
             };
 
-            let balance_change = BalanceChange::read(serialized).extend()?;
+            let balance_change = BalanceChange::read(
+                serialized,
+                Some(stored_tx.checkpoint_sequence_number as u64),
+            )
+            .extend()?;
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), balance_change));

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::cursor::{JsonCursor, Page};
+use crate::types::sui_address::SuiAddress;
+use crate::{
+    error::Error,
+    types::{
+        big_int::BigInt, date_time::DateTime, epoch::Epoch, move_package::MovePackage,
+        object::Object,
+    },
+};
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use move_binary_format::errors::PartialVMResult;
@@ -12,16 +21,6 @@ use sui_types::{
         AuthenticatorStateExpire as NativeAuthenticatorStateExpireTransaction,
         ChangeEpoch as NativeChangeEpochTransaction,
         EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind,
-    },
-};
-
-use crate::types::cursor::{JsonCursor, Page};
-use crate::types::sui_address::SuiAddress;
-use crate::{
-    error::Error,
-    types::{
-        big_int::BigInt, date_time::DateTime, epoch::Epoch, move_package::MovePackage,
-        object::Object,
     },
 };
 
@@ -186,7 +185,8 @@ impl ChangeEpochTransaction {
             );
 
             let runtime_id = native.id();
-            let object = Object::from_native(SuiAddress::from(runtime_id), native);
+
+            let object = Object::from_native(SuiAddress::from(runtime_id), native, None);
             let package = MovePackage::try_from(&object)
                 .map_err(|_| Error::Internal("Failed to create system package".to_string()))
                 .extend()?;

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -49,7 +49,7 @@ impl GenesisTransaction {
             let native =
                 NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
 
-            let object = Object::from_native(SuiAddress::from(native.id()), native);
+            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(0));
             connection.edges.push(Edge::new(c.encode_cursor(), object));
         }
 

--- a/crates/sui-graphql-rpc/src/types/validator.rs
+++ b/crates/sui-graphql-rpc/src/types/validator.rs
@@ -17,6 +17,7 @@ pub(crate) struct Validator {
     pub validator_summary: NativeSuiValidatorSummary,
     pub at_risk: Option<u64>,
     pub report_records: Option<Vec<Address>>,
+    pub checkpoint_sequence_number: Option<u64>,
 }
 
 #[Object]
@@ -25,6 +26,7 @@ impl Validator {
     async fn address(&self) -> Address {
         Address {
             address: SuiAddress::from(self.validator_summary.sui_address),
+            checkpoint_sequence_number: self.checkpoint_sequence_number,
         }
     }
 
@@ -90,7 +92,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.operation_cap_id(),
-            ObjectVersionKey::LatestAt(None),
+            ObjectVersionKey::LatestAt(self.checkpoint_sequence_number),
         )
         .await
         .extend()
@@ -102,7 +104,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.staking_pool_id(),
-            ObjectVersionKey::LatestAt(None),
+            ObjectVersionKey::LatestAt(self.checkpoint_sequence_number),
         )
         .await
         .extend()
@@ -114,7 +116,7 @@ impl Validator {
         MoveObject::query(
             ctx.data_unchecked(),
             self.exchange_rates_id(),
-            ObjectVersionKey::LatestAt(None),
+            ObjectVersionKey::LatestAt(self.checkpoint_sequence_number),
         )
         .await
         .extend()

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -165,6 +165,14 @@ pub struct RunGraphqlCommand {
 }
 
 #[derive(Debug, clap::Parser)]
+pub struct ForceObjectSnapshotCatchup {
+    #[clap(long = "start-cp")]
+    pub start_cp: u64,
+    #[clap(long = "end-cp")]
+    pub end_cp: u64,
+}
+
+#[derive(Debug, clap::Parser)]
 pub struct CreateCheckpointCommand {
     pub count: Option<u64>,
 }
@@ -214,6 +222,8 @@ pub enum SuiSubcommand {
     ViewCheckpoint,
     #[clap(name = "run-graphql")]
     RunGraphql(RunGraphqlCommand),
+    #[clap(name = "force-object-snapshot-catchup")]
+    ForceObjectSnapshotCatchup(ForceObjectSnapshotCatchup),
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -539,6 +539,26 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             }};
         }
         match command {
+            SuiSubcommand::ForceObjectSnapshotCatchup(ForceObjectSnapshotCatchup {
+                start_cp,
+                end_cp,
+            }) => {
+                let cluster = self.cluster.as_ref().unwrap();
+                let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
+
+                if end_cp > highest_checkpoint {
+                    bail!(
+                        "end_cp {} is greater than highest checkpoint {}",
+                        end_cp,
+                        highest_checkpoint,
+                    );
+                }
+
+                cluster
+                    .force_objects_snapshot_catchup(start_cp, end_cp)
+                    .await;
+                Ok(None)
+            }
             SuiSubcommand::RunGraphql(RunGraphqlCommand {
                 show_usage,
                 show_headers,


### PR DESCRIPTION
## Description 

Extends the OwnerImpl and ObjectImpl to take in an optional checkpoint_sequence_number to be used as context. Propagate checkpoint_sequence_number where possible to the paginate functions.

When making a query, the Address and Owner needs to know when the request was made, to ignore data from future checkpoints. This context permeates down the query, so we can have consistency within a query.

For example, the query transactionBlock { sender { objects } } will have txBlock pass its checkpoint_sequence_number to sender, and subsequently sender will pass that checkpoint_sequence_number to the objects resolver.

If such an entity is fetched on the top-level, then it will inherit the latest checkpoint sequence number at the time of query.

This does not address cross-query consistency.

Note that StakedSui and Validator APYs will not be consistent, and cross-query consistency is not guaranteed right now.

## Test Plan 

new tests
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
