### PR TITLE
Start tracking package lineage in analytics pipelines

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/package_handler.rs
@@ -3,9 +3,9 @@
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
-
 use sui_indexer::framework::Handler;
 use sui_rest_api::CheckpointData;
+use sui_types::full_checkpoint_content::CheckpointTransaction;
 use sui_types::object::Object;
 
 use crate::handlers::AnalyticsHandler;
@@ -28,17 +28,12 @@ impl Handler for PackageHandler {
             ..
         } = checkpoint_data;
         for checkpoint_transaction in checkpoint_transactions {
-            checkpoint_transaction
-                .output_objects
-                .iter()
-                .for_each(|object| {
-                    self.process_package(
-                        checkpoint_summary.epoch,
-                        checkpoint_summary.sequence_number,
-                        checkpoint_summary.timestamp_ms,
-                        object,
-                    )
-                });
+            self.process_transaction(
+                checkpoint_summary.epoch,
+                checkpoint_summary.sequence_number,
+                checkpoint_summary.timestamp_ms,
+                checkpoint_transaction,
+            )?;
         }
         Ok(())
     }
@@ -61,17 +56,41 @@ impl PackageHandler {
     pub fn new() -> Self {
         PackageHandler { packages: vec![] }
     }
-    fn process_package(&mut self, epoch: u64, checkpoint: u64, timestamp_ms: u64, object: &Object) {
+    fn process_transaction(
+        &mut self,
+        epoch: u64,
+        checkpoint: u64,
+        timestamp_ms: u64,
+        checkpoint_transaction: &CheckpointTransaction,
+    ) -> Result<()> {
+        for object in checkpoint_transaction.output_objects.iter() {
+            self.process_package(epoch, checkpoint, timestamp_ms, object)?;
+        }
+        Ok(())
+    }
+    fn process_package(
+        &mut self,
+        epoch: u64,
+        checkpoint: u64,
+        timestamp_ms: u64,
+        object: &Object,
+    ) -> Result<()> {
         if let sui_types::object::Data::Package(p) = &object.data {
+            let package_id = p.id();
+            let package_version = p.version().value();
+            let original_package_id = p.original_package_id();
             let package = MovePackageEntry {
-                package_id: p.id().to_string(),
+                package_id: package_id.to_string(),
+                package_version: Some(package_version),
                 checkpoint,
                 epoch,
                 timestamp_ms,
                 bcs: Base64::encode(bcs::to_bytes(p).unwrap()),
                 transaction_digest: object.previous_transaction.to_string(),
+                original_package_id: Some(original_package_id.to_string()),
             };
             self.packages.push(package)
         }
+        Ok(())
     }
 }

--- a/crates/sui-analytics-indexer/src/tables.rs
+++ b/crates/sui-analytics-indexer/src/tables.rs
@@ -232,4 +232,6 @@ pub(crate) struct MovePackageEntry {
     pub(crate) bcs: String,
     // txn publishing the package
     pub(crate) transaction_digest: String,
+    pub(crate) package_version: Option<u64>,
+    pub(crate) original_package_id: Option<String>,
 }


### PR DESCRIPTION
## Description 

This PR starts tracking the root package id for every package and records it under a newly added column called "root_package_id" in the package table. In future, once we have canonical package names, we could use other methods to track and record package lineage under the same column

## Test Plan 

Running locally and verifying
