### PR TITLE
Cut indexer files based on approx file size

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -41,7 +41,10 @@ pub struct AnalyticsProcessor<S: Serialize + ParquetSchema> {
     kill_sender: oneshot::Sender<()>,
     #[allow(dead_code)]
     max_checkpoint_sender: oneshot::Sender<()>,
+    num_checkpoint_iterations: u64,
 }
+
+const CHECK_FILE_SIZE_ITERATION_CYCLE: u64 = 50;
 
 #[async_trait::async_trait]
 impl<S: Serialize + ParquetSchema + 'static> Handler for AnalyticsProcessor<S> {
@@ -70,7 +73,10 @@ impl<S: Serialize + ParquetSchema + 'static> Handler for AnalyticsProcessor<S> {
         let num_checkpoints_processed =
             self.current_checkpoint_range.end - self.current_checkpoint_range.start;
         let cut_new_files = (num_checkpoints_processed >= self.config.checkpoint_interval)
-            || (self.last_commit_instant.elapsed().as_secs() > self.config.time_interval_s);
+            || (self.last_commit_instant.elapsed().as_secs() > self.config.time_interval_s)
+            || (self.num_checkpoint_iterations % CHECK_FILE_SIZE_ITERATION_CYCLE == 0
+                && self.writer.file_size()?.unwrap_or(0)
+                    > self.config.max_file_size_mb * 1024 * 1024);
         if cut_new_files {
             self.cut().await?;
             self.reset()?;
@@ -87,7 +93,7 @@ impl<S: Serialize + ParquetSchema + 'static> Handler for AnalyticsProcessor<S> {
             .end
             .checked_add(1)
             .context("Checkpoint sequence num overflow")?;
-
+        self.num_checkpoint_iterations += 1;
         Ok(())
     }
 }
@@ -141,6 +147,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
             max_checkpoint_sender,
             metrics,
             config,
+            num_checkpoint_iterations: 0,
         })
     }
 

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -83,6 +83,9 @@ pub struct AnalyticsIndexerConfig {
     /// Number of checkpoints to process before uploading to the datastore.
     #[clap(long, default_value = "10000", global = true)]
     pub checkpoint_interval: u64,
+    /// Maximum file size in mb before uploading to the datastore.
+    #[clap(long, default_value = "100", global = true)]
+    pub max_file_size_mb: u64,
     /// Checkpoint sequence number to start the download from
     #[clap(long, default_value = None, global = true)]
     pub starting_checkpoint_seq_num: Option<u64>,

--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -112,4 +112,10 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         )?;
         Ok(())
     }
+
+    fn file_size(&self) -> Result<Option<u64>> {
+        let file_path = self.file_path(self.epoch, self.checkpoint_range.clone())?;
+        let len = fs::metadata(file_path)?.len();
+        Ok(Some(len))
+    }
 }

--- a/crates/sui-analytics-indexer/src/writers/mod.rs
+++ b/crates/sui-analytics-indexer/src/writers/mod.rs
@@ -18,4 +18,6 @@ pub trait AnalyticsWriter<S: Serialize + ParquetSchema>: Send + Sync + 'static {
     fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool>;
     /// Reset internal state with given epoch and checkpoint sequence number
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()>;
+    /// Approx size in bytes of the current staging file if available
+    fn file_size(&self) -> Result<Option<u64>>;
 }

--- a/crates/sui-analytics-indexer/src/writers/parquet_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/parquet_writer.rs
@@ -128,4 +128,11 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for ParquetWriter {
         self.data = vec![];
         Ok(())
     }
+
+    fn file_size(&self) -> Result<Option<u64>> {
+        // parquet writer doesn't write records in a temp staging file
+        // and only flushes records after serializing and compressing them
+        // when flush is invoked
+        Ok(None)
+    }
 }


### PR DESCRIPTION
## Description 

This PR makes it possible to cut intermediate files generated in analytics indexer based on size. For certain data types like objects there is a high variation in record sizes i.e. object sizes could be from a few bytes to large number of kbytes. With the current approach of cutting files based on number of checkpoints processed, it could lead to very large or very small files sometimes depending on the settings. It'd be nice to be able to generate files of consistent size.
With this PR, we allow file writers to return intermediate file size which is used by analytics processor to decide when to cut. While this does not seem possible to do easily in parquet writer (since it doesn't serialize records to an intermediate file until flush is invoked), it is certainly possible to do in csv writers (and be leveraged for bq data stores)

## Test Plan 

Running locally and verifying file sizes
