### PR TITLE
[graphql] Exclude health endpoint from logging

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -25,7 +25,7 @@ pub struct LoggerConfig {
 impl Default for LoggerConfig {
     fn default() -> Self {
         Self {
-            log_request_query: true,
+            log_request_query: false,
             log_response: true,
             log_complexity: true,
         }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -46,6 +46,8 @@ use tower::{Layer, Service};
 use tracing::{info, warn};
 use uuid::Uuid;
 
+const HEALTH_UUID: Uuid = Uuid::nil();
+
 pub struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
 }
@@ -304,10 +306,11 @@ async fn health_checks(
     req: GraphQLRequest,
 ) -> impl axum::response::IntoResponse {
     // Simple request to check if the DB is up
-    // TODO: add more checks
+    // TODO: add more checks and figure out better ways to do these health checks
     let mut req = req.into_inner();
     req.data.insert(addr);
-    req.data.insert(Uuid::new_v4());
+    // insert the NIL UUID which helps avoid logging these health requests
+    req.data.insert(HEALTH_UUID);
     req.query = r#"
         query {
             chainIdentifier


### PR DESCRIPTION
## Description 

Due to the way things are set up, the health endpoint is filling up the logs, so we want to not log it. Unfortunately, all the `cost` logs will still push an `info` with 
`INFO sui_graphql_rpc::data::pg::query_cost: Estimated cost cost=0.54 max_db_query_cost=20000 exceeds=false`. Adding a Uuid to the log function in the `cost` module is not trivial. Need to assess if this is the right way.

Should be merged after #15871

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
