### PR TITLE
display full owner info when executing `sui client object <OBJECT_ID>` command

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2010,7 +2010,7 @@ pub struct ObjectOutput {
     pub digest: String,
     pub obj_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_type: Option<String>,
+    pub owner: Option<Owner>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prev_tx: Option<TransactionDigest>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2021,13 +2021,6 @@ pub struct ObjectOutput {
 
 impl From<&SuiObjectData> for ObjectOutput {
     fn from(obj: &SuiObjectData) -> Self {
-        let owner_type = match obj.owner {
-            Some(Owner::AddressOwner(_)) => Some("AddressOwner".to_string()),
-            Some(Owner::ObjectOwner(_)) => Some("ObjectOwner".to_string()),
-            Some(Owner::Shared { .. }) => Some("Shared".to_string()),
-            Some(Owner::Immutable) => Some("Immutable".to_string()),
-            None => None,
-        };
         let obj_type = match obj.type_.as_ref() {
             Some(x) => x.to_string(),
             None => "unknown".to_string(),
@@ -2037,7 +2030,7 @@ impl From<&SuiObjectData> for ObjectOutput {
             version: obj.version,
             digest: obj.digest.to_string(),
             obj_type,
-            owner_type,
+            owner: obj.owner.clone(),
             prev_tx: obj.previous_transaction,
             storage_rebate: obj.storage_rebate,
             content: obj.content.clone(),


### PR DESCRIPTION
## Description 

Display full owner info when executing `sui client object <OBJECT_ID>` command：
![image](https://github.com/MystenLabs/sui/assets/123343203/5b78f3b2-08cc-4243-a3e4-f98363ae0d2e)

Keep the output consistent with the use of `--json` parameters：
![image](https://github.com/MystenLabs/sui/assets/123343203/ea75eaad-f4af-4323-a9e9-5391f8a92deb)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
