### PR TITLE
Make test cluster wait for epoch more robust

### DIFF
--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -393,7 +393,15 @@ impl TestCluster {
                     loop {
                         let epoch = node.state().epoch_store_for_testing().epoch();
                         if epoch == target_epoch {
-                            break;
+                            if let Some(agg) = node.clone_authority_aggregator() {
+                                // This is a fullnode, we need to wait for its auth aggregator to reconfigure as well.
+                                if agg.committee.epoch() == target_epoch {
+                                    break;
+                                }
+                            } else {
+                                // This is a validator, we don't need to check the auth aggregator.
+                                break;
+                            }
                         }
                         tokio::time::sleep(Duration::from_secs(1)).await;
                         retries += 1;


### PR DESCRIPTION
## Description 

This should fix the simtest failure in test_validator_resign_effects.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
