### PR TITLE
deprecate ExportedKeyPair and Keypair.export

### DIFF
--- a/.changeset/angry-rocks-brush.md
+++ b/.changeset/angry-rocks-brush.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+deprecate ExportedKeypair

--- a/apps/wallet/src/background/accounts/Account.ts
+++ b/apps/wallet/src/background/accounts/Account.ts
@@ -4,7 +4,6 @@
 import { type Serializable } from '_src/shared/cryptography/keystore';
 import {
 	toSerializedSignature,
-	type ExportedKeypair,
 	type Keypair,
 	type SerializedSignature,
 } from '@mysten/sui.js/cryptography';
@@ -186,7 +185,7 @@ export function isSigningAccount(account: any): account is SigningAccount {
 
 export interface KeyPairExportableAccount {
 	readonly exportableKeyPair: true;
-	exportKeyPair(password: string): Promise<ExportedKeypair>;
+	exportKeyPair(password: string): Promise<string>;
 }
 
 export function isKeyPairExportableAccount(account: any): account is KeyPairExportableAccount {

--- a/apps/wallet/src/background/accounts/ImportedAccount.ts
+++ b/apps/wallet/src/background/accounts/ImportedAccount.ts
@@ -14,8 +14,8 @@ import {
 	type SigningAccount,
 } from './Account';
 
-type SessionStorageData = { keyPair: ExportedKeypair };
-type EncryptedData = { keyPair: ExportedKeypair };
+type SessionStorageData = { keyPair: ExportedKeypair | string };
+type EncryptedData = { keyPair: ExportedKeypair | string };
 
 export interface ImportedAccountSerialized extends SerializedAccount {
 	type: 'imported';
@@ -43,7 +43,7 @@ export class ImportedAccount
 	readonly exportableKeyPair = true;
 
 	static async createNew(inputs: {
-		keyPair: ExportedKeypair;
+		keyPair: string;
 		password: string;
 	}): Promise<Omit<ImportedAccountSerialized, 'id'>> {
 		const keyPair = fromExportedKeypair(inputs.keyPair);
@@ -118,10 +118,10 @@ export class ImportedAccount
 		return this.generateSignature(data, keyPair);
 	}
 
-	async exportKeyPair(password: string): Promise<ExportedKeypair> {
+	async exportKeyPair(password: string): Promise<string> {
 		const { encrypted } = await this.getStoredData();
 		const { keyPair } = await decrypt<EncryptedData>(password, encrypted);
-		return keyPair;
+		return fromExportedKeypair(keyPair, true).getSecretKey();
 	}
 
 	async #getKeyPair() {

--- a/apps/wallet/src/background/accounts/ImportedAccount.ts
+++ b/apps/wallet/src/background/accounts/ImportedAccount.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { decrypt, encrypt } from '_src/shared/cryptography/keystore';
-import { fromExportedKeypair } from '_src/shared/utils/from-exported-keypair';
-import { type ExportedKeypair } from '@mysten/sui.js/cryptography';
+import {
+	fromExportedKeypair,
+	type LegacyExportedKeyPair,
+} from '_src/shared/utils/from-exported-keypair';
 
 import {
 	Account,
@@ -14,8 +16,8 @@ import {
 	type SigningAccount,
 } from './Account';
 
-type SessionStorageData = { keyPair: ExportedKeypair | string };
-type EncryptedData = { keyPair: ExportedKeypair | string };
+type SessionStorageData = { keyPair: LegacyExportedKeyPair | string };
+type EncryptedData = { keyPair: LegacyExportedKeyPair | string };
 
 export interface ImportedAccountSerialized extends SerializedAccount {
 	type: 'imported';

--- a/apps/wallet/src/background/accounts/MnemonicAccount.ts
+++ b/apps/wallet/src/background/accounts/MnemonicAccount.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromExportedKeypair } from '_src/shared/utils/from-exported-keypair';
-import { type ExportedKeypair, type Keypair } from '@mysten/sui.js/cryptography';
+import { type Keypair } from '@mysten/sui.js/cryptography';
 
 import { MnemonicAccountSource } from '../account-sources/MnemonicAccountSource';
 import {
@@ -34,7 +34,7 @@ export function isMnemonicSerializedUiAccount(
 	return account.type === 'mnemonic-derived';
 }
 
-type SessionStorageData = { keyPair: ExportedKeypair };
+type SessionStorageData = { keyPair: string };
 
 export class MnemonicAccount
 	extends Account<MnemonicSerializedAccount, SessionStorageData>
@@ -93,7 +93,7 @@ export class MnemonicAccount
 			await mnemonicSource.unlock(password);
 		}
 		await this.setEphemeralValue({
-			keyPair: (await mnemonicSource.deriveKeyPair(derivationPath)).export(),
+			keyPair: (await mnemonicSource.deriveKeyPair(derivationPath)).getSecretKey(),
 		});
 		await this.onUnlocked();
 	}
@@ -138,11 +138,11 @@ export class MnemonicAccount
 		return this.getCachedData().then(({ sourceID }) => sourceID);
 	}
 
-	async exportKeyPair(password: string): Promise<ExportedKeypair> {
+	async exportKeyPair(password: string): Promise<string> {
 		const { derivationPath } = await this.getStoredData();
 		const mnemonicSource = await this.#getMnemonicSource();
 		await mnemonicSource.unlock(password);
-		return (await mnemonicSource.deriveKeyPair(derivationPath)).export();
+		return (await mnemonicSource.deriveKeyPair(derivationPath)).getSecretKey();
 	}
 
 	async #getKeyPair() {

--- a/apps/wallet/src/background/accounts/zklogin/ZkLoginAccount.ts
+++ b/apps/wallet/src/background/accounts/zklogin/ZkLoginAccount.ts
@@ -7,7 +7,6 @@ import { deobfuscate, obfuscate } from '_src/shared/cryptography/keystore';
 import { fromExportedKeypair } from '_src/shared/utils/from-exported-keypair';
 import {
 	toSerializedSignature,
-	type ExportedKeypair,
 	type PublicKey,
 	type SerializedSignature,
 } from '@mysten/sui.js/cryptography';
@@ -38,7 +37,7 @@ function serializeNetwork(network: NetworkEnvType): SerializedNetwork {
 }
 
 type CredentialData = {
-	ephemeralKeyPair: ExportedKeypair;
+	ephemeralKeyPair: string;
 	proofs?: PartialZkLoginSignature;
 	minEpoch: number;
 	maxEpoch: number;
@@ -278,7 +277,7 @@ export class ZkLoginAccount
 		const ephemeralValue = (await this.getEphemeralValue()) || {};
 		const activeNetwork = await networkEnv.getActiveNetwork();
 		const credentialsData: CredentialData = {
-			ephemeralKeyPair: ephemeralKeyPair.export(),
+			ephemeralKeyPair: ephemeralKeyPair.getSecretKey(),
 			minEpoch: Number(epoch),
 			maxEpoch,
 			network: activeNetwork,

--- a/apps/wallet/src/background/legacy-accounts/LegacyVault.ts
+++ b/apps/wallet/src/background/legacy-accounts/LegacyVault.ts
@@ -8,8 +8,11 @@ import {
 	toEntropy,
 	validateEntropy,
 } from '_shared/utils/bip39';
-import { fromExportedKeypair } from '_shared/utils/from-exported-keypair';
-import { mnemonicToSeedHex, type ExportedKeypair, type Keypair } from '@mysten/sui.js/cryptography';
+import {
+	fromExportedKeypair,
+	type LegacyExportedKeyPair,
+} from '_shared/utils/from-exported-keypair';
+import { mnemonicToSeedHex, type Keypair } from '@mysten/sui.js/cryptography';
 
 import { getFromLocalStorage } from '../storage-utils';
 
@@ -17,7 +20,7 @@ type StoredData = string | { v: 1 | 2; data: string };
 
 type V2DecryptedDataType = {
 	entropy: string;
-	importedKeypairs: ExportedKeypair[];
+	importedKeypairs: LegacyExportedKeyPair[];
 	qredoTokens?: Record<string, string>;
 	mnemonicSeedHex?: string;
 };

--- a/apps/wallet/src/background/legacy-accounts/storage-migration.ts
+++ b/apps/wallet/src/background/legacy-accounts/storage-migration.ts
@@ -71,7 +71,7 @@ async function makeMnemonicAccounts(password: string, vault: LegacyVault) {
 async function makeImportedAccounts(password: string, vault: LegacyVault) {
 	return Promise.all(
 		vault.importedKeypairs.map((keyPair) =>
-			ImportedAccount.createNew({ password, keyPair: keyPair.export() }),
+			ImportedAccount.createNew({ password, keyPair: keyPair.getSecretKey() }),
 		),
 	);
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/MethodPayload.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/MethodPayload.ts
@@ -5,7 +5,7 @@ import { type AccountSourceSerializedUI } from '_src/background/account-sources/
 import { type SerializedUIAccount } from '_src/background/accounts/Account';
 import { type ZkLoginProvider } from '_src/background/accounts/zklogin/providers';
 import { type Status } from '_src/background/legacy-accounts/storage-migration';
-import { type ExportedKeypair, type SerializedSignature } from '@mysten/sui.js/cryptography';
+import { type SerializedSignature } from '@mysten/sui.js/cryptography';
 
 import { isBasePayload } from './BasePayload';
 import type { Payload } from './Payload';
@@ -32,7 +32,7 @@ type MethodPayloads = {
 	unlockAccountSourceOrAccount: { id: string; password?: string };
 	createAccounts:
 		| { type: 'mnemonic-derived'; sourceID: string }
-		| { type: 'imported'; keyPair: ExportedKeypair; password: string }
+		| { type: 'imported'; keyPair: string; password: string }
 		| {
 				type: 'ledger';
 				accounts: { publicKey: string; derivationPath: string; address: string }[];
@@ -61,7 +61,7 @@ type MethodPayloads = {
 	setAutoLockMinutes: { minutes: number | null };
 	notifyUserActive: {};
 	getAccountKeyPair: { accountID: string; password: string };
-	getAccountKeyPairResponse: { accountID: string; keyPair: ExportedKeypair };
+	getAccountKeyPairResponse: { accountID: string; keyPair: string };
 	resetPassword: {
 		password: string;
 		recoveryData: PasswordRecoveryData[];

--- a/apps/wallet/src/shared/utils/from-exported-keypair.ts
+++ b/apps/wallet/src/shared/utils/from-exported-keypair.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ExportedKeypair, type Keypair } from '@mysten/sui.js/cryptography';
+import { type Keypair, type SignatureScheme } from '@mysten/sui.js/cryptography';
 import {
 	decodeSuiPrivateKey,
 	LEGACY_PRIVATE_KEY_SIZE,
@@ -12,8 +12,17 @@ import { Secp256k1Keypair } from '@mysten/sui.js/keypairs/secp256k1';
 import { Secp256r1Keypair } from '@mysten/sui.js/keypairs/secp256r1';
 import { fromB64 } from '@mysten/sui.js/utils';
 
+/**
+ * Wallet stored data might contain imported accounts with their keys stored in the previous format.
+ * Using this type to type-check it.
+ */
+export type LegacyExportedKeyPair = {
+	schema: SignatureScheme;
+	privateKey: string;
+};
+
 export function fromExportedKeypair(
-	secret: ExportedKeypair | string,
+	secret: LegacyExportedKeyPair | string,
 	legacySupport = false,
 ): Keypair {
 	let schema;

--- a/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/AccountsFormContext.tsx
@@ -3,7 +3,6 @@
 
 import { type ZkLoginProvider } from '_src/background/accounts/zklogin/providers';
 import { type Wallet } from '_src/shared/qredo-api';
-import { type ExportedKeypair } from '@mysten/sui.js/cryptography';
 import {
 	createContext,
 	useCallback,
@@ -19,7 +18,7 @@ export type AccountsFormValues =
 	| { type: 'new-mnemonic' }
 	| { type: 'import-mnemonic'; entropy: string }
 	| { type: 'mnemonic-derived'; sourceID: string }
-	| { type: 'imported'; keyPair: ExportedKeypair }
+	| { type: 'imported'; keyPair: string }
 	| {
 			type: 'ledger';
 			accounts: { publicKey: string; derivationPath: string; address: string }[];

--- a/apps/wallet/src/ui/app/components/accounts/ImportPrivateKeyForm.tsx
+++ b/apps/wallet/src/ui/app/components/accounts/ImportPrivateKeyForm.tsx
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { privateKeyValidation } from '../../helpers/validation/privateKeyValidation';
 import { Form } from '../../shared/forms/Form';
 import { TextAreaField } from '../../shared/forms/TextAreaField';
+import Alert from '../alert';
 
 const formSchema = z.object({
 	privateKey: privateKeyValidation,
@@ -29,12 +30,20 @@ export function ImportPrivateKeyForm({ onSubmit }: ImportPrivateKeyFormProps) {
 	const {
 		register,
 		formState: { isSubmitting, isValid },
+		watch,
 	} = form;
 	const navigate = useNavigate();
-
+	const privateKey = watch('privateKey');
+	const isHexadecimal = isValid && !privateKey.startsWith('suiprivkey');
 	return (
-		<Form className="flex flex-col h-full" form={form} onSubmit={onSubmit}>
+		<Form className="flex flex-col h-full gap-2" form={form} onSubmit={onSubmit}>
 			<TextAreaField label="Enter Private Key" rows={4} {...register('privateKey')} />
+			{isHexadecimal ? (
+				<Alert mode="warning">
+					Importing Hex encoded Private Key will soon be deprecated, please use Bech32 encoded
+					private key that starts with "suiprivkey" instead
+				</Alert>
+			) : null}
 			<div className="flex gap-2.5 mt-auto">
 				<Button variant="outline" size="tall" text="Cancel" onClick={() => navigate(-1)} />
 				<Button

--- a/apps/wallet/src/ui/app/helpers/validation/privateKeyValidation.ts
+++ b/apps/wallet/src/ui/app/helpers/validation/privateKeyValidation.ts
@@ -1,57 +1,47 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { decodeSuiPrivateKey } from '@mysten/sui.js/cryptography/keypair';
+import { decodeSuiPrivateKey, encodeSuiPrivateKey } from '@mysten/sui.js/cryptography/keypair';
 import { hexToBytes } from '@noble/hashes/utils';
-import * as Yup from 'yup';
 import { z } from 'zod';
 
 export const privateKeyValidation = z
 	.string()
 	.trim()
-	.nonempty('Private Key is a required field.')
+	.nonempty('Private Key is required.')
 	.transform((privateKey, context) => {
+		if (!privateKey.startsWith('suiprivkey')) {
+			const hexValue = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey;
+			let privateKeyBytes: Uint8Array | undefined;
+
+			try {
+				privateKeyBytes = hexToBytes(hexValue);
+			} catch (error) {
+				context.addIssue({
+					code: 'custom',
+					message: 'Invalid Private Key, please use a Bech32 encoded 33-byte string.',
+				});
+				return z.NEVER;
+			}
+
+			if (![32, 64].includes(privateKeyBytes.length)) {
+				context.addIssue({
+					code: 'custom',
+					message: 'Hex encoded Private Key must be either 32 or 64 bytes.',
+				});
+				return z.NEVER;
+			}
+
+			return encodeSuiPrivateKey(privateKeyBytes.slice(0, 32), 'ED25519');
+		}
 		try {
 			decodeSuiPrivateKey(privateKey);
 		} catch (error) {
 			context.addIssue({
 				code: 'custom',
-				message: 'Private Key must be a Bech32 encoded 33-byte string',
+				message: 'Invalid Private Key, please use a Bech32 encoded 33-byte string',
 			});
 			return z.NEVER;
 		}
 		return privateKey;
 	});
-
-/** @deprecated Prefer Zod over Yup for doing schema validation! */
-export const deprecatedPrivateKeyValidation = Yup.string()
-	.ensure()
-	.trim()
-	.required()
-	.transform((value: string) => {
-		if (value.startsWith('0x')) {
-			return value.substring(2);
-		}
-		return value;
-	})
-	.test(
-		'valid-hex',
-		`\${path} must be a hexadecimal value. It may optionally begin with "0x".`,
-		(value: string) => {
-			try {
-				hexToBytes(value);
-				return true;
-			} catch (e) {
-				return false;
-			}
-		},
-	)
-	.test('valid-bytes-length', `\${path} must be either 32 or 64 bytes.`, (value: string) => {
-		try {
-			const bytes = hexToBytes(value);
-			return [32, 64].includes(bytes.length);
-		} catch (e) {
-			return false;
-		}
-	})
-	.label('Private Key');

--- a/apps/wallet/src/ui/app/pages/accounts/ExportAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/ExportAccountPage.tsx
@@ -23,14 +23,12 @@ export function ExportAccountPage() {
 			if (!account) {
 				return null;
 			}
-			const key = (
+			return (
 				await backgroundClient.exportAccountKeyPair({
 					password,
 					accountID: account.id,
 				})
 			).keyPair;
-			console.log(key);
-			return key;
 		},
 	});
 	const navigate = useNavigate();

--- a/apps/wallet/src/ui/app/pages/accounts/ExportAccountPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/ExportAccountPage.tsx
@@ -23,13 +23,14 @@ export function ExportAccountPage() {
 			if (!account) {
 				return null;
 			}
-			const {
-				keyPair: { privateKey },
-			} = await backgroundClient.exportAccountKeyPair({
-				password,
-				accountID: account.id,
-			});
-			return privateKey;
+			const key = (
+				await backgroundClient.exportAccountKeyPair({
+					password,
+					accountID: account.id,
+				})
+			).keyPair;
+			console.log(key);
+			return key;
 		},
 	});
 	const navigate = useNavigate();

--- a/apps/wallet/src/ui/app/pages/accounts/ImportPrivateKeyPage.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/ImportPrivateKeyPage.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Text } from '_app/shared/text';
-import { validateExportedKeypair } from '_src/shared/utils/from-exported-keypair';
-import type { ExportedKeypair } from '@mysten/sui.js/cryptography';
 import { useNavigate } from 'react-router-dom';
 
 import { useAccountsFormContext } from '../../components/accounts/AccountsFormContext';
@@ -29,10 +27,7 @@ export function ImportPrivateKeyPage() {
 					onSubmit={({ privateKey }) => {
 						setAccountsFormValues({
 							type: 'imported',
-							keyPair: validateExportedKeypair({
-								schema: 'ED25519',
-								privateKey: privateKey,
-							} as ExportedKeypair),
+							keyPair: privateKey,
 						});
 						navigate('/accounts/protect-account?accountType=imported');
 					}}

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -21,6 +21,7 @@ export type ParsedKeypair = {
 	secretKey: Uint8Array;
 };
 
+/** @deprecated use string instead. See {@link Keypair.getSecretKey} */
 export type ExportedKeypair = {
 	schema: SignatureScheme;
 	privateKey: string;
@@ -99,6 +100,7 @@ export abstract class Keypair extends BaseSigner {
 	abstract getSecretKey(): string;
 
 	/**
+	 * @deprecated use {@link Keypair.getSecretKey} instead
 	 * This returns an exported keypair object, schema is the signature
 	 * scheme name, and the private key field is a Bech32 encoded string
 	 * of 33-byte `flag || private_key` that starts with `suiprivkey`.


### PR DESCRIPTION
## Description 

* deprecate `ExportedKeyPair` and `Keypair.export`
* stop using `ExportedKeyPair` in wallet
* support importing hex private keys

<img width="361" alt="Screenshot 2024-01-26 at 18 05 13" src="https://github.com/MystenLabs/sui/assets/10210143/541a0017-58d6-4498-a851-c7dbbb51fa5f">
<img width="361" alt="Screenshot 2024-01-26 at 18 05 33" src="https://github.com/MystenLabs/sui/assets/10210143/d31bec03-9576-4fd2-b2ea-08440ee9c601">
<img width="361" alt="Screenshot 2024-01-26 at 18 05 40" src="https://github.com/MystenLabs/sui/assets/10210143/125484c8-04cb-4bbd-8184-4a795b74a6e3">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
