### PR TITLE
[move-enums] Ellipsis patterns

### DIFF
--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -904,10 +904,8 @@ fn statement(
 
             let entry_block = VecDeque::from([make_jump(sloc, start_label, false)]);
 
-            let (body_entry_block, body_blocks) = block_(
-                context,
-                with_last(body, make_jump(sloc, end_label, false)),
-            );
+            let (body_entry_block, body_blocks) =
+                block_(context, with_last(body, make_jump(sloc, end_label, false)));
 
             context.exit_named_block(&name);
 

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -289,8 +289,8 @@ pub type Type = Spanned<Type_>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldBindings {
-    Named(Fields<LValue>),
-    Positional(Vec<LValue>),
+    Named(Fields<LValue>, Option<Loc>),
+    Positional(Vec<Ellipsis<LValue>>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -426,9 +426,24 @@ pub struct MatchArm_ {
 pub type MatchArm = Spanned<MatchArm_>;
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum Ellipsis<T> {
+    Binder(T),
+    Ellipsis(Loc),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum MatchPattern_ {
-    PositionalConstructor(ModuleAccess, Option<Vec<Type>>, Spanned<Vec<MatchPattern>>),
-    FieldConstructor(ModuleAccess, Option<Vec<Type>>, Fields<MatchPattern>),
+    PositionalConstructor(
+        ModuleAccess,
+        Option<Vec<Type>>,
+        Spanned<Vec<Ellipsis<MatchPattern>>>,
+    ),
+    FieldConstructor(
+        ModuleAccess,
+        Option<Vec<Type>>,
+        Fields<MatchPattern>,
+        Option<Loc>,
+    ),
     HeadConstructor(ModuleAccess, Option<Vec<Type>>),
     Binder(Mutability, Var),
     Literal(Value),
@@ -1652,6 +1667,17 @@ impl AstDebug for MatchArm_ {
     }
 }
 
+impl<T: AstDebug> AstDebug for Ellipsis<T> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Ellipsis::Binder(p) => p.ast_debug(w),
+            Ellipsis::Ellipsis(_) => {
+                w.write("..");
+            }
+        }
+    }
+}
+
 impl AstDebug for MatchPattern_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use MatchPattern_::*;
@@ -1669,7 +1695,7 @@ impl AstDebug for MatchPattern_ {
                 });
                 w.write(") ");
             }
-            FieldConstructor(name, tys_opt, fields) => {
+            FieldConstructor(name, tys_opt, fields, ellipsis) => {
                 name.ast_debug(w);
                 if let Some(ss) = tys_opt {
                     w.write("<");
@@ -1681,6 +1707,9 @@ impl AstDebug for MatchPattern_ {
                     w.write(format!(" {}#{} : ", field, idx));
                     pat.ast_debug(w);
                 });
+                if ellipsis.is_some() {
+                    w.write(" ..");
+                }
                 w.write("} ");
             }
             HeadConstructor(name, tys_opt) => {
@@ -1691,7 +1720,9 @@ impl AstDebug for MatchPattern_ {
                     w.write(">");
                 }
             }
-            Binder(mut_, name) => w.write(format!("{}{}", mut_.map(|_| "mut ").unwrap_or(""), name)),
+            Binder(mut_, name) => {
+                w.write(format!("{}{}", mut_.map(|_| "mut ").unwrap_or(""), name))
+            }
             Literal(v) => v.ast_debug(w),
             Wildcard => w.write("_"),
             Or(lhs, rhs) => {
@@ -1782,13 +1813,16 @@ impl AstDebug for Vec<Vec<Exp>> {
 impl AstDebug for FieldBindings {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
-            FieldBindings::Named(fields) => {
+            FieldBindings::Named(fields, ellipsis) => {
                 w.write("{");
                 w.comma(fields, |w, (_, f, idx_b)| {
                     let (idx, b) = idx_b;
                     w.write(&format!("{}#{}: ", idx, f));
                     b.ast_debug(w);
                 });
+                if ellipsis.is_some() {
+                    w.write("..");
+                }
                 w.write("}");
             }
             FieldBindings::Positional(vals) => {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -3104,7 +3104,7 @@ fn check_ellipsis_usage(context: &mut Context, ellipsis_locs: &[Loc]) {
         for loc in ellipsis_locs.iter().skip(1) {
             diag.add_secondary_label((*loc, "Ellipsis pattern used again here"));
         }
-        diag.add_note("An ellipsis pattern can only appear once in a field constructor.");
+        diag.add_note("An ellipsis pattern can only appear once in a constructor's pattern.");
         context.env().add_diag(diag);
     }
 }
@@ -3213,25 +3213,18 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
             let tys = optional_types(context, pts_opt);
             match head_ctor_name {
                 Some(head_ctor_name @ sp!(_, EM::Variant(_, _))) => {
-                    let ellipsis_locs = fields
-                        .value
-                        .iter()
-                        .filter_map(|f| match f {
-                            P::Ellipsis::Binder(_) => None,
-                            P::Ellipsis::Ellipsis(loc) => Some(*loc),
-                        })
-                        .collect::<Vec<_>>();
-
-                    let stripped_fields = fields
-                        .value
-                        .into_iter()
-                        .filter_map(|field_pat| match field_pat {
+                    let mut ellipsis_locs = vec![];
+                    let mut stripped_fields = vec![];
+                    for field in fields.value.into_iter() {
+                        match field {
                             P::Ellipsis::Binder((field, pat)) => {
-                                Some((field, match_pattern(context, pat)))
+                                stripped_fields.push((field, match_pattern(context, pat)));
                             }
-                            P::Ellipsis::Ellipsis(_) => None,
-                        })
-                        .collect();
+                            P::Ellipsis::Ellipsis(eloc) => {
+                                ellipsis_locs.push(eloc);
+                            }
+                        }
+                    }
                     let fields =
                         named_fields(context, loc, "pattern", "sub-pattern", stripped_fields);
                     check_ellipsis_usage(context, &ellipsis_locs);

--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -1161,11 +1161,12 @@ fn make_arm_unpack(
             TP::Constructor(mident, enum_, variant, tyargs, fields)
             | TP::BorrowConstructor(mident, enum_, variant, tyargs, fields) => {
                 let all_wild = fields
-                         .iter()
-                         .all(|(_, _, (_, (_, pat)))| matches!(pat.pat.value, TP::Wildcard)) || fields.is_empty();
+                    .iter()
+                    .all(|(_, _, (_, (_, pat)))| matches!(pat.pat.value, TP::Wildcard))
+                    || fields.is_empty();
                 if matches!(entry.ty.value, N::Type_::Ref(_, _)) && all_wild {
-                     continue;
-                 }
+                    continue;
+                }
                 let field_pats = fields.clone().map(|_key, (ndx, (_, pat))| (ndx, pat));
 
                 let field_tys = fields.map(|_key, (ndx, (ty, _))| (ndx, ty));

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -1579,9 +1579,7 @@ impl AstDebug for MatchPattern_ {
                 });
                 w.write("} ");
             }
-            Binder(name) => {
-                name.ast_debug(w)
-            }
+            Binder(name) => name.ast_debug(w),
             Literal(v) => v.ast_debug(w),
             Wildcard => w.write("_"),
             Or(lhs, rhs) => {

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -502,8 +502,8 @@ pub type Mutability = Option<Loc>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldBindings {
-    Named(Vec<(Field, Bind)>),
-    Positional(Vec<Bind>),
+    Named(Vec<Ellipsis<(Field, Bind)>>),
+    Positional(Vec<Ellipsis<Bind>>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -740,18 +740,24 @@ pub struct MatchArm_ {
 pub type MatchArm = Spanned<MatchArm_>;
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum Ellipsis<T> {
+    Binder(T),
+    Ellipsis(Loc),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum MatchPattern_ {
     // T<t1, ..., tn>(pat1, ..., patn)
     PositionalConstructor(
         NameAccessChain,
         Option<Vec<Type>>,
-        Spanned<Vec<MatchPattern>>,
+        Spanned<Vec<Ellipsis<MatchPattern>>>,
     ),
     // T<t1, ..., tn> { x1: pat1, ..., xn: patn }
     FieldConstructor(
         NameAccessChain,
         Option<Vec<Type>>,
-        Spanned<Vec<(Field, MatchPattern)>>,
+        Spanned<Vec<Ellipsis<(Field, MatchPattern)>>>,
     ),
     // T<t1, ..., tn>
     Name(Mutability, NameAccessChain, Option<Vec<Type>>),
@@ -2096,6 +2102,31 @@ impl AstDebug for MatchArm_ {
     }
 }
 
+impl<T: AstDebug> AstDebug for Ellipsis<T> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Ellipsis::Ellipsis(_) => {
+                w.write("..");
+            }
+            Ellipsis::Binder(p) => p.ast_debug(w),
+        }
+    }
+}
+
+impl AstDebug for Ellipsis<(Field, MatchPattern)> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Ellipsis::Ellipsis(_) => {
+                w.write("..");
+            }
+            Ellipsis::Binder((n, p)) => {
+                w.write(&format!("{}: ", n));
+                p.ast_debug(w);
+            }
+        }
+    }
+}
+
 impl AstDebug for MatchPattern_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use MatchPattern_::*;
@@ -2121,10 +2152,7 @@ impl AstDebug for MatchPattern_ {
                     w.write(">");
                 }
                 w.write(" {");
-                w.comma(fields.value.iter(), |w, (field, pat)| {
-                    w.write(format!(" {} : ", field));
-                    pat.ast_debug(w);
-                });
+                w.comma(fields.value.iter(), |w, field_pat| field_pat.ast_debug(w));
                 w.write("} ");
             }
             Name(mut_, name, tys_opt) => {
@@ -2256,14 +2284,27 @@ impl AstDebug for Bind_ {
     }
 }
 
+impl AstDebug for Ellipsis<(Field, Bind)> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Ellipsis::Ellipsis(_) => {
+                w.write("..");
+            }
+            Ellipsis::Binder((n, b)) => {
+                w.write(&format!("{}: ", n));
+                b.ast_debug(w);
+            }
+        }
+    }
+}
+
 impl AstDebug for FieldBindings {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
             FieldBindings::Named(bs) => {
                 w.write("{");
-                w.comma(bs, |w, (f, b)| {
-                    w.write(&format!("{}: ", f));
-                    b.ast_debug(w);
+                w.comma(bs, |w, e| {
+                    e.ast_debug(w);
                 });
                 w.write("}");
             }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis.move
@@ -1,0 +1,19 @@
+module 0x42::m {
+    public enum X has drop {
+        A { x: u64 },
+        B { x: u64, y: u64 },
+        C(u64, bool, bool),
+    }
+
+    public fun f(x: X): u64 {
+        match (x) {
+            X::A { .. } => 0,
+            X::B { x, .. } => x,
+            X::C(1, ..) => 1,
+            X::C(1, .., true) => 2,
+            X::C(.., true) => 1,
+            X::C(..) => 1,
+        }
+    }
+}
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.exp
@@ -1,0 +1,61 @@
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:10:20
+   │
+10 │             X::A { .., .. } => 0,
+   │                    ^^  -- Ellipsis pattern used again here
+   │                    │    
+   │                    Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:11:20
+   │
+11 │             X::B { .., .., .. } => 0,
+   │                    ^^  --  -- Ellipsis pattern used again here
+   │                    │   │    
+   │                    │   Ellipsis pattern used again here
+   │                    Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:12:20
+   │
+12 │             X::B { .., .., x} => x,
+   │                    ^^  -- Ellipsis pattern used again here
+   │                    │    
+   │                    Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:13:20
+   │
+13 │             X::B { .., x, .. } => x,
+   │                    ^^     -- Ellipsis pattern used again here
+   │                    │       
+   │                    Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:14:18
+   │
+14 │             X::C(.., x, ..) => 1,
+   │                  ^^     -- Ellipsis pattern used again here
+   │                  │       
+   │                  Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+
+error[E03015]: invalid pattern
+   ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:15:18
+   │
+15 │             X::C(.., ..) => 1,
+   │                  ^^  -- Ellipsis pattern used again here
+   │                  │    
+   │                  Multiple ellipsis patterns
+   │
+   = An ellipsis pattern can only appear once in a field constructor.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.exp
@@ -6,7 +6,7 @@ error[E03015]: invalid pattern
    │                    │    
    │                    Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 
 error[E03015]: invalid pattern
    ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:11:20
@@ -17,7 +17,7 @@ error[E03015]: invalid pattern
    │                    │   Ellipsis pattern used again here
    │                    Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 
 error[E03015]: invalid pattern
    ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:12:20
@@ -27,7 +27,7 @@ error[E03015]: invalid pattern
    │                    │    
    │                    Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 
 error[E03015]: invalid pattern
    ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:13:20
@@ -37,7 +37,7 @@ error[E03015]: invalid pattern
    │                    │       
    │                    Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 
 error[E03015]: invalid pattern
    ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:14:18
@@ -47,7 +47,7 @@ error[E03015]: invalid pattern
    │                  │       
    │                  Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 
 error[E03015]: invalid pattern
    ┌─ tests/move_2024/expansion/pattern_ellipsis_invalid.move:15:18
@@ -57,5 +57,5 @@ error[E03015]: invalid pattern
    │                  │    
    │                  Multiple ellipsis patterns
    │
-   = An ellipsis pattern can only appear once in a field constructor.
+   = An ellipsis pattern can only appear once in a constructor's pattern.
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/pattern_ellipsis_invalid.move
@@ -1,0 +1,18 @@
+module 0x42::m {
+    public enum X has drop {
+        A { x: u64 },
+        B { x: u64, y: u64 },
+        C(u64, bool, bool),
+    }
+
+    public fun g(x: X): u64 {
+        match (x) {
+            X::A { .., .. } => 0,
+            X::B { .., .., .. } => 0,
+            X::B { .., .., x} => x,
+            X::B { .., x, .. } => x,
+            X::C(.., x, ..) => 1,
+            X::C(.., ..) => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis.move
@@ -1,0 +1,51 @@
+module 0x42::m {
+    public enum X has drop {
+        A { x: u64 },
+        B { x: u64, y: u64 },
+        C(u64, bool, bool),
+    }
+
+    public enum Y {
+        A(X),
+        B(u64, X),
+        C { x: u64, y: X, z: u64},
+    }
+
+    public fun f(x: X): u64 {
+        match (x) {
+            X::A { .. } => 0,
+            X::B { x, .. } => x,
+            X::C(1, ..) => 1,
+            X::C(1, .., true) => 2,
+            X::C(.., true) => 1,
+            X::C(..) => 1,
+        }
+    }
+
+    public fun g(x: Y): u64 {
+        match (x) {
+            Y::A(X::A { .. }) => 0,
+            Y::A(X::B { x, .. }) => x,
+            Y::A(X::C(1, ..)) => 1,
+            Y::A(X::C(1, .., true)) => 2,
+            Y::A(X::C(.., true)) => 1,
+            Y::A(X::C(..)) => 1,
+            Y::B(.., X::A { .. }) => 0,
+            Y::B(.., X::B { x, .. }) => x,
+            Y::B(.., X::C(1, ..)) => 1,
+            Y::B(.., X::C(1, .., true)) => 2,
+            Y::B(.., X::C(.., true)) => 1,
+            Y::B(_, X::C(..)) => 1,
+            Y::C { x, .., y} => 1,
+        }
+    }
+
+    public fun h(x: Y): u64 {
+        match (x) {
+            Y::A(_) => 0,
+            // .. is zero or more!
+            Y::B(_, _, ..) => 0,
+            Y::C { x, y, z, ..} => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.exp
@@ -1,0 +1,92 @@
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:16:13
+   │
+16 │             Y::D(..) => 0,
+   │             ^^^^^^^^ Invalid variant pattern. Empty variants are not matched with positional variant syntax
+   │
+   = Remove '()' after the variant name
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:17:13
+   │
+17 │             Y::D{..} => 0,
+   │             ^^^^^^^^ Invalid variant pattern. Empty variants are not matched with variant field syntax
+   │
+   = Remove '{}' after the variant name
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:18:13
+   │
+18 │             Y::D(x, ..) => 0,
+   │             ^^^^^^^^^^^ Invalid variant pattern. Empty variants are not matched with positional variant syntax
+   │
+   = Remove '()' after the variant name
+
+error[E04015]: invalid use of native item
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:18:13
+   │
+18 │             Y::D(x, ..) => 0,
+   │             ^^^^^^^^^^^ Invalid usage for empty variant '0x42::m::Y::D'. Empty variants do not take any arguments.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:13
+   │
+19 │             Y::D{x, ..} => 0,
+   │             ^^^^^^^^^^^ Invalid variant pattern. Empty variants are not matched with variant field syntax
+   │
+   = Remove '{}' after the variant name
+
+error[E04015]: invalid use of native item
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:13
+   │
+19 │             Y::D{x, ..} => 0,
+   │             ^^^^^^^^^^^ Invalid usage for empty variant '0x42::m::Y::D'. Empty variants do not take any arguments.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:25:13
+   │
+25 │             X::D{} => 0,
+   │             ^^^^^^ Invalid variant pattern. Positional variant declarations require positional patterns.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:26:13
+   │
+26 │             X::D{..} => 0,
+   │             ^^^^^^^^ Invalid variant pattern. Positional variant declarations require positional patterns.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:27:13
+   │
+27 │             X::D{x, ..} => 0,
+   │             ^^^^^^^^^^^ Invalid variant pattern. Positional variant declarations require positional patterns.
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:27:13
+   │
+27 │             X::D{x, ..} => 0,
+   │             ^^^^^^^^^^^ Unbound field 'x' in '0x42::m::X::D'
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:33:13
+   │
+33 │             Z::D() => 0,
+   │             ^^^^^^ Invalid variant pattern. Named variant declarations require named patterns.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:34:13
+   │
+34 │             Z::D(..) => 0,
+   │             ^^^^^^^^ Invalid variant pattern. Named variant declarations require named patterns.
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:35:13
+   │
+35 │             Z::D(x, ..) => 0,
+   │             ^^^^^^^^^^^ Invalid variant pattern. Named variant declarations require named patterns.
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:35:13
+   │
+35 │             Z::D(x, ..) => 0,
+   │             ^^^^^^^^^^^ Unbound field '0' in '0x42::m::Z::D'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.move
@@ -1,0 +1,38 @@
+module 0x42::m {
+    public enum Y {
+        D
+    }
+
+    public enum X {
+        D()
+    }
+
+    public enum Z {
+        D{}
+    }
+
+    public fun f(x: Y): u64 {
+        match (x) {
+            Y::D(..) => 0,
+            Y::D{..} => 0,
+            Y::D(x, ..) => 0,
+            Y::D{x, ..} => 0,
+        }
+    }
+
+    public fun g(x: X): u64 {
+        match (x) {
+            X::D{} => 0,
+            X::D{..} => 0,
+            X::D{x, ..} => 0,
+        }
+    }
+
+    public fun h(x: Z): u64 {
+        match (x) {
+            Z::D() => 0,
+            Z::D(..) => 0,
+            Z::D(x, ..) => 0,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis.move
@@ -1,0 +1,46 @@
+module 0x42::m {
+    public struct X(u64, u64, bool)
+    public struct Y {
+        x: u64,
+        y: u64,
+        z: bool,
+    }
+
+    public fun f0(x: Y) {
+        let Y{..} = x;
+    }
+
+    public fun f1(x: Y): u64 {
+        let Y{x, ..} = x;
+        x
+    }
+
+    public fun f2(x: Y): u64 {
+        let Y{x, z, .. } = x;
+        if (z) x else 0
+    }
+
+    public fun f3(x: Y): u64 {
+        let Y{x, z, y, .. } = x;
+        if (z) x + y else 0
+    }
+
+    public fun g0(x: X) {
+        let X(..) = x;
+    }
+
+    public fun g1(x: X): u64 {
+        let X(x, ..) = x;
+        x
+    }
+
+    public fun g2(x: X): u64 {
+        let X(x, .., z) = x;
+        if (z) x else 0
+    }
+
+    public fun g3(x: X): u64 {
+        let X(x, y, z, ..) = x;
+        if (z) x + y else 0
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis_invalid.exp
@@ -1,0 +1,48 @@
+error[E03013]: positional call mismatch
+  ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:6:13
+  │
+6 │         let Y(..) = x;
+  │             ^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:10:13
+   │
+10 │         let Y(x, ..) = x;
+   │             ^^^^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:10:13
+   │
+10 │         let Y(x, ..) = x;
+   │             ^^^^^^^^ Unbound field '0' in '0x42::m::Y'
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:14:13
+   │
+14 │         let Y() = x;
+   │             ^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:18:13
+   │
+18 │         let X{..} = x;
+   │             ^^^^^ Invalid deconstruction. Positional struct field declarations require positional deconstruction
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:22:13
+   │
+22 │         let X{x, ..} = x;
+   │             ^^^^^^^^ Invalid deconstruction. Positional struct field declarations require positional deconstruction
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:22:13
+   │
+22 │         let X{x, ..} = x;
+   │             ^^^^^^^^ Unbound field 'x' in '0x42::m::X'
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/naming/struct_ellipsis_invalid.move:26:13
+   │
+26 │         let X{} = x;
+   │             ^^^ Invalid deconstruction. Positional struct field declarations require positional deconstruction
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/struct_ellipsis_invalid.move
@@ -1,0 +1,28 @@
+module 0x42::m {
+    public struct X()
+    public struct Y{}
+
+    public fun f0(x: Y) {
+        let Y(..) = x;
+    }
+
+    public fun f1(x: Y) {
+        let Y(x, ..) = x;
+    }
+
+    public fun f2(x: Y) {
+        let Y() = x;
+    }
+
+    public fun g0(x: X) {
+        let X{..} = x;
+    }
+
+    public fun g1(x: X) {
+        let X{x, ..} = x;
+    }
+
+    public fun g2(x: X) {
+        let X{} = x;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/enum_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/enum_invalid.exp
@@ -1,3 +1,19 @@
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/parser/enum_invalid.move:2:5
+  │
+2 │     enum Temperature {
+  │     ^^^^ Invalid enum declaration. Internal enum declarations are not yet supported
+  │
+  = Visibility annotations are required on enum declarations.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/parser/enum_invalid.move:8:5
+  │
+8 │     public(package) enum EnumWithPhantom<phantom T> {
+  │     ^^^^^^^^^^^^^^^ Invalid enum declaration. 'public(package)' enum declarations are not yet supported
+  │
+  = Visibility annotations are required on enum declarations.
+
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/enum_invalid.move:13:13
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis.move
@@ -1,0 +1,18 @@
+module 0x42::m {
+    public enum X has drop {
+        A { x: u64 },
+        B { x: u64, y: u64 },
+        C(u64, bool, bool),
+    }
+
+    public fun f(x: X): u64 {
+        match (x) {
+            X::A { .. } => 0,
+            X::B { x, .. } => x,
+            X::C(1, ..) => 1,
+            X::C(1, .., true) => 2,
+            X::C(.., true) => 1,
+            X::C(..) => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.exp
@@ -1,0 +1,6 @@
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/pattern_ellipsis_invalid.move:10:13
+   │
+10 │             ..
+   │             ^^ Invalid pattern
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/pattern_ellipsis_invalid.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+    public enum X has drop {
+        A { x: u64 },
+        B { x: u64, y: u64 },
+        C(u64, bool, bool),
+    }
+
+    public fun g(x: X): u64 {
+        match (x) {
+            ..
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis.move
@@ -1,0 +1,17 @@
+module 0x42::m {
+    public struct X has drop {
+        x: u64,
+        y: bool,
+        z: u64,
+    }
+
+    fun f(y: X): u64 {
+        let X { x, .. } = y;
+        x
+    }
+
+    fun g(y: X): bool {
+        let X { y, .. } = y;
+        y
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis_invalid.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/parser/struct_ellipsis_invalid.move:9:13
+  │
+9 │         let .. = y;
+  │             ^^
+  │             │
+  │             Unexpected '..'
+  │             Expected a variable or struct name
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/struct_ellipsis_invalid.move
@@ -1,0 +1,12 @@
+module 0x42::m {
+    public struct X has drop {
+        x: u64,
+        y: bool,
+        z: u64,
+    }
+
+    fun f(y: X): u64 {
+        let .. = y;
+        x
+    }
+}


### PR DESCRIPTION
## Description 

Add support for ellipsis patterns in both enum and struct patterns. 

Ellipsis patterns are supported in both named and positional patterns.
1. Only one ellipsis pattern may be present (both in positional and named patterns).
2. An ellipsis pattern corresponds to zero or more arguments.
3. Ellipsis patterns are only valid as field patterns, and cannot occur as a top-level pattern.

Some examples of valid patterns (for both struct and enum variant patterns): 

```
C(..)
C(x, ..)
C(x, .., y)
C(.., x)

N { x, .. }
N { x, y, .. }
N { .., x }
N { .. }
```

Some invalid patterns:

```
C(.., ..)
C(x, .., y, ..)
C(..) // if C is a named variant or does not have any parameters

N { .., .. }
N { .. } // If N is a positional/empty variant
```

## Test Plan 

Added additional positive and negative tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
