### PR TITLE
[graphq/rpc] e2e tests run in parallel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -408,6 +408,7 @@ jobs:
    services:
      postgres:
        image: postgres
+       command: -c 'max_connections=500'
        env:
          POSTGRES_PASSWORD: postgrespw
        options: >-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -408,7 +408,6 @@ jobs:
    services:
      postgres:
        image: postgres
-       command: -c 'max_connections=500'
        env:
          POSTGRES_PASSWORD: postgrespw
        options: >-
@@ -416,6 +415,7 @@ jobs:
          --health-interval 10s
          --health-timeout 5s
          --health-retries 5
+         --name postgres_container
        ports:
          - 5432:5432
    steps:
@@ -427,6 +427,8 @@ jobs:
        env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgrespw
+     - run: docker restart --time 0 postgres_container
+     - run: sleep 5
      - name: tests-requiring-postgres
        run: |
          cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -430,7 +430,7 @@ jobs:
        run: |
          cargo nextest run --test-threads 1 --package sui-graphql-rpc --test e2e_tests --test examples_validation_tests --features pg_integration
          cargo nextest run --test-threads 1 --package sui-graphql-rpc --lib --features pg_integration -- test_query_cost
-         cargo nextest run --test-threads 1 --package sui-graphql-e2e-tests --features pg_integration
+         cargo nextest run --package sui-graphql-e2e-tests --features pg_integration
          cargo nextest run --test-threads 1 --package sui-cluster-test --test local_cluster_test --features pg_integration
          cargo nextest run --test-threads 1 --package sui-indexer --test ingestion_tests --features pg_integration
 

--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -20,11 +20,24 @@ $ psql "postgres://$ME:$ME@localhost:5432/postgres" \
     -c "CREATE ROLE postgres WITH SUPERUSER LOGIN PASSWORD 'postgrespw';"
 ```
 
-3. Then, create the database that the tests expect, using the `postgres` user:
+3. Then, create the database that the tests expect, using the `postgres` user and increase the max connections since many tests might run in parallel.
 
 ```sh
 $ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
-    -c "CREATE DATABASE sui_indexer_v2;"
+    -c "CREATE DATABASE sui_indexer_v2; -c 'ALTER SYSTEM SET max_connections = 1000;"
+```
+
+4. Finally, restart the `postgres` server so the max connections change takes effect.
+
+Mac
+```sh
+brew services restart postgres
+
+```
+
+Linux
+```sh
+/etc/init.d/postgresql restart
 ```
 
 # Running Locally

--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -24,7 +24,7 @@ $ psql "postgres://$ME:$ME@localhost:5432/postgres" \
 
 ```sh
 $ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
-    -c "CREATE DATABASE sui_indexer_v2; -c 'ALTER SYSTEM SET max_connections = 1000;"
+    -c "CREATE DATABASE sui_indexer_v2; -c 'ALTER SYSTEM SET max_connections = 500;"
 ```
 
 4. Finally, restart the `postgres` server so the max connections change takes effect.

--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -29,9 +29,8 @@ $ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
 
 # Running Locally
 
-When running the tests locally, they need to be run serially (one at a time),
-and with the `pg_integration` feature enabled:
+When running the tests locally, they must be run with the `pg_integration` feature enabled:
 
 ```sh
-$ cargo nextest run -j 1 --features pg_integration
+$ cargo nextest run --features pg_integration
 ```

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -172,6 +172,23 @@ impl ConnectionConfig {
         }
     }
 
+    pub fn ci_integration_test_cfg_with_db_name(
+        db_name: String,
+        port: u16,
+        prom_port: u16,
+    ) -> Self {
+        Self {
+            db_url: format!("postgres://postgres:postgrespw@localhost:5432/{}", db_name),
+            port,
+            prom_port,
+            ..Default::default()
+        }
+    }
+
+    pub fn db_name(&self) -> String {
+        self.db_url.split('/').last().unwrap().to_string()
+    }
+
     pub fn db_url(&self) -> String {
         self.db_url.clone()
     }

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -14,7 +14,9 @@ use sui_indexer::errors::IndexerError;
 pub use sui_indexer::processors_v2::objects_snapshot_processor::SnapshotLagConfig;
 use sui_indexer::store::indexer_store_v2::IndexerStoreV2;
 use sui_indexer::store::PgIndexerStoreV2;
+use sui_indexer::test_utils::force_delete_database;
 use sui_indexer::test_utils::start_test_indexer_v2;
+use sui_indexer::test_utils::start_test_indexer_v2_impl;
 use sui_indexer::test_utils::ReaderWriterConfig;
 use sui_rest_api::node_state_getter::NodeStateGetter;
 use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
@@ -37,6 +39,7 @@ pub struct ExecutorCluster {
     pub graphql_server_join_handle: JoinHandle<()>,
     pub graphql_client: SimpleClient,
     pub snapshot_config: SnapshotLagConfig,
+    pub graphql_connection_config: ConnectionConfig,
 }
 
 pub struct Cluster {
@@ -106,11 +109,12 @@ pub async fn serve_executor(
         sui_rest_api::start_service(executor_server_url, executor, Some("/rest".to_owned())).await;
     });
 
-    let (pg_store, pg_handle) = start_test_indexer_v2(
+    let (pg_store, pg_handle) = start_test_indexer_v2_impl(
         Some(db_url),
         format!("http://{}", executor_server_url),
         true,
         ReaderWriterConfig::writer_mode(snapshot_config.clone()),
+        Some(graphql_connection_config.db_name()),
     )
     .await;
 
@@ -133,6 +137,7 @@ pub async fn serve_executor(
         graphql_server_join_handle: graphql_server_handle,
         graphql_client: client,
         snapshot_config: snapshot_config.unwrap_or_default(),
+        graphql_connection_config,
     }
 }
 
@@ -247,5 +252,13 @@ impl ExecutorCluster {
         })
         .await
         .expect("Timeout waiting for indexer to update objects snapshot");
+    }
+
+    pub async fn cleanup_resources(self) {
+        // Delete the database
+        let db_url = self.graphql_connection_config.db_url.clone();
+
+        drop(self);
+        force_delete_database(db_url).await;
     }
 }

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -257,8 +257,6 @@ impl ExecutorCluster {
     pub async fn cleanup_resources(self) {
         // Delete the database
         let db_url = self.graphql_connection_config.db_url.clone();
-
-        drop(self);
         force_delete_database(db_url).await;
     }
 }

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -172,10 +172,9 @@ fn replace_db_name(db_url: &str, new_db_name: &str) -> (String, String) {
 }
 
 pub async fn force_delete_database(db_url: String) {
-    // Connect to the `postgres` database to drop the active database.
+    // Replace the database name with the default `postgres`, which should be the last string after `/`
     // This is necessary because you can't drop a database while being connected to it.
-
-    // Replace the database name with `postgres`, which should be the last string after `/`
+    // Hence switch to the default `postgres` database to drop the active database.
     let (default_db_url, db_name) = replace_db_name(&db_url, "postgres");
 
     let blocking_pool = new_pg_connection_pool_impl(&default_db_url, Some(5)).unwrap();

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use diesel::connection::SimpleConnection;
 use mysten_metrics::init_metrics;
 use prometheus::Registry;
 use tokio::task::JoinHandle;
@@ -44,6 +45,23 @@ pub async fn start_test_indexer_v2(
     use_indexer_experimental_methods: bool,
     reader_writer_config: ReaderWriterConfig,
 ) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
+    start_test_indexer_v2_impl(
+        db_url,
+        rpc_url,
+        use_indexer_experimental_methods,
+        reader_writer_config,
+        None,
+    )
+    .await
+}
+
+pub async fn start_test_indexer_v2_impl(
+    db_url: Option<String>,
+    rpc_url: String,
+    use_indexer_experimental_methods: bool,
+    reader_writer_config: ReaderWriterConfig,
+    new_database: Option<String>,
+) -> (PgIndexerStoreV2, JoinHandle<Result<(), IndexerError>>) {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
     info!("Setting DB_POOL_SIZE to 10");
@@ -80,7 +98,31 @@ pub async fn start_test_indexer_v2(
 
     let indexer_metrics = IndexerMetrics::new(&registry);
 
-    let parsed_url = config.get_db_url().unwrap();
+    let mut parsed_url = config.get_db_url().unwrap();
+
+    if let Some(new_database) = new_database {
+        // Switch to default to create a new database
+        let (default_db_url, _) = replace_db_name(&parsed_url, "postgres");
+
+        // Open in default mode
+        let blocking_pool = new_pg_connection_pool_impl(&default_db_url, Some(5)).unwrap();
+
+        // Delete the old db if it exists
+        blocking_pool
+            .get()
+            .unwrap()
+            .batch_execute(&format!("DROP DATABASE IF EXISTS {}", new_database))
+            .unwrap();
+
+        // Create the new db
+        blocking_pool
+            .get()
+            .unwrap()
+            .batch_execute(&format!("CREATE DATABASE {}", new_database))
+            .unwrap();
+        parsed_url = replace_db_name(&parsed_url, &new_database).0;
+    }
+
     let blocking_pool = new_pg_connection_pool_impl(&parsed_url, Some(5)).unwrap();
     let store = PgIndexerStoreV2::new(blocking_pool.clone(), indexer_metrics.clone());
 
@@ -117,6 +159,31 @@ pub async fn start_test_indexer_v2(
     };
 
     (store, handle)
+}
+
+fn replace_db_name(db_url: &str, new_db_name: &str) -> (String, String) {
+    let pos = db_url.rfind('/').expect("Unable to find / in db_url");
+    let old_db_name = &db_url[pos + 1..];
+
+    (
+        format!("{}/{}", &db_url[..pos], new_db_name),
+        old_db_name.to_string(),
+    )
+}
+
+pub async fn force_delete_database(db_url: String) {
+    // Connect to the `postgres` database to drop the active database.
+    // This is necessary because you can't drop a database while being connected to it.
+
+    // Replace the database name with `postgres`, which should be the last string after `/`
+    let (default_db_url, db_name) = replace_db_name(&db_url, "postgres");
+
+    let blocking_pool = new_pg_connection_pool_impl(&default_db_url, Some(5)).unwrap();
+    blocking_pool
+        .get()
+        .unwrap()
+        .batch_execute(&format!("DROP DATABASE IF EXISTS {} WITH (FORCE)", db_name))
+        .unwrap();
 }
 
 /// Spawns an indexer thread with provided Postgres DB url

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -38,6 +38,8 @@ use move_vm_runtime::session::SerializedReturnValues;
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::fmt::{self, Write};
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::time::Duration;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -49,7 +51,6 @@ use sui_core::authority::AuthorityState;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_graphql_rpc::config::ConnectionConfig;
 use sui_graphql_rpc::test_infra::cluster::ExecutorCluster;
-use sui_graphql_rpc::test_infra::cluster::DEFAULT_INTERNAL_DATA_SOURCE_PORT;
 use sui_graphql_rpc::test_infra::cluster::{serve_executor, SnapshotLagConfig};
 use sui_json_rpc_api::QUERY_MAX_RESULT_LIMIT;
 use sui_json_rpc_types::{DevInspectResults, SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
@@ -179,7 +180,12 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
     fn default_syntax(&self) -> SyntaxChoice {
         self.default_syntax
     }
-
+    async fn cleanup_resources(&mut self) -> anyhow::Result<()> {
+        if let Some(cluster) = self.cluster.take() {
+            cluster.cleanup_resources().await;
+        }
+        Ok(())
+    }
     async fn init(
         default_syntax: SyntaxChoice,
         pre_compiled_deps: Option<&'a FullyCompiledProgram>,
@@ -189,6 +195,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 Self::ExtraInitArgs,
             )>,
         >,
+        path: &Path,
     ) -> (Self, Option<String>) {
         let rng = StdRng::from_seed(RNG_SEED);
         assert!(
@@ -297,6 +304,13 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 reference_gas_price,
                 object_snapshot_min_checkpoint_lag,
                 object_snapshot_max_checkpoint_lag,
+                // Hash the file path to create custom unique DB name
+                {
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    path.hash(&mut hasher);
+                    let db_name = format!("sui_graphql_test_{}", hasher.finish());
+                    db_name
+                },
             )
             .await
         } else {
@@ -1854,6 +1868,7 @@ async fn init_sim_executor(
     reference_gas_price: Option<u64>,
     object_snapshot_min_checkpoint_lag: Option<usize>,
     object_snapshot_max_checkpoint_lag: Option<usize>,
+    db_name: String,
 ) -> (
     Box<dyn TransactionalAdapter>,
     AccountSetup,
@@ -1919,9 +1934,25 @@ async fn init_sim_executor(
         None,
     );
 
+    // Take the last 4 digits of the db name and use it as the port number
+    let base_port = db_name
+        .chars()
+        .rev()
+        .take(4)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
+    let graphql_port = 20000 + base_port.parse::<u16>().unwrap();
+    let graphql_prom_port = graphql_port + 1;
+    let internal_data_port = graphql_prom_port + 1;
     let cluster = serve_executor(
-        ConnectionConfig::ci_integration_test_cfg(),
-        DEFAULT_INTERNAL_DATA_SOURCE_PORT,
+        ConnectionConfig::ci_integration_test_cfg_with_db_name(
+            db_name,
+            graphql_port,
+            graphql_prom_port,
+        ),
+        internal_data_port,
         Arc::new(read_replica),
         Some(SnapshotLagConfig::new(
             object_snapshot_min_checkpoint_lag,

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -120,7 +120,10 @@ pub trait MoveTestAdapter<'a>: Sized + Send {
         default_syntax: SyntaxChoice,
         option: Option<&'a FullyCompiledProgram>,
         init_data: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,
+        path: &Path,
     ) -> (Self, Option<String>);
+
+    async fn cleanup_resources(&mut self) -> Result<()>;
     async fn publish_modules(
         &mut self,
         modules: Vec<MaybeNamedCompiledModule>,
@@ -725,13 +728,14 @@ where
         }
     };
     let (mut adapter, result_opt) =
-        Adapter::init(default_syntax, fully_compiled_program_opt, init_opt).await;
+        Adapter::init(default_syntax, fully_compiled_program_opt, init_opt, path).await;
     if let Some(result) = result_opt {
         writeln!(output, "\ninit:\n{}", result)?;
     }
     for task in tasks {
         handle_known_task(&mut output, &mut adapter, task).await;
     }
+    adapter.cleanup_resources().await?;
     Ok((output, adapter))
 }
 

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -730,7 +730,12 @@ where
     let (mut adapter, result_opt) =
         Adapter::init(default_syntax, fully_compiled_program_opt, init_opt, path).await;
     if let Some(result) = result_opt {
-        writeln!(output, "\ninit:\n{}", result)?;
+        if let Err(e) = writeln!(output, "\ninit:\n{}", result) {
+            // TODO: if this fails, it masks the actual error, need better error handling
+            // in case cleanup_resources() fails
+            adapter.cleanup_resources().await?;
+            return Err(Box::new(e));
+        }
     }
     for task in tasks {
         handle_known_task(&mut output, &mut adapter, task).await;

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -65,10 +65,15 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         self.default_syntax
     }
 
+    async fn cleanup_resources(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn init(
         default_syntax: SyntaxChoice,
         pre_compiled_deps: Option<&'a FullyCompiledProgram>,
         task_opt: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,
+        _path: &Path,
     ) -> (Self, Option<String>) {
         let (additional_mapping, compiler_edition) = match task_opt.map(|t| t.command) {
             Some((InitCommand { named_addresses }, AdapterInitArgs { edition })) => {


### PR DESCRIPTION
## Description 

Reworks tests and DB logic so e2e tests can run in parallel, hence reducing test time from 21 mins to 13 mins. It shouldn't increase much in future.


* Graphql tests were the slowest of all CI tests @ 21 mins.
* The time to beat was the second slowest test test-extra (ubuntu-ghcloud) test which takes ~15mins
* With new changes, we’re down to 13 mins now and should stay roughly constant regardless of new e2e tests.
* Actual test time is now down from 9 mins to 1.5 mins.
* Most of the remaining total test time is building and installing containers

**How to use it:**
* When running the sui-graphql-e2e-tests , you no longer need to force serialization of e2e test using --test-threads 1 or -j 1 
* Note: this is only for the tests in sui/crates/sui-graphql-e2e-tests
* I have not applied this logic to other tests in sui/crates/sui-graphql-rpc  but these are trivial and don’t contribute much to test time.
* The logic works by giving each test its own DB. This means it’s more resource intensive on the DB and requires more open connections,
* Remember to set max_connections  to a high value (right now its 500)
* There is also a chance that the DB is not cleaned up after a test (if the test is manually terminated), so if you see dangling DBs of the name prefix sui_graphql_test_ , feel free to delete them
* We can probably do better here, maybe by running a cleanup script.

**Future Improvements:**
* Other Rust tests could be parallelized but it might require some tetris, and the ROI might not be worth it
* As new tests are added at some point we might hit the max connections limit. Need a way to adjust this dynamically.
* Port conflicts from multiple concurrent tests is another tricky issue, Ideally might want to have a resource manager task which coordinates resources to each test thread.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
