### PR TITLE
[gql][consistent-reads][2/n] Implement consistent reads for Balance

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
@@ -1,0 +1,485 @@
+processed 25 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 19-49:
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 51-51:
+Checkpoint created: 1
+
+task 3 'programmable'. lines 53-55:
+mutated: object(0,0), object(1,1), object(1,5)
+gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 3972672, non_refundable_storage_fee: 40128
+
+task 4 'create-checkpoint'. lines 57-57:
+Checkpoint created: 2
+
+task 5 'transfer-object'. lines 59-59:
+mutated: object(0,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 6 'create-checkpoint'. lines 61-61:
+Checkpoint created: 3
+
+task 7 'transfer-object'. lines 63-63:
+mutated: object(0,0), object(1,3)
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 9 'create-checkpoint'. lines 67-67:
+Checkpoint created: 4
+
+task 11 'create-checkpoint'. lines 71-71:
+Checkpoint created: 5
+
+task 13 'create-checkpoint'. lines 75-75:
+Checkpoint created: 6
+
+task 15 'create-checkpoint'. lines 79-79:
+Checkpoint created: 7
+
+task 16 'run-graphql'. lines 81-101:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "600"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999983336400"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "600"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "700"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "500"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "500"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "400"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 17 'force-object-snapshot-catchup'. lines 104-104:
+Objects snapshot updated to [0 to 2)
+
+task 18 'run-graphql'. lines 106-126:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "600"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999983336400"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "600"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "700"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "500"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "500"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "400"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 19 'force-object-snapshot-catchup'. lines 129-129:
+Objects snapshot updated to [0 to 3)
+
+task 20 'run-graphql'. lines 131-151:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "700"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999982296272"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 3,
+                  "totalBalance": "700"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "500"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "500"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "400"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 21 'force-object-snapshot-catchup'. lines 154-154:
+Objects snapshot updated to [0 to 4)
+
+task 22 'run-graphql'. lines 156-176:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "500"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999981273168"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 2,
+                  "totalBalance": "500"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": {
+              "totalBalance": "400"
+            },
+            "allBalances": {
+              "nodes": [
+                {
+                  "coinType": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "299999980250064"
+                },
+                {
+                  "coinType": {
+                    "repr": "0x5576855a47423a78766f2bdb5e3e9e87018f6585d7b74a0b41b8a6fd289d7504::fake::FAKE"
+                  },
+                  "coinObjectCount": 1,
+                  "totalBalance": "400"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 23 'force-object-snapshot-catchup'. lines 179-179:
+Objects snapshot updated to [0 to 6)
+
+task 24 'run-graphql'. lines 181-201:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "fakeCoinBalance": null,
+            "allBalances": {
+              "nodes": []
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -1,0 +1,201 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// cp | coins
+// ------------
+// 1  | (300, 100, 200) = 600
+// 2  | (400, 100, 200) = 700
+// 3  | (400, 100)      = 500
+// 4  | (400)           = 400
+// 7  | (400)
+
+// snapshot@[0, 2), all transaction blocks will have valid data.
+// snapshot@[0, 3), first transaction block is out of available range.
+// snapshot@[0, 4), first two transaction blocks are out of available range.
+// snapshot@[0, 6), all transaction blocks are out of available range.
+
+//# init --addresses P0=0x0 --accounts A B --simulator
+
+//# publish --sender A
+module P0::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (treasury_cap, metadata) = coin::create_currency(
+            witness,
+            2,
+            b"FAKE",
+            b"",
+            b"",
+            option::none(),
+            ctx,
+        );
+
+        let c1 = coin::mint(&mut treasury_cap, 100, ctx);
+        let c2 = coin::mint(&mut treasury_cap, 200, ctx);
+        let c3 = coin::mint(&mut treasury_cap, 300, ctx);
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+        transfer::public_transfer(c1, tx_context::sender(ctx));
+        transfer::public_transfer(c2, tx_context::sender(ctx));
+        transfer::public_transfer(c3, tx_context::sender(ctx));
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,5) 100 object(1,1)
+//> 0: sui::coin::mint<P0::fake::FAKE>(Input(0), Input(1));
+//> MergeCoins(Input(2), [Result(0)]);
+
+//# create-checkpoint
+
+//# transfer-object 1,2 --sender A --recipient B
+
+//# create-checkpoint
+
+//# transfer-object 1,3 --sender A --recipient B
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 2
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 3
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 4
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 6
+
+//# run-graphql
+{
+  transactionBlocks(filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -12,6 +12,7 @@ pub mod extensions;
 pub(crate) mod functional_group;
 mod metrics;
 mod mutation;
+pub(crate) mod raw_query;
 pub mod server;
 pub mod test_infra;
 mod types;

--- a/crates/sui-graphql-rpc/src/raw_query.rs
+++ b/crates/sui-graphql-rpc/src/raw_query.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{
+    query_builder::{BoxedSqlQuery, SqlQuery},
+    sql_query,
+};
+
+use crate::data::DieselBackend;
+
+pub(crate) type RawSqlQuery = BoxedSqlQuery<'static, DieselBackend, SqlQuery>;
+
+/// `RawQuery` is a utility for building and managing `diesel::query_builder::BoxedSqlQuery` queries
+/// dynamically.
+///
+/// 1. **Dynamic Value Binding**: Allows binding string values dynamically to the query, bypassing
+///    the need to specify types explicitly, as is typically required with Diesel's
+///    `sql_query.bind`.
+///
+/// 2. **Query String Merging**: Can be used to represent and merge query strings and their
+///    associated bindings. Placeholder strings and bindings are applied in sequential order.
+///
+/// Note: `RawQuery` only supports binding string values, as interpolating raw strings directly
+/// increases exposure to SQL injection attacks.
+#[derive(Clone)]
+pub(crate) struct RawQuery {
+    /// The `SELECT` and `FROM` clauses of the query.
+    select: String,
+    /// The `WHERE` clause of the query.
+    where_: Option<String>,
+    /// The `ORDER BY` clause of the query.
+    order_by: Vec<String>,
+    /// The `GROUP BY` clause of the query.
+    group_by: Vec<String>,
+    /// The `LIMIT` clause of the query.
+    limit: Option<i64>,
+    /// The list of string binds for this query.
+    binds: Vec<String>,
+}
+
+impl RawQuery {
+    /// Constructs a new `RawQuery` with the given `SELECT` clause and binds.
+    pub(crate) fn new(select: impl Into<String>, binds: Vec<String>) -> Self {
+        Self {
+            select: select.into(),
+            where_: None,
+            order_by: Vec::new(),
+            group_by: Vec::new(),
+            limit: None,
+            binds,
+        }
+    }
+
+    /// Adds a `WHERE` condition to the query, combining it with existing conditions using `AND`.
+    pub(crate) fn filter<T: std::fmt::Display>(mut self, condition: T) -> Self {
+        self.where_ = match self.where_ {
+            Some(where_) => Some(format!("({}) AND {}", where_, condition)),
+            None => Some(condition.to_string()),
+        };
+
+        self
+    }
+
+    /// Adds a `WHERE` condition to the query, combining it with existing conditions using `OR`.
+    #[allow(dead_code)]
+    pub(crate) fn or_filter<T: std::fmt::Display>(mut self, condition: T) -> Self {
+        self.where_ = match self.where_ {
+            Some(where_) => Some(format!("({}) OR {}", where_, condition)),
+            None => Some(condition.to_string()),
+        };
+
+        self
+    }
+
+    /// Adds an `ORDER BY` clause to the query.
+    pub(crate) fn order_by<T: ToString>(mut self, order: T) -> Self {
+        self.order_by.push(order.to_string());
+        self
+    }
+
+    /// Adds a `GROUP BY` clause to the query.
+    pub(crate) fn group_by<T: ToString>(mut self, group: T) -> Self {
+        self.group_by.push(group.to_string());
+        self
+    }
+
+    /// Adds a `LIMIT` clause to the query.
+    pub(crate) fn limit(mut self, limit: i64) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Adds the `String` value to the list of binds for this query.
+    pub(crate) fn bind_value(&mut self, condition: String) {
+        self.binds.push(condition);
+    }
+
+    /// Constructs the query string and returns it along with the list of binds for this query. This
+    /// function is not intended to be called directly, and instead should be used through the
+    /// `query!` macro.
+    pub(crate) fn finish(self) -> (String, Vec<String>) {
+        let mut select = self.select;
+
+        if let Some(where_) = self.where_ {
+            select.push_str(" WHERE ");
+            select.push_str(&where_);
+        }
+
+        let mut prefix = " GROUP BY ";
+        for group in self.group_by.iter() {
+            select.push_str(prefix);
+            select.push_str(group);
+            prefix = ", ";
+        }
+
+        let mut prefix = " ORDER BY ";
+        for order in self.order_by.iter() {
+            select.push_str(prefix);
+            select.push_str(order);
+            prefix = ", ";
+        }
+
+        if let Some(limit) = self.limit {
+            select.push_str(" LIMIT ");
+            select.push_str(&limit.to_string());
+        }
+
+        (select, self.binds)
+    }
+
+    /// Converts this `RawQuery` into a `diesel::query_builder::BoxedSqlQuery`. Consumes `self` into
+    /// a raw sql string and bindings, if any. A `BoxedSqlQuery` is constructed from the raw sql
+    /// string, and bindings are added using `sql_query.bind()`.
+    pub(crate) fn into_boxed(self) -> RawSqlQuery {
+        let (raw_sql_string, binds) = self.finish();
+
+        let mut result = String::with_capacity(raw_sql_string.len());
+
+        let mut sql_components = raw_sql_string.split("{}").enumerate();
+
+        if let Some((_, first)) = sql_components.next() {
+            result.push_str(first);
+        }
+
+        for (i, sql) in sql_components {
+            result.push_str(&format!("${}", i));
+            result.push_str(sql);
+        }
+
+        let mut diesel_query = sql_query(result).into_boxed();
+
+        for bind in binds {
+            diesel_query = diesel_query.bind::<diesel::sql_types::Text, _>(bind);
+        }
+
+        diesel_query
+    }
+}
+
+/// Applies the `AND` condition to the given `RawQuery` and binds input string values, if any.
+#[macro_export]
+macro_rules! filter {
+    ($query:expr, $condition:expr $(,$binds:expr)*) => {{
+        let mut query = $query;
+        query = query.filter($condition);
+        $(query.bind_value($binds.to_string());)*
+        query
+    }};
+}
+
+/// Applies the `OR` condition to the given `RawQuery` and binds input string values, if any.
+#[macro_export]
+macro_rules! or_filter {
+    ($query:expr, $condition:expr $(,$binds:expr)*) => {{
+        let mut query = $query;
+        query = query.or_filter($condition);
+        $(query.bind_value($binds.to_string());)*
+        query
+    }};
+}
+
+/// Accepts a `SELECT FROM` format string and optional subqueries. If subqueries are provided, there
+/// should be curly braces `{}` in the format string to interpolate each subquery's sql string into.
+/// Concatenates subqueries to the `SELECT FROM` clause, and creates a new `RawQuery` from the
+/// concatenated sql string. The binds from each subquery are added in the order they appear in the
+/// macro parameter. Subqueries are consumed into the new `RawQuery`.
+#[macro_export]
+macro_rules! query {
+    ($select:expr) => {
+        RawQuery::new($select, vec![])
+    };
+
+    ($select:expr $(,$subquery:expr)*) => {{
+        use $crate::raw_query::RawQuery;
+        let mut binds = vec![];
+
+        let select = format!(
+            $select,
+            $({
+                let (sub_sql, sub_binds) = $subquery.finish();
+                binds.extend(sub_binds);
+                sub_sql
+            }),*
+        );
+
+        RawQuery::new(select, binds)
+    }};
+}

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,20 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::cursor::{self, Page, Target};
+use super::checkpoint::Checkpoint;
+use super::cursor::{self, Page, RawPaginated, Target};
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
-use crate::data::{self, Db, DbConnection, QueryExecutor};
+use crate::data::{Db, DbConnection, QueryExecutor};
 use crate::error::Error;
+use crate::raw_query::RawQuery;
+use crate::{filter, query};
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
-use diesel::NullableExpressionMethods;
 use diesel::{
-    dsl::sql,
     sql_types::{BigInt as SqlBigInt, Nullable, Text},
-    ExpressionMethods, OptionalExtension, QueryDsl,
+    OptionalExtension, QueryableByName,
 };
 use std::str::FromStr;
-use sui_indexer::{schema_v2::objects, types_v2::OwnerType};
 use sui_types::{parse_sui_type_tag, TypeTag};
 
 /// The total balance for a particular coin type.
@@ -30,14 +30,17 @@ pub(crate) struct Balance {
 
 /// Representation of a row of balance information from the DB. We read the balance as a `String` to
 /// deal with the large (bigger than 2^63 - 1) balances.
-type StoredBalance = (
-    /* balance */ Option<String>,
-    /* count */ Option<i64>,
-    /* type */ String,
-);
+#[derive(QueryableByName)]
+pub struct StoredBalance {
+    #[diesel(sql_type = Nullable<Text>)]
+    pub balance: Option<String>,
+    #[diesel(sql_type = Nullable<SqlBigInt>)]
+    pub count: Option<i64>,
+    #[diesel(sql_type = Text)]
+    pub coin_type: String,
+}
 
 pub(crate) type Cursor = cursor::JsonCursor<String>;
-type Query<ST, GB> = data::Query<ST, objects::table, GB>;
 
 impl Balance {
     /// Query for the balance of coins owned by `address`, of coins with type `coin_type`. Note that
@@ -47,25 +50,22 @@ impl Balance {
         db: &Db,
         address: SuiAddress,
         coin_type: TypeTag,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<Balance>, Error> {
-        use objects::dsl;
-
         let stored: Option<StoredBalance> = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    dsl::objects
-                        .select((
-                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
-                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
-                            dsl::coin_type.assume_not_null(),
-                        ))
-                        .filter(dsl::owner_id.eq(address.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
-                        .filter(
-                            dsl::coin_type
-                                .eq(coin_type.to_canonical_string(/* with_prefix */ true)),
-                        )
-                        .group_by(dsl::coin_type)
+            .execute_repeatable(move |conn| {
+                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+                        return Ok(None);
+                    }
+                    rhs = checkpoint_viewed_at;
+                }
+
+                conn.result(move || {
+                    balance_query(address, Some(coin_type.clone()), lhs as i64, rhs as i64)
+                        .into_boxed()
                 })
                 .optional()
             })
@@ -80,27 +80,35 @@ impl Balance {
         db: &Db,
         page: Page<Cursor>,
         address: SuiAddress,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Balance>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredBalance, _, _, _>(conn, move || {
-                    use objects::dsl;
-                    dsl::objects
-                        .select((
-                            sql::<Nullable<Text>>("CAST(SUM(coin_balance) AS TEXT)"),
-                            sql::<Nullable<SqlBigInt>>("COUNT(*)"),
-                            dsl::coin_type.assume_not_null(),
-                        ))
-                        .filter(dsl::owner_id.eq(address.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Address as i16))
-                        .filter(dsl::coin_type.is_not_null())
-                        .group_by(dsl::coin_type)
-                        .into_boxed()
-                })
+        let response = db
+            .execute_repeatable(move |conn| {
+                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+                        return Ok(None);
+                    }
+                    rhs = checkpoint_viewed_at;
+                }
+
+                page.paginate_raw_query::<StoredBalance>(
+                    conn,
+                    balance_query(address, None, lhs as i64, rhs as i64),
+                )
+                .map(Some)
             })
             .await?;
 
-        let mut conn = Connection::new(prev, next);
+        let mut conn = Connection::new(false, false);
+
+        let Some((prev, next, results)) = response else {
+            return Ok(conn);
+        };
+
+        conn.has_previous_page = prev;
+        conn.has_next_page = next;
 
         for stored in results {
             let cursor = stored.cursor().encode_cursor();
@@ -112,35 +120,40 @@ impl Balance {
     }
 }
 
-impl Target<Cursor> for StoredBalance {
-    type Source = objects::table;
-
-    fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::coin_type.ge((**cursor).clone()))
+impl RawPaginated<Cursor> for StoredBalance {
+    fn filter_ge(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        // Specify candidates to help disambiguate
+        filter!(query, "coin_type >= {}", (**cursor).clone())
     }
 
-    fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::coin_type.le((**cursor).clone()))
+    fn filter_le(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        // Specify candidates to help disambiguate
+        filter!(query, "coin_type <= {}", (**cursor).clone())
     }
 
-    fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
-        use objects::dsl;
+    fn order(asc: bool, query: RawQuery) -> RawQuery {
         if asc {
-            query.order_by(dsl::coin_type.asc())
-        } else {
-            query.order_by(dsl::coin_type.desc())
+            return query.order_by("coin_type ASC");
         }
+        query.order_by("coin_type DESC")
     }
+}
 
+impl Target<Cursor> for StoredBalance {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.2.clone())
+        Cursor::new(self.coin_type.clone())
     }
 }
 
 impl TryFrom<StoredBalance> for Balance {
     type Error = Error;
 
-    fn try_from((balance, count, coin_type): StoredBalance) -> Result<Self, Error> {
+    fn try_from(s: StoredBalance) -> Result<Self, Error> {
+        let StoredBalance {
+            balance,
+            count,
+            coin_type,
+        } = s;
         let total_balance = balance
             .map(|b| BigInt::from_str(&b))
             .transpose()
@@ -159,4 +172,79 @@ impl TryFrom<StoredBalance> for Balance {
             total_balance,
         })
     }
+}
+
+/// Query the database for a `page` of coin balances. Each balance represents the total balance for
+/// a particular coin type, owned by `address`. This function is meant to be called within a thunk
+/// and returns a RawQuery that can be converted into a BoxedSqlQuery with `.into_boxed()`.
+fn balance_query(address: SuiAddress, coin_type: Option<TypeTag>, lhs: i64, rhs: i64) -> RawQuery {
+    // Construct the filtered inner query - apply the same filtering criteria to both
+    // objects_snapshot and objects_history tables.
+    let mut snapshot_objs = query!("SELECT * FROM objects_snapshot");
+    snapshot_objs = filter(snapshot_objs, address, coin_type.clone());
+
+    // Additionally filter objects_history table for results between the available range, or
+    // checkpoint_viewed_at, if provided.
+    let mut history_objs = query!("SELECT * FROM objects_history");
+    history_objs = filter(history_objs, address, coin_type.clone());
+    history_objs = filter!(
+        history_objs,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Combine the two queries, and select the most recent version of each object.
+    let candidates = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        snapshot_objs,
+        history_objs
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    // Objects that fulfill the filtering criteria may not be the most recent version available.
+    // Left join the candidates table on newer to filter out any objects that have a newer
+    // version.
+    let mut newer = query!("SELECT object_id, object_version FROM objects_history");
+    newer = filter!(
+        newer,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+    let final_ = query!(
+        r#"SELECT
+            CAST(SUM(coin_balance) AS TEXT) as balance,
+            COUNT(*) as count,
+            coin_type
+        FROM ({}) candidates
+        LEFT JOIN ({}) newer
+        ON (
+            candidates.object_id = newer.object_id
+            AND candidates.object_version < newer.object_version
+        )"#,
+        candidates,
+        newer
+    );
+
+    // Additionally for balance's query, group coins by coin_type.
+    filter!(final_, "newer.object_version IS NULL").group_by("coin_type")
+}
+
+/// Applies the filtering criteria for balances to the input `RawQuery` and returns a new
+/// `RawQuery`.
+fn filter(mut query: RawQuery, owner: SuiAddress, coin_type: Option<TypeTag>) -> RawQuery {
+    query = filter!(query, "coin_type IS NOT NULL");
+
+    query = filter!(
+        query,
+        format!("owner_id = '\\x{}'::bytea", hex::encode(owner.into_vec()))
+    );
+
+    if let Some(coin_type) = coin_type {
+        query = filter!(
+            query,
+            "coin_type = {}",
+            coin_type.to_canonical_display(/* with_prefix */ true)
+        );
+    };
+
+    query
 }

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -3,7 +3,7 @@
 
 use super::{
     base64::Base64,
-    cursor::{self, Page, Target},
+    cursor::{self, Page, Paginated, Target},
     date_time::DateTime,
     digest::Digest,
     epoch::Epoch,
@@ -265,7 +265,7 @@ impl Checkpoint {
     }
 }
 
-impl Target<Cursor> for StoredCheckpoint {
+impl Paginated<Cursor> for StoredCheckpoint {
     type Source = checkpoints::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -284,7 +284,9 @@ impl Target<Cursor> for StoredCheckpoint {
             query.order(dsl::sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredCheckpoint {
     fn cursor(&self) -> Cursor {
         Cursor::new(self.sequence_number as u64)
     }

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -8,7 +8,8 @@ use async_graphql::{
     *,
 };
 use diesel::{
-    query_builder::QueryFragment, query_dsl::LoadQuery, QueryDsl, QueryResult, QuerySource,
+    deserialize::FromSqlRow, query_builder::QueryFragment, query_dsl::LoadQuery,
+    sql_types::Untyped, QueryDsl, QueryResult, QuerySource,
 };
 use fastcrypto::encoding::{Base64, Encoding};
 use serde::{de::DeserializeOwned, Serialize};
@@ -17,6 +18,7 @@ use crate::{
     config::ServiceConfig,
     data::{Conn, DbConnection, DieselBackend, DieselConn, Query},
     error::Error,
+    raw_query::RawQuery,
 };
 
 /// Cursor that hides its value by encoding it as JSON and then Base64.
@@ -53,7 +55,7 @@ enum End {
 }
 
 /// Results from the database that are pointed to by cursors.
-pub(crate) trait Target<C: CursorType> {
+pub(crate) trait Paginated<C: CursorType>: Target<C> {
     type Source: QuerySource;
 
     /// Adds a filter to `query` to bound its result to be greater than or equal to `cursor`
@@ -74,7 +76,26 @@ pub(crate) trait Target<C: CursorType> {
     /// (returning the new query). The `asc` parameter controls whether the ordering is ASCending
     /// (`true`) or descending (`false`).
     fn order<ST, GB>(asc: bool, query: Query<ST, Self::Source, GB>) -> Query<ST, Self::Source, GB>;
+}
 
+/// Results from the database that are pointed to by cursors. Equivalent to `Paginated`, but for a
+/// `RawQuery`.
+pub(crate) trait RawPaginated<C: CursorType>: Target<C> {
+    /// Adds a filter to `query` to bound its result to be greater than or equal to `cursor`
+    /// (returning the new query).
+    fn filter_ge(cursor: &C, query: RawQuery) -> RawQuery;
+
+    /// Adds a filter to `query` to bound its results to be less than or equal to `cursor`
+    /// (returning the new query).
+    fn filter_le(cursor: &C, query: RawQuery) -> RawQuery;
+
+    /// Adds an `ORDER BY` clause to `query` to order rows according to their cursor values
+    /// (returning the new query). The `asc` parameter controls whether the ordering is ASCending
+    /// (`true`) or descending (`false`).
+    fn order(asc: bool, query: RawQuery) -> RawQuery;
+}
+
+pub(crate) trait Target<C: CursorType> {
     /// The cursor pointing at this target value.
     fn cursor(&self) -> C;
 }
@@ -194,10 +215,10 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         Q: Fn() -> Query<ST, T::Source, GB>,
         Query<ST, T::Source, GB>: LoadQuery<'static, DieselConn, T>,
         Query<ST, T::Source, GB>: QueryFragment<DieselBackend>,
-        <T as Target<C>>::Source: Send + 'static,
-        <<T as Target<C>>::Source as QuerySource>::FromClause: Send + 'static,
+        <T as Paginated<C>>::Source: Send + 'static,
+        <<T as Paginated<C>>::Source as QuerySource>::FromClause: Send + 'static,
         Q: Send + 'static,
-        T: Send + Target<C> + 'static,
+        T: Send + Paginated<C> + 'static,
         ST: Send + 'static,
         GB: Send + 'static,
     {
@@ -228,67 +249,132 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
             results
         };
 
-        // Detect whether the results imply the existence of a previous or next page.
-        let (prev, next, prefix, suffix) = match (
-            self.after(),
-            results.first(),
-            results.last(),
-            self.before(),
-            self.end,
-        ) {
-            // Results came back empty, despite supposedly including the `after` and `before`
-            // cursors, so the bounds must have been invalid, no matter which end the page was
-            // drawn from.
-            (_, None, _, _, _) | (_, _, None, _, _) => {
-                return Ok((false, false, vec![].into_iter()));
+        Ok(self.paginate_results(
+            results.first().map(|f| f.cursor()),
+            results.last().map(|l| l.cursor()),
+            results,
+        ))
+    }
+
+    /// This function is similar to `paginate_query`, but is specifically designed for handling
+    /// `RawQuery`. Treat the cursors of this page as upper- and lowerbound filters for a database
+    /// `query`. Returns two booleans indicating whether there is a previous or next page in the
+    /// range, followed by an iterator of values in the page, fetched from the database.
+    ///
+    /// The values returned implement `Target<C>`, so are able to compute their own cursors.
+    pub(crate) fn paginate_raw_query<T>(
+        &self,
+        conn: &mut Conn<'_>,
+        query: RawQuery,
+    ) -> QueryResult<(bool, bool, impl Iterator<Item = T>)>
+    where
+        T: Send + RawPaginated<C> + FromSqlRow<Untyped, DieselBackend> + 'static,
+    {
+        let new_query = move || {
+            let mut query = query.clone();
+            if let Some(after) = self.after() {
+                query = T::filter_ge(after, query);
             }
 
-            // Page drawn from the front, and the cursor for the first element does not match
-            // `after`. This implies the bound was invalid, so we return an empty result.
-            (Some(a), Some(f), _, _, End::Front) if f.cursor() != *a => {
-                return Ok((false, false, vec![].into_iter()));
+            if let Some(before) = self.before() {
+                query = T::filter_le(before, query);
             }
 
-            // Similar to above case, but for back of results.
-            (_, _, Some(l), Some(b), End::Back) if l.cursor() != *b => {
-                return Ok((false, false, vec![].into_iter()));
-            }
+            query = T::order(self.is_from_front(), query);
 
-            // From here onwards, we know that the results are non-empty and if a cursor was
-            // supplied on the end the page is being drawn from, it was found in the results
-            // (implying a page follows in that direction).
-            (after, _, Some(l), before, End::Front) => {
-                let has_previous_page = after.is_some();
-                let prefix = has_previous_page as usize;
-
-                // If results end with the before cursor, we will at least need to trim one element
-                // from the suffix and we trim more off the end if there is more after applying the
-                // limit.
-                let mut suffix = before.is_some_and(|b| *b == l.cursor()) as usize;
-                suffix += results.len().saturating_sub(self.limit() + prefix + suffix);
-                let has_next_page = suffix > 0;
-
-                (has_previous_page, has_next_page, prefix, suffix)
-            }
-
-            // Symmetric to the previous case, but drawing from the back.
-            (after, Some(f), _, before, End::Back) => {
-                let has_next_page = before.is_some();
-                let suffix = has_next_page as usize;
-
-                let mut prefix = after.is_some_and(|a| *a == f.cursor()) as usize;
-                prefix += results.len().saturating_sub(self.limit() + prefix + suffix);
-                let has_previous_page = prefix > 0;
-
-                (has_previous_page, has_next_page, prefix, suffix)
-            }
+            query = query.limit(self.limit() as i64 + 2);
+            query.into_boxed()
         };
+
+        let results: Vec<T> = if self.limit() == 0 {
+            // Avoid the database roundtrip in the degenerate case.
+            vec![]
+        } else {
+            let mut results: Vec<T> = conn.results(new_query)?;
+            if !self.is_from_front() {
+                results.reverse();
+            }
+            results
+        };
+
+        Ok(self.paginate_results(
+            results.first().map(|f| f.cursor()),
+            results.last().map(|l| l.cursor()),
+            results,
+        ))
+    }
+
+    /// Given the results of a database query, determine whether the result set has a previous and
+    /// next page and is consistent with the provided cursors.
+    ///
+    /// Returns two booleans indicating whether there is a previous or next page in the range,
+    /// followed by an iterator of values in the page, fetched from the database. The values
+    /// returned implement `Target<C>`, so are able to compute their own cursors.
+    fn paginate_results<T>(
+        &self,
+        f_cursor: Option<C>,
+        l_cursor: Option<C>,
+        results: Vec<T>,
+    ) -> (bool, bool, impl Iterator<Item = T>)
+    where
+        T: Send + 'static,
+    {
+        // Detect whether the results imply the existence of a previous or next page.
+        let (prev, next, prefix, suffix) =
+            match (self.after(), f_cursor, l_cursor, self.before(), self.end) {
+                // Results came back empty, despite supposedly including the `after` and `before`
+                // cursors, so the bounds must have been invalid, no matter which end the page was
+                // drawn from.
+                (_, None, _, _, _) | (_, _, None, _, _) => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // Page drawn from the front, and the cursor for the first element does not match
+                // `after`. This implies the bound was invalid, so we return an empty result.
+                (Some(a), Some(f), _, _, End::Front) if f != *a => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // Similar to above case, but for back of results.
+                (_, _, Some(l), Some(b), End::Back) if l != *b => {
+                    return (false, false, vec![].into_iter());
+                }
+
+                // From here onwards, we know that the results are non-empty and if a cursor was
+                // supplied on the end the page is being drawn from, it was found in the results
+                // (implying a page follows in that direction).
+                (after, _, Some(l), before, End::Front) => {
+                    let has_previous_page = after.is_some();
+                    let prefix = has_previous_page as usize;
+
+                    // If results end with the before cursor, we will at least need to trim one element
+                    // from the suffix and we trim more off the end if there is more after applying the
+                    // limit.
+                    let mut suffix = before.is_some_and(|b| *b == l) as usize;
+                    suffix += results.len().saturating_sub(self.limit() + prefix + suffix);
+                    let has_next_page = suffix > 0;
+
+                    (has_previous_page, has_next_page, prefix, suffix)
+                }
+
+                // Symmetric to the previous case, but drawing from the back.
+                (after, Some(f), _, before, End::Back) => {
+                    let has_next_page = before.is_some();
+                    let suffix = has_next_page as usize;
+
+                    let mut prefix = after.is_some_and(|a| *a == f) as usize;
+                    prefix += results.len().saturating_sub(self.limit() + prefix + suffix);
+                    let has_previous_page = prefix > 0;
+
+                    (has_previous_page, has_next_page, prefix, suffix)
+                }
+            };
 
         // If after trimming, we're going to return no elements, then forget whether there's a
         // previous or next page, because there will be no start or end cursor for this page to
         // anchor on.
         if results.len() == prefix + suffix {
-            return Ok((false, false, vec![].into_iter()));
+            return (false, false, vec![].into_iter());
         }
 
         // We finally made it -- trim the prefix and suffix rows from the result and send it!
@@ -300,7 +386,7 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
             results.nth_back(suffix - 1);
         }
 
-        Ok((prev, next, results))
+        (prev, next, results)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 
-use super::cursor::{self, Page, Target};
+use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
@@ -283,7 +283,7 @@ impl TryFrom<StoredEvent> for Event {
     }
 }
 
-impl Target<Cursor> for StoredEvent {
+impl Paginated<Cursor> for StoredEvent {
     type Source = events::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -314,7 +314,9 @@ impl Target<Cursor> for StoredEvent {
                 .then_order_by(dsl::event_sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredEvent {
     fn cursor(&self) -> Cursor {
         Cursor::new(EventKey {
             tx: self.tx_sequence_number as u64,

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -7,7 +7,7 @@ use super::balance::{self, Balance};
 use super::big_int::BigInt;
 use super::coin::Coin;
 use super::coin_metadata::CoinMetadata;
-use super::cursor::{self, Page, Target};
+use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::display::{Display, DisplayEntry};
 use super::dynamic_field::{DynamicField, DynamicFieldName};
@@ -1056,7 +1056,7 @@ impl ObjectFilter {
     }
 }
 
-impl Target<Cursor> for StoredObject {
+impl Paginated<Cursor> for StoredObject {
     type Source = objects::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -1075,7 +1075,9 @@ impl Target<Cursor> for StoredObject {
             query.order_by(dsl::object_id.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredObject {
     fn cursor(&self) -> Cursor {
         Cursor::new(self.object_id.clone())
     }

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -327,9 +327,14 @@ impl OwnerImpl {
         type_: Option<ExactTypeFilter>,
     ) -> Result<Option<Balance>> {
         let coin = type_.map_or_else(GAS::type_tag, |t| t.0);
-        Balance::query(ctx.data_unchecked(), self.address, coin)
-            .await
-            .extend()
+        Balance::query(
+            ctx.data_unchecked(),
+            self.address,
+            coin,
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn balances(
@@ -341,9 +346,14 @@ impl OwnerImpl {
         before: Option<balance::Cursor>,
     ) -> Result<Connection<String, Balance>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Balance::paginate(ctx.data_unchecked(), page, self.address)
-            .await
-            .extend()
+        Balance::paginate(
+            ctx.data_unchecked(),
+            page,
+            self.address,
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn coins(

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -34,7 +34,7 @@ use crate::{
 use super::{
     address::Address,
     base64::Base64,
-    cursor::{self, Page, Target},
+    cursor::{self, Page, Paginated, Target},
     digest::Digest,
     epoch::Epoch,
     gas::GasInput,
@@ -416,7 +416,7 @@ impl TransactionBlockFilter {
     }
 }
 
-impl Target<Cursor> for StoredTransaction {
+impl Paginated<Cursor> for StoredTransaction {
     type Source = transactions::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -435,7 +435,9 @@ impl Target<Cursor> for StoredTransaction {
             query.order_by(dsl::tx_sequence_number.desc())
         }
     }
+}
 
+impl Target<Cursor> for StoredTransaction {
     fn cursor(&self) -> Cursor {
         Cursor::new(self.tx_sequence_number as u64)
     }


### PR DESCRIPTION
## Description 

Implements consistent reads for the Balance type.

1. RawQuery struct builds a BoxedSqlQuery to support consistent reads. The query demands more than what diesel's dsl can provide today, so unfortunately we will have it in raw sql for the time being. 
2. Split the pagination methods of the Target trait into a separate, Paginated trait. Implement target to build a cursor for a database entity.
3. Break the validation step out from paginate_query, so that the new paginate_raw_query method, which accepts a thunk that builds a RawQuery, can also have its results validated.

## Test Plan 

consistency/balances.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
