### PR TITLE
[Consensus] implement `DagState` methods

### DIFF
--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -166,6 +166,8 @@ pub struct Authority {
 pub struct AuthorityIndex(u32);
 
 impl AuthorityIndex {
+    pub const ZERO: AuthorityIndex = AuthorityIndex(0);
+
     pub fn value(&self) -> usize {
         self.0 as usize
     }

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -159,13 +159,15 @@ pub struct Authority {
 /// Each authority is uniquely identified by its AuthorityIndex in the Committee.
 /// AuthorityIndex is between 0 (inclusive) and the total number of authorities (exclusive).
 ///
-/// NOTE: AuthorityIndex should not need to be created outside of this file or incremented.
+/// NOTE: for safety, invalid AuthorityIndex should be impossible to create. So AuthorityIndex
+/// should not be created outside of this file or be incremented.
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize,
 )]
 pub struct AuthorityIndex(u32);
 
 impl AuthorityIndex {
+    // Minimum committee size is 4, so 0 index is always valid.
     pub const ZERO: AuthorityIndex = AuthorityIndex(0);
 
     pub fn value(&self) -> usize {

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -160,7 +160,8 @@ pub struct Authority {
 /// AuthorityIndex is between 0 (inclusive) and the total number of authorities (exclusive).
 ///
 /// NOTE: for safety, invalid AuthorityIndex should be impossible to create. So AuthorityIndex
-/// should not be created or incremented outside of this file.
+/// should not be created or incremented outside of this file. AuthorityIndex received from peers
+/// should be validated before use.
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize,
 )]

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -160,7 +160,7 @@ pub struct Authority {
 /// AuthorityIndex is between 0 (inclusive) and the total number of authorities (exclusive).
 ///
 /// NOTE: for safety, invalid AuthorityIndex should be impossible to create. So AuthorityIndex
-/// should not be created outside of this file or be incremented.
+/// should not be created or incremented outside of this file.
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Default, Hash, Serialize, Deserialize,
 )]

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -90,7 +90,7 @@ impl BaseCommitter {
         // (created by Byzantine leaders).
         let wave = self.wave_number(leader.round);
         let decision_round = self.decision_round(wave);
-        let leader_blocks = self.dag_state.read().get_blocks_at_slot(leader);
+        let leader_blocks = self.dag_state.read().get_uncommitted_blocks_at_slot(leader);
         let mut leaders_with_enough_support: Vec<_> = leader_blocks
             .into_iter()
             .filter(|l| self.enough_leader_support(decision_round, l))
@@ -259,7 +259,10 @@ impl BaseCommitter {
     fn decide_leader_from_anchor(&self, anchor: &VerifiedBlock, leader_slot: Slot) -> LeaderStatus {
         // Get the block(s) proposed by the leader. There could be more than one leader block
         // per round (produced by a Byzantine leader).
-        let leader_blocks = self.dag_state.read().get_blocks_at_slot(leader_slot);
+        let leader_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_blocks_at_slot(leader_slot);
 
         // TODO: Re-evaluate this check once we have a better way to handle/track byzantine authorities.
         if leader_blocks.len() > 1 {
@@ -276,7 +279,7 @@ impl BaseCommitter {
         let potential_certificates = self
             .dag_state
             .read()
-            .linked_to_round(anchor, decision_round);
+            .ancestors_at_uncommitted_round(anchor, decision_round);
 
         // Use those potential certificates to determine which (if any) of the target leader
         // blocks can be committed.
@@ -305,7 +308,10 @@ impl BaseCommitter {
 
     /// Check whether the specified leader has 2f+1 non-votes (blames) to be directly skipped.
     fn enough_leader_blame(&self, voting_round: Round, leader: AuthorityIndex) -> bool {
-        let voting_blocks = self.dag_state.read().get_blocks_by_round(voting_round);
+        let voting_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_blocks_at_round(voting_round);
 
         let mut blame_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
         for voting_block in &voting_blocks {
@@ -330,7 +336,10 @@ impl BaseCommitter {
     /// Check whether the specified leader has 2f+1 certificates to be directly
     /// committed.
     fn enough_leader_support(&self, decision_round: Round, leader_block: &VerifiedBlock) -> bool {
-        let decision_blocks = self.dag_state.read().get_blocks_by_round(decision_round);
+        let decision_blocks = self
+            .dag_state
+            .read()
+            .get_uncommitted_blocks_at_round(decision_round);
 
         // Quickly reject if there isn't enough stake to support the leader from
         // the potential certificates.

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -258,7 +258,7 @@ impl BaseCommitter {
     /// skip the target leader.
     fn decide_leader_from_anchor(&self, anchor: &VerifiedBlock, leader_slot: Slot) -> LeaderStatus {
         // Get the block(s) proposed by the leader. There could be more than one leader block
-        // per round (produced by a Byzantine leader).
+        // in the slot from a Byzantine authority.
         let leader_blocks = self
             .dag_state
             .read()

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -57,6 +57,7 @@ pub trait BlockAPI {
     fn author(&self) -> AuthorityIndex;
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn ancestors(&self) -> &[BlockRef];
+    fn transactions(&self) -> &[Transaction];
     // TODO: add accessor for transactions.
 }
 
@@ -66,6 +67,7 @@ pub struct BlockV1 {
     author: AuthorityIndex,
     timestamp_ms: BlockTimestampMs,
     ancestors: Vec<BlockRef>,
+    transactions: Vec<Transaction>,
 }
 
 impl BlockV1 {
@@ -75,12 +77,14 @@ impl BlockV1 {
         author: AuthorityIndex,
         timestamp_ms: BlockTimestampMs,
         ancestors: Vec<BlockRef>,
+        transactions: Vec<Transaction>,
     ) -> BlockV1 {
         Self {
             round,
             author,
             timestamp_ms,
             ancestors,
+            transactions,
         }
     }
 }
@@ -100,6 +104,10 @@ impl BlockAPI for BlockV1 {
 
     fn ancestors(&self) -> &[BlockRef] {
         &self.ancestors
+    }
+
+    fn transactions(&self) -> &[Transaction] {
+        &self.transactions
     }
 }
 
@@ -365,6 +373,11 @@ impl TestBlock {
 
     pub(crate) fn set_ancestors(mut self, ancestors: Vec<BlockRef>) -> Self {
         self.block.ancestors = ancestors;
+        self
+    }
+
+    pub(crate) fn set_transactions(mut self, transactions: Vec<Transaction>) -> Self {
+        self.block.transactions = transactions;
         self
     }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -230,9 +230,9 @@ mod test {
         assert_eq!(core.last_proposed_round(), 0);
 
         // Add a few blocks which will get accepted
-        let block_1 = BlockV1::new(1, AuthorityIndex::new_for_test(0), 0, vec![]);
-        let block_2 = BlockV1::new(1, AuthorityIndex::new_for_test(1), 0, vec![]);
-        let block_3 = BlockV1::new(1, AuthorityIndex::new_for_test(2), 0, vec![]);
+        let block_1 = BlockV1::new(1, AuthorityIndex::new_for_test(0), 0, vec![], vec![]);
+        let block_2 = BlockV1::new(1, AuthorityIndex::new_for_test(1), 0, vec![], vec![]);
+        let block_3 = BlockV1::new(1, AuthorityIndex::new_for_test(2), 0, vec![], vec![]);
 
         let blocks = vec![block_1, block_2, block_3]
             .into_iter()

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -107,8 +107,8 @@ impl DagState {
     }
 
     pub(crate) fn get_uncommitted_blocks_at_round(&self, round: Round) -> Vec<VerifiedBlock> {
-        if round < self.round_lower_bound() {
-            panic!("Round {} blocks may not be cached in memory!", round);
+        if round <= self.last_commit_round() {
+            panic!("Round {} have committed blocks!", round);
         }
 
         let mut blocks = vec![];
@@ -132,11 +132,8 @@ impl DagState {
         later_block: &VerifiedBlock,
         earlier_round: Round,
     ) -> Vec<VerifiedBlock> {
-        if earlier_round < self.round_lower_bound() {
-            panic!(
-                "Round {} blocks may not be cached in memory!",
-                earlier_round
-            );
+        if earlier_round <= self.last_commit_round() {
+            panic!("Round {} have committed blocks!", earlier_round);
         }
         if earlier_round >= later_block.round() {
             panic!(
@@ -178,10 +175,10 @@ impl DagState {
             .collect()
     }
 
-    /// Lowest round where all known blocks are cached in memory.
-    fn round_lower_bound(&self) -> Round {
+    /// Highest round where a block is committed, which is last commit's leader round.
+    fn last_commit_round(&self) -> Round {
         match &self.last_commit {
-            Some(commit) => commit.leader.round.saturating_sub(CACHED_ROUNDS),
+            Some(commit) => commit.leader.round,
             None => 0,
         }
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -3,7 +3,8 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    ops::Bound::{Excluded, Included},
+    ops::Bound::{Excluded, Included, Unbounded},
+    panic,
     sync::Arc,
 };
 
@@ -124,6 +125,8 @@ impl DagState {
         blocks
     }
 
+    /// Gets all ancestors in the history of a block at a certain round.
+    /// The round must be higher than the last committed round.
     pub(crate) fn ancestors_at_uncommitted_round(
         &self,
         later_block: &VerifiedBlock,
@@ -143,26 +146,33 @@ impl DagState {
             );
         }
 
+        // Use BTreeSet to iterate through ancestors of later_block in round desc order.
         let mut linked: BTreeSet<BlockRef> = later_block.ancestors().iter().cloned().collect();
-        let mut round = later_block.round() - 1;
-        while round > earlier_round {
-            let mut next_linked = BTreeSet::new();
-            for r in linked.into_iter() {
-                let block = self
-                    .recent_blocks
-                    .get(&r)
-                    .unwrap_or_else(|| panic!("Block {:?} not found!", r));
-                next_linked.extend(block.ancestors().iter().cloned());
+        while !linked.is_empty() {
+            let round = linked.last().unwrap().round;
+            // Stop after finishing traversal for ancestors above earlier_round.
+            if round <= earlier_round {
+                break;
             }
-            linked = next_linked;
-            round -= 1;
+            let block_ref = linked.pop_last().unwrap();
+            let Some(block) = self.recent_blocks.get(&block_ref) else {
+                panic!("Block {:?} should be available in memory!", block_ref);
+            };
+            linked.extend(block.ancestors().iter().cloned());
         }
         linked
-            .into_iter()
+            .range((
+                Included(BlockRef::new(
+                    earlier_round,
+                    AuthorityIndex::ZERO,
+                    BlockDigest::MIN,
+                )),
+                Unbounded,
+            ))
             .map(|r| {
                 self.recent_blocks
-                    .get(&r)
-                    .unwrap_or_else(|| panic!("Block {:?} not found!", r))
+                    .get(r)
+                    .unwrap_or_else(|| panic!("Block {:?} should be available in memory!", r))
                     .clone()
             })
             .collect()
@@ -276,83 +286,156 @@ mod test {
 
     #[test]
     fn ancestors_at_uncommitted_round() {
+        // Initialize DagState.
         let context = Arc::new(Context::new_for_test());
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
-        // Populate a dag of blocks.
+        // Populate DagState.
 
-        // block_1_0 will be connected to anchor.
-        let block_1_0 =
-            VerifiedBlock::new_for_test(TestBlock::new(1, 0).set_timestamp_ms(100).build());
-        // Slot(1, 1) has 2 blocks. Only block_1_1 will be connected to anchor.
-        let block_1_1 =
-            VerifiedBlock::new_for_test(TestBlock::new(1, 1).set_timestamp_ms(110).build());
-        let block_1_1_1 =
-            VerifiedBlock::new_for_test(TestBlock::new(1, 1).set_timestamp_ms(111).build());
-        // block_1_2 will not be connected to anchor.
-        let block_1_2 =
-            VerifiedBlock::new_for_test(TestBlock::new(1, 2).set_timestamp_ms(120).build());
-        // block_1_3 will be connected to anchor.
-        let block_1_3 =
-            VerifiedBlock::new_for_test(TestBlock::new(1, 3).set_timestamp_ms(130).build());
-        let round_1 = vec![
-            block_1_0.clone(),
-            block_1_1.clone(),
-            block_1_1_1.clone(),
-            block_1_2.clone(),
-            block_1_3.clone(),
-        ];
-        let round_1_ancestors = vec![
-            block_1_0.reference(),
-            block_1_1.reference(),
-            block_1_3.reference(),
-        ];
-        let round_2 = vec![
+        // Round 10 refs will not have their blocks in DagState.
+        let round_10_refs: Vec<_> = (0..4)
+            .map(|a| {
+                VerifiedBlock::new_for_test(TestBlock::new(10, a).set_timestamp_ms(1000).build())
+                    .reference()
+            })
+            .collect();
+
+        // Round 11 blocks.
+        let round_11 = vec![
+            // This will connect to round 12.
             VerifiedBlock::new_for_test(
-                TestBlock::new(2, 0)
-                    .set_timestamp_ms(200)
-                    .set_ancestors(round_1_ancestors.clone())
+                TestBlock::new(11, 0)
+                    .set_timestamp_ms(1100)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+            // Slot(11, 1) has 3 blocks.
+            // This will connect to round 12.
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 1)
+                    .set_timestamp_ms(1110)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+            // This will connect to round 13.
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 1)
+                    .set_timestamp_ms(1111)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+            // This will not connect to any block.
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 1)
+                    .set_timestamp_ms(1112)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+            // This will not connect to any block.
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 2)
+                    .set_timestamp_ms(1120)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+            // This will connect to round 12.
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 3)
+                    .set_timestamp_ms(1130)
+                    .set_ancestors(round_10_refs.clone())
+                    .build(),
+            ),
+        ];
+
+        // Round 12 blocks.
+        let ancestors_for_round_12 = vec![
+            round_11[0].reference(),
+            round_11[1].reference(),
+            round_11[5].reference(),
+        ];
+        let round_12 = vec![
+            VerifiedBlock::new_for_test(
+                TestBlock::new(12, 0)
+                    .set_timestamp_ms(1200)
+                    .set_ancestors(ancestors_for_round_12.clone())
                     .build(),
             ),
             VerifiedBlock::new_for_test(
-                TestBlock::new(2, 2)
-                    .set_timestamp_ms(220)
-                    .set_ancestors(round_1_ancestors.clone())
+                TestBlock::new(12, 2)
+                    .set_timestamp_ms(1220)
+                    .set_ancestors(ancestors_for_round_12.clone())
                     .build(),
             ),
             VerifiedBlock::new_for_test(
-                TestBlock::new(2, 3)
-                    .set_timestamp_ms(230)
-                    .set_ancestors(round_1_ancestors.clone())
+                TestBlock::new(12, 3)
+                    .set_timestamp_ms(1230)
+                    .set_ancestors(ancestors_for_round_12.clone())
                     .build(),
             ),
         ];
-        let round_2_ancestors = round_2.iter().map(|b| b.reference()).collect();
+
+        // Round 13 blocks.
+        let ancestors_for_round_13 = vec![
+            round_12[0].reference(),
+            round_12[1].reference(),
+            round_12[2].reference(),
+            round_11[2].reference(),
+        ];
+        let round_13 = vec![
+            VerifiedBlock::new_for_test(
+                TestBlock::new(12, 0)
+                    .set_timestamp_ms(1300)
+                    .set_ancestors(ancestors_for_round_13.clone())
+                    .build(),
+            ),
+            VerifiedBlock::new_for_test(
+                TestBlock::new(12, 2)
+                    .set_timestamp_ms(1320)
+                    .set_ancestors(ancestors_for_round_13.clone())
+                    .build(),
+            ),
+            VerifiedBlock::new_for_test(
+                TestBlock::new(12, 3)
+                    .set_timestamp_ms(1330)
+                    .set_ancestors(ancestors_for_round_13.clone())
+                    .build(),
+            ),
+        ];
+
+        // Round 14 anchor block.
+        let ancestors_for_round_14 = round_13.iter().map(|b| b.reference()).collect();
         let anchor = VerifiedBlock::new_for_test(
-            TestBlock::new(3, 1)
-                .set_timestamp_ms(310)
-                .set_ancestors(round_2_ancestors)
+            TestBlock::new(14, 1)
+                .set_timestamp_ms(1410)
+                .set_ancestors(ancestors_for_round_14)
                 .build(),
         );
 
-        // Add all blocks to DagState.
-        for b in round_1
+        // Add all blocks (at and above round 11) to DagState.
+        for b in round_11
             .iter()
-            .chain(round_2.iter())
+            .chain(round_12.iter())
+            .chain(round_13.iter())
             .chain([anchor.clone()].iter())
         {
             dag_state.accept_block(b.clone());
         }
 
         // Check ancestors connected to anchor.
-        let ancestors = dag_state.ancestors_at_uncommitted_round(&anchor, 1);
+        let ancestors = dag_state.ancestors_at_uncommitted_round(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
+        let expected_refs = vec![
+            round_11[0].reference(),
+            round_11[1].reference(),
+            round_11[2].reference(),
+            round_11[5].reference(),
+        ];
         assert_eq!(
-            ancestors_refs, round_1_ancestors,
-            "Expected round 1 ancestors: {:?}. Got: {:?}",
-            round_1_ancestors, ancestors_refs
+            ancestors_refs, expected_refs,
+            "Expected round 11 ancestors: {:?}. Got: {:?}",
+            expected_refs, ancestors_refs
         );
     }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod mem_store;
-mod rocksdb_store;
+pub(crate) mod mem_store;
+pub(crate) mod rocksdb_store;
 
 #[cfg(test)]
 mod store_tests;


### PR DESCRIPTION
## Description 

Implement `DagState` methods used by commit rule.
There are some overlaps with #15806, but there shouldn't be a lot of conflicts hopefully.

## Test Plan 

Unit test.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
