### PR TITLE
[bridge 30/n] skip action if it's already processed on chain

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -25,7 +25,7 @@ use crate::{
     storage::BridgeOrchestratorTables,
     sui_client::{SuiClient, SuiClientInner},
     sui_transaction_builder::build_transaction,
-    types::{BridgeAction, VerifiedCertifiedBridgeAction},
+    types::{BridgeAction, BridgeActionStatus, VerifiedCertifiedBridgeAction},
 };
 use std::sync::Arc;
 use tracing::{error, info, warn};
@@ -76,46 +76,7 @@ where
         Vec<tokio::task::JoinHandle<()>>,
         mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
     ) {
-        let key = self.key;
-
-        let (sender, receiver) = mysten_metrics::metered_channel::channel(
-            CHANNEL_SIZE,
-            &mysten_metrics::get_metrics()
-                .unwrap()
-                .channels
-                .with_label_values(&["executor_signing_queue"]),
-        );
-
-        let (execution_tx, execution_rx) = mysten_metrics::metered_channel::channel(
-            CHANNEL_SIZE,
-            &mysten_metrics::get_metrics()
-                .unwrap()
-                .channels
-                .with_label_values(&["executor_execution_queue"]),
-        );
-        let execution_tx_clone = execution_tx.clone();
-        let sender_clone = sender.clone();
-        let mut tasks = vec![];
-        tasks.push(spawn_logged_monitored_task!(
-            Self::run_signature_aggregation_loop(
-                self.bridge_auth_agg,
-                sender_clone,
-                receiver,
-                execution_tx_clone,
-            )
-        ));
-
-        tasks.push(spawn_logged_monitored_task!(
-            Self::run_onchain_execution_loop(
-                self.sui_client.clone(),
-                key,
-                self.sui_address,
-                self.gas_object_id,
-                self.store.clone(),
-                execution_tx,
-                execution_rx,
-            )
-        ));
+        let (tasks, sender, _) = self.run_inner();
         (tasks, sender)
     }
 }
@@ -142,8 +103,65 @@ where
         }
     }
 
+    fn run_inner(
+        self,
+    ) -> (
+        Vec<tokio::task::JoinHandle<()>>,
+        mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
+        mysten_metrics::metered_channel::Sender<CertifiedBridgeActionExecutionWrapper>,
+    ) {
+        let key = self.key;
+
+        let (sender, receiver) = mysten_metrics::metered_channel::channel(
+            CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["executor_signing_queue"]),
+        );
+
+        let (execution_tx, execution_rx) = mysten_metrics::metered_channel::channel(
+            CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["executor_execution_queue"]),
+        );
+        let execution_tx_clone = execution_tx.clone();
+        let sender_clone = sender.clone();
+        let store_clone = self.store.clone();
+        let client_clone = self.sui_client.clone();
+        let mut tasks = vec![];
+        tasks.push(spawn_logged_monitored_task!(
+            Self::run_signature_aggregation_loop(
+                client_clone,
+                self.bridge_auth_agg,
+                store_clone,
+                sender_clone,
+                receiver,
+                execution_tx_clone,
+            )
+        ));
+
+        let execution_tx_clone = execution_tx.clone();
+        tasks.push(spawn_logged_monitored_task!(
+            Self::run_onchain_execution_loop(
+                self.sui_client.clone(),
+                key,
+                self.sui_address,
+                self.gas_object_id,
+                self.store.clone(),
+                execution_tx_clone,
+                execution_rx,
+            )
+        ));
+        (tasks, sender, execution_tx)
+    }
+
     async fn run_signature_aggregation_loop(
+        sui_client: Arc<SuiClient<C>>,
         auth_agg: Arc<BridgeAuthorityAggregator>,
+        store: Arc<BridgeOrchestratorTables>,
         signing_queue_sender: mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
         mut signing_queue_receiver: mysten_metrics::metered_channel::Receiver<
             BridgeActionExecutionWrapper,
@@ -158,24 +176,65 @@ where
             let auth_agg_clone = auth_agg.clone();
             let signing_queue_sender_clone = signing_queue_sender.clone();
             let execution_queue_sender_clone = execution_queue_sender.clone();
+            let sui_client_clone = sui_client.clone();
+            let store_clone = store.clone();
             spawn_logged_monitored_task!(Self::request_signature(
+                sui_client_clone,
                 auth_agg_clone,
                 action,
+                store_clone,
                 signing_queue_sender_clone,
                 execution_queue_sender_clone
             ));
         }
     }
 
+    // Checks if the action is already processed on chain.
+    // If yes, skip this action and remove it from the pending log.
+    // Returns true if the action is already processed.
+    async fn handle_already_processed_action_maybe(
+        sui_client: &Arc<SuiClient<C>>,
+        action: &BridgeAction,
+        store: &Arc<BridgeOrchestratorTables>,
+    ) -> bool {
+        let status = sui_client
+            .get_action_onchain_status_until_success(action)
+            .await;
+        match status {
+            BridgeActionStatus::Approved | BridgeActionStatus::Claimed => {
+                info!(
+                    "Action already approved or claimed, removing action from pending logs: {:?}",
+                    action
+                );
+                store
+                    .remove_pending_actions(&[action.digest()])
+                    .unwrap_or_else(|e| {
+                        panic!("Write to DB should not fail: {:?}", e);
+                    });
+                true
+            }
+            // Although theoretically a legit SuiToEthBridgeAction should not have
+            // status `RecordNotFound`
+            BridgeActionStatus::Pending | BridgeActionStatus::RecordNotFound => false,
+        }
+    }
+
     async fn request_signature(
+        sui_client: Arc<SuiClient<C>>,
         auth_agg: Arc<BridgeAuthorityAggregator>,
         action: BridgeActionExecutionWrapper,
+        store: Arc<BridgeOrchestratorTables>,
         signing_queue_sender: mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
         execution_queue_sender: mysten_metrics::metered_channel::Sender<
             CertifiedBridgeActionExecutionWrapper,
         >,
     ) {
         let BridgeActionExecutionWrapper(action, attempt_times) = action;
+        // If the action is already processed, skip it.
+        if Self::handle_already_processed_action_maybe(&sui_client, &action, &store).await {
+            return;
+        }
+
         // TODO: use different threshold based on action types.
         match auth_agg
             .request_committee_signatures(action.clone(), VALIDITY_THRESHOLD)
@@ -227,10 +286,15 @@ where
             let CertifiedBridgeActionExecutionWrapper(certificate, attempt_times) =
                 certificate_wrapper;
 
+            let action = certificate.data();
+            // If the action is already processed, skip it.
+            if Self::handle_already_processed_action_maybe(&sui_client, action, &store).await {
+                return;
+            }
+
             // TODO check gas coin balance here. If gas balance too low, do not proceed.
             let (_gas_coin, gas_object_ref) =
                 Self::get_gas_data_assert_ownership(sui_address, gas_object_id, &sui_client).await;
-            let action = certificate.data();
             let ceriticate_clone = certificate.clone();
             let tx_data = match build_transaction(sui_address, &gas_object_ref, ceriticate_clone) {
                 Ok(tx_data) => tx_data,
@@ -251,6 +315,7 @@ where
             );
             let signed_tx = Transaction::from_data(tx_data, vec![sig]);
             let tx_digest = *signed_tx.digest();
+
             info!(?tx_digest, ?gas_object_ref, "Sending transaction to Sui");
             // TODO: add metrics to detect low balances and so on
             match sui_client
@@ -290,6 +355,7 @@ where
         }
     }
 
+    // TODO: do we need a mechanism to periodically read pending actions from DB?
     async fn handle_execution_effects(
         tx_digest: TransactionDigest,
         effects: SuiTransactionBlockEffects,
@@ -381,7 +447,8 @@ mod tests {
     #[tokio::test]
     async fn test_onchain_execution_loop() {
         let (
-            tx,
+            signing_tx,
+            _execution_tx,
             sui_client_mock,
             mut tx_subscription,
             store,
@@ -432,7 +499,9 @@ mod tests {
         );
 
         // Kick it
-        submit_to_executor(&tx, action.clone()).await.unwrap();
+        submit_to_executor(&signing_tx, action.clone())
+            .await
+            .unwrap();
 
         // Expect to see the transaction to be requested and successfully executed hence removed from WAL
         tx_subscription.recv().await.unwrap();
@@ -469,7 +538,9 @@ mod tests {
         );
 
         // Kick it
-        submit_to_executor(&tx, action.clone()).await.unwrap();
+        submit_to_executor(&signing_tx, action.clone())
+            .await
+            .unwrap();
 
         // Expect to see the transaction to be requested and but failed
         tx_subscription.recv().await.unwrap();
@@ -506,7 +577,9 @@ mod tests {
         );
 
         // Kick it
-        submit_to_executor(&tx, action.clone()).await.unwrap();
+        submit_to_executor(&signing_tx, action.clone())
+            .await
+            .unwrap();
 
         // Failure will trigger retry, we wait for 2 requests before checking WAL log
         let tx_digest = tx_subscription.recv().await.unwrap();
@@ -538,7 +611,8 @@ mod tests {
     #[tokio::test]
     async fn test_signature_aggregation_loop() {
         let (
-            tx,
+            signing_tx,
+            _execution_tx,
             sui_client_mock,
             mut tx_subscription,
             store,
@@ -590,7 +664,9 @@ mod tests {
         );
 
         // Kick it
-        submit_to_executor(&tx, action.clone()).await.unwrap();
+        submit_to_executor(&signing_tx, action.clone())
+            .await
+            .unwrap();
 
         // Wait until the transaction is retried at least once (instead of deing dropped)
         loop {
@@ -644,6 +720,162 @@ mod tests {
             .get_all_pending_actions()
             .unwrap()
             .contains_key(&action.digest()));
+    }
+
+    #[tokio::test]
+    async fn test_skip_request_signature_if_already_processed_on_chain() {
+        let (
+            signing_tx,
+            _execution_tx,
+            sui_client_mock,
+            mut tx_subscription,
+            store,
+            _secrets,
+            _dummy_sui_key,
+            mock0,
+            mock1,
+            mock2,
+            mock3,
+            _handles,
+            _gas_object_ref,
+            _sui_address,
+        ) = setup();
+
+        // TODO: remove once we don't rely on env var to get object id
+        std::env::set_var("ROOT_BRIDGE_OBJECT_ID", "0x09");
+        std::env::set_var("ROOT_BRIDGE_OBJECT_INITIAL_SHARED_VERSION", "1");
+
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_tx_event_index = 0;
+        let action = get_test_sui_to_eth_bridge_action(
+            Some(sui_tx_digest),
+            Some(sui_tx_event_index),
+            None,
+            None,
+        );
+        mock_bridge_authority_signing_errors(
+            vec![&mock0, &mock1, &mock2, &mock3],
+            sui_tx_digest,
+            sui_tx_event_index,
+        );
+        store.insert_pending_actions(&[action.clone()]).unwrap();
+        assert_eq!(
+            store.get_all_pending_actions().unwrap()[&action.digest()],
+            action.clone()
+        );
+
+        // Kick it
+        submit_to_executor(&signing_tx, action.clone())
+            .await
+            .unwrap();
+        let action_digest = action.digest();
+
+        // Wait for 1 second. It should still in the process of retrying requesting sigs becaues we mock errors above.
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        tx_subscription.try_recv().unwrap_err();
+        // And the action is still in WAL
+        assert!(store
+            .get_all_pending_actions()
+            .unwrap()
+            .contains_key(&action_digest));
+
+        sui_client_mock.set_action_onchain_status(&action, BridgeActionStatus::Approved);
+
+        // The next retry will see the action is already processed on chain and remove it from WAL
+        let now = std::time::Instant::now();
+        while store
+            .get_all_pending_actions()
+            .unwrap()
+            .contains_key(&action_digest)
+        {
+            if now.elapsed().as_secs() > 10 {
+                panic!("Timeout waiting for action to be removed from WAL");
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+        tx_subscription.try_recv().unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_skip_tx_submission_if_already_processed_on_chain() {
+        let (
+            _signing_tx,
+            execution_tx,
+            sui_client_mock,
+            mut tx_subscription,
+            store,
+            secrets,
+            dummy_sui_key,
+            mock0,
+            mock1,
+            mock2,
+            mock3,
+            _handles,
+            gas_object_ref,
+            sui_address,
+        ) = setup();
+
+        // TODO: remove once we don't rely on env var to get object id
+        std::env::set_var("ROOT_BRIDGE_OBJECT_ID", "0x09");
+        std::env::set_var("ROOT_BRIDGE_OBJECT_INITIAL_SHARED_VERSION", "1");
+
+        let (action_certificate, _, _) = get_bridge_authority_approved_action(
+            vec![&mock0, &mock1, &mock2, &mock3],
+            vec![&secrets[0], &secrets[1], &secrets[2], &secrets[3]],
+        );
+
+        let action = action_certificate.data().clone();
+
+        let tx_data =
+            build_transaction(sui_address, &gas_object_ref, action_certificate.clone()).unwrap();
+        let tx_digest = get_tx_digest(tx_data, &dummy_sui_key);
+        mock_transaction_error(
+            &sui_client_mock,
+            tx_digest,
+            BridgeError::Generic("some random error".to_string()),
+            true,
+        );
+
+        let gas_coin = GasCoin::new_for_testing(1_000_000_000_000); // dummy gas coin
+        sui_client_mock.add_gas_object_info(
+            gas_coin.clone(),
+            gas_object_ref,
+            Owner::AddressOwner(sui_address),
+        );
+
+        sui_client_mock.set_action_onchain_status(&action, BridgeActionStatus::Pending);
+
+        store.insert_pending_actions(&[action.clone()]).unwrap();
+        assert_eq!(
+            store.get_all_pending_actions().unwrap()[&action.digest()],
+            action.clone()
+        );
+
+        // Kick it (send to the execution queue, skipping the signing queue)
+        execution_tx
+            .send(CertifiedBridgeActionExecutionWrapper(action_certificate, 0))
+            .await
+            .unwrap();
+
+        // Some requests come in and will fail.
+        tx_subscription.recv().await.unwrap();
+
+        // Set the action to be already approved on chain
+        sui_client_mock.set_action_onchain_status(&action, BridgeActionStatus::Approved);
+
+        // The next retry will see the action is already processed on chain and remove it from WAL
+        let now = std::time::Instant::now();
+        let action_digest = action.digest();
+        while store
+            .get_all_pending_actions()
+            .unwrap()
+            .contains_key(&action_digest)
+        {
+            if now.elapsed().as_secs() > 10 {
+                panic!("Timeout waiting for action to be removed from WAL");
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
     }
 
     fn mock_bridge_authority_sigs(
@@ -752,6 +984,7 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn setup() -> (
         mysten_metrics::metered_channel::Sender<BridgeActionExecutionWrapper>,
+        mysten_metrics::metered_channel::Sender<CertifiedBridgeActionExecutionWrapper>,
         SuiMockClient,
         tokio::sync::broadcast::Receiver<TransactionDigest>,
         Arc<BridgeOrchestratorTables>,
@@ -806,10 +1039,11 @@ mod tests {
             gas_object_ref.0,
         );
 
-        let (executor_handle, tx) = executor.run();
+        let (executor_handle, signing_tx, execution_tx) = executor.run_inner();
         handles.extend(executor_handle);
         (
-            tx,
+            signing_tx,
+            execution_tx,
             sui_client_mock,
             tx_subscription,
             store,

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod sui_mock_client;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+// TODO: can we log the error very time it gets retried?
 #[macro_export]
 macro_rules! retry_with_max_delay {
     ($func:expr, $max_delay:expr) => {{

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -186,7 +186,7 @@ async fn start_client_components(
 
     let committee = Arc::new(
         sui_client
-            .get_committee()
+            .get_bridge_committee()
             .await
             .expect("Failed to get committee"),
     );

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -19,7 +19,7 @@ use sui_types::transaction::Transaction;
 use sui_types::Identifier;
 
 use crate::sui_client::SuiClientInner;
-use crate::types::{BridgeAction, BridgeActionStatus, MoveTypeBridgeCommittee};
+use crate::types::{BridgeAction, BridgeActionDigest, BridgeActionStatus, MoveTypeBridgeCommittee};
 
 /// Mock client used in test environments.
 #[allow(clippy::type_complexity)]
@@ -35,6 +35,7 @@ pub struct SuiMockClient {
         Arc<Mutex<HashMap<TransactionDigest, BridgeResult<SuiTransactionBlockResponse>>>>,
     wildcard_transaction_response: Arc<Mutex<Option<BridgeResult<SuiTransactionBlockResponse>>>>,
     get_object_info: Arc<Mutex<HashMap<ObjectID, (GasCoin, ObjectRef, Owner)>>>,
+    onchain_status: Arc<Mutex<HashMap<BridgeActionDigest, BridgeActionStatus>>>,
 
     requested_transactions_tx: tokio::sync::broadcast::Sender<TransactionDigest>,
 }
@@ -50,6 +51,7 @@ impl SuiMockClient {
             transaction_responses: Default::default(),
             wildcard_transaction_response: Default::default(),
             get_object_info: Default::default(),
+            onchain_status: Default::default(),
             requested_transactions_tx: tokio::sync::broadcast::channel(10000).0,
         }
     }
@@ -83,6 +85,13 @@ impl SuiMockClient {
             .lock()
             .unwrap()
             .insert(tx_digest, response);
+    }
+
+    pub fn set_action_onchain_status(&self, action: &BridgeAction, status: BridgeActionStatus) {
+        self.onchain_status
+            .lock()
+            .unwrap()
+            .insert(action.digest(), status);
     }
 
     pub fn set_wildcard_transaction_response(
@@ -166,9 +175,15 @@ impl SuiClientInner for SuiMockClient {
 
     async fn get_action_onchain_status(
         &self,
-        _action: &BridgeAction,
+        action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {
-        unimplemented!()
+        Ok(self
+            .onchain_status
+            .lock()
+            .unwrap()
+            .get(&action.digest())
+            .cloned()
+            .unwrap_or(BridgeActionStatus::Pending))
     }
 
     async fn execute_transaction_block_with_effects(

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -202,7 +202,7 @@ pub enum TokenId {
     USDT = 4,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BridgeActionStatus {
     RecordNotFound,
     Pending,


### PR DESCRIPTION
## Description 

As title.

## Test Plan 

new unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
