### PR TITLE
[gql][consistent-reads][4/n] Implement consistent reads for suinsRegistration and stakedSui

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
@@ -1,0 +1,151 @@
+processed 15 tasks
+
+init:
+C: object(0,0)
+
+task 1 'run-graphql'. lines 6-18:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 2 'programmable'. lines 20-22:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 24-24:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [26, 51, 207, 117, 17, 148, 210, 33, 235, 213, 24, 171, 13, 208, 132, 252, 4, 165, 220, 48, 94, 12, 8, 136, 21, 131, 65, 239, 103, 69, 48, 145, 218, 131, 22, 109, 1, 175, 215, 221, 207, 138, 245, 248, 68, 244, 90, 170, 83, 244, 133, 72, 229, 17, 124, 35, 245, 162, 151, 140, 253, 66, 34, 68, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(3,0), object(3,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(_), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4 'create-checkpoint'. lines 26-26:
+Checkpoint created: 1
+
+task 5 'advance-epoch'. lines 28-28:
+Epoch advanced: 0
+
+task 6 'programmable'. lines 30-32:
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'run'. lines 34-34:
+events: Event { package_id: sui_system, transaction_module: Identifier("sui_system"), sender: C, type_: StructTag { address: sui_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [26, 51, 207, 117, 17, 148, 210, 33, 235, 213, 24, 171, 13, 208, 132, 252, 4, 165, 220, 48, 94, 12, 8, 136, 21, 131, 65, 239, 103, 69, 48, 145, 218, 131, 22, 109, 1, 175, 215, 221, 207, 138, 245, 248, 68, 244, 90, 170, 83, 244, 133, 72, 229, 17, 124, 35, 245, 162, 151, 140, 253, 66, 34, 68, 252, 204, 154, 66, 27, 187, 19, 193, 166, 106, 26, 169, 143, 10, 215, 80, 41, 237, 233, 72, 87, 119, 156, 105, 21, 180, 79, 148, 6, 139, 146, 30, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(7,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0), object(3,0)
+deleted: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 15078400,  storage_rebate: 14626656, non_refundable_storage_fee: 147744
+
+task 8 'create-checkpoint'. lines 36-36:
+Checkpoint created: 3
+
+task 9 'advance-epoch'. lines 38-38:
+Epoch advanced: 1
+
+task 10 'view-object'. lines 40-40:
+Owner: Account Address ( C )
+Version: 3
+Contents: sui_system::staking_pool::StakedSui {id: sui::object::UID {id: sui::object::ID {bytes: fake(3,1)}}, pool_id: sui::object::ID {bytes: _}, stake_activation_epoch: 1u64, principal: sui::balance::Balance<sui::sui::SUI> {value: 10000000000u64}}
+
+task 11 'view-object'. lines 42-42:
+Owner: Account Address ( C )
+Version: 5
+Contents: sui_system::staking_pool::StakedSui {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, pool_id: sui::object::ID {bytes: _}, stake_activation_epoch: 2u64, principal: sui::balance::Balance<sui::sui::SUI> {value: 10000000000u64}}
+
+task 12 'run-graphql'. lines 44-56:
+Response: {
+  "data": {
+    "address": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "ICDggqmfIcvsKEH05Z1OkE9J0V8cCp3Jn1KvicHvqn5qBAAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          },
+          {
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumBAAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 13 'run-graphql'. lines 58-102:
+Response: {
+  "data": {
+    "no_coins_after_obj_3_1_chkpt_1": {
+      "stakedSuis": {
+        "edges": []
+      }
+    },
+    "no_coins_before_obj_3_1_chkpt_1": {
+      "stakedSuis": {
+        "edges": []
+      }
+    },
+    "no_coins_after_obj_7_0_chkpt_1": {
+      "stakedSuis": {
+        "edges": []
+      }
+    },
+    "no_coins_before_obj_7_0_chkpt_1": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 104-147:
+Response: {
+  "data": {
+    "coins_after_obj_3_1_chkpt_3": {
+      "stakedSuis": {
+        "edges": []
+      }
+    },
+    "coins_before_obj_3_1_chkpt_3": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "ICDggqmfIcvsKEH05Z1OkE9J0V8cCp3Jn1KvicHvqn5qAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    },
+    "coins_after_obj_7_0_chkpt_3": {
+      "stakedSuis": {
+        "edges": [
+          {
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
+      }
+    },
+    "coins_before_obj_7_0_chkpt_3": {
+      "stakedSuis": {
+        "edges": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
@@ -1,0 +1,147 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --simulator --accounts C
+
+//# run-graphql
+{
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(2,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# run 0x3::sui_system::request_add_stake --args object(0x5) object(6,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# view-object 3,1
+
+//# view-object 7,0
+
+//# run-graphql
+{
+  address(address: "@{C}") {
+    stakedSuis {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_1,1} @{obj_7_0,1}
+# Even though there is a stake created after the initial one, the cursor locks the upper bound to
+# checkpoint 1 - at that point in time, we did not have any additional stakes.
+{
+  no_coins_after_obj_3_1_chkpt_1: address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  no_coins_before_obj_3_1_chkpt_1: address(address: "@{C}") {
+    stakedSuis(before: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  no_coins_after_obj_7_0_chkpt_1: address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  no_coins_before_obj_7_0_chkpt_1: address(address: "@{C}") {
+    stakedSuis(before: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors @{obj_3_1,3} @{obj_7_0,3}
+# The second stake was created at checkpoint 3, and thus will be visible.
+{
+  coins_after_obj_3_1_chkpt_3: address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  coins_before_obj_3_1_chkpt_3: address(address: "@{C}") {
+    stakedSuis(before: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  coins_after_obj_7_0_chkpt_3: address(address: "@{C}") {
+    stakedSuis(after: "@{cursor_1}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+  coins_before_obj_7_0_chkpt_3: address(address: "@{C}") {
+    stakedSuis(before: "@{cursor_1}") {
+      edges {
+        cursor
+        node {
+          principal
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.exp
@@ -87,7 +87,7 @@ Response: {
       "stakedSuis": {
         "edges": [
           {
-            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAQAAAAAAAAA=",
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAgAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -430,7 +430,7 @@ impl MoveObject {
         filter: ObjectFilter,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, MoveObject>, Error> {
-        Object::paginate_subtype_historical(db, page, filter, checkpoint_viewed_at, |object| {
+        Object::paginate_subtype(db, page, filter, checkpoint_viewed_at, |object| {
             let address = object.address;
             MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(


### PR DESCRIPTION
## Description 

Add consistent read support for Object subtypes, which end up being just suinsRegistration and stakedSui.

## Test Plan 

staked_sui.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
