### PR TITLE
[cli] Improve the way we display PTB info in table output

### DIFF
--- a/crates/sui-json-rpc-types/src/displays/mod.rs
+++ b/crates/sui-json-rpc-types/src/displays/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod transaction_displays;
+
+pub struct Pretty<'a, T>(pub &'a T);

--- a/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
+++ b/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
@@ -78,21 +78,18 @@ impl<'a> Display for Pretty<'a, SuiCommand> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(command) = self;
         match command {
-            SuiCommand::MoveCall(p) => write!(f, "{}", Pretty(&**p)),
-            SuiCommand::TransferObjects(objs, addr) => {
-                write!(f, "TransferObjects:\n ┌\n │ Arguments: \n │   ")?;
-                write_sep(f, objs.iter().map(Pretty), "\n │   ")?;
-                write!(f, "\n │ Address: {}\n └", Pretty(addr))
-            }
-            SuiCommand::SplitCoins(coin, amounts) => {
-                write!(
-                    f,
-                    "SplitCoins:\n ┌\n │ Coin: {}\n │ Amounts: \n │   ",
-                    Pretty(coin)
-                )?;
-                write_sep(f, amounts.iter().map(Pretty), "\n │   ")?;
+            SuiCommand::MakeMoveVec(ty_opt, elems) => {
+                write!(f, "MakeMoveVec:\n ┌")?;
+                if let Some(ty) = ty_opt {
+                    write!(f, "\n │ Type Tag: {ty}")?;
+                }
+                write!(f, "\n │ Arguments:\n │   ")?;
+                write_sep(f, elems.iter().map(Pretty), "\n │   ")?;
                 write!(f, "\n └")
             }
+
+            SuiCommand::MoveCall(p) => write!(f, "{}", Pretty(&**p)),
+
             SuiCommand::MergeCoins(target, coins) => {
                 write!(
                     f,
@@ -102,11 +99,29 @@ impl<'a> Display for Pretty<'a, SuiCommand> {
                 write_sep(f, coins.iter().map(Pretty), "\n │   ")?;
                 write!(f, "\n └")
             }
+
+            SuiCommand::SplitCoins(coin, amounts) => {
+                write!(
+                    f,
+                    "SplitCoins:\n ┌\n │ Coin: {}\n │ Amounts: \n │   ",
+                    Pretty(coin)
+                )?;
+                write_sep(f, amounts.iter().map(Pretty), "\n │   ")?;
+                write!(f, "\n └")
+            }
+
             SuiCommand::Publish(deps) => {
                 write!(f, "Publish:\n ┌\n │ Dependencies: \n │   ")?;
                 write_sep(f, deps, "\n │   ")?;
                 write!(f, "\n └")
             }
+
+            SuiCommand::TransferObjects(objs, addr) => {
+                write!(f, "TransferObjects:\n ┌\n │ Arguments: \n │   ")?;
+                write_sep(f, objs.iter().map(Pretty), "\n │   ")?;
+                write!(f, "\n │ Address: {}\n └", Pretty(addr))
+            }
+
             SuiCommand::Upgrade(deps, current_package_id, ticket) => {
                 write!(f, "Upgrade:\n ┌\n │ Dependencies: \n │   ")?;
                 write_sep(f, deps, "\n │   ")?;
@@ -114,8 +129,6 @@ impl<'a> Display for Pretty<'a, SuiCommand> {
                 write!(f, "\n │ Ticket: {}", Pretty(ticket))?;
                 write!(f, "\n └")
             }
-
-            SuiCommand::MakeMoveVec(_, _) => todo!(),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
+++ b/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::displays::Pretty;
+use std::fmt::{Display, Formatter};
+
+use crate::{
+    SuiArgument, SuiCallArg, SuiCommand, SuiObjectArg, SuiProgrammableMoveCall,
+    SuiProgrammableTransactionBlock,
+};
+use sui_types::transaction::write_sep;
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{style::HorizontalLine, Panel as TablePanel, Style as TableStyle},
+};
+
+impl<'a> Display for Pretty<'a, SuiProgrammableTransactionBlock> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut builder = TableBuilder::default();
+
+        let Pretty(ptb) = self;
+        let SuiProgrammableTransactionBlock { inputs, commands } = ptb;
+
+        for (i, input) in inputs.iter().enumerate() {
+            match input {
+                SuiCallArg::Pure(v) => {
+                    let pure_arg = if let Some(t) = v.value_type() {
+                        format!(
+                            "{i:<3} Pure Arg: Type: {}, Value: {}",
+                            t,
+                            v.value().to_json_value()
+                        )
+                    } else {
+                        format!("{i:<3} Pure Arg: {}", v.value().to_json_value())
+                    };
+                    builder.push_record(vec![pure_arg]);
+                }
+                SuiCallArg::Object(SuiObjectArg::ImmOrOwnedObject { object_id, .. }) => {
+                    builder.push_record(vec![format!("{i:<3} Imm/Owned Object ID: {}", object_id)]);
+                }
+                SuiCallArg::Object(SuiObjectArg::SharedObject { object_id, .. }) => {
+                    builder.push_record(vec![format!("{i:<3} Shared Object    ID: {}", object_id)]);
+                }
+                SuiCallArg::Object(SuiObjectArg::Receiving { object_id, .. }) => {
+                    builder.push_record(vec![format!("{i:<3} Receiving Object ID: {}", object_id)]);
+                }
+            }
+        }
+
+        let mut table = builder.build();
+        table.with(TablePanel::header("Input Objects"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        write!(f, "\n{}", table)?;
+
+        let mut builder = TableBuilder::default();
+
+        for (i, c) in commands.iter().enumerate() {
+            if i == commands.len() - 1 {
+                builder.push_record(vec![format!("{i:<2} {}", Pretty(c))]);
+            } else {
+                builder.push_record(vec![format!("{i:<2} {}\n", Pretty(c))]);
+            }
+        }
+        let mut table = builder.build();
+        table.with(TablePanel::header("Commands"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        write!(f, "\n{}", table)
+    }
+}
+
+impl<'a> Display for Pretty<'a, SuiCommand> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(command) = self;
+        match command {
+            SuiCommand::MoveCall(p) => write!(f, "{}", Pretty(&**p)),
+            SuiCommand::TransferObjects(objs, addr) => {
+                write!(f, "TransferObjects:\n ┌\n │ Arguments: \n │   ")?;
+                write_sep(f, objs.iter().map(Pretty), "\n │   ")?;
+                write!(f, "\n │ Address: {}\n └", Pretty(addr))
+            }
+            SuiCommand::SplitCoins(coin, amounts) => {
+                write!(
+                    f,
+                    "SplitCoins:\n ┌\n │ Coin: {}\n │ Amounts: \n │   ",
+                    Pretty(coin)
+                )?;
+                write_sep(f, amounts.iter().map(Pretty), "\n │   ")?;
+                write!(f, "\n └")
+            }
+            SuiCommand::MergeCoins(target, coins) => {
+                write!(
+                    f,
+                    "MergeCoins:\n ┌\n │ Target: {}\n │ Coins: \n │   ",
+                    Pretty(target)
+                )?;
+                write_sep(f, coins.iter().map(Pretty), "\n │   ")?;
+                write!(f, "\n └")
+            }
+            SuiCommand::Publish(deps) => {
+                write!(f, "Publish:\n ┌\n │ Dependencies: \n │   ")?;
+                write_sep(f, deps, "\n │   ")?;
+                write!(f, "\n └")
+            }
+            SuiCommand::Upgrade(deps, current_package_id, ticket) => {
+                write!(f, "Upgrade:\n ┌\n │ Dependencies: \n │   ")?;
+                write_sep(f, deps, "\n │   ")?;
+                write!(f, "\n │ Current Package ID: {current_package_id}")?;
+                write!(f, "\n │ Ticket: {}", Pretty(ticket))?;
+                write!(f, "\n └")
+            }
+
+            SuiCommand::MakeMoveVec(_, _) => todo!(),
+        }
+    }
+}
+
+impl<'a> Display for Pretty<'a, SuiProgrammableMoveCall> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(move_call) = self;
+        let SuiProgrammableMoveCall {
+            package,
+            module,
+            function,
+            type_arguments,
+            arguments,
+        } = move_call;
+
+        write!(
+            f,
+            "MoveCall:\n ┌\n │ Function:  {} \n │ Module:    {}\n │ Package:   {}",
+            function, module, package
+        )?;
+
+        if !type_arguments.is_empty() {
+            write!(f, "\n │ Type Arguments: \n │   ")?;
+            write_sep(f, type_arguments, "\n │   ")?;
+        }
+        if !arguments.is_empty() {
+            write!(f, "\n │ Arguments: \n │   ")?;
+            write_sep(f, arguments.iter().map(Pretty), "\n │   ")?;
+        }
+
+        write!(f, "\n └")
+    }
+}
+
+impl<'a> Display for Pretty<'a, SuiArgument> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(argument) = self;
+
+        let output = match argument {
+            SuiArgument::GasCoin => "GasCoin".to_string(),
+            SuiArgument::Input(i) => format!("Input  {}", i),
+            SuiArgument::Result(i) => format!("Result {}", i),
+            SuiArgument::NestedResult(j, k) => format!("Nested Result {}: {}", j, k),
+        };
+        write!(f, "{}", output)
+    }
+}

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -23,6 +23,7 @@ use sui_types::dynamic_field::DynamicFieldInfo;
 mod rpc_types_tests;
 
 mod balance_changes;
+mod displays;
 mod object_changes;
 mod sui_checkpoint;
 mod sui_coin;

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -272,7 +272,7 @@ impl Display for SuiTransactionBlockResponse {
         }
 
         if let Some(e) = &self.events {
-            writeln!(writer, "{}", e)?;
+            write!(writer, "{}", e)?;
         }
 
         if let Some(object_changes) = &self.object_changes {
@@ -336,7 +336,7 @@ fn write_obj_changes<T: Display>(
     builder: &mut TableBuilder,
 ) -> std::fmt::Result {
     if !values.is_empty() {
-        builder.push_record(vec![format!("\n{} Objects: ", output_string)]);
+        builder.push_record(vec![format!("{} Objects: ", output_string)]);
         for obj in values {
             builder.push_record(vec![format!("{}", obj)]);
         }
@@ -405,44 +405,44 @@ impl Display for SuiTransactionBlockKind {
         let mut writer = String::new();
         match &self {
             Self::ChangeEpoch(e) => {
-                writeln!(writer, "Transaction Kind : Epoch Change")?;
-                writeln!(writer, "New epoch ID : {}", e.epoch)?;
-                writeln!(writer, "Storage gas reward : {}", e.storage_charge)?;
-                writeln!(writer, "Computation gas reward : {}", e.computation_charge)?;
-                writeln!(writer, "Storage rebate : {}", e.storage_rebate)?;
-                writeln!(writer, "Timestamp : {}", e.epoch_start_timestamp_ms)?;
+                writeln!(writer, "Transaction Kind: Epoch Change")?;
+                writeln!(writer, "New epoch ID: {}", e.epoch)?;
+                writeln!(writer, "Storage gas reward: {}", e.storage_charge)?;
+                writeln!(writer, "Computation gas reward: {}", e.computation_charge)?;
+                writeln!(writer, "Storage rebate: {}", e.storage_rebate)?;
+                writeln!(writer, "Timestamp: {}", e.epoch_start_timestamp_ms)?;
             }
             Self::Genesis(_) => {
-                writeln!(writer, "Transaction Kind : Genesis Transaction")?;
+                writeln!(writer, "Transaction Kind: Genesis Transaction")?;
             }
             Self::ConsensusCommitPrologue(p) => {
-                writeln!(writer, "Transaction Kind : Consensus Commit Prologue")?;
+                writeln!(writer, "Transaction Kind: Consensus Commit Prologue")?;
                 writeln!(
                     writer,
-                    "Epoch: {}, Round: {}, Timestamp : {}",
+                    "Epoch: {}, Round: {}, Timestamp: {}",
                     p.epoch, p.round, p.commit_timestamp_ms
                 )?;
             }
             Self::ConsensusCommitPrologueV2(p) => {
-                writeln!(writer, "Transaction Kind : Consensus Commit Prologue V2")?;
+                writeln!(writer, "Transaction Kind: Consensus Commit Prologue V2")?;
                 writeln!(
                     writer,
-                    "Epoch: {}, Round: {}, Timestamp : {}, ConsensusCommitDigest : {}",
+                    "Epoch: {}, Round: {}, Timestamp: {}, ConsensusCommitDigest: {}",
                     p.epoch, p.round, p.commit_timestamp_ms, p.consensus_commit_digest
                 )?;
             }
             Self::ProgrammableTransaction(p) => {
-                writeln!(writer, "Transaction Kind : Programmable")?;
-                write!(writer, "{p}")?;
+                write!(writer, "Transaction Kind: Programmable")?;
+                write!(writer, "{}", crate::displays::Pretty(p))?;
             }
             Self::AuthenticatorStateUpdate(_) => {
-                writeln!(writer, "Transaction Kind : Authenticator State Update")?;
+                writeln!(writer, "Transaction Kind: Authenticator State Update")?;
             }
             Self::RandomnessStateUpdate(_) => {
-                writeln!(writer, "Transaction Kind : Randomness State Update")?;
+                writeln!(writer, "Transaction Kind: Randomness State Update")?;
             }
             Self::EndOfEpochTransaction(_) => {
-                writeln!(writer, "Transaction Kind : End of Epoch Transaction")?;
+                writeln!(writer, "Transaction Kind: End of Epoch Transaction")?;
             }
         }
         write!(f, "{}", writer)
@@ -883,21 +883,21 @@ impl Display for SuiTransactionBlockEffects {
         }
 
         if !self.mutated().is_empty() {
-            builder.push_record(vec![format!("\nMutated Objects: ")]);
+            builder.push_record(vec![format!("Mutated Objects: ")]);
             for oref in self.mutated() {
                 builder.push_record(vec![owned_objref_string(oref)]);
             }
         }
 
         if !self.shared_objects().is_empty() {
-            builder.push_record(vec![format!("\nShared Objects: ")]);
+            builder.push_record(vec![format!("Shared Objects: ")]);
             for oref in self.shared_objects() {
                 builder.push_record(vec![objref_string(oref)]);
             }
         }
 
         if !self.deleted().is_empty() {
-            builder.push_record(vec![format!("\nDeleted Objects: ")]);
+            builder.push_record(vec![format!("Deleted Objects: ")]);
 
             for oref in self.deleted() {
                 builder.push_record(vec![objref_string(oref)]);
@@ -905,7 +905,7 @@ impl Display for SuiTransactionBlockEffects {
         }
 
         if !self.wrapped().is_empty() {
-            builder.push_record(vec![format!("\nWrapped Objects: ")]);
+            builder.push_record(vec![format!("Wrapped Objects: ")]);
 
             for oref in self.wrapped() {
                 builder.push_record(vec![objref_string(oref)]);
@@ -913,20 +913,20 @@ impl Display for SuiTransactionBlockEffects {
         }
 
         if !self.unwrapped().is_empty() {
-            builder.push_record(vec![format!("\nUnwrapped Objects: ")]);
+            builder.push_record(vec![format!("Unwrapped Objects: ")]);
             for oref in self.unwrapped() {
                 builder.push_record(vec![owned_objref_string(oref)]);
             }
         }
 
         builder.push_record(vec![format!(
-            "\nGas Object: \n{}",
+            "Gas Object: \n{}",
             owned_objref_string(self.gas_object())
         )]);
 
         let gas_cost_summary = self.gas_cost_summary();
         builder.push_record(vec![format!(
-            "\nGas Cost Summary:\n   \
+            "Gas Cost Summary:\n   \
              Storage Cost: {}\n   \
              Computation Cost: {}\n   \
              Storage Rebate: {}\n   \

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -868,12 +868,13 @@ pub fn write_sep<T: Display>(
     items: impl IntoIterator<Item = T>,
     sep: &str,
 ) -> std::fmt::Result {
-    let mut xs = items.into_iter().peekable();
-    while let Some(x) = xs.next() {
-        write!(f, "{x}")?;
-        if xs.peek().is_some() {
-            write!(f, "{sep}")?;
-        }
+    let mut xs = items.into_iter();
+    let Some(x) = xs.next() else {
+        return Ok(());
+    };
+    write!(f, "{x}")?;
+    for x in xs {
+        write!(f, "{sep}{x}")?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Description 

Improves the way we display PTB info in table output. Previously, the inputs would output all the data in a long String, which breaks the table.
*Before*
<img width="2548" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/354b55b0-cb76-48da-9422-dc80fb7c7257">


*After*
<img width="1547" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/4ad9c38e-b520-4c58-9c50-0f705e7034e3">


## Test Plan 

Visual inspection.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Improved the way a transaction kind of type programmable is shown in the CLI's output.