### PR TITLE
generate and write bridge authority key to a file

### DIFF
--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -55,3 +55,7 @@ sui-config.workspace = true
 sui-test-transaction-builder.workspace = true
 test-cluster.workspace = true
 hex-literal = "0.3.4"
+
+[[bin]]
+name = "sui-bridge-validator-cli"
+path = "src/tools/validator_cli.rs"

--- a/crates/sui-bridge/src/tools/validator_cli.rs
+++ b/crates/sui-bridge/src/tools/validator_cli.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use clap::*;
+use fastcrypto::traits::EncodeDecodeBase64;
+use std::path::PathBuf;
+use sui_bridge::crypto::BridgeAuthorityKeyPair;
+use sui_types::crypto::get_key_pair;
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+struct Args {
+    #[clap(subcommand)]
+    command: BridgeValidatorCommand,
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub enum BridgeValidatorCommand {
+    #[clap(name = "create-bridge-validator-key")]
+    CreateBridgeValidatorKey { path: PathBuf },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    match args.command {
+        BridgeValidatorCommand::CreateBridgeValidatorKey { path } => {
+            generate_bridge_authority_key_and_write_to_file(&path)?;
+            println!("Bridge validator key generated at {}", path.display());
+        }
+    }
+
+    Ok(())
+}
+
+/// Generate Bridge Authority key (Secp256k1KeyPair) and write to a file as base64 encoded `privkey`.
+fn generate_bridge_authority_key_and_write_to_file(path: &PathBuf) -> Result<(), anyhow::Error> {
+    let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+    let base64_encoded = kp.encode_base64();
+    std::fs::write(path, base64_encoded)
+        .map_err(|err| anyhow!("Failed to write encoded key to path: {:?}", err))
+}


### PR DESCRIPTION
## Description 

usage:

```
./sui-bridge-validator-cli create-bridge-validator-key {file path}
```

## Test Plan 

tested locally

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
