### PR TITLE
[consensus] Add universal committer

### DIFF
--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
+use consensus_config::{AuthorityIndex, Stake};
 use parking_lot::RwLock;
 
 use crate::{
@@ -13,8 +14,6 @@ use crate::{
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
-
-use consensus_config::{AuthorityIndex, Stake};
 
 #[cfg(test)]
 #[path = "tests/base_committer_tests.rs"]
@@ -160,25 +159,25 @@ impl BaseCommitter {
         ))
     }
 
-    /// Return the wave in which the specified round belongs. This takes into
-    /// account the round offset for when pipelining is enabled.
-    fn wave_number(&self, round: Round) -> WaveNumber {
-        round.saturating_sub(self.options.round_offset) / self.options.wave_length
-    }
-
     /// Return the leader round of the specified wave. The leader round is always
     /// the first round of the wave. This takes into account round offset for when
     /// pipelining is enabled.
-    fn leader_round(&self, wave: WaveNumber) -> Round {
+    pub(crate) fn leader_round(&self, wave: WaveNumber) -> Round {
         (wave * self.options.wave_length) + self.options.round_offset
     }
 
     /// Return the decision round of the specified wave. The decision round is
     /// always the last round of the wave. This takes into account round offset
     /// for when pipelining is enabled.
-    fn decision_round(&self, wave: WaveNumber) -> Round {
+    pub(crate) fn decision_round(&self, wave: WaveNumber) -> Round {
         let wave_length = self.options.wave_length;
         (wave * wave_length) + wave_length - 1 + self.options.round_offset
+    }
+
+    /// Return the wave in which the specified round belongs. This takes into
+    /// account the round offset for when pipelining is enabled.
+    fn wave_number(&self, round: Round) -> WaveNumber {
+        round.saturating_sub(self.options.round_offset) / self.options.wave_length
     }
 
     /// Find which block is supported at a slot (author, round) by the given block.

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -270,6 +270,14 @@ impl Slot {
     pub fn new(round: Round, authority: AuthorityIndex) -> Self {
         Self { round, authority }
     }
+
+    #[cfg(test)]
+    pub fn new_for_test(round: Round, authority: u32) -> Self {
+        Self {
+            round,
+            authority: AuthorityIndex::new_for_test(authority),
+        }
+    }
 }
 
 impl From<BlockRef> for Slot {
@@ -449,7 +457,7 @@ impl fmt::Debug for VerifiedBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{:?}({}ms;{:?};{}v)",
+            "{:?}({}ms;{:?};{};v)",
             self.reference(),
             self.timestamp_ms(),
             self.ancestors(),

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Display;
 
+use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
 use crate::block::{BlockAPI, BlockRef, Round, Slot, VerifiedBlock};
@@ -39,6 +40,13 @@ pub(crate) struct Commit {
     pub last_committed_rounds: Vec<Round>,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[allow(unused)]
+pub(crate) enum Decision {
+    Direct,
+    Indirect,
+}
+
 /// The status of every leader output by the committers. While the core only cares
 /// about committed leaders, providing a richer status allows for easier debugging,
 /// testing, and composition with advanced commit strategies.
@@ -57,6 +65,22 @@ impl LeaderStatus {
             Self::Commit(block) => block.round(),
             Self::Skip(leader) => leader.round,
             Self::Undecided(leader) => leader.round,
+        }
+    }
+
+    pub fn authority(&self) -> AuthorityIndex {
+        match self {
+            Self::Commit(block) => block.author(),
+            Self::Skip(leader) => leader.authority,
+            Self::Undecided(leader) => leader.authority,
+        }
+    }
+
+    pub fn is_decided(&self) -> bool {
+        match self {
+            Self::Commit(_) => true,
+            Self::Skip(_) => true,
+            Self::Undecided(_) => false,
         }
     }
 }

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -47,7 +47,7 @@ impl Context {
         }
     }
 
-    /// Create a test context with a committee of optional given size and even stake
+    /// Create a test context with a committee of given size and even stake
     #[cfg(test)]
     pub(crate) fn new_for_test(
         committee_size: usize,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -44,11 +44,11 @@ pub(crate) struct DagState {
     // Last consensus commit of the dag.
     last_commit: Option<Commit>,
 
+    // Highest round of blocks accepted.
+    highest_accepted_round: Round,
+
     // Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
-
-    // Highest round of blocks accepted.
-    pub highest_round: Round,
 }
 
 #[allow(unused)]
@@ -68,7 +68,7 @@ impl DagState {
             cached_refs: vec![BTreeSet::new(); num_authorities],
             last_commit,
             store,
-            highest_round: 0,
+            highest_accepted_round: 0,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
@@ -87,8 +87,8 @@ impl DagState {
 
     /// Accepts a block into DagState and keeps it in memory.
     pub(crate) fn accept_block(&mut self, block: VerifiedBlock) {
-        self.highest_round = max(self.highest_round, block.round());
         let block_ref = block.reference();
+        let block_round = block.round();
 
         // TODO: Move this check to core
         // Ensure we don't write multiple blocks per slot for our own index
@@ -102,6 +102,7 @@ impl DagState {
         }
         self.recent_blocks.insert(block_ref, block);
         self.cached_refs[block_ref.author].insert(block_ref);
+        self.highest_accepted_round = max(self.highest_accepted_round, block_round);
     }
 
     /// Accepts a blocks into DagState and keeps it in memory.
@@ -199,6 +200,10 @@ impl DagState {
                     .clone()
             })
             .collect()
+    }
+
+    pub(crate) fn highest_accepted_round(&self) -> Round {
+        self.highest_accepted_round
     }
 
     /// Highest round where a block is committed, which is last commit's leader round.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -61,7 +61,6 @@ impl DagState {
             Some(commit) => commit.last_committed_rounds.clone(),
             None => vec![0; num_authorities],
         };
-        let highest_round = *last_committed_rounds.iter().max().unwrap();
 
         let mut state = Self {
             context,
@@ -69,7 +68,7 @@ impl DagState {
             cached_refs: vec![BTreeSet::new(); num_authorities],
             last_commit,
             store,
-            highest_round,
+            highest_round: 0,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -20,6 +20,7 @@ mod stake_aggregator;
 mod storage;
 mod threshold_clock;
 mod transactions_client;
+mod universal_committer;
 
 #[cfg(test)]
 mod test_dag;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
+    IntCounterVec, IntGauge, Registry,
 };
 use std::sync::Arc;
 
@@ -36,6 +37,8 @@ pub(crate) fn test_metrics() -> Arc<Metrics> {
 pub(crate) struct NodeMetrics {
     pub uptime: Histogram,
     pub quorum_receive_latency: Histogram,
+    #[allow(unused)]
+    pub committed_leaders_total: IntCounterVec,
     pub core_lock_enqueued: IntCounter,
     pub core_lock_dequeued: IntCounter,
     pub leader_timeout_total: IntCounter,
@@ -56,6 +59,13 @@ impl NodeMetrics {
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
                 registry
+            )
+            .unwrap(),
+            committed_leaders_total: register_int_counter_vec_with_registry!(
+                "committed_leaders_total",
+                "Total number of (direct or indirect) committed leaders per authority",
+                &["authority", "commit_type"],
+                registry,
             )
             .unwrap(),
             core_lock_enqueued: register_int_counter_with_registry!(

--- a/consensus/core/src/tests/base_committer_tests.rs
+++ b/consensus/core/src/tests/base_committer_tests.rs
@@ -5,7 +5,6 @@ use std::{collections::HashSet, sync::Arc};
 
 use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
-use tracing::info;
 
 use crate::{
     base_committer::base_committer_builder::BaseCommitterBuilder,
@@ -50,9 +49,9 @@ fn try_direct_commit() {
         let leader = committer
             .elect_leader(round)
             .expect("should have elected leader");
-        info!("Try direct commit for leader {leader}",);
+        tracing::info!("Try direct commit for leader {leader}",);
         let leader_status = committer.try_direct_decide(leader);
-        info!("Leader commit status: {leader_status}");
+        tracing::info!("Leader commit status: {leader_status}");
 
         if round < incomplete_wave_leader_round {
             if let LeaderStatus::Commit(ref committed_block) = leader_status {
@@ -95,9 +94,9 @@ fn idempotence() {
     let leader = committer
         .elect_leader(leader_round_wave_1)
         .expect("should have elected leader");
-    info!("Try direct commit for leader {leader}",);
+    tracing::info!("Try direct commit for leader {leader}",);
     let leader_status = committer.try_direct_decide(leader);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref block) = leader_status {
         assert_eq!(block.author(), leader.authority)
@@ -106,9 +105,9 @@ fn idempotence() {
     };
 
     // Commit the same leader again on the same dag state and get the same result
-    info!("Try direct commit for leader {leader} again",);
+    tracing::info!("Try direct commit for leader {leader} again",);
     let leader_status = committer.try_direct_decide(leader);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
         assert_eq!(committed_block.author(), leader.authority)
@@ -146,9 +145,9 @@ fn multiple_direct_commit() {
         let leader = committer
             .elect_leader(leader_round)
             .expect("should have elected leader");
-        info!("Try direct commit for leader {leader}",);
+        tracing::info!("Try direct commit for leader {leader}",);
         let leader_status = committer.try_direct_decide(leader);
-        info!("Leader commit status: {leader_status}");
+        tracing::info!("Leader commit status: {leader_status}");
 
         if let LeaderStatus::Commit(ref committed_block) = leader_status {
             assert_eq!(committed_block.author(), leader.authority)
@@ -199,9 +198,9 @@ fn direct_skip() {
     );
 
     // Ensure no blocks are committed.
-    info!("Try direct commit for leader {leader_wave_1}",);
+    tracing::info!("Try direct commit for leader {leader_wave_1}",);
     let leader_status = committer.try_direct_decide(leader_wave_1);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_leader) = leader_status {
         assert_eq!(skipped_leader, leader_wave_1);
@@ -308,9 +307,9 @@ fn indirect_commit() {
     let leader_wave_2 = committer
         .elect_leader(committer.leader_round(2))
         .expect("should have elected leader");
-    info!("Try direct commit for leader {leader_wave_2}");
+    tracing::info!("Try direct commit for leader {leader_wave_2}");
     let leader_status = committer.try_direct_decide(leader_wave_2);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
@@ -321,9 +320,9 @@ fn indirect_commit() {
     };
 
     // Try direct commit leader from wave 1 which should result in Undecided
-    info!("Try direct commit for leader {leader_wave_1}");
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
     let leader_status = committer.try_direct_decide(leader_wave_1);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {
         assert_eq!(undecided_slot, leader_wave_1)
@@ -341,9 +340,9 @@ fn indirect_commit() {
 
     // Ensure we commit the leader of wave 1 indirectly with the committed leader
     // of wave 2 as the anchor.
-    info!("Try indirect commit for leader {leader_wave_1}",);
+    tracing::info!("Try indirect commit for leader {leader_wave_1}",);
     let leader_status = committer.try_indirect_decide(leader_wave_1, decided_leaders.iter());
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority)
@@ -426,9 +425,9 @@ fn indirect_skip() {
     let leader_wave_3 = committer
         .elect_leader(leader_round_wave_3)
         .expect("should have elected leader");
-    info!("Try direct commit for leader {leader_wave_3}");
+    tracing::info!("Try direct commit for leader {leader_wave_3}");
     let leader_status = committer.try_direct_decide(leader_wave_3);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     let mut decided_leaders = vec![];
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
@@ -445,9 +444,9 @@ fn indirect_skip() {
     let leader_wave_2 = committer
         .elect_leader(leader_round_wave_2)
         .expect("should have elected leader");
-    info!("Try direct commit for leader {leader_wave_2}");
+    tracing::info!("Try direct commit for leader {leader_wave_2}");
     let leader_status = committer.try_direct_decide(leader_wave_2);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {
         assert_eq!(undecided_slot, leader_wave_2)
@@ -456,9 +455,9 @@ fn indirect_skip() {
     };
 
     // 3. Ensure we skip leader of wave 2 indirectly.
-    info!("Try indirect commit for leader {leader_wave_2}",);
+    tracing::info!("Try indirect commit for leader {leader_wave_2}",);
     let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Skip(skipped_slot) = leader_status {
         assert_eq!(skipped_slot, leader_wave_2)
@@ -471,9 +470,9 @@ fn indirect_skip() {
     let leader_wave_1 = committer
         .elect_leader(leader_round_wave_1)
         .expect("should have elected leader");
-    info!("Try direct commit for leader {leader_wave_1}");
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
     let leader_status = committer.try_direct_decide(leader_wave_1);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_1.authority);
@@ -545,9 +544,9 @@ fn undecided() {
 
     // Ensure we directly mark leader of wave 1 undecided as there are less than
     // 2f+1 blames and 2f+1 certs
-    info!("Try direct commit for leader {leader_wave_1}");
+    tracing::info!("Try direct commit for leader {leader_wave_1}");
     let leader_status = committer.try_direct_decide(leader_wave_1);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {
         assert_eq!(undecided_slot, leader_wave_1)
@@ -557,9 +556,9 @@ fn undecided() {
 
     // Ensure we indirectly mark leader of wave 1 undecided as there is no anchor
     // to make an indirect decision.
-    info!("Try indirect commit for leader {leader_wave_1}");
+    tracing::info!("Try indirect commit for leader {leader_wave_1}");
     let leader_status = committer.try_indirect_decide(leader_wave_1, [].iter());
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Undecided(undecided_slot) = leader_status {
         assert_eq!(undecided_slot, leader_wave_1)
@@ -713,9 +712,9 @@ fn test_byzantine_direct_commit() {
     //   decision round. But all of these blocks also have good votes from A, B, C & D.
     // Expect a successful direct commit.
 
-    info!("Try direct commit for leader {leader_wave_4}");
+    tracing::info!("Try direct commit for leader {leader_wave_4}");
     let leader_status = committer.try_direct_decide(leader_wave_4);
-    info!("Leader commit status: {leader_status}");
+    tracing::info!("Leader commit status: {leader_status}");
 
     if let LeaderStatus::Commit(ref committed_block) = leader_status {
         assert_eq!(committed_block.author(), leader_wave_4.authority);

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::{
+    block::{BlockAPI, Slot},
+    commit::LeaderStatus,
+    context::Context,
+    dag_state::DagState,
+    storage::mem_store::MemStore,
+    test_dag::{build_dag, build_dag_layer},
+    universal_committer::universal_committer_builder::UniversalCommitterBuilder,
+};
+
+/// Commit one leader.
+#[test]
+fn direct_commit() {
+    telemetry_subscribers::init_for_testing();
+    // Commitee of 4 with even stake
+    let context = Arc::new(Context::new_for_test(4));
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+
+    // Create committer without pipelining and only 1 leader per round
+    let committer = UniversalCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Build fully connected fully connected dag with empty blocks
+    // adding up to voting round of wave 2 to the dag so that we have
+    // 2 completed waves and one incomplete wave. The universal committer
+    // should mark the potential leaders in r6 undecided because there is no way
+    // to get enough certificates for r6 leaders without completing wave 2.
+    // note: without pipelining or multi-leader enabled there should only be one committer.
+    let leader_round_wave_1 = committer.committers[0].leader_round(1);
+    let voting_round_wave_2 = committer.committers[0].leader_round(2) + 1;
+    build_dag(context, dag_state, None, voting_round_wave_2);
+
+    // Genesis cert will not be included in commit sequence, marking it as last decided
+    let last_decided = Slot::new_for_test(0, 0);
+    let sequence = committer.try_commit(last_decided);
+    tracing::info!("Commit sequence: {sequence:?}");
+
+    assert_eq!(sequence.len(), 1);
+    if let LeaderStatus::Commit(ref block) = sequence[0] {
+        assert_eq!(
+            block.author(),
+            committer.get_leaders(leader_round_wave_1)[0]
+        )
+    } else {
+        panic!("Expected a committed leader")
+    };
+}
+
+/// Indirect-commit the first leader.
+#[test]
+fn indirect_commit() {
+    telemetry_subscribers::init_for_testing();
+    // Commitee of 4 with even stake
+    let context = Arc::new(Context::new_for_test(4));
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+
+    // Create committer without pipelining and only 1 leader per round
+    let committer = UniversalCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Add enough blocks to reach the leader round of wave 1.
+    let leader_round_wave_1 = committer.committers[0].leader_round(1);
+    let references_leader_wave_1 = build_dag(
+        context.clone(),
+        dag_state.clone(),
+        None,
+        leader_round_wave_1,
+    );
+
+    // Filter out that leader.
+    let leader_wave_1 = committer.get_leaders(leader_round_wave_1)[0];
+    let references_without_leader_wave_1: Vec<_> = references_leader_wave_1
+        .iter()
+        .cloned()
+        .filter(|x| x.author != leader_wave_1)
+        .collect();
+
+    // Only 2f+1 validators vote for the leader of wave 1.
+    let connections_with_leader_wave_1 = context
+        .committee
+        .authorities()
+        .take(context.committee.quorum_threshold() as usize)
+        .map(|authority| (authority.0, references_leader_wave_1.clone()))
+        .collect();
+    let references_with_votes_for_leader_wave_1 =
+        build_dag_layer(connections_with_leader_wave_1, dag_state.clone());
+
+    // The validators not part of the 2f+1 above do not vote for the leader
+    // of wave 1
+    let connections_without_leader_wave_1 = context
+        .committee
+        .authorities()
+        .skip(context.committee.quorum_threshold() as usize)
+        .map(|authority| (authority.0, references_without_leader_wave_1.clone()))
+        .collect();
+    let references_without_votes_for_leader_wave_1 =
+        build_dag_layer(connections_without_leader_wave_1, dag_state.clone());
+
+    // Only f+1 validators certify the leader of wave 1.
+    let mut references_decision_round_wave_1 = Vec::new();
+
+    let connections_with_certs_for_leader_wave_1 = context
+        .committee
+        .authorities()
+        .take(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_with_votes_for_leader_wave_1.clone()))
+        .collect();
+    references_decision_round_wave_1.extend(build_dag_layer(
+        connections_with_certs_for_leader_wave_1,
+        dag_state.clone(),
+    ));
+
+    let references_voting_round_wave_1: Vec<_> = references_without_votes_for_leader_wave_1
+        .into_iter()
+        .chain(references_with_votes_for_leader_wave_1)
+        .take(context.committee.quorum_threshold() as usize)
+        .collect();
+
+    // The validators not part of the f+1 above will not certify the leader of wave 1.
+    let connections_without_votes_for_leader_1 = context
+        .committee
+        .authorities()
+        .skip(context.committee.validity_threshold() as usize)
+        .map(|authority| (authority.0, references_voting_round_wave_1.clone()))
+        .collect();
+    references_decision_round_wave_1.extend(build_dag_layer(
+        connections_without_votes_for_leader_1,
+        dag_state.clone(),
+    ));
+
+    // Add enough blocks to decide the leader of wave 2 connecting to the references
+    // manually constructed of the decision round of wave 1.
+    let leader_round_wave_3 = committer.committers[0].leader_round(3);
+    build_dag(
+        context.clone(),
+        dag_state.clone(),
+        Some(references_decision_round_wave_1),
+        leader_round_wave_3,
+    );
+
+    let last_decided = Slot::new_for_test(0, 0);
+    let sequence = committer.try_commit(last_decided);
+    tracing::info!("Commit sequence: {sequence:?}");
+    assert_eq!(sequence.len(), 2);
+
+    if let LeaderStatus::Commit(ref block) = sequence[0] {
+        assert_eq!(block.author(), leader_wave_1);
+    } else {
+        panic!("Expected a committed leader")
+    };
+}

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -20,7 +20,7 @@ use crate::{
 fn direct_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
-    let context = Arc::new(Context::new_for_test(4));
+    let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),
@@ -62,7 +62,7 @@ fn direct_commit() {
 fn indirect_commit() {
     telemetry_subscribers::init_for_testing();
     // Commitee of 4 with even stake
-    let context = Arc::new(Context::new_for_test(4));
+    let context = Arc::new(Context::new_for_test(4).0);
     let dag_state = Arc::new(RwLock::new(DagState::new(
         context.clone(),
         Arc::new(MemStore::new()),

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::VecDeque, sync::Arc};
+
+use consensus_config::AuthorityIndex;
+use parking_lot::RwLock;
+
+use crate::{
+    base_committer::BaseCommitter,
+    block::{Round, Slot},
+    commit::{Decision, LeaderStatus},
+    context::Context,
+    dag_state::DagState,
+};
+
+#[cfg(test)]
+#[path = "tests/universal_committer_tests.rs"]
+pub mod universal_committer_tests;
+
+/// A universal committer uses a collection of committers to commit a sequence of leaders.
+/// It can be configured to use a combination of different commit strategies, including
+/// multi-leaders, backup leaders, and pipelines.
+#[allow(unused)]
+pub struct UniversalCommitter {
+    /// The per-epoch configuration of this authority.
+    context: Arc<Context>,
+    /// Block store representing the Dag state
+    dag_state: Arc<RwLock<DagState>>,
+    /// The list of committers for multi-leader or pipelining
+    committers: Vec<BaseCommitter>,
+}
+
+impl UniversalCommitter {
+    /// Try to commit part of the dag. This function is idempotent and returns a list of
+    /// ordered decided leaders.
+    #[tracing::instrument(skip_all, fields(last_decided = %last_decided))]
+    pub fn try_commit(&self, last_decided: Slot) -> Vec<LeaderStatus> {
+        let highest_known_round = self.dag_state.read().highest_round;
+
+        // Try to decide as many leaders as possible, starting with the highest round.
+        let mut leaders = VecDeque::new();
+        // try to commit a leader up to the highest_known_round - 2. There is no
+        // reason to try and iterate on higher rounds as in order to make a direct
+        // decision for a leader at round R we need blocks from round R+2 to figure
+        // out that enough certificates and support exist to commit a leader.
+        'outer: for round in (last_decided.round..=highest_known_round.saturating_sub(2)).rev() {
+            for committer in self.committers.iter().rev() {
+                // Skip committers that don't have a leader for this round.
+                let Some(leader) = committer.elect_leader(round) else {
+                    continue;
+                };
+
+                // now that we reached the last committed leader we can stop the commit rule
+                if leader == last_decided {
+                    tracing::debug!("Reached last committed {leader}, now exit");
+                    break 'outer;
+                }
+
+                tracing::debug!("Trying to decide {leader} with {committer}",);
+
+                // Try to directly decide the leader.
+                let mut status = committer.try_direct_decide(leader);
+                tracing::debug!("Outcome of direct rule: {status}");
+
+                // If we can't directly decide the leader, try to indirectly decide it.
+                if status.is_decided() {
+                    leaders.push_front((status.clone(), Decision::Direct));
+                } else {
+                    status = committer.try_indirect_decide(leader, leaders.iter().map(|(x, _)| x));
+                    leaders.push_front((status.clone(), Decision::Indirect));
+                    tracing::debug!("Outcome of indirect rule: {status}");
+                }
+            }
+        }
+
+        // The decided sequence is the longest prefix of decided leaders.
+        leaders
+            .into_iter()
+            // Filter out all the genesis.
+            .filter(|(x, _)| x.round() > 0)
+            // Stop the sequence upon encountering an undecided leader.
+            .take_while(|(x, _)| x.is_decided())
+            // We want to report metrics at this point to ensure that the decisions
+            // are reported only once hence we increase our accuracy
+            .inspect(|(x, direct_decided)| {
+                self.update_metrics(x, *direct_decided);
+                tracing::debug!("Decided {x}");
+            })
+            .map(|(x, _)| x)
+            .collect()
+    }
+
+    /// Return list of leaders for the round. Syncer may give those leaders some extra time.
+    /// To preserve (theoretical) liveness, we should wait `Delta` time for at least the first leader.
+    /// Can return empty vec if round does not have a designated leader.
+    pub fn get_leaders(&self, round: Round) -> Vec<AuthorityIndex> {
+        self.committers
+            .iter()
+            .filter_map(|committer| committer.elect_leader(round))
+            .map(|l| l.authority)
+            .collect()
+    }
+
+    /// Update metrics.
+    fn update_metrics(&self, leader: &LeaderStatus, decision: Decision) {
+        let authority = leader.authority().to_string();
+        let decision_str = if decision == Decision::Direct {
+            "direct"
+        } else {
+            "indirect"
+        };
+        let status = match leader {
+            LeaderStatus::Commit(..) => format!("{decision_str}-commit"),
+            LeaderStatus::Skip(..) => format!("{decision_str}-skip"),
+            LeaderStatus::Undecided(..) => return,
+        };
+        self.context
+            .metrics
+            .node_metrics
+            .committed_leaders_total
+            .with_label_values(&[&authority, &status])
+            .inc();
+    }
+}
+
+/// A builder for a universal committer. By default, the builder creates a single
+/// base committer, that is, a single leader and no pipeline.
+#[cfg(test)]
+#[allow(unused)]
+mod universal_committer_builder {
+    use super::*;
+
+    use crate::{
+        base_committer::BaseCommitterOptions, commit::DEFAULT_WAVE_LENGTH,
+        leader_schedule::LeaderSchedule,
+    };
+
+    pub struct UniversalCommitterBuilder {
+        context: Arc<Context>,
+        leader_schedule: LeaderSchedule,
+        dag_state: Arc<RwLock<DagState>>,
+        wave_length: Round,
+        number_of_leaders: usize,
+        pipeline: bool,
+    }
+
+    impl UniversalCommitterBuilder {
+        pub fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+            let leader_schedule = LeaderSchedule::new(context.clone());
+            Self {
+                context,
+                leader_schedule,
+                dag_state,
+                wave_length: DEFAULT_WAVE_LENGTH,
+                number_of_leaders: 1,
+                pipeline: false,
+            }
+        }
+
+        pub fn with_wave_length(mut self, wave_length: Round) -> Self {
+            self.wave_length = wave_length;
+            self
+        }
+
+        pub fn with_number_of_leaders(mut self, number_of_leaders: usize) -> Self {
+            self.number_of_leaders = number_of_leaders;
+            self
+        }
+
+        pub fn with_pipeline(mut self, pipeline: bool) -> Self {
+            self.pipeline = pipeline;
+            self
+        }
+
+        pub fn build(self) -> UniversalCommitter {
+            let mut committers = Vec::new();
+            let pipeline_stages = if self.pipeline { self.wave_length } else { 1 };
+            for round_offset in 0..pipeline_stages {
+                for leader_offset in 0..self.number_of_leaders {
+                    let options = BaseCommitterOptions {
+                        wave_length: self.wave_length,
+                        round_offset,
+                        leader_offset: leader_offset as Round,
+                    };
+                    let committer = BaseCommitter::new(
+                        self.context.clone(),
+                        self.leader_schedule.clone(),
+                        self.dag_state.clone(),
+                        options,
+                    );
+                    committers.push(committer);
+                }
+            }
+
+            UniversalCommitter {
+                context: self.context,
+                dag_state: self.dag_state,
+                committers,
+            }
+        }
+    }
+}

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -22,7 +22,7 @@ pub mod universal_committer_tests;
 /// It can be configured to use a combination of different commit strategies, including
 /// multi-leaders, backup leaders, and pipelines.
 #[allow(unused)]
-pub struct UniversalCommitter {
+pub(crate) struct UniversalCommitter {
     /// The per-epoch configuration of this authority.
     context: Arc<Context>,
     /// Block store representing the Dag state
@@ -91,8 +91,7 @@ impl UniversalCommitter {
             .collect()
     }
 
-    /// Return list of leaders for the round. Syncer may give those leaders some extra time.
-    /// To preserve (theoretical) liveness, we should wait `Delta` time for at least the first leader.
+    /// Return list of leaders for the round.
     /// Can return empty vec if round does not have a designated leader.
     pub fn get_leaders(&self, round: Round) -> Vec<AuthorityIndex> {
         self.committers
@@ -136,7 +135,7 @@ mod universal_committer_builder {
         leader_schedule::LeaderSchedule,
     };
 
-    pub struct UniversalCommitterBuilder {
+    pub(crate) struct UniversalCommitterBuilder {
         context: Arc<Context>,
         leader_schedule: LeaderSchedule,
         dag_state: Arc<RwLock<DagState>>,


### PR DESCRIPTION
## Description
The `UniversalCommitter` uses a collection of `BaseCommitter`'s to commit a sequence of leaders. It will be configured to enable multi-leader & pipelining in Mysticeti.

Note: Feel free to ignore test util changes as most of that will be reviewed and checked in with [PR#15806](https://github.com/MystenLabs/sui/pull/15806)

## Test Plan
Added a few basic tests to ensure things are working, but will add more tests in a follow up PR so this PR can remain small.