### PR TITLE
[GraphQL] Fix flaky E2E test

### DIFF
--- a/crates/sui-graphql-rpc-client/src/simple_client.rs
+++ b/crates/sui-graphql-rpc-client/src/simple_client.rs
@@ -103,6 +103,12 @@ impl SimpleClient {
         GraphqlResponse::from_resp(self.execute_impl(mutation, variables, vec![], true).await?)
             .await
     }
+
+    /// Send a request to the GraphQL server to check if it is alive.
+    pub async fn ping(&self) -> Result<(), ClientError> {
+        self.inner.get(format!("{}/health", self.url)).send().await?;
+        Ok(())
+    }
 }
 
 #[allow(clippy::type_complexity)]

--- a/crates/sui-graphql-rpc-client/src/simple_client.rs
+++ b/crates/sui-graphql-rpc-client/src/simple_client.rs
@@ -106,7 +106,10 @@ impl SimpleClient {
 
     /// Send a request to the GraphQL server to check if it is alive.
     pub async fn ping(&self) -> Result<(), ClientError> {
-        self.inner.get(format!("{}/health", self.url)).send().await?;
+        self.inner
+            .get(format!("{}/health", self.url))
+            .send()
+            .await?;
         Ok(())
     }
 }

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -199,11 +199,10 @@ impl ExecutorCluster {
             .indexer_store
             .get_latest_tx_checkpoint_sequence_number()
             .await
-            .unwrap()
             .unwrap();
 
-        let checkpoint_diff = std::cmp::max(1, checkpoint.saturating_sub(current_checkpoint));
-        let timeout = base_timeout.mul_f64(checkpoint_diff as f64);
+        let diff = checkpoint.saturating_sub(current_checkpoint.unwrap_or(0)).max(1);
+        let timeout = base_timeout.mul_f64(diff as f64);
 
         tokio::time::timeout(timeout, async {
             while self
@@ -211,8 +210,7 @@ impl ExecutorCluster {
                 .get_latest_tx_checkpoint_sequence_number()
                 .await
                 .unwrap()
-                .unwrap()
-                < checkpoint
+                < Some(checkpoint)
             {
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -201,7 +201,9 @@ impl ExecutorCluster {
             .await
             .unwrap();
 
-        let diff = checkpoint.saturating_sub(current_checkpoint.unwrap_or(0)).max(1);
+        let diff = checkpoint
+            .saturating_sub(current_checkpoint.unwrap_or(0))
+            .max(1);
         let timeout = base_timeout.mul_f64(diff as f64);
 
         tokio::time::timeout(timeout, async {

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -116,7 +116,6 @@ pub async fn serve_executor(
 
     // Starts graphql server
     let graphql_server_handle = start_graphql_server(graphql_connection_config.clone()).await;
-    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let server_url = format!(
         "http://{}:{}/",
@@ -186,7 +185,7 @@ async fn start_validator_with_fullnode(internal_data_source_rpc_port: Option<u16
 /// Repeatedly ping the GraphQL server for 10s, until it responds
 async fn wait_for_graphql_server(client: &SimpleClient) {
     tokio::time::timeout(Duration::from_secs(10), async {
-        while let Err(_) = client.ping().await {
+        while client.ping().await.is_err() {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
     })

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -32,8 +32,6 @@ mod tests {
         let cluster =
             sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
 
-        // Wait for servers to start and catchup
-
         let query = r#"
             {
                 chainIdentifier

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -550,7 +550,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cluster = self.cluster.as_ref().unwrap();
                 let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
                 cluster
-                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
+                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(30))
                     .await;
 
                 cluster

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -550,7 +550,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cluster = self.cluster.as_ref().unwrap();
                 let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
                 cluster
-                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(40))
+                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
                     .await;
 
                 cluster

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -550,7 +550,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cluster = self.cluster.as_ref().unwrap();
                 let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
                 cluster
-                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(30))
+                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(40))
                     .await;
 
                 cluster


### PR DESCRIPTION
## Description

Add a step to the E2E set-up to poll for a response from the GraphQL server before proceeding with the test to prevent it from failing due to the server not coming up fast enough.

## Test Plan

```
sui-graphlql-rpc$ cargo nextest run \
  -j 1 --features pg_integration    \
  --test e2e_tests
```