### PR TITLE
[GraphQL/SuiNS] Introduce NameService

### DIFF
--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -9,6 +9,7 @@ use super::dynamic_field::DynamicFieldName;
 use super::move_package::MovePackage;
 use super::object::ObjectVersionKey;
 use super::stake::StakedSui;
+use super::suins_registration::NameService;
 use super::suins_registration::SuinsRegistration;
 use crate::data::Db;
 use crate::types::balance::{self, Balance};
@@ -358,7 +359,7 @@ impl OwnerImpl {
     }
 
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        Ok(SuinsRegistration::reverse_resolve_to_name(
+        Ok(NameService::reverse_resolve_to_name(
             ctx.data_unchecked::<Db>(),
             ctx.data_unchecked::<NameServiceConfig>(),
             self.0,

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -13,6 +13,7 @@ use sui_sdk::SuiClient;
 use sui_types::transaction::{TransactionData, TransactionKind};
 use sui_types::{gas_coin::GAS, transaction::TransactionDataAPI, TypeTag};
 
+use super::suins_registration::NameService;
 use super::{
     address::Address,
     available_range::AvailableRange,
@@ -30,7 +31,7 @@ use super::{
     owner::Owner,
     protocol_config::ProtocolConfigs,
     sui_address::SuiAddress,
-    suins_registration::{Domain, SuinsRegistration},
+    suins_registration::Domain,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
     transaction_metadata::TransactionMetadata,
     type_filter::ExactTypeFilter,
@@ -344,7 +345,7 @@ impl Query {
         ctx: &Context<'_>,
         domain: Domain,
     ) -> Result<Option<Address>> {
-        Ok(SuinsRegistration::resolve_to_record(
+        Ok(NameService::resolve_to_record(
             ctx.data_unchecked::<Db>(),
             ctx.data_unchecked::<NameServiceConfig>(),
             &domain,

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -31,6 +31,10 @@ use sui_types::{base_types::SuiAddress as NativeSuiAddress, dynamic_field::Field
 const MOD_REGISTRATION: &IdentStr = ident_str!("suins_registration");
 const TYP_REGISTRATION: &IdentStr = ident_str!("SuinsRegistration");
 
+/// Represents the "core" of the name service (e.g. the on-chain registry and reverse registry). It
+/// doesn't contain any fields because we look them up based on the `NameServiceConfig`.
+pub(crate) struct NameService;
+
 /// Wrap SuiNS Domain type to expose as a string scalar in GraphQL.
 #[derive(Debug)]
 pub(crate) struct Domain(NativeDomain);
@@ -296,7 +300,7 @@ impl SuinsRegistration {
     }
 }
 
-impl SuinsRegistration {
+impl NameService {
     /// Lookup the SuiNS NameRecord for the given `domain` name. `config` specifies where to find
     /// the domain name registry, and its type.
     pub(crate) async fn resolve_to_record(
@@ -342,7 +346,9 @@ impl SuinsRegistration {
 
         Ok(Some(field.value))
     }
+}
 
+impl SuinsRegistration {
     /// Query the database for a `page` of SuiNS registrations. The page uses the same cursor type
     /// as is used for `Object`, and is further filtered to a particular `owner`. `config` specifies
     /// where to find the domain name registry and its type.


### PR DESCRIPTION
## Description

Based on feedback from Manos that it is confusing to have the resolution functions hanging off `SuinsRegistration`.

This slightly goes against an earlier recommendation I made to not introduce functions on types that don't need `self` unless they are constructors of some kind, but it is done to match the pattern we have for queries.

## Test Plan

Existing tests:

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run -j 1 --features pg_integration
```