### PR TITLE
[gql][consistent-reads][7/n] Extend Balance cursor to include checkpoint_viewed_at

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
@@ -273,12 +273,7 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
           "sender": {
@@ -357,7 +352,28 @@ Response: {
         }
       ]
     }
-  }
+  },
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        0,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
 }
 
 task 21 'force-object-snapshot-catchup'. lines 154-154:
@@ -369,20 +385,10 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
           "sender": {
@@ -436,7 +442,47 @@ Response: {
         }
       ]
     }
-  }
+  },
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        0,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        1,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
 }
 
 task 23 'force-object-snapshot-catchup'. lines 179-179:
@@ -448,38 +494,96 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         },
         {
-          "sender": {
-            "fakeCoinBalance": null,
-            "allBalances": {
-              "nodes": []
-            }
-          }
+          "sender": null
         }
       ]
     }
-  }
+  },
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        0,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        1,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        2,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 8,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        3,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.exp
@@ -67,13 +67,13 @@ Response: {
       "stakedSuis": {
         "edges": [
           {
-            "cursor": "IDLuQPCJwtNtJdWpqvgnIYNh9j3UPusKYypeSFizl71GBAAAAAAAAAA=",
+            "cursor": "ICDggqmfIcvsKEH05Z1OkE9J0V8cCp3Jn1KvicHvqn5qBAAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }
           },
           {
-            "cursor": "IDvOI7rihmN5l/DCAX2XZWgE5SkROHUiqREJ4j+afiaXBAAAAAAAAAA=",
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumBAAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }
@@ -127,7 +127,14 @@ Response: {
     },
     "coins_before_obj_3_1_chkpt_3": {
       "stakedSuis": {
-        "edges": []
+        "edges": [
+          {
+            "cursor": "ICDggqmfIcvsKEH05Z1OkE9J0V8cCp3Jn1KvicHvqn5qAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
       }
     },
     "coins_after_obj_7_0_chkpt_3": {
@@ -139,7 +146,7 @@ Response: {
       "stakedSuis": {
         "edges": [
           {
-            "cursor": "IDLuQPCJwtNtJdWpqvgnIYNh9j3UPusKYypeSFizl71GAwAAAAAAAAA=",
+            "cursor": "IKWvyP6Q/TMZqbCP3Cifyxq7zXZ7vbcmAKuOpxLegnumAwAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
@@ -107,7 +107,7 @@ Response: {
       "allBalances": {
         "edges": [
           {
-            "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki",
+            "cursor": "eyJjb2luX3R5cGUiOiIweDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDI6OnN1aTo6U1VJIiwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
             "node": {
               "coinType": {
                 "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
@@ -117,7 +117,7 @@ Response: {
             }
           },
           {
-            "cursor": "IjB4NDRiYmNhMTVlYmRhYzJhYjA4MzZhMTY1MTc2MWQ3YzBkMDgzZDUzNTkzMWY5NmYyYWVhN2EzNmE1ZGM4NWUxMzo6ZmFrZTo6RkFLRSI",
+            "cursor": "eyJjb2luX3R5cGUiOiIweDRjMjYwMTJhNWMxNDgwMTJkYjY3MzE2OGExZGEwYjM3N2M1MmIzMTkzNjRmNTNjN2NkYjk4MWE2NDM4ODdhMzA6OmZha2U6OkZBS0UiLCJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MX0",
             "node": {
               "coinType": {
                 "repr": "0x44bbca15ebdac2ab0836a1651761d7c0d083d535931f96f2aea7a36a5dc85e13::fake::FAKE"
@@ -131,14 +131,14 @@ Response: {
       "firstBalance": {
         "edges": [
           {
-            "cursor": "IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjo6c3VpOjpTVUki"
+            "cursor": "eyJjb2luX3R5cGUiOiIweDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDI6OnN1aTo6U1VJIiwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9"
           }
         ]
       },
       "lastBalance": {
         "edges": [
           {
-            "cursor": "IjB4NDRiYmNhMTVlYmRhYzJhYjA4MzZhMTY1MTc2MWQ3YzBkMDgzZDUzNTkzMWY5NmYyYWVhN2EzNmE1ZGM4NWUxMzo6ZmFrZTo6RkFLRSI"
+            "cursor": "eyJjb2luX3R5cGUiOiIweDRjMjYwMTJhNWMxNDgwMTJkYjY3MzE2OGExZGEwYjM3N2M1MmIzMTkzNjRmNTNjN2NkYjk4MWE2NDM4ODdhMzA6OmZha2U6OkZBS0UiLCJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MX0"
           }
         ]
       }

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::Conn;
+use crate::raw_query::RawQuery;
+use crate::types::checkpoint::Checkpoint;
+use crate::{filter, query};
+
+pub(crate) enum View {
+    /// Return objects that fulfill the filtering criteria, even if there are more recent versions
+    /// of the object within the checkpoint range
+    Historical,
+    /// Return objects that fulfill the filtering criteria and are the most recent version within
+    /// the checkpoint range
+    Consistent,
+}
+
+/// Constructs a `RawQuery` against the `objects_snapshot` and `objects_history` table to fetch
+/// objects that satisfy some filtering criteria `filter_fn` within the provided checkpoint range
+/// `lhs` and `rhs`. If the `view` parameter is set to `Consistent`, the query additionally filters
+/// out objects that satisfy the provided filters, but are not the most recent version of the object
+/// within the checkpoint range. If the view parameter is set to `Historical`, this final filter is
+/// not applied.
+pub(crate) fn build_objects_query<F>(view: View, lhs: i64, rhs: i64, filter_fn: F) -> RawQuery
+where
+    F: Fn(RawQuery) -> RawQuery,
+{
+    // Construct the filtered inner query - apply the same filtering criteria to both
+    // objects_snapshot and objects_history tables.
+    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
+    snapshot_objs = filter_fn(snapshot_objs);
+
+    // Additionally filter objects_history table for results between the available range, or
+    // checkpoint_viewed_at, if provided.
+    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
+    history_objs = filter_fn(history_objs);
+    history_objs = filter!(
+        history_objs,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Combine the two queries, and select the most recent version of each object. The result set is
+    // the most recent version of objects from `objects_snapshot` and `objects_history` that match
+    // the filter criteria.
+    let candidates = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        snapshot_objs,
+        history_objs
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    // The following conditions ensure that the version of object matching our filters is the latest
+    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
+    // `object_keys` field), then this extra check is not required (it will filter out correct
+    // results).
+    match view {
+        View::Consistent => {
+            let mut newer = query!("SELECT object_id, object_version FROM objects_history");
+            newer = filter!(
+                newer,
+                format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+            );
+            let query = query!(
+                r#"SELECT candidates.*
+                FROM ({}) candidates
+                LEFT JOIN ({}) newer
+                ON (
+                    candidates.object_id = newer.object_id
+                    AND candidates.object_version < newer.object_version
+                )"#,
+                candidates,
+                newer
+            );
+            filter!(query, "newer.object_version IS NULL")
+        }
+        View::Historical => {
+            query!("SELECT * FROM ({}) candidates", candidates)
+        }
+    }
+}
+
+/// Given a `checkpoint_viewed_at` representing the checkpoint sequence number when the query was
+/// made, check whether the value falls under the current available range of the database. Returns
+/// `None` if the `checkpoint_viewed_at` lies outside the range, otherwise return a tuple consisting
+/// of the available range's lower bound and the `checkpoint_viewed_at`, or the upper bound of the
+/// database if `checkpoint_viewed_at` is `None`.
+pub(crate) fn consistent_range(
+    conn: &mut Conn,
+    checkpoint_viewed_at: Option<u64>,
+) -> Result<Option<(u64, u64)>, diesel::result::Error> {
+    let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+    if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+        if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+            return Ok(None);
+        }
+        rhs = checkpoint_viewed_at;
+    }
+
+    Ok(Some((lhs, rhs)))
+}

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 pub use sui_graphql_rpc_client as client;
 pub mod commands;
 pub mod config;
+pub(crate) mod consistency;
 pub mod context_data;
 pub(crate) mod data;
 mod error;

--- a/crates/sui-graphql-rpc/src/raw_query.rs
+++ b/crates/sui-graphql-rpc/src/raw_query.rs
@@ -186,11 +186,15 @@ macro_rules! or_filter {
 /// macro parameter. Subqueries are consumed into the new `RawQuery`.
 #[macro_export]
 macro_rules! query {
+    // Matches the case where no subqueries are provided. A `RawQuery` is constructed from the given
+    // select clause.
     ($select:expr) => {
         RawQuery::new($select, vec![])
     };
 
-    ($select:expr $(,$subquery:expr)*) => {{
+    // Expects a select clause and one or more subqueries. The select clause should contain curly
+    // braces for subqueries to be interpolated into.
+    ($select:expr $(,$subquery:expr)+) => {{
         use $crate::raw_query::RawQuery;
         let mut binds = vec![];
 

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -21,14 +21,14 @@ use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
+use crate::consistency::{build_objects_query, consistent_range, View};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::raw_query::RawQuery;
 use crate::types::base64::Base64;
-use crate::types::checkpoint::Checkpoint;
 use crate::types::intersect;
-use crate::{filter, or_filter, query};
+use crate::{filter, or_filter};
 use async_graphql::connection::{CursorType, Edge};
 use async_graphql::{connection::Connection, *};
 use diesel::{CombineDsl, ExpressionMethods, OptionalExtension, QueryDsl};
@@ -726,14 +726,9 @@ impl Object {
 
         let response = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok::<_, diesel::result::Error>(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
@@ -787,14 +782,9 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 conn.results(move || {
                     // If an object was created or mutated in a checkpoint outside the current
@@ -849,14 +839,9 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 conn.results(move || {
                     // If an object was created or mutated in a checkpoint outside the current
@@ -905,14 +890,9 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 conn.results(move || {
                     // If an object was created or mutated in a checkpoint outside the current
@@ -1388,58 +1368,13 @@ pub(crate) fn validate_cursor_consistency(
 }
 
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64) -> RawQuery {
-    // Construct the filtered inner query - apply the same filtering criteria to both
-    // objects_snapshot and objects_history tables.
-    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
-    snapshot_objs = filter.apply(snapshot_objs);
-
-    // Additionally filter objects_history table for results between the available range, or
-    // checkpoint_viewed_at, if provided.
-    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
-    history_objs = filter.apply(history_objs);
-    history_objs = filter!(
-        history_objs,
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-
-    // Combine the two queries, and select the most recent version of each object.
-    let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
-        snapshot_objs,
-        history_objs
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
-
-    // The following conditions ensure that the version of object matching our filters is the latest
-    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
-    // `object_keys` field), then this extra check is not required (it will filter out correct
-    // results).
-    if filter.object_keys.is_none() {
-        // Objects that fulfill the filtering criteria may not be the most recent version available.
-        // Left join the candidates table on newer to filter out any objects that have a newer
-        // version.
-        let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-        newer = filter!(
-            newer,
-            format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-        );
-        let query = query!(
-            r#"SELECT candidates.*
-            FROM ({}) candidates
-            LEFT JOIN ({}) newer
-            ON (
-                candidates.object_id = newer.object_id
-                AND candidates.object_version < newer.object_version
-            )"#,
-            candidates,
-            newer
-        );
-
-        filter!(query, "newer.object_version IS NULL")
+    let view = if filter.object_keys.is_some() {
+        View::Historical
     } else {
-        query!("SELECT * FROM ({}) candidates", candidates)
-    }
+        View::Consistent
+    };
+
+    build_objects_query(view, lhs, rhs, move |query| filter.apply(query))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

Even though `Balance` does not resolve to other non-Scalar nodes, because there is a `Balance` connection, we will still need to track `checkpoint_viewed_at`. This is so that the caller stays on the same checkpoint while paginating through a balance connection.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
