### PR TITLE
[gql][consistent-reads][9/n] Add context to TransactionBlock and Effects for consistency.

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -8,35 +8,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        },
-        {
-          "cursor": "OA",
-          "node": {
-            "sequenceNumber": 8
-          }
-        },
-        {
-          "cursor": "OQ",
-          "node": {
-            "sequenceNumber": 9
-          }
-        },
-        {
-          "cursor": "MTA",
-          "node": {
-            "sequenceNumber": 10
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -46,17 +21,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -71,25 +39,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
@@ -104,23 +72,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -131,25 +86,31 @@ Response: {
     "checkpoints": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
+          "node": {
+            "sequenceNumber": 3
           }
         }
       ]
@@ -167,25 +128,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -201,31 +162,37 @@ Response: {
     "checkpoints": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NH0",
+          "node": {
+            "sequenceNumber": 4
           }
         }
       ]
@@ -238,59 +205,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        },
-        {
-          "cursor": "Ng",
-          "node": {
-            "sequenceNumber": 6
-          }
-        },
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        },
-        {
-          "cursor": "OA",
-          "node": {
-            "sequenceNumber": 8
-          }
-        },
-        {
-          "cursor": "OQ",
-          "node": {
-            "sequenceNumber": 9
-          }
-        },
-        {
-          "cursor": "MTA",
-          "node": {
-            "sequenceNumber": 10
-          }
-        },
-        {
-          "cursor": "MTE",
-          "node": {
-            "sequenceNumber": 11
-          }
-        },
-        {
-          "cursor": "MTI",
-          "node": {
-            "sequenceNumber": 12
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -300,35 +218,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Mg",
-          "node": {
-            "sequenceNumber": 2
-          }
-        },
-        {
-          "cursor": "Mw",
-          "node": {
-            "sequenceNumber": 3
-          }
-        },
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -338,23 +231,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -364,24 +244,30 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -401,79 +287,79 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
         },
         {
-          "cursor": "NA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NH0",
           "node": {
             "sequenceNumber": 4
           }
         },
         {
-          "cursor": "NQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NX0",
           "node": {
             "sequenceNumber": 5
           }
         },
         {
-          "cursor": "Ng",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Nn0",
           "node": {
             "sequenceNumber": 6
           }
         },
         {
-          "cursor": "Nw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6N30",
           "node": {
             "sequenceNumber": 7
           }
         },
         {
-          "cursor": "OA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OH0",
           "node": {
             "sequenceNumber": 8
           }
         },
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -493,25 +379,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
@@ -531,25 +417,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -30,7 +30,7 @@
 
 //# create-checkpoint 12
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -44,7 +44,7 @@
   }
 }
 
-//# run-graphql --cursors 6 8
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6} {"checkpoint_viewed_at":null,"sequence_number":8}
 {
   checkpoints(first: 4, after: "@{cursor_0}", before: "@{cursor_1}") {
     pageInfo {
@@ -58,7 +58,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -72,7 +72,7 @@
   }
 }
 
-//# run-graphql --cursors 3 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -86,7 +86,7 @@
   }
 }
 
-//# run-graphql --cursors 3
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -100,7 +100,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -114,7 +114,7 @@
   }
 }
 
-//# run-graphql --cursors 4
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
 {
   checkpoints(before: "@{cursor_0}") {
     pageInfo {
@@ -128,7 +128,7 @@
   }
 }
 
-//# run-graphql --cursors 4
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
 {
   checkpoints(after: "@{cursor_0}") {
     pageInfo {
@@ -142,7 +142,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -156,7 +156,7 @@
   }
 }
 
-//# run-graphql --cursors 3 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -170,7 +170,7 @@
   }
 }
 
-//# run-graphql --cursors 9
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":9}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
@@ -1,4 +1,4 @@
-processed 25 tasks
+processed 31 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -41,36 +41,11 @@ Checkpoint created: 6
 task 15 'create-checkpoint'. lines 79-79:
 Checkpoint created: 7
 
-task 16 'run-graphql'. lines 81-101:
+task 16 'run-graphql'. lines 81-102:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
-        {
-          "sender": {
-            "fakeCoinBalance": {
-              "totalBalance": "600"
-            },
-            "allBalances": {
-              "nodes": [
-                {
-                  "coinType": {
-                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "299999983336400"
-                },
-                {
-                  "coinType": {
-                    "repr": "0x336283c39790fdda49011270655dd4b80b1bec01416c8c22d278ddfb01383691::fake::FAKE"
-                  },
-                  "coinObjectCount": 3,
-                  "totalBalance": "600"
-                }
-              ]
-            }
-          }
-        },
         {
           "sender": {
             "fakeCoinBalance": {
@@ -95,7 +70,17 @@ Response: {
               ]
             }
           }
-        },
+        }
+      ]
+    }
+  }
+}
+
+task 17 'run-graphql'. lines 104-125:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -120,7 +105,17 @@ Response: {
               ]
             }
           }
-        },
+        }
+      ]
+    }
+  }
+}
+
+task 18 'run-graphql'. lines 127-148:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -151,130 +146,14 @@ Response: {
   }
 }
 
-task 17 'force-object-snapshot-catchup'. lines 104-104:
-Objects snapshot updated to [0 to 2)
-
-task 18 'run-graphql'. lines 106-126:
-Response: {
-  "data": {
-    "transactionBlocks": {
-      "nodes": [
-        {
-          "sender": {
-            "fakeCoinBalance": {
-              "totalBalance": "600"
-            },
-            "allBalances": {
-              "nodes": [
-                {
-                  "coinType": {
-                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "299999983336400"
-                },
-                {
-                  "coinType": {
-                    "repr": "0x336283c39790fdda49011270655dd4b80b1bec01416c8c22d278ddfb01383691::fake::FAKE"
-                  },
-                  "coinObjectCount": 3,
-                  "totalBalance": "600"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "sender": {
-            "fakeCoinBalance": {
-              "totalBalance": "700"
-            },
-            "allBalances": {
-              "nodes": [
-                {
-                  "coinType": {
-                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "299999982296272"
-                },
-                {
-                  "coinType": {
-                    "repr": "0x336283c39790fdda49011270655dd4b80b1bec01416c8c22d278ddfb01383691::fake::FAKE"
-                  },
-                  "coinObjectCount": 3,
-                  "totalBalance": "700"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "sender": {
-            "fakeCoinBalance": {
-              "totalBalance": "600"
-            },
-            "allBalances": {
-              "nodes": [
-                {
-                  "coinType": {
-                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "299999981273168"
-                },
-                {
-                  "coinType": {
-                    "repr": "0x336283c39790fdda49011270655dd4b80b1bec01416c8c22d278ddfb01383691::fake::FAKE"
-                  },
-                  "coinObjectCount": 2,
-                  "totalBalance": "600"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "sender": {
-            "fakeCoinBalance": {
-              "totalBalance": "300"
-            },
-            "allBalances": {
-              "nodes": [
-                {
-                  "coinType": {
-                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "299999980250064"
-                },
-                {
-                  "coinType": {
-                    "repr": "0x336283c39790fdda49011270655dd4b80b1bec01416c8c22d278ddfb01383691::fake::FAKE"
-                  },
-                  "coinObjectCount": 1,
-                  "totalBalance": "300"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    }
-  }
-}
-
-task 19 'force-object-snapshot-catchup'. lines 129-129:
+task 19 'force-object-snapshot-catchup'. lines 150-150:
 Objects snapshot updated to [0 to 3)
 
-task 20 'run-graphql'. lines 131-151:
+task 20 'run-graphql'. lines 152-173:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
-        {
-          "sender": null
-        },
         {
           "sender": {
             "fakeCoinBalance": {
@@ -299,7 +178,17 @@ Response: {
               ]
             }
           }
-        },
+        }
+      ]
+    }
+  }
+}
+
+task 21 'run-graphql'. lines 175-196:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -324,7 +213,17 @@ Response: {
               ]
             }
           }
-        },
+        }
+      ]
+    }
+  }
+}
+
+task 22 'run-graphql'. lines 198-219:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -352,44 +251,51 @@ Response: {
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 8,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }
 
-task 21 'force-object-snapshot-catchup'. lines 154-154:
+task 23 'force-object-snapshot-catchup'. lines 221-221:
 Objects snapshot updated to [0 to 4)
 
-task 22 'run-graphql'. lines 156-176:
+task 24 'run-graphql'. lines 223-244:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
         {
           "sender": null
-        },
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
         {
-          "sender": null
-        },
+          "line": 9,
+          "column": 9
+        }
+      ],
+      "path": [
+        "transactionBlocks",
+        "nodes",
+        0,
+        "sender",
+        "allBalances"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    }
+  ]
+}
+
+task 25 'run-graphql'. lines 246-267:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -414,7 +320,17 @@ Response: {
               ]
             }
           }
-        },
+        }
+      ]
+    }
+  }
+}
+
+task 26 'run-graphql'. lines 269-290:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
         {
           "sender": {
             "fakeCoinBalance": {
@@ -442,66 +358,17 @@ Response: {
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 8,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        0,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    },
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 8,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        1,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    }
-  ]
+  }
 }
 
-task 23 'force-object-snapshot-catchup'. lines 179-179:
+task 27 'force-object-snapshot-catchup'. lines 293-293:
 Objects snapshot updated to [0 to 6)
 
-task 24 'run-graphql'. lines 181-201:
+task 28 'run-graphql'. lines 295-316:
 Response: {
   "data": {
     "transactionBlocks": {
       "nodes": [
-        {
-          "sender": null
-        },
-        {
-          "sender": null
-        },
-        {
-          "sender": null
-        },
         {
           "sender": null
         }
@@ -513,7 +380,7 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 8,
+          "line": 9,
           "column": 9
         }
       ],
@@ -527,57 +394,68 @@ Response: {
       "extensions": {
         "code": "BAD_USER_INPUT"
       }
-    },
+    }
+  ]
+}
+
+task 29 'run-graphql'. lines 318-339:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": null
+        }
+      ]
+    }
+  },
+  "errors": [
     {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 8,
+          "line": 9,
           "column": 9
         }
       ],
       "path": [
         "transactionBlocks",
         "nodes",
-        1,
+        0,
         "sender",
         "allBalances"
       ],
       "extensions": {
         "code": "BAD_USER_INPUT"
       }
-    },
+    }
+  ]
+}
+
+task 30 'run-graphql'. lines 341-362:
+Response: {
+  "data": {
+    "transactionBlocks": {
+      "nodes": [
+        {
+          "sender": null
+        }
+      ]
+    }
+  },
+  "errors": [
     {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 8,
+          "line": 9,
           "column": 9
         }
       ],
       "path": [
         "transactionBlocks",
         "nodes",
-        2,
-        "sender",
-        "allBalances"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    },
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
-          "line": 8,
-          "column": 9
-        }
-      ],
-      "path": [
-        "transactionBlocks",
-        "nodes",
-        3,
+        0,
         "sender",
         "allBalances"
       ],

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -78,9 +78,10 @@ module P0::fake {
 
 //# create-checkpoint
 
-//# run-graphql
+//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
-  transactionBlocks(filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -100,12 +101,10 @@ module P0::fake {
   }
 }
 
-
-//# force-object-snapshot-catchup --start-cp 0 --end-cp 2
-
-//# run-graphql
+//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
-  transactionBlocks(filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -125,12 +124,35 @@ module P0::fake {
   }
 }
 
+//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 3
 
-//# run-graphql
+//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
-  transactionBlocks(filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -150,12 +172,104 @@ module P0::fake {
   }
 }
 
+//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 4
 
-//# run-graphql
+//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+# Outside available range
 {
-  transactionBlocks(filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+# Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
@@ -178,9 +292,56 @@ module P0::fake {
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 6
 
-//# run-graphql
+//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+# Outside available range
 {
-  transactionBlocks(filter: {signAddress: "@{A}"}) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+# Outside available range
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
+    nodes {
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
+        }
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+# Outside available range
+{
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
       sender {
         fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
@@ -817,6 +817,22 @@ Response: {
       "extensions": {
         "code": "BAD_USER_INPUT"
       }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 30,
+          "column": 5
+        }
+      ],
+      "path": [
+        "queryAddressCoinsAtChkpt1AfterSnapshotCatchup",
+        "coins"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
   ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1506,26 +1506,6 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 21,
-          "column": 11
-        }
-      ],
-      "path": [
-        "all_transactions",
-        "nodes",
-        0,
-        "gasInput",
-        "gasSponsor",
-        "objects"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    },
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
           "line": 32,
           "column": 9
         }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -372,8 +372,63 @@ Response: {
                 {
                   "contents": {
                     "json": {
-                      "id": "0x70f945962e4970054c616f08fe5e8d1787f15fc5580419ca942011806544da14",
-                      "value": "0"
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
                     },
                     "type": {
                       "repr": "0xa1662d86913fcc0599e90b211eb750fd7f81f4315647bef64775264d2b6f7272::M1::Object"
@@ -429,8 +484,30 @@ Response: {
                 {
                   "contents": {
                     "json": {
-                      "id": "0x70f945962e4970054c616f08fe5e8d1787f15fc5580419ca942011806544da14",
-                      "value": "100"
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
                     },
                     "type": {
                       "repr": "0xa1662d86913fcc0599e90b211eb750fd7f81f4315647bef64775264d2b6f7272::M1::Object"
@@ -440,7 +517,29 @@ Response: {
                 {
                   "contents": {
                     "json": {
-                      "id": "0x795566e4526c0488dc7c2980368054e823b58f2b7c1864d8f750a72d0d353b93",
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
                       "value": "2"
                     },
                     "type": {
@@ -1029,18 +1128,36 @@ Response: {
     "all_transactions": {
       "nodes": [
         {
-          "sender": null,
-          "gasInput": null
-        },
-        {
           "sender": {
             "objects": {
               "nodes": [
                 {
                   "contents": {
                     "json": {
-                      "id": "0x70f945962e4970054c616f08fe5e8d1787f15fc5580419ca942011806544da14",
-                      "value": "100"
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
                     },
                     "type": {
                       "repr": "0xa1662d86913fcc0599e90b211eb750fd7f81f4315647bef64775264d2b6f7272::M1::Object"
@@ -1050,7 +1167,104 @@ Response: {
                 {
                   "contents": {
                     "json": {
-                      "id": "0x795566e4526c0488dc7c2980368054e823b58f2b7c1864d8f750a72d0d353b93",
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
+                      "value": "2"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "gasInput": null
+        },
+        {
+          "sender": {
+            "objects": {
+              "nodes": [
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x0194a75e9cabf4694c92860b640c8c4c6a264f9f199e9a37f19d0aad863e4ed7",
+                      "value": "6"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x04ecd94f1e7baf7e0bda982b73232c0b03c7537c1b9539fc4da02b8f837720b6",
+                      "value": "4"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x153c7707f234f57d35ecb75fcbff3cc022f3015cf0c56d90167c6938e4d5e217",
+                      "value": "200"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x27084fa7263f2cfc395c4c7f6ae7d517047c31cf2a73dc0c00682e3e109b9441",
+                      "value": "3"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0x5ea4c93816a711296163d1fa69ed20c094a7c581191b9849d009b0d7904ab0b9",
+                      "value": "5"
+                    },
+                    "type": {
+                      "repr": "0x1c555fea7b9ba9d30f5a84ec16152e240422ac72dc4dd44d242acd7793f1e077::M1::Object"
+                    }
+                  }
+                },
+                {
+                  "contents": {
+                    "json": {
+                      "id": "0xb1b7dc9a1f1f1e8c3b9fd3fdabbfe351d8a76e6143f84da861b5e4294a334c2e",
                       "value": "2"
                     },
                     "type": {
@@ -1292,15 +1506,16 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 8,
-          "column": 9
+          "line": 21,
+          "column": 11
         }
       ],
       "path": [
         "all_transactions",
         "nodes",
         0,
-        "sender",
+        "gasInput",
+        "gasSponsor",
         "objects"
       ],
       "extensions": {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1506,6 +1506,26 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
+          "line": 21,
+          "column": 11
+        }
+      ],
+      "path": [
+        "all_transactions",
+        "nodes",
+        0,
+        "gasInput",
+        "gasSponsor",
+        "objects"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
           "line": 32,
           "column": 9
         }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -47,7 +47,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -65,7 +65,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -83,7 +83,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "cursor": "eyJ0eCI6NiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -101,7 +101,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "cursor": "eyJ0eCI6NywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -129,7 +129,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -147,7 +147,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -165,7 +165,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "cursor": "eyJ0eCI6NiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -183,7 +183,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "cursor": "eyJ0eCI6NywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -211,7 +211,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -229,7 +229,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -257,7 +257,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -285,7 +285,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -31,7 +31,7 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "eyJ0eCI6MiwiZSI6MH0",
+          "cursor": "eyJ0eCI6MiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -49,7 +49,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -67,7 +67,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
+          "cursor": "eyJ0eCI6MywiZSI6MSwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -94,47 +94,10 @@ Response: {
   "data": {
     "events": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
-          }
-        },
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -145,46 +108,9 @@ Response: {
     "events": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "eyJ0eCI6MiwiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
-          }
-        },
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -199,7 +125,7 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -217,7 +143,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
+          "cursor": "eyJ0eCI6MywiZSI6MSwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -53,7 +53,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":2,"e":0}
+//# run-graphql --cursors {"tx":2,"e":0,"checkpoint_viewed_at":null}
 {
   events(first: 2 after: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {
@@ -79,7 +79,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":3,"e":1}
+//# run-graphql --cursors {"tx":3,"e":1,"checkpoint_viewed_at":null}
 {
   events(last: 2 before: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.exp
@@ -981,7 +981,7 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjowfQ",
           "node": {
             "kind": {
               "__typename": "GenesisTransaction"
@@ -989,7 +989,7 @@ Response: {
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjoxfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -997,7 +997,7 @@ Response: {
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjoyfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1005,7 +1005,7 @@ Response: {
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjozfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1013,7 +1013,7 @@ Response: {
           }
         },
         {
-          "cursor": "NA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjo0fQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1021,7 +1021,7 @@ Response: {
           }
         },
         {
-          "cursor": "NQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjo1fQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1039,7 +1039,7 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjowfQ",
           "node": {
             "kind": {
               "__typename": "GenesisTransaction"
@@ -1057,7 +1057,7 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjoxfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1065,7 +1065,7 @@ Response: {
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjoyfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1073,7 +1073,7 @@ Response: {
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjozfQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1081,7 +1081,7 @@ Response: {
           }
         },
         {
-          "cursor": "NA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjo0fQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1089,7 +1089,7 @@ Response: {
           }
         },
         {
-          "cursor": "NQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjo1fQ",
           "node": {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
@@ -1118,10 +1118,10 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "Mg"
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjoyfQ"
         },
         {
-          "cursor": "Mw"
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjozfQ"
         }
       ]
     }
@@ -1134,10 +1134,10 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "Mw"
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjozfQ"
         },
         {
-          "cursor": "NA"
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjo0fQ"
         }
       ]
     }
@@ -1150,7 +1150,7 @@ Response: {
     "transactionBlocks": {
       "edges": [
         {
-          "cursor": "Mw"
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6NCwidHhfc2VxdWVuY2VfbnVtYmVyIjozfQ"
         }
       ]
     }

--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -416,10 +416,10 @@
 
 ### <a id=262141></a>
 ### First Ten After Checkpoint
-####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
+####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 0. Note that the cursor is opaque.
 
 ><pre>{
->  checkpoints(first: 10, after: "MTE=") {
+>  checkpoints(first: 10, after: "eyJjIjoyMjgwMDU4MCwicyI6MH0") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -432,7 +432,7 @@
 ####  Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 
 ><pre>{
->  checkpoints(last: 20, before: "MTAw") {
+>  checkpoints(last: 20, before: "eyJjIjoyMjgwMDY1MSwicyI6MjI4MDA2MzJ9") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -587,12 +587,12 @@
 
 ### <a id=458748></a>
 ### With Tx Block Connection
-####  Fetch the first 20 transactions after 231220100 (encoded as a
+####  Fetch the first 20 transactions after 885733467 (encoded as a
 ####  cursor) in epoch 97.
 
 ><pre>{
 >  epoch(id: 97) {
->    transactionBlocks(first: 20, after:"MjMxMjIwMTAw") {
+>    transactionBlocks(first: 20, after:"eyJjIjoyMjgwMDY5MiwidCI6ODg1NzMzNDY3fQ") {
 >      pageInfo {
 >        hasNextPage
 >        endCursor
@@ -624,11 +624,11 @@
 ### <a id=458749></a>
 ### With Tx Block Connection Latest Epoch
 ####  the last checkpoint of epoch 97 is 8097645, and the last transaction
-####  number of the checkpoint is 261225985 (encoded as a cursor).
+####  number of the checkpoint is 261225985.
 
 ><pre>{
 >  epoch {
->    transactionBlocks(first: 20, after: "MjYxMjI1OTg1") {
+>    transactionBlocks(first: 20, after: "eyJjIjo4MDk3NjQ1LCJ0IjoyNjEyMjU5ODV9") {
 >      pageInfo {
 >        hasNextPage
 >        endCursor
@@ -691,7 +691,7 @@
 ><pre>query ByEmittingPackageModuleAndEventType {
 >  events(
 >    first: 1
->    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+>    after: "eyJ0eCI6Njc2MywiZSI6MCwiYyI6MjI4MDA3NDJ9"
 >    filter: {
 >      emittingModule: "0x3::sui_system",
 >      eventType: "0x3::validator::StakingRequestEvent"

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
-# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
+# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 0. Note that the cursor is opaque.
 {
-  checkpoints(first: 10, after: "MTE=") {
+  checkpoints(first: 10, after: "eyJjIjoyMjgwMDU4MCwicyI6MH0") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
 # Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 {
-  checkpoints(last: 20, before: "MTAw") {
+  checkpoints(last: 20, before: "eyJjIjoyMjgwMDY1MSwicyI6MjI4MDA2MzJ9") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
@@ -1,8 +1,8 @@
-# Fetch the first 20 transactions after 231220100 (encoded as a
+# Fetch the first 20 transactions after 885733467 (encoded as a
 # cursor) in epoch 97.
 {
   epoch(id: 97) {
-    transactionBlocks(first: 20, after:"MjMxMjIwMTAw") {
+    transactionBlocks(first: 20, after:"eyJjIjoyMjgwMDY5MiwidCI6ODg1NzMzNDY3fQ") {
       pageInfo {
         hasNextPage
         endCursor

--- a/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection_latest_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection_latest_epoch.graphql
@@ -1,8 +1,8 @@
 # the last checkpoint of epoch 97 is 8097645, and the last transaction
-# number of the checkpoint is 261225985 (encoded as a cursor).
+# number of the checkpoint is 261225985.
 {
   epoch {
-    transactionBlocks(first: 20, after: "MjYxMjI1OTg1") {
+    transactionBlocks(first: 20, after: "eyJjIjo4MDk3NjQ1LCJ0IjoyNjEyMjU5ODV9") {
       pageInfo {
         hasNextPage
         endCursor

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
@@ -1,7 +1,7 @@
 query ByEmittingPackageModuleAndEventType {
   events(
     first: 1
-    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+    after: "eyJ0eCI6Njc2MywiZSI6MCwiYyI6MjI4MDA3NDJ9"
     filter: {
       emittingModule: "0x3::sui_system",
       eventType: "0x3::validator::StakingRequestEvent"

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
+
 use crate::data::Conn;
 use crate::raw_query::RawQuery;
 use crate::types::checkpoint::Checkpoint;
@@ -13,6 +15,13 @@ pub(crate) enum View {
     /// Return objects that fulfill the filtering criteria and are the most recent version within
     /// the checkpoint range
     Consistent,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub(crate) struct ConsistentIndexCursor {
+    pub ix: usize,
+    /// The checkpoint sequence number at which the entity corresponding to this cursor was viewed at.
+    pub c: u64,
 }
 
 /// Constructs a `RawQuery` against the `objects_snapshot` and `objects_history` table to fetch

--- a/crates/sui-graphql-rpc/src/mutation.rs
+++ b/crates/sui-graphql-rpc/src/mutation.rs
@@ -131,7 +131,8 @@ impl Mutation {
                     native,
                     events,
                 },
-                checkpoint_viewed_at: None,
+                // set to u64::MAX, as the executed transaction has not been indexed yet
+                checkpoint_viewed_at: u64::MAX,
             },
         })
     }

--- a/crates/sui-graphql-rpc/src/mutation.rs
+++ b/crates/sui-graphql-rpc/src/mutation.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::transaction_block_effects::TransactionBlockEffectsKind;
 use crate::{
     error::Error, types::execution_result::ExecutionResult,
     types::transaction_block_effects::TransactionBlockEffects,
@@ -124,10 +125,13 @@ impl Mutation {
             } else {
                 Some(result.errors)
             },
-            effects: TransactionBlockEffects::Executed {
-                tx_data,
-                native,
-                events,
+            effects: TransactionBlockEffects {
+                kind: TransactionBlockEffectsKind::Executed {
+                    tx_data,
+                    native,
+                    events,
+                },
+                checkpoint_viewed_at: None,
             },
         })
     }

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -160,9 +160,14 @@ impl Address {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
-            .await
-            .extend()
+        TransactionBlock::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -15,14 +15,22 @@ pub(crate) struct AvailableRange {
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.first))
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            CheckpointId::by_seq_num(self.first),
+            Some(self.last),
+        )
+        .await
+        .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.last))
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            CheckpointId::by_seq_num(self.last),
+            Some(self.last),
+        )
+        .await
+        .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -10,10 +10,8 @@ use crate::error::Error;
 
 pub(crate) struct BalanceChange {
     stored: StoredBalanceChange,
-
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
 }
 
 /// Effects to the balance (sum of coin values per coin type) owned by an address or object.
@@ -26,7 +24,7 @@ impl BalanceChange {
         match self.stored.owner {
             O::AddressOwner(addr) | O::ObjectOwner(addr) => Some(Owner {
                 address: SuiAddress::from(addr),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             }),
 
             O::Shared { .. } | O::Immutable => None,
@@ -49,7 +47,7 @@ impl BalanceChange {
     /// `BalanceChange` was queried for, or `None` if the data was requested at the latest
     /// checkpoint. This is stored on `BalanceChange` so that when viewing that entity's state, it
     /// will be as if it was read at the same checkpoint.
-    pub(crate) fn read(bytes: &[u8], checkpoint_viewed_at: Option<u64>) -> Result<Self, Error> {
+    pub(crate) fn read(bytes: &[u8], checkpoint_viewed_at: u64) -> Result<Self, Error> {
         let stored = bcs::from_bytes(bytes)
             .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;
 

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -126,7 +126,7 @@ impl Checkpoint {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
+        TransactionBlock::paginate(ctx.data_unchecked(), page, filter, None) // TODO (wlmyng) - to be replaced with checkpoint_viewed_at from Checkpoint
             .await
             .extend()
     }
@@ -201,7 +201,8 @@ impl Checkpoint {
 
         let (prev, next, results) = db
             .execute(move |conn| {
-                page.paginate_query::<StoredCheckpoint, _, _, _>(conn, move || {
+                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
+                page.paginate_query::<StoredCheckpoint, _, _, _>(conn, None, move || {
                     let mut query = dsl::checkpoints.into_boxed();
                     if let Some(epoch) = filter {
                         query = query.filter(dsl::epoch.eq(epoch as i64));

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -20,6 +20,7 @@ use async_graphql::{
 };
 use diesel::{CombineDsl, ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
+use serde::{Deserialize, Serialize};
 use sui_indexer::{
     models_v2::checkpoints::StoredCheckpoint,
     schema_v2::{checkpoints, objects_snapshot},
@@ -38,10 +39,22 @@ pub(crate) struct Checkpoint {
     /// Representation of transaction data in the Indexer's Store. The indexer stores the
     /// transaction data and its effects together, in one table.
     pub stored: StoredCheckpoint,
+    // The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    // requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
 }
 
-pub(crate) type Cursor = cursor::JsonCursor<u64>;
+pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
 type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
+
+/// The cursor returned for each `Checkpoint` in a connection's page of results. The
+/// `checkpoint_viewed_at` will set the consistent upper bound for subsequent queries made on this
+/// cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct CheckpointCursor {
+    pub checkpoint_viewed_at: Option<u64>,
+    pub sequence_number: u64,
+}
 
 /// Checkpoints contain finalized transactions and are used for node synchronization
 /// and global transaction ordering.
@@ -126,9 +139,14 @@ impl Checkpoint {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter, None) // TODO (wlmyng) - to be replaced with checkpoint_viewed_at from Checkpoint
-            .await
-            .extend()
+        TransactionBlock::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 }
 
@@ -158,64 +176,114 @@ impl Checkpoint {
     /// Look up a `Checkpoint` in the database, filtered by either sequence number or digest. If
     /// both filters are supplied they will both be applied. If none are supplied, the latest
     /// checkpoint is fetched.
-    pub(crate) async fn query(db: &Db, filter: CheckpointId) -> Result<Option<Self>, Error> {
+    pub(crate) async fn query(
+        db: &Db,
+        filter: CheckpointId,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Option<Self>, Error> {
         use checkpoints::dsl;
 
         let digest = filter.digest.map(|d| d.to_vec());
         let seq_num = filter.sequence_number.map(|n| n as i64);
 
-        let stored = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    let mut query = dsl::checkpoints
-                        .order_by(dsl::sequence_number.desc())
-                        .into_boxed();
+        let (stored, checkpoint_viewed_at): (Option<StoredCheckpoint>, u64) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
 
-                    if let Some(digest) = digest.clone() {
-                        query = query.filter(dsl::checkpoint_digest.eq(digest));
-                    }
+                let stored = conn
+                    .first(move || {
+                        let mut query = dsl::checkpoints
+                            .order_by(dsl::sequence_number.desc())
+                            .into_boxed();
 
-                    if let Some(seq_num) = seq_num {
-                        query = query.filter(dsl::sequence_number.eq(seq_num));
-                    }
+                        if let Some(digest) = digest.clone() {
+                            query = query.filter(dsl::checkpoint_digest.eq(digest));
+                        }
 
-                    query
-                })
-                .optional()
+                        if let Some(seq_num) = seq_num {
+                            query = query.filter(dsl::sequence_number.eq(seq_num));
+                        }
+
+                        query
+                    })
+                    .optional()?;
+
+                Ok::<_, diesel::result::Error>((stored, checkpoint_viewed_at))
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))?;
 
-        Ok(stored.map(|stored| Checkpoint { stored }))
+        Ok(stored.map(|stored| Checkpoint {
+            stored,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        }))
     }
 
-    /// Query the database for a `page` of checkpoints. The Page uses checkpoint sequence numbers as
-    /// the cursor, and can optionally be further `filter`-ed by an epoch number (to only return
-    /// checkpoints within that epoch).
+    /// Query the database for a `page` of checkpoints. The Page uses the checkpoint sequence number
+    /// of the stored checkpoint and the checkpoint at which this was viewed at as the cursor, and
+    /// can optionally be further `filter`-ed by an epoch number (to only return checkpoints within
+    /// that epoch).
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
+    /// the cursor if they are consistent.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: Option<u64>,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Checkpoint>, Error> {
         use checkpoints::dsl;
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
-                page.paginate_query::<StoredCheckpoint, _, _, _>(conn, None, move || {
-                    let mut query = dsl::checkpoints.into_boxed();
-                    if let Some(epoch) = filter {
-                        query = query.filter(dsl::epoch.eq(epoch as i64));
-                    }
-                    query
-                })
+        let ((prev, next, results), rhs) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
+
+                let result = page.paginate_query::<StoredCheckpoint, _, _, _>(
+                    conn,
+                    Some(checkpoint_viewed_at),
+                    move || {
+                        let mut query = dsl::checkpoints.into_boxed();
+                        query = query.filter(dsl::sequence_number.le(checkpoint_viewed_at as i64));
+                        if let Some(epoch) = filter {
+                            query = query.filter(dsl::epoch.eq(epoch as i64));
+                        }
+                        query
+                    },
+                )?;
+
+                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
             })
             .await?;
 
+        // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
+        // current available range. This sets a consistent upper bound for the nested queries.
         let mut conn = Connection::new(prev, next);
+        let checkpoint_viewed_at = checkpoint_viewed_at.unwrap_or(rhs);
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            conn.edges.push(Edge::new(cursor, Checkpoint { stored }));
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Checkpoint {
+                    stored,
+                    checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                },
+            ));
         }
 
         Ok(conn)
@@ -257,11 +325,11 @@ impl Paginated<Cursor> for StoredCheckpoint {
     type Source = checkpoints::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.ge(**cursor as i64))
+        query.filter(checkpoints::dsl::sequence_number.ge(cursor.sequence_number as i64))
     }
 
     fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.le(**cursor as i64))
+        query.filter(checkpoints::dsl::sequence_number.le(cursor.sequence_number as i64))
     }
 
     fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -276,6 +344,36 @@ impl Paginated<Cursor> for StoredCheckpoint {
 
 impl Target<Cursor> for StoredCheckpoint {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.sequence_number as u64)
+        Cursor::new(CheckpointCursor {
+            sequence_number: self.sequence_number as u64,
+            checkpoint_viewed_at: None,
+        })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(CheckpointCursor {
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            sequence_number: self.sequence_number as u64,
+        })
+    }
+}
+
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(after_cursor.checkpoint_viewed_at)
+            } else {
+                Err(Error::Client(
+                    "Cursors are inconsistent and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
+        }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
+        (None, None) => Ok(None),
     }
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -333,9 +333,7 @@ impl Coin {
         for stored in results {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
-            let cursor = stored
-                .consistent_cursor(checkpoint_viewed_at)
-                .encode_cursor();
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             let object =
                 Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
 

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -15,9 +15,7 @@ use super::display::DisplayEntry;
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::{MoveObject, MoveObjectImpl};
 use super::move_value::MoveValue;
-use super::object::{
-    self, validate_cursor_consistency, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus,
-};
+use super::object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus};
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
@@ -305,7 +303,7 @@ impl Coin {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let response = db

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -211,9 +211,13 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
     /// followed by an iterator of values in the page, fetched from the database.
     ///
     /// The values returned implement `Target<C>`, so are able to compute their own cursors.
+    ///
+    /// `checkpoint_viewed_at` is a required parameter to and passed to each element to construct a
+    /// consistent cursor.
     pub(crate) fn paginate_query<T, Q, ST, GB>(
         &self,
         conn: &mut Conn<'_>,
+        checkpoint_viewed_at: Option<u64>, // TODO (wlmyng) make this required once all paginable types have this value threaded through
         query: Q,
     ) -> QueryResult<(bool, bool, impl Iterator<Item = T>)>
     where
@@ -255,8 +259,14 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         };
 
         Ok(self.paginate_results(
-            results.first().map(|f| f.cursor()),
-            results.last().map(|l| l.cursor()),
+            results.first().map(|f| match checkpoint_viewed_at {
+                Some(checkpoint_viewed_at) => f.consistent_cursor(checkpoint_viewed_at),
+                None => f.cursor(),
+            }),
+            results.last().map(|l| match checkpoint_viewed_at {
+                Some(checkpoint_viewed_at) => l.consistent_cursor(checkpoint_viewed_at),
+                None => l.cursor(),
+            }),
             results,
         ))
     }
@@ -266,7 +276,8 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
     /// `query`. Returns two booleans indicating whether there is a previous or next page in the
     /// range, followed by an iterator of values in the page, fetched from the database.
     ///
-    /// The values returned implement `Target<C>`, so are able to compute their own cursors.
+    /// `checkpoint_viewed_at` is a required parameter to and passed to each element to construct a
+    /// consistent cursor.
     pub(crate) fn paginate_raw_query<T>(
         &self,
         conn: &mut Conn<'_>,

--- a/crates/sui-graphql-rpc/src/types/dry_run_result.rs
+++ b/crates/sui-graphql-rpc/src/types/dry_run_result.rs
@@ -3,7 +3,7 @@
 
 use super::base64::Base64;
 use super::move_type::MoveType;
-use super::transaction_block::TransactionBlock;
+use super::transaction_block::{TransactionBlock, TransactionBlockInner};
 use super::transaction_block_kind::programmable::TransactionArgument;
 use crate::error::Error;
 use async_graphql::*;
@@ -65,10 +65,13 @@ impl TryFrom<DevInspectResults> for DryRunResult {
             })?;
         let tx_data: NativeTransactionData = bcs::from_bytes(&results.raw_txn_data)
             .map_err(|e| Error::Internal(format!("Unable to deserialize transaction data: {e}")))?;
-        let transaction = Some(TransactionBlock::DryRun {
-            tx_data,
-            effects,
-            events,
+        let transaction = Some(TransactionBlock {
+            inner: TransactionBlockInner::DryRun {
+                tx_data,
+                effects,
+                events,
+            },
+            checkpoint_viewed_at: None,
         });
         Ok(Self {
             error: results.error,

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -228,9 +228,7 @@ impl DynamicField {
         for stored in results {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
-            let cursor = stored
-                .consistent_cursor(checkpoint_viewed_at)
-                .encode_cursor();
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
 
             let object =
                 Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -10,9 +10,7 @@ use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 use super::cursor::{Page, Target};
-use super::object::{
-    self, deserialize_move_struct, validate_cursor_consistency, Object, ObjectKind, ObjectLookupKey,
-};
+use super::object::{self, deserialize_move_struct, Object, ObjectKind, ObjectLookupKey};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
@@ -201,7 +199,7 @@ impl DynamicField {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let Some(((prev, next, results), checkpoint_viewed_at)) = db

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -89,7 +89,7 @@ impl Epoch {
     async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
-            None => Checkpoint::query(ctx.data_unchecked(), CheckpointId::default())
+            None => Checkpoint::query(ctx.data_unchecked(), CheckpointId::default(), None)
                 .await
                 .extend()?
                 .map_or(self.stored.first_checkpoint_id as u64, |c| {
@@ -200,7 +200,7 @@ impl Epoch {
     ) -> Result<Connection<String, Checkpoint>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let epoch = self.stored.epoch as u64;
-        Checkpoint::paginate(ctx.data_unchecked(), page, Some(epoch))
+        Checkpoint::paginate(ctx.data_unchecked(), page, Some(epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -230,7 +230,7 @@ impl Epoch {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
+        TransactionBlock::paginate(ctx.data_unchecked(), page, filter, None) // TODO (wlmyng) - to be replaced with checkpoint_viewed_at from Epoch
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,6 +3,7 @@
 
 use std::str::FromStr;
 
+use super::checkpoint::Checkpoint;
 use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
@@ -18,7 +19,6 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use serde::{Deserialize, Serialize};
 use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
 use sui_indexer::schema_v2::{events, transactions, tx_senders};
-use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::ObjectID;
 use sui_types::Identifier;
 use sui_types::{
@@ -36,6 +36,9 @@ use sui_types::{
 pub(crate) struct Event {
     pub stored: Option<StoredEvent>,
     pub native: NativeEvent,
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
 }
 
 /// Contents of an Event's cursor.
@@ -46,6 +49,10 @@ pub(crate) struct EventKey {
 
     /// Event Sequence Number
     e: u64,
+
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    checkpoint_viewed_at: Option<u64>,
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<EventKey>;
@@ -107,14 +114,9 @@ impl Event {
             return Ok(None);
         }
 
-        let checkpoint_viewed_at = self
-            .stored
-            .as_ref()
-            .map(|e| e.checkpoint_sequence_number as u64);
-
         Ok(Some(Address {
             address: self.native.sender.into(),
-            checkpoint_viewed_at,
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         }))
     }
 
@@ -137,62 +139,100 @@ impl Event {
 }
 
 impl Event {
-    /// Query the database for a `page` of events. The Page uses a combination of transaction and
-    /// event sequence numbers as the cursor, and can optionally be further `filter`-ed by the
-    /// `EventFilter`.
+    /// Query the database for a `page` of events. The Page uses the transaction, event, and
+    /// checkpoint sequence numbers as the cursor to determine the correct page of results. The
+    /// query can optionally be further `filter`-ed by the `EventFilter`.
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
+    /// the cursor if they are consistent.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: EventFilter,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Event>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
-                page.paginate_query::<StoredEvent, _, _, _>(conn, None, move || {
-                    let mut query = events::dsl::events.into_boxed();
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-                    // The transactions table doesn't have an index on the senders column, so use
-                    // `tx_senders`.
-                    if let Some(sender) = &filter.sender {
+        let ((prev, next, results), checkpoint_viewed_at) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
+
+                let result = page.paginate_query::<StoredEvent, _, _, _>(
+                    conn,
+                    Some(checkpoint_viewed_at),
+                    move || {
+                        let mut query = events::dsl::events.into_boxed();
+
+                        // Bound events by the provided `checkpoint_viewed_at`. From EXPLAIN
+                        // ANALYZE, using the checkpoint sequence number directly instead of
+                        // translating into a transaction sequence number bound is more efficient.
                         query = query.filter(
-                            events::dsl::tx_sequence_number.eq_any(
-                                tx_senders::dsl::tx_senders
-                                    .select(tx_senders::dsl::tx_sequence_number)
-                                    .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
-                            ),
-                        )
-                    }
+                            events::dsl::checkpoint_sequence_number.le(checkpoint_viewed_at as i64),
+                        );
 
-                    if let Some(digest) = &filter.transaction_digest {
-                        query = query.filter(
-                            events::dsl::tx_sequence_number.eq_any(
-                                transactions::dsl::transactions
-                                    .select(transactions::dsl::tx_sequence_number)
-                                    .filter(
-                                        transactions::dsl::transaction_digest.eq(digest.to_vec()),
-                                    ),
-                            ),
-                        )
-                    }
+                        // The transactions table doesn't have an index on the senders column, so use
+                        // `tx_senders`.
+                        if let Some(sender) = &filter.sender {
+                            query = query.filter(
+                                events::dsl::tx_sequence_number.eq_any(
+                                    tx_senders::dsl::tx_senders
+                                        .select(tx_senders::dsl::tx_sequence_number)
+                                        .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
+                                ),
+                            )
+                        }
 
-                    if let Some(module) = &filter.emitting_module {
-                        query = module.apply(query, events::dsl::package, events::dsl::module);
-                    }
+                        if let Some(digest) = &filter.transaction_digest {
+                            query = query.filter(
+                                events::dsl::tx_sequence_number.eq_any(
+                                    transactions::dsl::transactions
+                                        .select(transactions::dsl::tx_sequence_number)
+                                        .filter(
+                                            transactions::dsl::transaction_digest
+                                                .eq(digest.to_vec()),
+                                        ),
+                                ),
+                            )
+                        }
 
-                    if let Some(type_) = &filter.event_type {
-                        query = type_.apply(query, events::dsl::event_type);
-                    }
+                        if let Some(module) = &filter.emitting_module {
+                            query = module.apply(query, events::dsl::package, events::dsl::module);
+                        }
 
-                    query
-                })
+                        if let Some(type_) = &filter.event_type {
+                            query = type_.apply(query, events::dsl::event_type);
+                        }
+
+                        query
+                    },
+                )?;
+
+                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
             })
             .await?;
 
         let mut conn = Connection::new(prev, next);
 
+        // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
+        // current available range. This sets a consistent upper bound for the nested queries.
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            conn.edges.push(Edge::new(cursor, stored.try_into()?));
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event::try_from_stored_event(stored, Some(checkpoint_viewed_at))?,
+            ));
         }
 
         Ok(conn)
@@ -201,6 +241,7 @@ impl Event {
     pub(crate) fn try_from_stored_transaction(
         stored_tx: &StoredTransaction,
         idx: usize,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Self, Error> {
         let Some(Some(serialized_event)) = stored_tx.events.get(idx) else {
             return Err(Error::Internal(format!(
@@ -234,30 +275,14 @@ impl Event {
         Ok(Self {
             stored: Some(stored_event),
             native: native_event,
+            checkpoint_viewed_at,
         })
     }
-}
 
-impl From<SuiEvent> for Event {
-    fn from(event: SuiEvent) -> Self {
-        let native = NativeEvent {
-            sender: event.sender,
-            package_id: event.package_id,
-            transaction_module: event.transaction_module,
-            type_: event.type_,
-            contents: event.bcs,
-        };
-        Self {
-            stored: None,
-            native,
-        }
-    }
-}
-
-impl TryFrom<StoredEvent> for Event {
-    type Error = Error;
-
-    fn try_from(stored: StoredEvent) -> Result<Self, Self::Error> {
+    fn try_from_stored_event(
+        stored: StoredEvent,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Self, Error> {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
@@ -280,6 +305,7 @@ impl TryFrom<StoredEvent> for Event {
                 type_,
                 contents,
             },
+            checkpoint_viewed_at,
         })
     }
 }
@@ -322,6 +348,35 @@ impl Target<Cursor> for StoredEvent {
         Cursor::new(EventKey {
             tx: self.tx_sequence_number as u64,
             e: self.event_sequence_number as u64,
+            checkpoint_viewed_at: None,
         })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(EventKey {
+            tx: self.tx_sequence_number as u64,
+            e: self.event_sequence_number as u64,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        })
+    }
+}
+
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(after_cursor.checkpoint_viewed_at)
+            } else {
+                Err(Error::Client(
+                    "Cursors are inconsistent and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
+        }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
+        (None, None) => Ok(None),
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use super::checkpoint::Checkpoint;
-use super::cursor::{self, Page, Paginated, Target};
+use super::cursor::{self, Checkpointed, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
@@ -157,7 +157,7 @@ impl Event {
         filter: EventFilter,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Event>, Error> {
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let ((prev, next, results), checkpoint_viewed_at) = db
@@ -169,7 +169,7 @@ impl Event {
 
                 let result = page.paginate_query::<StoredEvent, _, _, _>(
                     conn,
-                    Some(checkpoint_viewed_at),
+                    checkpoint_viewed_at,
                     move || {
                         let mut query = events::dsl::events.into_boxed();
 
@@ -361,22 +361,8 @@ impl Target<Cursor> for StoredEvent {
     }
 }
 
-pub(crate) fn validate_cursor_consistency(
-    after: Option<&Cursor>,
-    before: Option<&Cursor>,
-) -> Result<Option<u64>, Error> {
-    match (after, before) {
-        (Some(after_cursor), Some(before_cursor)) => {
-            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
-                Ok(after_cursor.checkpoint_viewed_at)
-            } else {
-                Err(Error::Client(
-                    "Cursors are inconsistent and cannot be used together in the same query."
-                        .to_string(),
-                ))
-            }
-        }
-        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
-        (None, None) => Ok(None),
+impl Checkpointed for Cursor {
+    fn checkpoint_viewed_at(&self) -> Option<u64> {
+        self.checkpoint_viewed_at
     }
 }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -147,7 +147,8 @@ impl Event {
     ) -> Result<Connection<String, Event>, Error> {
         let (prev, next, results) = db
             .execute(move |conn| {
-                page.paginate_query::<StoredEvent, _, _, _>(conn, move || {
+                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
+                page.paginate_query::<StoredEvent, _, _, _>(conn, None, move || {
                     let mut query = events::dsl::events.into_boxed();
 
                     // The transactions table doesn't have an index on the senders column, so use

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -40,9 +40,8 @@ pub(crate) struct GasEffects {
     pub summary: GasCostSummary,
     pub object_id: SuiAddress,
     pub object_version: u64,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Configuration for this transaction's gas price and the coins used to pay for gas.
@@ -136,7 +135,7 @@ impl GasEffects {
             self.object_id,
             ObjectLookupKey::VersionAt {
                 version: self.object_version,
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -153,10 +152,7 @@ impl GasEffects {
     /// was queried for, or `None` if the data was requested at the latest checkpoint. This is
     /// stored on `GasEffects` so that when viewing that entity's state, it will be as if it was
     /// read at the same checkpoint.
-    pub(crate) fn from(
-        effects: &NativeTransactionEffects,
-        checkpoint_viewed_at: Option<u64>,
-    ) -> Self {
+    pub(crate) fn from(effects: &NativeTransactionEffects, checkpoint_viewed_at: u64) -> Self {
         let ((id, version, _digest), _owner) = effects.gas_object();
         Self {
             summary: GasCostSummary::from(effects.gas_cost_summary()),

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -553,9 +553,13 @@ impl ObjectImpl<'_> {
         };
         let digest = native.previous_transaction;
 
-        TransactionBlock::query(ctx.data_unchecked(), digest.into())
-            .await
-            .extend()
+        TransactionBlock::query(
+            ctx.data_unchecked(),
+            digest.into(),
+            self.0.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn storage_rebate(&self) -> Option<BigInt> {
@@ -585,9 +589,14 @@ impl ObjectImpl<'_> {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter)
-            .await
-            .extend()
+        TransactionBlock::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            self.0.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     pub(crate) async fn bcs(&self) -> Result<Option<Base64>> {

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -11,9 +11,8 @@ use super::{
 
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Effect on an individual Object (keyed by its ID).
@@ -35,7 +34,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -53,7 +52,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -12,7 +12,11 @@ use super::{
 // A helper type representing the read of a specific version of an object. Intended to be
 // "flattened" into other GraphQL types.
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct ObjectRead(pub NativeObjectRef);
+pub(crate) struct ObjectRead {
+    pub native: NativeObjectRef,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[Object]
 impl ObjectRead {
@@ -29,7 +33,7 @@ impl ObjectRead {
     /// 32-byte hash that identifies the object's contents at this version, encoded as a Base58
     /// string.
     async fn digest(&self) -> String {
-        self.0 .2.base58_encode()
+        self.native.2.base58_encode()
     }
 
     /// The object at this version.  May not be available due to pruning.
@@ -39,7 +43,7 @@ impl ObjectRead {
             self.address_impl(),
             ObjectLookupKey::VersionAt {
                 version: self.version_impl(),
-                checkpoint_viewed_at: None,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -49,10 +53,10 @@ impl ObjectRead {
 
 impl ObjectRead {
     fn address_impl(&self) -> SuiAddress {
-        SuiAddress::from(self.0 .0)
+        SuiAddress::from(self.native.0)
     }
 
     fn version_impl(&self) -> u64 {
-        self.0 .1.value()
+        self.native.1.value()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -321,7 +321,7 @@ impl Query {
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
+        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default(), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -248,7 +248,7 @@ impl Query {
         ctx: &Context<'_>,
         digest: Digest,
     ) -> Result<Option<TransactionBlock>> {
-        TransactionBlock::query(ctx.data_unchecked(), digest)
+        TransactionBlock::query(ctx.data_unchecked(), digest, None)
             .await
             .extend()
     }
@@ -305,7 +305,7 @@ impl Query {
         filter: Option<TransactionBlockFilter>,
     ) -> Result<Connection<String, TransactionBlock>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
+        TransactionBlock::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default(), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -227,7 +227,7 @@ impl Query {
 
     /// Fetch epoch information by ID (defaults to the latest epoch).
     async fn epoch(&self, ctx: &Context<'_>, id: Option<u64>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), id).await.extend()
+        Epoch::query(ctx.data_unchecked(), id, None).await.extend()
     }
 
     /// Fetch checkpoint information by sequence number or digest (defaults to the latest available

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -237,9 +237,13 @@ impl Query {
         ctx: &Context<'_>,
         id: Option<CheckpointId>,
     ) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), id.unwrap_or_default())
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            id.unwrap_or_default(),
+            /* checkpoint_viewed_at */ None,
+        )
+        .await
+        .extend()
     }
 
     /// Fetch a transaction block by its transaction digest.
@@ -289,9 +293,14 @@ impl Query {
         before: Option<checkpoint::Cursor>,
     ) -> Result<Connection<String, Checkpoint>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Checkpoint::paginate(ctx.data_unchecked(), page, None)
-            .await
-            .extend()
+        Checkpoint::paginate(
+            ctx.data_unchecked(),
+            page,
+            /* epoch */ None,
+            /* checkpoint_viewed_at */ None,
+        )
+        .await
+        .extend()
     }
 
     /// The transaction blocks that exist in the network.

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -304,16 +304,24 @@ impl StakedSui {
 
     /// The epoch at which this stake became active.
     async fn activated_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native.activation_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.activation_epoch()),
+            self.super_.super_.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The epoch at which this object was requested to join a stake pool.
     async fn requested_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native.request_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.request_epoch()),
+            self.super_.super_.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The object id of the validator staking pool this stake belongs to.

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -8,6 +8,7 @@ use async_graphql::{
 };
 use diesel::{alias, ExpressionMethods, NullableExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
+use serde::{Deserialize, Serialize};
 use sui_indexer::{
     models_v2::transactions::StoredTransaction,
     schema_v2::{
@@ -34,18 +35,29 @@ use crate::{
 use super::{
     address::Address,
     base64::Base64,
+    checkpoint::Checkpoint,
     cursor::{self, Page, Paginated, Target},
     digest::Digest,
     epoch::Epoch,
     gas::GasInput,
     sui_address::SuiAddress,
-    transaction_block_effects::TransactionBlockEffects,
+    transaction_block_effects::{TransactionBlockEffects, TransactionBlockEffectsKind},
     transaction_block_kind::TransactionBlockKind,
     type_filter::FqNameFilter,
 };
 
+/// Wraps the actual transaction block data with the checkpoint sequence number at which the data
+/// was viewed, for consistent results on paginating through and resolving nested types.
 #[derive(Clone, Debug)]
-pub(crate) enum TransactionBlock {
+pub(crate) struct TransactionBlock {
+    pub inner: TransactionBlockInner,
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum TransactionBlockInner {
     /// A transaction block that has been indexed and stored in the database,
     /// containing all information that the other two variants have, and more.
     Stored {
@@ -97,8 +109,17 @@ pub(crate) struct TransactionBlockFilter {
     pub transaction_ids: Option<Vec<Digest>>,
 }
 
-pub(crate) type Cursor = cursor::JsonCursor<u64>;
+pub(crate) type Cursor = cursor::JsonCursor<TransactionBlockCursor>;
 type Query<ST, GB> = data::Query<ST, transactions::table, GB>;
+
+/// The cursor returned for each `TransactionBlock` in a connection's page of results. The
+/// `checkpoint_viewed_at` will set the consistent upper bound for subsequent queries made on this
+/// cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct TransactionBlockCursor {
+    pub checkpoint_viewed_at: Option<u64>,
+    pub tx_sequence_number: u64,
+}
 
 #[Object]
 impl TransactionBlock {
@@ -114,16 +135,9 @@ impl TransactionBlock {
     async fn sender(&self) -> Option<Address> {
         let sender = self.native().sender();
 
-        let checkpoint_viewed_at = match self {
-            TransactionBlock::Stored { stored_tx, .. } => {
-                Some(stored_tx.checkpoint_sequence_number as u64)
-            }
-            _ => None,
-        };
-
         (sender != NativeSuiAddress::ZERO).then(|| Address {
             address: SuiAddress::from(sender),
-            checkpoint_viewed_at,
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         })
     }
 
@@ -133,8 +147,8 @@ impl TransactionBlock {
     /// If the owner of the gas object(s) is not the same as the sender, the transaction block is a
     /// sponsored transaction block.
     async fn gas_input(&self) -> Option<GasInput> {
-        let checkpoint_sequence_number = match self {
-            TransactionBlock::Stored { stored_tx, .. } => {
+        let checkpoint_sequence_number = match &self.inner {
+            TransactionBlockInner::Stored { stored_tx, .. } => {
                 Some(stored_tx.checkpoint_sequence_number as u64)
             }
             _ => None,
@@ -181,51 +195,73 @@ impl TransactionBlock {
 
     /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
     async fn bcs(&self) -> Option<Base64> {
-        match self {
-            TransactionBlock::Stored { stored_tx, .. } => {
+        match &self.inner {
+            TransactionBlockInner::Stored { stored_tx, .. } => {
                 Some(Base64::from(&stored_tx.raw_transaction))
             }
-            TransactionBlock::Executed { tx_data, .. } => {
+            TransactionBlockInner::Executed { tx_data, .. } => {
                 bcs::to_bytes(&tx_data).ok().map(Base64::from)
             }
             // Dry run transaction does not have signatures so no sender signed data.
-            TransactionBlock::DryRun { .. } => None,
+            TransactionBlockInner::DryRun { .. } => None,
         }
     }
 }
 
 impl TransactionBlock {
     fn native(&self) -> &NativeTransactionData {
-        match self {
-            TransactionBlock::Stored { native, .. } => native.transaction_data(),
-            TransactionBlock::Executed { tx_data, .. } => tx_data.transaction_data(),
-            TransactionBlock::DryRun { tx_data, .. } => tx_data,
+        match &self.inner {
+            TransactionBlockInner::Stored { native, .. } => native.transaction_data(),
+            TransactionBlockInner::Executed { tx_data, .. } => tx_data.transaction_data(),
+            TransactionBlockInner::DryRun { tx_data, .. } => tx_data,
         }
     }
 
     fn native_signed_data(&self) -> Option<&NativeSenderSignedData> {
-        match self {
-            TransactionBlock::Stored { native, .. } => Some(native),
-            TransactionBlock::Executed { tx_data, .. } => Some(tx_data),
-            TransactionBlock::DryRun { .. } => None,
+        match &self.inner {
+            TransactionBlockInner::Stored { native, .. } => Some(native),
+            TransactionBlockInner::Executed { tx_data, .. } => Some(tx_data),
+            TransactionBlockInner::DryRun { .. } => None,
         }
     }
 
-    /// Look up a `TransactionBlock` in the database, by its transaction digest.
-    pub(crate) async fn query(db: &Db, digest: Digest) -> Result<Option<Self>, Error> {
+    /// Look up a `TransactionBlock` in the database, by its transaction digest. If
+    /// `checkpoint_viewed_at` is provided, the transaction block will inherit the value. Otherwise,
+    /// it will be set to the upper bound of the available range at the time of the query.
+    pub(crate) async fn query(
+        db: &Db,
+        digest: Digest,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Option<Self>, Error> {
         use transactions::dsl;
 
-        let stored: Option<StoredTransaction> = db
-            .execute(move |conn| {
-                conn.result(move || {
-                    dsl::transactions.filter(dsl::transaction_digest.eq(digest.to_vec()))
-                })
-                .optional()
+        let (stored, checkpoint_viewed_at): (Option<StoredTransaction>, u64) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
+
+                let stored = conn
+                    .result(move || {
+                        dsl::transactions.filter(dsl::transaction_digest.eq(digest.to_vec()))
+                    })
+                    .optional()?;
+
+                Ok::<_, diesel::result::Error>((stored, checkpoint_viewed_at))
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch transaction: {e}")))?;
 
-        stored.map(TransactionBlock::try_from).transpose()
+        let Some(stored) = stored else {
+            return Ok(None);
+        };
+
+        let inner = TransactionBlockInner::try_from(stored)?;
+        Ok(Some(TransactionBlock {
+            inner,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        }))
     }
 
     /// Look up multiple `TransactionBlock`s by their digests. Returns a map from those digests to
@@ -235,6 +271,7 @@ impl TransactionBlock {
     pub(crate) async fn multi_query(
         db: &Db,
         digests: Vec<Digest>,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<BTreeMap<Digest, Self>, Error> {
         use transactions::dsl;
         let digests: Vec<_> = digests.into_iter().map(|d| d.to_vec()).collect();
@@ -253,128 +290,196 @@ impl TransactionBlock {
             let digest = Digest::try_from(&tx.transaction_digest[..])
                 .map_err(|e| Error::Internal(format!("Bad digest for transaction: {e}")))?;
 
-            let transaction = TransactionBlock::try_from(tx)?;
+            let inner = TransactionBlockInner::try_from(tx)?;
+            let transaction = TransactionBlock {
+                inner,
+                checkpoint_viewed_at,
+            };
             transactions.insert(digest, transaction);
         }
 
         Ok(transactions)
     }
 
+    /// Query the database for a `page` of TransactionBlocks. The page uses `tx_sequence_number` and
+    /// `checkpoint_viewed_at` as the cursor, and can optionally be further `filter`-ed.
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
+    /// the cursor if they are consistent.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: TransactionBlockFilter,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, TransactionBlock>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredTransaction, _, _, _>(conn, move || {
-                    use transactions as tx;
-                    let mut query = tx::dsl::transactions.into_boxed();
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-                    if let Some(f) = &filter.function {
-                        let sub_query = tx_calls::dsl::tx_calls
-                            .select(tx_calls::dsl::tx_sequence_number)
-                            .into_boxed();
+        let response = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
 
-                        query = query.filter(tx::dsl::tx_sequence_number.eq_any(f.apply(
-                            sub_query,
-                            tx_calls::dsl::package,
-                            tx_calls::dsl::module,
-                            tx_calls::dsl::func,
-                        )));
-                    }
+                let result = page.paginate_query::<StoredTransaction, _, _, _>(
+                    conn,
+                    Some(checkpoint_viewed_at),
+                    move || {
+                        use transactions as tx;
+                        let mut query = tx::dsl::transactions.into_boxed();
 
-                    if let Some(k) = &filter.kind {
-                        query = query.filter(tx::dsl::transaction_kind.eq(*k as i16))
-                    }
+                        if let Some(f) = &filter.function {
+                            let sub_query = tx_calls::dsl::tx_calls
+                                .select(tx_calls::dsl::tx_sequence_number)
+                                .into_boxed();
 
-                    if let Some(c) = &filter.after_checkpoint {
-                        // Translate bound on checkpoint number into a bound on transaction sequence
-                        // number to make better use of indices. Experimentally, postgres struggles
-                        // to use the index on checkpoint sequence number to handle inequality
-                        // constraints -- it still uses the index on transaction sequence number --
-                        // but it's fine to use that index on an equality query.
-                        //
-                        // Diesel also does not like the same table appearing multiple times in a
-                        // single query, so we create an alias of the `transactions` table to query
-                        // for the transaction sequence number bound.
-                        let tx_ = alias!(tx as tx_after);
-                        let sub_query = tx_
-                            .select(tx_.field(tx::dsl::tx_sequence_number))
-                            .filter(tx_.field(tx::dsl::checkpoint_sequence_number).eq(*c as i64))
-                            .order(tx_.field(tx::dsl::tx_sequence_number).desc())
-                            .limit(1);
+                            query = query.filter(tx::dsl::tx_sequence_number.eq_any(f.apply(
+                                sub_query,
+                                tx_calls::dsl::package,
+                                tx_calls::dsl::module,
+                                tx_calls::dsl::func,
+                            )));
+                        }
 
-                        query = query.filter(
-                            tx::dsl::tx_sequence_number
-                                .nullable()
-                                .gt(sub_query.single_value()),
-                        );
-                    }
+                        if let Some(k) = &filter.kind {
+                            query = query.filter(tx::dsl::transaction_kind.eq(*k as i16))
+                        }
 
-                    if let Some(c) = &filter.at_checkpoint {
-                        query = query.filter(tx::dsl::checkpoint_sequence_number.eq(*c as i64));
-                    }
+                        if let Some(c) = &filter.after_checkpoint {
+                            // Translate bound on checkpoint number into a bound on transaction sequence
+                            // number to make better use of indices. Experimentally, postgres struggles
+                            // to use the index on checkpoint sequence number to handle inequality
+                            // constraints -- it still uses the index on transaction sequence number --
+                            // but it's fine to use that index on an equality query.
+                            //
+                            // Diesel also does not like the same table appearing multiple times in a
+                            // single query, so we create an alias of the `transactions` table to query
+                            // for the transaction sequence number bound.
+                            let tx_ = alias!(tx as tx_after);
+                            let sub_query = tx_
+                                .select(tx_.field(tx::dsl::tx_sequence_number))
+                                .filter(
+                                    tx_.field(tx::dsl::checkpoint_sequence_number).eq(*c as i64),
+                                )
+                                .order(tx_.field(tx::dsl::tx_sequence_number).desc())
+                                .limit(1);
 
-                    if let Some(c) = &filter.before_checkpoint {
+                            query = query.filter(
+                                tx::dsl::tx_sequence_number
+                                    .nullable()
+                                    .gt(sub_query.single_value()),
+                            );
+                        }
+
+                        if let Some(c) = &filter.at_checkpoint {
+                            query = query.filter(tx::dsl::checkpoint_sequence_number.eq(*c as i64));
+                        }
+
                         // See comment on handling `after_checkpoint` filter (above) for context.
+                        // The effective checkpoint to filter "before", given both the
+                        // `before_checkpoint` and `checkpoint_viewed_at`, becomes the smaller of
+                        // the two. The difference is that filtering on `checkpoint_viewed_at`
+                        // should include the tx_sequence_number, while filtering on
+                        // `before_checkpoint` should exclude it.
                         let tx_ = alias!(tx as tx_before);
                         let sub_query = tx_
                             .select(tx_.field(tx::dsl::tx_sequence_number))
-                            .filter(tx_.field(tx::dsl::checkpoint_sequence_number).eq(*c as i64))
-                            .order(tx_.field(tx::dsl::tx_sequence_number).asc())
-                            .limit(1);
+                            .limit(1)
+                            .into_boxed();
 
-                        query = query.filter(
-                            tx::dsl::tx_sequence_number
-                                .nullable()
-                                .lt(sub_query.single_value()),
-                        );
-                    }
+                        if filter
+                            .before_checkpoint
+                            .map_or(true, |cp| cp >= checkpoint_viewed_at)
+                        {
+                            let sub_query = sub_query
+                                .filter(
+                                    tx_.field(tx::dsl::checkpoint_sequence_number)
+                                        .eq(checkpoint_viewed_at as i64),
+                                )
+                                .order(tx_.field(tx::dsl::tx_sequence_number).desc());
 
-                    if let Some(a) = &filter.sign_address {
-                        let sub_query = tx_senders::dsl::tx_senders
-                            .select(tx_senders::dsl::tx_sequence_number)
-                            .filter(tx_senders::dsl::sender.eq(a.into_vec()));
-                        query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
-                    }
+                            query = query.filter(
+                                tx::dsl::tx_sequence_number
+                                    .nullable()
+                                    .le(sub_query.single_value()),
+                            );
+                        } else if let Some(c) = &filter.before_checkpoint {
+                            let sub_query = sub_query
+                                .filter(
+                                    tx_.field(tx::dsl::checkpoint_sequence_number).eq(*c as i64),
+                                )
+                                .order(tx_.field(tx::dsl::tx_sequence_number).asc());
 
-                    if let Some(a) = &filter.recv_address {
-                        let sub_query = tx_recipients::dsl::tx_recipients
-                            .select(tx_recipients::dsl::tx_sequence_number)
-                            .filter(tx_recipients::dsl::recipient.eq(a.into_vec()));
-                        query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
-                    }
+                            query = query.filter(
+                                tx::dsl::tx_sequence_number
+                                    .nullable()
+                                    .lt(sub_query.single_value()),
+                            );
+                        }
 
-                    if let Some(o) = &filter.input_object {
-                        let sub_query = tx_input_objects::dsl::tx_input_objects
-                            .select(tx_input_objects::dsl::tx_sequence_number)
-                            .filter(tx_input_objects::dsl::object_id.eq(o.into_vec()));
-                        query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
-                    }
+                        if let Some(a) = &filter.sign_address {
+                            let sub_query = tx_senders::dsl::tx_senders
+                                .select(tx_senders::dsl::tx_sequence_number)
+                                .filter(tx_senders::dsl::sender.eq(a.into_vec()));
+                            query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
+                        }
 
-                    if let Some(o) = &filter.changed_object {
-                        let sub_query = tx_changed_objects::dsl::tx_changed_objects
-                            .select(tx_changed_objects::dsl::tx_sequence_number)
-                            .filter(tx_changed_objects::dsl::object_id.eq(o.into_vec()));
-                        query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
-                    }
+                        if let Some(a) = &filter.recv_address {
+                            let sub_query = tx_recipients::dsl::tx_recipients
+                                .select(tx_recipients::dsl::tx_sequence_number)
+                                .filter(tx_recipients::dsl::recipient.eq(a.into_vec()));
+                            query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
+                        }
 
-                    if let Some(txs) = &filter.transaction_ids {
-                        let digests: Vec<_> = txs.iter().map(|d| d.to_vec()).collect();
-                        query = query.filter(tx::dsl::transaction_digest.eq_any(digests));
-                    }
+                        if let Some(o) = &filter.input_object {
+                            let sub_query = tx_input_objects::dsl::tx_input_objects
+                                .select(tx_input_objects::dsl::tx_sequence_number)
+                                .filter(tx_input_objects::dsl::object_id.eq(o.into_vec()));
+                            query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
+                        }
 
-                    query
-                })
+                        if let Some(o) = &filter.changed_object {
+                            let sub_query = tx_changed_objects::dsl::tx_changed_objects
+                                .select(tx_changed_objects::dsl::tx_sequence_number)
+                                .filter(tx_changed_objects::dsl::object_id.eq(o.into_vec()));
+                            query = query.filter(tx::dsl::tx_sequence_number.eq_any(sub_query));
+                        }
+
+                        if let Some(txs) = &filter.transaction_ids {
+                            let digests: Vec<_> = txs.iter().map(|d| d.to_vec()).collect();
+                            query = query.filter(tx::dsl::transaction_digest.eq_any(digests));
+                        }
+
+                        query
+                    },
+                )?;
+
+                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
             })
             .await?;
 
+        let ((prev, next, results), checkpoint_viewed_at) = response;
+
         let mut conn = Connection::new(prev, next);
 
+        // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
+        // current available range. This sets a consistent upper bound for the nested queries.
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            let transaction = TransactionBlock::try_from(stored)?;
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            let inner = TransactionBlockInner::try_from(stored)?;
+            let transaction = TransactionBlock {
+                inner,
+                checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            };
             conn.edges.push(Edge::new(cursor, transaction));
         }
 
@@ -420,11 +525,11 @@ impl Paginated<Cursor> for StoredTransaction {
     type Source = transactions::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(transactions::dsl::tx_sequence_number.ge(**cursor as i64))
+        query.filter(transactions::dsl::tx_sequence_number.ge(cursor.tx_sequence_number as i64))
     }
 
     fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(transactions::dsl::tx_sequence_number.le(**cursor as i64))
+        query.filter(transactions::dsl::tx_sequence_number.le(cursor.tx_sequence_number as i64))
     }
 
     fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -439,18 +544,28 @@ impl Paginated<Cursor> for StoredTransaction {
 
 impl Target<Cursor> for StoredTransaction {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.tx_sequence_number as u64)
+        Cursor::new(TransactionBlockCursor {
+            tx_sequence_number: self.tx_sequence_number as u64,
+            checkpoint_viewed_at: None,
+        })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(TransactionBlockCursor {
+            tx_sequence_number: self.tx_sequence_number as u64,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        })
     }
 }
 
-impl TryFrom<StoredTransaction> for TransactionBlock {
+impl TryFrom<StoredTransaction> for TransactionBlockInner {
     type Error = Error;
 
     fn try_from(stored_tx: StoredTransaction) -> Result<Self, Error> {
         let native = bcs::from_bytes(&stored_tx.raw_transaction)
             .map_err(|e| Error::Internal(format!("Error deserializing transaction block: {e}")))?;
 
-        Ok(TransactionBlock::Stored { stored_tx, native })
+        Ok(TransactionBlockInner::Stored { stored_tx, native })
     }
 }
 
@@ -458,28 +573,54 @@ impl TryFrom<TransactionBlockEffects> for TransactionBlock {
     type Error = Error;
 
     fn try_from(effects: TransactionBlockEffects) -> Result<Self, Error> {
-        match effects {
-            TransactionBlockEffects::Stored { stored_tx, .. } => {
-                TransactionBlock::try_from(stored_tx.clone())
+        let checkpoint_viewed_at = effects.checkpoint_viewed_at;
+        let inner = match effects.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
+                TransactionBlockInner::try_from(stored_tx.clone())
             }
-            TransactionBlockEffects::Executed {
+            TransactionBlockEffectsKind::Executed {
                 tx_data,
                 native,
                 events,
-            } => Ok(TransactionBlock::Executed {
+            } => Ok(TransactionBlockInner::Executed {
                 tx_data: tx_data.clone(),
                 effects: native.clone(),
                 events: events.clone(),
             }),
-            TransactionBlockEffects::DryRun {
+            TransactionBlockEffectsKind::DryRun {
                 tx_data,
                 native,
                 events,
-            } => Ok(TransactionBlock::DryRun {
+            } => Ok(TransactionBlockInner::DryRun {
                 tx_data: tx_data.clone(),
                 effects: native.clone(),
                 events: events.clone(),
             }),
+        }?;
+
+        Ok(TransactionBlock {
+            inner,
+            checkpoint_viewed_at,
+        })
+    }
+}
+
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(after_cursor.checkpoint_viewed_at)
+            } else {
+                Err(Error::Client(
+                    "Cursors are inconsistent and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
         }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
+        (None, None) => Ok(None),
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -377,6 +377,7 @@ impl TransactionBlockEffects {
         Checkpoint::query(
             ctx.data_unchecked(),
             CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -26,12 +26,22 @@ use super::{
     event::Event,
     gas::GasEffects,
     object_change::ObjectChange,
-    transaction_block::TransactionBlock,
+    transaction_block::{TransactionBlock, TransactionBlockInner},
     unchanged_shared_object::UnchangedSharedObject,
 };
 
-#[derive(Clone)]
-pub(crate) enum TransactionBlockEffects {
+/// Wraps the actual transaction block effects data with the checkpoint sequence number at which the
+/// data was viewed, for consistent results on paginating through and resolving nested types.
+#[derive(Clone, Debug)]
+pub(crate) struct TransactionBlockEffects {
+    pub kind: TransactionBlockEffectsKind,
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum TransactionBlockEffectsKind {
     /// A transaction that has been indexed and stored in the database,
     /// containing all information that the other two variants have, and more.
     Stored {
@@ -162,6 +172,7 @@ impl TransactionBlockEffects {
                 .iter()
                 .map(|d| Digest::from(*d))
                 .collect(),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()?;
@@ -186,7 +197,7 @@ impl TransactionBlockEffects {
 
     /// Effects to the gas object.
     async fn gas_effects(&self) -> Option<GasEffects> {
-        Some(GasEffects::from(self.native(), None)) // TODO (wlmyng) - pass in self.checkpoint_viewed_at
+        Some(GasEffects::from(self.native(), self.checkpoint_viewed_at))
     }
 
     /// Shared objects that are referenced by but not changed by this transaction.
@@ -249,7 +260,7 @@ impl TransactionBlockEffects {
         for c in cs {
             let object_change = ObjectChange {
                 native: object_changes[*c].clone(),
-                checkpoint_viewed_at: None, // TODO (wlmyng) pass in self.checkpoint_viewed_at
+                checkpoint_viewed_at: self.checkpoint_viewed_at,
             };
 
             connection
@@ -273,7 +284,7 @@ impl TransactionBlockEffects {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
 
-        let Self::Stored { stored_tx, .. } = self else {
+        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
             return Ok(connection);
         };
 
@@ -289,8 +300,8 @@ impl TransactionBlockEffects {
                 continue;
             };
 
-            let balance_change = BalanceChange::read(serialized, None) // TODO (wlmyng) - pass in txBlock's checkpoint_viewed_at
-                .extend()?;
+            let balance_change =
+                BalanceChange::read(serialized, self.checkpoint_viewed_at).extend()?;
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), balance_change));
@@ -310,9 +321,10 @@ impl TransactionBlockEffects {
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let mut connection = Connection::new(false, false);
-        let len = match self {
-            Self::Stored { stored_tx, .. } => stored_tx.events.len(),
-            Self::Executed { events, .. } | Self::DryRun { events, .. } => events.len(),
+        let len = match &self.kind {
+            TransactionBlockEffectsKind::Stored { stored_tx, .. } => stored_tx.events.len(),
+            TransactionBlockEffectsKind::Executed { events, .. }
+            | TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
         };
         let Some((prev, next, cs)) = page.paginate_indices(len) else {
             return Ok(connection);
@@ -322,11 +334,12 @@ impl TransactionBlockEffects {
         connection.has_next_page = next;
 
         for c in cs {
-            let event = match self {
-                Self::Stored { stored_tx, .. } => {
+            let event = match &self.kind {
+                TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
                     Event::try_from_stored_transaction(stored_tx, *c).extend()?
                 }
-                Self::Executed { events, .. } | Self::DryRun { events, .. } => Event {
+                TransactionBlockEffectsKind::Executed { events, .. }
+                | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[*c].clone(),
                 },
@@ -339,7 +352,7 @@ impl TransactionBlockEffects {
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized in.
     async fn timestamp(&self) -> Result<Option<DateTime>, Error> {
-        let Self::Stored { stored_tx, .. } = self else {
+        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
         Ok(Some(DateTime::from_ms(stored_tx.timestamp_ms)?))
@@ -355,7 +368,7 @@ impl TransactionBlockEffects {
     /// The checkpoint this transaction was finalized in.
     async fn checkpoint(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
         // If the transaction data is not a stored transaction, it's not in the checkpoint yet so we return None.
-        let Self::Stored { stored_tx, .. } = self else {
+        let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind else {
             return Ok(None);
         };
 
@@ -371,7 +384,7 @@ impl TransactionBlockEffects {
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
     async fn bcs(&self) -> Result<Base64> {
-        let bytes = if let Self::Stored { stored_tx, .. } = self {
+        let bytes = if let TransactionBlockEffectsKind::Stored { stored_tx, .. } = &self.kind {
             stored_tx.raw_effects.clone()
         } else {
             bcs::to_bytes(&self.native())
@@ -385,10 +398,10 @@ impl TransactionBlockEffects {
 
 impl TransactionBlockEffects {
     fn native(&self) -> &NativeTransactionEffects {
-        match self {
-            TransactionBlockEffects::Stored { native, .. } => native,
-            TransactionBlockEffects::Executed { native, .. } => native,
-            TransactionBlockEffects::DryRun { native, .. } => native,
+        match &self.kind {
+            TransactionBlockEffectsKind::Stored { native, .. } => native,
+            TransactionBlockEffectsKind::Executed { native, .. } => native,
+            TransactionBlockEffectsKind::DryRun { native, .. } => native,
         }
     }
 }
@@ -409,35 +422,41 @@ impl TryFrom<TransactionBlock> for TransactionBlockEffects {
     type Error = Error;
 
     fn try_from(block: TransactionBlock) -> Result<Self, Error> {
-        match block {
-            TransactionBlock::Stored { stored_tx, .. } => {
-                let native = bcs::from_bytes(&stored_tx.raw_effects).map_err(|e| {
-                    Error::Internal(format!("Error deserializing transaction effects: {e}"))
-                })?;
-
-                Ok(TransactionBlockEffects::Stored {
-                    stored_tx: stored_tx.clone(),
-                    native,
-                })
+        let checkpoint_viewed_at = block.checkpoint_viewed_at;
+        let kind = match block.inner {
+            TransactionBlockInner::Stored { stored_tx, .. } => {
+                bcs::from_bytes(&stored_tx.raw_effects)
+                    .map(|native| TransactionBlockEffectsKind::Stored {
+                        stored_tx: stored_tx.clone(),
+                        native,
+                    })
+                    .map_err(|e| {
+                        Error::Internal(format!("Error deserializing transaction effects: {e}"))
+                    })
             }
-            TransactionBlock::Executed {
+            TransactionBlockInner::Executed {
                 tx_data,
                 effects,
                 events,
-            } => Ok(TransactionBlockEffects::Executed {
+            } => Ok(TransactionBlockEffectsKind::Executed {
                 tx_data,
                 native: effects,
                 events,
             }),
-            TransactionBlock::DryRun {
+            TransactionBlockInner::DryRun {
                 tx_data,
                 effects,
                 events,
-            } => Ok(TransactionBlockEffects::DryRun {
+            } => Ok(TransactionBlockEffectsKind::DryRun {
                 tx_data,
                 native: effects,
                 events,
             }),
-        }
+        }?;
+
+        Ok(Self {
+            kind,
+            checkpoint_viewed_at,
+        })
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -362,9 +362,13 @@ impl TransactionBlockEffects {
 
     /// The epoch this transaction was finalized in.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native().executed_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native().executed_epoch()),
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The checkpoint this transaction was finalized in.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -336,12 +336,14 @@ impl TransactionBlockEffects {
         for c in cs {
             let event = match &self.kind {
                 TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
-                    Event::try_from_stored_transaction(stored_tx, *c).extend()?
+                    Event::try_from_stored_transaction(stored_tx, *c, self.checkpoint_viewed_at)
+                        .extend()?
                 }
                 TransactionBlockEffectsKind::Executed { events, .. }
                 | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[*c].clone(),
+                    checkpoint_viewed_at: self.checkpoint_viewed_at,
                 },
             };
             connection.edges.push(Edge::new(c.encode_cursor(), event));

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -11,35 +11,47 @@ use sui_types::{
     transaction::AuthenticatorStateUpdate as NativeAuthenticatorStateUpdateTransaction,
 };
 
-use crate::types::{
-    cursor::{JsonCursor, Page},
-    epoch::Epoch,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        cursor::{JsonCursor, Page},
+        epoch::Epoch,
+    },
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct AuthenticatorStateUpdateTransaction(
-    pub NativeAuthenticatorStateUpdateTransaction,
-);
+pub(crate) struct AuthenticatorStateUpdateTransaction {
+    pub native: NativeAuthenticatorStateUpdateTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CActiveJwk = JsonCursor<usize>;
+pub(crate) type CActiveJwk = JsonCursor<ConsistentIndexCursor>;
 
 /// The active JSON Web Key representing a set of public keys for an OpenID provider
-struct ActiveJwk(NativeActiveJwk);
+struct ActiveJwk {
+    native: NativeActiveJwk,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
+}
 
 /// System transaction for updating the on-chain state used by zkLogin.
 #[Object]
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// Consensus round of the authenticator state update.
     async fn round(&self) -> u64 {
-        self.0.round
+        self.native.round
     }
 
     /// Newly active JWKs (JSON Web Keys).
@@ -54,7 +66,11 @@ impl AuthenticatorStateUpdateTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.new_active_jwks.len()) else {
+        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+            self.native.new_active_jwks.len(),
+            self.checkpoint_viewed_at,
+        )?
+        else {
             return Ok(connection);
         };
 
@@ -62,7 +78,10 @@ impl AuthenticatorStateUpdateTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let active_jwk = ActiveJwk(self.0.new_active_jwks[*c].clone());
+            let active_jwk = ActiveJwk {
+                native: self.native.new_active_jwks[c.ix].clone(),
+                checkpoint_viewed_at: c.c,
+            };
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), active_jwk));
@@ -73,7 +92,7 @@ impl AuthenticatorStateUpdateTransaction {
 
     /// The initial version of the authenticator object that it was shared at.
     async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.0.authenticator_obj_initial_shared_version.value()
+        self.native.authenticator_obj_initial_shared_version.value()
     }
 }
 
@@ -81,39 +100,42 @@ impl AuthenticatorStateUpdateTransaction {
 impl ActiveJwk {
     /// The string (Issuing Authority) that identifies the OIDC provider.
     async fn iss(&self) -> &str {
-        &self.0.jwk_id.iss
+        &self.native.jwk_id.iss
     }
 
     /// The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
     async fn kid(&self) -> &str {
-        &self.0.jwk_id.kid
+        &self.native.jwk_id.kid
     }
 
     /// The JWK key type parameter, (RFC 7517, Section 4.1).
     async fn kty(&self) -> &str {
-        &self.0.jwk.kty
+        &self.native.jwk.kty
     }
 
     /// The JWK RSA public exponent, (RFC 7517, Section 9.3).
     async fn e(&self) -> &str {
-        &self.0.jwk.e
+        &self.native.jwk.e
     }
 
     /// The JWK RSA modulus, (RFC 7517, Section 9.3).
     async fn n(&self) -> &str {
-        &self.0.jwk.n
+        &self.native.jwk.n
     }
 
     /// The JWK algorithm parameter, (RFC 7517, Section 4.4).
     async fn alg(&self) -> &str {
-        &self.0.jwk.alg
+        &self.native.jwk.alg
     }
 
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -31,7 +31,8 @@ struct ActiveJwk(NativeActiveJwk);
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }
@@ -110,7 +111,8 @@ impl ActiveJwk {
 
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -24,6 +24,8 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
     round: u64,
     commit_timestamp_ms: CheckpointTimestamp,
     consensus_commit_digest: Option<ConsensusCommitDigest>,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
 }
 
 /// System transaction that runs at the beginning of a checkpoint, and is responsible for setting
@@ -32,10 +34,13 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// Consensus round of the commit.
@@ -56,24 +61,30 @@ impl ConsensusCommitPrologueTransaction {
     }
 }
 
-impl From<NativeConsensusCommitPrologueTransactionV1> for ConsensusCommitPrologueTransaction {
-    fn from(ccp: NativeConsensusCommitPrologueTransactionV1) -> Self {
+impl ConsensusCommitPrologueTransaction {
+    pub(crate) fn from_v1(
+        ccp: NativeConsensusCommitPrologueTransactionV1,
+        checkpoint_viewed_at: u64,
+    ) -> Self {
         Self {
             epoch: ccp.epoch,
             round: ccp.round,
             commit_timestamp_ms: ccp.commit_timestamp_ms,
             consensus_commit_digest: None,
+            checkpoint_viewed_at,
         }
     }
-}
 
-impl From<NativeConsensusCommitPrologueTransactionV2> for ConsensusCommitPrologueTransaction {
-    fn from(ccp: NativeConsensusCommitPrologueTransactionV2) -> Self {
+    pub(crate) fn from_v2(
+        ccp: NativeConsensusCommitPrologueTransactionV2,
+        checkpoint_viewed_at: u64,
+    ) -> Self {
         Self {
             epoch: ccp.epoch,
             round: ccp.round,
             commit_timestamp_ms: ccp.commit_timestamp_ms,
             consensus_commit_digest: Some(ccp.consensus_commit_digest),
+            checkpoint_viewed_at,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -32,7 +32,8 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -15,6 +15,7 @@ use sui_types::{
     },
 };
 
+use crate::consistency::ConsistentIndexCursor;
 use crate::types::cursor::{JsonCursor, Page};
 use crate::types::sui_address::SuiAddress;
 use crate::{
@@ -26,7 +27,11 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct EndOfEpochTransaction(pub Vec<NativeEndOfEpochTransactionKind>);
+pub(crate) struct EndOfEpochTransaction {
+    pub native: Vec<NativeEndOfEpochTransactionKind>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[derive(Union, Clone, PartialEq, Eq)]
 pub(crate) enum EndOfEpochTransactionKind {
@@ -38,7 +43,11 @@ pub(crate) enum EndOfEpochTransactionKind {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct ChangeEpochTransaction(pub NativeChangeEpochTransaction);
+pub(crate) struct ChangeEpochTransaction {
+    pub native: NativeChangeEpochTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 /// System transaction for creating the on-chain state used by zkLogin.
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
@@ -49,9 +58,11 @@ pub(crate) struct AuthenticatorStateCreateTransaction {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct AuthenticatorStateExpireTransaction(
-    pub NativeAuthenticatorStateExpireTransaction,
-);
+pub(crate) struct AuthenticatorStateExpireTransaction {
+    pub native: NativeAuthenticatorStateExpireTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
 pub(crate) struct RandomnessStateCreateTransaction {
@@ -67,8 +78,8 @@ pub(crate) struct CoinDenyListStateCreateTransaction {
     dummy: Option<bool>,
 }
 
-pub(crate) type CTxn = JsonCursor<usize>;
-pub(crate) type CPackage = JsonCursor<usize>;
+pub(crate) type CTxn = JsonCursor<ConsistentIndexCursor>;
+pub(crate) type CPackage = JsonCursor<ConsistentIndexCursor>;
 
 /// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions
 /// at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other
@@ -87,7 +98,9 @@ impl EndOfEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -95,7 +108,7 @@ impl EndOfEpochTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let tx = EndOfEpochTransactionKind::from(self.0[*c].clone());
+            let tx = EndOfEpochTransactionKind::from(self.native[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), tx));
         }
 
@@ -112,41 +125,44 @@ impl EndOfEpochTransaction {
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// The protocol version in effect in the new epoch.
     async fn protocol_version(&self) -> u64 {
-        self.0.protocol_version.as_u64()
+        self.native.protocol_version.as_u64()
     }
 
     /// The total amount of gas charged for storage during the previous epoch (in MIST).
     async fn storage_charge(&self) -> BigInt {
-        BigInt::from(self.0.storage_charge)
+        BigInt::from(self.native.storage_charge)
     }
 
     /// The total amount of gas charged for computation during the previous epoch (in MIST).
     async fn computation_charge(&self) -> BigInt {
-        BigInt::from(self.0.computation_charge)
+        BigInt::from(self.native.computation_charge)
     }
 
     /// The SUI returned to transaction senders for cleaning up objects (in MIST).
     async fn storage_rebate(&self) -> BigInt {
-        BigInt::from(self.0.storage_rebate)
+        BigInt::from(self.native.storage_rebate)
     }
 
     /// The total gas retained from storage fees, that will not be returned by storage rebates when
     /// the relevant objects are cleaned up (in MIST).
     async fn non_refundable_storage_fee(&self) -> BigInt {
-        BigInt::from(self.0.non_refundable_storage_fee)
+        BigInt::from(self.native.non_refundable_storage_fee)
     }
 
     /// Time at which the next epoch will start.
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)
+        DateTime::from_ms(self.native.epoch_start_timestamp_ms as i64)
     }
 
     /// System packages (specifically framework and move stdlib) that are written before the new
@@ -163,7 +179,11 @@ impl ChangeEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.system_packages.len()) else {
+        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+            self.native.system_packages.len(),
+            self.checkpoint_viewed_at,
+        )?
+        else {
             return Ok(connection);
         };
 
@@ -171,7 +191,7 @@ impl ChangeEpochTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let (version, modules, deps) = &self.0.system_packages[*c];
+            let (version, modules, deps) = &self.native.system_packages[c.ix];
             let compiled_modules = modules
                 .iter()
                 .map(|bytes| CompiledModule::deserialize_with_defaults(bytes))
@@ -187,7 +207,7 @@ impl ChangeEpochTransaction {
             );
 
             let runtime_id = native.id();
-            let object = Object::from_native(SuiAddress::from(runtime_id), native, None);
+            let object = Object::from_native(SuiAddress::from(runtime_id), native, Some(c.c));
             let package = MovePackage::try_from(&object)
                 .map_err(|_| Error::Internal("Failed to create system package".to_string()))
                 .extend()?;
@@ -203,30 +223,39 @@ impl ChangeEpochTransaction {
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.min_epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// The initial version that the AuthenticatorStateUpdate was shared at.
     async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.0.authenticator_obj_initial_shared_version.value()
+        self.native.authenticator_obj_initial_shared_version.value()
     }
 }
 
-impl From<NativeEndOfEpochTransactionKind> for EndOfEpochTransactionKind {
-    fn from(kind: NativeEndOfEpochTransactionKind) -> Self {
+impl EndOfEpochTransactionKind {
+    fn from(kind: NativeEndOfEpochTransactionKind, checkpoint_viewed_at: u64) -> Self {
         use EndOfEpochTransactionKind as K;
         use NativeEndOfEpochTransactionKind as N;
 
         match kind {
-            N::ChangeEpoch(ce) => K::ChangeEpoch(ChangeEpochTransaction(ce)),
+            N::ChangeEpoch(ce) => K::ChangeEpoch(ChangeEpochTransaction {
+                native: ce,
+                checkpoint_viewed_at,
+            }),
             N::AuthenticatorStateCreate => {
                 K::AuthenticatorStateCreate(AuthenticatorStateCreateTransaction { dummy: None })
             }
             N::AuthenticatorStateExpire(ase) => {
-                K::AuthenticatorStateExpire(AuthenticatorStateExpireTransaction(ase))
+                K::AuthenticatorStateExpire(AuthenticatorStateExpireTransaction {
+                    native: ase,
+                    checkpoint_viewed_at,
+                })
             }
             N::RandomnessStateCreate => {
                 K::RandomnessStateCreate(RandomnessStateCreateTransaction { dummy: None })

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -112,7 +112,8 @@ impl EndOfEpochTransaction {
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }
@@ -202,7 +203,8 @@ impl ChangeEpochTransaction {
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -11,16 +11,23 @@ use sui_types::{
     transaction::{GenesisObject, GenesisTransaction as NativeGenesisTransaction},
 };
 
-use crate::types::{
-    cursor::{JsonCursor, Page},
-    object::Object,
-    sui_address::SuiAddress,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        cursor::{JsonCursor, Page},
+        object::Object,
+        sui_address::SuiAddress,
+    },
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct GenesisTransaction(pub NativeGenesisTransaction);
+pub(crate) struct GenesisTransaction {
+    pub native: NativeGenesisTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CObject = JsonCursor<usize>;
+pub(crate) type CObject = JsonCursor<ConsistentIndexCursor>;
 
 /// System transaction that initializes the network and writes the initial set of objects on-chain.
 #[Object]
@@ -37,7 +44,9 @@ impl GenesisTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.objects.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.objects.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -45,11 +54,11 @@ impl GenesisTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let GenesisObject::RawObject { data, owner } = self.0.objects[*c].clone();
+            let GenesisObject::RawObject { data, owner } = self.native.objects[c.ix].clone();
             let native =
                 NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
 
-            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(0));
+            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(c.c));
             connection.edges.push(Edge::new(c.encode_cursor(), object));
         }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -32,24 +32,43 @@ pub(crate) enum TransactionBlockKind {
     EndOfEpoch(EndOfEpochTransaction),
 }
 
-impl From<NativeTransactionKind> for TransactionBlockKind {
-    fn from(kind: NativeTransactionKind) -> Self {
+impl TransactionBlockKind {
+    pub(crate) fn from(kind: NativeTransactionKind, checkpoint_viewed_at: u64) -> Self {
         use NativeTransactionKind as K;
         use TransactionBlockKind as T;
 
         match kind {
-            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock(pt)),
-            K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction(ce)),
-            K::Genesis(g) => T::Genesis(GenesisTransaction(g)),
-            K::ConsensusCommitPrologue(ccp) => T::ConsensusCommitPrologue(ccp.into()),
-            K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(ccp.into()),
+            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock {
+                native: pt,
+                checkpoint_viewed_at,
+            }),
+            K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction {
+                native: ce,
+                checkpoint_viewed_at,
+            }),
+            K::Genesis(g) => T::Genesis(GenesisTransaction {
+                native: g,
+                checkpoint_viewed_at,
+            }),
+            K::ConsensusCommitPrologue(ccp) => T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v1(ccp, checkpoint_viewed_at),
+            ),
+            K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v2(ccp, checkpoint_viewed_at),
+            ),
             K::AuthenticatorStateUpdate(asu) => {
-                T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
+                T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
+                    native: asu,
+                    checkpoint_viewed_at,
+                })
             }
-            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
+            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction {
+                native: eoe,
+                checkpoint_viewed_at,
+            }),
             K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
                 native: rsu,
-                checkpoint_viewed_at: None, // TODO (wlmyng)
+                checkpoint_viewed_at,
             }),
         }
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -47,7 +47,10 @@ impl From<NativeTransactionKind> for TransactionBlockKind {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
             }
             K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
-            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction(rsu)),
+            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
+                native: rsu,
+                checkpoint_viewed_at: None, // TODO (wlmyng)
+            }),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -1,13 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{
-    base64::Base64,
-    cursor::{JsonCursor, Page},
-    move_function::MoveFunction,
-    move_type::MoveType,
-    object_read::ObjectRead,
-    sui_address::SuiAddress,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        base64::Base64,
+        cursor::{JsonCursor, Page},
+        move_function::MoveFunction,
+        move_type::MoveType,
+        object_read::ObjectRead,
+        sui_address::SuiAddress,
+    },
 };
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -21,10 +24,14 @@ use sui_types::transaction::{
 };
 
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct ProgrammableTransactionBlock(pub NativeProgrammableTransactionBlock);
+pub(crate) struct ProgrammableTransactionBlock {
+    pub native: NativeProgrammableTransactionBlock,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CInput = JsonCursor<usize>;
-pub(crate) type CTxn = JsonCursor<usize>;
+pub(crate) type CInput = JsonCursor<ConsistentIndexCursor>;
+pub(crate) type CTxn = JsonCursor<ConsistentIndexCursor>;
 
 #[derive(Union, Clone, Eq, PartialEq)]
 enum TransactionInput {
@@ -82,7 +89,10 @@ enum ProgrammableTransaction {
 }
 
 #[derive(Clone, Eq, PartialEq)]
-struct MoveCallTransaction(NativeMoveCallTransaction);
+struct MoveCallTransaction {
+    native: NativeMoveCallTransaction,
+    checkpoint_viewed_at: u64,
+}
 
 /// Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public
 /// transfer) and must not be previously immutable or shared.
@@ -205,7 +215,9 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.inputs.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.inputs.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -213,7 +225,7 @@ impl ProgrammableTransactionBlock {
         connection.has_next_page = next;
 
         for c in cs {
-            let input = TransactionInput::from(self.0.inputs[*c].clone());
+            let input = TransactionInput::from(self.native.inputs[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), input));
         }
 
@@ -232,7 +244,9 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.commands.len()) else {
+        let Some((prev, next, cs)) = page
+            .paginate_consistent_indices(self.native.commands.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -240,7 +254,7 @@ impl ProgrammableTransactionBlock {
         connection.has_next_page = next;
 
         for c in cs {
-            let txn = ProgrammableTransaction::from(self.0.commands[*c].clone());
+            let txn = ProgrammableTransaction::from(self.native.commands[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), txn));
         }
 
@@ -253,26 +267,26 @@ impl ProgrammableTransactionBlock {
 impl MoveCallTransaction {
     /// The storage ID of the package the function being called is defined in.
     async fn package(&self) -> SuiAddress {
-        self.0.package.into()
+        self.native.package.into()
     }
 
     /// The name of the module the function being called is defined in.
     async fn module(&self) -> &str {
-        self.0.module.as_str()
+        self.native.module.as_str()
     }
 
     /// The name of the function being called.
     async fn function_name(&self) -> &str {
-        self.0.function.as_str()
+        self.native.function.as_str()
     }
 
     /// The function being called, resolved.
     async fn function(&self, ctx: &Context<'_>) -> Result<Option<MoveFunction>> {
         MoveFunction::query(
             ctx.data_unchecked(),
-            self.0.package.into(),
-            self.0.module.as_str(),
-            self.0.function.as_str(),
+            self.native.package.into(),
+            self.native.module.as_str(),
+            self.native.function.as_str(),
         )
         .await
         .extend()
@@ -280,7 +294,7 @@ impl MoveCallTransaction {
 
     /// The actual type parameters passed in for this move call.
     async fn type_arguments(&self) -> Vec<MoveType> {
-        self.0
+        self.native
             .type_arguments
             .iter()
             .map(|tag| MoveType::new(tag.clone()))
@@ -289,7 +303,7 @@ impl MoveCallTransaction {
 
     /// The actual function parameters passed in for this move call.
     async fn arguments(&self) -> Vec<TransactionArgument> {
-        self.0
+        self.native
             .arguments
             .iter()
             .map(|arg| TransactionArgument::from(*arg))
@@ -297,8 +311,8 @@ impl MoveCallTransaction {
     }
 }
 
-impl From<NativeCallArg> for TransactionInput {
-    fn from(argument: NativeCallArg) -> Self {
+impl TransactionInput {
+    fn from(argument: NativeCallArg, checkpoint_viewed_at: u64) -> Self {
         use NativeCallArg as N;
         use NativeObjectArg as O;
         use TransactionInput as I;
@@ -309,7 +323,10 @@ impl From<NativeCallArg> for TransactionInput {
             }),
 
             N::Object(O::ImmOrOwnedObject(oref)) => I::OwnedOrImmutable(OwnedOrImmutable {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             }),
 
             N::Object(O::SharedObject {
@@ -323,18 +340,24 @@ impl From<NativeCallArg> for TransactionInput {
             }),
 
             N::Object(O::Receiving(oref)) => I::Receiving(Receiving {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             }),
         }
     }
 }
 
-impl From<NativeProgrammableTransaction> for ProgrammableTransaction {
-    fn from(pt: NativeProgrammableTransaction) -> Self {
+impl ProgrammableTransaction {
+    fn from(pt: NativeProgrammableTransaction, checkpoint_viewed_at: u64) -> Self {
         use NativeProgrammableTransaction as N;
         use ProgrammableTransaction as P;
         match pt {
-            N::MoveCall(call) => P::MoveCall(MoveCallTransaction(*call)),
+            N::MoveCall(call) => P::MoveCall(MoveCallTransaction {
+                native: *call,
+                checkpoint_viewed_at,
+            }),
 
             N::TransferObjects(inputs, address) => P::TransferObjects(TransferObjectsTransaction {
                 inputs: inputs.into_iter().map(TransactionArgument::from).collect(),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -6,30 +6,40 @@ use async_graphql::*;
 use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
 
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct RandomnessStateUpdateTransaction(pub NativeRandomnessStateUpdate);
+pub(crate) struct RandomnessStateUpdateTransaction {
+    pub native: NativeRandomnessStateUpdate,
+    /// The checkpoint sequence number at which this was viewed at, or None if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
+}
 
 /// System transaction to update the source of on-chain randomness.
 #[Object]
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
-            .await
-            .extend()
+        // TODO (wlmyng)
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// Randomness round of the update.
     async fn randomness_round(&self) -> u64 {
-        self.0.randomness_round
+        self.native.randomness_round
     }
 
     /// Updated random bytes, encoded as Base64.
     async fn random_bytes(&self) -> Base64 {
-        Base64::from(&self.0.random_bytes)
+        Base64::from(&self.native.random_bytes)
     }
 
     /// The initial version the randomness object was shared at.
     async fn randomness_obj_initial_shared_version(&self) -> u64 {
-        self.0.randomness_obj_initial_shared_version.value()
+        self.native.randomness_obj_initial_shared_version.value()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -8,9 +8,8 @@ use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct RandomnessStateUpdateTransaction {
     pub native: NativeRandomnessStateUpdate,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// System transaction to update the source of on-chain randomness.
@@ -18,11 +17,10 @@ pub(crate) struct RandomnessStateUpdateTransaction {
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
         Epoch::query(
             ctx.data_unchecked(),
             Some(self.native.epoch),
-            self.checkpoint_viewed_at,
+            Some(self.checkpoint_viewed_at),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -42,10 +42,11 @@ pub(crate) struct SharedObjectDelete {
 /// Error for converting from an `InputSharedObject`.
 pub(crate) struct SharedObjectChanged;
 
-impl TryFrom<NativeInputSharedObject> for UnchangedSharedObject {
-    type Error = SharedObjectChanged;
-
-    fn try_from(input: NativeInputSharedObject) -> Result<Self, Self::Error> {
+impl UnchangedSharedObject {
+    pub fn try_from(
+        input: NativeInputSharedObject,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Self, SharedObjectChanged> {
         use NativeInputSharedObject as I;
         use UnchangedSharedObject as U;
 
@@ -53,7 +54,10 @@ impl TryFrom<NativeInputSharedObject> for UnchangedSharedObject {
             I::Mutate(_) => Err(SharedObjectChanged),
 
             I::ReadOnly(oref) => Ok(U::Read(SharedObjectRead {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             })),
 
             I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {


### PR DESCRIPTION
## Description 

Modify representation of `TransactionBlock` and its cursor, and `TransactionBlockEffects` to also store a `checkpoint_viewed_at` for consistency through pagination and with nested fields.

This is so that for a query like the one below, each transaction block will resolve to a sender whose transaction blocks would be consistent with the `checkpoint_viewed_at` - thus, the query will return the same "last" transaction for each outer transaction.
```
{
  address(address: "...") {
    transactionBlocks { nodes { sender { transactionBlocks(last: 1) { digest } } } }
  }
}
```

## Test Plan 

Existing tests have been updated to reflect the behavior described above.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
