### PR TITLE
[bridge 31/n] harden bridge authority signing server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11898,6 +11898,7 @@ dependencies = [
  "futures",
  "git-version",
  "hex-literal 0.3.4",
+ "lru 0.10.0",
  "move-core-types",
  "mysten-metrics",
  "num_enum 0.6.1",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -45,6 +45,7 @@ fastcrypto.workspace = true
 tap.workspace = true
 rand.workspace = true
 workspace-hack.workspace = true
+lru.workspace = true
 shared-crypto.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-bridge/src/crypto.rs
+++ b/crates/sui-bridge/src/crypto.rs
@@ -67,7 +67,7 @@ impl<'a> ConciseableName<'a> for BridgeAuthorityPublicKeyBytes {
 }
 
 // TODO: include epoch ID here to reduce race conditions?
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BridgeAuthoritySignInfo {
     pub authority_pub_key: BridgeAuthorityPublicKey,
     pub signature: BridgeAuthorityRecoverableSignature,

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -3,7 +3,7 @@
 
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BridgeError {
     // The input is not an invalid transaction digest/hash
     InvalidTxHash,

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -1,19 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-use std::sync::Arc;
+#![allow(clippy::type_complexity)]
 
 use crate::crypto::{BridgeAuthorityKeyPair, BridgeAuthoritySignInfo};
-use crate::error::BridgeError;
+use crate::error::{BridgeError, BridgeResult};
 use crate::eth_client::EthClient;
-use crate::sui_client::SuiClient;
-use crate::types::SignedBridgeAction;
+use crate::sui_client::{SuiClient, SuiClientInner};
+use crate::types::{BridgeAction, SignedBridgeAction};
 use async_trait::async_trait;
 use axum::Json;
+use ethers::providers::JsonRpcClient;
 use ethers::types::TxHash;
-use sui_sdk::SuiClient as SuiSdkClient;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::str::FromStr;
+use std::sync::Arc;
 use sui_types::digests::TransactionDigest;
+use tap::TapFallible;
+use tokio::sync::{oneshot, Mutex};
 use tracing::info;
 use tracing::instrument;
 
@@ -37,22 +42,186 @@ pub trait BridgeRequestHandlerTrait {
     ) -> Result<Json<SignedBridgeAction>, BridgeError>;
 }
 
-pub struct BridgeRequestHandler {
-    signer: BridgeAuthorityKeyPair,
-    eth_client: Arc<EthClient<ethers::providers::Http>>,
-    sui_client: Arc<SuiClient<SuiSdkClient>>,
+#[async_trait::async_trait]
+trait ActionVerifier<K>: Send + Sync {
+    async fn verify(&self, key: K) -> BridgeResult<BridgeAction>;
 }
 
-impl BridgeRequestHandler {
-    pub fn new(
-        signer: BridgeAuthorityKeyPair,
-        sui_client: Arc<SuiClient<SuiSdkClient>>,
-        eth_client: Arc<EthClient<ethers::providers::Http>>,
+struct SuiActionVerifier<C> {
+    sui_client: Arc<SuiClient<C>>,
+}
+
+struct EthActionVerifier<P> {
+    eth_client: Arc<EthClient<P>>,
+}
+
+#[async_trait::async_trait]
+impl<C> ActionVerifier<(TransactionDigest, u16)> for SuiActionVerifier<C>
+where
+    C: SuiClientInner + Send + Sync + 'static,
+{
+    async fn verify(&self, key: (TransactionDigest, u16)) -> BridgeResult<BridgeAction> {
+        let (tx_digest, event_idx) = key;
+        self.sui_client
+            .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, event_idx)
+            .await
+            .tap_ok(|action| info!("Sui action found: {:?}", action))
+    }
+}
+
+#[async_trait::async_trait]
+impl<C> ActionVerifier<(TxHash, u16)> for EthActionVerifier<C>
+where
+    C: JsonRpcClient + Send + Sync + 'static,
+{
+    async fn verify(&self, key: (TxHash, u16)) -> BridgeResult<BridgeAction> {
+        let (tx_hash, event_idx) = key;
+        self.eth_client
+            .get_finalized_bridge_action_maybe(tx_hash, event_idx)
+            .await
+            .tap_ok(|action| info!("Eth action found: {:?}", action))
+    }
+}
+
+struct SignerWithCache<K> {
+    signer: Arc<BridgeAuthorityKeyPair>,
+    verifier: Arc<dyn ActionVerifier<K>>,
+    mutex: Arc<Mutex<()>>,
+    cache: LruCache<K, Arc<Mutex<Option<BridgeResult<SignedBridgeAction>>>>>,
+}
+
+impl<K> SignerWithCache<K>
+where
+    K: std::hash::Hash + Eq + Clone + Send + Sync + 'static,
+{
+    fn new(
+        signer: Arc<BridgeAuthorityKeyPair>,
+        verifier: impl ActionVerifier<K> + 'static,
     ) -> Self {
         Self {
             signer,
-            eth_client,
-            sui_client,
+            verifier: Arc::new(verifier),
+            mutex: Arc::new(Mutex::new(())),
+            cache: LruCache::new(NonZeroUsize::new(1000).unwrap()),
+        }
+    }
+
+    fn spawn(
+        mut self,
+        mut rx: mysten_metrics::metered_channel::Receiver<(
+            K,
+            oneshot::Sender<BridgeResult<SignedBridgeAction>>,
+        )>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                let (key, tx) = rx
+                    .recv()
+                    .await
+                    .unwrap_or_else(|| panic!("Server signer's channel is closed"));
+                let result = self.sign(key).await;
+                // The receiver may be dropped before the sender (client connection was dropped for example),
+                // we ignore the error in that case.
+                let _ = tx.send(result);
+            }
+        })
+    }
+
+    async fn get_cache_entry(
+        &mut self,
+        key: K,
+    ) -> Arc<Mutex<Option<BridgeResult<SignedBridgeAction>>>> {
+        // This mutex exists to make sure everyone gets the same entry, namely no double insert
+        let _ = self.mutex.lock().await;
+        self.cache
+            .get_or_insert(key, || Arc::new(Mutex::new(None)))
+            .clone()
+    }
+
+    async fn sign(&mut self, key: K) -> BridgeResult<SignedBridgeAction> {
+        let signer = self.signer.clone();
+        let verifier = self.verifier.clone();
+        let entry = self.get_cache_entry(key.clone()).await;
+        let mut guard = entry.lock().await;
+        if let Some(result) = &*guard {
+            return result.clone();
+        }
+        match verifier.verify(key.clone()).await {
+            Ok(bridge_action) => {
+                let sig = BridgeAuthoritySignInfo::new(&bridge_action, &signer);
+                let result = SignedBridgeAction::new_from_data_and_sig(bridge_action, sig);
+                // Cache result if Ok
+                *guard = Some(Ok(result.clone()));
+                Ok(result)
+            }
+            Err(e) => {
+                match e {
+                    // Only cache non-transient errors
+                    BridgeError::BridgeEventInUnrecognizedSuiPackage
+                    | BridgeError::BridgeEventInUnrecognizedEthContract
+                    | BridgeError::BridgeEventNotActionable
+                    | BridgeError::NoBridgeEventsInTxPosition => {
+                        *guard = Some(Err(e.clone()));
+                    }
+                    _ => (),
+                }
+                Err(e)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn get_testing_only(
+        &mut self,
+        key: K,
+    ) -> Option<&Arc<Mutex<Option<BridgeResult<SignedBridgeAction>>>>> {
+        let _ = self.mutex.lock().await;
+        self.cache.get(&key)
+    }
+}
+
+pub struct BridgeRequestHandler {
+    sui_signer_tx: mysten_metrics::metered_channel::Sender<(
+        (TransactionDigest, u16),
+        oneshot::Sender<BridgeResult<SignedBridgeAction>>,
+    )>,
+    eth_signer_tx: mysten_metrics::metered_channel::Sender<(
+        (TxHash, u16),
+        oneshot::Sender<BridgeResult<SignedBridgeAction>>,
+    )>,
+}
+
+impl BridgeRequestHandler {
+    pub fn new<
+        SC: SuiClientInner + Send + Sync + 'static,
+        EP: JsonRpcClient + Send + Sync + 'static,
+    >(
+        signer: BridgeAuthorityKeyPair,
+        sui_client: Arc<SuiClient<SC>>,
+        eth_client: Arc<EthClient<EP>>,
+    ) -> Self {
+        let (sui_signer_tx, sui_rx) = mysten_metrics::metered_channel::channel(
+            1000,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["server_sui_action_signing_queue"]),
+        );
+        let (eth_signer_tx, eth_rx) = mysten_metrics::metered_channel::channel(
+            1000,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channels
+                .with_label_values(&["server_eth_action_signing_queue"]),
+        );
+        let signer = Arc::new(signer);
+
+        SignerWithCache::new(signer.clone(), SuiActionVerifier { sui_client }).spawn(sui_rx);
+        SignerWithCache::new(signer.clone(), EthActionVerifier { eth_client }).spawn(eth_rx);
+
+        Self {
+            sui_signer_tx,
+            eth_signer_tx,
         }
     }
 }
@@ -66,18 +235,17 @@ impl BridgeRequestHandlerTrait for BridgeRequestHandler {
         event_idx: u16,
     ) -> Result<Json<SignedBridgeAction>, BridgeError> {
         info!("Received handle eth tx request");
-        // TODO add caching and avoid simalutaneous requests
         let tx_hash = TxHash::from_str(&tx_hash_hex).map_err(|_| BridgeError::InvalidTxHash)?;
-        let bridge_action = self
-            .eth_client
-            .get_finalized_bridge_action_maybe(tx_hash, event_idx)
-            .await?;
-        info!(action_digest=?bridge_action.digest(), "Retrieved matched Bridge Action: {:?}", bridge_action);
-        let sig = BridgeAuthoritySignInfo::new(&bridge_action, &self.signer);
-        Ok(Json(SignedBridgeAction::new_from_data_and_sig(
-            bridge_action,
-            sig,
-        )))
+
+        let (tx, rx) = oneshot::channel();
+        self.eth_signer_tx
+            .send(((tx_hash, event_idx), tx))
+            .await
+            .unwrap_or_else(|_| panic!("Server eth signing channel is closed"));
+        let signed_action = rx
+            .blocking_recv()
+            .unwrap_or_else(|_| panic!("Server signing task's oneshot channel is dropped"))?;
+        Ok(Json(signed_action))
     }
 
     #[instrument(level = "info", skip(self))]
@@ -87,18 +255,233 @@ impl BridgeRequestHandlerTrait for BridgeRequestHandler {
         event_idx: u16,
     ) -> Result<Json<SignedBridgeAction>, BridgeError> {
         info!("Received handle sui tx request");
-        // TODO add caching and avoid simultaneous requests
         let tx_digest = TransactionDigest::from_str(&tx_digest_base58)
             .map_err(|_e| BridgeError::InvalidTxHash)?;
-        let bridge_action = self
-            .sui_client
-            .get_bridge_action_by_tx_digest_and_event_idx_maybe(&tx_digest, event_idx)
-            .await?;
-        info!(action_digest=?bridge_action.digest(), "Retrieved matched Bridge Action: {:?}", bridge_action);
-        let sig = BridgeAuthoritySignInfo::new(&bridge_action, &self.signer);
-        Ok(Json(SignedBridgeAction::new_from_data_and_sig(
-            bridge_action,
-            sig,
-        )))
+        let (tx, rx) = oneshot::channel();
+        self.sui_signer_tx
+            .send(((tx_digest, event_idx), tx))
+            .await
+            .unwrap_or_else(|_| panic!("Server sui signing channel is closed"));
+        let signed_action = rx
+            .blocking_recv()
+            .unwrap_or_else(|_| panic!("Server signing task's oneshot channel is dropped"))?;
+        Ok(Json(signed_action))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::{
+        eth_mock_provider::EthMockProvider,
+        events::{init_all_struct_tags, MoveTokenBridgeEvent, SuiToEthTokenBridgeV1},
+        sui_mock_client::SuiMockClient,
+        test_utils::{
+            get_test_log_and_action, get_test_sui_to_eth_bridge_action, mock_last_finalized_block,
+        },
+        types::{BridgeActionType, BridgeChainId, TokenId},
+    };
+    use ethers::types::{Address as EthAddress, TransactionReceipt};
+    use sui_json_rpc_types::SuiEvent;
+    use sui_types::{base_types::SuiAddress, crypto::get_key_pair};
+
+    #[tokio::test]
+    async fn test_sui_signer_with_cache() {
+        let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+        let signer = Arc::new(kp);
+        let sui_client_mock = SuiMockClient::default();
+        let sui_verifier = SuiActionVerifier {
+            sui_client: Arc::new(SuiClient::new_for_testing(sui_client_mock.clone())),
+        };
+        let mut sui_signer_with_cache = SignerWithCache::new(signer.clone(), sui_verifier);
+
+        // Test `get_cache_entry` creates a new entry if not exist
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_event_idx = 42;
+        assert!(sui_signer_with_cache
+            .get_testing_only((sui_tx_digest, sui_event_idx))
+            .await
+            .is_none());
+        let entry = sui_signer_with_cache
+            .get_cache_entry((sui_tx_digest, sui_event_idx))
+            .await;
+        let entry_ = sui_signer_with_cache
+            .get_testing_only((sui_tx_digest, sui_event_idx))
+            .await;
+        assert!(entry_.unwrap().lock().await.is_none());
+
+        let action =
+            get_test_sui_to_eth_bridge_action(Some(sui_tx_digest), Some(sui_event_idx), None, None);
+        let sig = BridgeAuthoritySignInfo::new(&action, &signer);
+        let signed_action = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig);
+        entry.lock().await.replace(Ok(signed_action));
+        let entry_ = sui_signer_with_cache
+            .get_testing_only((sui_tx_digest, sui_event_idx))
+            .await;
+        assert!(entry_.unwrap().lock().await.is_some());
+
+        // Test `sign` caches Err result
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_event_idx = 0;
+
+        // Mock an non-cacheable error such as rpc error
+        sui_client_mock.add_events_by_tx_digest_error(sui_tx_digest);
+        sui_signer_with_cache
+            .sign((sui_tx_digest, sui_event_idx))
+            .await
+            .unwrap_err();
+        let entry_ = sui_signer_with_cache
+            .get_testing_only((sui_tx_digest, sui_event_idx))
+            .await;
+        assert!(entry_.unwrap().lock().await.is_none());
+
+        // Mock a cacheable error such as no bridge events in tx position (empty event list)
+        sui_client_mock.add_events_by_tx_digest(sui_tx_digest, vec![]);
+        assert!(matches!(
+            sui_signer_with_cache
+                .sign((sui_tx_digest, sui_event_idx))
+                .await,
+            Err(BridgeError::NoBridgeEventsInTxPosition)
+        ));
+        let entry_ = sui_signer_with_cache
+            .get_testing_only((sui_tx_digest, sui_event_idx))
+            .await;
+        assert_eq!(
+            entry_.unwrap().lock().await.clone().unwrap().unwrap_err(),
+            BridgeError::NoBridgeEventsInTxPosition,
+        );
+
+        // TODO: test BridgeEventInUnrecognizedSuiPackage, SuiBridgeEvent::try_from_sui_event
+        // and BridgeEventNotActionable to be cached
+
+        // Test `sign` caches Ok result
+        let emitted_event_1 = MoveTokenBridgeEvent {
+            message_type: BridgeActionType::TokenTransfer as u8,
+            seq_num: 1,
+            source_chain: BridgeChainId::SuiLocalTest as u8,
+            sender_address: SuiAddress::random_for_testing_only().to_vec(),
+            target_chain: BridgeChainId::EthLocalTest as u8,
+            target_address: EthAddress::random().as_bytes().to_vec(),
+            token_type: TokenId::USDC as u8,
+            amount: 12345,
+        };
+
+        // TODO: remove once we don't rely on env var to get package id
+        std::env::set_var("BRIDGE_PACKAGE_ID", "0x0b");
+        init_all_struct_tags();
+
+        let mut sui_event_1 = SuiEvent::random_for_testing();
+        sui_event_1.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
+        sui_event_1.bcs = bcs::to_bytes(&emitted_event_1).unwrap();
+        let sui_tx_digest = sui_event_1.id.tx_digest;
+
+        let mut sui_event_2 = SuiEvent::random_for_testing();
+        sui_event_2.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
+        sui_event_2.bcs = bcs::to_bytes(&emitted_event_1).unwrap();
+        let sui_event_idx_2 = 1;
+        sui_client_mock.add_events_by_tx_digest(sui_tx_digest, vec![sui_event_2.clone()]);
+
+        sui_client_mock.add_events_by_tx_digest(
+            sui_tx_digest,
+            vec![sui_event_1.clone(), sui_event_2.clone()],
+        );
+        let signed_1 = sui_signer_with_cache
+            .sign((sui_tx_digest, sui_event_idx))
+            .await
+            .unwrap();
+        let signed_2 = sui_signer_with_cache
+            .sign((sui_tx_digest, sui_event_idx_2))
+            .await
+            .unwrap();
+
+        // Because the result is cached now, the verifier should not be called again.
+        // Even though we remove the `add_events_by_tx_digest` mock, we will still get the same result.
+        sui_client_mock.add_events_by_tx_digest(sui_tx_digest, vec![]);
+        assert_eq!(
+            sui_signer_with_cache
+                .sign((sui_tx_digest, sui_event_idx))
+                .await
+                .unwrap(),
+            signed_1
+        );
+        assert_eq!(
+            sui_signer_with_cache
+                .sign((sui_tx_digest, sui_event_idx_2))
+                .await
+                .unwrap(),
+            signed_2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_eth_signer_with_cache() {
+        let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+        let signer = Arc::new(kp);
+        let eth_mock_provider = EthMockProvider::default();
+        let contract_address = EthAddress::random();
+        let eth_client = EthClient::new_mocked(
+            eth_mock_provider.clone(),
+            HashSet::from_iter(vec![contract_address]),
+        );
+        let eth_verifier = EthActionVerifier {
+            eth_client: Arc::new(eth_client),
+        };
+        let mut eth_signer_with_cache = SignerWithCache::new(signer.clone(), eth_verifier);
+
+        // Test `get_cache_entry` creates a new entry if not exist
+        let eth_tx_hash = TxHash::random();
+        let eth_event_idx = 42;
+        assert!(eth_signer_with_cache
+            .get_testing_only((eth_tx_hash, eth_event_idx))
+            .await
+            .is_none());
+        let entry = eth_signer_with_cache
+            .get_cache_entry((eth_tx_hash, eth_event_idx))
+            .await;
+        let entry_ = eth_signer_with_cache
+            .get_testing_only((eth_tx_hash, eth_event_idx))
+            .await;
+        // first unwrap should not pacic because the entry should have been inserted by `get_cache_entry`
+        assert!(entry_.unwrap().lock().await.is_none());
+
+        let (_, action) = get_test_log_and_action(contract_address, eth_tx_hash, eth_event_idx);
+        let sig = BridgeAuthoritySignInfo::new(&action, &signer);
+        let signed_action = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig);
+        entry.lock().await.replace(Ok(signed_action.clone()));
+        let entry_ = eth_signer_with_cache
+            .get_testing_only((eth_tx_hash, eth_event_idx))
+            .await;
+        assert_eq!(
+            entry_.unwrap().lock().await.clone().unwrap().unwrap(),
+            signed_action
+        );
+
+        // Test `sign` caches Ok result
+        let eth_tx_hash = TxHash::random();
+        let eth_event_idx = 0;
+        let (log, _action) = get_test_log_and_action(contract_address, eth_tx_hash, eth_event_idx);
+        eth_mock_provider
+            .add_response::<[TxHash; 1], TransactionReceipt, TransactionReceipt>(
+                "eth_getTransactionReceipt",
+                [log.transaction_hash.unwrap()],
+                TransactionReceipt {
+                    block_number: log.block_number,
+                    logs: vec![log.clone()],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        mock_last_finalized_block(&eth_mock_provider, log.block_number.unwrap().as_u64());
+
+        eth_signer_with_cache
+            .sign((eth_tx_hash, eth_event_idx))
+            .await
+            .unwrap();
+        let entry_ = eth_signer_with_cache
+            .get_testing_only((eth_tx_hash, eth_event_idx))
+            .await;
+        entry_.unwrap().lock().await.clone().unwrap().unwrap();
     }
 }


### PR DESCRIPTION
## Description 

This PR hardens the bridge authority signing server:
1. introduce `ActionVerifier` trait to verify if an action is legit. Two impls are `SuiActionVerifier` that checks sui initialized transfers, and `EthActionVerifier` that checks eth initialized transfer. We will soon have a governance verifier.
2. add a LRU cache in signing server such that duplicated requests will not lead to wasted work. Non-transient errors will be cached too.

## Test Plan 

unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
