### PR TITLE
Tracking transaction queueing latency after becoming ready for execution

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -509,7 +509,7 @@ impl AuthorityMetrics {
             )
             .unwrap(),
             execution_queueing_delay_s: register_histogram_with_registry!(
-                "execution_queueing_delay_ms",
+                "execution_queueing_delay_s",
                 "Queueing delay between a transaction is ready for execution until it starts executing.",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -266,6 +266,8 @@ pub struct AuthorityMetrics {
     /// Count of multisig signatures
     pub multisig_sig_count: IntCounter,
 
+    // Tracks recent average txn queueing delay between when it is ready for execution
+    // until it starts executing.
     pub execution_queueing_latency: LatencyObserver,
 }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -232,7 +232,7 @@ pub struct AuthorityMetrics {
 
     pub(crate) execution_driver_executed_transactions: IntCounter,
     pub(crate) execution_driver_dispatch_queue: IntGauge,
-    pub(crate) execution_queueing_delay_ms: IntGauge,
+    pub(crate) execution_queueing_delay_s: Histogram,
 
     pub(crate) skipped_consensus_txns: IntCounter,
     pub(crate) skipped_consensus_txns_cache_hit: IntCounter,
@@ -508,9 +508,10 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
-            execution_queueing_delay_ms: register_int_gauge_with_registry!(
+            execution_queueing_delay_s: register_histogram_with_registry!(
                 "execution_queueing_delay_ms",
-                "Average queueing delay between a transaction is ready for execution until it starts executing.",
+                "Queueing delay between a transaction is ready for execution until it starts executing.",
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -29,7 +29,7 @@ mod execution_driver_tests;
 // to be retried.
 pub const EXECUTION_MAX_ATTEMPTS: u32 = 10;
 const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
-const QUEUEING_DELAY_SAMPLING_RATIO: f64 = 0.1;
+const QUEUEING_DELAY_SAMPLING_RATIO: f64 = 0.05;
 
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -99,8 +99,8 @@ pub async fn execution_process(
             if let Some(latency) = authority.metrics.execution_queueing_latency.latency() {
                 authority
                     .metrics
-                    .execution_queueing_delay_ms
-                    .set(latency.as_millis() as i64);
+                    .execution_queueing_delay_s
+                    .observe(latency.as_secs_f64());
             }
         }
 

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -7,6 +7,10 @@ use std::{
 };
 
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use rand::{
+    rngs::{OsRng, StdRng},
+    Rng, SeedableRng,
+};
 use sui_macros::fail_point_async;
 use tokio::{
     sync::{mpsc::UnboundedReceiver, oneshot, Semaphore},
@@ -25,6 +29,7 @@ mod execution_driver_tests;
 // to be retried.
 pub const EXECUTION_MAX_ATTEMPTS: u32 = 10;
 const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const QUEUEING_DELAY_SAMPLING_RATIO: f64 = 0.1;
 
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.
@@ -37,6 +42,7 @@ pub async fn execution_process(
 
     // Rate limit concurrent executions to # of cpus.
     let limit = Arc::new(Semaphore::new(num_cpus::get()));
+    let mut rng = StdRng::from_rng(&mut OsRng).unwrap();
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
@@ -44,11 +50,13 @@ pub async fn execution_process(
 
         let certificate;
         let expected_effects_digest;
+        let txn_ready_time;
         tokio::select! {
             result = rx_ready_certificates.recv() => {
                 if let Some(pending_cert) = result {
                     certificate = pending_cert.certificate;
                     expected_effects_digest = pending_cert.expected_effects_digest;
+                    txn_ready_time = pending_cert.stats.ready_time.unwrap();
                 } else {
                     // Should only happen after the AuthorityState has shut down and tx_ready_certificate
                     // has been dropped by TransactionManager.
@@ -82,6 +90,19 @@ pub async fn execution_process(
         // hold semaphore permit until task completes. unwrap ok because we never close
         // the semaphore in this context.
         let permit = limit.acquire_owned().await.unwrap();
+
+        if rng.gen_range(0.0..1.0) < QUEUEING_DELAY_SAMPLING_RATIO {
+            authority
+                .metrics
+                .execution_queueing_latency
+                .report(txn_ready_time.elapsed());
+            if let Some(latency) = authority.metrics.execution_queueing_latency.latency() {
+                authority
+                    .metrics
+                    .execution_queueing_delay_ms
+                    .set(latency.as_millis() as i64);
+            }
+        }
 
         // Certificate execution can take significant time, so run it in a separate task.
         spawn_monitored_task!(async move {

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::default::Default;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
+use tokio::time::Duration;
 use tokio::time::Instant;
 
 /// Increment an IntGauge metric, and decrement it when the scope ends.
@@ -15,6 +21,49 @@ macro_rules! scoped_counter {
             metrics.$field.dec();
         })
     }};
+}
+
+pub struct LatencyObserver {
+    data: Mutex<LatencyObserverInner>,
+    latency_ms: AtomicU64,
+}
+
+#[derive(Default)]
+struct LatencyObserverInner {
+    points: VecDeque<Duration>,
+    sum: Duration,
+}
+
+impl LatencyObserver {
+    pub fn new() -> Self {
+        Self {
+            data: Mutex::new(LatencyObserverInner::default()),
+            latency_ms: AtomicU64::new(u64::MAX),
+        }
+    }
+
+    pub fn report(&self, latency: Duration) {
+        const MAX_SAMPLES: usize = 64;
+        let mut data = self.data.lock();
+        data.points.push_back(latency);
+        data.sum += latency;
+        if data.points.len() >= MAX_SAMPLES {
+            let pop = data.points.pop_front().expect("data vector is not empty");
+            data.sum -= pop; // This does not overflow because of how running sum is calculated
+        }
+        let latency = data.sum.as_millis() as u64 / data.points.len() as u64;
+        self.latency_ms.store(latency, Ordering::Relaxed);
+    }
+
+    pub fn latency(&self) -> Option<Duration> {
+        let latency = self.latency_ms.load(Ordering::Relaxed);
+        if latency == u64::MAX {
+            // Not initialized yet (0 data points)
+            None
+        } else {
+            Some(Duration::from_millis(latency))
+        }
+    }
 }
 
 /// RateTracker tracks events in a rolling window, and calculates the rate of events.

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -65,6 +65,12 @@ impl LatencyObserver {
     }
 }
 
+impl Default for LatencyObserver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// RateTracker tracks events in a rolling window, and calculates the rate of events.
 /// Internally, the tracker divides the tracking window into multiple BIN_DURATION,
 /// and counts events in each BIN_DURATION in a fixed sized buffer.

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -6,7 +6,6 @@ use std::collections::VecDeque;
 use std::default::Default;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 use tokio::time::Duration;
 use tokio::time::Instant;
 


### PR DESCRIPTION
## Description 

Trying to reuse the existing `LatencyObserver` to track the queueing delay. It computes the average queueing latency of the last 64 samples. To not add too much overhead (since the observer also takes a lock when updating the metrics), I added sampling to track queueing delay (currently set to 5%, which means 1 sample per 2 second if we have 10 qps, or 250 samples per second if we have 5000 qps).

Also added metrics for exposing the queueing delay.

## Test Plan 

Cluster testing to test metrics reporting correct value.

<img width="850" alt="Screenshot 2024-01-25 at 11 34 53 PM" src="https://github.com/MystenLabs/sui/assets/9200652/53b00905-d218-4c80-82cd-e526dc331b24">

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
