### PR TITLE
indexer: package upgrade awareness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12566,6 +12566,7 @@ dependencies = [
  "sui-keys",
  "sui-move-build",
  "sui-open-rpc",
+ "sui-package-resolver",
  "sui-protocol-config",
  "sui-rest-api",
  "sui-sdk",

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -484,7 +484,7 @@ pub mod tests {
     }
 
     pub async fn test_query_depth_limit_impl() {
-        let (connection_config, _cluster) = prep_cluster().await;
+        let (connection_config, cluster) = prep_cluster().await;
 
         async fn exec_query_depth_limit(
             depth: u32,
@@ -517,6 +517,9 @@ pub mod tests {
         }
 
         // Should complete successfully
+        cluster
+            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .await;
         let resp = exec_query_depth_limit(1, "{ chainIdentifier }", &connection_config).await;
         assert!(resp.is_ok());
         let resp = exec_query_depth_limit(

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -32,6 +32,10 @@ mod tests {
         let cluster =
             sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
 
+        cluster
+            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .await;
+
         let query = r#"
             {
                 chainIdentifier
@@ -86,6 +90,9 @@ mod tests {
             None,
         )
         .await;
+        cluster
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
+            .await;
 
         let query = r#"
             {
@@ -118,6 +125,9 @@ mod tests {
             None,
         )
         .await;
+        cluster
+            .wait_for_checkpoint_catchup(0, Duration::from_secs(10))
+            .await;
 
         let query = r#"
             {
@@ -160,6 +170,9 @@ mod tests {
             None,
         )
         .await;
+        cluster
+            .wait_for_checkpoint_catchup(1, Duration::from_secs(10))
+            .await;
 
         let query = r#"{obj1: object(address: $framework_addr) {address}
             obj2: object(address: $deepbook_addr) {address}}"#;

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -41,6 +41,7 @@ sui-json-rpc-types.workspace = true
 sui-open-rpc.workspace = true
 sui-sdk.workspace = true
 sui-types.workspace = true
+sui-package-resolver.workspace = true
 sui-protocol-config.workspace = true
 telemetry-subscribers.workspace = true
 sui-rest-api.workspace = true

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -36,25 +36,24 @@ use crate::metrics::IndexerMetrics;
 use crate::types_v2::IndexedPackage;
 use crate::types_v2::{IndexedObjectChange, IndexerResult};
 
-// GC the cache every 10 minutes
-pub const PACKAGE_CACHE_GC_INTERVAL: Duration = Duration::from_secs(600);
-
-/// An in-mem cache for packages during writer path indexing.
+// GC the buffer every 300 checkpoints, or 5 minutes
+pub const BUFFER_GC_INTERVAL: Duration = Duration::from_secs(300);
+/// An in-mem buffer for modules during writer path indexing.
 /// It has static lifetime. Since we batch process checkpoints,
 /// it's possible that when a package is looked up (e.g. to create dynamic field),
 /// it has not been persisted in the database yet. So it works as an in-mem
-/// store for package resolution. To avoid bloating memory, we GC packages
+/// store for package resolution. To avoid bloating memory, we GC modules
 /// that are older than the committed checkpoints.
-pub struct IndexingPackageCache {
-    packages: HashMap<(ObjectID, String), (Arc<CompiledModule>, CheckpointSequenceNumber)>,
+pub struct IndexingModuleBuffer {
+    modules: HashMap<(ObjectID, String), (Arc<CompiledModule>, CheckpointSequenceNumber)>,
 }
 
-impl IndexingPackageCache {
+impl IndexingModuleBuffer {
     pub fn start(
         commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
     ) -> Arc<Mutex<Self>> {
         let cache = Arc::new(Mutex::new(Self {
-            packages: HashMap::new(),
+            modules: HashMap::new(),
         }));
         let cache_clone = cache.clone();
         spawn_monitored_task!(Self::remove_committed(cache_clone, commit_watcher));
@@ -65,30 +64,30 @@ impl IndexingPackageCache {
         cache: Arc<Mutex<Self>>,
         commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
     ) {
-        let mut interval = tokio::time::interval_at(Instant::now(), PACKAGE_CACHE_GC_INTERVAL);
+        let mut interval = tokio::time::interval_at(Instant::now(), BUFFER_GC_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
-            let _scope = monitored_scope("InMemObjectCache::remove_committed");
+            let _scope = monitored_scope("IndexingModuleBuffer::remove_committed");
             let Some(committed_checkpoint) = *commit_watcher.borrow() else {
                 continue;
             };
-            debug!("About to GC packages older than: {committed_checkpoint}");
+            debug!("About to GC modules older than: {committed_checkpoint}");
 
             let mut cache = cache.lock().unwrap();
             let mut to_remove = vec![];
-            for (id, (_, checkpoint_seq)) in cache.packages.iter() {
+            for (id, (_, checkpoint_seq)) in cache.modules.iter() {
                 if *checkpoint_seq <= committed_checkpoint {
                     to_remove.push(id.clone());
                 }
             }
             for id in to_remove {
-                cache.packages.remove(&id);
+                cache.modules.remove(&id);
             }
         }
     }
 
-    pub fn insert_packages(&mut self, new_packages: &[IndexedPackage]) {
+    pub fn insert_modules(&mut self, new_packages: &[IndexedPackage]) {
         let new_packages = new_packages
             .iter()
             .flat_map(|p| {
@@ -104,16 +103,92 @@ impl IndexingPackageCache {
                     })
             })
             .collect::<HashMap<_, _>>();
-        self.packages.extend(new_packages);
+        self.modules.extend(new_packages);
     }
 
     pub fn get_module_by_id(&self, id: &ModuleId) -> Option<Arc<CompiledModule>> {
         let package_id = ObjectID::from(*id.address());
         let name = id.name().to_string();
-        self.packages
+        self.modules
             .get(&(package_id, name))
             .as_ref()
             .map(|(m, _)| m.clone())
+    }
+}
+
+pub struct IndexingPackageBuffer {
+    packages: HashMap<
+        ObjectID,
+        (
+            Arc<Object>,
+            u64, /* package version */
+            CheckpointSequenceNumber,
+        ),
+    >,
+}
+
+impl IndexingPackageBuffer {
+    pub fn start(
+        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
+    ) -> Arc<Mutex<Self>> {
+        let cache = Arc::new(Mutex::new(Self {
+            packages: HashMap::new(),
+        }));
+        let cache_clone = cache.clone();
+        spawn_monitored_task!(Self::remove_committed(cache_clone, commit_watcher));
+        cache
+    }
+
+    pub async fn remove_committed(
+        cache: Arc<Mutex<Self>>,
+        commit_watcher: watch::Receiver<Option<CheckpointSequenceNumber>>,
+    ) {
+        let mut interval = tokio::time::interval_at(Instant::now(), BUFFER_GC_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let _scope = monitored_scope("IndexingPackageBuffer::remove_committed");
+            let Some(committed_checkpoint) = *commit_watcher.borrow() else {
+                continue;
+            };
+            debug!("About to GC packages older than: {committed_checkpoint}");
+
+            let mut cache = cache.lock().unwrap();
+            let mut to_remove = vec![];
+            for (id, (_, _, checkpoint_seq)) in cache.packages.iter() {
+                if *checkpoint_seq <= committed_checkpoint {
+                    to_remove.push(*id);
+                }
+            }
+            for id in to_remove {
+                cache.packages.remove(&id);
+            }
+        }
+    }
+
+    pub fn insert_packages(&mut self, new_package_objects: &[(IndexedPackage, Object)]) {
+        let new_packages = new_package_objects
+            .iter()
+            .map(|(p, obj)| {
+                (
+                    p.package_id,
+                    (
+                        Arc::new(obj.clone()),
+                        p.move_package.version().value(),
+                        p.checkpoint_sequence_number,
+                    ),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        self.packages.extend(new_packages);
+    }
+
+    pub fn get_package(&self, id: &ObjectID) -> Option<Arc<Object>> {
+        self.packages.get(id).as_ref().map(|(o, _, _)| o.clone())
+    }
+
+    pub fn get_version(&self, id: &ObjectID) -> Option<u64> {
+        self.packages.get(id).as_ref().map(|(_, v, _)| *v)
     }
 }
 

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -48,7 +48,7 @@ pub struct IndexerMetrics {
     pub indexing_get_object_in_mem_hit: IntCounter,
     pub indexing_get_object_db_hit: IntCounter,
     pub indexing_module_resolver_in_mem_hit: IntCounter,
-    pub indexing_module_resolver_in_mem_miss: IntCounter,
+    pub indexing_package_resolver_in_mem_hit: IntCounter,
     pub indexing_packages_latency: Histogram,
     pub checkpoint_objects_index_latency: Histogram,
     pub checkpoint_db_commit_latency: Histogram,
@@ -274,9 +274,9 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
-            indexing_module_resolver_in_mem_miss: register_int_counter_with_registry!(
-                "indexing_module_resolver_in_mem_miss",
-                "Total number module resolver miss in mem",
+            indexing_package_resolver_in_mem_hit: register_int_counter_with_registry!(
+                "indexing_package_resolver_in_mem_hit",
+                "Total number package resolver hit in mem",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

make indexer package upgrading aware 

## Test Plan 

via repro script and make sure that before the change, DF indexing will error but no longer the case after.
- on one terminal
```
sui_release genesis -f && sui_release start
```
- on second terminal
```
SUI=/Users/gegao/Documents/sui/target/release/sui ./repro.sh --object
SUI=/Users/gegao/Documents/sui/target/release/sui ./repro.sh --event
SUI=/Users/gegao/Documents/sui/target/release/sui ./repro.sh --dynamic-field
```
- on 3rd terminal
```
RUST_LOG=error DB_POOL_SIZE=10 cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url http://0.0.0.0:9000 --fullnode-sync-worker --use-v2 --reset-db
```

before the change on main
```
2024-01-23T17:50:41.829029Z ERROR sui_indexer::handlers::checkpoint_handler_v2: failed to create dynamic field info for obj: 0x52c53c726f396d22ff9cda3564771cc3ac935f077d67157e578a8a8134415759:SequenceNumber(7). Err: Indexer failed to resolve object to move struct with error: `Failed to create dynamic field info for obj 0x52c53c726f396d22ff9cda3564771cc3ac935f077d67157e578a8a8134415759:0x7, type: 0x2::dynamic_field::Field<u64, 0xf06f2505911a551d5ce03741ec079e7a17185e257ccb7d9d5bc311e3cf326210::m::T>. Error: Failure serializing object in the requested format: "Could not find module"`
2024-01-23T17:50:41.833133Z ERROR sui_indexer::handlers::checkpoint_handler_v2: failed to create dynamic field info for history obj: 0x52c53c726f396d22ff9cda3564771cc3ac935f077d67157e578a8a8134415759:SequenceNumber(7). Err: Indexer failed to resolve object to move struct with error: `Failed to create dynamic field info for obj 0x52c53c726f396d22ff9cda3564771cc3ac935f077d67157e578a8a8134415759:0x7, type: 0x2::dynamic_field::Field<u64, 0xf06f2505911a551d5ce03741ec079e7a17185e257ccb7d9d5bc311e3cf326210::m::T>. Error: Failure serializing object in the requested format: "Could not find module"`
```
and on this branch, we no longer have this error.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
