### PR TITLE
[Consensus 2.0] introduce block signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,7 @@ dependencies = [
 name = "consensus-config"
 version = "0.1.0"
 dependencies = [
+ "bcs",
  "fastcrypto",
  "insta",
  "multiaddr",

--- a/consensus/config/Cargo.toml
+++ b/consensus/config/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bcs.workspace = true
 fastcrypto.workspace = true
 multiaddr.workspace = true
 rand.workspace = true

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -133,6 +133,10 @@ impl Committee {
             .map(|(i, a)| (AuthorityIndex(i as u32), a))
     }
 
+    pub fn exists(&self, index: AuthorityIndex) -> bool {
+        index.value() < self.size()
+    }
+
     pub fn size(&self) -> usize {
         self.authorities.len()
     }

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -10,12 +10,18 @@ use std::{
 };
 
 use bytes::Bytes;
-use consensus_config::{AuthorityIndex, DefaultHashFunction, Epoch, DIGEST_LENGTH};
+use consensus_config::{
+    to_intent_message, AuthorityIndex, AuthoritySignature, DefaultHashFunction, Epoch,
+    NetworkKeySignature, DIGEST_LENGTH,
+};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::{Digest, HashFunction};
+use fastcrypto::traits::{Signer, ToFromBytes};
 use serde::{Deserialize, Serialize};
 
 use crate::context::Context;
+use crate::ensure;
+use crate::error::{ConsensusError, ConsensusResult};
 
 const GENESIS_ROUND: Round = 0;
 
@@ -72,7 +78,7 @@ impl Block {
             .committee
             .authorities()
             .map(|(authority_index, _)| {
-                let signed = SignedBlock::new(Block::V1(BlockV1::genesis(
+                let signed = SignedBlock::new_genesis(Block::V1(BlockV1::genesis(
                     authority_index,
                     context.committee.epoch(),
                 )));
@@ -294,12 +300,43 @@ pub(crate) struct SignedBlock {
 impl SignedBlock {
     // TODO: add verification.
 
-    // TODO: will refactor once the signing approach has been introduced.
-    pub(crate) fn new(block: Block) -> Self {
+    /// Should only be used when constructing the genesis blocks
+    pub(crate) fn new_genesis(block: Block) -> Self {
         Self {
             inner: block,
             signature: Bytes::default(),
         }
+    }
+    pub(crate) fn new<S>(block: Block, signer: &S) -> ConsensusResult<Self>
+    where
+        S: Signer<NetworkKeySignature>,
+    {
+        let digest = compute_digest(&block)?;
+        let signature = NetworkKeySignature::new(&to_intent_message(digest), signer);
+        let signature_bytes = signature.as_bytes();
+        Ok(Self {
+            inner: block,
+            signature: signature_bytes.to_vec().into(),
+        })
+    }
+
+    #[allow(unused)]
+    /// This method is only verifying the block's signature for now. It does not do any kind of validation so it can
+    /// fail for numerous reasons.
+    pub(crate) fn verify(&self, context: &Context) -> ConsensusResult<()> {
+        let digest = compute_digest(&self.inner)?;
+
+        ensure!(
+            context.committee.exists(self.inner.author()),
+            ConsensusError::UnknownAuthority(self.inner.author().to_string())
+        );
+        let authority = context.committee.authority(self.inner.author());
+
+        let signature = NetworkKeySignature::from_bytes(self.signature.as_ref())?;
+
+        signature
+            .verify(&to_intent_message(digest), &authority.network_key)
+            .map_err(ConsensusError::CryptographicOperationFailure)
     }
 
     /// Serialises the block using the bcs serializer
@@ -326,7 +363,7 @@ impl VerifiedBlock {
         signed_block: SignedBlock,
         serialized: bytes::Bytes,
     ) -> Result<Self, bcs::Error> {
-        let digest = Self::compute_digest(&signed_block.inner)?;
+        let digest = compute_digest(&signed_block.inner)?;
         Ok(VerifiedBlock {
             block: Arc::new(signed_block),
             digest,
@@ -343,7 +380,7 @@ impl VerifiedBlock {
 
     #[cfg(test)]
     pub(crate) fn new_for_test(block: Block) -> Self {
-        let digest = Self::compute_digest(&block).unwrap();
+        let digest = compute_digest(&block).unwrap();
         // Use empty signature in test.
         let signed_block = SignedBlock {
             inner: block,
@@ -376,12 +413,12 @@ impl VerifiedBlock {
     pub fn serialized(&self) -> &bytes::Bytes {
         &self.serialized
     }
+}
 
-    fn compute_digest(block: &Block) -> Result<BlockDigest, bcs::Error> {
-        let mut hasher = DefaultHashFunction::new();
-        hasher.update(bcs::to_bytes(block)?);
-        Ok(BlockDigest(hasher.finalize().into()))
-    }
+fn compute_digest(block: &Block) -> Result<BlockDigest, bcs::Error> {
+    let mut hasher = DefaultHashFunction::new();
+    hasher.update(bcs::to_bytes(block)?);
+    Ok(BlockDigest(hasher.finalize().into()))
 }
 
 /// Allow quick access on the underlying Block without having to always refer to the inner block ref.
@@ -468,3 +505,43 @@ impl TestBlock {
 
 // TODO: add basic verification for BlockRef and BlockDigest.
 // TODO: add tests for SignedBlock and VerifiedBlock conversion.
+
+#[cfg(test)]
+mod tests {
+    use crate::block::{SignedBlock, TestBlock};
+    use crate::context::Context;
+    use crate::error::ConsensusError;
+    use fastcrypto::error::FastCryptoError;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_block_signing() {
+        let (context, key_pairs) = Context::new_for_test();
+        let context = Arc::new(context);
+
+        // Create a block that authority 2 has created
+        let block = TestBlock::new(10, 2).build();
+
+        // Create a signed block with authority's 2 private key
+        let author_two_key = &key_pairs[2].0;
+        let signed_block = SignedBlock::new(block, author_two_key).expect("Shouldn't fail signing");
+
+        // Now verify the block's signature
+        let result = signed_block.verify(&context);
+        assert!(result.is_ok());
+
+        // Try to sign authority's 2 block with authority's 1 key
+        let block = TestBlock::new(10, 2).build();
+        let author_one_key = &key_pairs[1].0;
+        let signed_block = SignedBlock::new(block, author_one_key).expect("Shouldn't fail signing");
+
+        // Now verify the block, it should fail
+        let result = signed_block.verify(&context);
+        match result.err().unwrap() {
+            ConsensusError::CryptographicOperationFailure(err) => {
+                assert_eq!(err, FastCryptoError::InvalidSignature);
+            }
+            err => panic!("Unexpected error: {err:?}"),
+        }
+    }
+}

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -10,6 +10,8 @@ use crate::metrics::Metrics;
 
 #[cfg(test)]
 use crate::metrics::test_metrics;
+#[cfg(test)]
+use consensus_config::{NetworkKeyPair, ProtocolKeyPair};
 
 /// Context contains per-epoch configuration and metrics shared by all components
 /// of this authority.
@@ -46,16 +48,17 @@ impl Context {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        let (committee, _) = Committee::new_for_test(0, vec![1, 1, 1, 1]);
+    pub(crate) fn new_for_test() -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {
+        let (committee, keypairs) = Committee::new_for_test(0, vec![1, 1, 1, 1]);
         let metrics = test_metrics();
-        Context::new(
+        let context = Context::new(
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters::default(),
             ProtocolConfig::get_for_min_version(),
             metrics,
-        )
+        );
+        (context, keypairs)
     }
 
     #[cfg(test)]

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -159,7 +159,8 @@ mod test {
 
     #[tokio::test]
     async fn test_core_thread() {
-        let context = Arc::new(Context::new_for_test());
+        let (context, mut key_pairs) = Context::new_for_test();
+        let context = Arc::new(context);
         let block_manager = BlockManager::new();
         let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
         let transactions_consumer = TransactionsConsumer::new(tx_receiver);
@@ -170,6 +171,7 @@ mod test {
             block_manager,
             signals,
             CoreOptions::default(),
+            key_pairs.remove(context.own_index.value()).0,
         );
 
         let (core_dispatcher, handle) = CoreThreadDispatcher::start(core, context);

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::error::FastCryptoError;
 use thiserror::Error;
 use typed_store::TypedStoreError;
 
@@ -13,7 +14,29 @@ pub enum ConsensusError {
 
     #[error("RocksDB failure: {0}")]
     RocksDBFailure(#[from] TypedStoreError),
+
+    #[error("FastCrypto failure: {0}")]
+    CryptographicOperationFailure(#[from] FastCryptoError),
+
+    #[error("Unknown authority provided: {0}")]
+    UnknownAuthority(String),
 }
 
 #[allow(unused)]
 pub type ConsensusResult<T> = Result<T, ConsensusError>;
+
+#[macro_export]
+macro_rules! bail {
+    ($e:expr) => {
+        return Err($e);
+    };
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! ensure {
+    ($cond:expr, $e:expr) => {
+        if !($cond) {
+            bail!($e);
+        }
+    };
+}

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_block() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test().0);
         let mut aggregator = ThresholdClock::new(0, context);
 
         aggregator.add_block(BlockRef::new(
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_threshold_clock_add_blocks() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test().0);
         let mut aggregator = ThresholdClock::new(0, context);
 
         let block_refs = vec![

--- a/consensus/core/src/transactions_client.rs
+++ b/consensus/core/src/transactions_client.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_submit_and_consume() {
-        let context = Arc::new(Context::new_for_test());
+        let context = Arc::new(Context::new_for_test().0);
         let (client, tx_receiver) = TransactionsClient::new(context);
         let mut consumer = TransactionsConsumer::new(tx_receiver);
 

--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -35,6 +35,7 @@ impl TryFrom<u8> for IntentVersion {
 pub enum AppId {
     Sui = 0,
     Narwhal = 1,
+    Consensus = 2,
 }
 
 // TODO(joyqvq): Use num_derive
@@ -65,6 +66,7 @@ pub enum IntentScope {
     ProofOfPossession = 5, // Used as a signature representing an authority's proof of possession of its authority protocol key.
     HeaderDigest = 6,      // Used for narwhal authority signature on header digest.
     BridgeEventUnused = 7, // for bridge purposes but it's currently not included in messages.
+    BlockDigest = 8,       // Used for consensus authority signature on block's digest
 }
 
 impl TryFrom<u8> for IntentScope {
@@ -131,6 +133,14 @@ impl Intent {
             scope,
             version: IntentVersion::V0,
             app_id: AppId::Narwhal,
+        }
+    }
+
+    pub fn consensus_app(scope: IntentScope) -> Self {
+        Self {
+            scope,
+            version: IntentVersion::V0,
+            app_id: AppId::Consensus,
         }
     }
 }


### PR DESCRIPTION
## Description 

Adding the block signer using the message `intents`. A new app is introduced `Consensus`.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
