### PR TITLE
[gql][consistent-reads][3/n] Implement consistent reads for Object and MoveObject

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
@@ -1,0 +1,604 @@
+processed 23 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 15-32:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 34-34:
+created: object(2,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 36-36:
+created: object(3,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'create-checkpoint'. lines 38-38:
+Checkpoint created: 1
+
+task 5 'run-graphql'. lines 40-68:
+Response: {
+  "data": {
+    "one_of_these_will_yield_an_object": {
+      "objects": {
+        "nodes": []
+      }
+    },
+    "if_the_other_does_not": {
+      "nodes": [
+        {
+          "version": 3,
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run'. lines 70-70:
+created: object(6,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'run'. lines 72-72:
+created: object(7,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'create-checkpoint'. lines 74-74:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 76-104:
+Response: {
+  "data": {
+    "paginating_on_checkpoint_1": {
+      "objects": {
+        "nodes": []
+      }
+    },
+    "should_not_have_more_than_one_result": {
+      "nodes": [
+        {
+          "version": 3,
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 106-121:
+Response: {
+  "data": {
+    "four_objects": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 123-148:
+Response: {
+  "data": {
+    "objects_at_version": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'programmable'. lines 150-151:
+mutated: object(0,0), object(2,0), object(3,0), object(6,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 5206608, non_refundable_storage_fee: 52592
+
+task 13 'create-checkpoint'. lines 153-153:
+Checkpoint created: 3
+
+task 14 'run-graphql'. lines 155-217:
+Response: {
+  "data": {
+    "after_obj_6_0_at_checkpoint_2": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            },
+            "owner_at_latest_state_has_sui_only": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 4,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                          "value": "1"
+                        }
+                      }
+                    },
+                    {
+                      "version": 6,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                          "value": "3"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                          "value": "2"
+                        }
+                      }
+                    },
+                    {
+                      "version": 1,
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                          "balance": {
+                            "value": "300000000000000"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "version": 3,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                          "value": "0"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_6_0_at_checkpoint_2": {
+      "nodes": [
+        {
+          "version": 4,
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                "value": "1"
+              }
+            },
+            "note_that_owner_result_should_reflect_latest_state": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 4,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                          "value": "1"
+                        }
+                      }
+                    },
+                    {
+                      "version": 6,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                          "value": "3"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                          "value": "2"
+                        }
+                      }
+                    },
+                    {
+                      "version": 1,
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                          "balance": {
+                            "value": "300000000000000"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "version": 3,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                          "value": "0"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "version": 6,
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                "value": "3"
+              }
+            },
+            "note_that_owner_result_should_reflect_latest_state": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 4,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                          "value": "1"
+                        }
+                      }
+                    },
+                    {
+                      "version": 6,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                          "value": "3"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                          "value": "2"
+                        }
+                      }
+                    },
+                    {
+                      "version": 1,
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                        },
+                        "json": {
+                          "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                          "balance": {
+                            "value": "300000000000000"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "version": 3,
+                      "contents": {
+                        "type": {
+                          "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                          "value": "0"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 16 'create-checkpoint'. lines 221-221:
+Checkpoint created: 4
+
+task 18 'create-checkpoint'. lines 225-225:
+Checkpoint created: 5
+
+task 19 'force-object-snapshot-catchup'. lines 227-227:
+Objects snapshot updated to [0 to 4)
+
+task 20 'run-graphql'. lines 229-257:
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 15,
+          "column": 3
+        }
+      ],
+      "path": [
+        "before_obj_6_0_at_checkpoint_2"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "after_obj_6_0_at_checkpoint_2_now_before_available_range",
+        "objects"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 21 'run-graphql'. lines 259-275:
+Response: {
+  "data": {
+    "owned_by_address_b_latest": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x50cf8ec636181af2ae7b9871c475ad554d8babd9520a2701e48cb800ddca315f",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x67ae81c5818ecc2435d197cf37a8a879e170530d90ee1a83f6cb7ff44bc56703",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0x7c1d908c30b3a16d5ce8458da3b4e4067ed843784b177940c85b4cad8dc3912b",
+                "value": "2"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0x646d0c542528600527e1e61ab81bdd885e0f03d2895e935ebff96b5adb0ad84c::M1::Object"
+              },
+              "json": {
+                "id": "0xdcd5c1378ee6550b4655f97ad9d43dc96072e55ee15b17737b1b06ad61b222c6",
+                "value": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 22 'run-graphql'. lines 277-303:
+Response: {
+  "data": {
+    "objects_at_version": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
@@ -1,0 +1,303 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+
+// cp | object_id | owner
+// ----------------------
+// 1  | obj_2_0   | A
+// 1  | obj_3_0   | A
+// 2  | obj_6_0   | A
+// 2  | obj_7_0   | A
+// All owned by B after checkpoint 3.
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::create --args 1 @A
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_2_0} @{obj_3_0}
+{
+  one_of_these_will_yield_an_object: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  if_the_other_does_not: objects(filter: {type: "@{Test}"}, after: "@{cursor_1}") {
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::create --args 2 @A
+
+//# run Test::M1::create --args 3 @A
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_2_0,1} @{obj_3_0,1}
+{
+  paginating_on_checkpoint_1: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  should_not_have_more_than_one_result: objects(filter: {type: "@{Test}"}, after: "@{cursor_1}") {
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  four_objects: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  objects_at_version: address(address: "@{A}") {
+    objects(
+      filter: {
+        type: "@{Test}",
+        objectKeys: [
+            {objectId: "@{obj_2_0}", version: 3},
+            {objectId: "@{obj_3_0}", version: 4},
+            {objectId: "@{obj_6_0}", version: 5},
+            {objectId: "@{obj_7_0}", version: 6}
+            ]
+      }
+    ) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_6_0,2}
+{
+  after_obj_6_0_at_checkpoint_2: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        owner_at_latest_state_has_sui_only: owner {
+          ... on AddressOwner {
+            owner {
+              objects {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  before_obj_6_0_at_checkpoint_2: objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        note_that_owner_result_should_reflect_latest_state: owner {
+          ... on AddressOwner {
+            owner {
+              objects {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 4
+
+//# run-graphql --cursors @{obj_6_0,2}
+{
+  after_obj_6_0_at_checkpoint_2_now_before_available_range: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  before_obj_6_0_at_checkpoint_2: objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Should have all the objects
+{
+  owned_by_address_b_latest: address(address: "@{B}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# No longer accessible, as there are more recent versions owned by address B.
+{
+  objects_at_version: address(address: "@{A}") {
+    objects(
+      filter: {
+        type: "@{Test}",
+        objectKeys: [
+            {objectId: "@{obj_2_0}", version: 3},
+            {objectId: "@{obj_3_0}", version: 4},
+            {objectId: "@{obj_6_0}", version: 5},
+            {objectId: "@{obj_7_0}", version: 6}
+            ]
+      }
+    ) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.exp
@@ -1,0 +1,341 @@
+processed 15 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 10-31:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5456800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 33-33:
+created: object(2,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 35-35:
+created: object(3,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'run'. lines 37-37:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 1301652, non_refundable_storage_fee: 13148
+
+task 5 'create-checkpoint'. lines 39-39:
+Checkpoint created: 1
+
+task 6 'run-graphql'. lines 41-69:
+Response: {
+  "data": {
+    "after_obj_3_0": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "100"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_3_0": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 7 'run'. lines 71-71:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 8 'create-checkpoint'. lines 73-73:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 75-104:
+Response: {
+  "data": {
+    "after_obj_3_0_chkpt_1": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "100"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_3_0_chkpt_1": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 106-181:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0x84e2a26b6d4635aff08d1c23572eaf610f5472d7c142e9345fe908813210179b",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "200"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "after_obj_3_0_chkpt_2": {
+      "consistent_with_above": {
+        "nodes": [
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "200"
+              }
+            },
+            "owner": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 4,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x84e2a26b6d4635aff08d1c23572eaf610f5472d7c142e9345fe908813210179b",
+                          "value": "1"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                          "value": "200"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_3_0_chkpt_2": {
+      "consistent_with_above": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 11 'run'. lines 183-183:
+mutated: object(0,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 12 'create-checkpoint'. lines 185-185:
+Checkpoint created: 3
+
+task 13 'run-graphql'. lines 187-250:
+Response: {
+  "data": {
+    "after_obj_3_0_chkpt_2": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "200"
+              }
+            },
+            "this_should_differ": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 4,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x84e2a26b6d4635aff08d1c23572eaf610f5472d7c142e9345fe908813210179b",
+                          "value": "1"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                          "value": "200"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_3_0_chkpt_2": {
+      "objects": {
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 252-327:
+Response: {
+  "data": {
+    "address": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0x84e2a26b6d4635aff08d1c23572eaf610f5472d7c142e9345fe908813210179b",
+                "value": "300"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "200"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "after_obj_3_0_chkpt_3": {
+      "consistent_with_above": {
+        "nodes": [
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+              },
+              "json": {
+                "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                "value": "200"
+              }
+            },
+            "owner": {
+              "owner": {
+                "objects": {
+                  "nodes": [
+                    {
+                      "version": 6,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0x84e2a26b6d4635aff08d1c23572eaf610f5472d7c142e9345fe908813210179b",
+                          "value": "300"
+                        }
+                      }
+                    },
+                    {
+                      "version": 5,
+                      "contents": {
+                        "type": {
+                          "repr": "0x3f0c6e4f85d1e65c8898b1ff76eb610c9cef63aae0522bfea31545f5bd227e61::M1::Object"
+                        },
+                        "json": {
+                          "id": "0xfa6606bf7cb04f836e8563c9d0c7bf4f84809cfb9947137ac14ab9ca588a4686",
+                          "value": "200"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "before_obj_3_0_chkpt_3": {
+      "consistent_with_above": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
@@ -1,0 +1,327 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Simple test case to check that object pagination is bounded by the checkpoint in the cursor. Use
+// one object as a cursor to view the other object that gets mutated per checkpoint. The ordering is
+// consistent even if the cursor object is mutated.
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun update(value: u64, o: &mut Object) {
+        o.value = value;
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::create --args 1 @A
+
+//# run Test::M1::update --sender A --args 100 object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_3_0}
+{
+  after_obj_3_0: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  before_obj_3_0: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::update --sender A --args 200 object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_3_0,1}
+# This query should yield the same results as the previous one.
+{
+  after_obj_3_0_chkpt_1: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  before_obj_3_0_chkpt_1: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_0,2}
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  after_obj_3_0_chkpt_2: address(address: "@{A}") {
+    consistent_with_above: objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  before_obj_3_0_chkpt_2: address(address: "@{A}") {
+    consistent_with_above: objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::update --sender A --args 300 object(3,0)
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_3_0,2}
+# This query should yield the same results as the previous one.
+{
+    after_obj_3_0_chkpt_2: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        this_should_differ: owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  before_obj_3_0_chkpt_2: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        this_should_differ: owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_0,3}
+{
+  address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  after_obj_3_0_chkpt_3: address(address: "@{A}") {
+    consistent_with_above: objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  before_obj_3_0_chkpt_3: address(address: "@{A}") {
+    consistent_with_above: objects(filter: {type: "@{Test}"}, before: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+        owner {
+          ... on AddressOwner {
+            owner {
+              objects(filter: {type: "@{Test}"}) {
+                nodes {
+                  version
+                  contents {
+                    type {
+                      repr
+                    }
+                    json
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1,0 +1,1350 @@
+processed 15 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 17-38:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5479600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 40-41:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 43-43:
+Checkpoint created: 1
+
+task 4 'programmable'. lines 45-48:
+created: object(4,0), object(4,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 4932400,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'create-checkpoint'. lines 50-50:
+Checkpoint created: 2
+
+task 6 'programmable'. lines 52-56:
+created: object(6,0), object(6,1), object(6,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7 'create-checkpoint'. lines 58-58:
+Checkpoint created: 3
+
+task 9 'create-checkpoint'. lines 62-62:
+Checkpoint created: 4
+
+task 10 'run-graphql'. lines 64-138:
+Response: {
+  "data": {
+    "address_at_latest_checkpoint_4": {
+      "objects": {
+        "nodes": [
+          {
+            "contents": {
+              "json": {
+                "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                "value": "6"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                "value": "4"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                "value": "200"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                "value": "3"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                "value": "5"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                "value": "2"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "latest_tx_at_checkpoint_3": {
+      "nodes": [
+        {
+          "sender": {
+            "objects_consistent_with_address_at_latest_checkpoint_4": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                        "value": "6"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "299999993044572"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "object_at_checkpoint_2": {
+      "owner": {
+        "owner": {
+          "objects": {
+            "nodes": [
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                    "value": "6"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                    "value": "4"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                    "value": "200"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                    "value": "3"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                    "value": "5"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                    "value": "2"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 11 'run-graphql'. lines 140-184:
+Response: {
+  "data": {
+    "all_transactions": {
+      "nodes": [
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "0"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "0"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "300000000000000"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "100"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "100"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "299999996697200"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                        "value": "6"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "299999993044572"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 12 'force-object-snapshot-catchup'. lines 186-186:
+Objects snapshot updated to [0 to 3)
+
+task 13 'run-graphql'. lines 188-262:
+Response: {
+  "data": {
+    "address_at_latest_checkpoint_4": {
+      "objects": {
+        "nodes": [
+          {
+            "contents": {
+              "json": {
+                "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                "value": "6"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                "value": "4"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                "value": "200"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                "value": "3"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                "value": "5"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          },
+          {
+            "contents": {
+              "json": {
+                "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                "value": "2"
+              },
+              "type": {
+                "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "latest_tx_at_checkpoint_3": {
+      "nodes": [
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                        "value": "6"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "299999993044572"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "object_at_checkpoint_2": {
+      "owner": {
+        "owner": {
+          "objects": {
+            "nodes": [
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                    "value": "6"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                    "value": "4"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                    "value": "200"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                    "value": "3"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                    "value": "5"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              },
+              {
+                "contents": {
+                  "json": {
+                    "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                    "value": "2"
+                  },
+                  "type": {
+                    "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 264-311:
+Response: {
+  "data": {
+    "all_transactions": {
+      "nodes": [
+        {
+          "sender": null,
+          "gasInput": null
+        },
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "100"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "100"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": []
+            }
+          }
+        },
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": {
+            "gasSponsor": {
+              "objects": {
+                "nodes": [
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                        "value": "6"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                        "value": "4"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                        "value": "200"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                        "value": "3"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                        "value": "5"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  },
+                  {
+                    "contents": {
+                      "json": {
+                        "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                        "value": "2"
+                      },
+                      "type": {
+                        "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "gasPayment": {
+              "nodes": [
+                {
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      },
+                      "json": {
+                        "id": "0x9a99f1273c6373f96096f30cda76d71bc1f9294918ac5eb49569c363a4888c16",
+                        "balance": {
+                          "value": "299999993044572"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "all_transactions",
+        "nodes",
+        0,
+        "sender",
+        "objects"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 21,
+          "column": 11
+        }
+      ],
+      "path": [
+        "all_transactions",
+        "nodes",
+        0,
+        "gasInput",
+        "gasSponsor",
+        "objects"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 32,
+          "column": 9
+        }
+      ],
+      "path": [
+        "all_transactions",
+        "nodes",
+        0,
+        "gasInput",
+        "gasPayment"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
@@ -1,0 +1,311 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Check that if the sender and gas sponsor of a tx are the same, that the historical data returned
+// is also the same. Check that the data for an object at version is consistent. Verify that when
+// objects_snapshot has caught up to [0, 3), we can still see all objects since all are live.
+
+
+// cp | version
+// ------------
+// 1  | (2)
+// 2  | (3, 3, 3)
+// 3  | (4, 4, 4, 4)
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun set_value(o: &mut Object, value: u64) {
+        o.value = value;
+    }
+}
+
+//# programmable --sender A --inputs 0 1 @A
+//> 0: Test::M1::create(Input(0), Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(2,0) 100 2 3 @A
+//> Test::M1::set_value(Input(0), Input(1));
+//> Test::M1::create(Input(2), Input(4));
+//> Test::M1::create(Input(3), Input(4));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(2,0) 200 4 5 6 @A
+//> Test::M1::set_value(Input(0), Input(1));
+//> Test::M1::create(Input(2), Input(5));
+//> Test::M1::create(Input(3), Input(5));
+//> Test::M1::create(Input(4), Input(5));
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  address_at_latest_checkpoint_4: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects_consistent_with_address_at_latest_checkpoint_4: objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+      gasInput {
+        gasSponsor {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+        gasPayment {
+          nodes {
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  object_at_checkpoint_2: object(address: "@{obj_2_0}", version: 3) {
+    owner {
+      ... on AddressOwner {
+        owner {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  all_transactions: transactionBlocks(first: 4, filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+      gasInput {
+        gasSponsor {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+        gasPayment {
+          nodes {
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 3
+
+//# run-graphql
+{
+  address_at_latest_checkpoint_4: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+  latest_tx_at_checkpoint_3: transactionBlocks(last: 1, filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+      gasInput {
+        gasSponsor {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+        gasPayment {
+          nodes {
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  object_at_checkpoint_2: object(address: "@{obj_2_0}", version: 3) {
+    owner {
+      ... on AddressOwner {
+        owner {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# First transaction should have no results since its data is no longer in objects_snapshot. Second
+# transaction is still valid - since objects_snapshot table is at [0, 3), it will have data from
+# checkpoint 2.
+{
+  all_transactions: transactionBlocks(first: 4, filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        objects(filter: {type: "@{Test}"}) {
+          nodes {
+            contents {
+              json
+              type {
+                repr
+              }
+            }
+          }
+        }
+      }
+      gasInput {
+        gasSponsor {
+          objects(filter: {type: "@{Test}"}) {
+            nodes {
+              contents {
+                json
+                type {
+                  repr
+                }
+              }
+            }
+          }
+        }
+        gasPayment {
+          nodes {
+            asMoveObject {
+              contents {
+                type {
+                  repr
+                }
+                json
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
@@ -17,7 +17,7 @@ Response: {
     "suiCoins": {
       "edges": [
         {
-          "cursor": "IIOWz4Z094IUkdYH1ciKsXMXyOb0Ql+XNUnKWqNc1SFH",
+          "cursor": "IIOWz4Z094IUkdYH1ciKsXMXyOb0Ql+XNUnKWqNc1SFHAQAAAAAAAAA=",
           "node": {
             "coinBalance": "299999983336400",
             "contents": {
@@ -28,7 +28,7 @@ Response: {
           }
         },
         {
-          "cursor": "ILyzHKcc29xOYtaOLcUZ9woz5N8kNsVRffj1Gz5O4yRl",
+          "cursor": "ILyzHKcc29xOYtaOLcUZ9woz5N8kNsVRffj1Gz5O4yRlAAAAAAAAAAA=",
           "node": {
             "coinBalance": "30000000000000000",
             "contents": {
@@ -39,7 +39,7 @@ Response: {
           }
         },
         {
-          "cursor": "IOsoTu6Ftm7PLUqS0JKQBgvgpPd0Qdyx4P4zRO2kJCq1",
+          "cursor": "IOsoTu6Ftm7PLUqS0JKQBgvgpPd0Qdyx4P4zRO2kJCq1AAAAAAAAAAA=",
           "node": {
             "coinBalance": "300000000000000",
             "contents": {
@@ -54,7 +54,7 @@ Response: {
     "fakeCoins": {
       "edges": [
         {
-          "cursor": "IF605EJGo7cGAmlcXKEt6i+p/Z5EjQ6jZMAxs9rLnkJb",
+          "cursor": "IF605EJGo7cGAmlcXKEt6i+p/Z5EjQ6jZMAxs9rLnkJbAQAAAAAAAAA=",
           "node": {
             "coinBalance": "1",
             "contents": {
@@ -65,7 +65,7 @@ Response: {
           }
         },
         {
-          "cursor": "IF+Vddhm0K5+3n7hBBxf3vTbha9vHHxvihArwAbMm02T",
+          "cursor": "IF+Vddhm0K5+3n7hBBxf3vTbha9vHHxvihArwAbMm02TAQAAAAAAAAA=",
           "node": {
             "coinBalance": "2",
             "contents": {
@@ -76,7 +76,7 @@ Response: {
           }
         },
         {
-          "cursor": "II0sTPyPSlf2EGuvQDxJ3JzBVfV2xkvkjf5ze1zcIsa6",
+          "cursor": "II0sTPyPSlf2EGuvQDxJ3JzBVfV2xkvkjf5ze1zcIsa6AQAAAAAAAAA=",
           "node": {
             "coinBalance": "3",
             "contents": {
@@ -92,7 +92,7 @@ Response: {
       "coins": {
         "edges": [
           {
-            "cursor": "IIOWz4Z094IUkdYH1ciKsXMXyOb0Ql+XNUnKWqNc1SFH",
+            "cursor": "IIOWz4Z094IUkdYH1ciKsXMXyOb0Ql+XNUnKWqNc1SFHAQAAAAAAAAA=",
             "node": {
               "coinBalance": "299999983336400",
               "contents": {

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.exp
@@ -40,19 +40,19 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IBuhnN1m7Mf4aSqiFE9YHaTqXm06hWPLzf66Yz7aDN+B"
+            "cursor": "IBuhnN1m7Mf4aSqiFE9YHaTqXm06hWPLzf66Yz7aDN+BAQAAAAAAAAA="
           },
           {
-            "cursor": "IH9LnEWueBvpi0fPbNI9o35ULhV+XeuLI4zxxI57zqkt"
+            "cursor": "IH9LnEWueBvpi0fPbNI9o35ULhV+XeuLI4zxxI57zqktAQAAAAAAAAA="
           },
           {
-            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDP"
+            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDPAQAAAAAAAAA="
           },
           {
-            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96Taw"
+            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96TawAQAAAAAAAAA="
           },
           {
-            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWL"
+            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWLAQAAAAAAAAA="
           }
         ]
       }
@@ -67,10 +67,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IBuhnN1m7Mf4aSqiFE9YHaTqXm06hWPLzf66Yz7aDN+B"
+            "cursor": "IBuhnN1m7Mf4aSqiFE9YHaTqXm06hWPLzf66Yz7aDN+BAQAAAAAAAAA="
           },
           {
-            "cursor": "IH9LnEWueBvpi0fPbNI9o35ULhV+XeuLI4zxxI57zqkt"
+            "cursor": "IH9LnEWueBvpi0fPbNI9o35ULhV+XeuLI4zxxI57zqktAQAAAAAAAAA="
           }
         ]
       }
@@ -85,10 +85,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDP"
+            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDPAQAAAAAAAAA="
           },
           {
-            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96Taw"
+            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96TawAQAAAAAAAAA="
           }
         ]
       }
@@ -103,10 +103,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96Taw"
+            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96TawAQAAAAAAAAA="
           },
           {
-            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWL"
+            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWLAQAAAAAAAAA="
           }
         ]
       }
@@ -121,10 +121,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDP"
+            "cursor": "IKmcPzAQymZ1dAi1LumON1viDhTpIKUoJ9O5QxzkBHDPAQAAAAAAAAA="
           },
           {
-            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96Taw"
+            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96TawAQAAAAAAAAA="
           }
         ]
       }
@@ -139,10 +139,10 @@ Response: {
       "objects": {
         "edges": [
           {
-            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96Taw"
+            "cursor": "IMrdU+teF18sCx888Cv6pUJK5WxoWs5m1z7C9xg96TawAQAAAAAAAAA="
           },
           {
-            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWL"
+            "cursor": "INjjPJ3tlzCtRRiX2IAe6RJ1G22AhYQ7bhMHkLfW8pWLAQAAAAAAAAA="
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -58,13 +58,13 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_5_0}
 {
   address(address: "@{A}") {
     # select the 2nd and 3rd objects
     # note that order does not correspond
     # to order in which objects were created
-    objects(first: 2 after: "@{obj_5_0_cursor}") {
+    objects(first: 2 after: "@{cursor_0}") {
       edges {
         cursor
       }
@@ -72,11 +72,11 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_4_0}
 {
   address(address: "@{A}") {
     # select 4th and last object
-    objects(first: 2 after: "@{obj_4_0_cursor}") {
+    objects(first: 2 after: "@{cursor_0}") {
       edges {
         cursor
       }
@@ -84,11 +84,11 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
+//# run-graphql --cursors @{obj_3_0}
 {
   address(address: "@{A}") {
     # select 3rd and 4th object
-    objects(last: 2 before: "@{obj_3_0_cursor}") {
+    objects(last: 2 before: "@{cursor_0}") {
       edges {
         cursor
       }

--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
@@ -9,7 +9,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IHzGD0rHsr7s2TnCZtw4XopARGmiwhFw/GFX3hwYsuBX",
+          "cursor": "IHzGD0rHsr7s2TnCZtw4XopARGmiwhFw/GFX3hwYsuBXAAAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -52,7 +52,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IHzGD0rHsr7s2TnCZtw4XopARGmiwhFw/GFX3hwYsuBX",
+          "cursor": "IHzGD0rHsr7s2TnCZtw4XopARGmiwhFw/GFX3hwYsuBXAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -62,7 +62,7 @@ Response: {
           }
         },
         {
-          "cursor": "IIHMnvkeALMPjTeJ/OOC5YxcRUCNj2lhNJxXlLo4Bhnu",
+          "cursor": "IIHMnvkeALMPjTeJ/OOC5YxcRUCNj2lhNJxXlLo4BhnuAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -72,7 +72,7 @@ Response: {
           }
         },
         {
-          "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnum",
+          "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedSui": {
@@ -87,7 +87,7 @@ Response: {
       "stakedSuis": {
         "edges": [
           {
-            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnum",
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAQAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -29,7 +29,11 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": []
+              "nodes": [
+                {
+                  "address": "0x8396cf8674f7821491d607d5c88ab17317c8e6f4425f973549ca5aa35cd52147"
+                }
+              ]
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -192,7 +196,11 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": []
+              "nodes": [
+                {
+                  "address": "0x8396cf8674f7821491d607d5c88ab17317c8e6f4425f973549ca5aa35cd52147"
+                }
+              ]
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -464,7 +472,11 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": []
+              "nodes": [
+                {
+                  "address": "0x8396cf8674f7821491d607d5c88ab17317c8e6f4425f973549ca5aa35cd52147"
+                }
+              ]
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"
@@ -855,7 +867,11 @@ Response: {
               "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             },
             "gasPayment": {
-              "nodes": []
+              "nodes": [
+                {
+                  "address": "0x8396cf8674f7821491d607d5c88ab17317c8e6f4425f973549ca5aa35cd52147"
+                }
+              ]
             },
             "gasPrice": "1000",
             "gasBudget": "5000000000"

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -95,6 +95,7 @@ impl Balance {
 
                 page.paginate_raw_query::<StoredBalance>(
                     conn,
+                    rhs,
                     balance_query(address, None, lhs as i64, rhs as i64),
                 )
                 .map(Some)

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -65,6 +65,12 @@ impl GasInput {
         last: Option<u64>,
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, Object>> {
+        // A possible user error during dry run or execution would be to supply a gas payment that
+        // is not a Move object (i.e a package). Even though the transaction would fail to run, this
+        // service will still attempt to present execution results. If the return type of this field
+        // is a `MoveObject`, then GraphQL will fail on the top-level with an internal error.
+        // Instead, we return an `Object` here, so that the rest of the `TransactionBlock` will
+        // still be viewable.
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let filter = ObjectFilter {

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -430,7 +430,7 @@ impl MoveObject {
         filter: ObjectFilter,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, MoveObject>, Error> {
-        Object::paginate_subtype(db, page, filter, checkpoint_viewed_at, |object| {
+        Object::paginate_subtype_historical(db, page, filter, checkpoint_viewed_at, |object| {
             let address = object.address;
             MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 
 use super::balance::{self, Balance};
 use super::big_int::BigInt;
 use super::coin::Coin;
 use super::coin_metadata::CoinMetadata;
-use super::cursor::{self, Page, Paginated, Target};
+use super::cursor::{self, Page, Paginated, RawPaginated, Target};
 use super::digest::Digest;
 use super::display::{Display, DisplayEntry};
 use super::dynamic_field::{DynamicField, DynamicFieldName};
@@ -23,9 +24,11 @@ use super::{owner::Owner, sui_address::SuiAddress, transaction_block::Transactio
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
+use crate::raw_query::RawQuery;
 use crate::types::base64::Base64;
 use crate::types::checkpoint::Checkpoint;
 use crate::types::intersect;
+use crate::{filter, or_filter, query};
 use async_graphql::connection::{CursorType, Edge};
 use async_graphql::{connection::Connection, *};
 use diesel::{
@@ -34,6 +37,7 @@ use diesel::{
 };
 use move_core_types::annotated_value::{MoveStruct, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
+use serde::{Deserialize, Serialize};
 use sui_indexer::models_v2::objects::{
     StoredDeletedHistoryObject, StoredHistoryObject, StoredObject,
 };
@@ -182,8 +186,16 @@ pub(crate) enum ObjectLookupKey {
     },
 }
 
-pub(crate) type Cursor = cursor::BcsCursor<Vec<u8>>;
+pub(crate) type Cursor = cursor::BcsCursor<HistoricalObjectCursor>;
 type Query<ST, GB> = data::Query<ST, objects::table, GB>;
+
+/// The inner struct for the `Object`'s cursor. The `object_id` is used as the cursor, while the
+/// `checkpoint_viewed_at` sets the consistent upper bound for the cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub(crate) struct HistoricalObjectCursor {
+    object_id: Vec<u8>,
+    checkpoint_viewed_at: u64,
+}
 
 /// Interface implemented by on-chain values that are addressable by an ID (also referred to as its
 /// address). This includes Move objects and packages.
@@ -673,7 +685,7 @@ impl Object {
         filter: ObjectFilter,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Object>, Error> {
-        Self::paginate_subtype(db, page, filter, checkpoint_viewed_at, Ok).await
+        Self::paginate_subtype_historical(db, page, filter, checkpoint_viewed_at, Ok).await
     }
 
     /// Query the database for a `page` of some sub-type of Object. The page uses the bytes of an
@@ -736,6 +748,76 @@ impl Object {
         for stored in results {
             let cursor = stored.cursor().encode_cursor();
             let object = Self::try_from_stored_object(stored, checkpoint_viewed_at)?;
+            conn.edges.push(Edge::new(cursor, downcast(object)?));
+        }
+
+        Ok(conn)
+    }
+
+    /// Query the database for a `page` of some sub-type of Object. The page uses the bytes of an
+    /// Object ID as the cursor, and can optionally be further `filter`-ed. The subtype is created
+    /// using the `downcast` function, which is allowed to fail, if the downcast has failed.
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If a `Page<Cursor>` is also provided, then this function will defer to the
+    /// `checkpoint_viewed_at` in the cursor if they are consistent. Otherwise, use the value from
+    /// the parameter, or set to None. This is so that paginated queries are consistent with the
+    /// previous query that created the cursor.
+    pub(crate) async fn paginate_subtype_historical<T: OutputType>(
+        db: &Db,
+        page: Page<Cursor>,
+        filter: ObjectFilter,
+        checkpoint_viewed_at: Option<u64>,
+        downcast: impl Fn(Object) -> Result<T, Error>,
+    ) -> Result<Connection<String, T>, Error> {
+        // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
+        // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
+        // paginated queries are consistent with the previous query that created the cursor.
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
+
+        let response = db
+            .execute_repeatable(move |conn| {
+                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+                        return Ok::<_, diesel::result::Error>(None);
+                    }
+                    rhs = checkpoint_viewed_at;
+                }
+
+                let result = page.paginate_raw_query::<StoredHistoryObject>(
+                    conn,
+                    rhs,
+                    objects_query(&filter, lhs as i64, rhs as i64),
+                )?;
+
+                Ok(Some((result, rhs)))
+            })
+            .await?;
+
+        let Some(((prev, next, results), checkpoint_viewed_at)) = response else {
+            return Err(Error::Client(
+                "Requested data is outside the available range".to_string(),
+            ));
+        };
+
+        let mut conn: Connection<String, T> = Connection::new(prev, next);
+
+        for stored in results {
+            // To maintain consistency, the returned cursor should have the same upper-bound as the
+            // checkpoint found on the cursor.
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            let object =
+                Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
             conn.edges.push(Edge::new(cursor, downcast(object)?));
         }
 
@@ -1054,17 +1136,93 @@ impl ObjectFilter {
                 .chain(self.object_ids.iter().flatten().map(|id| (*id, None))),
         ))
     }
+
+    /// Applies ObjectFilter to the input `RawQuery` and returns a new `RawQuery`.
+    pub(crate) fn apply(&self, mut query: RawQuery) -> RawQuery {
+        // Start by applying the filters on IDs and/or keys because they are combined as
+        // a disjunction, while the remaining queries are conjunctions.
+        if let Some(object_ids) = &self.object_ids {
+            // Maximally strict - match a vec of 0 elements
+            if object_ids.is_empty() {
+                query = or_filter!(query, "1=0");
+            } else {
+                let mut inner = String::new();
+                let mut prefix = "object_id IN (";
+                for id in object_ids {
+                    // SAFETY: Writing to a `String` cannot fail.
+                    write!(
+                        &mut inner,
+                        "{prefix}'\\x{}'::bytea",
+                        hex::encode(id.into_vec())
+                    )
+                    .unwrap();
+                    prefix = ",";
+                }
+                inner.push(')');
+                query = or_filter!(query, inner);
+            }
+        }
+
+        if let Some(object_keys) = &self.object_keys {
+            // Maximally strict - match a vec of 0 elements
+            if object_keys.is_empty() {
+                query = or_filter!(query, "1=0");
+            } else {
+                let mut inner = String::new();
+                let mut prefix = "(";
+                for ObjectKey { object_id, version } in object_keys {
+                    // SAFETY: Writing to a `String` cannot fail.
+                    write!(
+                        &mut inner,
+                        "{prefix}(object_id = '\\x{}'::bytea AND object_version = {})",
+                        hex::encode(object_id.into_vec()),
+                        version
+                    )
+                    .unwrap();
+                    prefix = " OR ";
+                }
+                inner.push(')');
+                query = or_filter!(query, inner);
+            }
+        }
+
+        if let Some(owner) = self.owner {
+            query = filter!(
+                query,
+                format!(
+                    "owner_id = '\\x{}'::bytea AND owner_type = {}",
+                    hex::encode(owner.into_vec()),
+                    OwnerType::Address as i16
+                )
+            );
+        }
+
+        if let Some(type_) = &self.type_ {
+            return type_.apply_raw(query, "object_type");
+        }
+
+        query
+    }
+}
+
+impl HistoricalObjectCursor {
+    pub(crate) fn new(object_id: Vec<u8>, checkpoint_viewed_at: u64) -> Self {
+        Self {
+            object_id,
+            checkpoint_viewed_at,
+        }
+    }
 }
 
 impl Paginated<Cursor> for StoredObject {
     type Source = objects::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::object_id.ge((**cursor).clone()))
+        query.filter(objects::dsl::object_id.ge(cursor.object_id.clone()))
     }
 
     fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(objects::dsl::object_id.le((**cursor).clone()))
+        query.filter(objects::dsl::object_id.le(cursor.object_id.clone()))
     }
 
     fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -1079,7 +1237,63 @@ impl Paginated<Cursor> for StoredObject {
 
 impl Target<Cursor> for StoredObject {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.object_id.clone())
+        Cursor::new(HistoricalObjectCursor::new(
+            self.object_id.clone(),
+            self.checkpoint_sequence_number as u64,
+        ))
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(HistoricalObjectCursor::new(
+            self.object_id.clone(),
+            checkpoint_viewed_at,
+        ))
+    }
+}
+
+impl RawPaginated<Cursor> for StoredHistoryObject {
+    fn filter_ge(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        filter!(
+            query,
+            format!(
+                "candidates.object_id >= '\\x{}'::bytea",
+                hex::encode(cursor.object_id.clone())
+            )
+        )
+    }
+
+    fn filter_le(cursor: &Cursor, query: RawQuery) -> RawQuery {
+        filter!(
+            query,
+            format!(
+                "candidates.object_id <= '\\x{}'::bytea",
+                hex::encode(cursor.object_id.clone())
+            )
+        )
+    }
+
+    fn order(asc: bool, query: RawQuery) -> RawQuery {
+        if asc {
+            query.order_by("candidates.object_id ASC")
+        } else {
+            query.order_by("candidates.object_id DESC")
+        }
+    }
+}
+
+impl Target<Cursor> for StoredHistoryObject {
+    fn cursor(&self) -> Cursor {
+        Cursor::new(HistoricalObjectCursor {
+            object_id: self.object_id.clone(),
+            checkpoint_viewed_at: self.checkpoint_sequence_number as u64,
+        })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(HistoricalObjectCursor::new(
+            self.object_id.clone(),
+            checkpoint_viewed_at,
+        ))
     }
 }
 
@@ -1140,6 +1354,82 @@ pub(crate) async fn deserialize_move_struct(
     })?;
 
     Ok((struct_tag, move_struct))
+}
+
+/// Check that the cursors, if provided, have the same checkpoint_viewed_at.
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(Some(after_cursor.checkpoint_viewed_at))
+            } else {
+                Err(Error::Client(
+                    "The provided cursors are taken from different checkpoints and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
+        }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(Some(cursor.checkpoint_viewed_at)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64) -> RawQuery {
+    // Construct the filtered inner query - apply the same filtering criteria to both
+    // objects_snapshot and objects_history tables.
+    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
+    snapshot_objs = filter.apply(snapshot_objs);
+
+    // Additionally filter objects_history table for results between the available range, or
+    // checkpoint_viewed_at, if provided.
+    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
+    history_objs = filter.apply(history_objs);
+    history_objs = filter!(
+        history_objs,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Combine the two queries, and select the most recent version of each object.
+    let candidates = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        snapshot_objs,
+        history_objs
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    // The following conditions ensure that the version of object matching our filters is the latest
+    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
+    // `object_keys` field), then this extra check is not required (it will filter out correct
+    // results).
+    if filter.object_keys.is_none() {
+        // Objects that fulfill the filtering criteria may not be the most recent version available.
+        // Left join the candidates table on newer to filter out any objects that have a newer
+        // version.
+        let mut newer = query!("SELECT object_id, object_version FROM objects_history");
+        newer = filter!(
+            newer,
+            format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+        );
+        let query = query!(
+            r#"SELECT candidates.*
+            FROM ({}) candidates
+            LEFT JOIN ({}) newer
+            ON (
+                candidates.object_id = newer.object_id
+                AND candidates.object_version < newer.object_version
+            )"#,
+            candidates,
+            newer
+        );
+
+        filter!(query, "newer.object_version IS NULL")
+    } else {
+        query!("SELECT * FROM ({}) candidates", candidates)
+    }
 }
 
 #[cfg(test)]
@@ -1261,5 +1551,61 @@ mod tests {
 
         // No overlap between these two.
         assert_eq!(f2.clone().intersect(f3.clone()), None);
+    }
+
+    #[test]
+    fn test_validate_cursor_consistency_all_none() {
+        let result = validate_cursor_consistency(None, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_cursor_consistency_all_same() {
+        let obj1 = SuiAddress::from_str("0x1").unwrap();
+        let obj2 = SuiAddress::from_str("0x2").unwrap();
+
+        let result = validate_cursor_consistency(
+            Some(&Cursor::new(HistoricalObjectCursor::new(
+                obj1.into_vec(),
+                1,
+            ))),
+            Some(&Cursor::new(HistoricalObjectCursor::new(
+                obj2.into_vec(),
+                1,
+            ))),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_cursor_consistency_only_after() {
+        let obj1 = SuiAddress::from_str("0x1").unwrap();
+
+        let result = validate_cursor_consistency(
+            Some(&Cursor::new(HistoricalObjectCursor::new(
+                obj1.into_vec(),
+                1,
+            ))),
+            None,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_cursor_consistency_after_ne_before() {
+        let obj1 = SuiAddress::from_str("0x1").unwrap();
+        let obj2 = SuiAddress::from_str("0x2").unwrap();
+
+        let result = validate_cursor_consistency(
+            Some(&Cursor::new(HistoricalObjectCursor::new(
+                obj1.into_vec(),
+                1,
+            ))),
+            Some(&Cursor::new(HistoricalObjectCursor::new(
+                obj2.into_vec(),
+                2,
+            ))),
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{string_input::impl_string_input, sui_address::SuiAddress};
-use crate::data::{DieselBackend, Query};
+use crate::raw_query::RawQuery;
+use crate::{
+    data::{DieselBackend, Query},
+    filter,
+};
 use async_graphql::*;
 use diesel::{
     expression::{is_aggregate::No, ValidGrouping},
@@ -102,6 +106,43 @@ impl TypeFilter {
                 query.filter(field.eq(exact))
             }
         }
+    }
+
+    /// Modify `query` to apply this filter to `field`, returning the new query.
+    pub(crate) fn apply_raw(&self, mut query: RawQuery, field: &str) -> RawQuery {
+        match self {
+            TypeFilter::ByModule(ModuleFilter::ByPackage(p)) => {
+                let pattern = format!("{p}::%");
+                let statement = field.to_string() + " LIKE {}";
+                query = filter!(query, statement, pattern);
+            }
+
+            TypeFilter::ByModule(ModuleFilter::ByModule(p, m)) => {
+                let pattern = format!("{p}::{m}::%");
+                let statement = field.to_string() + " LIKE {}";
+                query = filter!(query, statement, pattern);
+            }
+
+            // A type filter without type parameters is interpreted as either an exact match, or a
+            // match for all generic instantiations of the type.
+            TypeFilter::ByType(TypeTag::Struct(tag)) if tag.type_params.is_empty() => {
+                let exact_pattern = tag.to_canonical_string(/* with_prefix */ true);
+                let generic_pattern =
+                    format!("{}<%", tag.to_canonical_display(/* with_prefix */ true));
+
+                let statement = field.to_string() + " = {} OR " + field + " LIKE {}";
+
+                query = filter!(query, statement, exact_pattern, generic_pattern);
+            }
+
+            TypeFilter::ByType(tag) => {
+                let exact_pattern = tag.to_canonical_string(/* with_prefix */ true);
+                let statement = field.to_string() + " = {}";
+                query = filter!(query, statement, exact_pattern);
+            }
+        }
+
+        query
     }
 
     /// Try to create a filter whose results are the intersection of the results of the input

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -590,7 +590,8 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     .wait_for_objects_snapshot_catchup(Duration::from_secs(30))
                     .await;
 
-                let interpolated = self.interpolate_query(&contents, &cursors)?;
+                let interpolated =
+                    self.interpolate_query(&contents, &cursors, highest_checkpoint)?;
                 let resp = cluster
                     .graphql_client
                     .execute_to_graphql(interpolated.trim().to_owned(), show_usage, vec![], vec![])
@@ -1088,35 +1089,21 @@ impl<'a> SuiTestAdapter<'a> {
         self.executor
     }
 
-    fn named_variables(&self, cursors: &[String]) -> BTreeMap<String, String> {
+    fn named_variables(
+        &self,
+        cursors: &[String],
+        highest_checkpoint: u64,
+    ) -> BTreeMap<String, String> {
         let mut variables = BTreeMap::new();
+        let mut objects_mapping: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+
         let named_addrs = self
             .compiled_state
             .named_address_mapping
             .iter()
             .map(|(name, addr)| (name.clone(), format!("{:#02x}", addr)));
 
-        let objects = self
-            .object_enumeration
-            .iter()
-            .flat_map(|(oid, fid)| match fid {
-                FakeID::Known(_) => vec![],
-                FakeID::Enumerated(x, y) => vec![
-                    (format!("obj_{x}_{y}"), oid.to_string()),
-                    // Add a binding to treat this object as a cursor
-                    (
-                        format!("obj_{x}_{y}_cursor"),
-                        Base64::encode(bcs::to_bytes(&oid.to_vec()).unwrap_or_default()),
-                    ),
-                ],
-            });
-
-        let cursors = cursors
-            .iter()
-            .enumerate()
-            .map(|(idx, c)| (format!("cursor_{idx}"), Base64::encode(c)));
-
-        for (name, addr) in named_addrs.chain(objects).chain(cursors) {
+        for (name, addr) in named_addrs {
             let addr = addr.to_string();
 
             // Required variant
@@ -1125,11 +1112,54 @@ impl<'a> SuiTestAdapter<'a> {
             let name = name.to_string() + "_opt";
             variables.insert(name.clone(), addr.clone());
         }
+
+        for (oid, fid) in &self.object_enumeration {
+            if let FakeID::Enumerated(x, y) = fid {
+                objects_mapping.insert(format!("obj_{x}_{y}"), oid.to_vec());
+                variables.insert(format!("obj_{x}_{y}"), oid.to_string());
+                variables.insert(format!("obj_{x}_{y}_opt"), oid.to_string());
+            }
+        }
+
+        for (idx, s) in cursors.iter().enumerate() {
+            // an object cursor may be either @{obj_x_y} or @{obj_x_y,n}
+            // if the former, then use highest_checkpoint
+            if s.starts_with("@{obj_") && s.ends_with('}') {
+                let end_of_key = s.find(',').unwrap_or(s.len() - 1);
+                let obj_lookup = s[2..end_of_key].to_string();
+
+                let obj_id = objects_mapping.get(&obj_lookup).unwrap_or_else(|| {
+                    panic!(
+                        "Unknown object lookup: {}\nAllowed variable mappings are {:#?}",
+                        obj_lookup, variables
+                    )
+                });
+
+                let checkpoint = if end_of_key == s.len() - 1 {
+                    highest_checkpoint
+                } else {
+                    s[end_of_key + 1..s.len() - 1].parse::<u64>().unwrap()
+                };
+
+                let bcsd = bcs::to_bytes(&(obj_id.clone(), checkpoint)).unwrap_or_default();
+                let base64d = Base64::encode(bcsd);
+
+                variables.insert(format!("cursor_{idx}"), base64d);
+            } else {
+                variables.insert(format!("cursor_{idx}"), Base64::encode(s));
+            }
+        }
+
         variables
     }
 
-    fn interpolate_query(&self, contents: &str, cursors: &[String]) -> anyhow::Result<String> {
-        let variables = self.named_variables(cursors);
+    fn interpolate_query(
+        &self,
+        contents: &str,
+        cursors: &[String],
+        highest_checkpoint: u64,
+    ) -> anyhow::Result<String> {
+        let variables = self.named_variables(cursors, highest_checkpoint);
         let mut interpolated_query = contents.to_string();
 
         let re = regex::Regex::new(r"@\{([^\}]+)\}").unwrap();


### PR DESCRIPTION
## Description 

1.  Implement raw-query version of the existing TypeFilter and ObjectFilter logic
2. Note that when object_keys - object_id and object_version - are provided, the WHERE condition gets dropped. This is so that we can actually return data like the gas payment of a transaction. In other words, return the historical rather than the consistent view.
3. Extend `test_adapter` to handle complex `Object` cursors.
4. extend paginate_raw_query again to accept a cursor_fn that transforms each element's cursor. This is predominantly for Object, as the checkpoint_sequence_number to be set on an object as context should come from the method parameters, not the object itself.

## Test Plan 

tx_address_objects.move
objects_pagination.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
