### PR TITLE
Create ExecutionCache traits with passthrough "cache"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,6 +2236,19 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.16",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
@@ -4035,6 +4048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "error-code"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,7 +4231,7 @@ checksum = "40bf114f1017ace0f622f1652f59c2c5e1abfe7d88891cca0c43da979b351de0"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "chrono",
  "convert_case 0.6.0",
  "elliptic-curve 0.13.4",
@@ -5056,7 +5078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f822a2716041492e071691606474f5a7e4fa7c2acbfd7da7b29884fb448291c7"
 dependencies = [
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.4.2",
@@ -6542,6 +6564,27 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8017ec3548ffe7d4cef7ac0e12b044c01164a74c0f3119420faeaf13490ad8b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "quanta",
+ "rustc_version",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -9547,6 +9590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11245,6 +11299,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12029,6 +12098,7 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.10.5",
  "lru 0.10.0",
+ "moka",
  "more-asserts",
  "move-binary-format",
  "move-bytecode-utils",
@@ -12219,7 +12289,7 @@ dependencies = [
 name = "sui-execution"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-bytecode-verifier-next-vm",
@@ -14143,6 +14213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14313,7 +14389,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9186daca5c58cb307d09731e0ba06b13fd6c036c90672b9bfc31cecf76cf689"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "serde",
@@ -15018,6 +15094,12 @@ name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "triomphe"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
 
 [[package]]
 name = "try-lock"
@@ -16046,7 +16128,7 @@ dependencies = [
  "cached_proc_macro_types",
  "camino",
  "cargo-platform",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "cassowary",
  "cast",
  "cbc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,19 +2236,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.16",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
@@ -4048,15 +4035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "error-code"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,7 +4209,7 @@ checksum = "40bf114f1017ace0f622f1652f59c2c5e1abfe7d88891cca0c43da979b351de0"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "chrono",
  "convert_case 0.6.0",
  "elliptic-curve 0.13.4",
@@ -5078,7 +5056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f822a2716041492e071691606474f5a7e4fa7c2acbfd7da7b29884fb448291c7"
 dependencies = [
  "camino",
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.4.2",
@@ -6564,27 +6542,6 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "moka"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8017ec3548ffe7d4cef7ac0e12b044c01164a74c0f3119420faeaf13490ad8b"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "once_cell",
- "parking_lot 0.12.1",
- "quanta",
- "rustc_version",
- "skeptic",
- "smallvec",
- "tagptr",
- "thiserror",
- "triomphe",
- "uuid 1.2.2",
 ]
 
 [[package]]
@@ -9590,17 +9547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
-dependencies = [
- "bitflags 1.3.2",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11299,21 +11245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata 0.14.2",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12098,7 +12029,6 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.10.5",
  "lru 0.10.0",
- "moka",
  "more-asserts",
  "move-binary-format",
  "move-bytecode-utils",
@@ -12289,7 +12219,7 @@ dependencies = [
 name = "sui-execution"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-bytecode-verifier-next-vm",
@@ -14213,12 +14143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14389,7 +14313,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9186daca5c58cb307d09731e0ba06b13fd6c036c90672b9bfc31cecf76cf689"
 dependencies = [
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "serde",
@@ -15094,12 +15018,6 @@ name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
-
-[[package]]
-name = "triomphe"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
 
 [[package]]
 name = "try-lock"
@@ -16128,7 +16046,7 @@ dependencies = [
  "cached_proc_macro_types",
  "camino",
  "cargo-platform",
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "cassowary",
  "cast",
  "cbc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,6 @@ criterion = { version = "0.5.0", features = [
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.4.0"
-moka = { version = "0.12", features = ["sync"] }
 # datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,6 +297,7 @@ criterion = { version = "0.5.0", features = [
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.4.0"
+moka = { version = "0.12", features = ["sync"] }
 # datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"

--- a/crates/mysten-common/src/sync/notify_read.rs
+++ b/crates/mysten-common/src/sync/notify_read.rs
@@ -56,7 +56,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
         }
     }
 
-    pub fn register_all(&self, keys: Vec<K>) -> Vec<Registration<K, V>> {
+    pub fn register_all(&self, keys: &[K]) -> Vec<Registration<K, V>> {
         self.count_pending.fetch_add(keys.len(), Ordering::Relaxed);
         let mut registrations = vec![];
         for key in keys.iter() {
@@ -163,7 +163,7 @@ mod tests {
     #[tokio::test]
     pub async fn test_notify_read() {
         let notify_read = NotifyRead::<u64, u64>::new();
-        let mut registrations = notify_read.register_all(vec![1, 2, 3]);
+        let mut registrations = notify_read.register_all(&[1, 2, 3]);
         assert_eq!(3, notify_read.count_pending.load(Ordering::Relaxed));
         registrations.pop();
         assert_eq!(2, notify_read.count_pending.load(Ordering::Relaxed));

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -23,6 +23,7 @@ im.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 lru.workspace = true
+moka.workspace = true
 num_cpus.workspace = true
 object_store.workspace = true
 once_cell.workspace = true

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -23,7 +23,6 @@ im.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 lru.workspace = true
-moka.workspace = true
 num_cpus.workspace = true
 object_store.workspace = true
 once_cell.workspace = true

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3932,8 +3932,7 @@ impl AuthorityState {
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiResult<Option<VerifiedSignedTransaction>> {
         let lock_info = self
-            // TODO(cache): we need to use the cache for locks
-            .database
+            .execution_cache
             .get_lock(*object_ref, epoch_store.epoch())
             .map_err(SuiError::from)?;
         let lock_info = match lock_info {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_store_types::{StoreObject, StoreObjectWrapper};
+use crate::transaction_outputs::TransactionOutputs;
 use crate::verify_indexes::verify_indexes;
 use anyhow::anyhow;
 use arc_swap::{ArcSwap, Guard};
@@ -135,6 +136,7 @@ use crate::checkpoints::CheckpointStore;
 use crate::consensus_adapter::ConsensusAdapter;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
+use crate::in_mem_execution_cache::{ExecutionCacheRead, ExecutionCacheWrite, InMemoryCache};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::{StateAccumulator, WrappedObject};
@@ -621,6 +623,8 @@ pub struct AuthorityState {
 
     /// The database
     input_loader: TransactionInputLoader,
+    execution_cache: Arc<InMemoryCache>,
+
     pub database: Arc<AuthorityStore>, // TODO: remove pub
 
     epoch_store: ArcSwap<AuthorityPerEpochStore>,
@@ -890,7 +894,11 @@ impl AuthorityState {
 
         if transaction.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(transaction, effects.data(), &self.database)
+                .acquire_shared_locks_from_effects(
+                    transaction,
+                    effects.data(),
+                    self.execution_cache.as_ref(),
+                )
                 .await?;
         }
 
@@ -900,8 +908,8 @@ impl AuthorityState {
             .enqueue(vec![transaction.clone()], epoch_store)?;
 
         let observed_effects = self
-            .database
-            .notify_read_executed_effects(vec![digest])
+            .execution_cache
+            .notify_read_executed_effects(&[digest])
             .instrument(tracing::debug_span!(
                 "notify_read_effects_in_execute_certificate_with_effects"
             ))
@@ -946,7 +954,12 @@ impl AuthorityState {
             self.enqueue_certificates_for_execution(vec![certificate.clone()], epoch_store)?;
         }
 
-        let effects = self.notify_read_effects(certificate).await?;
+        let effects = self
+            .execution_cache
+            .notify_read_executed_effects(&[*certificate.digest()])
+            .await?
+            .pop()
+            .expect("must return correct number of effects");
         self.sign_effects(effects, epoch_store)
     }
 
@@ -1033,15 +1046,11 @@ impl AuthorityState {
 
     pub async fn notify_read_effects(
         &self,
-        certificate: &VerifiedCertificate,
-    ) -> SuiResult<TransactionEffects> {
-        let tx_digest = *certificate.digest();
-        Ok(self
-            .database
-            .notify_read_executed_effects(vec![tx_digest])
-            .await?
-            .pop()
-            .expect("notify_read_effects should return exactly 1 element"))
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<TransactionEffects>> {
+        self.execution_cache
+            .notify_read_executed_effects(digests)
+            .await
     }
 
     async fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
@@ -1278,14 +1287,13 @@ impl AuthorityState {
         // Allow testing what happens if we crash here.
         fail_point_async!("crash");
 
-        self.database
-            .update_state(
-                inner_temporary_store,
-                &certificate.clone().into_unsigned(),
-                effects,
-                epoch_store.epoch(),
-            )
-            .await?;
+        let transaction_outputs = TransactionOutputs::build_transaction_outputs(
+            certificate.clone().into_unsigned(),
+            effects.clone(),
+            inner_temporary_store,
+        );
+        self.execution_cache
+            .write_transaction_outputs(epoch_store.epoch(), transaction_outputs);
 
         // commit_certificate finished, the tx is fully committed to the store.
         tx_guard.commit_tx();
@@ -1940,7 +1948,8 @@ impl AuthorityState {
                 };
                 // When we process the index, the latest object hasn't been written yet so
                 // the old object must be present.
-                let Some(old_object) = self.database.get_object_by_key(id, *old_version)? else {
+                let Some(old_object) = self.execution_cache.get_object_by_key(id, *old_version)?
+                else {
                     panic!("tx_digest={:?}, error processing object owner index, cannot find owner for object {:?} at version {:?}", tx_digest, id, old_version);
                 };
                 if old_object.owner != owner {
@@ -2059,7 +2068,7 @@ impl AuthorityState {
                 } else {
                     // If not found, try to find it in the database.
                     let object = self
-                        .database
+                        .execution_cache
                         .get_object_by_key(&object_id, o.version())?
                         .ok_or_else(|| UserInputError::ObjectNotFound {
                             object_id,
@@ -2356,6 +2365,7 @@ impl AuthorityState {
         secret: StableSyncAuthoritySigner,
         supported_protocol_versions: SupportedProtocolVersions,
         store: Arc<AuthorityStore>,
+        execution_cache: Arc<InMemoryCache>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         committee_store: Arc<CommitteeStore>,
         indexes: Option<Arc<IndexStore>>,
@@ -2397,7 +2407,7 @@ impl AuthorityState {
             indirect_objects_threshold,
             archive_readers,
         );
-        let input_loader = TransactionInputLoader::new(store.clone());
+        let input_loader = TransactionInputLoader::new(execution_cache.clone());
         let epoch = epoch_store.epoch();
         let state = Arc::new(AuthorityState {
             name,
@@ -2405,6 +2415,7 @@ impl AuthorityState {
             execution_lock: RwLock::new(epoch),
             epoch_store: ArcSwap::new(epoch_store.clone()),
             input_loader,
+            execution_cache,
             database: store,
             indexes,
             subscription_handler: Arc::new(SubscriptionHandler::new(prometheus_registry)),
@@ -2437,6 +2448,10 @@ impl AuthorityState {
             .expect("Error indexing genesis objects.");
 
         state
+    }
+
+    pub fn get_cache_reader(&self) -> &Arc<InMemoryCache> {
+        &self.execution_cache
     }
 
     pub async fn prune_checkpoints_for_eligible_epochs(
@@ -2904,7 +2919,9 @@ impl AuthorityState {
 
     #[instrument(level = "trace", skip_all)]
     pub async fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
-        self.database.get_object(object_id).map_err(Into::into)
+        self.execution_cache
+            .get_object(object_id)
+            .map_err(Into::into)
     }
 
     pub async fn get_sui_system_package_object_ref(&self) -> SuiResult<ObjectRef> {
@@ -2917,7 +2934,7 @@ impl AuthorityState {
 
     // This function is only used for testing.
     pub fn get_sui_system_state_object_for_testing(&self) -> SuiResult<SuiSystemState> {
-        self.database.get_sui_system_state_object_unsafe()
+        self.execution_cache.get_sui_system_state_object_unsafe()
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -2969,7 +2986,10 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub fn get_object_read(&self, object_id: &ObjectID) -> SuiResult<ObjectRead> {
         Ok(
-            match self.database.get_latest_object_or_tombstone(*object_id)? {
+            match self
+                .execution_cache
+                .get_latest_object_or_tombstone(*object_id)?
+            {
                 Some((_, ObjectOrTombstone::Object(object))) => {
                     let layout = self.get_object_layout(&object)?;
                     ObjectRead::Exists(object.compute_object_reference(), object, layout)
@@ -3028,7 +3048,7 @@ impl AuthorityState {
     ) -> SuiResult<PastObjectRead> {
         // Firstly we see if the object ever existed by getting its latest data
         let Some(obj_ref) = self
-            .database
+            .execution_cache
             .get_latest_object_ref_or_tombstone(*object_id)?
         else {
             return Ok(PastObjectRead::ObjectNotExists(*object_id));
@@ -3080,7 +3100,7 @@ impl AuthorityState {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<Option<(Object, Option<MoveStructLayout>)>> {
-        let Some(object) = self.database.get_object_by_key(object_id, version)? else {
+        let Some(object) = self.execution_cache.get_object_by_key(object_id, version)? else {
             return Ok(None);
         };
 
@@ -3095,6 +3115,7 @@ impl AuthorityState {
             .map(|object| {
                 self.load_epoch_store_one_call_per_task()
                     .executor()
+                    // TODO(cache) - must read through cache
                     .type_layout_resolver(Box::new(self.database.as_ref()))
                     .get_annotated_layout(&object.type_().clone().into())
             })
@@ -3107,7 +3128,7 @@ impl AuthorityState {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<Owner> {
-        self.database
+        self.execution_cache
             .get_object_by_key(object_id, version)?
             .ok_or_else(|| {
                 SuiError::from(UserInputError::ObjectNotFound {
@@ -3185,7 +3206,7 @@ impl AuthorityState {
             .collect::<Vec<_>>();
         let mut move_objects = vec![];
 
-        let objects = self.database.multi_get_object_by_key(&object_ids)?;
+        let objects = self.execution_cache.multi_get_object_by_key(&object_ids)?;
 
         for (o, id) in objects.into_iter().zip(object_ids) {
             let object = o.ok_or_else(|| {
@@ -3301,7 +3322,7 @@ impl AuthorityState {
         &self,
         digest: &TransactionEventsDigest,
     ) -> SuiResult<TransactionEvents> {
-        self.database
+        self.execution_cache
             .get_events(digest)?
             .ok_or(SuiError::TransactionEventsNotFound { digest: *digest })
     }
@@ -3313,6 +3334,28 @@ impl AuthorityState {
                 error: "extended object indexing is not enabled on this server".into(),
             }),
         }
+    }
+
+    pub fn get_transactions_and_serialized_sizes(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<(VerifiedTransaction, usize)>>> {
+        let txns = self.execution_cache.multi_get_transaction_blocks(digests)?;
+        txns.into_iter()
+            .map(|txn| {
+                txn.map(|txn| {
+                    // Note: if the transaction is read from the db, we are wasting some
+                    // effort relative to reading the raw bytes from the db instead of
+                    // calling serialized_size. However, transactions should usually be
+                    // fetched from cache.
+                    match txn.serialized_size() {
+                        Ok(size) => Ok(((*txn).clone(), size)),
+                        Err(e) => Err(e),
+                    }
+                })
+                .transpose()
+            })
+            .collect::<Result<Vec<_>, _>>()
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -3680,7 +3723,10 @@ impl AuthorityState {
         if let Some(effects) =
             self.get_signed_effects_and_maybe_resign(transaction_digest, epoch_store)?
         {
-            if let Some(transaction) = self.database.get_transaction_block(transaction_digest)? {
+            if let Some(transaction) = self
+                .execution_cache
+                .get_transaction_block(transaction_digest)?
+            {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
                 let events = if let Some(digest) = effects.events_digest() {
                     self.get_transaction_events(digest)?
@@ -3688,7 +3734,7 @@ impl AuthorityState {
                     TransactionEvents::default()
                 };
                 return Ok(Some((
-                    transaction.into_message(),
+                    (*transaction).clone().into_message(),
                     TransactionStatus::Executed(cert_sig, effects.into_inner(), events),
                 )));
             } else {
@@ -3716,7 +3762,9 @@ impl AuthorityState {
         transaction_digest: &TransactionDigest,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<Option<VerifiedSignedTransactionEffects>> {
-        let effects = self.database.get_executed_effects(transaction_digest)?;
+        let effects = self
+            .execution_cache
+            .get_executed_effects(transaction_digest)?;
         match effects {
             Some(effects) => Ok(Some(self.sign_effects(effects, epoch_store)?)),
             None => Ok(None),
@@ -3871,6 +3919,7 @@ impl AuthorityState {
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiResult<Option<VerifiedSignedTransaction>> {
         let lock_info = self
+            // TODO(cache): we need to use the cache for locks
             .database
             .get_lock(*object_ref, epoch_store.epoch())
             .map_err(SuiError::from)?;
@@ -3911,15 +3960,16 @@ impl AuthorityState {
         Ok(tx_option)
     }
 
-    pub async fn get_objects(&self, _objects: &[ObjectID]) -> SuiResult<Vec<Option<Object>>> {
-        self.database.get_objects(_objects)
+    pub async fn get_objects(&self, objects: &[ObjectID]) -> SuiResult<Vec<Option<Object>>> {
+        self.execution_cache.get_objects(objects)
     }
 
     pub async fn get_object_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
-        self.database.get_latest_object_ref_or_tombstone(object_id)
+        self.execution_cache
+            .get_latest_object_ref_or_tombstone(object_id)
     }
 
     /// Ordinarily, protocol upgrades occur when 2f + 1 + (f *
@@ -4404,7 +4454,7 @@ impl AuthorityState {
         // The tx could have been executed by state sync already - if so simply return an error.
         // The checkpoint builder will shortly be terminated by reconfiguration anyway.
         if self
-            .database
+            .execution_cache
             .is_tx_already_executed(tx_digest)
             .expect("read cannot fail")
         {
@@ -4607,23 +4657,23 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         Vec<Option<TransactionEvents>>,
     )> {
         let txns = if !transactions.is_empty() {
-            self.database
+            self.execution_cache
                 .multi_get_transaction_blocks(transactions)?
                 .into_iter()
-                .map(|t| t.map(|t| t.into_inner()))
+                .map(|t| t.map(|t| (*t).clone().into_inner()))
                 .collect()
         } else {
             vec![]
         };
 
         let fx = if !effects.is_empty() {
-            self.database.multi_get_executed_effects(effects)?
+            self.execution_cache.multi_get_executed_effects(effects)?
         } else {
             vec![]
         };
 
         let evts = if !events.is_empty() {
-            self.database.multi_get_events(events)?
+            self.execution_cache.multi_get_events(events)?
         } else {
             vec![]
         };
@@ -4697,7 +4747,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         object_id: ObjectID,
         version: VersionNumber,
     ) -> SuiResult<Option<Object>> {
-        self.database
+        self.execution_cache
             .get_object_by_key(&object_id, version)
             .map_err(Into::into)
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3367,29 +3367,6 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn get_transactions_and_serialized_sizes(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<(VerifiedTransaction, usize)>>> {
-        let txns = self.execution_cache.multi_get_transaction_blocks(digests)?;
-        txns.into_iter()
-            .map(|txn| {
-                txn.map(|txn| {
-                    // Note: if the transaction is read from the db, we are wasting some
-                    // effort relative to reading the raw bytes from the db instead of
-                    // calling serialized_size. However, transactions should usually be
-                    // fetched from cache.
-                    match txn.serialized_size() {
-                        Ok(size) => Ok(((*txn).clone(), size)),
-                        Err(e) => Err(e),
-                    }
-                })
-                .transpose()
-            })
-            .collect::<Result<Vec<_>, _>>()
-    }
-
-    #[instrument(level = "trace", skip_all)]
     pub fn loaded_child_object_versions(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority/authority_notify_read.rs
+++ b/crates/sui-core/src/authority/authority_notify_read.rs
@@ -1,20 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::AuthorityStore;
 use async_trait::async_trait;
-use either::Either;
-use futures::future::join_all;
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Instant;
 use sui_types::base_types::{TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::TransactionEffects;
-use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::SuiResult;
-use tracing::{debug, instrument};
 
 #[async_trait]
 pub trait EffectsNotifyRead: Send + Sync + 'static {
@@ -38,85 +28,4 @@ pub trait EffectsNotifyRead: Send + Sync + 'static {
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<TransactionEffects>>>;
-}
-
-#[async_trait]
-impl EffectsNotifyRead for Arc<AuthorityStore> {
-    #[instrument(level = "trace", skip_all)]
-    async fn notify_read_executed_effects(
-        &self,
-        digests: Vec<TransactionDigest>,
-    ) -> SuiResult<Vec<TransactionEffects>> {
-        let timer = Instant::now();
-        // We need to register waiters _before_ reading from the database to avoid race conditions
-        let registrations = self
-            .executed_effects_notify_read
-            .register_all(digests.clone());
-        let effects = self.multi_get_executed_effects(&digests)?;
-        let mut needs_wait = false;
-        let mut results: FuturesUnordered<_> = effects
-            .into_iter()
-            .zip(registrations)
-            .map(|(e, r)| match e {
-                // Note that Some() clause also drops registration that is already fulfilled
-                Some(ready) => Either::Left(futures::future::ready(ready)),
-                None => {
-                    needs_wait = true;
-                    Either::Right(r)
-                }
-            })
-            .collect();
-        let mut effects_map = HashMap::new();
-        let mut last_finished = None;
-        while let Some(finished) = results.next().await {
-            last_finished = Some(*finished.transaction_digest());
-            effects_map.insert(*finished.transaction_digest(), finished);
-        }
-        if needs_wait {
-            // Only log the duration if we ended up waiting.
-            // We need this to be debug log in order to debug long checkpoint building latencies.
-            debug!(duration=?timer.elapsed(), ?last_finished, "Finished notify_read_effects");
-        }
-        // Map from digests to ensures returned order is the same as order of digests
-        Ok(digests
-            .iter()
-            .map(|d| {
-                effects_map
-                    .remove(d)
-                    .expect("Every effect must have been added after each task finishes above")
-            })
-            .collect())
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    async fn notify_read_executed_effects_digests(
-        &self,
-        digests: Vec<TransactionDigest>,
-    ) -> SuiResult<Vec<TransactionEffectsDigest>> {
-        // We need to register waiters _before_ reading from the database to avoid race conditions
-        let registrations = self
-            .executed_effects_digests_notify_read
-            .register_all(digests.clone());
-
-        let effects_digests = self.multi_get_executed_effects_digests(&digests)?;
-
-        let results = effects_digests
-            .into_iter()
-            .zip(registrations)
-            .map(|(a, r)| match a {
-                // Note that Some() clause also drops registration that is already fulfilled
-                Some(ready) => Either::Left(futures::future::ready(ready)),
-                None => Either::Right(r),
-            });
-
-        Ok(join_all(results).await)
-    }
-
-    #[instrument(level = "trace", skip_all)]
-    fn multi_get_executed_effects(
-        &self,
-        digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
-        AuthorityStore::multi_get_executed_effects(self, digests)
-    }
 }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -55,7 +55,7 @@ use crate::consensus_handler::{
 };
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::reconfiguration::ReconfigState;
-use crate::in_mem_execution_cache::{ExecutionCacheRead, InMemoryCache};
+use crate::in_mem_execution_cache::{ExecutionCache, ExecutionCacheRead};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::post_consensus_tx_reorder::PostConsensusTxReorder;
 use crate::signature_verifier::*;
@@ -208,7 +208,7 @@ pub struct ExecutionIndicesWithStats {
 pub struct ExecutionComponents {
     pub(crate) executor: Arc<dyn Executor + Send + Sync>,
     // TODO: use strategies (e.g. LRU?) to constraint memory usage
-    pub(crate) module_cache: Arc<SyncModuleCache<ResolverWrapper<InMemoryCache>>>,
+    pub(crate) module_cache: Arc<SyncModuleCache<ResolverWrapper<ExecutionCache>>>,
     metrics: Arc<ResolverMetrics>,
 }
 
@@ -655,7 +655,7 @@ impl AuthorityPerEpochStore {
         db_options: Option<Options>,
         metrics: Arc<EpochMetrics>,
         epoch_start_configuration: EpochStartConfiguration,
-        cache_reader: Arc<InMemoryCache>,
+        cache_reader: Arc<ExecutionCache>,
         cache_metrics: Arc<ResolverMetrics>,
         signature_verifier_metrics: Arc<SignatureVerifierMetrics>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
@@ -860,7 +860,7 @@ impl AuthorityPerEpochStore {
         name: AuthorityName,
         new_committee: Committee,
         epoch_start_configuration: EpochStartConfiguration,
-        cache: Arc<InMemoryCache>,
+        cache: Arc<ExecutionCache>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
     ) -> Arc<Self> {
@@ -920,7 +920,7 @@ impl AuthorityPerEpochStore {
         self.epoch_start_state().protocol_version()
     }
 
-    pub fn module_cache(&self) -> &Arc<SyncModuleCache<ResolverWrapper<InMemoryCache>>> {
+    pub fn module_cache(&self) -> &Arc<SyncModuleCache<ResolverWrapper<ExecutionCache>>> {
         &self.execution_component.module_cache
     }
 
@@ -3013,7 +3013,7 @@ impl GetSharedLocks for AuthorityPerEpochStore {
 impl ExecutionComponents {
     fn new(
         protocol_config: &ProtocolConfig,
-        store: Arc<InMemoryCache>,
+        store: Arc<ExecutionCache>,
         metrics: Arc<ResolverMetrics>,
         // Keep this as a parameter for possible future use
         _expensive_safety_check_config: &ExpensiveSafetyCheckConfig,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -656,7 +656,7 @@ impl AuthorityPerEpochStore {
         db_options: Option<Options>,
         metrics: Arc<EpochMetrics>,
         epoch_start_configuration: EpochStartConfiguration,
-        cache_reader: Arc<ExecutionCache>,
+        execution_cache: Arc<ExecutionCache>,
         cache_metrics: Arc<ResolverMetrics>,
         signature_verifier_metrics: Arc<SignatureVerifierMetrics>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
@@ -701,7 +701,7 @@ impl AuthorityPerEpochStore {
 
         let execution_component = ExecutionComponents::new(
             &protocol_config,
-            cache_reader.clone(),
+            execution_cache.clone(),
             cache_metrics,
             expensive_safety_check_config,
         );
@@ -735,7 +735,7 @@ impl AuthorityPerEpochStore {
 
         if authenticator_state_enabled {
             info!("authenticator_state enabled");
-            let authenticator_state = get_authenticator_state(cache_reader.as_ref())
+            let authenticator_state = get_authenticator_state(execution_cache.as_ref())
                 .expect("Read cannot fail")
                 .expect("Authenticator state must exist");
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -12,6 +12,7 @@ use crate::authority::authority_store_types::{
     get_store_object_pair, ObjectContentDigest, StoreObject, StoreObjectPair, StoreObjectWrapper,
 };
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
+use crate::transaction_outputs::TransactionOutputs;
 use either::Either;
 use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
@@ -33,7 +34,6 @@ use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentS
 use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
-use typed_store::rocks::errors::typed_store_err_from_bcs_err;
 use typed_store::traits::Map;
 use typed_store::{
     rocks::{DBBatch, DBMap},
@@ -404,7 +404,7 @@ impl AuthorityStore {
         object_id: &ObjectID,
         version: &SequenceNumber,
         epoch_id: EpochId,
-    ) -> Result<Option<TransactionDigest>, TypedStoreError> {
+    ) -> SuiResult<Option<TransactionDigest>> {
         let object_key = (epoch_id, ObjectKey(*object_id, *version));
 
         match self
@@ -966,6 +966,37 @@ impl AuthorityStore {
         Ok(self.perpetual_tables.epoch_start_configuration.get(&())?)
     }
 
+    fn force_reload_system_packages_into_cache(&self) {
+        info!("Reload all system packages in the cache");
+        self.package_cache
+            .force_reload_system_packages(BuiltInFramework::all_package_ids(), self);
+    }
+
+    /// Acquires read locks for affected indirect objects
+    #[instrument(level = "trace", skip_all)]
+    async fn acquire_read_locks_for_indirect_objects(
+        &self,
+        written: &WrittenObjects,
+    ) -> Vec<RwLockGuard> {
+        // locking is required to avoid potential race conditions with the pruner
+        // potential race:
+        //   - transaction execution branches to reference count increment
+        //   - pruner decrements ref count to 0
+        //   - compaction job compresses existing merge values to an empty vector
+        //   - tx executor commits ref count increment instead of the full value making object inaccessible
+        // read locks are sufficient because ref count increments are safe,
+        // concurrent transaction executions produce independent ref count increments and don't corrupt the state
+        let digests = written
+            .values()
+            .filter_map(|object| {
+                let StoreObjectPair(_, indirect_object) =
+                    get_store_object_pair(object.clone(), self.indirect_objects_threshold);
+                indirect_object.map(|obj| obj.inner().digest())
+            })
+            .collect();
+        self.objects_lock_table.acquire_read_locks(digests).await
+    }
+
     /// Updates the state resulting from the execution of a certificate.
     ///
     /// Internally it checks that all locks for active inputs are at the correct
@@ -973,14 +1004,22 @@ impl AuthorityStore {
     #[instrument(level = "debug", skip_all)]
     pub async fn update_state(
         &self,
-        inner_temporary_store: InnerTemporaryStore,
-        transaction: &VerifiedTransaction,
-        effects: &TransactionEffects,
         epoch_id: EpochId,
+        tx_outputs: TransactionOutputs,
     ) -> SuiResult {
-        let _locks = self
-            .acquire_read_locks_for_indirect_objects(&inner_temporary_store)
-            .await;
+        let TransactionOutputs {
+            transaction,
+            effects,
+            markers,
+            wrapped,
+            deleted,
+            written,
+            events,
+            ..
+        } = tx_outputs;
+
+        let _locks = self.acquire_read_locks_for_indirect_objects(&written).await;
+
         // Extract the new state from the execution
         let mut write_batch = self.perpetual_tables.transactions.batch();
 
@@ -993,196 +1032,22 @@ impl AuthorityStore {
 
         // Add batched writes for objects and locks.
         let effects_digest = effects.digest();
-        self.update_objects_and_locks(
-            &mut write_batch,
-            inner_temporary_store,
-            effects,
-            transaction,
-            epoch_id,
-        )
-        .await?;
-
-        // Store the signed effects of the transaction
-        // We can't write this until after sequencing succeeds (which happens in
-        // batch_update_objects), as effects_exists is used as a check in many places
-        // for "did the tx finish".
-        write_batch
-            .insert_batch(&self.perpetual_tables.effects, [(effects_digest, effects)])?
-            .insert_batch(
-                &self.perpetual_tables.executed_effects,
-                [(transaction_digest, effects_digest)],
-            )?;
-
-        // test crashing before writing the batch
-        fail_point_async!("crash");
-
-        // Commit.
-        write_batch.write()?;
-
-        if transaction.transaction_data().is_end_of_epoch_tx() {
-            // At the end of epoch, since system packages may have been upgraded, force
-            // reload them in the cache.
-            self.force_reload_system_packages_into_cache();
-        }
-
-        // test crashing before notifying
-        fail_point_async!("crash");
-
-        self.executed_effects_digests_notify_read
-            .notify(transaction_digest, &effects_digest);
-        self.executed_effects_notify_read
-            .notify(transaction_digest, effects);
-
-        self.metrics
-            .pending_notify_read
-            .set(self.executed_effects_notify_read.num_pending() as i64);
-
-        debug!(effects_digest = ?effects.digest(), "commit_certificate finished");
-
-        Ok(())
-    }
-
-    fn force_reload_system_packages_into_cache(&self) {
-        info!("Reload all system packages in the cache");
-        self.package_cache
-            .force_reload_system_packages(BuiltInFramework::all_package_ids(), self);
-    }
-
-    /// Acquires read locks for affected indirect objects
-    #[instrument(level = "trace", skip_all)]
-    async fn acquire_read_locks_for_indirect_objects(
-        &self,
-        inner_temporary_store: &InnerTemporaryStore,
-    ) -> Vec<RwLockGuard> {
-        // locking is required to avoid potential race conditions with the pruner
-        // potential race:
-        //   - transaction execution branches to reference count increment
-        //   - pruner decrements ref count to 0
-        //   - compaction job compresses existing merge values to an empty vector
-        //   - tx executor commits ref count increment instead of the full value making object inaccessible
-        // read locks are sufficient because ref count increments are safe,
-        // concurrent transaction executions produce independent ref count increments and don't corrupt the state
-        let digests = inner_temporary_store
-            .written
-            .values()
-            .filter_map(|object| {
-                let StoreObjectPair(_, indirect_object) =
-                    get_store_object_pair(object.clone(), self.indirect_objects_threshold);
-                indirect_object.map(|obj| obj.inner().digest())
-            })
-            .collect();
-        self.objects_lock_table.acquire_read_locks(digests).await
-    }
-
-    /// Helper function for updating the objects and locks in the state
-    #[instrument(level = "trace", skip_all)]
-    async fn update_objects_and_locks(
-        &self,
-        write_batch: &mut DBBatch,
-        inner_temporary_store: InnerTemporaryStore,
-        effects: &TransactionEffects,
-        transaction: &VerifiedTransaction,
-        epoch_id: EpochId,
-    ) -> SuiResult {
-        let InnerTemporaryStore {
-            input_objects,
-            mutable_inputs,
-            written,
-            events,
-            max_binary_format_version: _,
-            loaded_runtime_objects: _,
-            no_extraneous_module_bytes: _,
-            runtime_packages_loaded_from_db: _,
-            lamport_version,
-        } = inner_temporary_store;
-        trace!(written =? written.iter().map(|(obj_id, obj)| (obj_id, obj.version())).collect::<Vec<_>>(),
-               "batch_update_objects: temp store written");
-
-        let deleted: HashMap<_, _> = effects.all_tombstones().into_iter().collect();
-
-        // Get the actual set of objects that have been received -- any received
-        // object will show up in the modified-at set.
-        let received_objects: Vec<_> = {
-            let modified_at: HashSet<_> = effects.modified_at_versions().into_iter().collect();
-            let possible_to_receive = transaction.transaction_data().receiving_objects();
-            possible_to_receive
-                .into_iter()
-                .filter(|obj_ref| modified_at.contains(&(obj_ref.0, obj_ref.1)))
-                .collect()
-        };
-
-        // We record any received or deleted objects since they could be pruned, and smear shared
-        // object deletions in the marker table. For deleted entries in the marker table we need to
-        // make sure we don't accidentally overwrite entries.
-        let markers_to_place = {
-            let received = received_objects.iter().map(|(object_id, version, _)| {
-                (
-                    (epoch_id, ObjectKey(*object_id, *version)),
-                    MarkerValue::Received,
-                )
-            });
-
-            let deleted = deleted.into_iter().map(|(object_id, version)| {
-                let object_key = (epoch_id, ObjectKey(object_id, version));
-                if input_objects
-                    .get(&object_id)
-                    .is_some_and(|object| object.is_shared())
-                {
-                    (
-                        object_key,
-                        MarkerValue::SharedDeleted(*transaction.digest()),
-                    )
-                } else {
-                    (object_key, MarkerValue::OwnedDeleted)
-                }
-            });
-
-            // We "smear" shared deleted objects in the marker table to allow for proper sequencing
-            // of transactions that are submitted after the deletion of the shared object.
-            // NB: that we do _not_ smear shared objects that were taken immutably in the
-            // transaction.
-            let smeared_objects = effects.deleted_mutably_accessed_shared_objects();
-            let shared_smears = smeared_objects.into_iter().map(move |object_id| {
-                let object_key = (epoch_id, ObjectKey(object_id, lamport_version));
-                (
-                    object_key,
-                    MarkerValue::SharedDeleted(*transaction.digest()),
-                )
-            });
-
-            received.chain(deleted).chain(shared_smears)
-        };
 
         write_batch.insert_batch(
             &self.perpetual_tables.object_per_epoch_marker_table,
-            markers_to_place,
+            markers
+                .iter()
+                .map(|(key, marker_value)| ((epoch_id, *key), *marker_value)),
         )?;
 
-        let owned_inputs: Vec<_> = mutable_inputs
-            .into_iter()
-            .filter_map(|(id, ((version, digest), owner))| {
-                owner.is_address_owned().then_some((id, version, digest))
-            })
-            .collect();
-
-        let tombstones = effects
-            .deleted()
-            .into_iter()
-            .chain(effects.unwrapped_then_deleted())
-            .map(|oref| (oref, StoreObject::Deleted))
-            .chain(
-                effects
-                    .wrapped()
-                    .into_iter()
-                    .map(|oref| (oref, StoreObject::Wrapped)),
-            )
-            .map(|(oref, store_object)| {
-                (
-                    ObjectKey::from(oref),
-                    StoreObjectWrapper::from(store_object),
-                )
-            });
-        write_batch.insert_batch(&self.perpetual_tables.objects, tombstones)?;
+        write_batch.insert_batch(
+            &self.perpetual_tables.objects,
+            deleted
+                .into_iter()
+                .map(|key| (key, StoreObject::Deleted))
+                .chain(wrapped.into_iter().map(|key| (key, StoreObject::Wrapped)))
+                .map(|(key, store_object)| (key, StoreObjectWrapper::from(store_object))),
+        )?;
 
         // Insert each output object into the stores
         let (new_objects, new_indirect_move_objects): (Vec<_>, Vec<_>) = written
@@ -1236,16 +1101,9 @@ impl AuthorityStore {
 
         write_batch.insert_batch(&self.perpetual_tables.events, events)?;
 
-        let new_locks_to_init: Vec<_> = written
-            .values()
-            .filter_map(|new_object| {
-                if new_object.is_address_owned() {
-                    Some(new_object.compute_object_reference())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // TODO(cache): once we cache locks (see TODO in in_mem_execution_cache.rs) we will have to
+        // re-enable this code
+        /*
 
         // NOTE: We just check here that locks exist, not that they are locked to a specific TX. Why?
         // 1. Lock existence prevents re-execution of old certs when objects have been upgraded
@@ -1256,15 +1114,52 @@ impl AuthorityStore {
         // 4. Locks may have existed when we started processing this tx, but could have since
         //    been deleted by a concurrent tx that finished first. In that case, check if the
         //    tx effects exist.
-        self.check_owned_object_locks_exist(&owned_inputs)?;
+        self.check_owned_object_locks_exist(&locks_to_delete)?;
 
-        self.initialize_locks_impl(write_batch, &new_locks_to_init, false)?;
-        self.delete_locks(write_batch, &owned_inputs)?;
+        self.initialize_locks_impl(&mut write_batch, &new_locks_to_init, false)?;
 
-        // Make sure to delete the locks for any received objects.
-        // Any objects that occur as a `Receiving` argument but have not been received will not
-        // have their locks touched.
-        self.delete_locks(write_batch, &received_objects)
+        // Note: deletes locks for received objects as well (but not for objects that were in
+        // `Receiving` arguments which were not received)
+        self.delete_locks(&mut write_batch, &locks_to_delete)?;
+        */
+
+        write_batch
+            .insert_batch(
+                &self.perpetual_tables.effects,
+                [(effects_digest, effects.clone())],
+            )?
+            .insert_batch(
+                &self.perpetual_tables.executed_effects,
+                [(transaction_digest, effects_digest)],
+            )?;
+
+        // test crashing before writing the batch
+        fail_point_async!("crash");
+
+        // Commit.
+        write_batch.write()?;
+
+        if transaction.transaction_data().is_end_of_epoch_tx() {
+            // At the end of epoch, since system packages may have been upgraded, force
+            // reload them in the cache.
+            self.force_reload_system_packages_into_cache();
+        }
+
+        // test crashing before notifying
+        fail_point_async!("crash");
+
+        self.executed_effects_digests_notify_read
+            .notify(transaction_digest, &effects_digest);
+        self.executed_effects_notify_read
+            .notify(transaction_digest, &effects);
+
+        self.metrics
+            .pending_notify_read
+            .set(self.executed_effects_notify_read.num_pending() as i64);
+
+        debug!(effects_digest = ?effects.digest(), "commit_certificate finished");
+
+        Ok(())
     }
 
     /// Acquires a lock for a transaction on the given objects if they have all been initialized previously
@@ -1491,7 +1386,11 @@ impl AuthorityStore {
     }
 
     /// Removes locks for a given list of ObjectRefs.
-    fn delete_locks(&self, write_batch: &mut DBBatch, objects: &[ObjectRef]) -> SuiResult {
+    pub(crate) fn delete_locks(
+        &self,
+        write_batch: &mut DBBatch,
+        objects: &[ObjectRef],
+    ) -> SuiResult {
         trace!(?objects, "delete_locks");
         write_batch.delete_batch(
             &self.perpetual_tables.owned_object_transaction_locks,
@@ -1758,28 +1657,6 @@ impl AuthorityStore {
             .transactions
             .get(tx_digest)
             .map(|v| v.map(|v| v.into()))
-    }
-
-    pub fn get_transactions_and_serialized_sizes<'a>(
-        &self,
-        digests: impl IntoIterator<Item = &'a TransactionDigest>,
-    ) -> Result<Vec<Option<(VerifiedTransaction, usize)>>, TypedStoreError> {
-        self.perpetual_tables
-            .transactions
-            .multi_get_raw_bytes(digests)?
-            .into_iter()
-            .map(|raw_bytes_option| {
-                raw_bytes_option
-                    .map(|tx_bytes| {
-                        let tx: VerifiedTransaction =
-                            bcs::from_bytes::<TrustedTransaction>(&tx_bytes)
-                                .map_err(typed_store_err_from_bcs_err)?
-                                .into();
-                        Ok((tx, tx_bytes.len()))
-                    })
-                    .transpose()
-            })
-            .collect()
     }
 
     /// This function reads the DB directly to get the system state object.

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -343,7 +343,11 @@ pub async fn enqueue_all_and_execute_all(
         .unwrap();
     let mut output = Vec::new();
     for cert in certificates {
-        let effects = authority.notify_read_effects(&cert).await?;
+        let effects = authority
+            .notify_read_effects(&[*cert.digest()])
+            .await?
+            .pop()
+            .unwrap();
         output.push(effects);
     }
     Ok(output)
@@ -375,7 +379,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
         .process_consensus_transactions_for_tests(
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
-            authority.db(),
+            authority.get_cache_reader().as_ref(),
             &authority.metrics.skipped_consensus_txns,
         )
         .await
@@ -399,7 +403,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
         .process_consensus_transactions_for_tests(
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
-            &authority.db(),
+            authority.get_cache_reader().as_ref(),
             &authority.metrics.skipped_consensus_txns,
         )
         .await

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -343,11 +343,7 @@ pub async fn enqueue_all_and_execute_all(
         .unwrap();
     let mut output = Vec::new();
     for cert in certificates {
-        let effects = authority
-            .notify_read_effects(&[*cert.digest()])
-            .await?
-            .pop()
-            .unwrap();
+        let effects = authority.notify_read_effects(&cert).await?;
         output.push(effects);
     }
     Ok(output)

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -8,6 +8,7 @@ use crate::authority::{AuthorityState, AuthorityStore};
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::epoch_metrics::EpochMetrics;
+use crate::in_mem_execution_cache::InMemoryCache;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::signature_verifier::SignatureVerifierMetrics;
 use fastcrypto::traits::KeyPair;
@@ -260,7 +261,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             name,
             secret,
             SupportedProtocolVersions::SYSTEM_DEFAULT,
-            authority_store,
+            authority_store.clone(),
+            InMemoryCache::new(authority_store).into(),
             epoch_store,
             committee_store,
             index_store,

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -208,6 +208,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             None => ExpensiveSafetyCheckConfig::default(),
             Some(config) => config,
         };
+        let cache = Arc::new(InMemoryCache::new(authority_store.clone()));
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -215,7 +216,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             None,
             EpochMetrics::new(&registry),
             epoch_start_configuration,
-            authority_store.clone(),
+            cache.clone(),
             cache_metrics,
             signature_verifier_metrics,
             &expensive_safety_checks,
@@ -261,8 +262,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             name,
             secret,
             SupportedProtocolVersions::SYSTEM_DEFAULT,
-            authority_store.clone(),
-            InMemoryCache::new(authority_store).into(),
+            authority_store,
+            cache,
             epoch_store,
             committee_store,
             index_store,

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -8,7 +8,7 @@ use crate::authority::{AuthorityState, AuthorityStore};
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::epoch_metrics::EpochMetrics;
-use crate::in_mem_execution_cache::InMemoryCache;
+use crate::in_mem_execution_cache::ExecutionCache;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::signature_verifier::SignatureVerifierMetrics;
 use fastcrypto::traits::KeyPair;
@@ -208,7 +208,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             None => ExpensiveSafetyCheckConfig::default(),
             Some(config) => config,
         };
-        let cache = Arc::new(InMemoryCache::new(authority_store.clone()));
+        let cache = Arc::new(ExecutionCache::new(authority_store.clone()));
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -307,7 +307,6 @@ impl<'a> TestAuthorityBuilder<'a> {
         // TODO: we should probably have a better way to do this.
         if let Some(starting_objects) = self.starting_objects {
             state
-                .database
                 .insert_objects_unsafe_for_testing_only(starting_objects)
                 .await
                 .unwrap();

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -208,7 +208,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             None => ExpensiveSafetyCheckConfig::default(),
             Some(config) => config,
         };
-        let cache = Arc::new(ExecutionCache::new(authority_store.clone()));
+        let cache = Arc::new(ExecutionCache::new(authority_store.clone(), &registry));
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -48,14 +48,13 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tracing::{debug, error, info, instrument, trace, warn};
-use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::authority::AuthorityStore;
+use crate::authority::AuthorityState;
 use crate::checkpoints::checkpoint_executor::data_ingestion_handler::store_checkpoint_locally;
 use crate::state_accumulator::StateAccumulator;
 use crate::transaction_manager::TransactionManager;
-use crate::{authority::EffectsNotifyRead, checkpoints::CheckpointStore};
+use crate::{checkpoints::CheckpointStore, in_mem_execution_cache::ExecutionCacheRead};
 
 use self::metrics::CheckpointExecutorMetrics;
 
@@ -83,8 +82,11 @@ pub enum StopReason {
 
 pub struct CheckpointExecutor {
     mailbox: broadcast::Receiver<VerifiedCheckpoint>,
+    // TODO: AuthorityState is only needed because we have to call deprecated_insert_finalized_transactions
+    // once that code is fully deprecated we can remove this
+    state: Arc<AuthorityState>,
     checkpoint_store: Arc<CheckpointStore>,
-    authority_store: Arc<AuthorityStore>,
+    cache_reader: Arc<dyn ExecutionCacheRead>,
     tx_manager: Arc<TransactionManager>,
     accumulator: Arc<StateAccumulator>,
     config: CheckpointExecutorConfig,
@@ -95,17 +97,17 @@ impl CheckpointExecutor {
     pub fn new(
         mailbox: broadcast::Receiver<VerifiedCheckpoint>,
         checkpoint_store: Arc<CheckpointStore>,
-        authority_store: Arc<AuthorityStore>,
-        tx_manager: Arc<TransactionManager>,
+        state: Arc<AuthorityState>,
         accumulator: Arc<StateAccumulator>,
         config: CheckpointExecutorConfig,
         prometheus_registry: &Registry,
     ) -> Self {
         Self {
             mailbox,
+            state: state.clone(),
             checkpoint_store,
-            authority_store,
-            tx_manager,
+            cache_reader: state.get_cache_reader().clone(),
+            tx_manager: state.transaction_manager().clone(),
             accumulator,
             config,
             metrics: CheckpointExecutorMetrics::new(prometheus_registry),
@@ -115,15 +117,15 @@ impl CheckpointExecutor {
     pub fn new_for_tests(
         mailbox: broadcast::Receiver<VerifiedCheckpoint>,
         checkpoint_store: Arc<CheckpointStore>,
-        authority_store: Arc<AuthorityStore>,
-        tx_manager: Arc<TransactionManager>,
+        state: Arc<AuthorityState>,
         accumulator: Arc<StateAccumulator>,
     ) -> Self {
         Self {
             mailbox,
+            state: state.clone(),
             checkpoint_store,
-            authority_store,
-            tx_manager,
+            cache_reader: state.get_cache_reader().clone(),
+            tx_manager: state.transaction_manager().clone(),
             accumulator,
             config: Default::default(),
             metrics: CheckpointExecutorMetrics::new_for_tests(),
@@ -405,16 +407,18 @@ impl CheckpointExecutor {
         let metrics = self.metrics.clone();
         let local_execution_timeout_sec = self.config.local_execution_timeout_sec;
         let data_ingestion_dir = self.config.data_ingestion_dir.clone();
-        let authority_store = self.authority_store.clone();
         let checkpoint_store = self.checkpoint_store.clone();
+        let cache_reader = self.cache_reader.clone();
         let tx_manager = self.tx_manager.clone();
         let accumulator = self.accumulator.clone();
+        let state = self.state.clone();
 
         pending.push_back(spawn_monitored_task!(async move {
             let epoch_store = epoch_store.clone();
             while let Err(err) = execute_checkpoint(
                 checkpoint.clone(),
-                authority_store.clone(),
+                &state,
+                cache_reader.as_ref(),
                 checkpoint_store.clone(),
                 epoch_store.clone(),
                 tx_manager.clone(),
@@ -445,10 +449,8 @@ impl CheckpointExecutor {
         checkpoint: VerifiedCheckpoint,
     ) {
         let change_epoch_fx = self
-            .authority_store
-            .perpetual_tables
-            .effects
-            .get(&execution_digests.effects)
+            .cache_reader
+            .get_effects(&execution_digests.effects)
             .expect("Fetching effects for change_epoch tx cannot fail")
             .expect("Change_epoch tx effects must exist");
 
@@ -457,7 +459,7 @@ impl CheckpointExecutor {
                 .acquire_shared_locks_from_effects(
                     &change_epoch_tx,
                     &change_epoch_fx,
-                    &self.authority_store,
+                    self.cache_reader.as_ref(),
                 )
                 .await
                 .expect("Acquiring shared locks for change_epoch tx cannot fail");
@@ -470,11 +472,12 @@ impl CheckpointExecutor {
             )
             .expect("Enqueueing change_epoch tx cannot fail");
         handle_execution_effects(
+            &self.state,
             vec![execution_digests],
             vec![change_epoch_tx_digest],
             checkpoint.clone(),
             self.checkpoint_store.clone(),
-            self.authority_store.clone(),
+            self.cache_reader.as_ref(),
             epoch_store.clone(),
             self.tx_manager.clone(),
             self.accumulator.clone(),
@@ -499,7 +502,7 @@ impl CheckpointExecutor {
                 if let Some((change_epoch_execution_digests, change_epoch_tx)) =
                     extract_end_of_epoch_tx(
                         checkpoint,
-                        self.authority_store.clone(),
+                        self.cache_reader.as_ref(),
                         self.checkpoint_store.clone(),
                         epoch_store.clone(),
                     )
@@ -538,13 +541,14 @@ impl CheckpointExecutor {
                         .collect();
 
                     let effects = self
-                        .authority_store
-                        .notify_read_executed_effects(all_tx_digests.clone())
+                        .cache_reader
+                        .notify_read_executed_effects(&all_tx_digests)
                         .await
                         .expect("Failed to get executed effects for finalizing checkpoint");
 
                     finalize_checkpoint(
-                        self.authority_store.clone(),
+                        &self.state,
+                        self.cache_reader.as_ref(),
                         self.checkpoint_store.clone(),
                         &all_tx_digests,
                         epoch_store.clone(),
@@ -578,7 +582,8 @@ impl CheckpointExecutor {
 #[instrument(level = "debug", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
 async fn execute_checkpoint(
     checkpoint: VerifiedCheckpoint,
-    authority_store: Arc<AuthorityStore>,
+    state: &AuthorityState,
+    cache_reader: &dyn ExecutionCacheRead,
     checkpoint_store: Arc<CheckpointStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
     transaction_manager: Arc<TransactionManager>,
@@ -598,7 +603,7 @@ async fn execute_checkpoint(
 
     let (execution_digests, all_tx_digests, executable_txns) = get_unexecuted_transactions(
         checkpoint.clone(),
-        authority_store.clone(),
+        cache_reader,
         checkpoint_store.clone(),
         epoch_store.clone(),
     );
@@ -611,7 +616,8 @@ async fn execute_checkpoint(
         execution_digests,
         all_tx_digests.clone(),
         executable_txns,
-        authority_store.clone(),
+        state,
+        cache_reader,
         checkpoint_store.clone(),
         epoch_store.clone(),
         transaction_manager,
@@ -628,11 +634,12 @@ async fn execute_checkpoint(
 
 #[instrument(level = "error", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
 async fn handle_execution_effects(
+    state: &AuthorityState,
     execution_digests: Vec<ExecutionDigests>,
     all_tx_digests: Vec<TransactionDigest>,
     checkpoint: VerifiedCheckpoint,
     checkpoint_store: Arc<CheckpointStore>,
-    authority_store: Arc<AuthorityStore>,
+    cache_reader: &dyn ExecutionCacheRead,
     epoch_store: Arc<AuthorityPerEpochStore>,
     transaction_manager: Arc<TransactionManager>,
     accumulator: Arc<StateAccumulator>,
@@ -645,7 +652,7 @@ async fn handle_execution_effects(
     // Whether the checkpoint is next to execute and blocking additional executions.
     let mut blocking_execution = false;
     loop {
-        let effects_future = authority_store.notify_read_executed_effects(all_tx_digests.clone());
+        let effects_future = cache_reader.notify_read_executed_effects(&all_tx_digests);
 
         match timeout(log_timeout_sec, effects_future).await {
             Err(_elapsed) => {
@@ -680,7 +687,7 @@ async fn handle_execution_effects(
 
                 // Only log details when the checkpoint is next to execute, but has not finished
                 // execution within log_timeout_sec.
-                let missing_digests: Vec<TransactionDigest> = authority_store
+                let missing_digests: Vec<TransactionDigest> = cache_reader
                     .multi_get_executed_effects_digests(&all_tx_digests)
                     .expect("multi_get_executed_effects cannot fail")
                     .iter()
@@ -728,7 +735,7 @@ async fn handle_execution_effects(
                         tx_digest,
                         expected_effects_digest,
                         &actual_effects.digest(),
-                        authority_store.clone(),
+                        cache_reader,
                     );
                 }
 
@@ -738,7 +745,8 @@ async fn handle_execution_effects(
                 // the change epoch tx, which is done after all other checkpoint execution
                 if checkpoint.end_of_epoch_data.is_none() {
                     finalize_checkpoint(
-                        authority_store.clone(),
+                        state,
+                        cache_reader,
                         checkpoint_store.clone(),
                         &all_tx_digests,
                         epoch_store.clone(),
@@ -760,10 +768,10 @@ fn assert_not_forked(
     tx_digest: &TransactionDigest,
     expected_digest: &TransactionEffectsDigest,
     actual_effects_digest: &TransactionEffectsDigest,
-    authority_store: Arc<AuthorityStore>,
+    cache_reader: &dyn ExecutionCacheRead,
 ) {
     if *expected_digest != *actual_effects_digest {
-        let actual_effects = authority_store
+        let actual_effects = cache_reader
             .get_executed_effects(tx_digest)
             .expect("get_executed_effects cannot fail")
             .expect("actual effects should exist");
@@ -790,7 +798,7 @@ fn assert_not_forked(
 // Given a checkpoint, find the end of epoch transaction, if it exists
 fn extract_end_of_epoch_tx(
     checkpoint: &VerifiedCheckpoint,
-    authority_store: Arc<AuthorityStore>,
+    cache_reader: &dyn ExecutionCacheRead,
     checkpoint_store: Arc<CheckpointStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
 ) -> Option<(ExecutionDigests, VerifiedExecutableTransaction)> {
@@ -814,17 +822,17 @@ fn extract_end_of_epoch_tx(
         .last()
         .expect("Final checkpoint must have at least one transaction");
 
-    let change_epoch_tx = authority_store
+    let change_epoch_tx = cache_reader
         .get_transaction_block(&digests.transaction)
         .expect("read cannot fail");
 
     let change_epoch_tx = VerifiedExecutableTransaction::new_from_checkpoint(
-        change_epoch_tx.unwrap_or_else(||
+        (*change_epoch_tx.unwrap_or_else(||
             panic!(
                 "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
                 digests.transaction,
             )
-        ),
+        )).clone(),
         epoch_store.epoch(),
         *checkpoint_sequence,
     );
@@ -842,7 +850,7 @@ fn extract_end_of_epoch_tx(
 // execution digests, transaction digests, and transactions to be executed.
 fn get_unexecuted_transactions(
     checkpoint: VerifiedCheckpoint,
-    authority_store: Arc<AuthorityStore>,
+    cache_reader: &dyn ExecutionCacheRead,
     checkpoint_store: Arc<CheckpointStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
 ) -> (
@@ -883,7 +891,7 @@ fn get_unexecuted_transactions(
             .expect("Final checkpoint must have at least one transaction")
             .transaction;
 
-        let change_epoch_tx = authority_store
+        let change_epoch_tx = cache_reader
             .get_transaction_block(&change_epoch_tx_digest)
             .expect("read cannot fail")
             .unwrap_or_else(||
@@ -898,7 +906,7 @@ fn get_unexecuted_transactions(
     let all_tx_digests: Vec<TransactionDigest> =
         execution_digests.iter().map(|tx| tx.transaction).collect();
 
-    let executed_effects_digests = authority_store
+    let executed_effects_digests = cache_reader
         .multi_get_executed_effects_digests(&all_tx_digests)
         .expect("failed to read executed_effects from store");
 
@@ -918,7 +926,7 @@ fn get_unexecuted_transactions(
                         tx_digest,
                         effects_digest,
                         actual_effects_digest,
-                        authority_store.clone(),
+                        cache_reader,
                     );
                     None
                 }
@@ -943,7 +951,7 @@ fn get_unexecuted_transactions(
             })
             .collect()
     } else {
-        authority_store
+        cache_reader
             .multi_get_transaction_blocks(&unexecuted_txns)
             .expect("Failed to get checkpoint txes from store")
             .into_iter()
@@ -960,7 +968,7 @@ fn get_unexecuted_transactions(
                 assert!(!tx.data().intent_message().value.is_end_of_epoch_tx());
                 (
                     VerifiedExecutableTransaction::new_from_checkpoint(
-                        tx,
+                        Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone()),
                         epoch_store.epoch(),
                         *checkpoint_sequence,
                     ),
@@ -980,7 +988,8 @@ async fn execute_transactions(
     execution_digests: Vec<ExecutionDigests>,
     all_tx_digests: Vec<TransactionDigest>,
     executable_txns: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
-    authority_store: Arc<AuthorityStore>,
+    state: &AuthorityState,
+    cache_reader: &dyn ExecutionCacheRead,
     checkpoint_store: Arc<CheckpointStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
     transaction_manager: Arc<TransactionManager>,
@@ -1000,16 +1009,14 @@ async fn execute_transactions(
         .iter()
         .filter(|(tx, _)| tx.contains_shared_object())
         .map(|(tx, _)| {
-            effects_digests
+            *effects_digests
                 .get(tx.digest())
                 .expect("Transaction digest not found in effects_digests")
         })
         .collect::<Vec<_>>();
 
-    let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> = authority_store
-        .perpetual_tables
-        .effects
-        .multi_get(shared_effects_digests.clone())?
+    let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> = cache_reader
+        .multi_get_effects(&shared_effects_digests)?
         .into_iter()
         .zip(shared_effects_digests)
         .map(|(fx, fx_digest)| {
@@ -1030,7 +1037,7 @@ async fn execute_transactions(
                 .acquire_shared_locks_from_effects(
                     tx,
                     digest_to_effects.get(tx.digest()).unwrap(),
-                    &authority_store,
+                    cache_reader,
                 )
                 .await?;
         }
@@ -1052,11 +1059,12 @@ async fn execute_transactions(
         .enqueue_with_expected_effects_digest(executable_txns.clone(), &epoch_store)?;
 
     handle_execution_effects(
+        state,
         execution_digests,
         all_tx_digests,
         checkpoint.clone(),
         checkpoint_store,
-        authority_store,
+        cache_reader,
         epoch_store,
         transaction_manager,
         accumulator,
@@ -1078,7 +1086,8 @@ async fn execute_transactions(
 
 #[instrument(level = "debug", skip_all)]
 fn finalize_checkpoint(
-    authority_store: Arc<AuthorityStore>,
+    state: &AuthorityState,
+    cache_reader: &dyn ExecutionCacheRead,
     checkpoint_store: Arc<CheckpointStore>,
     tx_digests: &[TransactionDigest],
     epoch_store: Arc<AuthorityPerEpochStore>,
@@ -1091,7 +1100,7 @@ fn finalize_checkpoint(
         epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
     }
     // TODO remove once we no longer need to support this table for read RPC
-    authority_store.deprecated_insert_finalized_transactions(
+    state.database.deprecated_insert_finalized_transactions(
         tx_digests,
         epoch_store.epoch(),
         checkpoint.sequence_number,
@@ -1102,7 +1111,7 @@ fn finalize_checkpoint(
         store_checkpoint_locally(
             path,
             checkpoint,
-            authority_store,
+            cache_reader,
             checkpoint_store,
             tx_digests.to_vec(),
         )?;

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -106,7 +106,7 @@ impl CheckpointExecutor {
             mailbox,
             state: state.clone(),
             checkpoint_store,
-            cache_reader: state.get_cache_reader().clone(),
+            cache_reader: state.get_cache_reader(),
             tx_manager: state.transaction_manager().clone(),
             accumulator,
             config,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use sui_swarm_config::test_utils::{empty_contents, CommitteeFixture};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
+use typed_store::Map;
 
 /// Test checkpoint executor happy path, test that checkpoint executor correctly
 /// picks up where it left off in the event of a mid-epoch node crash.
@@ -79,8 +80,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let mut executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         checkpoint_store.clone(),
-        state.database.clone(),
-        state.transaction_manager().clone(),
+        state.clone(),
         accumulator.clone(),
     );
 
@@ -351,8 +351,7 @@ pub async fn test_reconfig_crash_recovery() {
     let mut executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         checkpoint_store.clone(),
-        authority_state.database.clone(),
-        authority_state.transaction_manager().clone(),
+        authority_state.clone(),
         accumulator.clone(),
     );
 
@@ -400,8 +399,7 @@ async fn init_executor_test(
     let executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         store.clone(),
-        state.database.clone(),
-        state.transaction_manager().clone(),
+        state.clone(),
         accumulator.clone(),
     );
     (

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -942,7 +942,6 @@ impl CheckpointBuilder {
             .collect();
         let transactions_and_sizes = self
             .state
-            .database
             .get_transactions_and_serialized_sizes(&all_digests)?;
         let mut all_effects_and_transaction_sizes = Vec::with_capacity(all_effects.len());
         let mut transaction_keys = Vec::new();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -942,6 +942,7 @@ impl CheckpointBuilder {
             .collect();
         let transactions_and_sizes = self
             .state
+            .get_cache_reader()
             .get_transactions_and_serialized_sizes(&all_digests)?;
         let mut all_effects_and_transaction_sizes = Vec::with_capacity(all_effects.len());
         let mut transaction_keys = Vec::new();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -666,7 +666,7 @@ pub struct CheckpointBuilder {
     epoch_store: Arc<AuthorityPerEpochStore>,
     notify: Arc<Notify>,
     notify_aggregator: Arc<Notify>,
-    effects_store: Box<dyn EffectsNotifyRead>,
+    effects_store: Arc<dyn EffectsNotifyRead>,
     accumulator: Arc<StateAccumulator>,
     output: Box<dyn CheckpointOutput>,
     exit: watch::Receiver<()>,
@@ -704,7 +704,7 @@ impl CheckpointBuilder {
         tables: Arc<CheckpointStore>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         notify: Arc<Notify>,
-        effects_store: Box<dyn EffectsNotifyRead>,
+        effects_store: Arc<dyn EffectsNotifyRead>,
         accumulator: Arc<StateAccumulator>,
         output: Box<dyn CheckpointOutput>,
         exit: watch::Receiver<()>,
@@ -1698,7 +1698,7 @@ impl CheckpointService {
         state: Arc<AuthorityState>,
         checkpoint_store: Arc<CheckpointStore>,
         epoch_store: Arc<AuthorityPerEpochStore>,
-        effects_store: Box<dyn EffectsNotifyRead>,
+        effects_store: Arc<dyn EffectsNotifyRead>,
         accumulator: Arc<StateAccumulator>,
         checkpoint_output: Box<dyn CheckpointOutput>,
         certified_checkpoint_output: Box<dyn CertifiedCheckpointOutput>,
@@ -1963,7 +1963,7 @@ mod tests {
         let (output, mut result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);
         let (certified_output, mut certified_result) =
             mpsc::channel::<CertifiedCheckpointSummary>(10);
-        let store = Box::new(store);
+        let store = Arc::new(store);
 
         let ckpt_dir = tempfile::tempdir().unwrap();
         let checkpoint_store = CheckpointStore::new(ckpt_dir.path());

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -5,12 +5,13 @@ use crate::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, ConsensusStats, ConsensusStatsAPI, ExecutionIndicesWithStats,
 };
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
-use crate::authority::{AuthorityMetrics, AuthorityState, AuthorityStore};
+use crate::authority::{AuthorityMetrics, AuthorityState};
 use crate::checkpoints::{CheckpointService, CheckpointServiceNotify};
 use crate::consensus_throughput_calculator::ConsensusThroughputCalculator;
 use crate::consensus_types::committee_api::CommitteeAPI;
 use crate::consensus_types::consensus_output_api::ConsensusOutputAPI;
 use crate::consensus_types::AuthorityIndex;
+use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::scoring_decision::update_low_scoring_authorities;
 use crate::transaction_manager::TransactionManager;
 use arc_swap::ArcSwap;
@@ -35,7 +36,6 @@ use sui_types::executable_transaction::{
 use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
 };
-use sui_types::storage::ObjectStore;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::transaction::{SenderSignedData, VerifiedTransaction};
 use tracing::{debug, error, info, instrument, trace_span};
@@ -80,9 +80,7 @@ impl ConsensusHandlerInitializer {
             )),
         }
     }
-    pub fn new_consensus_handler(
-        &self,
-    ) -> ConsensusHandler<Arc<AuthorityStore>, CheckpointService> {
+    pub fn new_consensus_handler(&self) -> ConsensusHandler<CheckpointService> {
         let new_epoch_start_state = self.epoch_store.epoch_start_state();
         let committee = new_epoch_start_state.get_narwhal_committee();
 
@@ -90,7 +88,7 @@ impl ConsensusHandlerInitializer {
             self.epoch_store.clone(),
             self.checkpoint_service.clone(),
             self.state.transaction_manager().clone(),
-            self.state.db(),
+            self.state.get_cache_reader().clone(),
             self.low_scoring_authorities.clone(),
             committee,
             self.state.metrics.clone(),
@@ -99,7 +97,7 @@ impl ConsensusHandlerInitializer {
     }
 }
 
-pub struct ConsensusHandler<T, C> {
+pub struct ConsensusHandler<C> {
     /// A store created for each epoch. ConsensusHandler is recreated each epoch, with the
     /// corresponding store. This store is also used to get the current epoch ID.
     epoch_store: Arc<AuthorityPerEpochStore>,
@@ -108,8 +106,8 @@ pub struct ConsensusHandler<T, C> {
     /// checking chain consistency, and accumulating per-epoch consensus output stats.
     last_consensus_stats: ExecutionIndicesWithStats,
     checkpoint_service: Arc<C>,
-    /// parent_sync_store is needed when determining the next version to assign for shared objects.
-    object_store: T,
+    /// cache reader is needed when determining the next version to assign for shared objects.
+    cache_reader: Arc<dyn ExecutionCacheRead>,
     /// Reputation scores used by consensus adapter that we update, forwarded from consensus
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     /// The narwhal committee used to do stake computations for deciding set of low scoring authorities
@@ -126,12 +124,12 @@ pub struct ConsensusHandler<T, C> {
 
 const PROCESSED_CACHE_CAP: usize = 1024 * 1024;
 
-impl<T, C> ConsensusHandler<T, C> {
+impl<C> ConsensusHandler<C> {
     pub fn new(
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         transaction_manager: Arc<TransactionManager>,
-        object_store: T,
+        cache_reader: Arc<dyn ExecutionCacheRead>,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
         committee: Committee,
         metrics: Arc<AuthorityMetrics>,
@@ -151,7 +149,7 @@ impl<T, C> ConsensusHandler<T, C> {
             epoch_store,
             last_consensus_stats,
             checkpoint_service,
-            object_store,
+            cache_reader,
             low_scoring_authorities,
             committee,
             metrics,
@@ -197,9 +195,7 @@ fn update_index_and_hash(
 }
 
 #[async_trait]
-impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> ExecutionState
-    for ConsensusHandler<T, C>
-{
+impl<C: CheckpointServiceNotify + Send + Sync> ExecutionState for ConsensusHandler<C> {
     /// This function will be called by Narwhal, after Narwhal sequenced this certificate.
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput) {
@@ -213,9 +209,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync> Exe
     }
 }
 
-impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync>
-    ConsensusHandler<T, C>
-{
+impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output_internal(
         &mut self,
@@ -457,7 +451,7 @@ impl<T: ObjectStore + Send + Sync, C: CheckpointServiceNotify + Send + Sync>
                 all_transactions,
                 &self.last_consensus_stats,
                 &self.checkpoint_service,
-                &self.object_store,
+                self.cache_reader.as_ref(),
                 round,
                 timestamp,
                 &self.metrics.skipped_consensus_txns,
@@ -517,7 +511,7 @@ pub struct MysticetiConsensusHandler {
 
 impl MysticetiConsensusHandler {
     pub fn new(
-        mut consensus_handler: ConsensusHandler<Arc<AuthorityStore>, CheckpointService>,
+        mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut receiver: tokio::sync::mpsc::UnboundedReceiver<
             mysticeti_core::consensus::linearizer::CommittedSubDag,
         >,
@@ -539,7 +533,7 @@ impl Drop for MysticetiConsensusHandler {
     }
 }
 
-impl<T, C> ConsensusHandler<T, C> {
+impl<C> ConsensusHandler<C> {
     fn consensus_commit_prologue_transaction(
         &self,
         round: u64,
@@ -869,7 +863,7 @@ mod tests {
             epoch_store,
             Arc::new(CheckpointServiceNoop {}),
             state.transaction_manager().clone(),
-            state.db(),
+            state.get_cache_reader().clone(),
             Arc::new(ArcSwap::default()),
             committee.clone(),
             metrics,

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -15,9 +15,8 @@ use futures::{
 use moka::sync::Cache as MokaCache;
 use mysten_common::sync::notify_read::NotifyRead;
 use parking_lot::Mutex;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
-use sui_types::base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber};
 use sui_types::digests::{
     ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
 };
@@ -25,9 +24,18 @@ use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::message_envelope::Message;
 use sui_types::object::Object;
-use sui_types::storage::{MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject};
+use sui_types::storage::{
+    error::{Error as StorageError, Result as StorageResult},
+    BackingPackageStore, ChildObjectResolver, MarkerValue, ObjectKey, ObjectOrTombstone,
+    ObjectStore, PackageObject, ParentSync,
+};
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState};
 use sui_types::transaction::VerifiedTransaction;
+use sui_types::{
+    base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber},
+    object::Owner,
+    storage::InputKey,
+};
 use tracing::instrument;
 use typed_store::Map;
 
@@ -63,31 +71,147 @@ pub trait ExecutionCacheRead: Send + Sync {
 
     fn multi_get_object_by_key(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<Option<Object>>>;
 
-    /// Variant of multi_get_object_by_key used by transaction signing that returns better error messages
-    /// when objects are not found. Returns an error if any object is not found.
-    fn multi_get_object_by_objref(&self, objrefs: &[ObjectRef]) -> SuiResult<Vec<Object>>;
-
-    /// If the shared object was deleted, return deletion info for the current live version
-    fn get_last_shared_object_deletion_info(
-        &self,
-        object_id: &ObjectID,
-        epoch_id: EpochId,
-    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>>;
-
-    /// If the shared object was deleted, return deletion info for the specified version.
-    fn get_deleted_shared_object_previous_tx_digest(
-        &self,
-        object_id: &ObjectID,
-        version: &SequenceNumber,
-        epoch_id: EpochId,
-    ) -> SuiResult<Option<TransactionDigest>>;
-
-    fn have_received_object_at_version(
+    fn object_exists_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
-        epoch_id: EpochId,
     ) -> SuiResult<bool>;
+
+    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<bool>>;
+
+    /// Load a list of objects from the store by object reference.
+    /// If they exist in the store, they are returned directly.
+    /// If any object missing, we try to figure out the best error to return.
+    /// If the object we are asking is currently locked at a future version, we know this
+    /// transaction is out-of-date and we return a ObjectVersionUnavailableForConsumption,
+    /// which indicates this is not retriable.
+    /// Otherwise, we return a ObjectNotFound error, which indicates this is retriable.
+    fn multi_get_object_with_more_accurate_error_return(
+        &self,
+        object_refs: &[ObjectRef],
+    ) -> Result<Vec<Object>, SuiError> {
+        let objects = self.multi_get_object_by_key(
+            &object_refs.iter().map(ObjectKey::from).collect::<Vec<_>>(),
+        )?;
+        let mut result = Vec::new();
+        for (object_opt, object_ref) in objects.into_iter().zip(object_refs) {
+            match object_opt {
+                None => {
+                    let lock = self.get_latest_lock_for_object_id(object_ref.0)?;
+                    let error = if lock.1 >= object_ref.1 {
+                        UserInputError::ObjectVersionUnavailableForConsumption {
+                            provided_obj_ref: *object_ref,
+                            current_version: lock.1,
+                        }
+                    } else {
+                        UserInputError::ObjectNotFound {
+                            object_id: object_ref.0,
+                            version: Some(object_ref.1),
+                        }
+                    };
+                    return Err(SuiError::UserInputError { error });
+                }
+                Some(object) => {
+                    result.push(object);
+                }
+            }
+        }
+        assert_eq!(result.len(), object_refs.len());
+        Ok(result)
+    }
+
+    /// Used by transaction manager to determine if input objects are ready. Distinct from multi_get_object_by_key
+    /// because it also consults markers to handle the case where an object will never become available (e.g.
+    /// because it has been received by some other transaction already).
+    fn multi_input_objects_available(
+        &self,
+        keys: &[InputKey],
+        receiving_objects: HashSet<InputKey>,
+        epoch: EpochId,
+    ) -> Result<Vec<bool>, SuiError> {
+        let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+            .iter()
+            .enumerate()
+            .partition(|(_, key)| key.version().is_some());
+
+        let mut versioned_results = vec![];
+        for ((idx, input_key), has_key) in keys_with_version.iter().zip(
+            self.multi_object_exists_by_key(
+                &keys_with_version
+                    .iter()
+                    .map(|(_, k)| ObjectKey(k.id(), k.version().unwrap()))
+                    .collect::<Vec<_>>(),
+            )?
+            .into_iter(),
+        ) {
+            // If the key exists at the specified version, then the object is available.
+            if has_key {
+                versioned_results.push((*idx, true))
+            } else if receiving_objects.contains(input_key) {
+                // There could be a more recent version of this object, and the object at the
+                // specified version could have already been pruned. In such a case `has_key` will
+                // be false, but since this is a receiving object we should mark it as available if
+                // we can determine that an object with a version greater than or equal to the
+                // specified version exists or was deleted. We will then let mark it as available
+                // to let the the transaction through so it can fail at execution.
+                let is_available = self
+                    .get_object(&input_key.id())?
+                    .map(|obj| obj.version() >= input_key.version().unwrap())
+                    .unwrap_or(false)
+                    || self.have_deleted_owned_object_at_version_or_after(
+                        &input_key.id(),
+                        input_key.version().unwrap(),
+                        epoch,
+                    )?;
+                versioned_results.push((*idx, is_available));
+            } else if self
+                .get_deleted_shared_object_previous_tx_digest(
+                    &input_key.id(),
+                    &input_key.version().unwrap(),
+                    epoch,
+                )?
+                .is_some()
+            {
+                // If the object is an already deleted shared object, mark it as available if the
+                // version for that object is in the shared deleted marker table.
+                versioned_results.push((*idx, true));
+            } else {
+                versioned_results.push((*idx, false));
+            }
+        }
+
+        let unversioned_results = keys_without_version.into_iter().map(|(idx, key)| {
+            (
+                idx,
+                match self
+                    .get_latest_object_ref_or_tombstone(key.id())
+                    .expect("read cannot fail")
+                {
+                    None => false,
+                    Some(entry) => entry.2.is_alive(),
+                },
+            )
+        });
+
+        let mut results = versioned_results
+            .into_iter()
+            .chain(unversioned_results)
+            .collect::<Vec<_>>();
+        results.sort_by_key(|(idx, _)| *idx);
+        Ok(results.into_iter().map(|(_, result)| result).collect())
+    }
+
+    /// Return the object with version less then or eq to the provided seq number.
+    /// This is used by indexer to find the correct version of dynamic field child object.
+    /// We do not store the version of the child object, but because of lamport timestamp,
+    /// we know the child must have version number less then or eq to the parent.
+    fn find_object_lt_or_eq_version(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> Option<Object>;
+
+    fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef>;
 
     fn multi_get_transaction_blocks(
         &self,
@@ -211,6 +335,74 @@ pub trait ExecutionCacheRead: Send + Sync {
     }
 
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState>;
+
+    // Marker methods
+
+    /// Get the marker at a specific version
+    fn get_marker_value(
+        &self,
+        object_id: &ObjectID,
+        version: &SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<MarkerValue>>;
+
+    /// Get the latest marker for a given object.
+    fn get_latest_marker(
+        &self,
+        object_id: &ObjectID,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<(SequenceNumber, MarkerValue)>>;
+
+    /// If the shared object was deleted, return deletion info for the current live version
+    fn get_last_shared_object_deletion_info(
+        &self,
+        object_id: &ObjectID,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>> {
+        match self.get_latest_marker(object_id, epoch_id)? {
+            Some((version, MarkerValue::SharedDeleted(digest))) => Ok(Some((version, digest))),
+            _ => Ok(None),
+        }
+    }
+
+    /// If the shared object was deleted, return deletion info for the specified version.
+    fn get_deleted_shared_object_previous_tx_digest(
+        &self,
+        object_id: &ObjectID,
+        version: &SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<TransactionDigest>> {
+        match self.get_marker_value(object_id, version, epoch_id)? {
+            Some(MarkerValue::SharedDeleted(digest)) => Ok(Some(digest)),
+            _ => Ok(None),
+        }
+    }
+
+    fn have_received_object_at_version(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<bool> {
+        match self.get_marker_value(object_id, &version, epoch_id)? {
+            Some(MarkerValue::Received) => Ok(true),
+            _ => Ok(false),
+        }
+    }
+
+    fn have_deleted_owned_object_at_version_or_after(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<bool> {
+        match self.get_latest_marker(object_id, epoch_id)? {
+            Some((marker_version, MarkerValue::OwnedDeleted)) if marker_version >= version => {
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
 }
 
 pub trait ExecutionCacheWrite: Send + Sync {
@@ -246,20 +438,61 @@ impl From<Object> for ObjectEntry {
     }
 }
 
+type MarkerKey = (EpochId, ObjectID);
+
+enum CacheResult<T> {
+    /// Entry is in the cache
+    Hit(T),
+    /// Entry is not in the cache and is known to not exist
+    NegativeHit,
+    /// Entry is not in the cache and may or may not exist in the store
+    Miss,
+}
+
 pub struct InMemoryCache {
-    // Objects are not cached using an LRU because we manage cache evictions manually due to sui
-    // semantics.
+    /// The object dirty set. All writes go into this table first. After we flush the data to the
+    /// db, the data is removed from this table and inserted into the object_cache.
+    ///
+    /// This table may contain both live and dead objects, since we flush both live and dead
+    /// objects to the db in order to support past object queries on fullnodes.
+    /// When we move data into the object_cache we only retain the live objects.
+    ///
+    /// Further, we only remove objects in FIFO order, which ensures that the the cached
+    /// sequence of objects has no gaps. In other words, if we have versions 4, 8, 13 of
+    /// an object, we can deduce that version 9 does not exist. This also makes child object
+    /// reads efficient. `object_cache` cannot contain a more recent version of an object than
+    /// `objects`, and neither can have any gaps. Therefore if there is any object <= the version
+    /// bound for a child read in objects, it is the correct object to return.
     objects: DashMap<ObjectID, BTreeMap<SequenceNumber, ObjectEntry>>,
 
-    // packages are cache separately from objects because they are immutable and can be used by any
-    // number of transactions
+    /// Contains live, non-package objects that have been committed to the db.
+    /// As with `objects`, we remove objects from this table in FIFO order (or we allow the cache
+    /// to evict all versions of the object at once), which ensures that the the cached sequence
+    /// of objects has no gaps. See the comment above for more details.
+    // TODO(cache): this is not populated yet, we will populate it when we implement flushing.
+    object_cache: MokaCache<ObjectID, Arc<Mutex<BTreeMap<SequenceNumber, ObjectEntry>>>>,
+
+    // Packages are cached separately from objects because they are immutable and can be used by any
+    // number of transactions. Additionally, many operations require loading large numbers of packages
+    // (due to dependencies), so we want to try to keep all packages in memory.
+    // Note that, like any other dirty object, all packages are also stored in `objects` until they are
+    // flushed to disk.
     packages: MokaCache<ObjectID, PackageObject>,
 
-    // Markers for received objects and deleted shared objects. This cache can be invalidated at
-    // any time, but if there is an entry, it must contain the most recent marker for the object.
+    // Markers for received objects and deleted shared objects. This contains all of the dirty
+    // marker state, which is committed to the db at the same time as other transaction data.
+    // After markers are committed to the db we remove them from this table and insert them into
+    // marker_cache.
+    markers: DashMap<MarkerKey, BTreeMap<SequenceNumber, MarkerValue>>,
+
+    // Because markers (e.g. received markers) can be read by many transactions, we also cache
+    // them. Markers are added to this cache in two ways:
+    // 1. When they are committed to the db and removed from the `markers` table.
+    // 2. After a cache miss in which we retrieve the marker from the db.
+
     // Note that MokaCache can only return items by value, so we store the map as an Arc<Mutex>.
     // (There should be no contention on the inner mutex, it is used only for interior mutability.)
-    markers: MokaCache<ObjectID, Arc<Mutex<BTreeMap<SequenceNumber, MarkerValue>>>>,
+    marker_cache: MokaCache<MarkerKey, Arc<Mutex<BTreeMap<SequenceNumber, MarkerValue>>>>,
 
     // Objects that were read at transaction signing time - allows us to access them again at
     // execution time with a single lock / hash lookup
@@ -280,11 +513,15 @@ pub struct InMemoryCache {
 
 impl InMemoryCache {
     pub fn new(store: Arc<AuthorityStore>) -> Self {
+        let object_cache = MokaCache::builder()
+            .max_capacity(10000)
+            .initial_capacity(10000)
+            .build();
         let packages = MokaCache::builder()
             .max_capacity(10000)
             .initial_capacity(10000)
             .build();
-        let markers = MokaCache::builder()
+        let marker_cache = MokaCache::builder()
             .max_capacity(10000)
             .initial_capacity(10000)
             .build();
@@ -295,8 +532,10 @@ impl InMemoryCache {
 
         Self {
             objects: DashMap::new(),
+            object_cache,
             packages,
-            markers,
+            markers: DashMap::new(),
+            marker_cache,
             _transaction_objects: transaction_objects,
             transaction_effects: DashMap::new(),
             executed_effects_digests: DashMap::new(),
@@ -331,6 +570,42 @@ impl InMemoryCache {
             .insert(version, ObjectEntry::Wrapped);
     }
 
+    fn get_object_by_key_cache_only(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> CacheResult<Object> {
+        macro_rules! check_cache_entry {
+            ($objects: expr) => {
+                if let Some(object) = $objects.get(&version) {
+                    if let ObjectEntry::Object(object) = object {
+                        return CacheResult::Hit(object.clone());
+                    } else {
+                        // object exists but is a tombstone
+                        return CacheResult::NegativeHit;
+                    }
+                }
+
+                if get_last(&*$objects).0 < &version {
+                    // If the version is greater than the last version in the cache, then we know
+                    // that the object does not exist anywhere
+                    return CacheResult::NegativeHit;
+                }
+            };
+        }
+
+        if let Some(objects) = self.objects.get(object_id) {
+            check_cache_entry!(objects);
+        }
+
+        if let Some(objects) = self.object_cache.get(object_id) {
+            let objects = objects.lock();
+            check_cache_entry!(objects);
+        }
+
+        CacheResult::Miss
+    }
+
     pub fn as_notify_read_wrapper(self: Arc<Self>) -> NotifyReadWrapper {
         NotifyReadWrapper(self)
     }
@@ -355,7 +630,10 @@ impl ExecutionCacheRead for InMemoryCache {
             return Ok(Some(p));
         }
 
-        if let Some(p) = self.store.get_object(package_id)? {
+        // We try the dirty objects cache as well before going to the database. This is necessary
+        // because the package could be evicted from the package cache before it is committed
+        // to the database.
+        if let Some(p) = ExecutionCacheRead::get_object(self, package_id)? {
             if p.is_package() {
                 let p = PackageObject::new(p);
                 self.packages.insert(*package_id, p.clone());
@@ -396,10 +674,19 @@ impl ExecutionCacheRead for InMemoryCache {
             };
         }
 
+        if let Some(objects) = self.object_cache.get(id) {
+            let objects = objects.lock();
+            // If any version of the object is in the cache, it must be the most recent version.
+            return match get_last(&*objects).1 {
+                ObjectEntry::Object(object) => Ok(Some(object.clone())),
+                _ => Ok(None),
+            };
+        }
+
         // We don't insert objects into the cache because they are usually only
         // read once.
         // TODO: we might want to cache immutable reads (RO shared objects and immutable objects)
-        self.store.get_object(id)
+        self.store.get_object(id).map_err(Into::into)
     }
 
     fn get_object_by_key(
@@ -407,19 +694,13 @@ impl ExecutionCacheRead for InMemoryCache {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<Option<Object>> {
-        if let Some(objects) = self.objects.get(object_id) {
-            if let Some(object) = objects.get(&version) {
-                if let ObjectEntry::Object(object) = object {
-                    return Ok(Some(object.clone()));
-                } else {
-                    return Ok(None);
-                }
-            }
+        match self.get_object_by_key_cache_only(object_id, version) {
+            CacheResult::Hit(object) => Ok(Some(object)),
+            CacheResult::NegativeHit => Ok(None),
+            // We don't insert objects into the cache after a miss because they are usually only
+            // read once.
+            CacheResult::Miss => Ok(self.store.get_object_by_key(object_id, version)?),
         }
-
-        // We don't insert objects into the cache because they are usually only
-        // read once.
-        self.store.get_object_by_key(object_id, version)
     }
 
     fn multi_get_object_by_key(
@@ -431,11 +712,13 @@ impl ExecutionCacheRead for InMemoryCache {
         let mut fetch_indices = Vec::with_capacity(object_keys.len());
 
         for (i, key) in object_keys.iter().enumerate() {
-            if let Some(object) = self.get_object_by_key(&key.0, key.1)? {
-                results[i] = Some(object);
-            } else {
-                fallback_keys.push(*key);
-                fetch_indices.push(i);
+            match self.get_object_by_key_cache_only(&key.0, key.1) {
+                CacheResult::Hit(object) => results[i] = Some(object),
+                CacheResult::NegativeHit => (),
+                CacheResult::Miss => {
+                    fallback_keys.push(*key);
+                    fetch_indices.push(i);
+                }
             }
         }
 
@@ -450,31 +733,43 @@ impl ExecutionCacheRead for InMemoryCache {
         Ok(results)
     }
 
-    fn multi_get_object_by_objref(&self, objrefs: &[ObjectRef]) -> SuiResult<Vec<Object>> {
-        let mut results = vec![None; objrefs.len()];
-        let mut fallback_keys = Vec::with_capacity(objrefs.len());
-        let mut fetch_indices = Vec::with_capacity(objrefs.len());
+    fn object_exists_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<bool> {
+        match self.get_object_by_key_cache_only(object_id, version) {
+            CacheResult::Hit(_) => Ok(true),
+            CacheResult::NegativeHit => Ok(false),
+            CacheResult::Miss => self.store.object_exists_by_key(object_id, version),
+        }
+    }
 
-        for (i, objref) in objrefs.iter().enumerate() {
-            if let Some(object) = self.get_object_by_key(&objref.0, objref.1)? {
-                results[i] = Some(object);
-            } else {
-                fallback_keys.push(*objref);
-                fetch_indices.push(i);
+    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<bool>> {
+        let mut results = vec![false; object_keys.len()];
+        let mut fallback_keys = Vec::with_capacity(object_keys.len());
+        let mut fetch_indices = Vec::with_capacity(object_keys.len());
+
+        for (i, key) in object_keys.iter().enumerate() {
+            match self.get_object_by_key_cache_only(&key.0, key.1) {
+                CacheResult::Hit(_) => results[i] = true,
+                CacheResult::NegativeHit => (),
+                CacheResult::Miss => {
+                    fallback_keys.push(*key);
+                    fetch_indices.push(i);
+                }
             }
         }
 
-        let store_results = self
-            .store
-            .multi_get_object_with_more_accurate_error_return(&fallback_keys)?;
+        let store_results = self.store.multi_object_exists_by_key(&fallback_keys)?;
         assert_eq!(store_results.len(), fetch_indices.len());
         assert_eq!(store_results.len(), fallback_keys.len());
 
         for (i, result) in fetch_indices.into_iter().zip(store_results.into_iter()) {
-            results[i] = Some(result);
+            results[i] = result;
         }
 
-        Ok(results.into_iter().map(|r| r.unwrap()).collect())
+        Ok(results)
     }
 
     fn get_latest_object_ref_or_tombstone(
@@ -503,7 +798,7 @@ impl ExecutionCacheRead for InMemoryCache {
                 return Ok(Some((objref.into(), ObjectOrTombstone::Tombstone(objref))));
             } else {
                 let key: ObjectKey = objref.into();
-                let object = self.get_object_by_key(&objref.0, objref.1)?;
+                let object = ExecutionCacheRead::get_object_by_key(self, &objref.0, objref.1)?;
                 return Ok(object.map(|o| (key, o.into())));
             }
         }
@@ -511,54 +806,42 @@ impl ExecutionCacheRead for InMemoryCache {
         self.store.get_latest_object_or_tombstone(object_id)
     }
 
-    /// If the shared object was deleted, return deletion info for the current live version
-    fn get_last_shared_object_deletion_info(
+    fn find_object_lt_or_eq_version(
         &self,
-        object_id: &ObjectID,
-        epoch_id: EpochId,
-    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>> {
-        if let Some(markers) = self.markers.get(object_id) {
-            if let (version, MarkerValue::SharedDeleted(digest)) = get_last(&*markers.lock()) {
-                return Ok(Some((*version, *digest)));
-            }
-        }
-
-        // TODO: should we update the cache?
-        self.store
-            .get_last_shared_object_deletion_info(object_id, epoch_id)
-    }
-
-    /// If the shared object was deleted, return deletion info for the specified version.
-    fn get_deleted_shared_object_previous_tx_digest(
-        &self,
-        object_id: &ObjectID,
-        version: &SequenceNumber,
-        epoch_id: EpochId,
-    ) -> SuiResult<Option<TransactionDigest>> {
-        if let Some(markers) = self.markers.get(object_id) {
-            if let Some(MarkerValue::SharedDeleted(digest)) = markers.lock().get(version) {
-                return Ok(Some(*digest));
-            }
-        }
-
-        self.store
-            .get_deleted_shared_object_previous_tx_digest(object_id, version, epoch_id)
-    }
-
-    fn have_received_object_at_version(
-        &self,
-        object_id: &ObjectID,
+        object_id: ObjectID,
         version: SequenceNumber,
-        epoch_id: EpochId,
-    ) -> SuiResult<bool> {
-        if let Some(markers) = self.markers.get(object_id) {
-            if let Some(MarkerValue::Received) = markers.lock().get(&version) {
-                return Ok(true);
+    ) -> Option<Object> {
+        // Both self.objects and self.object_cache have no gaps, and self.object_cache
+        // cannot have a more recent version than self.objects.
+        // note that while binary searching would be more efficient for random keys, child
+        // reads will be disproportionately more likely to be for a very recent version.
+        if let Some(objects) = self.objects.get(&object_id) {
+            for (_, object) in objects.range(..=version).rev() {
+                if let ObjectEntry::Object(object) = object {
+                    return Some(object.clone());
+                }
             }
         }
 
-        self.store
-            .have_received_object_at_version(object_id, version, epoch_id)
+        if let Some(objects) = self.object_cache.get(&object_id) {
+            let objects = objects.lock();
+            for (_, object) in objects.range(..=version).rev() {
+                if let ObjectEntry::Object(object) = object {
+                    return Some(object.clone());
+                }
+            }
+        }
+
+        self.store.find_object_lt_or_eq_version(object_id, version)
+    }
+
+    fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef> {
+        // TODO(cache) - read lock from cache
+        let lock = self
+            .store
+            .get_latest_lock_for_object_id(object_id)
+            .expect("read cannot fail");
+        Ok(lock)
     }
 
     fn multi_get_transaction_blocks(
@@ -678,13 +961,64 @@ impl ExecutionCacheRead for InMemoryCache {
     }
 
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState> {
-        get_sui_system_state(&ObjectStoreWrapper(self))
+        get_sui_system_state(self)
+    }
+
+    fn get_marker_value(
+        &self,
+        object_id: &ObjectID,
+        version: &SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<MarkerValue>> {
+        // first check the dirty markers
+        if let Some(markers) = self.markers.get(&(epoch_id, *object_id)) {
+            if let Some(marker) = markers.get(version) {
+                return Ok(Some(*marker));
+            }
+        }
+
+        // now check the cache
+        if let Some(markers) = self.marker_cache.get(&(epoch_id, *object_id)) {
+            if let Some(marker) = markers.lock().get(version) {
+                return Ok(Some(*marker));
+            }
+        }
+
+        // fall back to the db
+        // NOTE: we cannot insert this marker into the cache, because the cache
+        // must always contain the latest marker version if it contains any marker
+        // for an object.
+        self.store.get_marker_value(object_id, version, epoch_id)
+    }
+
+    fn get_latest_marker(
+        &self,
+        object_id: &ObjectID,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<(SequenceNumber, MarkerValue)>> {
+        // Note: the reads from the dirty set and the cache are both safe, because both
+        // of these structures are guaranteed to contain the latest marker if they have
+        // an entry at all for a given object.
+
+        if let Some(markers) = self.markers.get(&(epoch_id, *object_id)) {
+            let (k, v) = get_last(&*markers);
+            return Ok(Some((*k, *v)));
+        }
+
+        if let Some(markers) = self.marker_cache.get(&(epoch_id, *object_id)) {
+            let markers = markers.lock();
+            let (k, v) = get_last(&*markers);
+            return Ok(Some((*k, *v)));
+        }
+
+        // TODO: we could insert this marker into the cache since it is the latest
+        self.store.get_latest_marker(object_id, epoch_id)
     }
 }
 
 impl ExecutionCacheWrite for InMemoryCache {
     #[instrument(level = "debug", skip_all)]
-    fn write_transaction_outputs(&self, _epoch_id: EpochId, tx_outputs: TransactionOutputs) {
+    fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: TransactionOutputs) {
         let TransactionOutputs {
             transaction,
             effects,
@@ -697,13 +1031,12 @@ impl ExecutionCacheWrite for InMemoryCache {
             ..
         } = &tx_outputs;
 
-        // Update all marekrs
+        // Update all markers
         for (object_key, marker_value) in markers.iter() {
             self.markers
-                .entry_by_ref(&object_key.0)
-                .or_insert_with(|| Arc::new(Mutex::new(BTreeMap::new())))
-                .value()
-                .lock()
+                .entry((epoch_id, object_key.0))
+                .or_default()
+                .value_mut()
                 .insert(object_key.1, *marker_value);
         }
 
@@ -753,9 +1086,6 @@ impl ExecutionCacheWrite for InMemoryCache {
 
         let tx_digest = *transaction.digest();
         let effects_digest = effects.digest();
-
-        self.transaction_effects
-            .insert(effects_digest, effects.clone());
 
         self.transaction_effects
             .insert(effects_digest, effects.clone());
@@ -822,19 +1152,91 @@ impl EffectsNotifyRead for NotifyReadWrapper {
     }
 }
 
-// Wrapper to avoid having to disambiguate traits everywhere
-struct ObjectStoreWrapper<'a>(&'a InMemoryCache);
-
-impl<'a> ObjectStore for ObjectStoreWrapper<'a> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
-        self.0.get_object(object_id)
+impl ObjectStore for InMemoryCache {
+    fn get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
+        ExecutionCacheRead::get_object(self, object_id).map_err(StorageError::custom)
     }
 
     fn get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: sui_types::base_types::VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
-        self.0.get_object_by_key(object_id, version)
+    ) -> StorageResult<Option<Object>> {
+        ExecutionCacheRead::get_object_by_key(self, object_id, version)
+            .map_err(StorageError::custom)
+    }
+}
+
+impl ChildObjectResolver for InMemoryCache {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        let Some(child_object) =
+            self.find_object_lt_or_eq_version(*child, child_version_upper_bound)
+        else {
+            return Ok(None);
+        };
+
+        let parent = *parent;
+        if child_object.owner != Owner::ObjectOwner(parent.into()) {
+            return Err(SuiError::InvalidChildObjectAccess {
+                object: *child,
+                given_parent: parent,
+                actual_owner: child_object.owner,
+            });
+        }
+        Ok(Some(child_object))
+    }
+
+    fn get_object_received_at_version(
+        &self,
+        owner: &ObjectID,
+        receiving_object_id: &ObjectID,
+        receive_object_at_version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<Object>> {
+        let Some(recv_object) = ExecutionCacheRead::get_object_by_key(
+            self,
+            receiving_object_id,
+            receive_object_at_version,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        // Check for:
+        // * Invalid access -- treat as the object does not exist. Or;
+        // * If we've already received the object at the version -- then treat it as though it doesn't exist.
+        // These two cases must remain indisguishable to the caller otherwise we risk forks in
+        // transaction replay due to possible reordering of transactions during replay.
+        if recv_object.owner != Owner::AddressOwner((*owner).into())
+            || self.have_received_object_at_version(
+                receiving_object_id,
+                receive_object_at_version,
+                epoch_id,
+            )?
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(recv_object))
+    }
+}
+
+impl BackingPackageStore for InMemoryCache {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
+        ExecutionCacheRead::get_package_object(self, package_id)
+    }
+}
+
+impl ParentSync for InMemoryCache {
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
+        ExecutionCacheRead::get_latest_object_ref_or_tombstone(self, object_id)
     }
 }

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -1,0 +1,840 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::authority_notify_read::EffectsNotifyRead;
+use crate::authority::AuthorityStore;
+use crate::transaction_outputs::TransactionOutputs;
+use async_trait::async_trait;
+
+use dashmap::DashMap;
+use either::Either;
+use futures::{
+    future::{join_all, BoxFuture},
+    FutureExt,
+};
+use moka::sync::Cache as MokaCache;
+use mysten_common::sync::notify_read::NotifyRead;
+use parking_lot::Mutex;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use sui_types::base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber};
+use sui_types::digests::{
+    ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
+};
+use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::message_envelope::Message;
+use sui_types::object::Object;
+use sui_types::storage::{MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject};
+use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState};
+use sui_types::transaction::VerifiedTransaction;
+use tracing::instrument;
+use typed_store::Map;
+
+pub trait ExecutionCacheRead: Send + Sync {
+    fn get_package_object(&self, id: &ObjectID) -> SuiResult<Option<PackageObject>>;
+    fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]);
+
+    fn get_object(&self, id: &ObjectID) -> SuiResult<Option<Object>>;
+
+    fn get_objects(&self, objects: &[ObjectID]) -> SuiResult<Vec<Option<Object>>> {
+        let mut ret = Vec::with_capacity(objects.len());
+        for object_id in objects {
+            ret.push(self.get_object(object_id)?);
+        }
+        Ok(ret)
+    }
+
+    fn get_latest_object_ref_or_tombstone(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>>;
+
+    fn get_latest_object_or_tombstone(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<(ObjectKey, ObjectOrTombstone)>>;
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<Option<Object>>;
+
+    fn multi_get_object_by_key(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<Option<Object>>>;
+
+    /// Variant of multi_get_object_by_key used by transaction signing that returns better error messages
+    /// when objects are not found. Returns an error if any object is not found.
+    fn multi_get_object_by_objref(&self, objrefs: &[ObjectRef]) -> SuiResult<Vec<Object>>;
+
+    /// If the shared object was deleted, return deletion info for the current live version
+    fn get_last_shared_object_deletion_info(
+        &self,
+        object_id: &ObjectID,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>>;
+
+    /// If the shared object was deleted, return deletion info for the specified version.
+    fn get_deleted_shared_object_previous_tx_digest(
+        &self,
+        object_id: &ObjectID,
+        version: &SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<TransactionDigest>>;
+
+    fn have_received_object_at_version(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<bool>;
+
+    fn multi_get_transaction_blocks(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<Arc<VerifiedTransaction>>>>;
+
+    fn get_transaction_block(
+        &self,
+        digest: &TransactionDigest,
+    ) -> SuiResult<Option<Arc<VerifiedTransaction>>> {
+        self.multi_get_transaction_blocks(&[*digest])
+            .map(|mut blocks| {
+                blocks
+                    .pop()
+                    .expect("multi-get must return correct number of items")
+            })
+    }
+
+    fn multi_get_executed_effects_digests(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffectsDigest>>>;
+
+    fn is_tx_already_executed(&self, digest: &TransactionDigest) -> SuiResult<bool> {
+        self.multi_get_executed_effects_digests(&[*digest])
+            .map(|mut digests| {
+                digests
+                    .pop()
+                    .expect("multi-get must return correct number of items")
+                    .is_some()
+            })
+    }
+
+    fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        let effects_digests = self.multi_get_executed_effects_digests(digests)?;
+        assert_eq!(effects_digests.len(), digests.len());
+
+        let mut results = vec![None; digests.len()];
+        let mut fetch_digests = Vec::with_capacity(digests.len());
+        let mut fetch_indices = Vec::with_capacity(digests.len());
+
+        for (i, digest) in effects_digests.into_iter().enumerate() {
+            if let Some(digest) = digest {
+                fetch_digests.push(digest);
+                fetch_indices.push(i);
+            }
+        }
+
+        let effects = self.multi_get_effects(&fetch_digests)?;
+        for (i, effects) in fetch_indices.into_iter().zip(effects.into_iter()) {
+            results[i] = effects;
+        }
+
+        Ok(results)
+    }
+
+    fn get_executed_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> SuiResult<Option<TransactionEffects>> {
+        self.multi_get_executed_effects(&[*digest])
+            .map(|mut effects| {
+                effects
+                    .pop()
+                    .expect("multi-get must return correct number of items")
+            })
+    }
+
+    fn multi_get_effects(
+        &self,
+        digests: &[TransactionEffectsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>>;
+
+    fn get_effects(
+        &self,
+        digest: &TransactionEffectsDigest,
+    ) -> SuiResult<Option<TransactionEffects>> {
+        self.multi_get_effects(&[*digest]).map(|mut effects| {
+            effects
+                .pop()
+                .expect("multi-get must return correct number of items")
+        })
+    }
+
+    fn multi_get_events(
+        &self,
+        event_digests: &[TransactionEventsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEvents>>>;
+
+    fn get_events(&self, digest: &TransactionEventsDigest) -> SuiResult<Option<TransactionEvents>> {
+        self.multi_get_events(&[*digest]).map(|mut events| {
+            events
+                .pop()
+                .expect("multi-get must return correct number of items")
+        })
+    }
+
+    fn notify_read_executed_effects_digests<'a>(
+        &'a self,
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, SuiResult<Vec<TransactionEffectsDigest>>>;
+
+    fn notify_read_executed_effects<'a>(
+        &'a self,
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, SuiResult<Vec<TransactionEffects>>> {
+        async move {
+            let digests = self.notify_read_executed_effects_digests(digests).await?;
+            // once digests are available, effects must be present as well
+            self.multi_get_effects(&digests).map(|effects| {
+                effects
+                    .into_iter()
+                    .map(|e| e.expect("digests must exist"))
+                    .collect()
+            })
+        }
+        .boxed()
+    }
+
+    fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState>;
+}
+
+pub trait ExecutionCacheWrite: Send + Sync {
+    /// Write the output of a transaction.
+    ///
+    /// Because of the child object consistency rule (readers that observe parents must observe all
+    /// children of that parent, up to the parent's version bound), implementations of this method
+    /// must not write any top-level (address-owned or shared) objects before they have written all
+    /// of the object-owned objects (i.e. child objects) in the `objects` list.
+    ///
+    /// In the future, we may modify this method to expose finer-grained information about
+    /// parent/child relationships. (This may be especially necessary for distributed object
+    /// storage, but is unlikely to be an issue before we tackle that problem).
+    ///
+    /// This function may evict the mutable input objects (and successfully received objects) of
+    /// transaction from the cache, since they cannot be read by any other transaction.
+    ///
+    /// Any write performed by this method immediately notifies any waiter that has previously
+    /// called notify_read_objects_for_execution or notify_read_objects_for_signing for the object
+    /// in question.
+    fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: TransactionOutputs);
+}
+
+enum ObjectEntry {
+    Object(Object),
+    Deleted,
+    Wrapped,
+}
+
+impl From<Object> for ObjectEntry {
+    fn from(object: Object) -> Self {
+        ObjectEntry::Object(object)
+    }
+}
+
+pub struct InMemoryCache {
+    // Objects are not cached using an LRU because we manage cache evictions manually due to sui
+    // semantics.
+    objects: DashMap<ObjectID, BTreeMap<SequenceNumber, ObjectEntry>>,
+
+    // packages are cache separately from objects because they are immutable and can be used by any
+    // number of transactions
+    packages: MokaCache<ObjectID, PackageObject>,
+
+    // Markers for received objects and deleted shared objects. This cache can be invalidated at
+    // any time, but if there is an entry, it must contain the most recent marker for the object.
+    // Note that MokaCache can only return items by value, so we store the map as an Arc<Mutex>.
+    // (There should be no contention on the inner mutex, it is used only for interior mutability.)
+    markers: MokaCache<ObjectID, Arc<Mutex<BTreeMap<SequenceNumber, MarkerValue>>>>,
+
+    // Objects that were read at transaction signing time - allows us to access them again at
+    // execution time with a single lock / hash lookup
+    _transaction_objects: MokaCache<TransactionDigest, Vec<Object>>,
+
+    transaction_effects: DashMap<TransactionEffectsDigest, TransactionEffects>,
+
+    executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
+
+    // Transaction outputs that have not yet been written to the DB. Items are removed from this
+    // table as they are flushed to the db.
+    pending_transaction_writes: DashMap<TransactionDigest, TransactionOutputs>,
+
+    executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+
+    store: Arc<AuthorityStore>,
+}
+
+impl InMemoryCache {
+    pub fn new(store: Arc<AuthorityStore>) -> Self {
+        let packages = MokaCache::builder()
+            .max_capacity(10000)
+            .initial_capacity(10000)
+            .build();
+        let markers = MokaCache::builder()
+            .max_capacity(10000)
+            .initial_capacity(10000)
+            .build();
+        let transaction_objects = MokaCache::builder()
+            .max_capacity(10000)
+            .initial_capacity(10000)
+            .build();
+
+        Self {
+            objects: DashMap::new(),
+            packages,
+            markers,
+            _transaction_objects: transaction_objects,
+            transaction_effects: DashMap::new(),
+            executed_effects_digests: DashMap::new(),
+            pending_transaction_writes: DashMap::new(),
+            executed_effects_digests_notify_read: NotifyRead::new(),
+            store,
+        }
+    }
+
+    fn insert_object(&self, object_id: &ObjectID, object: &Object) {
+        let version = object.version();
+        tracing::debug!("inserting object {:?}: {:?}", object_id, version);
+        self.objects
+            .entry(*object_id)
+            .or_default()
+            .insert(object.version(), object.clone().into());
+    }
+
+    fn insert_deleted_tombstone(&self, object_id: &ObjectID, version: SequenceNumber) {
+        tracing::debug!("inserting deleted tombstone {:?}: {:?}", object_id, version);
+        self.objects
+            .entry(*object_id)
+            .or_default()
+            .insert(version, ObjectEntry::Deleted);
+    }
+
+    fn insert_wrapped_tombstone(&self, object_id: &ObjectID, version: SequenceNumber) {
+        tracing::debug!("inserting wrapped tombstone {:?}: {:?}", object_id, version);
+        self.objects
+            .entry(*object_id)
+            .or_default()
+            .insert(version, ObjectEntry::Wrapped);
+    }
+
+    pub fn as_notify_read_wrapper(self: Arc<Self>) -> NotifyReadWrapper {
+        NotifyReadWrapper(self)
+    }
+}
+
+fn get_last<K, V>(map: &BTreeMap<K, V>) -> (&K, &V) {
+    map.iter().next_back().expect("map cannot be empty")
+}
+
+impl ExecutionCacheRead for InMemoryCache {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
+        if let Some(p) = self.packages.get(package_id) {
+            #[cfg(debug_assertions)]
+            {
+                assert_eq!(
+                    self.store.get_object(package_id).unwrap().unwrap().digest(),
+                    p.object().digest(),
+                    "Package object cache is inconsistent for package {:?}",
+                    package_id
+                )
+            }
+            return Ok(Some(p));
+        }
+
+        if let Some(p) = self.store.get_object(package_id)? {
+            if p.is_package() {
+                let p = PackageObject::new(p);
+                self.packages.insert(*package_id, p.clone());
+                Ok(Some(p))
+            } else {
+                Err(SuiError::UserInputError {
+                    error: UserInputError::MoveObjectAsPackage {
+                        object_id: *package_id,
+                    },
+                })
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]) {
+        for package_id in system_package_ids {
+            if let Some(p) = self
+                .store
+                .get_object(package_id)
+                .expect("Failed to update system packages")
+            {
+                assert!(p.is_package());
+                self.packages.insert(*package_id, PackageObject::new(p));
+            }
+            // It's possible that a package is not found if it's newly added system package ID
+            // that hasn't got created yet. This should be very very rare though.
+        }
+    }
+
+    fn get_object(&self, id: &ObjectID) -> SuiResult<Option<Object>> {
+        if let Some(objects) = self.objects.get(id) {
+            // If any version of the object is in the cache, it must be the most recent version.
+            return match get_last(&*objects).1 {
+                ObjectEntry::Object(object) => Ok(Some(object.clone())),
+                _ => Ok(None),
+            };
+        }
+
+        // We don't insert objects into the cache because they are usually only
+        // read once.
+        // TODO: we might want to cache immutable reads (RO shared objects and immutable objects)
+        self.store.get_object(id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        if let Some(objects) = self.objects.get(object_id) {
+            if let Some(object) = objects.get(&version) {
+                if let ObjectEntry::Object(object) = object {
+                    return Ok(Some(object.clone()));
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+
+        // We don't insert objects into the cache because they are usually only
+        // read once.
+        self.store.get_object_by_key(object_id, version)
+    }
+
+    fn multi_get_object_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>, SuiError> {
+        let mut results = vec![None; object_keys.len()];
+        let mut fallback_keys = Vec::with_capacity(object_keys.len());
+        let mut fetch_indices = Vec::with_capacity(object_keys.len());
+
+        for (i, key) in object_keys.iter().enumerate() {
+            if let Some(object) = self.get_object_by_key(&key.0, key.1)? {
+                results[i] = Some(object);
+            } else {
+                fallback_keys.push(*key);
+                fetch_indices.push(i);
+            }
+        }
+
+        let store_results = self.store.multi_get_object_by_key(&fallback_keys)?;
+        assert_eq!(store_results.len(), fetch_indices.len());
+        assert_eq!(store_results.len(), fallback_keys.len());
+
+        for (i, result) in fetch_indices.into_iter().zip(store_results.into_iter()) {
+            results[i] = result;
+        }
+
+        Ok(results)
+    }
+
+    fn multi_get_object_by_objref(&self, objrefs: &[ObjectRef]) -> SuiResult<Vec<Object>> {
+        let mut results = vec![None; objrefs.len()];
+        let mut fallback_keys = Vec::with_capacity(objrefs.len());
+        let mut fetch_indices = Vec::with_capacity(objrefs.len());
+
+        for (i, objref) in objrefs.iter().enumerate() {
+            if let Some(object) = self.get_object_by_key(&objref.0, objref.1)? {
+                results[i] = Some(object);
+            } else {
+                fallback_keys.push(*objref);
+                fetch_indices.push(i);
+            }
+        }
+
+        let store_results = self
+            .store
+            .multi_get_object_with_more_accurate_error_return(&fallback_keys)?;
+        assert_eq!(store_results.len(), fetch_indices.len());
+        assert_eq!(store_results.len(), fallback_keys.len());
+
+        for (i, result) in fetch_indices.into_iter().zip(store_results.into_iter()) {
+            results[i] = Some(result);
+        }
+
+        Ok(results.into_iter().map(|r| r.unwrap()).collect())
+    }
+
+    fn get_latest_object_ref_or_tombstone(
+        &self,
+        object_id: ObjectID,
+    ) -> SuiResult<Option<ObjectRef>> {
+        if let Some(objects) = self.objects.get(&object_id) {
+            let (version, object) = get_last(&*objects);
+            let objref = match object {
+                ObjectEntry::Object(object) => object.compute_object_reference(),
+                ObjectEntry::Deleted => (object_id, *version, ObjectDigest::OBJECT_DIGEST_DELETED),
+                ObjectEntry::Wrapped => (object_id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED),
+            };
+            return Ok(Some(objref));
+        }
+
+        self.store.get_latest_object_ref_or_tombstone(object_id)
+    }
+
+    fn get_latest_object_or_tombstone(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<Option<(ObjectKey, ObjectOrTombstone)>, SuiError> {
+        if let Some(objref) = self.get_latest_object_ref_or_tombstone(object_id)? {
+            if !objref.2.is_alive() {
+                return Ok(Some((objref.into(), ObjectOrTombstone::Tombstone(objref))));
+            } else {
+                let key: ObjectKey = objref.into();
+                let object = self.get_object_by_key(&objref.0, objref.1)?;
+                return Ok(object.map(|o| (key, o.into())));
+            }
+        }
+
+        self.store.get_latest_object_or_tombstone(object_id)
+    }
+
+    /// If the shared object was deleted, return deletion info for the current live version
+    fn get_last_shared_object_deletion_info(
+        &self,
+        object_id: &ObjectID,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<(SequenceNumber, TransactionDigest)>> {
+        if let Some(markers) = self.markers.get(object_id) {
+            if let (version, MarkerValue::SharedDeleted(digest)) = get_last(&*markers.lock()) {
+                return Ok(Some((*version, *digest)));
+            }
+        }
+
+        // TODO: should we update the cache?
+        self.store
+            .get_last_shared_object_deletion_info(object_id, epoch_id)
+    }
+
+    /// If the shared object was deleted, return deletion info for the specified version.
+    fn get_deleted_shared_object_previous_tx_digest(
+        &self,
+        object_id: &ObjectID,
+        version: &SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<Option<TransactionDigest>> {
+        if let Some(markers) = self.markers.get(object_id) {
+            if let Some(MarkerValue::SharedDeleted(digest)) = markers.lock().get(version) {
+                return Ok(Some(*digest));
+            }
+        }
+
+        self.store
+            .get_deleted_shared_object_previous_tx_digest(object_id, version, epoch_id)
+    }
+
+    fn have_received_object_at_version(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+        epoch_id: EpochId,
+    ) -> SuiResult<bool> {
+        if let Some(markers) = self.markers.get(object_id) {
+            if let Some(MarkerValue::Received) = markers.lock().get(&version) {
+                return Ok(true);
+            }
+        }
+
+        self.store
+            .have_received_object_at_version(object_id, version, epoch_id)
+    }
+
+    fn multi_get_transaction_blocks(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<Arc<VerifiedTransaction>>>> {
+        let mut results = vec![None; digests.len()];
+        let mut fetch_indices = Vec::with_capacity(digests.len());
+        let mut fetch_digests = Vec::with_capacity(digests.len());
+
+        for (i, digest) in digests.iter().enumerate() {
+            if let Some(tx) = self.pending_transaction_writes.get(digest) {
+                results[i] = Some(tx.transaction.clone());
+            } else {
+                fetch_indices.push(i);
+                fetch_digests.push(*digest);
+            }
+        }
+
+        let multiget_results = self.store.multi_get_transaction_blocks(&fetch_digests)?;
+        assert_eq!(multiget_results.len(), fetch_indices.len());
+        assert_eq!(multiget_results.len(), fetch_digests.len());
+
+        for (i, result) in fetch_indices.into_iter().zip(multiget_results.into_iter()) {
+            results[i] = result.map(Arc::new);
+        }
+
+        Ok(results)
+    }
+
+    fn multi_get_executed_effects_digests(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffectsDigest>>> {
+        let mut results = vec![None; digests.len()];
+        let mut fetch_indices = Vec::with_capacity(digests.len());
+        let mut fetch_digests = Vec::with_capacity(digests.len());
+
+        for (i, digest) in digests.iter().enumerate() {
+            if let Some(digest) = self.executed_effects_digests.get(digest) {
+                results[i] = Some(*digest);
+            } else {
+                fetch_indices.push(i);
+                fetch_digests.push(*digest);
+            }
+        }
+
+        let multiget_results = self
+            .store
+            .multi_get_executed_effects_digests(&fetch_digests)?;
+        assert_eq!(multiget_results.len(), fetch_indices.len());
+        assert_eq!(multiget_results.len(), fetch_digests.len());
+
+        for (i, result) in fetch_indices.into_iter().zip(multiget_results.into_iter()) {
+            results[i] = result;
+        }
+
+        Ok(results)
+    }
+
+    fn multi_get_effects(
+        &self,
+        digests: &[TransactionEffectsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        let mut results = vec![None; digests.len()];
+        let mut fetch_indices = Vec::with_capacity(digests.len());
+        let mut fetch_digests = Vec::with_capacity(digests.len());
+
+        for (i, digest) in digests.iter().enumerate() {
+            if let Some(effects) = self.transaction_effects.get(digest) {
+                results[i] = Some(effects.clone());
+            } else {
+                fetch_indices.push(i);
+                fetch_digests.push(*digest);
+            }
+        }
+
+        let fetch_results = self.store.perpetual_tables.effects.multi_get(digests)?;
+        for (i, result) in fetch_indices.into_iter().zip(fetch_results.into_iter()) {
+            results[i] = result;
+        }
+
+        Ok(results)
+    }
+
+    fn notify_read_executed_effects_digests<'a>(
+        &'a self,
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, SuiResult<Vec<TransactionEffectsDigest>>> {
+        async move {
+            let registrations = self
+                .executed_effects_digests_notify_read
+                .register_all(digests);
+
+            let executed_effects_digests = self.multi_get_executed_effects_digests(digests)?;
+
+            let results = executed_effects_digests
+                .into_iter()
+                .zip(registrations)
+                .map(|(a, r)| match a {
+                    // Note that Some() clause also drops registration that is already fulfilled
+                    Some(ready) => Either::Left(futures::future::ready(ready)),
+                    None => Either::Right(r),
+                });
+
+            Ok(join_all(results).await)
+        }
+        .boxed()
+    }
+
+    fn multi_get_events(
+        &self,
+        event_digests: &[TransactionEventsDigest],
+    ) -> SuiResult<Vec<Option<TransactionEvents>>> {
+        // TODO: use cache?
+        self.store.multi_get_events(event_digests)
+    }
+
+    fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState> {
+        get_sui_system_state(&ObjectStoreWrapper(self))
+    }
+}
+
+impl ExecutionCacheWrite for InMemoryCache {
+    #[instrument(level = "debug", skip_all)]
+    fn write_transaction_outputs(&self, _epoch_id: EpochId, tx_outputs: TransactionOutputs) {
+        let TransactionOutputs {
+            transaction,
+            effects,
+            markers,
+            written,
+            deleted,
+            wrapped,
+            locks_to_delete,
+            new_locks_to_init,
+            ..
+        } = &tx_outputs;
+
+        // Update all marekrs
+        for (object_key, marker_value) in markers.iter() {
+            self.markers
+                .entry_by_ref(&object_key.0)
+                .or_insert_with(|| Arc::new(Mutex::new(BTreeMap::new())))
+                .value()
+                .lock()
+                .insert(object_key.1, *marker_value);
+        }
+
+        // Write children before parents to ensure that readers do not observe a parent object
+        // before its most recent children are visible.
+        for (object_id, object) in written.iter() {
+            if object.is_child_object() {
+                self.insert_object(object_id, object);
+            }
+        }
+        for (object_id, object) in written.iter() {
+            if !object.is_child_object() {
+                self.insert_object(object_id, object);
+                if object.is_package() {
+                    self.packages
+                        .insert(*object_id, PackageObject::new(object.clone()));
+                }
+            }
+        }
+
+        for ObjectKey(id, version) in deleted.iter() {
+            self.insert_deleted_tombstone(id, *version);
+        }
+        for ObjectKey(id, version) in wrapped.iter() {
+            self.insert_wrapped_tombstone(id, *version);
+        }
+
+        // TODO(cache): remove dead objects from cache - this cannot actually be done
+        // until until objects are committed to the db, because
+        /*
+        for (id, version) in effects.modified_at_versions().iter() {
+            // delete the given id, version from self.objects. if no versions remain, remove the
+            // entry from self.objects
+            match self.objects.entry(*id) {
+                dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                    entry.get_mut().remove(version);
+                    if entry.get().is_empty() {
+                        entry.remove();
+                    }
+                }
+                dashmap::mapref::entry::Entry::Vacant(_) => panic!("object not found"),
+            }
+        }
+        */
+
+        write_locks(&self.store, locks_to_delete, new_locks_to_init);
+
+        let tx_digest = *transaction.digest();
+        let effects_digest = effects.digest();
+
+        self.transaction_effects
+            .insert(effects_digest, effects.clone());
+
+        self.transaction_effects
+            .insert(effects_digest, effects.clone());
+
+        self.executed_effects_digests
+            .insert(tx_digest, effects_digest);
+
+        self.pending_transaction_writes
+            .insert(tx_digest, tx_outputs);
+
+        self.executed_effects_digests_notify_read
+            .notify(&tx_digest, &effects_digest);
+    }
+}
+
+// TODO(cache): this is not safe, because now we are committing persistent state to the db, while the rest
+// of the transaction outputs could simply be lost if the validator restarts. To fix this we must
+// cache locks (which we want to do anyway) but that's a big enough change for it to be worth
+// saving for a separate PR.
+#[instrument(level = "trace", skip_all)]
+fn write_locks(
+    store: &AuthorityStore,
+    locks_to_delete: &[ObjectRef],
+    new_locks_to_init: &[ObjectRef],
+) {
+    store
+        .check_owned_object_locks_exist(locks_to_delete)
+        .expect("locks must exist for certificate to be executed");
+    let lock_table = &store.perpetual_tables.owned_object_transaction_locks;
+    let mut batch = lock_table.batch();
+    AuthorityStore::initialize_locks(lock_table, &mut batch, new_locks_to_init, false)
+        .expect("Failed to initialize locks");
+    store
+        .delete_locks(&mut batch, locks_to_delete)
+        .expect("Failed to delete locks");
+    batch.write().expect("Failed to write locks");
+}
+
+// TODO: Remove EffectsNotifyRead trait and just use ExecutionCacheRead directly everywhere.
+/// This wrapper is used so that we don't have to disambiguate traits at every callsite.
+pub struct NotifyReadWrapper(Arc<InMemoryCache>);
+
+#[async_trait]
+impl EffectsNotifyRead for NotifyReadWrapper {
+    async fn notify_read_executed_effects(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> SuiResult<Vec<TransactionEffects>> {
+        self.0.notify_read_executed_effects(&digests).await
+    }
+
+    async fn notify_read_executed_effects_digests(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> SuiResult<Vec<TransactionEffectsDigest>> {
+        self.0.notify_read_executed_effects_digests(&digests).await
+    }
+
+    fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        self.0.multi_get_executed_effects(digests)
+    }
+}
+
+// Wrapper to avoid having to disambiguate traits everywhere
+struct ObjectStoreWrapper<'a>(&'a InMemoryCache);
+
+impl<'a> ObjectStore for ObjectStoreWrapper<'a> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+        self.0.get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: sui_types::base_types::VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        self.0.get_object_by_key(object_id, version)
+    }
+}

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -6,20 +6,16 @@ use crate::authority::AuthorityStore;
 use crate::transaction_outputs::TransactionOutputs;
 use async_trait::async_trait;
 
-use dashmap::DashMap;
 use either::Either;
 use futures::{
     future::{join_all, BoxFuture},
     FutureExt,
 };
-use moka::sync::Cache as MokaCache;
 use mysten_common::sync::notify_read::NotifyRead;
-use parking_lot::Mutex;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
-use sui_types::digests::{
-    ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
-};
+use sui_storage::package_object_cache::PackageObjectCache;
+use sui_types::digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::message_envelope::Message;
@@ -38,6 +34,8 @@ use sui_types::{
 };
 use tracing::instrument;
 use typed_store::Map;
+
+pub type ExecutionCache = PassthroughCache;
 
 pub trait ExecutionCacheRead: Send + Sync {
     fn get_package_object(&self, id: &ObjectID) -> SuiResult<Option<PackageObject>>;
@@ -423,274 +421,53 @@ pub trait ExecutionCacheWrite: Send + Sync {
     /// Any write performed by this method immediately notifies any waiter that has previously
     /// called notify_read_objects_for_execution or notify_read_objects_for_signing for the object
     /// in question.
-    fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: TransactionOutputs);
-}
-
-enum ObjectEntry {
-    Object(Object),
-    Deleted,
-    Wrapped,
-}
-
-impl From<Object> for ObjectEntry {
-    fn from(object: Object) -> Self {
-        ObjectEntry::Object(object)
-    }
-}
-
-type MarkerKey = (EpochId, ObjectID);
-
-enum CacheResult<T> {
-    /// Entry is in the cache
-    Hit(T),
-    /// Entry is not in the cache and is known to not exist
-    NegativeHit,
-    /// Entry is not in the cache and may or may not exist in the store
-    Miss,
-}
-
-pub struct InMemoryCache {
-    /// The object dirty set. All writes go into this table first. After we flush the data to the
-    /// db, the data is removed from this table and inserted into the object_cache.
-    ///
-    /// This table may contain both live and dead objects, since we flush both live and dead
-    /// objects to the db in order to support past object queries on fullnodes.
-    /// When we move data into the object_cache we only retain the live objects.
-    ///
-    /// Further, we only remove objects in FIFO order, which ensures that the the cached
-    /// sequence of objects has no gaps. In other words, if we have versions 4, 8, 13 of
-    /// an object, we can deduce that version 9 does not exist. This also makes child object
-    /// reads efficient. `object_cache` cannot contain a more recent version of an object than
-    /// `objects`, and neither can have any gaps. Therefore if there is any object <= the version
-    /// bound for a child read in objects, it is the correct object to return.
-    objects: DashMap<ObjectID, BTreeMap<SequenceNumber, ObjectEntry>>,
-
-    /// Contains live, non-package objects that have been committed to the db.
-    /// As with `objects`, we remove objects from this table in FIFO order (or we allow the cache
-    /// to evict all versions of the object at once), which ensures that the the cached sequence
-    /// of objects has no gaps. See the comment above for more details.
-    // TODO(cache): this is not populated yet, we will populate it when we implement flushing.
-    object_cache: MokaCache<ObjectID, Arc<Mutex<BTreeMap<SequenceNumber, ObjectEntry>>>>,
-
-    // Packages are cached separately from objects because they are immutable and can be used by any
-    // number of transactions. Additionally, many operations require loading large numbers of packages
-    // (due to dependencies), so we want to try to keep all packages in memory.
-    // Note that, like any other dirty object, all packages are also stored in `objects` until they are
-    // flushed to disk.
-    packages: MokaCache<ObjectID, PackageObject>,
-
-    // Markers for received objects and deleted shared objects. This contains all of the dirty
-    // marker state, which is committed to the db at the same time as other transaction data.
-    // After markers are committed to the db we remove them from this table and insert them into
-    // marker_cache.
-    markers: DashMap<MarkerKey, BTreeMap<SequenceNumber, MarkerValue>>,
-
-    // Because markers (e.g. received markers) can be read by many transactions, we also cache
-    // them. Markers are added to this cache in two ways:
-    // 1. When they are committed to the db and removed from the `markers` table.
-    // 2. After a cache miss in which we retrieve the marker from the db.
-
-    // Note that MokaCache can only return items by value, so we store the map as an Arc<Mutex>.
-    // (There should be no contention on the inner mutex, it is used only for interior mutability.)
-    marker_cache: MokaCache<MarkerKey, Arc<Mutex<BTreeMap<SequenceNumber, MarkerValue>>>>,
-
-    // Objects that were read at transaction signing time - allows us to access them again at
-    // execution time with a single lock / hash lookup
-    _transaction_objects: MokaCache<TransactionDigest, Vec<Object>>,
-
-    transaction_effects: DashMap<TransactionEffectsDigest, TransactionEffects>,
-
-    transaction_events: DashMap<TransactionEventsDigest, TransactionEvents>,
-
-    executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
-
-    // Transaction outputs that have not yet been written to the DB. Items are removed from this
-    // table as they are flushed to the db.
-    pending_transaction_writes: DashMap<TransactionDigest, TransactionOutputs>,
-
-    executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
-
-    store: Arc<AuthorityStore>,
-}
-
-impl InMemoryCache {
-    pub fn new(store: Arc<AuthorityStore>) -> Self {
-        let object_cache = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
-            .build();
-        let packages = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
-            .build();
-        let marker_cache = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
-            .build();
-        let transaction_objects = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
-            .build();
-
-        Self {
-            objects: DashMap::new(),
-            object_cache,
-            packages,
-            markers: DashMap::new(),
-            marker_cache,
-            _transaction_objects: transaction_objects,
-            transaction_effects: DashMap::new(),
-            executed_effects_digests: DashMap::new(),
-            pending_transaction_writes: DashMap::new(),
-            executed_effects_digests_notify_read: NotifyRead::new(),
-            transaction_events: DashMap::new(),
-            store,
-        }
-    }
-
-    fn insert_object(&self, object_id: &ObjectID, object: &Object) {
-        let version = object.version();
-        tracing::debug!("inserting object {:?}: {:?}", object_id, version);
-        self.objects
-            .entry(*object_id)
-            .or_default()
-            .insert(object.version(), object.clone().into());
-    }
-
-    fn insert_deleted_tombstone(&self, object_id: &ObjectID, version: SequenceNumber) {
-        tracing::debug!("inserting deleted tombstone {:?}: {:?}", object_id, version);
-        self.objects
-            .entry(*object_id)
-            .or_default()
-            .insert(version, ObjectEntry::Deleted);
-    }
-
-    fn insert_wrapped_tombstone(&self, object_id: &ObjectID, version: SequenceNumber) {
-        tracing::debug!("inserting wrapped tombstone {:?}: {:?}", object_id, version);
-        self.objects
-            .entry(*object_id)
-            .or_default()
-            .insert(version, ObjectEntry::Wrapped);
-    }
-
-    fn get_object_by_key_cache_only(
+    fn write_transaction_outputs(
         &self,
-        object_id: &ObjectID,
-        version: SequenceNumber,
-    ) -> CacheResult<Object> {
-        macro_rules! check_cache_entry {
-            ($objects: expr) => {
-                if let Some(object) = $objects.get(&version) {
-                    if let ObjectEntry::Object(object) = object {
-                        return CacheResult::Hit(object.clone());
-                    } else {
-                        // object exists but is a tombstone
-                        return CacheResult::NegativeHit;
-                    }
-                }
+        epoch_id: EpochId,
+        tx_outputs: TransactionOutputs,
+    ) -> BoxFuture<'_, SuiResult>;
 
-                if get_last(&*$objects).0 < &version {
-                    // If the version is greater than the last version in the cache, then we know
-                    // that the object does not exist anywhere
-                    return CacheResult::NegativeHit;
-                }
-            };
+    /// Attempt to acquire object locks for all of the owned input locks.
+    fn acquire_transaction_locks<'a>(
+        &'a self,
+        epoch_id: EpochId,
+        owned_input_objects: &'a [ObjectRef],
+        tx_digest: TransactionDigest,
+    ) -> BoxFuture<'a, SuiResult>;
+}
+
+pub struct PassthroughCache {
+    store: Arc<AuthorityStore>,
+    package_cache: Arc<PackageObjectCache>,
+    executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+}
+
+impl PassthroughCache {
+    pub fn new(store: Arc<AuthorityStore>) -> Self {
+        Self {
+            store,
+            package_cache: PackageObjectCache::new(),
+            executed_effects_digests_notify_read: NotifyRead::new(),
         }
-
-        if let Some(objects) = self.objects.get(object_id) {
-            check_cache_entry!(objects);
-        }
-
-        if let Some(objects) = self.object_cache.get(object_id) {
-            let objects = objects.lock();
-            check_cache_entry!(objects);
-        }
-
-        CacheResult::Miss
     }
 
-    pub fn as_notify_read_wrapper(self: Arc<Self>) -> NotifyReadWrapper {
+    pub fn as_notify_read_wrapper(self: Arc<Self>) -> NotifyReadWrapper<Self> {
         NotifyReadWrapper(self)
     }
 }
 
-fn get_last<K, V>(map: &BTreeMap<K, V>) -> (&K, &V) {
-    map.iter().next_back().expect("map cannot be empty")
-}
-
-impl ExecutionCacheRead for InMemoryCache {
+impl ExecutionCacheRead for PassthroughCache {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
-        if let Some(p) = self.packages.get(package_id) {
-            #[cfg(debug_assertions)]
-            {
-                if let Some(store_package) = self.store.get_object(package_id).unwrap() {
-                    assert_eq!(
-                        store_package.digest(),
-                        p.object().digest(),
-                        "Package object cache is inconsistent for package {:?}",
-                        package_id
-                    );
-                }
-            }
-            return Ok(Some(p));
-        }
-
-        // We try the dirty objects cache as well before going to the database. This is necessary
-        // because the package could be evicted from the package cache before it is committed
-        // to the database.
-        if let Some(p) = ExecutionCacheRead::get_object(self, package_id)? {
-            if p.is_package() {
-                let p = PackageObject::new(p);
-                self.packages.insert(*package_id, p.clone());
-                Ok(Some(p))
-            } else {
-                Err(SuiError::UserInputError {
-                    error: UserInputError::MoveObjectAsPackage {
-                        object_id: *package_id,
-                    },
-                })
-            }
-        } else {
-            Ok(None)
-        }
+        self.package_cache
+            .get_package_object(package_id, &*self.store)
     }
 
     fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]) {
-        for package_id in system_package_ids {
-            if let Some(p) = self
-                .store
-                .get_object(package_id)
-                .expect("Failed to update system packages")
-            {
-                assert!(p.is_package());
-                self.packages.insert(*package_id, PackageObject::new(p));
-            }
-            // It's possible that a package is not found if it's newly added system package ID
-            // that hasn't got created yet. This should be very very rare though.
-        }
+        self.package_cache
+            .force_reload_system_packages(system_package_ids.iter().cloned(), self);
     }
 
     fn get_object(&self, id: &ObjectID) -> SuiResult<Option<Object>> {
-        if let Some(objects) = self.objects.get(id) {
-            // If any version of the object is in the cache, it must be the most recent version.
-            return match get_last(&*objects).1 {
-                ObjectEntry::Object(object) => Ok(Some(object.clone())),
-                _ => Ok(None),
-            };
-        }
-
-        if let Some(objects) = self.object_cache.get(id) {
-            let objects = objects.lock();
-            // If any version of the object is in the cache, it must be the most recent version.
-            return match get_last(&*objects).1 {
-                ObjectEntry::Object(object) => Ok(Some(object.clone())),
-                _ => Ok(None),
-            };
-        }
-
-        // We don't insert objects into the cache because they are usually only
-        // read once.
-        // TODO: we might want to cache immutable reads (RO shared objects and immutable objects)
         self.store.get_object(id).map_err(Into::into)
     }
 
@@ -699,43 +476,14 @@ impl ExecutionCacheRead for InMemoryCache {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<Option<Object>> {
-        match self.get_object_by_key_cache_only(object_id, version) {
-            CacheResult::Hit(object) => Ok(Some(object)),
-            CacheResult::NegativeHit => Ok(None),
-            // We don't insert objects into the cache after a miss because they are usually only
-            // read once.
-            CacheResult::Miss => Ok(self.store.get_object_by_key(object_id, version)?),
-        }
+        Ok(self.store.get_object_by_key(object_id, version)?)
     }
 
     fn multi_get_object_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, SuiError> {
-        let mut results = vec![None; object_keys.len()];
-        let mut fallback_keys = Vec::with_capacity(object_keys.len());
-        let mut fetch_indices = Vec::with_capacity(object_keys.len());
-
-        for (i, key) in object_keys.iter().enumerate() {
-            match self.get_object_by_key_cache_only(&key.0, key.1) {
-                CacheResult::Hit(object) => results[i] = Some(object),
-                CacheResult::NegativeHit => (),
-                CacheResult::Miss => {
-                    fallback_keys.push(*key);
-                    fetch_indices.push(i);
-                }
-            }
-        }
-
-        let store_results = self.store.multi_get_object_by_key(&fallback_keys)?;
-        assert_eq!(store_results.len(), fetch_indices.len());
-        assert_eq!(store_results.len(), fallback_keys.len());
-
-        for (i, result) in fetch_indices.into_iter().zip(store_results.into_iter()) {
-            results[i] = result;
-        }
-
-        Ok(results)
+        self.store.multi_get_object_by_key(object_keys)
     }
 
     fn object_exists_by_key(
@@ -743,54 +491,17 @@ impl ExecutionCacheRead for InMemoryCache {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<bool> {
-        match self.get_object_by_key_cache_only(object_id, version) {
-            CacheResult::Hit(_) => Ok(true),
-            CacheResult::NegativeHit => Ok(false),
-            CacheResult::Miss => self.store.object_exists_by_key(object_id, version),
-        }
+        self.store.object_exists_by_key(object_id, version)
     }
 
     fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<bool>> {
-        let mut results = vec![false; object_keys.len()];
-        let mut fallback_keys = Vec::with_capacity(object_keys.len());
-        let mut fetch_indices = Vec::with_capacity(object_keys.len());
-
-        for (i, key) in object_keys.iter().enumerate() {
-            match self.get_object_by_key_cache_only(&key.0, key.1) {
-                CacheResult::Hit(_) => results[i] = true,
-                CacheResult::NegativeHit => (),
-                CacheResult::Miss => {
-                    fallback_keys.push(*key);
-                    fetch_indices.push(i);
-                }
-            }
-        }
-
-        let store_results = self.store.multi_object_exists_by_key(&fallback_keys)?;
-        assert_eq!(store_results.len(), fetch_indices.len());
-        assert_eq!(store_results.len(), fallback_keys.len());
-
-        for (i, result) in fetch_indices.into_iter().zip(store_results.into_iter()) {
-            results[i] = result;
-        }
-
-        Ok(results)
+        self.store.multi_object_exists_by_key(object_keys)
     }
 
     fn get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> SuiResult<Option<ObjectRef>> {
-        if let Some(objects) = self.objects.get(&object_id) {
-            let (version, object) = get_last(&*objects);
-            let objref = match object {
-                ObjectEntry::Object(object) => object.compute_object_reference(),
-                ObjectEntry::Deleted => (object_id, *version, ObjectDigest::OBJECT_DIGEST_DELETED),
-                ObjectEntry::Wrapped => (object_id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED),
-            };
-            return Ok(Some(objref));
-        }
-
         self.store.get_latest_object_ref_or_tombstone(object_id)
     }
 
@@ -798,16 +509,6 @@ impl ExecutionCacheRead for InMemoryCache {
         &self,
         object_id: ObjectID,
     ) -> Result<Option<(ObjectKey, ObjectOrTombstone)>, SuiError> {
-        if let Some(objref) = self.get_latest_object_ref_or_tombstone(object_id)? {
-            if !objref.2.is_alive() {
-                return Ok(Some((objref.into(), ObjectOrTombstone::Tombstone(objref))));
-            } else {
-                let key: ObjectKey = objref.into();
-                let object = ExecutionCacheRead::get_object_by_key(self, &objref.0, objref.1)?;
-                return Ok(object.map(|o| (key, o.into())));
-            }
-        }
-
         self.store.get_latest_object_or_tombstone(object_id)
     }
 
@@ -816,120 +517,37 @@ impl ExecutionCacheRead for InMemoryCache {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<Object> {
-        // Both self.objects and self.object_cache have no gaps, and self.object_cache
-        // cannot have a more recent version than self.objects.
-        // note that while binary searching would be more efficient for random keys, child
-        // reads will be disproportionately more likely to be for a very recent version.
-        if let Some(objects) = self.objects.get(&object_id) {
-            for (_, object) in objects.range(..=version).rev() {
-                if let ObjectEntry::Object(object) = object {
-                    return Some(object.clone());
-                }
-            }
-        }
-
-        if let Some(objects) = self.object_cache.get(&object_id) {
-            let objects = objects.lock();
-            for (_, object) in objects.range(..=version).rev() {
-                if let ObjectEntry::Object(object) = object {
-                    return Some(object.clone());
-                }
-            }
-        }
-
         self.store.find_object_lt_or_eq_version(object_id, version)
     }
 
     fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef> {
-        // TODO(cache) - read lock from cache
-        let lock = self
-            .store
-            .get_latest_lock_for_object_id(object_id)
-            .expect("read cannot fail");
-        Ok(lock)
+        self.store.get_latest_lock_for_object_id(object_id)
     }
 
     fn multi_get_transaction_blocks(
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<Arc<VerifiedTransaction>>>> {
-        let mut results = vec![None; digests.len()];
-        let mut fetch_indices = Vec::with_capacity(digests.len());
-        let mut fetch_digests = Vec::with_capacity(digests.len());
-
-        for (i, digest) in digests.iter().enumerate() {
-            if let Some(tx) = self.pending_transaction_writes.get(digest) {
-                results[i] = Some(tx.transaction.clone());
-            } else {
-                fetch_indices.push(i);
-                fetch_digests.push(*digest);
-            }
-        }
-
-        let multiget_results = self.store.multi_get_transaction_blocks(&fetch_digests)?;
-        assert_eq!(multiget_results.len(), fetch_indices.len());
-        assert_eq!(multiget_results.len(), fetch_digests.len());
-
-        for (i, result) in fetch_indices.into_iter().zip(multiget_results.into_iter()) {
-            results[i] = result.map(Arc::new);
-        }
-
-        Ok(results)
+        Ok(self
+            .store
+            .multi_get_transaction_blocks(digests)?
+            .into_iter()
+            .map(|o| o.map(Arc::new))
+            .collect())
     }
 
     fn multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<TransactionEffectsDigest>>> {
-        let mut results = vec![None; digests.len()];
-        let mut fetch_indices = Vec::with_capacity(digests.len());
-        let mut fetch_digests = Vec::with_capacity(digests.len());
-
-        for (i, digest) in digests.iter().enumerate() {
-            if let Some(digest) = self.executed_effects_digests.get(digest) {
-                results[i] = Some(*digest);
-            } else {
-                fetch_indices.push(i);
-                fetch_digests.push(*digest);
-            }
-        }
-
-        let multiget_results = self
-            .store
-            .multi_get_executed_effects_digests(&fetch_digests)?;
-        assert_eq!(multiget_results.len(), fetch_indices.len());
-        assert_eq!(multiget_results.len(), fetch_digests.len());
-
-        for (i, result) in fetch_indices.into_iter().zip(multiget_results.into_iter()) {
-            results[i] = result;
-        }
-
-        Ok(results)
+        self.store.multi_get_executed_effects_digests(digests)
     }
 
     fn multi_get_effects(
         &self,
         digests: &[TransactionEffectsDigest],
     ) -> SuiResult<Vec<Option<TransactionEffects>>> {
-        let mut results = vec![None; digests.len()];
-        let mut fetch_indices = Vec::with_capacity(digests.len());
-        let mut fetch_digests = Vec::with_capacity(digests.len());
-
-        for (i, digest) in digests.iter().enumerate() {
-            if let Some(effects) = self.transaction_effects.get(digest) {
-                results[i] = Some(effects.clone());
-            } else {
-                fetch_indices.push(i);
-                fetch_digests.push(*digest);
-            }
-        }
-
-        let fetch_results = self.store.perpetual_tables.effects.multi_get(digests)?;
-        for (i, result) in fetch_indices.into_iter().zip(fetch_results.into_iter()) {
-            results[i] = result;
-        }
-
-        Ok(results)
+        Ok(self.store.perpetual_tables.effects.multi_get(digests)?)
     }
 
     fn notify_read_executed_effects_digests<'a>(
@@ -961,29 +579,7 @@ impl ExecutionCacheRead for InMemoryCache {
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> SuiResult<Vec<Option<TransactionEvents>>> {
-        let mut results = vec![None; event_digests.len()];
-        let mut fallback_digests = Vec::with_capacity(event_digests.len());
-        let mut fallback_indices = Vec::with_capacity(event_digests.len());
-
-        for (i, digest) in event_digests.iter().enumerate() {
-            if let Some(events) = self.transaction_events.get(digest) {
-                results[i] = Some(events.clone());
-            } else {
-                fallback_digests.push(*digest);
-                fallback_indices.push(i);
-            }
-        }
-
-        let fallback_results = self.store.multi_get_events(&fallback_digests)?;
-        assert_eq!(fallback_results.len(), fallback_indices.len());
-        assert_eq!(fallback_results.len(), fallback_digests.len());
-        for (i, result) in fallback_indices
-            .into_iter()
-            .zip(fallback_results.into_iter())
-        {
-            results[i] = result;
-        }
-        Ok(results)
+        self.store.multi_get_events(event_digests)
     }
 
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState> {
@@ -996,24 +592,6 @@ impl ExecutionCacheRead for InMemoryCache {
         version: &SequenceNumber,
         epoch_id: EpochId,
     ) -> SuiResult<Option<MarkerValue>> {
-        // first check the dirty markers
-        if let Some(markers) = self.markers.get(&(epoch_id, *object_id)) {
-            if let Some(marker) = markers.get(version) {
-                return Ok(Some(*marker));
-            }
-        }
-
-        // now check the cache
-        if let Some(markers) = self.marker_cache.get(&(epoch_id, *object_id)) {
-            if let Some(marker) = markers.lock().get(version) {
-                return Ok(Some(*marker));
-            }
-        }
-
-        // fall back to the db
-        // NOTE: we cannot insert this marker into the cache, because the cache
-        // must always contain the latest marker version if it contains any marker
-        // for an object.
         self.store.get_marker_value(object_id, version, epoch_id)
     }
 
@@ -1022,144 +600,49 @@ impl ExecutionCacheRead for InMemoryCache {
         object_id: &ObjectID,
         epoch_id: EpochId,
     ) -> SuiResult<Option<(SequenceNumber, MarkerValue)>> {
-        // Note: the reads from the dirty set and the cache are both safe, because both
-        // of these structures are guaranteed to contain the latest marker if they have
-        // an entry at all for a given object.
-
-        if let Some(markers) = self.markers.get(&(epoch_id, *object_id)) {
-            let (k, v) = get_last(&*markers);
-            return Ok(Some((*k, *v)));
-        }
-
-        if let Some(markers) = self.marker_cache.get(&(epoch_id, *object_id)) {
-            let markers = markers.lock();
-            let (k, v) = get_last(&*markers);
-            return Ok(Some((*k, *v)));
-        }
-
-        // TODO: we could insert this marker into the cache since it is the latest
         self.store.get_latest_marker(object_id, epoch_id)
     }
 }
 
-impl ExecutionCacheWrite for InMemoryCache {
+impl ExecutionCacheWrite for PassthroughCache {
     #[instrument(level = "debug", skip_all)]
-    fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: TransactionOutputs) {
-        let TransactionOutputs {
-            transaction,
-            effects,
-            markers,
-            written,
-            deleted,
-            wrapped,
-            locks_to_delete,
-            new_locks_to_init,
-            events,
-            ..
-        } = &tx_outputs;
+    fn write_transaction_outputs<'a>(
+        &'a self,
+        epoch_id: EpochId,
+        tx_outputs: TransactionOutputs,
+    ) -> BoxFuture<'a, SuiResult> {
+        async move {
+            let tx_digest = *tx_outputs.transaction.digest();
+            let effects_digest = tx_outputs.effects.digest();
+            self.store
+                .write_transaction_outputs(epoch_id, tx_outputs)
+                .await?;
 
-        // Update all markers
-        for (object_key, marker_value) in markers.iter() {
-            self.markers
-                .entry((epoch_id, object_key.0))
-                .or_default()
-                .value_mut()
-                .insert(object_key.1, *marker_value);
+            self.executed_effects_digests_notify_read
+                .notify(&tx_digest, &effects_digest);
+            Ok(())
         }
-
-        // Write children before parents to ensure that readers do not observe a parent object
-        // before its most recent children are visible.
-        for (object_id, object) in written.iter() {
-            if object.is_child_object() {
-                self.insert_object(object_id, object);
-            }
-        }
-        for (object_id, object) in written.iter() {
-            if !object.is_child_object() {
-                self.insert_object(object_id, object);
-                if object.is_package() {
-                    self.packages
-                        .insert(*object_id, PackageObject::new(object.clone()));
-                }
-            }
-        }
-
-        for ObjectKey(id, version) in deleted.iter() {
-            self.insert_deleted_tombstone(id, *version);
-        }
-        for ObjectKey(id, version) in wrapped.iter() {
-            self.insert_wrapped_tombstone(id, *version);
-        }
-
-        // TODO(cache): remove dead objects from cache - this cannot actually be done
-        // until until objects are committed to the db, because
-        /*
-        for (id, version) in effects.modified_at_versions().iter() {
-            // delete the given id, version from self.objects. if no versions remain, remove the
-            // entry from self.objects
-            match self.objects.entry(*id) {
-                dashmap::mapref::entry::Entry::Occupied(mut entry) => {
-                    entry.get_mut().remove(version);
-                    if entry.get().is_empty() {
-                        entry.remove();
-                    }
-                }
-                dashmap::mapref::entry::Entry::Vacant(_) => panic!("object not found"),
-            }
-        }
-        */
-
-        write_locks(&self.store, locks_to_delete, new_locks_to_init);
-
-        let tx_digest = *transaction.digest();
-        let effects_digest = effects.digest();
-
-        self.transaction_effects
-            .insert(effects_digest, effects.clone());
-
-        self.transaction_events
-            .insert(events.digest(), events.clone());
-
-        self.executed_effects_digests
-            .insert(tx_digest, effects_digest);
-
-        self.pending_transaction_writes
-            .insert(tx_digest, tx_outputs);
-
-        self.executed_effects_digests_notify_read
-            .notify(&tx_digest, &effects_digest);
+        .boxed()
     }
-}
 
-// TODO(cache): this is not safe, because now we are committing persistent state to the db, while the rest
-// of the transaction outputs could simply be lost if the validator restarts. To fix this we must
-// cache locks (which we want to do anyway) but that's a big enough change for it to be worth
-// saving for a separate PR.
-#[instrument(level = "trace", skip_all)]
-fn write_locks(
-    store: &AuthorityStore,
-    locks_to_delete: &[ObjectRef],
-    new_locks_to_init: &[ObjectRef],
-) {
-    store
-        .check_owned_object_locks_exist(locks_to_delete)
-        .expect("locks must exist for certificate to be executed");
-    let lock_table = &store.perpetual_tables.owned_object_transaction_locks;
-    let mut batch = lock_table.batch();
-    AuthorityStore::initialize_locks(lock_table, &mut batch, new_locks_to_init, false)
-        .expect("Failed to initialize locks");
-    store
-        .delete_locks(&mut batch, locks_to_delete)
-        .expect("Failed to delete locks");
-    batch.write().expect("Failed to write locks");
+    fn acquire_transaction_locks<'a>(
+        &'a self,
+        epoch_id: EpochId,
+        owned_input_objects: &'a [ObjectRef],
+        tx_digest: TransactionDigest,
+    ) -> BoxFuture<'a, SuiResult> {
+        self.store
+            .acquire_transaction_locks(epoch_id, owned_input_objects, tx_digest)
+            .boxed()
+    }
 }
 
 // TODO: Remove EffectsNotifyRead trait and just use ExecutionCacheRead directly everywhere.
 /// This wrapper is used so that we don't have to disambiguate traits at every callsite.
-pub struct NotifyReadWrapper(Arc<InMemoryCache>);
+pub struct NotifyReadWrapper<T>(Arc<T>);
 
 #[async_trait]
-impl EffectsNotifyRead for NotifyReadWrapper {
+impl<T: ExecutionCacheRead + 'static> EffectsNotifyRead for NotifyReadWrapper<T> {
     async fn notify_read_executed_effects(
         &self,
         digests: Vec<TransactionDigest>,
@@ -1182,91 +665,100 @@ impl EffectsNotifyRead for NotifyReadWrapper {
     }
 }
 
-impl ObjectStore for InMemoryCache {
-    fn get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
-        ExecutionCacheRead::get_object(self, object_id).map_err(StorageError::custom)
-    }
+macro_rules! implement_storage_traits {
+    ($implementor: ident) => {
+        impl ObjectStore for $implementor {
+            fn get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
+                ExecutionCacheRead::get_object(self, object_id).map_err(StorageError::custom)
+            }
 
-    fn get_object_by_key(
-        &self,
-        object_id: &ObjectID,
-        version: sui_types::base_types::VersionNumber,
-    ) -> StorageResult<Option<Object>> {
-        ExecutionCacheRead::get_object_by_key(self, object_id, version)
-            .map_err(StorageError::custom)
-    }
-}
-
-impl ChildObjectResolver for InMemoryCache {
-    fn read_child_object(
-        &self,
-        parent: &ObjectID,
-        child: &ObjectID,
-        child_version_upper_bound: SequenceNumber,
-    ) -> SuiResult<Option<Object>> {
-        let Some(child_object) =
-            self.find_object_lt_or_eq_version(*child, child_version_upper_bound)
-        else {
-            return Ok(None);
-        };
-
-        let parent = *parent;
-        if child_object.owner != Owner::ObjectOwner(parent.into()) {
-            return Err(SuiError::InvalidChildObjectAccess {
-                object: *child,
-                given_parent: parent,
-                actual_owner: child_object.owner,
-            });
-        }
-        Ok(Some(child_object))
-    }
-
-    fn get_object_received_at_version(
-        &self,
-        owner: &ObjectID,
-        receiving_object_id: &ObjectID,
-        receive_object_at_version: SequenceNumber,
-        epoch_id: EpochId,
-    ) -> SuiResult<Option<Object>> {
-        let Some(recv_object) = ExecutionCacheRead::get_object_by_key(
-            self,
-            receiving_object_id,
-            receive_object_at_version,
-        )?
-        else {
-            return Ok(None);
-        };
-
-        // Check for:
-        // * Invalid access -- treat as the object does not exist. Or;
-        // * If we've already received the object at the version -- then treat it as though it doesn't exist.
-        // These two cases must remain indisguishable to the caller otherwise we risk forks in
-        // transaction replay due to possible reordering of transactions during replay.
-        if recv_object.owner != Owner::AddressOwner((*owner).into())
-            || self.have_received_object_at_version(
-                receiving_object_id,
-                receive_object_at_version,
-                epoch_id,
-            )?
-        {
-            return Ok(None);
+            fn get_object_by_key(
+                &self,
+                object_id: &ObjectID,
+                version: sui_types::base_types::VersionNumber,
+            ) -> StorageResult<Option<Object>> {
+                ExecutionCacheRead::get_object_by_key(self, object_id, version)
+                    .map_err(StorageError::custom)
+            }
         }
 
-        Ok(Some(recv_object))
-    }
+        impl ChildObjectResolver for $implementor {
+            fn read_child_object(
+                &self,
+                parent: &ObjectID,
+                child: &ObjectID,
+                child_version_upper_bound: SequenceNumber,
+            ) -> SuiResult<Option<Object>> {
+                let Some(child_object) =
+                    self.find_object_lt_or_eq_version(*child, child_version_upper_bound)
+                else {
+                    return Ok(None);
+                };
+
+                let parent = *parent;
+                if child_object.owner != Owner::ObjectOwner(parent.into()) {
+                    return Err(SuiError::InvalidChildObjectAccess {
+                        object: *child,
+                        given_parent: parent,
+                        actual_owner: child_object.owner,
+                    });
+                }
+                Ok(Some(child_object))
+            }
+
+            fn get_object_received_at_version(
+                &self,
+                owner: &ObjectID,
+                receiving_object_id: &ObjectID,
+                receive_object_at_version: SequenceNumber,
+                epoch_id: EpochId,
+            ) -> SuiResult<Option<Object>> {
+                let Some(recv_object) = ExecutionCacheRead::get_object_by_key(
+                    self,
+                    receiving_object_id,
+                    receive_object_at_version,
+                )?
+                else {
+                    return Ok(None);
+                };
+
+                // Check for:
+                // * Invalid access -- treat as the object does not exist. Or;
+                // * If we've already received the object at the version -- then treat it as though it doesn't exist.
+                // These two cases must remain indisguishable to the caller otherwise we risk forks in
+                // transaction replay due to possible reordering of transactions during replay.
+                if recv_object.owner != Owner::AddressOwner((*owner).into())
+                    || self.have_received_object_at_version(
+                        receiving_object_id,
+                        receive_object_at_version,
+                        epoch_id,
+                    )?
+                {
+                    return Ok(None);
+                }
+
+                Ok(Some(recv_object))
+            }
+        }
+
+        impl BackingPackageStore for $implementor {
+            fn get_package_object(
+                &self,
+                package_id: &ObjectID,
+            ) -> SuiResult<Option<PackageObject>> {
+                ExecutionCacheRead::get_package_object(self, package_id)
+            }
+        }
+
+        impl ParentSync for $implementor {
+            fn get_latest_parent_entry_ref_deprecated(
+                &self,
+                object_id: ObjectID,
+            ) -> SuiResult<Option<ObjectRef>> {
+                ExecutionCacheRead::get_latest_object_ref_or_tombstone(self, object_id)
+            }
+        }
+    };
 }
 
-impl BackingPackageStore for InMemoryCache {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
-        ExecutionCacheRead::get_package_object(self, package_id)
-    }
-}
-
-impl ParentSync for InMemoryCache {
-    fn get_latest_parent_entry_ref_deprecated(
-        &self,
-        object_id: ObjectID,
-    ) -> SuiResult<Option<ObjectRef>> {
-        ExecutionCacheRead::get_latest_object_ref_or_tombstone(self, object_id)
-    }
-}
+implement_storage_traits!(PassthroughCache);

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -500,6 +500,8 @@ pub struct InMemoryCache {
 
     transaction_effects: DashMap<TransactionEffectsDigest, TransactionEffects>,
 
+    transaction_events: DashMap<TransactionEventsDigest, TransactionEvents>,
+
     executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
 
     // Transaction outputs that have not yet been written to the DB. Items are removed from this
@@ -541,6 +543,7 @@ impl InMemoryCache {
             executed_effects_digests: DashMap::new(),
             pending_transaction_writes: DashMap::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
+            transaction_events: DashMap::new(),
             store,
         }
     }
@@ -620,12 +623,14 @@ impl ExecutionCacheRead for InMemoryCache {
         if let Some(p) = self.packages.get(package_id) {
             #[cfg(debug_assertions)]
             {
-                assert_eq!(
-                    self.store.get_object(package_id).unwrap().unwrap().digest(),
-                    p.object().digest(),
-                    "Package object cache is inconsistent for package {:?}",
-                    package_id
-                )
+                if let Some(store_package) = self.store.get_object(package_id).unwrap() {
+                    assert_eq!(
+                        store_package.digest(),
+                        p.object().digest(),
+                        "Package object cache is inconsistent for package {:?}",
+                        package_id
+                    );
+                }
             }
             return Ok(Some(p));
         }
@@ -956,8 +961,29 @@ impl ExecutionCacheRead for InMemoryCache {
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> SuiResult<Vec<Option<TransactionEvents>>> {
-        // TODO: use cache?
-        self.store.multi_get_events(event_digests)
+        let mut results = vec![None; event_digests.len()];
+        let mut fallback_digests = Vec::with_capacity(event_digests.len());
+        let mut fallback_indices = Vec::with_capacity(event_digests.len());
+
+        for (i, digest) in event_digests.iter().enumerate() {
+            if let Some(events) = self.transaction_events.get(digest) {
+                results[i] = Some(events.clone());
+            } else {
+                fallback_digests.push(*digest);
+                fallback_indices.push(i);
+            }
+        }
+
+        let fallback_results = self.store.multi_get_events(&fallback_digests)?;
+        assert_eq!(fallback_results.len(), fallback_indices.len());
+        assert_eq!(fallback_results.len(), fallback_digests.len());
+        for (i, result) in fallback_indices
+            .into_iter()
+            .zip(fallback_results.into_iter())
+        {
+            results[i] = result;
+        }
+        Ok(results)
     }
 
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState> {
@@ -1028,6 +1054,7 @@ impl ExecutionCacheWrite for InMemoryCache {
             wrapped,
             locks_to_delete,
             new_locks_to_init,
+            events,
             ..
         } = &tx_outputs;
 
@@ -1089,6 +1116,9 @@ impl ExecutionCacheWrite for InMemoryCache {
 
         self.transaction_effects
             .insert(effects_digest, effects.clone());
+
+        self.transaction_events
+            .insert(events.digest(), events.clone());
 
         self.executed_effects_digests
             .insert(tx_digest, effects_digest);

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_notify_read::EffectsNotifyRead;
+use crate::authority::authority_store::SuiLockResult;
 use crate::authority::AuthorityStore;
 use crate::transaction_outputs::TransactionOutputs;
 use async_trait::async_trait;
@@ -208,6 +209,8 @@ pub trait ExecutionCacheRead: Send + Sync {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<Object>;
+
+    fn get_lock(&self, obj_ref: ObjectRef, epoch_id: EpochId) -> SuiLockResult;
 
     fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef>;
 
@@ -518,6 +521,10 @@ impl ExecutionCacheRead for PassthroughCache {
         version: SequenceNumber,
     ) -> Option<Object> {
         self.store.find_object_lt_or_eq_version(object_id, version)
+    }
+
+    fn get_lock(&self, obj_ref: ObjectRef, epoch_id: EpochId) -> SuiLockResult {
+        self.store.get_lock(obj_ref, epoch_id)
     }
 
     fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef> {

--- a/crates/sui-core/src/in_mem_execution_cache.rs
+++ b/crates/sui-core/src/in_mem_execution_cache.rs
@@ -249,6 +249,29 @@ pub trait ExecutionCacheRead: Send + Sync {
             })
     }
 
+    #[instrument(level = "trace", skip_all)]
+    fn get_transactions_and_serialized_sizes(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<(VerifiedTransaction, usize)>>> {
+        let txns = self.multi_get_transaction_blocks(digests)?;
+        txns.into_iter()
+            .map(|txn| {
+                txn.map(|txn| {
+                    // Note: if the transaction is read from the db, we are wasting some
+                    // effort relative to reading the raw bytes from the db instead of
+                    // calling serialized_size. However, transactions should usually be
+                    // fetched from cache.
+                    match txn.serialized_size() {
+                        Ok(size) => Ok(((*txn).clone(), size)),
+                        Err(e) => Err(e),
+                    }
+                })
+                .transpose()
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
     fn multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod consensus_validator;
 pub mod db_checkpoint_handler;
 pub mod epoch;
 mod execution_driver;
+pub mod in_mem_execution_cache;
 pub mod metrics;
 pub mod module_cache_metrics;
 pub mod mysticeti_adapter;
@@ -35,6 +36,7 @@ pub mod test_utils;
 mod transaction_input_loader;
 mod transaction_manager;
 pub mod transaction_orchestrator;
+mod transaction_outputs;
 pub mod verify_indexes;
 
 #[cfg(test)]

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -175,7 +175,11 @@ impl LocalAuthorityClient {
                 //let certificate = certificate.verify(epoch_store.committee())?;
                 state
                     .enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store)?;
-                let effects = state.notify_read_effects(&certificate).await?;
+                let effects = state
+                    .notify_read_effects(&[*certificate.digest()])
+                    .await?
+                    .pop()
+                    .unwrap();
                 state.sign_effects(effects, &epoch_store)?
             }
         }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -175,11 +175,7 @@ impl LocalAuthorityClient {
                 //let certificate = certificate.verify(epoch_store.committee())?;
                 state
                     .enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store)?;
-                let effects = state
-                    .notify_read_effects(&[*certificate.digest()])
-                    .await?
-                    .pop()
-                    .unwrap();
+                let effects = state.notify_read_effects(&certificate).await?;
                 state.sign_effects(effects, &epoch_store)?
             }
         }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -45,11 +45,10 @@ use sui_types::{
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-use crate::authority::{
-    test_authority_builder::TestAuthorityBuilder, AuthorityState, EffectsNotifyRead,
-};
+use crate::authority::{test_authority_builder::TestAuthorityBuilder, AuthorityState};
 use crate::authority_aggregator::{AuthorityAggregator, TimeoutConfig};
 use crate::epoch::committee_store::CommitteeStore;
+use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::state_accumulator::StateAccumulator;
 use crate::test_authority_clients::LocalAuthorityClient;
 
@@ -125,7 +124,9 @@ where
 pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) {
     match timeout(
         WAIT_FOR_TX_TIMEOUT,
-        state.database.notify_read_executed_effects(vec![digest]),
+        state
+            .get_cache_reader()
+            .notify_read_executed_effects(&[digest]),
     )
     .await
     {
@@ -140,7 +141,9 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
 pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<AuthorityState>) {
     match timeout(
         WAIT_FOR_TX_TIMEOUT,
-        state.database.notify_read_executed_effects(digests.clone()),
+        state
+            .get_cache_reader()
+            .notify_read_executed_effects(&digests),
     )
     .await
     {

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -48,7 +48,6 @@ use tracing::{info, warn};
 use crate::authority::{test_authority_builder::TestAuthorityBuilder, AuthorityState};
 use crate::authority_aggregator::{AuthorityAggregator, TimeoutConfig};
 use crate::epoch::committee_store::CommitteeStore;
-use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::state_accumulator::StateAccumulator;
 use crate::test_authority_clients::LocalAuthorityClient;
 

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -84,7 +84,9 @@ impl TransactionInputLoader {
             }
         }
 
-        let objects = self.cache.multi_get_object_by_objref(&object_refs)?;
+        let objects = self
+            .cache
+            .multi_get_object_with_more_accurate_error_return(&object_refs)?;
         assert_eq!(objects.len(), object_refs.len());
         for (index, object) in fetch_indices.into_iter().zip(objects.into_iter()) {
             input_results[index] = Some(ObjectReadResult {

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -28,7 +28,7 @@ use tracing::{error, info, instrument, trace, warn};
 
 use crate::authority::AuthorityMetrics;
 use crate::{
-    authority::authority_per_epoch_store::AuthorityPerEpochStore, authority::AuthorityState,
+    authority::authority_per_epoch_store::AuthorityPerEpochStore,
     in_mem_execution_cache::ExecutionCacheRead,
 };
 use sui_types::transaction::SenderSignedData;
@@ -443,11 +443,8 @@ impl TransactionManager {
                     .value
                     .input_objects()
                     .expect("input_objects() cannot fail");
-                let mut input_object_keys = AuthorityState::get_input_object_keys(
-                    &digest,
-                    &input_object_kinds,
-                    epoch_store,
-                );
+                let mut input_object_keys =
+                    epoch_store.get_input_object_keys(&digest, &input_object_kinds);
 
                 if input_object_kinds.len() != input_object_keys.len() {
                     error!("Duplicated input objects: {:?}", input_object_kinds);

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -7,9 +7,10 @@ Transaction Orchestrator is a Node component that utilizes Quorum Driver to
 submit transactions to validators for finality, and proactively executes
 finalized transactions locally, when possible.
 */
-use crate::authority::{AuthorityState, EffectsNotifyRead};
+use crate::authority::AuthorityState;
 use crate::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
+use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::quorum_driver::reconfig_observer::{OnsiteReconfigObserver, ReconfigObserver};
 use crate::quorum_driver::{QuorumDriverHandler, QuorumDriverHandlerBuilder, QuorumDriverMetrics};
 use crate::safe_client::SafeClientMetricsBase;
@@ -280,13 +281,14 @@ where
         // So we also subscribe to that. If we hear from `effects_await` first, it means
         // the ticket misses the previous notification, and we want to ask quorum driver
         // to form a certificate for us again, to serve this request.
-        let effects_await = self
-            .validator_state
-            .database
-            .notify_read_executed_effects(vec![tx_digest]);
+        let cache_reader = self.validator_state.get_cache_reader().clone();
         let qd = self.clone_quorum_driver();
         Ok(async move {
-            match select(ticket, effects_await.boxed()).await {
+            let digests = [tx_digest];
+            let effects_await = cache_reader.notify_read_executed_effects(&digests);
+            // let-and-return necessary to satisfy borrow checker.
+            #[allow(clippy::let_and_return)]
+            let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),
                 Either::Right((_, unfinished_quorum_driver_task)) => {
                     debug!(
@@ -296,7 +298,8 @@ where
                     qd.submit_transaction_no_ticket(transaction.into()).await?;
                     Ok(unfinished_quorum_driver_task.await)
                 }
-            }
+            };
+            res
         })
     }
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -10,7 +10,6 @@ finalized transactions locally, when possible.
 use crate::authority::AuthorityState;
 use crate::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
-use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::quorum_driver::reconfig_observer::{OnsiteReconfigObserver, ReconfigObserver};
 use crate::quorum_driver::{QuorumDriverHandler, QuorumDriverHandlerBuilder, QuorumDriverMetrics};
 use crate::safe_client::SafeClientMetricsBase;

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use sui_types::base_types::ObjectRef;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
+use sui_types::inner_temporary_store::{InnerTemporaryStore, WrittenObjects};
+use sui_types::storage::{MarkerValue, ObjectKey};
+use sui_types::transaction::{TransactionDataAPI, VerifiedTransaction};
+
+/// TransactionOutputs
+pub struct TransactionOutputs {
+    pub transaction: Arc<VerifiedTransaction>,
+    pub effects: TransactionEffects,
+    pub events: TransactionEvents,
+
+    pub markers: Vec<(ObjectKey, MarkerValue)>,
+    pub wrapped: Vec<ObjectKey>,
+    pub deleted: Vec<ObjectKey>,
+    pub locks_to_delete: Vec<ObjectRef>,
+    pub new_locks_to_init: Vec<ObjectRef>,
+    pub written: WrittenObjects,
+}
+
+impl TransactionOutputs {
+    // Convert InnerTemporaryStore + Effects into the exact set of updates to the store
+    pub fn build_transaction_outputs(
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        inner_temporary_store: InnerTemporaryStore,
+    ) -> TransactionOutputs {
+        let InnerTemporaryStore {
+            input_objects,
+            mutable_inputs,
+            written,
+            events,
+            max_binary_format_version: _,
+            loaded_runtime_objects: _,
+            no_extraneous_module_bytes: _,
+            runtime_packages_loaded_from_db: _,
+            lamport_version,
+        } = inner_temporary_store;
+
+        let tx_digest = *transaction.digest();
+
+        let deleted: HashMap<_, _> = effects.all_tombstones().into_iter().collect();
+
+        // Get the actual set of objects that have been received -- any received
+        // object will show up in the modified-at set.
+        let modified_at: HashSet<_> = effects.modified_at_versions().into_iter().collect();
+        let possible_to_receive = transaction.transaction_data().receiving_objects();
+        let received_objects = possible_to_receive
+            .iter()
+            .cloned()
+            .filter(|obj_ref| modified_at.contains(&(obj_ref.0, obj_ref.1)));
+
+        // We record any received or deleted objects since they could be pruned, and smear shared
+        // object deletions in the marker table. For deleted entries in the marker table we need to
+        // make sure we don't accidentally overwrite entries.
+        let markers: Vec<_> = {
+            let received = received_objects
+                .clone()
+                .map(|objref| (ObjectKey::from(objref), MarkerValue::Received));
+
+            let deleted = deleted.into_iter().map(|(object_id, version)| {
+                let object_key = ObjectKey(object_id, version);
+                if input_objects
+                    .get(&object_id)
+                    .is_some_and(|object| object.is_shared())
+                {
+                    (object_key, MarkerValue::SharedDeleted(tx_digest))
+                } else {
+                    (object_key, MarkerValue::OwnedDeleted)
+                }
+            });
+
+            // We "smear" shared deleted objects in the marker table to allow for proper sequencing
+            // of transactions that are submitted after the deletion of the shared object.
+            // NB: that we do _not_ smear shared objects that were taken immutably in the
+            // transaction.
+            let smeared_objects = effects.deleted_mutably_accessed_shared_objects();
+            let shared_smears = smeared_objects.into_iter().map(move |object_id| {
+                (
+                    ObjectKey(object_id, lamport_version),
+                    MarkerValue::SharedDeleted(tx_digest),
+                )
+            });
+
+            received.chain(deleted).chain(shared_smears).collect()
+        };
+
+        let locks_to_delete: Vec<_> = mutable_inputs
+            .into_iter()
+            .filter_map(|(id, ((version, digest), owner))| {
+                owner.is_address_owned().then_some((id, version, digest))
+            })
+            .chain(received_objects)
+            .collect();
+
+        let new_locks_to_init: Vec<_> = written
+            .values()
+            .filter_map(|new_object| {
+                if new_object.is_address_owned() {
+                    Some(new_object.compute_object_reference())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let deleted = effects
+            .deleted()
+            .into_iter()
+            .chain(effects.unwrapped_then_deleted())
+            .map(ObjectKey::from)
+            .collect();
+
+        let wrapped = effects.wrapped().into_iter().map(ObjectKey::from).collect();
+
+        TransactionOutputs {
+            transaction: Arc::new(transaction),
+            effects,
+            events,
+            markers,
+            wrapped,
+            deleted,
+            locks_to_delete,
+            new_locks_to_init,
+            written,
+        }
+    }
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4753,7 +4753,12 @@ async fn test_shared_object_transaction_ok() {
     authority.try_execute_for_test(&certificate).await.unwrap();
 
     // Ensure transaction effects are available.
-    authority.notify_read_effects(&certificate).await.unwrap();
+    authority
+        .notify_read_effects(&[*certificate.digest()])
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
 
     // Ensure shared object sequence number increased.
     let shared_object_version = authority
@@ -4853,7 +4858,7 @@ async fn test_consensus_message_processed() {
                 .acquire_shared_locks_from_effects(
                     &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
                     &effects1,
-                    authority2.db(),
+                    authority2.get_cache_reader().as_ref(),
                 )
                 .await
                 .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -42,6 +42,7 @@ use sui_types::messages_consensus::{ConsensusCommitPrologue, ConsensusCommitProl
 use sui_types::object::Data;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::randomness_state::get_randomness_state_obj_initial_shared_version;
+use sui_types::storage::GetSharedLocks;
 use sui_types::sui_system_state::SuiSystemStateWrapper;
 use sui_types::utils::{
     to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4754,12 +4754,7 @@ async fn test_shared_object_transaction_ok() {
     authority.try_execute_for_test(&certificate).await.unwrap();
 
     // Ensure transaction effects are available.
-    authority
-        .notify_read_effects(&[*certificate.digest()])
-        .await
-        .unwrap()
-        .pop()
-        .unwrap();
+    authority.notify_read_effects(&certificate).await.unwrap();
 
     // Ensure shared object sequence number increased.
     let shared_object_version = authority

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -127,7 +127,7 @@ async fn submit_transaction_to_consensus_adapter() {
                 .process_consensus_transactions_for_tests(
                     vec![SequencedConsensusTransaction::new_test(transaction.clone())],
                     &Arc::new(CheckpointServiceNoop {}),
-                    self.0.db(),
+                    self.0.get_cache_reader().as_ref(),
                     &self.0.metrics.skipped_consensus_txns,
                 )
                 .await?;

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -6,7 +6,6 @@ use crate::authority::AuthorityState;
 use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
 };
-use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::safe_client::SafeClient;
 use crate::test_authority_clients::LocalAuthorityClient;
 use crate::test_utils::{

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -252,8 +252,8 @@ pub async fn do_cert_with_shared_objects(
 ) -> TransactionEffects {
     send_consensus(authority, cert).await;
     authority
-        .get_cache_reader()
-        .notify_read_executed_effects(&[*cert.digest()])
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![*cert.digest()])
         .await
         .unwrap()
         .pop()
@@ -429,14 +429,14 @@ async fn test_execution_with_dependencies() {
     }
 
     // All certs should get executed eventually.
-    let digests: Vec<_> = executed_shared_certs
+    let digests = executed_shared_certs
         .iter()
         .chain(executed_owned_certs.iter())
         .map(|cert| *cert.digest())
         .collect();
     authorities[3]
-        .get_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .get_effects_notify_read()
+        .notify_read_executed_effects(digests)
         .await
         .unwrap();
 }
@@ -493,8 +493,8 @@ async fn test_per_object_overload() {
     }
     for authority in authorities.iter().take(3) {
         authority
-            .get_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .get_effects_notify_read()
+            .notify_read_executed_effects(vec![*create_counter_cert.digest()])
             .await
             .unwrap()
             .pop()
@@ -508,8 +508,8 @@ async fn test_per_object_overload() {
         .unwrap();
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
-        .get_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![*create_counter_cert.digest()])
         .await
         .unwrap()
         .pop()
@@ -618,8 +618,8 @@ async fn test_txn_age_overload() {
     }
     for authority in authorities.iter().take(3) {
         authority
-            .get_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .get_effects_notify_read()
+            .notify_read_executed_effects(vec![*create_counter_cert.digest()])
             .await
             .unwrap()
             .pop()
@@ -633,8 +633,8 @@ async fn test_txn_age_overload() {
         .unwrap();
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
-        .get_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![*create_counter_cert.digest()])
         .await
         .unwrap()
         .pop()

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -264,7 +264,7 @@ async fn test_upgrade_package_happy_path() {
 
     let package = runner
         .authority_state
-        .database
+        .get_cache_reader()
         .get_package_object(&runner.package.0)
         .unwrap()
         .unwrap();
@@ -838,7 +838,7 @@ async fn test_publish_override_happy_path() {
 
     let package = runner
         .authority_state
-        .database
+        .get_cache_reader()
         .get_package_object(&new_package.0)
         .unwrap()
         .unwrap();
@@ -891,7 +891,7 @@ async fn test_publish_transitive_happy_path() {
 
     let root_move_package = runner
         .authority_state
-        .database
+        .get_cache_reader()
         .get_package_object(&root_package.0)
         .unwrap()
         .unwrap();
@@ -982,7 +982,7 @@ async fn test_publish_transitive_override_happy_path() {
 
     let root_move_package = runner
         .authority_state
-        .database
+        .get_cache_reader()
         .get_package_object(&root_package.0)
         .unwrap()
         .unwrap();

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -10,7 +10,7 @@ use sui_types::{
     move_package::UpgradePolicy,
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    storage::{BackingPackageStore, ObjectStore},
+    storage::ObjectStore,
     transaction::{Argument, ObjectArg, ProgrammableTransaction, TEST_ONLY_GAS_UNIT_FOR_PUBLISH},
     MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID,
 };

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -78,7 +78,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),
-        Box::new(state.db()),
+        Box::new(state.get_cache_reader().clone().as_notify_read_wrapper()),
         Arc::new(accumulator),
         Box::new(output),
         Box::new(certified_output),

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -78,7 +78,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),
-        Box::new(state.get_cache_reader().clone().as_notify_read_wrapper()),
+        state.get_effects_notify_read(),
         Arc::new(accumulator),
         Box::new(output),
         Box::new(certified_output),

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -25,6 +25,7 @@ use crate::{
         test_authority_builder::TestAuthorityBuilder,
         AuthorityState,
     },
+    in_mem_execution_cache::ExecutionCacheRead,
     move_call,
 };
 use move_core_types::ident_str;
@@ -560,7 +561,7 @@ impl TestRunner {
         epoch: EpochId,
     ) -> Option<TransactionDigest> {
         self.authority_state
-            .database
+            .get_cache_reader()
             .get_deleted_shared_object_previous_tx_digest(object_id, version, epoch)
             .unwrap()
     }

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -25,7 +25,6 @@ use crate::{
         test_authority_builder::TestAuthorityBuilder,
         AuthorityState,
     },
-    in_mem_execution_cache::ExecutionCacheRead,
     move_call,
 };
 use move_core_types::ident_str;

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -33,7 +33,7 @@ fn make_transaction_manager(
     // transaction_manager output from rx_ready_certificates.
     let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
     let transaction_manager = TransactionManager::new(
-        state.database.clone(),
+        state.get_cache_reader().clone(),
         &state.epoch_store_for_testing(),
         tx_ready_certificates,
         state.metrics.clone(),

--- a/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
@@ -160,7 +160,7 @@ impl StressTestRunner {
         let epoch_store = state.load_epoch_store_one_call_per_task();
         let mut layout_resolver = epoch_store
             .executor()
-            .type_layout_resolver(Box::new(state.database.as_ref()));
+            .type_layout_resolver(Box::new(state.get_cache_reader().as_ref()));
         for (obj_ref, _) in effects.created() {
             let object_opt = state
                 .database
@@ -322,12 +322,12 @@ mod add_stake {
                 .get_created_object_of_type_name(effects, "StakedSui")
                 .await
                 .unwrap();
-            let store = runner.db();
             let state = runner.state();
+            let cache = state.get_cache_reader();
             let epoch_store = state.load_epoch_store_one_call_per_task();
             let mut layout_resolver = epoch_store
                 .executor()
-                .type_layout_resolver(Box::new(store.as_ref()));
+                .type_layout_resolver(Box::new(cache.as_ref()));
             let staked_amount =
                 object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             assert_eq!(staked_amount, self.stake_amount);

--- a/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/sui-e2e-tests/tests/dynamic_committee_tests.rs
@@ -158,9 +158,10 @@ impl StressTestRunner {
         let state = self.state();
 
         let epoch_store = state.load_epoch_store_one_call_per_task();
+        let backing_package_store = state.get_backing_package_store();
         let mut layout_resolver = epoch_store
             .executor()
-            .type_layout_resolver(Box::new(state.get_cache_reader().as_ref()));
+            .type_layout_resolver(Box::new(backing_package_store.as_ref()));
         for (obj_ref, _) in effects.created() {
             let object_opt = state
                 .database
@@ -323,7 +324,7 @@ mod add_stake {
                 .await
                 .unwrap();
             let state = runner.state();
-            let cache = state.get_cache_reader();
+            let cache = state.get_backing_package_store();
             let epoch_store = state.load_epoch_store_one_call_per_task();
             let mut layout_resolver = epoch_store
                 .executor()

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -12,7 +12,6 @@ use serde_json::json;
 use std::sync::Arc;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_config::node::RunWithRange;
-use sui_core::authority::EffectsNotifyRead;
 use sui_json_rpc_types::{
     type_and_fields_from_move_struct, EventPage, SuiEvent, SuiExecutionStatus,
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
@@ -72,8 +71,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
 
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
+        .notify_read_effects(&[digest])
         .await
         .unwrap();
 
@@ -118,8 +116,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
     handle
         .sui_node
         .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
+        .notify_read_effects(&[digest])
         .await
         .unwrap();
 
@@ -511,8 +508,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
 
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
+        .notify_read_effects(&[digest])
         .await
         .unwrap();
 
@@ -613,18 +609,19 @@ async fn test_full_node_sync_flood() -> Result<(), anyhow::Error> {
     }
 
     // make sure the node syncs up to the last digest sent by each task.
-    let digests = future::join_all(futures)
+    let digests: Vec<_> = future::join_all(futures)
         .await
         .iter()
         .map(|r| r.clone().unwrap())
         .flat_map(|(a, b)| std::iter::once(a).chain(std::iter::once(b)))
         .collect();
-    fullnode
-        .state()
-        .db()
-        .notify_read_executed_effects(digests)
-        .await
-        .unwrap();
+    for digest in digests.into_iter() {
+        fullnode
+            .state()
+            .notify_read_effects(&[digest])
+            .await
+            .unwrap();
+    }
 
     Ok(())
 }
@@ -658,11 +655,7 @@ async fn test_full_node_sub_and_query_move_event_ok() -> Result<(), anyhow::Erro
         .unwrap();
 
     let (sender, object_id, digest) = create_devnet_nft(context, package_id).await;
-    node.state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
-        .await
-        .unwrap();
+    node.state().notify_read_effects(&[digest]).await.unwrap();
 
     // Wait for streaming
     let bcs = match timeout(Duration::from_secs(5), sub.next()).await {
@@ -900,8 +893,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert!(!is_executed_locally);
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
+        .notify_read_effects(&[digest])
         .await
         .unwrap();
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
@@ -1199,11 +1191,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
         .await
         .sui_node;
 
-    node.state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
-        .await
-        .unwrap();
+    node.state().notify_read_effects(&[digest]).await.unwrap();
 
     loop {
         // Ensure this full node is able to transition to the next epoch
@@ -1220,8 +1208,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
     let (_transferred_object, _, _, digest_after_restore, ..) =
         transfer_coin(&test_cluster.wallet).await?;
     node.state()
-        .db()
-        .notify_read_executed_effects(vec![digest_after_restore])
+        .notify_read_effects(&[digest_after_restore])
         .await
         .unwrap();
     Ok(())

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -7,7 +7,6 @@ use rand::distributions::Distribution;
 use std::ops::Deref;
 use std::time::{Duration, SystemTime};
 use sui_config::node::OverloadThresholdConfig;
-use sui_core::authority::EffectsNotifyRead;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_macros::{register_fail_point_async, sim_test};
@@ -133,8 +132,7 @@ async fn shared_object_deletion_multiple_times() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(digests)
+        .notify_read_effects(&digests)
         .await
         .unwrap();
 }
@@ -189,8 +187,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(digests)
+        .notify_read_effects(&digests)
         .await
         .unwrap();
 }
@@ -302,8 +299,7 @@ async fn shared_object_deletion_multi_certs() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .db()
-        .notify_read_executed_effects(vec![inc_tx_a_digest, inc_tx_b_digest])
+        .notify_read_effects(&[inc_tx_a_digest, inc_tx_b_digest])
         .await
         .unwrap();
 }

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -132,7 +132,8 @@ async fn shared_object_deletion_multiple_times() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .notify_read_effects(&digests)
+        .get_effects_notify_read()
+        .notify_read_executed_effects(digests)
         .await
         .unwrap();
 }
@@ -187,7 +188,8 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .notify_read_effects(&digests)
+        .get_effects_notify_read()
+        .notify_read_executed_effects(digests)
         .await
         .unwrap();
 }
@@ -299,7 +301,8 @@ async fn shared_object_deletion_multi_certs() {
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
     fullnode
         .state()
-        .notify_read_effects(&[inc_tx_a_digest, inc_tx_b_digest])
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![inc_tx_a_digest, inc_tx_b_digest])
         .await
         .unwrap();
 }

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -11,7 +11,6 @@ use rand::{
     Rng,
 };
 use std::collections::{HashMap, HashSet};
-use sui_core::authority::EffectsNotifyRead;
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use tokio::time::{sleep, Duration, Instant};
@@ -147,8 +146,7 @@ async fn test_net_determinism() {
     handle
         .sui_node
         .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
+        .notify_read_effects(&[digest])
         .await
         .unwrap();
 }

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -146,7 +146,8 @@ async fn test_net_determinism() {
     handle
         .sui_node
         .state()
-        .notify_read_effects(&[digest])
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![digest])
         .await
         .unwrap();
 }

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -4,7 +4,6 @@
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_core::authority::EffectsNotifyRead;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
@@ -59,12 +58,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
         .await?;
 
     // Wait for data sync to catch up
-    handle
-        .state()
-        .db()
-        .notify_read_executed_effects(vec![digest])
-        .await
-        .unwrap();
+    handle.state().notify_read_effects(&[digest]).await.unwrap();
 
     // Transaction Orchestrator proactivcely executes txn locally
     let txn = txns.swap_remove(0);

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -58,7 +58,12 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
         .await?;
 
     // Wait for data sync to catch up
-    handle.state().notify_read_effects(&[digest]).await.unwrap();
+    handle
+        .state()
+        .get_effects_notify_read()
+        .notify_read_executed_effects(vec![digest])
+        .await
+        .unwrap();
 
     // Transaction Orchestrator proactivcely executes txn locally
     let txn = txns.swap_remove(0);

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::AuthorityState;
-use sui_core::in_mem_execution_cache::{ExecutionCacheRead, InMemoryCache};
+use sui_core::in_mem_execution_cache::{ExecutionCache, ExecutionCacheRead};
 use sui_core::subscription_handler::SubscriptionHandler;
 use sui_json_rpc_types::{
     Coin as SuiCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
@@ -88,7 +88,7 @@ pub trait StateRead: Send + Sync {
         limit: usize,
     ) -> StateReadResult<Vec<(ObjectID, DynamicFieldInfo)>>;
 
-    fn get_cache_reader(&self) -> Arc<InMemoryCache>;
+    fn get_cache_reader(&self) -> Arc<ExecutionCache>;
 
     fn get_owner_objects(
         &self,
@@ -303,7 +303,7 @@ impl StateRead for AuthorityState {
         Ok(self.get_dynamic_fields(owner, cursor, limit)?)
     }
 
-    fn get_cache_reader(&self) -> Arc<InMemoryCache> {
+    fn get_cache_reader(&self) -> Arc<ExecutionCache> {
         self.get_cache_reader().clone()
     }
 

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -9,7 +9,8 @@ use mysten_metrics::spawn_monitored_task;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use sui_core::authority::{AuthorityState, AuthorityStore};
+use sui_core::authority::AuthorityState;
+use sui_core::in_mem_execution_cache::{ExecutionCacheRead, InMemoryCache};
 use sui_core::subscription_handler::SubscriptionHandler;
 use sui_json_rpc_types::{
     Coin as SuiCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
@@ -87,7 +88,7 @@ pub trait StateRead: Send + Sync {
         limit: usize,
     ) -> StateReadResult<Vec<(ObjectID, DynamicFieldInfo)>>;
 
-    fn get_db(&self) -> Arc<AuthorityStore>;
+    fn get_cache_reader(&self) -> Arc<InMemoryCache>;
 
     fn get_owner_objects(
         &self,
@@ -302,8 +303,8 @@ impl StateRead for AuthorityState {
         Ok(self.get_dynamic_fields(owner, cursor, limit)?)
     }
 
-    fn get_db(&self) -> Arc<AuthorityStore> {
-        self.db()
+    fn get_cache_reader(&self) -> Arc<InMemoryCache> {
+        self.get_cache_reader().clone()
     }
 
     fn get_owner_objects(
@@ -575,10 +576,10 @@ impl<S: ?Sized + StateRead> ObjectProvider for Arc<S> {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Option<Object>, Self::Error> {
-        let database = self.get_db();
+        let cache = self.get_cache_reader();
         let id = *id;
         let version = *version;
-        spawn_monitored_task!(async move { database.find_object_lt_or_eq_version(id, version) })
+        spawn_monitored_task!(async move { cache.find_object_lt_or_eq_version(id, version) })
             .await
             .map_err(StateReadError::from)
     }
@@ -610,10 +611,10 @@ impl<S: ?Sized + StateRead> ObjectProvider for (Arc<S>, Arc<TransactionKeyValueS
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Option<Object>, Self::Error> {
-        let database = self.0.get_db();
+        let cache = self.0.get_cache_reader();
         let id = *id;
         let version = *version;
-        spawn_monitored_task!(async move { database.find_object_lt_or_eq_version(id, version) })
+        spawn_monitored_task!(async move { cache.find_object_lt_or_eq_version(id, version) })
             .await
             .map_err(StateReadError::from)
     }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -395,7 +395,7 @@ async fn exchange_rates(
                 error: e.to_string(),
             })?;
         let validator = get_validator_from_table(
-            state.get_db().as_ref(),
+            state.get_cache_reader().as_ref(),
             system_state_summary.inactive_pools_id,
             &pool_id,
         )?; // TODO(wlmyng): roll this into StateReadError
@@ -422,7 +422,7 @@ async fn exchange_rates(
                 })?;
 
                 let exchange_rate: PoolTokenExchangeRate = get_dynamic_field_from_store(
-                    state.get_db().as_ref(),
+                    &state.get_cache_reader().as_ref(),
                     exchange_rates_id,
                     &epoch,
                 )?;

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -395,7 +395,7 @@ async fn exchange_rates(
                 error: e.to_string(),
             })?;
         let validator = get_validator_from_table(
-            state.get_cache_reader().as_ref(),
+            state.get_object_store().as_ref(),
             system_state_summary.inactive_pools_id,
             &pool_id,
         )?; // TODO(wlmyng): roll this into StateReadError
@@ -422,7 +422,7 @@ async fn exchange_rates(
                 })?;
 
                 let exchange_rate: PoolTokenExchangeRate = get_dynamic_field_from_store(
-                    &state.get_cache_reader().as_ref(),
+                    &state.get_object_store().as_ref(),
                     exchange_rates_id,
                     &epoch,
                 )?;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -887,7 +887,7 @@ impl ReadApiServer for ReadApi {
                 .into_iter()
                 .enumerate()
                 .map(|(seq, e)| {
-                    let layout = store.executor().type_layout_resolver(Box::new(state.get_db())).get_annotated_layout(&e.type_)?;
+                    let layout = store.executor().type_layout_resolver(Box::new(&state.get_cache_reader().as_ref())).get_annotated_layout(&e.type_)?;
                     SuiEvent::try_from(
                         e,
                         *effect.transaction_digest(),
@@ -1072,7 +1072,7 @@ fn to_sui_transaction_events(
     let epoch_store = fullnode_api.state.load_epoch_store_one_call_per_task();
     let mut layout_resolver = epoch_store
         .executor()
-        .type_layout_resolver(Box::new(fullnode_api.state.get_db()));
+        .type_layout_resolver(Box::new(fullnode_api.state.get_cache_reader()));
     Ok(SuiTransactionBlockEvents::try_from(
         events,
         tx_digest,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -887,7 +887,7 @@ impl ReadApiServer for ReadApi {
                 .into_iter()
                 .enumerate()
                 .map(|(seq, e)| {
-                    let layout = store.executor().type_layout_resolver(Box::new(&state.get_cache_reader().as_ref())).get_annotated_layout(&e.type_)?;
+                    let layout = store.executor().type_layout_resolver(Box::new(&state.get_backing_package_store().as_ref())).get_annotated_layout(&e.type_)?;
                     SuiEvent::try_from(
                         e,
                         *effect.transaction_digest(),
@@ -1070,9 +1070,10 @@ fn to_sui_transaction_events(
     events: TransactionEvents,
 ) -> Result<SuiTransactionBlockEvents, Error> {
     let epoch_store = fullnode_api.state.load_epoch_store_one_call_per_task();
+    let backing_package_store = fullnode_api.state.get_backing_package_store();
     let mut layout_resolver = epoch_store
         .executor()
-        .type_layout_resolver(Box::new(fullnode_api.state.get_cache_reader()));
+        .type_layout_resolver(Box::new(backing_package_store.as_ref()));
     Ok(SuiTransactionBlockEvents::try_from(
         events,
         tx_digest,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -160,7 +160,7 @@ impl TransactionExecutionApi {
             let epoch_store = self.state.load_epoch_store_one_call_per_task();
             let mut layout_resolver = epoch_store
                 .executor()
-                .type_layout_resolver(Box::new(self.state.get_db()));
+                .type_layout_resolver(Box::new(self.state.get_cache_reader()));
             events = Some(SuiTransactionBlockEvents::try_from(
                 transaction_events,
                 digest,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -158,9 +158,10 @@ impl TransactionExecutionApi {
         let mut events: Option<SuiTransactionBlockEvents> = None;
         if opts.show_events {
             let epoch_store = self.state.load_epoch_store_one_call_per_task();
+            let backing_package_store = self.state.get_backing_package_store();
             let mut layout_resolver = epoch_store
                 .executor()
-                .type_layout_resolver(Box::new(self.state.get_cache_reader()));
+                .type_layout_resolver(Box::new(backing_package_store.as_ref()));
             events = Some(SuiTransactionBlockEvents::try_from(
                 transaction_events,
                 digest,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -73,7 +73,7 @@ use sui_core::epoch::committee_store::CommitteeStore;
 use sui_core::epoch::data_removal::EpochDataRemover;
 use sui_core::epoch::epoch_metrics::EpochMetrics;
 use sui_core::epoch::reconfiguration::ReconfigurationInitiator;
-use sui_core::in_mem_execution_cache::InMemoryCache;
+use sui_core::in_mem_execution_cache::ExecutionCache;
 use sui_core::module_cache_metrics::ResolverMetrics;
 use sui_core::signature_verifier::SignatureVerifierMetrics;
 use sui_core::state_accumulator::StateAccumulator;
@@ -441,7 +441,7 @@ impl SuiNode {
             &prometheus_registry,
         )
         .await?;
-        let execution_cache = Arc::new(InMemoryCache::new(store.clone()));
+        let execution_cache = Arc::new(ExecutionCache::new(store.clone()));
 
         let cur_epoch = store.get_recovery_epoch_at_restart()?;
         let committee = committee_store

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -441,6 +441,8 @@ impl SuiNode {
             &prometheus_registry,
         )
         .await?;
+        let execution_cache = Arc::new(InMemoryCache::new(store.clone()));
+
         let cur_epoch = store.get_recovery_epoch_at_restart()?;
         let committee = committee_store
             .get_committee(&cur_epoch)?
@@ -459,7 +461,7 @@ impl SuiNode {
             Some(epoch_options.options),
             EpochMetrics::new(&registry_service.default_registry()),
             epoch_start_configuration,
-            store.clone(),
+            execution_cache.clone(),
             cache_metrics,
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
@@ -501,8 +503,6 @@ impl SuiNode {
             genesis.checkpoint_contents().clone(),
             &epoch_store,
         );
-
-        let execution_cache = Arc::new(InMemoryCache::new(store.clone()));
 
         let state_sync_store = RocksDbStore::new(
             store.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -441,7 +441,7 @@ impl SuiNode {
             &prometheus_registry,
         )
         .await?;
-        let execution_cache = Arc::new(ExecutionCache::new(store.clone()));
+        let execution_cache = Arc::new(ExecutionCache::new(store.clone(), &prometheus_registry));
 
         let cur_epoch = store.get_recovery_epoch_at_restart()?;
         let committee = committee_store

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1224,7 +1224,7 @@ impl SuiNode {
             state.clone(),
             checkpoint_store,
             epoch_store,
-            Box::new(state.get_cache_reader().clone().as_notify_read_wrapper()),
+            state.get_effects_notify_read(),
             accumulator,
             checkpoint_output,
             Box::new(certified_checkpoint_output),

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -2167,7 +2167,7 @@ async fn create_epoch_store(
         None,
         EpochMetrics::new(&registry),
         epoch_start_config,
-        authority_state.database.clone(),
+        authority_state.get_cache_reader().clone(),
         cache_metrics,
         signature_verifier_metrics,
         &ExpensiveSafetyCheckConfig::default(),

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -2167,7 +2167,7 @@ async fn create_epoch_store(
         None,
         EpochMetrics::new(&registry),
         epoch_start_config,
-        authority_state.get_cache_reader().clone(),
+        authority_state.get_execution_cache(),
         cache_metrics,
         signature_verifier_metrics,
         &ExpensiveSafetyCheckConfig::default(),

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -295,6 +295,7 @@ impl WalletContext {
         &self,
         tx: Transaction,
     ) -> SuiTransactionBlockResponse {
+        tracing::debug!("Executing transaction: {:?}", tx);
         let response = self.execute_transaction_may_fail(tx).await.unwrap();
         assert!(
             response.status_ok().unwrap(),

--- a/crates/sui-single-node-benchmark/src/mock_consensus.rs
+++ b/crates/sui-single-node-benchmark/src/mock_consensus.rs
@@ -69,7 +69,7 @@ impl MockConsensusClient {
                             .process_consensus_transactions_for_tests(
                                 mem::take(&mut transactions),
                                 &checkpoint_service,
-                                &validator.database,
+                                validator.get_cache_reader().as_ref(),
                                 &counter,
                             )
                             .await

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -285,8 +285,7 @@ impl SingleValidator {
         let checkpoint_executor = CheckpointExecutor::new_for_tests(
             ckpt_receiver,
             validator.get_checkpoint_store().clone(),
-            validator.db(),
-            validator.transaction_manager().clone(),
+            validator.clone(),
             Arc::new(StateAccumulator::new(validator.db())),
         );
         (checkpoint_executor, ckpt_sender)

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use std::{fs, io};
 use sui_config::{genesis::Genesis, NodeConfig};
 use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
-use sui_core::in_mem_execution_cache::InMemoryCache;
+use sui_core::in_mem_execution_cache::ExecutionCache;
 use sui_network::default_mysten_network_config;
 use sui_protocol_config::Chain;
 use sui_sdk::SuiClientBuilder;
@@ -662,7 +662,7 @@ fn start_summary_sync(
         .await?;
         let state_sync_store = RocksDbStore::new(
             store.clone(),
-            Arc::new(InMemoryCache::new(store)),
+            Arc::new(ExecutionCache::new(store)),
             committee_store,
             checkpoint_store.clone(),
         );
@@ -1240,7 +1240,7 @@ pub async fn state_sync_from_archive(
         .unwrap_or(0);
     let state_sync_store = RocksDbStore::new(
         store.clone(),
-        Arc::new(InMemoryCache::new(store)),
+        Arc::new(ExecutionCache::new(store)),
         committee_store,
         checkpoint_store.clone(),
     );

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -662,7 +662,7 @@ fn start_summary_sync(
         .await?;
         let state_sync_store = RocksDbStore::new(
             store.clone(),
-            Arc::new(ExecutionCache::new(store)),
+            Arc::new(ExecutionCache::new_with_no_metrics(store)),
             committee_store,
             checkpoint_store.clone(),
         );
@@ -1240,7 +1240,7 @@ pub async fn state_sync_from_archive(
         .unwrap_or(0);
     let state_sync_store = RocksDbStore::new(
         store.clone(),
-        Arc::new(ExecutionCache::new(store)),
+        Arc::new(ExecutionCache::new_with_no_metrics(store)),
         committee_store,
         checkpoint_store.clone(),
     );

--- a/crates/sui-types/src/storage/error.rs
+++ b/crates/sui-types/src/storage/error.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use typed_store_error::TypedStoreError;
+
 pub type Result<T, E = Error> = ::std::result::Result<T, E>;
 
 #[derive(Debug)]
@@ -60,5 +62,11 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO: change output based on kind?
         write!(f, "{:?}", self)
+    }
+}
+
+impl From<TypedStoreError> for Error {
+    fn from(e: TypedStoreError) -> Self {
+        Self::custom(e)
     }
 }

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -462,6 +462,12 @@ pub enum ObjectOrTombstone {
     Tombstone(ObjectRef),
 }
 
+impl From<Object> for ObjectOrTombstone {
+    fn from(object: Object) -> Self {
+        ObjectOrTombstone::Object(object)
+    }
+}
+
 /// Fetch the `ObjectKey`s (IDs and versions) for non-shared input objects.  Includes owned,
 /// and immutable objects as well as the gas objects, but not move packages or shared objects.
 pub fn transaction_input_object_keys(tx: &SenderSignedData) -> SuiResult<Vec<ObjectKey>> {

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -318,13 +318,12 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
 /// dynamic field as a Validator type. We need the version to determine which inner type to use for
 /// the Validator type. This is assuming that the validator is stored in the table as
 /// ValidatorWrapper type.
-pub fn get_validator_from_table<S, K>(
-    object_store: &S,
+pub fn get_validator_from_table<K>(
+    object_store: &dyn ObjectStore,
     table_id: ObjectID,
     key: &K,
 ) -> Result<SuiValidatorSummary, SuiError>
 where
-    S: ObjectStore,
     K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
 {
     let field: ValidatorWrapper = get_dynamic_field_from_store(object_store, table_id, key)

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2148,14 +2148,17 @@ impl SenderSignedData {
         SenderSignedDataDigest::new(hash.into())
     }
 
+    pub fn serialized_size(&self) -> SuiResult<usize> {
+        bcs::serialized_size(self).map_err(|e| SuiError::TransactionSerializationError {
+            error: e.to_string(),
+        })
+    }
+
     /// Perform cheap validity checks on the sender signed transaction, including its size,
     /// input count, command count, etc.
     pub fn validity_check(&self, config: &ProtocolConfig) -> SuiResult {
         // Enforce overall transaction size limit.
-        let tx_size =
-            bcs::serialized_size(self).map_err(|e| SuiError::TransactionSerializationError {
-                error: e.to_string(),
-            })?;
+        let tx_size = self.serialized_size()?;
         let max_tx_size_bytes = config.max_tx_size_bytes();
 
         fp_ensure!(

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -127,14 +127,14 @@ pub fn assert_accounts_match(
     executor: &Executor,
 ) -> Result<(), TestCaseError> {
     let state = executor.state.clone();
-    let store = state.db();
+    let cache = state.get_cache_reader();
     let epoch_store = state.load_epoch_store_one_call_per_task();
     let mut layout_resolver = epoch_store
         .executor()
-        .type_layout_resolver(Box::new(store.as_ref()));
+        .type_layout_resolver(Box::new(cache.as_ref()));
     for (idx, account) in universe.accounts().iter().enumerate() {
         for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
-            let object = store.get_object(&acc_object.id()).unwrap().unwrap();
+            let object = cache.get_object(&acc_object.id()).unwrap().unwrap();
             let total_sui_value =
                 object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             let account_balance_i = account.current_balances[balance_idx];

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -127,14 +127,15 @@ pub fn assert_accounts_match(
     executor: &Executor,
 ) -> Result<(), TestCaseError> {
     let state = executor.state.clone();
-    let cache = state.get_cache_reader();
+    let backing_package_store = state.get_backing_package_store();
+    let object_store = state.get_object_store();
     let epoch_store = state.load_epoch_store_one_call_per_task();
     let mut layout_resolver = epoch_store
         .executor()
-        .type_layout_resolver(Box::new(cache.as_ref()));
+        .type_layout_resolver(Box::new(backing_package_store.as_ref()));
     for (idx, account) in universe.accounts().iter().enumerate() {
         for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
-            let object = cache.get_object(&acc_object.id()).unwrap().unwrap();
+            let object = object_store.get_object(&acc_object.id()).unwrap().unwrap();
             let total_sui_value =
                 object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             let account_balance_i = account.current_balances[balance_idx];


### PR DESCRIPTION
This PR creates the execution cache traits (from #15768), but implements them only by delegating directly to AuthorityStore.

The intent is to put in most of the plumbing for caching, in a safely mergable state, without doing any of the dangerous work yet.
