### PR TITLE
[graphql] Switch to prometheus metrics

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -131,7 +131,7 @@ impl Extension for QueryLimitsChecker {
             metrics
                 .request_metrics
                 .query_payload_too_large_size
-                .observe(query.len() as u64);
+                .observe(query.len() as f64);
             info!(
                 query_id = %query_id,
                 session_id = %session_id,
@@ -205,19 +205,19 @@ impl Extension for QueryLimitsChecker {
         metrics
             .request_metrics
             .input_nodes
-            .observe(running_costs.input_nodes as u64);
+            .observe(running_costs.input_nodes as f64);
         metrics
             .request_metrics
             .output_nodes
-            .observe(running_costs.output_nodes);
+            .observe(running_costs.output_nodes as f64);
         metrics
             .request_metrics
             .query_depth
-            .observe(running_costs.depth as u64);
+            .observe(running_costs.depth as f64);
         metrics
             .request_metrics
             .query_payload_size
-            .observe(query.len() as u64);
+            .observe(query.len() as f64);
         Ok(doc)
     }
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -715,4 +715,45 @@ pub mod tests {
             vec!["Connection's page size of 51 exceeds max of 50".to_string()]
         );
     }
+
+    pub async fn test_query_complexity_metrics_impl() {
+        let (connection_config, _cluster) = prep_cluster().await;
+
+        let binding_address: SocketAddr = "0.0.0.0:9185".parse().unwrap();
+        let registry = mysten_metrics::start_prometheus_server(binding_address).default_registry();
+        let metrics = Metrics::new(&registry);
+
+        let service_config = ServiceConfig::default();
+        let db_url: String = connection_config.db_url.clone();
+        let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
+        let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
+        let pg_conn_pool = PgManager::new(reader);
+        let schema = ServerBuilder::new(8000, "127.0.0.1".to_string(), metrics.clone())
+            .context_data(db)
+            .context_data(pg_conn_pool)
+            .context_data(service_config)
+            .context_data(query_id())
+            .context_data(ip_address())
+            .context_data(metrics.clone())
+            .extension(QueryLimitsChecker::default())
+            .build_schema();
+        let _ = schema.execute("{ chainIdentifier }").await;
+        let metrics2 = metrics.request_metrics;
+        assert_eq!(metrics2.input_nodes.get_sample_count(), 1);
+        assert_eq!(metrics2.output_nodes.get_sample_count(), 1);
+        assert_eq!(metrics2.query_depth.get_sample_count(), 1);
+        assert_eq!(metrics2.input_nodes.get_sample_sum(), 1.);
+        assert_eq!(metrics2.output_nodes.get_sample_sum(), 1.);
+        assert_eq!(metrics2.query_depth.get_sample_sum(), 1.);
+
+        let _ = schema
+            .execute("{ chainIdentifier protocolConfig { configs { value key }} }")
+            .await;
+        assert_eq!(metrics2.input_nodes.get_sample_count(), 2);
+        assert_eq!(metrics2.output_nodes.get_sample_count(), 2);
+        assert_eq!(metrics2.query_depth.get_sample_count(), 2);
+        assert_eq!(metrics2.input_nodes.get_sample_sum(), 2. + 4.);
+        assert_eq!(metrics2.output_nodes.get_sample_sum(), 2. + 4.);
+        assert_eq!(metrics2.query_depth.get_sample_sum(), 1. + 3.);
+    }
 }

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -526,4 +526,10 @@ mod tests {
     async fn test_query_max_page_limit() {
         test_query_max_page_limit_impl().await;
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_query_complexity_metrics() {
+        test_query_complexity_metrics_impl().await;
+    }
 }


### PR DESCRIPTION
## Description 

Switched back to prometheus metrics as it is easier to work with the percentiles in Grafana due to prometheus not establishing exact percentiles like the mysten metrics, where the histogram is set to 50, 90, 99 percentiles.

It also adds back the previous test on query complexity.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
