### PR TITLE
[Pick #15894][GraphQL/Cursor][BUGFIX] Pagination Edge Case

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -1,9 +1,9 @@
-processed 12 tasks
+processed 17 tasks
 
-task 1 'create-checkpoint'. lines 22-22:
+task 1 'create-checkpoint'. lines 31-31:
 Checkpoint created: 12
 
-task 2 'run-graphql'. lines 24-36:
+task 2 'run-graphql'. lines 33-45:
 Response: {
   "data": {
     "checkpoints": {
@@ -41,7 +41,7 @@ Response: {
   }
 }
 
-task 3 'run-graphql'. lines 38-50:
+task 3 'run-graphql'. lines 47-59:
 Response: {
   "data": {
     "checkpoints": {
@@ -61,7 +61,7 @@ Response: {
   }
 }
 
-task 4 'run-graphql'. lines 52-64:
+task 4 'run-graphql'. lines 61-73:
 Response: {
   "data": {
     "checkpoints": {
@@ -99,7 +99,65 @@ Response: {
   }
 }
 
-task 5 'run-graphql'. lines 66-78:
+task 5 'run-graphql'. lines 75-87:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "NA",
+          "node": {
+            "sequenceNumber": 4
+          }
+        },
+        {
+          "cursor": "NQ",
+          "node": {
+            "sequenceNumber": 5
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6 'run-graphql'. lines 89-101:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "MA",
+          "node": {
+            "sequenceNumber": 0
+          }
+        },
+        {
+          "cursor": "MQ",
+          "node": {
+            "sequenceNumber": 1
+          }
+        },
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 7 'run-graphql'. lines 103-115:
 Response: {
   "data": {
     "checkpoints": {
@@ -137,7 +195,107 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 80-92:
+task 8 'run-graphql'. lines 117-129:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "MA",
+          "node": {
+            "sequenceNumber": 0
+          }
+        },
+        {
+          "cursor": "MQ",
+          "node": {
+            "sequenceNumber": 1
+          }
+        },
+        {
+          "cursor": "Mg",
+          "node": {
+            "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "Mw",
+          "node": {
+            "sequenceNumber": 3
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9 'run-graphql'. lines 131-143:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "NQ",
+          "node": {
+            "sequenceNumber": 5
+          }
+        },
+        {
+          "cursor": "Ng",
+          "node": {
+            "sequenceNumber": 6
+          }
+        },
+        {
+          "cursor": "Nw",
+          "node": {
+            "sequenceNumber": 7
+          }
+        },
+        {
+          "cursor": "OA",
+          "node": {
+            "sequenceNumber": 8
+          }
+        },
+        {
+          "cursor": "OQ",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
+        },
+        {
+          "cursor": "MTE",
+          "node": {
+            "sequenceNumber": 11
+          }
+        },
+        {
+          "cursor": "MTI",
+          "node": {
+            "sequenceNumber": 12
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 145-157:
 Response: {
   "data": {
     "checkpoints": {
@@ -175,7 +333,7 @@ Response: {
   }
 }
 
-task 7 'run-graphql'. lines 94-106:
+task 11 'run-graphql'. lines 159-171:
 Response: {
   "data": {
     "checkpoints": {
@@ -201,7 +359,39 @@ Response: {
   }
 }
 
-task 8 'run-graphql'. lines 108-120:
+task 12 'run-graphql'. lines 173-185:
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "MTA",
+          "node": {
+            "sequenceNumber": 10
+          }
+        },
+        {
+          "cursor": "MTE",
+          "node": {
+            "sequenceNumber": 11
+          }
+        },
+        {
+          "cursor": "MTI",
+          "node": {
+            "sequenceNumber": 12
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 187-199:
 Response: {
   "data": {
     "checkpoints": {
@@ -293,7 +483,7 @@ Response: {
   }
 }
 
-task 9 'run-graphql'. lines 122-134:
+task 14 'run-graphql'. lines 201-213:
 Response: {
   "data": {
     "checkpoints": {
@@ -331,7 +521,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 136-148:
+task 15 'run-graphql'. lines 215-227:
 Response: {
   "data": {
     "checkpoints": {
@@ -369,7 +559,7 @@ Response: {
   }
 }
 
-task 11 'run-graphql'. lines 150-162:
+task 16 'run-graphql'. lines 229-241:
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -1,23 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//# init --addresses Test=0x0 --simulator
+
 // Test cursor connection pagination logic
 // The implementation privileges `after`, `before`, `first`, and `last` in that order.
 // Currently implemented only for items ordered in ascending order by `sequenceNumber`.
 
-// Assuming checkpoints 0 through 12
-// first: 4, after: 6 -> checkpoints 7, 8, 9, 10
-// first: 4, after: 6, before: 8 -> checkpoints 7
-// first: 4, before: 6 -> checkpoints 0, 1, 2, 3
-// last: 4, after: 6 -> checkpoints 9, 10, 11, 12
-// last: 4, before: 6 -> checkpoints 2, 3, 4, 5
-// last: 4, after: 3, before: 6 -> checkpoints 4, 5
-// no first or last -> checkpoints 0, 1, ..., 11, 12
-// first: 4 -> checkpoints 0, 1, 2, 3
-// last: 4 -> checkpoints 9, 10, 11, 12
-// first: 4, last: 2 -> error
+// Summary of tests:
+//
+// F A L B | checkpoints
+// --------+------------
+// 4 6     |  7 - 10
+// 4 6   8 |  7 -  7
+// 4     6 |  0 -  3
+// 4 3   6 |  4 -  5
+// 4     3 |  0 -  2
+//   6 4   |  9 - 12
+//       4 |  0 -  3
+//   4     |  5 - 12
+//     4 6 |  2 -  5
+//   3 4 6 |  4 -  5
+//   9 4   | 10 - 12
+//         |  0 - 12
+// 4       |  0 -  3
+//     4   |  9 - 12
+// 4   2   |   error
 
-//# init --addresses Test=0x0 --simulator
 
 //# create-checkpoint 12
 
@@ -63,9 +72,65 @@
   }
 }
 
+//# run-graphql --cursors 3 6
+{
+  checkpoints(first: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 3
+{
+  checkpoints(first: 4, before: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
 //# run-graphql --cursors 6
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 4
+{
+  checkpoints(before: "@{cursor_0}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 4
+{
+  checkpoints(after: "@{cursor_0}") {
     pageInfo {
       hasPreviousPage
       hasNextPage
@@ -94,6 +159,20 @@
 //# run-graphql --cursors 3 6
 {
   checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors 9
+{
+  checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {
       hasPreviousPage
       hasNextPage


### PR DESCRIPTION
## Description

Fix handling the case where we are drawing from one side of the page (e.g. the front), without a cursor on that side but with a cursor on the other side which ends up included in the fetched results.

In this case, we should be trimming the cursor on the off-side and indicating that there is a further page in that direction, but instead we include it in the results and assume that because we couldn't satisfy the limit requested, there are no further results.

This PR generalises the special case that was introduced for the situation where both the before and after cursors were supplied and both were found in the results, regardless of the limit -- now we correctly detect a trailing `before` cursor when drawing from the front and a leading `after` cursor when drawing from the back and strip them.

## Test Plan

New E2E tests:

```
sui-graphql-e2e-tests$ cargo nextest run \
  -j 1 --features pg_integration         \
  -- checkpoint_connection_pagination.move
```

### Release notes

Fixes a pagination bug where cursors were not correctly trimmed from a page that was smaller than the supplied limit.