### PR TITLE
[gql][consistent-reads][10/n] Add context to Events for consistent reads

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1506,26 +1506,6 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
-          "line": 21,
-          "column": 11
-        }
-      ],
-      "path": [
-        "all_transactions",
-        "nodes",
-        0,
-        "gasInput",
-        "gasSponsor",
-        "objects"
-      ],
-      "extensions": {
-        "code": "BAD_USER_INPUT"
-      }
-    },
-    {
-      "message": "Requested data is outside the available range",
-      "locations": [
-        {
           "line": 32,
           "column": 9
         }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.exp
@@ -47,7 +47,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -65,7 +65,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -83,7 +83,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "cursor": "eyJ0eCI6NiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -101,7 +101,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "cursor": "eyJ0eCI6NywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -129,7 +129,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -147,7 +147,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -165,7 +165,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NiwiZSI6MH0",
+          "cursor": "eyJ0eCI6NiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -183,7 +183,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NywiZSI6MH0",
+          "cursor": "eyJ0eCI6NywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M2"
@@ -211,7 +211,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -229,7 +229,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -257,7 +257,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -285,7 +285,7 @@ Response: {
     "events": {
       "edges": [
         {
-          "cursor": "eyJ0eCI6NCwiZSI6MH0",
+          "cursor": "eyJ0eCI6NCwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.exp
@@ -31,7 +31,7 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "eyJ0eCI6MiwiZSI6MH0",
+          "cursor": "eyJ0eCI6MiwiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -49,7 +49,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -67,7 +67,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
+          "cursor": "eyJ0eCI6MywiZSI6MSwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -94,47 +94,10 @@ Response: {
   "data": {
     "events": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
-          }
-        },
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "2"
-            },
-            "bcs": "AgAAAAAAAAA="
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -145,46 +108,9 @@ Response: {
     "events": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "eyJ0eCI6MiwiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "0"
-            },
-            "bcs": "AAAAAAAAAAA="
-          }
-        },
-        {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
-          "node": {
-            "sendingModule": {
-              "name": "M1"
-            },
-            "type": {
-              "repr": "0xcb0c195606f2cf51dd41b7d4b592d801c2c22d4f8a90bc785512d290c293c4c6::M1::EventA"
-            },
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "json": {
-              "new_value": "1"
-            },
-            "bcs": "AQAAAAAAAAA="
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -199,7 +125,7 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "eyJ0eCI6MywiZSI6MH0",
+          "cursor": "eyJ0eCI6MywiZSI6MCwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"
@@ -217,7 +143,7 @@ Response: {
           }
         },
         {
-          "cursor": "eyJ0eCI6MywiZSI6MX0",
+          "cursor": "eyJ0eCI6MywiZSI6MSwiY2hlY2twb2ludF92aWV3ZWRfYXQiOjF9",
           "node": {
             "sendingModule": {
               "name": "M1"

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -53,7 +53,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":2,"e":0}
+//# run-graphql --cursors {"tx":2,"e":0,"checkpoint_viewed_at":null}
 {
   events(first: 2 after: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {
@@ -79,7 +79,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":3,"e":1}
+//# run-graphql --cursors {"tx":3,"e":1,"checkpoint_viewed_at":null}
 {
   events(last: 2 before: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -3,6 +3,7 @@
 
 use std::str::FromStr;
 
+use super::checkpoint::Checkpoint;
 use super::cursor::{self, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
@@ -18,7 +19,6 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use serde::{Deserialize, Serialize};
 use sui_indexer::models_v2::{events::StoredEvent, transactions::StoredTransaction};
 use sui_indexer::schema_v2::{events, transactions, tx_senders};
-use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::ObjectID;
 use sui_types::Identifier;
 use sui_types::{
@@ -36,6 +36,9 @@ use sui_types::{
 pub(crate) struct Event {
     pub stored: Option<StoredEvent>,
     pub native: NativeEvent,
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
 }
 
 /// Contents of an Event's cursor.
@@ -46,6 +49,10 @@ pub(crate) struct EventKey {
 
     /// Event Sequence Number
     e: u64,
+
+    /// The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    /// requested at the latest checkpoint.
+    checkpoint_viewed_at: Option<u64>,
 }
 
 pub(crate) type Cursor = cursor::JsonCursor<EventKey>;
@@ -107,14 +114,9 @@ impl Event {
             return Ok(None);
         }
 
-        let checkpoint_viewed_at = self
-            .stored
-            .as_ref()
-            .map(|e| e.checkpoint_sequence_number as u64);
-
         Ok(Some(Address {
             address: self.native.sender.into(),
-            checkpoint_viewed_at,
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
         }))
     }
 
@@ -137,62 +139,100 @@ impl Event {
 }
 
 impl Event {
-    /// Query the database for a `page` of events. The Page uses a combination of transaction and
-    /// event sequence numbers as the cursor, and can optionally be further `filter`-ed by the
-    /// `EventFilter`.
+    /// Query the database for a `page` of events. The Page uses the transaction, event, and
+    /// checkpoint sequence numbers as the cursor to determine the correct page of results. The
+    /// query can optionally be further `filter`-ed by the `EventFilter`.
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
+    /// the cursor if they are consistent.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: EventFilter,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Event>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
-                page.paginate_query::<StoredEvent, _, _, _>(conn, None, move || {
-                    let mut query = events::dsl::events.into_boxed();
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-                    // The transactions table doesn't have an index on the senders column, so use
-                    // `tx_senders`.
-                    if let Some(sender) = &filter.sender {
+        let ((prev, next, results), checkpoint_viewed_at) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
+
+                let result = page.paginate_query::<StoredEvent, _, _, _>(
+                    conn,
+                    Some(checkpoint_viewed_at),
+                    move || {
+                        let mut query = events::dsl::events.into_boxed();
+
+                        // Bound events by the provided `checkpoint_viewed_at`. From EXPLAIN
+                        // ANALYZE, using the checkpoint sequence number directly instead of
+                        // translating into a transaction sequence number bound is more efficient.
                         query = query.filter(
-                            events::dsl::tx_sequence_number.eq_any(
-                                tx_senders::dsl::tx_senders
-                                    .select(tx_senders::dsl::tx_sequence_number)
-                                    .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
-                            ),
-                        )
-                    }
+                            events::dsl::checkpoint_sequence_number.le(checkpoint_viewed_at as i64),
+                        );
 
-                    if let Some(digest) = &filter.transaction_digest {
-                        query = query.filter(
-                            events::dsl::tx_sequence_number.eq_any(
-                                transactions::dsl::transactions
-                                    .select(transactions::dsl::tx_sequence_number)
-                                    .filter(
-                                        transactions::dsl::transaction_digest.eq(digest.to_vec()),
-                                    ),
-                            ),
-                        )
-                    }
+                        // The transactions table doesn't have an index on the senders column, so use
+                        // `tx_senders`.
+                        if let Some(sender) = &filter.sender {
+                            query = query.filter(
+                                events::dsl::tx_sequence_number.eq_any(
+                                    tx_senders::dsl::tx_senders
+                                        .select(tx_senders::dsl::tx_sequence_number)
+                                        .filter(tx_senders::dsl::sender.eq(sender.into_vec())),
+                                ),
+                            )
+                        }
 
-                    if let Some(module) = &filter.emitting_module {
-                        query = module.apply(query, events::dsl::package, events::dsl::module);
-                    }
+                        if let Some(digest) = &filter.transaction_digest {
+                            query = query.filter(
+                                events::dsl::tx_sequence_number.eq_any(
+                                    transactions::dsl::transactions
+                                        .select(transactions::dsl::tx_sequence_number)
+                                        .filter(
+                                            transactions::dsl::transaction_digest
+                                                .eq(digest.to_vec()),
+                                        ),
+                                ),
+                            )
+                        }
 
-                    if let Some(type_) = &filter.event_type {
-                        query = type_.apply(query, events::dsl::event_type);
-                    }
+                        if let Some(module) = &filter.emitting_module {
+                            query = module.apply(query, events::dsl::package, events::dsl::module);
+                        }
 
-                    query
-                })
+                        if let Some(type_) = &filter.event_type {
+                            query = type_.apply(query, events::dsl::event_type);
+                        }
+
+                        query
+                    },
+                )?;
+
+                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
             })
             .await?;
 
         let mut conn = Connection::new(prev, next);
 
+        // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
+        // current available range. This sets a consistent upper bound for the nested queries.
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            conn.edges.push(Edge::new(cursor, stored.try_into()?));
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Event::try_from_stored_event(stored, Some(checkpoint_viewed_at))?,
+            ));
         }
 
         Ok(conn)
@@ -201,6 +241,7 @@ impl Event {
     pub(crate) fn try_from_stored_transaction(
         stored_tx: &StoredTransaction,
         idx: usize,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Self, Error> {
         let Some(Some(serialized_event)) = stored_tx.events.get(idx) else {
             return Err(Error::Internal(format!(
@@ -234,30 +275,14 @@ impl Event {
         Ok(Self {
             stored: Some(stored_event),
             native: native_event,
+            checkpoint_viewed_at,
         })
     }
-}
 
-impl From<SuiEvent> for Event {
-    fn from(event: SuiEvent) -> Self {
-        let native = NativeEvent {
-            sender: event.sender,
-            package_id: event.package_id,
-            transaction_module: event.transaction_module,
-            type_: event.type_,
-            contents: event.bcs,
-        };
-        Self {
-            stored: None,
-            native,
-        }
-    }
-}
-
-impl TryFrom<StoredEvent> for Event {
-    type Error = Error;
-
-    fn try_from(stored: StoredEvent) -> Result<Self, Self::Error> {
+    fn try_from_stored_event(
+        stored: StoredEvent,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Self, Error> {
         let Some(Some(sender_bytes)) = stored.senders.first() else {
             return Err(Error::Internal("No senders found for event".to_string()));
         };
@@ -280,6 +305,7 @@ impl TryFrom<StoredEvent> for Event {
                 type_,
                 contents,
             },
+            checkpoint_viewed_at,
         })
     }
 }
@@ -322,6 +348,35 @@ impl Target<Cursor> for StoredEvent {
         Cursor::new(EventKey {
             tx: self.tx_sequence_number as u64,
             e: self.event_sequence_number as u64,
+            checkpoint_viewed_at: None,
         })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(EventKey {
+            tx: self.tx_sequence_number as u64,
+            e: self.event_sequence_number as u64,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        })
+    }
+}
+
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(after_cursor.checkpoint_viewed_at)
+            } else {
+                Err(Error::Client(
+                    "Cursors are inconsistent and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
+        }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
+        (None, None) => Ok(None),
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -321,7 +321,7 @@ impl Query {
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default())
+        Event::paginate(ctx.data_unchecked(), page, filter.unwrap_or_default(), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -336,12 +336,14 @@ impl TransactionBlockEffects {
         for c in cs {
             let event = match &self.kind {
                 TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
-                    Event::try_from_stored_transaction(stored_tx, *c).extend()?
+                    Event::try_from_stored_transaction(stored_tx, *c, self.checkpoint_viewed_at)
+                        .extend()?
                 }
                 TransactionBlockEffectsKind::Executed { events, .. }
                 | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[*c].clone(),
+                    checkpoint_viewed_at: self.checkpoint_viewed_at,
                 },
             };
             connection.edges.push(Edge::new(c.encode_cursor(), event));


### PR DESCRIPTION
## Description 

Add `checkpoint_viewed_at` to internal representation for `Event` and `Event`'s cursor to support consistent queries through pagination and nested fields. `Event.paginate` is updated to be bound by `checkpoint_viewed_at`. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
