### PR TITLE
docs: add sui move 2024 conventions

### DIFF
--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -1,0 +1,331 @@
+---
+title: Conventions
+description: Recommended Sui Move 2024 best practices
+---
+
+The recommendations below are based on 2024 Move.
+
+## Add section titles
+
+```move
+module conventions::comments {
+  // === Imports ===
+
+  // === Constants ===
+
+  // === Errors ===
+
+  // === Structs ===
+
+  // === Public-View Functions ===
+
+  // === Public-Mutative Functions ===
+
+  // === Public-Friend Functions ===
+
+  // === Admin Functions ===
+
+  // === Private Functions ===
+
+  // === Test Functions ===
+}
+```
+
+## CRUD functions names
+
+- `add`: Adds a value.
+- `new`: Creates an object.
+- `drop`: Drops a struct.
+- `empty`: Creates a struct.
+- `remove`: Removes a value.
+- `exists`: Checks if a key exists.
+- `contains`: Checks if a collection contains a value.
+- `property_name`: Reads a property.
+- `destroy_empty`: Destroys an object or data structure that has values with the **drop** ability.
+- `to_object_name`: Transforms an Object X to Object Y.
+- `from_object_name`: Transforms an Object Y to Object X.
+- `property_name_mut`: Returns a mutable reference.
+- `property_name_immut`: Returns an immutable reference.
+
+## Potato Structs
+
+#### Do not call structs as Potato. It is a pattern recognized by the lack of abilities.
+
+```move
+module conventions::request {
+  // ✅ Right
+  struct Lock {}
+
+  // ❌ Wrong
+  struct RequestPotato {}
+}
+```
+
+## Read Functions
+
+#### Be mindful of the dot syntax when naming functions. Avoid using the object name on function names.
+
+```move
+module conventions::lib {
+  struct Profile {
+    age: u64
+  }
+
+  // ✅ Right
+  public fun age(self: &Profile):  u64 {
+    self.age
+  }
+
+  // ❌ Wrong
+  public fun profile_age(self: &Profile): u64 {
+    self.age
+  }
+}
+
+module conventions::lib {
+  use conventions::lib::{Self, Profile};
+
+  public fun get_tokens(profile: &Profile) {
+
+  // ✅ Right
+  let name = profile.age();
+
+  // ❌ Wrong
+  let name2 = profile.profile_age();
+}
+```
+## Empty Function
+
+#### Functions that create data structures must be called empty.
+
+```move
+module conventions::data_structure {
+  struct DataStructure has copy, drop, store {
+    bits: vector<u8>
+  }
+
+  public fun empty(): DataStructure {}
+}
+```
+## New Function
+
+#### Functions that create objects must be called new.
+
+```move
+module conventions::object {
+  struct Object has key, store {
+    id: UID
+  }
+
+  public fun new(ctx:&mut TxContext): Object {}
+}
+```
+
+## Shared Objects
+
+#### Shared objects must be created via a new function and be shared in a separate function. The share function must be named share.
+
+```move
+module conventions::profile {
+  struct Profile has key {
+    id: UID
+  }
+
+  public fun new(ctx:&mut TxContext): Profile {}
+
+  public fun share(profile: Profile) {}
+}
+```
+
+## Reference Functions
+
+#### Functions that return a reference must be named property_name_mut or property_name_immut. The borrow is implied by the mut and immut.
+
+```move
+module conventions::profile {
+  struct Profile has key {
+    id: UID,
+    name: String,
+    age: u8
+  }
+
+  // profile.name_immut()
+  public fun name_immut(self: &Profile): &String {}
+
+  // profile.age_mut()
+  public fun age_mut(self: &mut Profile): &mut u8 {}
+}
+```
+
+## Separation of Concerns
+
+#### Modules must be designed around one Object or Data Structure. A variant structure should have its own module to avoid complexity and bugs.
+
+```move
+module conventions::wallet {
+  struct Wallet has key, store {
+    id: UID,
+    amount: u64
+  }
+}
+
+module conventions::claw_back_wallet {
+  struct Wallet has key {
+    id: UID,
+    amount: u64
+  }
+}
+```
+
+## Errors
+
+#### Errors must be CamelCase, start with an E and be descriptive.
+
+```move
+module conventions::errors {
+  // ✅ Right
+  const ENameHasMaxLengthOf64Chars: u64 = 0;
+
+  // ❌ Wrong
+  const INVALID_NAME: u64 = 0;
+}
+```
+
+## Struct Property Comments
+
+#### Describe the properties of your structs.
+
+```move
+module conventions::profile {
+  struct Profile has key, store {
+    id: UID,
+    // The age of the user
+    age: u8,
+    // The first name of the user
+    name: String
+  }
+}
+```
+
+## Destroy Functions
+
+#### Provide functions to delete objects and structs. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
+
+```move
+module conventions::wallet {
+  struct Wallet<Value> {
+    id: UID,
+    value: Value
+  }
+
+  // Value has drop
+  public fun drop<Value: drop>(wallet: &mut Wallet<Value>) {}
+
+  // Value doesn't have drop
+  // Does NOT throw if the `wallet` is not empty.
+  public fun destroy<Value>(wallet: &mut Wallet<Value>) {}
+
+  // Value doesn't have drop
+  // Throws if the `wallet` is not empty.
+  public fun destroy_empty<Value>(wallet: &mut Wallet<Value>) {}
+}
+```
+
+## Pure Functions
+
+#### Keep your functions pure to maintain composability. Do not use transfer::transfer or transfer::public_transfer inside core functions.
+
+```move
+module conventions::amm {
+  struct Pool has key {
+    id: UID
+  }
+
+  // ✅ Right
+  // Return the excess coins even if they have zero value.
+  public fun add_liquidity<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>): (Coin<LpCoin>, Coin<CoinX>, Coin<CoinY>) {}
+
+  // ✅ Right
+  public fun add_liquidity_and_transfer<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, recipient: address) {
+    let (lp_coin, coin_x, coin_y) = add_liquidity(pool, coin_x, coin_y);
+    transfer::public_transfer(lp_coin, recipient);
+    transfer::public_transfer(coin_x, recipient);
+    transfer::public_transfer(coin_y, recipient);
+  }
+
+  // ❌ Wrong
+  public fun add_liquidity<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
+    transfer::public_transfer(coin_x, tx_context::sender(ctx));
+    transfer::public_transfer(coin_y, tx_context::sender(ctx));
+
+    coin_lp
+  }
+}
+```
+
+## Coin argument
+
+#### Pass the Coin by value with the right amount directly, it's better for transaction readability from the frontend.
+
+```move
+module conventions::amm {
+  struct Pool has key {
+    id: UID
+  }
+
+  // ✅ Right
+  public fun swap<CoinX, CoinY>(coin_in: Coin<CoinX>): Coin<CoinY> {}
+
+  // ❌ Wrong
+  public fun swap<CoinX, CoinY>(coin_in: &mut Coin<CoinX>): Coin<CoinY> {}
+}
+```
+
+## Account Information
+
+#### To maintain composability, do not store the user's account data in a hashmap - e.g. (Table/Bag/VecSet). Create an object and return it to the user. Moreover, parallelization on Sui depends on objects so it's always a good idea to split the app state to a maximum.
+
+```move
+module conventions::social_network {
+  struct Account has key, store {
+    id: UID,
+    name: String
+  }
+
+  struct State has key {
+    id: UID,
+    accounts: Table<address, String>
+  }
+
+  // ✅ Right
+  public fun new(name: String): Account {}
+
+  // ❌ Wrong
+  public fun new(state: &mut State, name: String) {}
+}
+```
+
+## Admin Capability
+
+#### In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
+
+```move
+module conventions::social_network {
+  struct Account has key {
+    id: UID,
+    name: String
+  }
+
+  struct Admin has key {
+    id: UID,
+  }
+
+  // ✅ Right
+  // cap.update(&mut account, b"jose");
+  public fun update(_: &Admin, account: &mut Account, new_name: String) {}
+
+  // ❌ Wrong
+  // account.update(&cap, b"jose");
+  public fun update(account: &mut Account, _: &Admin, new_name: String) {}
+}
+```

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -54,7 +54,7 @@ module conventions::comments {
 ```move
 module conventions::request {
   // ✅ Right
-  struct Lock {}
+  struct Request {}
 
   // ❌ Wrong
   struct RequestPotato {}

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -71,7 +71,7 @@ module conventions::request {
 Be mindful of the dot syntax when naming functions. Avoid using the object name on function names.
 
 ```move
-module conventions::lib {
+module conventions::profile {
 
   struct Profile {
     age: u64

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -48,7 +48,7 @@ module conventions::comments {
 
 ## Potato Structs
 
-#### Do not call structs as Potato. It is a pattern recognized by the lack of abilities.
+Do not call structs as Potato. It is a pattern recognized by the lack of abilities.
 
 ```move
 module conventions::request {
@@ -62,7 +62,7 @@ module conventions::request {
 
 ## Read Functions
 
-#### Be mindful of the dot syntax when naming functions. Avoid using the object name on function names.
+Be mindful of the dot syntax when naming functions. Avoid using the object name on function names.
 
 ```move
 module conventions::lib {
@@ -97,7 +97,7 @@ module conventions::defi {
 ```
 ## Empty Function
 
-#### Functions that create data structures must be called empty.
+Functions that create data structures must be called empty.
 
 ```move
 module conventions::collection {
@@ -115,7 +115,7 @@ module conventions::collection {
 ```
 ## New Function
 
-#### Functions that create objects must be called new.
+Functions that create objects must be called new.
 
 ```move
 module conventions::object {
@@ -137,7 +137,7 @@ module conventions::object {
 
 ## Shared Objects
 
-#### Library modules that share objects should provide two functions: one to create the object and another to share it. It allows the caller to access its UID and run custom functionality before sharing it.
+Library modules that share objects should provide two functions: one to create the object and another to share it. It allows the caller to access its UID and run custom functionality before sharing it.
 
 ```move
 module conventions::profile {
@@ -164,7 +164,7 @@ module conventions::profile {
 
 ## Reference Functions
 
-#### Functions that return a reference must be named property_name_mut or property_name.
+Functions that return a reference must be named property_name_mut or property_name.
 
 ```move
 module conventions::profile {
@@ -193,7 +193,7 @@ module conventions::profile {
 
 ## Separation of Concerns
 
-#### Modules must be designed around one Object or Data Structure. A variant structure should have its own module to avoid complexity and bugs.
+Modules must be designed around one Object or Data Structure. A variant structure should have its own module to avoid complexity and bugs.
 
 ```move
 module conventions::wallet {
@@ -219,7 +219,7 @@ module conventions::claw_back_wallet {
 
 ## Errors
 
-#### Errors must be CamelCase, start with an E and be descriptive.
+Errors must be CamelCase, start with an E and be descriptive.
 
 ```move
 module conventions::errors {
@@ -233,7 +233,7 @@ module conventions::errors {
 
 ## Struct Property Comments
 
-#### Describe the properties of your structs.
+Describe the properties of your structs.
 
 ```move
 module conventions::profile {
@@ -254,7 +254,7 @@ module conventions::profile {
 
 ## Destroy Functions
 
-#### Provide functions to delete objects. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
+Provide functions to delete objects. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
 
 ```move
 module conventions::wallet {
@@ -286,7 +286,7 @@ module conventions::wallet {
 
 ## Pure Functions
 
-#### Keep your functions pure to maintain composability. Do not use transfer::transfer or transfer::public_transfer inside core functions.
+Keep your functions pure to maintain composability. Do not use transfer::transfer or transfer::public_transfer inside core functions.
 
 ```move
 module conventions::amm {
@@ -328,7 +328,7 @@ module conventions::amm {
 
 ## Coin argument
 
-#### Pass the Coin by value with the right amount directly, it's better for transaction readability from the frontend.
+Pass the Coin by value with the right amount directly, it's better for transaction readability from the frontend.
 
 ```move
 module conventions::amm {
@@ -356,7 +356,7 @@ module conventions::amm {
 
 ## Access Control
 
-#### To maintain composability, use capabilities instead of addresses for access control.
+To maintain composability, use capabilities instead of addresses for access control.
 
 ```move
 module conventions::access_control {
@@ -404,7 +404,7 @@ module conventions::access_control {
 
 ## Data Storage in Owned vs Shared Objects
 
-#### If your dApp data has a one to one relationship, we recommend to use Owned Objects.
+If your dApp data has a one to one relationship, we recommend to use Owned Objects.
 
 ```move
 module conventions::vesting_wallet {
@@ -442,7 +442,7 @@ module conventions::vesting_wallet {
   */
   public fun new_shared(deposit: Coin<SUI>, ctx: &mut TxContext) {
     // Implementation omitted.
-    // It shares the `SharedWallet`
+    // It shares the `SharedWallet`.
     abort(0)
   }
 }
@@ -450,7 +450,7 @@ module conventions::vesting_wallet {
 
 ## Admin Capability
 
-#### In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
+In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
 
 ```move
 module conventions::social_network {

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -318,11 +318,11 @@ module conventions::amm {
 
   // ❌ Wrong
   public fun impure_add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
+    let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
     transfer::public_transfer(coin_x, tx_context::sender(ctx));
     transfer::public_transfer(coin_y, tx_context::sender(ctx));
 
-    // Implementation omitted.
-    abort(0)
+    lp_coin
   }
 }
 ```
@@ -381,7 +381,7 @@ module conventions::access_control {
   }
 
   // ✅ Right
-  // With this function, another protocol can hold the `Account` in behalf of a user.
+  // With this function, another protocol can hold the `Account` on behalf of a user.
   public fun withdraw(state: &mut State, account: &mut Account, ctx: &mut TxContext): Coin<SUI> {
     let authorized_balance = account.balance;
 
@@ -454,6 +454,11 @@ module conventions::vesting_wallet {
 
 ```move
 module conventions::social_network {
+
+  use std::string::String;
+
+  use sui::object::UID;
+
   struct Account has key {
     id: UID,
     name: String
@@ -465,10 +470,16 @@ module conventions::social_network {
 
   // ✅ Right
   // cap.update(&mut account, b"jose");
-  public fun update(_: &Admin, account: &mut Account, new_name: String) {}
+  public fun update(_: &Admin, account: &mut Account, new_name: String) {
+    // Implementation omitted.
+    abort(0)
+  }
 
   // ❌ Wrong
   // account.update(&cap, b"jose");
-  public fun update(account: &mut Account, _: &Admin, new_name: String) {}
+  public fun set(account: &mut Account, _: &Admin, new_name: String) {
+    // Implementation omitted.
+    abort(0)
+  }
 }
 ```

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -54,7 +54,7 @@ These are the available CRUD functions:
 
 ## Potato structs
 
-Do use 'potato' in the name of structs. The lack of abilities define it as a potato pattern.
+Do not use 'potato' in the name of structs. The lack of abilities define it as a potato pattern.
 
 ```move
 module conventions::request {

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -40,7 +40,7 @@ module conventions::comments {
 - `drop`: Drops a struct.
 - `empty`: Creates a struct.
 - `remove`: Removes a value.
-- `exists`: Checks if a key exists.
+- `exists_`: Checks if a key exists.
 - `contains`: Checks if a collection contains a value.
 - `destroy_empty`: Destroys an object or data structure that has values with the **drop** ability.
 - `to_object_name`: Transforms an Object X to Object Y.

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -355,7 +355,7 @@ module conventions::amm {
   }
 
   // ❌ Wrong
-  public fun exchange<CoinX, CoinY>(coin_in: &mut Coin<CoinX>): Coin<CoinY> {
+  public fun exchange<CoinX, CoinY>(coin_in: &mut Coin<CoinX>, value: u64): Coin<CoinY> {
     // Implementation omitted.
     abort(0)
   }

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -1,11 +1,13 @@
 ---
 title: Conventions
-description: Recommended Sui Move 2024 best practices
+description: Recommended Move 2024 best practices for the Sui blockchain.
 ---
 
-The recommendations below are based on 2024 Move.
+The following recommendations are based on 2024 Move.
 
 ## Add section titles
+
+Use titles in code comments to create sections for your Move code files. Structure your titles using `===` on either side of the title.
 
 ```move
 module conventions::comments {
@@ -35,6 +37,8 @@ module conventions::comments {
 
 ## CRUD functions names
 
+These are the available CRUD functions:
+
 - `add`: Adds a value.
 - `new`: Creates an object.
 - `drop`: Drops a struct.
@@ -48,9 +52,9 @@ module conventions::comments {
 - `property_name`: Returns an immutable reference or a copy.
 - `property_name_mut`: Returns a mutable reference.
 
-## Potato Structs
+## Potato structs
 
-Do not call structs as Potato. It is a pattern recognized by the lack of abilities.
+Do use 'potato' in the name of structs. The lack of abilities define it as a potato pattern.
 
 ```move
 module conventions::request {
@@ -62,7 +66,7 @@ module conventions::request {
 }
 ```
 
-## Read Functions
+## Read functions
 
 Be mindful of the dot syntax when naming functions. Avoid using the object name on function names.
 
@@ -97,9 +101,9 @@ module conventions::defi {
   let name2 = profile.profile_age();
 }
 ```
-## Empty Function
+## Empty function
 
-Functions that create data structures must be called empty.
+Name the functions that create data structures as `empty`.
 
 ```move
 module conventions::collection {
@@ -115,9 +119,9 @@ module conventions::collection {
   }
 }
 ```
-## New Function
+## New function
 
-Functions that create objects must be called new.
+Name the functions that create objects as `new`.
 
 ```move
 module conventions::object {
@@ -137,7 +141,7 @@ module conventions::object {
 }
 ```
 
-## Shared Objects
+## Shared objects
 
 Library modules that share objects should provide two functions: one to create the object and another to share it. It allows the caller to access its UID and run custom functionality before sharing it.
 
@@ -164,9 +168,9 @@ module conventions::profile {
 }
 ```
 
-## Reference Functions
+## Reference functions
 
-Functions that return a reference must be named property_name_mut or property_name.
+Name the functions that return a reference as `<PROPERTY-NAME>_mut` or `<PROPERTY-NAME>`, replacing with <PROPERTY-NAME\> the actual name of the property.
 
 ```move
 module conventions::profile {
@@ -193,10 +197,9 @@ module conventions::profile {
 }
 ```
 
-## Separation of Concerns
+## Separation of concerns
 
-Modules must be designed around one Object or Data Structure. A variant structure should have its own module to avoid complexity and bugs.
-
+Design your modules around one object or data structure. A variant structure should have its own module to avoid complexity and bugs.
 ```move
 module conventions::wallet {
 
@@ -221,7 +224,7 @@ module conventions::claw_back_wallet {
 
 ## Errors
 
-Errors must be CamelCase, start with an E and be descriptive.
+Use PascalCase for errors, start with an E and be descriptive.
 
 ```move
 module conventions::errors {
@@ -233,7 +236,7 @@ module conventions::errors {
 }
 ```
 
-## Struct Property Comments
+## Struct property comments
 
 Describe the properties of your structs.
 
@@ -254,10 +257,9 @@ module conventions::profile {
 }
 ```
 
-## Destroy Functions
+## Destroy functions
 
-Provide functions to delete objects. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
-
+Provide functions to delete objects. Destroy empty objects with the function `destroy_empty`. Use the function `drop` for objects that have types that can be dropped.
 ```move
 module conventions::wallet {
 
@@ -286,10 +288,9 @@ module conventions::wallet {
 }
 ```
 
-## Pure Functions
+## Pure functions
 
-Keep your functions pure to maintain composability. Do not use transfer::transfer or transfer::public_transfer inside core functions.
-
+Keep your functions pure to maintain composability. Do not use `transfer::transfer` or `transfer::public_transfer` inside core functions.
 ```move
 module conventions::amm {
 
@@ -330,7 +331,7 @@ module conventions::amm {
 
 ## Coin argument
 
-Pass the Coin by value with the right amount directly, it's better for transaction readability from the frontend.
+Pass the `Coin` object by value with the right amount directly because it's better for transaction readability from the frontend.
 
 ```move
 module conventions::amm {
@@ -356,7 +357,7 @@ module conventions::amm {
 }
 ```
 
-## Access Control
+## Access control
 
 To maintain composability, use capabilities instead of addresses for access control.
 
@@ -404,9 +405,9 @@ module conventions::access_control {
 }
 ```
 
-## Data Storage in Owned vs Shared Objects
+## Data storage in owned vs shared objects
 
-If your dApp data has a one to one relationship, we recommend to use Owned Objects.
+If your dApp data has a one to one relationship, it's best to use owned objects.
 
 ```move
 module conventions::vesting_wallet {
@@ -431,7 +432,7 @@ module conventions::vesting_wallet {
 
   /*
   * A vesting wallet releases a certain amount of coin over a period of time.
-  * If the entire balance belongs to one user and the wallet has no additional functionalities, it is best to store it in an Owned Object.
+  * If the entire balance belongs to one user and the wallet has no additional functionalities, it is best to store it in an owned object.
   */
   public fun new(deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
     // Implementation omitted.
@@ -450,7 +451,7 @@ module conventions::vesting_wallet {
 }
 ```
 
-## Admin Capability
+## Admin capability
 
 In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
 

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -11,19 +11,21 @@ The recommendations below are based on 2024 Move.
 module conventions::comments {
   // === Imports ===
 
-  // === Constants ===
+  // === Friends ===
 
   // === Errors ===
 
-  // === Structs ===
+  // === Constants ===
 
-  // === Public-View Functions ===
+  // === Structs ===
 
   // === Public-Mutative Functions ===
 
-  // === Public-Friend Functions ===
+  // === Public-View Functions ===
 
   // === Admin Functions ===
+
+  // === Public-Friend Functions ===
 
   // === Private Functions ===
 

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -43,7 +43,7 @@ module conventions::comments {
 - `destroy_empty`: Destroys an object or data structure that has values with the **drop** ability.
 - `to_object_name`: Transforms an Object X to Object Y.
 - `from_object_name`: Transforms an Object Y to Object X.
-- `property_name`: Returns an immutable reference.
+- `property_name`: Returns an immutable reference or a copy.
 - `property_name_mut`: Returns a mutable reference.
 
 ## Potato Structs

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -440,8 +440,9 @@ module conventions::vesting_wallet {
   * If you wish to add extra functionality to a vesting wallet, it is best to share the object.
   * For example, if you wish the issuer of the wallet to be able to cancel the contract in the future.
   */
-  public fun new_shared(shared_wallet: &mut SharedWallet, deposit: Coin<SUI>, ctx: &mut TxContext) {
+  public fun new_shared(deposit: Coin<SUI>, ctx: &mut TxContext) {
     // Implementation omitted.
+    // It shares the `SharedWallet`
     abort(0)
   }
 }

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -67,6 +67,7 @@ module conventions::request {
 
 ```move
 module conventions::lib {
+
   struct Profile {
     age: u64
   }
@@ -82,7 +83,8 @@ module conventions::lib {
   }
 }
 
-module conventions::lib {
+module conventions::defi {
+
   use conventions::lib::{Self, Profile};
 
   public fun get_tokens(profile: &Profile) {
@@ -99,12 +101,17 @@ module conventions::lib {
 #### Functions that create data structures must be called empty.
 
 ```move
-module conventions::data_structure {
-  struct DataStructure has copy, drop, store {
+module conventions::collection {
+
+  struct Collection has copy, drop, store {
     bits: vector<u8>
   }
 
-  public fun empty(): DataStructure {}
+  public fun empty(): Collection {
+    Collection {
+      bits: vector[]
+    }
+  }
 }
 ```
 ## New Function
@@ -113,47 +120,75 @@ module conventions::data_structure {
 
 ```move
 module conventions::object {
+
+  use sui::object::{Self, UID};
+  use sui::tx_context::TxContext;
+
   struct Object has key, store {
     id: UID
   }
 
-  public fun new(ctx:&mut TxContext): Object {}
+  public fun new(ctx:&mut TxContext): Object {
+    Object {
+      id: object::new(ctx)
+    }
+  }
 }
 ```
 
 ## Shared Objects
 
-#### Shared objects must be created via a new function and be shared in a separate function. The share function must be named share.
+#### Library modules that share objects should provide two functions: one to create the object and another to share it. It allows the caller to access its UID and run custom functionality before sharing it.
 
 ```move
 module conventions::profile {
+
+  use sui::object::{Self, UID};
+  use sui::tx_context::TxContext;
+  use sui::transfer::share_object;
+
   struct Profile has key {
     id: UID
   }
 
-  public fun new(ctx:&mut TxContext): Profile {}
+  public fun new(ctx:&mut TxContext): Profile {
+    Profile {
+      id: object::new(ctx)
+    }
+  }
 
-  public fun share(profile: Profile) {}
+  public fun share(profile: Profile) {
+    share_object(profile);
+  }
 }
 ```
 
 ## Reference Functions
 
-#### Functions that return a reference must be named property_name_mut or property_name_immut. The borrow is implied by the mut and immut.
+#### Functions that return a reference must be named property_name_mut or property_name.
 
 ```move
 module conventions::profile {
+
+  use std::string::String;
+
+  use sui::object::UID;
+
   struct Profile has key {
     id: UID,
     name: String,
     age: u8
   }
 
-  // profile.name_immut()
-  public fun name_immut(self: &Profile): &String {}
+  // profile.name()
+  public fun name(self: &Profile): &String {
+    &self.name
+  }
 
   // profile.age_mut()
-  public fun age_mut(self: &mut Profile): &mut u8 {}
+  public fun age_mut(self: &mut Profile): &mut u8 {
+    &mut self.age
+  }
 }
 ```
 
@@ -163,6 +198,9 @@ module conventions::profile {
 
 ```move
 module conventions::wallet {
+
+  use sui::object::UID;
+
   struct Wallet has key, store {
     id: UID,
     amount: u64
@@ -170,6 +208,9 @@ module conventions::wallet {
 }
 
 module conventions::claw_back_wallet {
+
+  use sui::object::UID;
+
   struct Wallet has key {
     id: UID,
     amount: u64
@@ -197,11 +238,16 @@ module conventions::errors {
 
 ```move
 module conventions::profile {
+
+  use std::string::String;
+
+  use sui::object::UID;
+
   struct Profile has key, store {
     id: UID,
-    // The age of the user
+    /// The age of the user
     age: u8,
-    // The first name of the user
+    /// The first name of the user
     name: String
   }
 }
@@ -209,25 +255,33 @@ module conventions::profile {
 
 ## Destroy Functions
 
-#### Provide functions to delete objects and structs. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
+#### Provide functions to delete objects. Empty objects must be destroyed with the function destroy_empty. The function drop must be used for objects that have types that can be dropped.
 
 ```move
 module conventions::wallet {
+
+  use sui::object::{Self, UID};
+  use sui::balance::{Self, Balance};
+  use sui::sui::SUI;
+
   struct Wallet<Value> {
     id: UID,
     value: Value
   }
 
   // Value has drop
-  public fun drop<Value: drop>(wallet: &mut Wallet<Value>) {}
+  public fun drop<Value: drop>(self: Wallet<Value>) {
+    let Wallet { id, value: _ } = self;
+    object::delete(id);
+  }
 
   // Value doesn't have drop
-  // Does NOT throw if the `wallet` is not empty.
-  public fun destroy<Value>(wallet: &mut Wallet<Value>) {}
-
-  // Value doesn't have drop
-  // Throws if the `wallet` is not empty.
-  public fun destroy_empty<Value>(wallet: &mut Wallet<Value>) {}
+  // Throws if the `wallet.value` is not empty.
+  public fun destroy_empty(self: Wallet<Balance<SUI>>) {
+    let Wallet { id, value } = self;
+    object::delete(id);
+    balance::destroy_zero(value);
+  }
 }
 ```
 
@@ -237,28 +291,38 @@ module conventions::wallet {
 
 ```move
 module conventions::amm {
+
+  use sui::transfer;
+  use sui::coin::Coin;
+  use sui::object::UID;
+  use sui::tx_context::{Self, TxContext};
+
   struct Pool has key {
     id: UID
   }
 
   // ✅ Right
   // Return the excess coins even if they have zero value.
-  public fun add_liquidity<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>): (Coin<LpCoin>, Coin<CoinX>, Coin<CoinY>) {}
+  public fun add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>): (Coin<LpCoin>, Coin<CoinX>, Coin<CoinY>) {
+    // Implementation omitted.
+    abort(0)
+  }
 
   // ✅ Right
-  public fun add_liquidity_and_transfer<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, recipient: address) {
-    let (lp_coin, coin_x, coin_y) = add_liquidity(pool, coin_x, coin_y);
+  public fun add_liquidity_and_transfer<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, recipient: address) {
+    let (lp_coin, coin_x, coin_y) = add_liquidity<CoinX, CoinY, LpCoin>(pool, coin_x, coin_y);
     transfer::public_transfer(lp_coin, recipient);
     transfer::public_transfer(coin_x, recipient);
     transfer::public_transfer(coin_y, recipient);
   }
 
   // ❌ Wrong
-  public fun add_liquidity<CoinX, CoinY, LP_Coin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
+  public fun impure_add_liquidity<CoinX, CoinY, LpCoin>(pool: &mut Pool, coin_x: Coin<CoinX>, coin_y: Coin<CoinY>, ctx: &mut TxContext): Coin<LpCoin> {
     transfer::public_transfer(coin_x, tx_context::sender(ctx));
     transfer::public_transfer(coin_y, tx_context::sender(ctx));
 
-    coin_lp
+    // Implementation omitted.
+    abort(0)
   }
 }
 ```
@@ -269,39 +333,116 @@ module conventions::amm {
 
 ```move
 module conventions::amm {
+
+  use sui::coin::Coin;
+  use sui::object::UID;
+
   struct Pool has key {
     id: UID
   }
 
   // ✅ Right
-  public fun swap<CoinX, CoinY>(coin_in: Coin<CoinX>): Coin<CoinY> {}
+  public fun swap<CoinX, CoinY>(coin_in: Coin<CoinX>): Coin<CoinY> {
+    // Implementation omitted.
+    abort(0)
+  }
 
   // ❌ Wrong
-  public fun swap<CoinX, CoinY>(coin_in: &mut Coin<CoinX>): Coin<CoinY> {}
+  public fun exchange<CoinX, CoinY>(coin_in: &mut Coin<CoinX>): Coin<CoinY> {
+    // Implementation omitted.
+    abort(0)
+  }
 }
 ```
 
-## Account Information
+## Access Control
 
-#### To maintain composability, do not store the user's account data in a hashmap - e.g. (Table/Bag/VecSet). Create an object and return it to the user. Moreover, parallelization on Sui depends on objects so it's always a good idea to split the app state to a maximum.
+#### To maintain composability, use capabilities instead of addresses for access control.
 
 ```move
-module conventions::social_network {
+module conventions::access_control {
+
+  use sui::sui::SUI;
+  use sui::object::UID;
+  use sui::balance::Balance;
+  use sui::coin::{Self, Coin};
+  use sui::table::{Self, Table};
+  use sui::tx_context::{Self, TxContext};
+
   struct Account has key, store {
     id: UID,
-    name: String
+    balance: u64
   }
 
   struct State has key {
     id: UID,
-    accounts: Table<address, String>
+    accounts: Table<address, u64>,
+    balance: Balance<SUI>
   }
 
   // ✅ Right
-  public fun new(name: String): Account {}
+  // With this function, another protocol can hold the `Account` in behalf of a user.
+  public fun withdraw(state: &mut State, account: &mut Account, ctx: &mut TxContext): Coin<SUI> {
+    let authorized_balance = account.balance;
+
+    account.balance = 0;
+
+    coin::take(&mut state.balance, authorized_balance, ctx)
+  }
 
   // ❌ Wrong
-  public fun new(state: &mut State, name: String) {}
+  // This is less composable.
+  public fun wrong_withdraw(state: &mut State, ctx: &mut TxContext): Coin<SUI> {
+    let sender = tx_context::sender(ctx);
+
+    let authorized_balance = *table::borrow(&state.accounts, sender);
+    coin::take(&mut state.balance, authorized_balance, ctx)
+  }
+}
+```
+
+## Data Storage in Owned vs Shared Objects
+
+#### If your dApp data has a one to one relationship, we recommend to use Owned Objects.
+
+```move
+module conventions::vesting_wallet {
+
+  use sui::sui::SUI;
+  use sui::coin::Coin;
+  use sui::object::UID;
+  use sui::table::Table;
+  use sui::balance::Balance;
+  use sui::tx_context::TxContext;
+
+  struct OwnedWallet has key {
+    id: UID,
+    balance: Balance<SUI>
+  }
+
+  struct SharedWallet has key {
+    id: UID,
+    balance: Balance<SUI>,
+    accounts: Table<address, u64>
+  }
+
+  /*
+  * A vesting wallet releases a certain amount of coin over a period of time.
+  * If the entire balance belongs to one user and the wallet has no additional functionalities, it is best to store it in an Owned Object.
+  */
+  public fun new(deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
+    // Implementation omitted.
+    abort(0)
+  }
+
+  /*
+  * If you wish to add extra functionality to a vesting wallet, it is best to share the object.
+  * For example, if you wish the issuer of the wallet to be able to cancel the contract in the future.
+  */
+  public fun new_shared(shared_wallet: &mut SharedWallet, deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
+    // Implementation omitted.
+    abort(0)
+  }
 }
 ```
 

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -40,7 +40,6 @@ module conventions::comments {
 - `remove`: Removes a value.
 - `exists`: Checks if a key exists.
 - `contains`: Checks if a collection contains a value.
-- `property_name`: Reads a property.
 - `destroy_empty`: Destroys an object or data structure that has values with the **drop** ability.
 - `to_object_name`: Transforms an Object X to Object Y.
 - `from_object_name`: Transforms an Object Y to Object X.

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -101,6 +101,7 @@ module conventions::defi {
   let name2 = profile.profile_age();
 }
 ```
+
 ## Empty function
 
 Name the functions that create data structures as `empty`.
@@ -119,6 +120,7 @@ module conventions::collection {
   }
 }
 ```
+
 ## New function
 
 Name the functions that create objects as `new`.
@@ -200,6 +202,7 @@ module conventions::profile {
 ## Separation of concerns
 
 Design your modules around one object or data structure. A variant structure should have its own module to avoid complexity and bugs.
+
 ```move
 module conventions::wallet {
 
@@ -260,6 +263,7 @@ module conventions::profile {
 ## Destroy functions
 
 Provide functions to delete objects. Destroy empty objects with the function `destroy_empty`. Use the function `drop` for objects that have types that can be dropped.
+
 ```move
 module conventions::wallet {
 
@@ -291,6 +295,7 @@ module conventions::wallet {
 ## Pure functions
 
 Keep your functions pure to maintain composability. Do not use `transfer::transfer` or `transfer::public_transfer` inside core functions.
+
 ```move
 module conventions::amm {
 

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -44,8 +44,8 @@ module conventions::comments {
 - `destroy_empty`: Destroys an object or data structure that has values with the **drop** ability.
 - `to_object_name`: Transforms an Object X to Object Y.
 - `from_object_name`: Transforms an Object Y to Object X.
+- `property_name`: Returns an immutable reference.
 - `property_name_mut`: Returns a mutable reference.
-- `property_name_immut`: Returns an immutable reference.
 
 ## Potato Structs
 
@@ -395,8 +395,10 @@ module conventions::access_control {
   public fun wrong_withdraw(state: &mut State, ctx: &mut TxContext): Coin<SUI> {
     let sender = tx_context::sender(ctx);
 
-    let authorized_balance = *table::borrow(&state.accounts, sender);
-    coin::take(&mut state.balance, authorized_balance, ctx)
+    let authorized_balance = table::borrow_mut(&mut state.accounts, sender);
+    let value = *authorized_balance;
+    *authorized_balance = 0;
+    coin::take(&mut state.balance, value, ctx)
   }
 }
 ```
@@ -439,7 +441,7 @@ module conventions::vesting_wallet {
   * If you wish to add extra functionality to a vesting wallet, it is best to share the object.
   * For example, if you wish the issuer of the wallet to be able to cancel the contract in the future.
   */
-  public fun new_shared(shared_wallet: &mut SharedWallet, deposit: Coin<SUI>, ctx: &mut TxContext): OwnedWallet {
+  public fun new_shared(shared_wallet: &mut SharedWallet, deposit: Coin<SUI>, ctx: &mut TxContext) {
     // Implementation omitted.
     abort(0)
   }

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -264,7 +264,7 @@ module conventions::wallet {
   use sui::balance::{Self, Balance};
   use sui::sui::SUI;
 
-  struct Wallet<Value> {
+  struct Wallet<Value> has key, store {
     id: UID,
     value: Value
   }

--- a/docs/content/sidebars/concepts.js
+++ b/docs/content/sidebars/concepts.js
@@ -104,6 +104,7 @@ const concepts = [
 							'concepts/sui-move-concepts/patterns/app-extensions',
 						],
 					},
+					'concepts/sui-move-concepts/conventions',
 				],
 			},
 			{


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

We added conventions for Sui Move 2024 to the documentations.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
