### PR TITLE
[GraphQL] paginate activeValidators and reportRecords

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -220,18 +220,20 @@ Response: {
   }
 }
 
-task 20 'run-graphql'. lines 154-168:
+task 20 'run-graphql'. lines 154-170:
 Response: {
   "data": {
     "epoch": {
       "validatorSet": {
-        "activeValidators": [
-          {
-            "address": {
-              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+        "activeValidators": {
+          "nodes": [
+            {
+              "address": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     },
     "address": {
@@ -240,7 +242,7 @@ Response: {
   }
 }
 
-task 21 'run-graphql'. lines 170-176:
+task 21 'run-graphql'. lines 172-178:
 Response: {
   "data": {
     "epoch": {
@@ -249,17 +251,17 @@ Response: {
   }
 }
 
-task 22 'run'. lines 178-178:
+task 22 'run'. lines 180-180:
 created: object(22,0)
 mutated: object(0,1)
 gas summary: computation_cost: 999000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 23 'run'. lines 180-180:
+task 23 'run'. lines 182-182:
 created: object(23,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 182-182:
+task 24 'run'. lines 184-184:
 created: object(24,0)
 mutated: object(0,1)
 gas summary: computation_cost: 235000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -156,8 +156,10 @@ module Test::M1 {
   epoch {
     validatorSet {
       activeValidators {
-        address {
-          address
+        nodes {
+          address {
+            address
+          }
         }
       }
     }

--- a/crates/sui-graphql-e2e-tests/tests/epoch/epoch.exp
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/epoch.exp
@@ -38,12 +38,19 @@ Checkpoint created: 5
 task 9 'advance-epoch'. lines 31-32:
 Epoch advanced: 2
 
-task 10 'run-graphql'. lines 33-47:
+task 10 'run-graphql'. lines 33-52:
 Response: {
   "data": {
     "epoch": {
       "validatorSet": {
-        "totalStake": "20000010002000000"
+        "totalStake": "20000010002000000",
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0"
+            }
+          ]
+        }
       },
       "totalGasFees": "1000000",
       "totalStakeRewards": "1000000",

--- a/crates/sui-graphql-e2e-tests/tests/epoch/epoch.move
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/epoch.move
@@ -35,6 +35,11 @@
   epoch(id: 2) {
     validatorSet {
       totalStake
+      activeValidators {
+        nodes {
+          name
+        }
+      }
     }
     totalGasFees
     totalStakeRewards

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -137,7 +137,7 @@ Checkpoint created: 5
 task 27 'advance-epoch'. lines 99-101:
 Epoch advanced: 2
 
-task 28 'run-graphql'. lines 103-113:
+task 28 'run-graphql'. lines 103-118:
 Response: {
   "data": {
     "epoch": {
@@ -145,7 +145,10 @@ Response: {
         "activeValidators": [
           {
             "apy": 2,
-            "name": "validator-0"
+            "name": "validator-0",
+            "reportRecords": {
+              "nodes": []
+            }
           }
         ]
       }

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -40,117 +40,121 @@ Checkpoint created: 3
 task 9 'advance-epoch'. lines 53-53:
 Epoch advanced: 1
 
-task 10 'run-graphql'. lines 55-65:
+task 10 'run-graphql'. lines 55-67:
 Response: {
   "data": {
     "epoch": {
       "validatorSet": {
-        "activeValidators": [
-          {
-            "apy": 1,
-            "name": "validator-0"
-          }
-        ]
+        "activeValidators": {
+          "nodes": [
+            {
+              "apy": 1,
+              "name": "validator-0"
+            }
+          ]
+        }
       }
     }
   }
 }
 
-task 11 'run'. lines 67-67:
+task 11 'run'. lines 69-69:
 created: object(11,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 12 'run'. lines 69-69:
+task 12 'run'. lines 71-71:
 created: object(12,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 13 'run'. lines 71-71:
+task 13 'run'. lines 73-73:
 created: object(13,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 14 'run'. lines 73-73:
+task 14 'run'. lines 75-75:
 created: object(14,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 15 'run'. lines 75-75:
+task 15 'run'. lines 77-77:
 created: object(15,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 16 'run'. lines 77-77:
+task 16 'run'. lines 79-79:
 created: object(16,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 17 'run'. lines 79-79:
+task 17 'run'. lines 81-81:
 created: object(17,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 18 'run'. lines 81-81:
+task 18 'run'. lines 83-83:
 created: object(18,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 19 'run'. lines 83-83:
+task 19 'run'. lines 85-85:
 created: object(19,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 20 'run'. lines 85-85:
+task 20 'run'. lines 87-87:
 created: object(20,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 21 'run'. lines 87-87:
+task 21 'run'. lines 89-89:
 created: object(21,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 22 'run'. lines 89-89:
+task 22 'run'. lines 91-91:
 created: object(22,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 23 'run'. lines 91-91:
+task 23 'run'. lines 93-93:
 created: object(23,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 93-93:
+task 24 'run'. lines 95-95:
 created: object(24,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run'. lines 95-95:
+task 25 'run'. lines 97-97:
 created: object(25,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 26 'create-checkpoint'. lines 97-97:
+task 26 'create-checkpoint'. lines 99-99:
 Checkpoint created: 5
 
-task 27 'advance-epoch'. lines 99-101:
+task 27 'advance-epoch'. lines 101-103:
 Epoch advanced: 2
 
-task 28 'run-graphql'. lines 103-118:
+task 28 'run-graphql'. lines 105-122:
 Response: {
   "data": {
     "epoch": {
       "validatorSet": {
-        "activeValidators": [
-          {
-            "apy": 2,
-            "name": "validator-0",
-            "reportRecords": {
-              "nodes": []
+        "activeValidators": {
+          "nodes": [
+            {
+              "apy": 2,
+              "name": "validator-0",
+              "reportRecords": {
+                "nodes": []
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.move
@@ -107,6 +107,11 @@ module P0::m {
       activeValidators {
         apy
         name
+        reportRecords {
+          nodes {
+            address
+          }
+        }
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.move
@@ -29,12 +29,12 @@ module P0::m {
         };
         v
     }
-    
+
     public entry fun new(ctx: &mut TxContext){
         let id = object::new(ctx);
         let w = weight();
         sui::transfer::public_transfer(
-            Big { id, weight: w }, 
+            Big { id, weight: w },
             sender(ctx)
         )
     }
@@ -57,8 +57,10 @@ module P0::m {
   epoch(id: 1) {
     validatorSet {
       activeValidators {
-        apy
-        name
+        nodes {
+          apy
+          name
+        }
       }
     }
   }
@@ -105,11 +107,13 @@ module P0::m {
   epoch(id: 2) {
     validatorSet {
       activeValidators {
-        apy
-        name
-        reportRecords {
-          nodes {
-            address
+        nodes {
+          apy
+          name
+          reportRecords {
+            nodes {
+              address
+            }
           }
         }
       }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -519,30 +519,32 @@
 >      inactivePoolsSize
 >      validatorCandidatesSize
 >      activeValidators {
->        name
->        description
->        imageUrl
->        projectUrl
->        exchangeRates {
->          storageRebate
->          bcs
->          hasPublicTransfer
+>        nodes {
+>          name
+>          description
+>          imageUrl
+>          projectUrl
+>          exchangeRates {
+>            storageRebate
+>            bcs
+>            hasPublicTransfer
+>          }
+>          exchangeRatesSize
+>          stakingPoolActivationEpoch
+>          stakingPoolSuiBalance
+>          rewardsPool
+>          poolTokenBalance
+>          pendingStake
+>          pendingTotalSuiWithdraw
+>          pendingPoolTokenWithdraw
+>          votingPower
+>          gasPrice
+>          commissionRate
+>          nextEpochStake
+>          nextEpochGasPrice
+>          nextEpochCommissionRate
+>          atRisk
 >        }
->        exchangeRatesSize
->        stakingPoolActivationEpoch
->        stakingPoolSuiBalance
->        rewardsPool
->        poolTokenBalance
->        pendingStake
->        pendingTotalSuiWithdraw
->        pendingPoolTokenWithdraw
->        votingPower
->        gasPrice
->        commissionRate
->        nextEpochStake
->        nextEpochGasPrice
->        nextEpochCommissionRate
->        atRisk
 >      }
 >    }
 >  }
@@ -1217,9 +1219,11 @@
 >          referenceGasPrice
 >          validatorSet {
 >            activeValidators {
->              name
->              description
->              exchangeRatesSize
+>              nodes {
+>                name
+>                description
+>                exchangeRatesSize
+>              }
 >            }
 >            totalStake
 >          }

--- a/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/specific_epoch.graphql
@@ -15,30 +15,32 @@
       inactivePoolsSize
       validatorCandidatesSize
       activeValidators {
-        name
-        description
-        imageUrl
-        projectUrl
-        exchangeRates {
-          storageRebate
-          bcs
-          hasPublicTransfer
+        nodes {
+          name
+          description
+          imageUrl
+          projectUrl
+          exchangeRates {
+            storageRebate
+            bcs
+            hasPublicTransfer
+          }
+          exchangeRatesSize
+          stakingPoolActivationEpoch
+          stakingPoolSuiBalance
+          rewardsPool
+          poolTokenBalance
+          pendingStake
+          pendingTotalSuiWithdraw
+          pendingPoolTokenWithdraw
+          votingPower
+          gasPrice
+          commissionRate
+          nextEpochStake
+          nextEpochGasPrice
+          nextEpochCommissionRate
+          atRisk
         }
-        exchangeRatesSize
-        stakingPoolActivationEpoch
-        stakingPoolSuiBalance
-        rewardsPool
-        poolTokenBalance
-        pendingStake
-        pendingTotalSuiWithdraw
-        pendingPoolTokenWithdraw
-        votingPower
-        gasPrice
-        commissionRate
-        nextEpochStake
-        nextEpochGasPrice
-        nextEpochCommissionRate
-        atRisk
       }
     }
   }

--- a/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -20,9 +20,11 @@
           referenceGasPrice
           validatorSet {
             activeValidators {
-              name
-              description
-              exchangeRatesSize
+              nodes {
+                name
+                description
+                exchangeRatesSize
+              }
             }
             totalStake
           }

--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -102,6 +102,35 @@ type Address implements IOwner {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter): TransactionBlockConnection!
 }
 
+type AddressConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [AddressEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Address!]!
+}
+
+"""
+An edge in a connection.
+"""
+type AddressEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Address!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 An address-owned object is owned by a specific 32-byte address that is
 either an account address (derived from a particular signature scheme) or
@@ -3978,12 +4007,27 @@ type Validator {
 	"""
 	The addresses of other validators this validator has reported.
 	"""
-	reportRecords: [Address!]
+	reportRecords(first: Int, before: String, last: Int, after: String): AddressConnection!
 	"""
 	The APY of this validator in basis points.
 	To get the APY in percentage, divide by 100.
 	"""
 	apy: Int
+}
+
+type ValidatorConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
 }
 
 """
@@ -4001,6 +4045,20 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
@@ -4008,10 +4066,6 @@ type ValidatorSet {
 	Total amount of stake for all active validators at the beginning of the epoch.
 	"""
 	totalStake: BigInt
-	"""
-	The current list of active validators.
-	"""
-	activeValidators: [Validator!]
 	"""
 	Validators that are pending removal from the active validator set, expressed as indices in
 	to `activeValidators`.
@@ -4021,6 +4075,10 @@ type ValidatorSet {
 	stakePoolMappingsSize: Int
 	inactivePoolsSize: Int
 	validatorCandidatesSize: Int
+	"""
+	The current set of active validators.
+	"""
+	activeValidators(first: Int, before: String, last: Int, after: String): ValidatorConnection!
 }
 
 schema {

--- a/crates/sui-graphql-rpc/src/types/validator_set.rs
+++ b/crates/sui-graphql-rpc/src/types/validator_set.rs
@@ -1,22 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::cursor::{JsonCursor, Page};
+use async_graphql::connection::{Connection, CursorType, Edge};
+
 use super::big_int::BigInt;
 use super::validator::Validator;
 use async_graphql::*;
 
 /// Representation of `0x3::validator_set::ValidatorSet`.
 #[derive(Clone, Debug, SimpleObject, Default)]
+#[graphql(complex)]
 pub(crate) struct ValidatorSet {
     /// Total amount of stake for all active validators at the beginning of the epoch.
     pub total_stake: Option<BigInt>,
 
+    #[graphql(skip)]
     /// The current list of active validators.
     pub active_validators: Option<Vec<Validator>>,
 
     /// Validators that are pending removal from the active validator set, expressed as indices in
     /// to `activeValidators`.
     pub pending_removals: Option<Vec<u64>>,
+
+    // TODO: finish implementing the commented out fields below.
 
     // pending_active_validators: Option<MoveObject>,
     pub pending_active_validators_size: Option<u64>,
@@ -26,4 +33,41 @@ pub(crate) struct ValidatorSet {
     pub inactive_pools_size: Option<u64>,
     // validator_candidates: Option<MoveObject>,
     pub validator_candidates_size: Option<u64>,
+}
+
+type CValidator = JsonCursor<usize>;
+
+#[ComplexObject]
+impl ValidatorSet {
+    /// The current set of active validators.
+    async fn active_validators(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        before: Option<CValidator>,
+        last: Option<u64>,
+        after: Option<CValidator>,
+    ) -> Result<Connection<String, Validator>> {
+        let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+
+        let mut connection = Connection::new(false, false);
+        let Some(validators) = &self.active_validators else {
+            return Ok(connection);
+        };
+
+        let Some((prev, next, cs)) = page.paginate_indices(validators.len()) else {
+            return Ok(connection);
+        };
+
+        connection.has_previous_page = prev;
+        connection.has_next_page = next;
+
+        for c in cs {
+            connection
+                .edges
+                .push(Edge::new(c.encode_cursor(), validators[*c].clone()));
+        }
+
+        Ok(connection)
+    }
 }

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -106,6 +106,35 @@ type Address implements IOwner {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, relation: AddressTransactionBlockRelationship, filter: TransactionBlockFilter): TransactionBlockConnection!
 }
 
+type AddressConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [AddressEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Address!]!
+}
+
+"""
+An edge in a connection.
+"""
+type AddressEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Address!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 An address-owned object is owned by a specific 32-byte address that is
 either an account address (derived from a particular signature scheme) or
@@ -3982,12 +4011,27 @@ type Validator {
 	"""
 	The addresses of other validators this validator has reported.
 	"""
-	reportRecords: [Address!]
+	reportRecords(first: Int, before: String, last: Int, after: String): AddressConnection!
 	"""
 	The APY of this validator in basis points.
 	To get the APY in percentage, divide by 100.
 	"""
 	apy: Int
+}
+
+type ValidatorConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
 }
 
 """
@@ -4005,6 +4049,20 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
@@ -4012,10 +4070,6 @@ type ValidatorSet {
 	Total amount of stake for all active validators at the beginning of the epoch.
 	"""
 	totalStake: BigInt
-	"""
-	The current list of active validators.
-	"""
-	activeValidators: [Validator!]
 	"""
 	Validators that are pending removal from the active validator set, expressed as indices in
 	to `activeValidators`.
@@ -4025,6 +4079,10 @@ type ValidatorSet {
 	stakePoolMappingsSize: Int
 	inactivePoolsSize: Int
 	validatorCandidatesSize: Int
+	"""
+	The current set of active validators.
+	"""
+	activeValidators(first: Int, before: String, last: Int, after: String): ValidatorConnection!
 }
 
 schema {


### PR DESCRIPTION
## Description 

`activeValidators` and `reportRecords` may result in long arrays of results so we need to paginate them.

## Test Plan 

Added to existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
