### PR TITLE
[Move] Clean-ups spotted from #14592

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, bail, ensure};
+use anyhow::{anyhow, ensure};
 use bip32::DerivationPath;
 use clap::*;
 use colored::Colorize;
@@ -720,9 +720,12 @@ impl SuiClientCommands {
                 tx_digest,
                 profile_output,
             } => {
-                if !cfg!(feature = "gas-profiler") {
-                    bail!("gas-profiler feature is not enabled, rebuild or reinstall with --features gas-profiler");
-                }
+                move_vm_profiler::gas_profiler_feature_disabled! {
+                    anyhow::bail!(
+                        "gas-profiler feature is not enabled, rebuild or reinstall with \
+                         --features gas-profiler"
+                    );
+                };
 
                 let cmd = ReplayToolCommand::ProfileTransaction {
                     tx_digest,

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2158,6 +2158,7 @@ name = "move-vm-config"
 version = "0.1.0"
 dependencies = [
  "move-binary-format",
+ "once_cell",
 ]
 
 [[package]]
@@ -2188,6 +2189,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/run.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/run.rs
@@ -21,12 +21,8 @@ use move_core_types::{
     transaction_argument::{convert_txn_args, TransactionArgument},
 };
 use move_package::compilation::compiled_package::CompiledPackage;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::gas_schedule::CostTable;
-#[cfg(feature = "gas-profiler")]
-use move_vm_types::gas::GasMeter;
 use std::{fs, path::Path};
 
 pub fn run(
@@ -89,8 +85,10 @@ pub fn run(
         // script fun. parse module, extract script ID to pass to VM
         let module = CompiledModule::deserialize_with_defaults(&bytecode)
             .map_err(|e| anyhow!("Error deserializing module: {:?}", e))?;
-        #[cfg(feature = "gas-profiler")]
-        {
+        move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
+            use move_vm_types::gas::GasMeter;
+
             let gas_rem: u64 = gas_status.remaining_gas().into();
             gas_status.set_profiler(GasProfiler::init(
                 &session.vm_config().profiler_config,

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
@@ -548,12 +548,13 @@ fn run_with_module(
         .into_iter()
         .map(|tag| session.load_type(&tag))
         .collect::<VMResult<Vec<_>>>();
-    #[cfg(feature = "gas-profiler")]
-    gas.set_profiler(GasProfiler::init(
-        &session.vm_config().profiler_config,
-        entry_name.to_string(),
-        gas.remaining_gas().into(),
-    ));
+    move_vm_profiler::gas_profiler_feature_enabled! {
+        gas.set_profiler(GasProfiler::init(
+            &session.vm_config().profiler_config,
+            entry_name.to_string(),
+            gas.remaining_gas().into(),
+        ));
+    }
     let res = type_args.and_then(|type_args| {
         session.execute_entry_function(
             &module_id,

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -118,7 +118,6 @@ impl Interpreter {
         };
         profile_open_frame!(gas_meter, function.pretty_string());
 
-
         if function.is_native() {
             for arg in args {
                 interpreter
@@ -143,7 +142,6 @@ impl Interpreter {
                 })?;
 
             profile_close_frame!(gas_meter, function.pretty_string());
-
 
             Ok(return_values.into_iter().collect())
         } else {
@@ -216,8 +214,9 @@ impl Interpreter {
                 }
                 ExitCode::Call(fh_idx) => {
                     let func = resolver.function_from_handle(fh_idx);
-                    let _func_name = func.pretty_string();
-                    profile_open_frame!(gas_meter, _func_name.clone());
+                    #[cfg(feature = "gas-profiler")]
+                    let func_name = func.pretty_string();
+                    profile_open_frame!(gas_meter, func_name.clone());
 
                     // Charge gas
                     let module_id = func.module_id();
@@ -233,11 +232,11 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), vec![])?;
+                        self.call_native(&resolver, gas_meter, extensions, func, vec![])?;
 
                         current_frame.pc += 1; // advance past the Call instruction in the caller
 
-                        profile_close_frame!(gas_meter, _func_name.clone());
+                        profile_close_frame!(gas_meter, func_name.clone());
                         continue;
                     }
                     let frame = self
@@ -258,8 +257,9 @@ impl Interpreter {
                         .instantiate_generic_function(idx, current_frame.ty_args())
                         .map_err(|e| set_err_info!(current_frame, e))?;
                     let func = resolver.function_from_instantiation(idx);
-                    let _func_name = func.pretty_string();
-                    profile_open_frame!(gas_meter, _func_name.clone());
+                    #[cfg(feature = "gas-profiler")]
+                    let func_name = func.pretty_string();
+                    profile_open_frame!(gas_meter, func_name.clone());
 
                     // Charge gas
                     let module_id = func.module_id();
@@ -276,9 +276,9 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), ty_args)?;
+                        self.call_native(&resolver, gas_meter, extensions, func, ty_args)?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
-                        profile_close_frame!(gas_meter, _func_name.clone());
+                        profile_close_frame!(gas_meter, func_name.clone());
 
                         continue;
                     }

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -27,8 +27,6 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_config::runtime::VMConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -489,6 +487,7 @@ impl VMRuntime {
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -488,8 +488,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
-        #[cfg(feature = "gas-profiler")]
-        {
+        move_vm_profiler::gas_profiler_feature_enabled! {
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -19,8 +19,6 @@ use move_core_types::{
     resolver::MoveResolver,
     runtime_value::MoveTypeLayout,
 };
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -102,6 +100,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/session.rs
@@ -101,8 +101,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
-        #[cfg(feature = "gas-profiler")]
-        {
+        move_vm_profiler::gas_profiler_feature_enabled! {
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/interpreter.rs
@@ -233,7 +233,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), vec![])?;
+                        self.call_native(&resolver, gas_meter, extensions, func, vec![])?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                         profile_close_frame!(gas_meter, func_name.clone());
                         continue;

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/runtime.rs
@@ -27,8 +27,6 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_config::runtime::VMConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -488,6 +486,7 @@ impl VMRuntime {
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/next-vm/crates/move-vm-runtime/src/session.rs
@@ -19,8 +19,6 @@ use move_core_types::{
     resolver::MoveResolver,
     runtime_value::MoveTypeLayout,
 };
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -102,6 +100,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/move-execution/v0/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v0/move-vm/runtime/src/interpreter.rs
@@ -242,7 +242,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), vec![])?;
+                        self.call_native(&resolver, gas_meter, extensions, func, vec![])?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                         profile_close_frame!(gas_meter, func_name.clone());
 
@@ -291,7 +291,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), ty_args)?;
+                        self.call_native(&resolver, gas_meter, extensions, func, ty_args)?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                         profile_close_frame!(gas_meter, func_name.clone());
                         continue;

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/interpreter.rs
@@ -245,7 +245,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), vec![])?;
+                        self.call_native(&resolver, gas_meter, extensions, func, vec![])?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                         profile_close_frame!(gas_meter, func_name.clone());
                         continue;
@@ -293,7 +293,7 @@ impl Interpreter {
                         .map_err(|e| set_err_info!(current_frame, e))?;
 
                     if func.is_native() {
-                        self.call_native(&resolver, gas_meter, extensions, func.clone(), ty_args)?;
+                        self.call_native(&resolver, gas_meter, extensions, func, ty_args)?;
                         current_frame.pc += 1; // advance past the Call instruction in the caller
                         profile_close_frame!(gas_meter, func_name.clone());
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -27,8 +27,6 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_config::runtime::VMConfig;
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -463,6 +461,7 @@ impl VMRuntime {
             .loader
             .load_script(script.borrow(), &type_arguments, data_store)?;
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             let rem = gas_meter.remaining_gas().into();
             gas_meter.set_profiler(GasProfiler::init_default_cfg(func.pretty_string(), rem));
         }
@@ -526,6 +525,7 @@ impl VMRuntime {
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/runtime.rs
@@ -525,8 +525,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
     ) -> VMResult<SerializedReturnValues> {
-        #[cfg(feature = "gas-profiler")]
-        {
+        move_vm_profiler::gas_profiler_feature_enabled! {
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/session.rs
@@ -19,8 +19,6 @@ use move_core_types::{
     resolver::MoveResolver,
     runtime_value::MoveTypeLayout,
 };
-#[cfg(feature = "gas-profiler")]
-use move_vm_profiler::GasProfiler;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,
@@ -102,6 +100,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<SerializedReturnValues> {
         move_vm_profiler::gas_profiler_feature_enabled! {
+            use move_vm_profiler::GasProfiler;
             if gas_meter.get_profiler_mut().is_none() {
                 gas_meter.set_profiler(GasProfiler::init_default_cfg(
                     function_name.to_string(),

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -29,16 +29,12 @@ mod checked {
         identifier::IdentStr,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_profiler::GasProfiler;
     use move_vm_runtime::native_extensions::NativeContextExtensions;
     use move_vm_runtime::{
         move_vm::MoveVM,
         session::{LoadedFunctionInstantiation, SerializedReturnValues},
     };
     use move_vm_types::data_store::DataStore;
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
     use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
@@ -203,8 +199,10 @@ mod checked {
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
             move_vm_profiler::gas_profiler_feature_enabled! {
-                let tx_digest = tx_context.digest();
+                use move_vm_profiler::GasProfiler;
+                use move_vm_types::gas::GasMeter;
 
+                let tx_digest = tx_context.digest();
                 let remaining_gas: u64 =
                     move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())
                         .into();

--- a/sui-execution/next-vm/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/next-vm/sui-adapter/src/programmable_transactions/context.rs
@@ -29,16 +29,12 @@ mod checked {
         identifier::IdentStr,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_profiler::GasProfiler;
     use move_vm_runtime::native_extensions::NativeContextExtensions;
     use move_vm_runtime::{
         move_vm::MoveVM,
         session::{LoadedFunctionInstantiation, SerializedReturnValues},
     };
     use move_vm_types::data_store::DataStore;
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
     use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
@@ -200,6 +196,9 @@ mod checked {
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
             move_vm_profiler::gas_profiler_feature_enabled! {
+                use move_vm_profiler::GasProfiler;
+                use move_vm_types::gas::GasMeter;
+
                 let tx_digest = tx_context.digest();
                 let remaining_gas: u64 =
                     move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -24,11 +24,7 @@ mod checked {
         account_address::AccountAddress,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_profiler::GasProfiler;
     use move_vm_runtime::{move_vm::MoveVM, session::Session};
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
@@ -205,6 +201,9 @@ mod checked {
             // Set the profiler if in CLI
             #[skip_checked_arithmetic]
             move_vm_profiler::gas_profiler_feature_enabled! {
+                use move_vm_profiler::GasProfiler;
+                use move_vm_types::gas::GasMeter;
+
                 let tx_digest = tx_context.digest();
                 let remaining_gas: u64 =
                     move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -28,16 +28,12 @@ mod checked {
         identifier::IdentStr,
         language_storage::{ModuleId, StructTag, TypeTag},
     };
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_profiler::GasProfiler;
     use move_vm_runtime::native_extensions::NativeContextExtensions;
     use move_vm_runtime::{
         move_vm::MoveVM,
         session::{LoadedFunctionInstantiation, SerializedReturnValues},
     };
     use move_vm_types::data_store::DataStore;
-    #[cfg(feature = "gas-profiler")]
-    use move_vm_types::gas::GasMeter;
     use move_vm_types::loaded_data::runtime_types::Type;
     use move_vm_types::values::GlobalValue;
     use sui_move_natives::object_runtime::{
@@ -199,6 +195,9 @@ mod checked {
             // Set the profiler if feature is enabled
             #[skip_checked_arithmetic]
             move_vm_profiler::gas_profiler_feature_enabled! {
+                use move_vm_profiler::GasProfiler;
+                use move_vm_types::gas::GasMeter;
+
                 let tx_digest = tx_context.digest();
                 let remaining_gas: u64 =
                     move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())


### PR DESCRIPTION
## Description

- Don't `clone` the function in the interpreter.
- Use the `enable` and `disable` macros consistently, rather than `#[cfg(feature = "gas-profiler")]`.
- Added a guard around the body of these macros so that the compiler wouldn't complain about unreachable statements following an invocation of this macro.
- Use `OsStr` and `OsString` to avoid throwing away reasonable paths that don't convert through strings.

## Test Plan

Existing tests:

```
external-crates/move$ cargo nextest run --features gas-profiler
external-crates/move$ cargo nextest run
sui$ cargo nextest run --features gas-profiler
sui$ cargo nextest run
```

Try a replay with the feature enabled (should succeed):

```
sui$ cargo run --bin sui --features gas-profiler \
  -- client profile-transaction                  \
  -t BNNhdU2HJzSJz4MrWaT2ya5mW1Z5mGiC9wBzc84Ptg1j
```

Try a replay with the feature disabled (should fail with an error):

```
sui$ cargo run --bin sui                         \
  -- client profile-transaction                  \
  -t BNNhdU2HJzSJz4MrWaT2ya5mW1Z5mGiC9wBzc84Ptg1j
```