### PR TITLE
[zksend] Use serialize instead of build in SDK

### DIFF
--- a/.changeset/three-bats-warn.md
+++ b/.changeset/three-bats-warn.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zksend': patch
+---
+
+Fix window opening for transactions with unresolved data

--- a/sdk/zksend/src/channel/events.ts
+++ b/sdk/zksend/src/channel/events.ts
@@ -10,7 +10,7 @@ export const ZkSendRequestData = variant('type', [
 	}),
 	object({
 		type: literal('sign-transaction-block'),
-		bytes: string('`bytes` is required'),
+		data: string('`data` is required'),
 		address: string('`address` is required'),
 	}),
 	object({


### PR DESCRIPTION
## Description 

It looks like the `build` before the window open causes the transaction to fail. Moving to use serialize instead.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
