### PR TITLE
[gql][consistent-reads][11/n] Set consistent context for checkpoints

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.exp
@@ -8,35 +8,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        },
-        {
-          "cursor": "OA",
-          "node": {
-            "sequenceNumber": 8
-          }
-        },
-        {
-          "cursor": "OQ",
-          "node": {
-            "sequenceNumber": 9
-          }
-        },
-        {
-          "cursor": "MTA",
-          "node": {
-            "sequenceNumber": 10
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -46,17 +21,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -71,25 +39,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
@@ -104,23 +72,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -131,25 +86,31 @@ Response: {
     "checkpoints": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
+          "node": {
+            "sequenceNumber": 3
           }
         }
       ]
@@ -167,25 +128,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -201,31 +162,37 @@ Response: {
     "checkpoints": {
       "pageInfo": {
         "hasPreviousPage": false,
-        "hasNextPage": true
+        "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NH0",
+          "node": {
+            "sequenceNumber": 4
           }
         }
       ]
@@ -238,59 +205,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        },
-        {
-          "cursor": "Ng",
-          "node": {
-            "sequenceNumber": 6
-          }
-        },
-        {
-          "cursor": "Nw",
-          "node": {
-            "sequenceNumber": 7
-          }
-        },
-        {
-          "cursor": "OA",
-          "node": {
-            "sequenceNumber": 8
-          }
-        },
-        {
-          "cursor": "OQ",
-          "node": {
-            "sequenceNumber": 9
-          }
-        },
-        {
-          "cursor": "MTA",
-          "node": {
-            "sequenceNumber": 10
-          }
-        },
-        {
-          "cursor": "MTE",
-          "node": {
-            "sequenceNumber": 11
-          }
-        },
-        {
-          "cursor": "MTI",
-          "node": {
-            "sequenceNumber": 12
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -300,35 +218,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "Mg",
-          "node": {
-            "sequenceNumber": 2
-          }
-        },
-        {
-          "cursor": "Mw",
-          "node": {
-            "sequenceNumber": 3
-          }
-        },
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -338,23 +231,10 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
-        "hasNextPage": true
+        "hasPreviousPage": false,
+        "hasNextPage": false
       },
-      "edges": [
-        {
-          "cursor": "NA",
-          "node": {
-            "sequenceNumber": 4
-          }
-        },
-        {
-          "cursor": "NQ",
-          "node": {
-            "sequenceNumber": 5
-          }
-        }
-      ]
+      "edges": []
     }
   }
 }
@@ -364,24 +244,30 @@ Response: {
   "data": {
     "checkpoints": {
       "pageInfo": {
-        "hasPreviousPage": true,
+        "hasPreviousPage": false,
         "hasNextPage": false
       },
       "edges": [
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
+          "node": {
+            "sequenceNumber": 9
+          }
+        },
+        {
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -401,79 +287,79 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
         },
         {
-          "cursor": "NA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NH0",
           "node": {
             "sequenceNumber": 4
           }
         },
         {
-          "cursor": "NQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6NX0",
           "node": {
             "sequenceNumber": 5
           }
         },
         {
-          "cursor": "Ng",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Nn0",
           "node": {
             "sequenceNumber": 6
           }
         },
         {
-          "cursor": "Nw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6N30",
           "node": {
             "sequenceNumber": 7
           }
         },
         {
-          "cursor": "OA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OH0",
           "node": {
             "sequenceNumber": 8
           }
         },
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }
@@ -493,25 +379,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "MA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MH0",
           "node": {
             "sequenceNumber": 0
           }
         },
         {
-          "cursor": "MQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MX0",
           "node": {
             "sequenceNumber": 1
           }
         },
         {
-          "cursor": "Mg",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6Mn0",
           "node": {
             "sequenceNumber": 2
           }
         },
         {
-          "cursor": "Mw",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6M30",
           "node": {
             "sequenceNumber": 3
           }
@@ -531,25 +417,25 @@ Response: {
       },
       "edges": [
         {
-          "cursor": "OQ",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6OX0",
           "node": {
             "sequenceNumber": 9
           }
         },
         {
-          "cursor": "MTA",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTB9",
           "node": {
             "sequenceNumber": 10
           }
         },
         {
-          "cursor": "MTE",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTF9",
           "node": {
             "sequenceNumber": 11
           }
         },
         {
-          "cursor": "MTI",
+          "cursor": "eyJjaGVja3BvaW50X3ZpZXdlZF9hdCI6MTIsInNlcXVlbmNlX251bWJlciI6MTJ9",
           "node": {
             "sequenceNumber": 12
           }

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -30,7 +30,7 @@
 
 //# create-checkpoint 12
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -44,7 +44,7 @@
   }
 }
 
-//# run-graphql --cursors 6 8
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6} {"checkpoint_viewed_at":null,"sequence_number":8}
 {
   checkpoints(first: 4, after: "@{cursor_0}", before: "@{cursor_1}") {
     pageInfo {
@@ -58,7 +58,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -72,7 +72,7 @@
   }
 }
 
-//# run-graphql --cursors 3 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -86,7 +86,7 @@
   }
 }
 
-//# run-graphql --cursors 3
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -100,7 +100,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -114,7 +114,7 @@
   }
 }
 
-//# run-graphql --cursors 4
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
 {
   checkpoints(before: "@{cursor_0}") {
     pageInfo {
@@ -128,7 +128,7 @@
   }
 }
 
-//# run-graphql --cursors 4
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
 {
   checkpoints(after: "@{cursor_0}") {
     pageInfo {
@@ -142,7 +142,7 @@
   }
 }
 
-//# run-graphql --cursors 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -156,7 +156,7 @@
   }
 }
 
-//# run-graphql --cursors 3 6
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -170,7 +170,7 @@
   }
 }
 
-//# run-graphql --cursors 9
+//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":9}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
@@ -817,6 +817,22 @@ Response: {
       "extensions": {
         "code": "BAD_USER_INPUT"
       }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
+          "line": 30,
+          "column": 5
+        }
+      ],
+      "path": [
+        "queryAddressCoinsAtChkpt1AfterSnapshotCatchup",
+        "coins"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
     }
   ]
 }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.exp
@@ -1506,6 +1506,26 @@ Response: {
       "message": "Requested data is outside the available range",
       "locations": [
         {
+          "line": 21,
+          "column": 11
+        }
+      ],
+      "path": [
+        "all_transactions",
+        "nodes",
+        0,
+        "gasInput",
+        "gasSponsor",
+        "objects"
+      ],
+      "extensions": {
+        "code": "BAD_USER_INPUT"
+      }
+    },
+    {
+      "message": "Requested data is outside the available range",
+      "locations": [
+        {
           "line": 32,
           "column": 9
         }

--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -15,14 +15,22 @@ pub(crate) struct AvailableRange {
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.first))
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            CheckpointId::by_seq_num(self.first),
+            Some(self.last),
+        )
+        .await
+        .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), CheckpointId::by_seq_num(self.last))
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            CheckpointId::by_seq_num(self.last),
+            Some(self.last),
+        )
+        .await
+        .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -20,6 +20,7 @@ use async_graphql::{
 };
 use diesel::{CombineDsl, ExpressionMethods, OptionalExtension, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
+use serde::{Deserialize, Serialize};
 use sui_indexer::{
     models_v2::checkpoints::StoredCheckpoint,
     schema_v2::{checkpoints, objects_snapshot},
@@ -38,10 +39,22 @@ pub(crate) struct Checkpoint {
     /// Representation of transaction data in the Indexer's Store. The indexer stores the
     /// transaction data and its effects together, in one table.
     pub stored: StoredCheckpoint,
+    // The checkpoint_sequence_number at which this was viewed at, or `None` if the data was
+    // requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
 }
 
-pub(crate) type Cursor = cursor::JsonCursor<u64>;
+pub(crate) type Cursor = cursor::JsonCursor<CheckpointCursor>;
 type Query<ST, GB> = data::Query<ST, checkpoints::table, GB>;
+
+/// The cursor returned for each `Checkpoint` in a connection's page of results. The
+/// `checkpoint_viewed_at` will set the consistent upper bound for subsequent queries made on this
+/// cursor.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct CheckpointCursor {
+    pub checkpoint_viewed_at: Option<u64>,
+    pub sequence_number: u64,
+}
 
 /// Checkpoints contain finalized transactions and are used for node synchronization
 /// and global transaction ordering.
@@ -126,9 +139,14 @@ impl Checkpoint {
             return Ok(Connection::new(false, false));
         };
 
-        TransactionBlock::paginate(ctx.data_unchecked(), page, filter, None) // TODO (wlmyng) - to be replaced with checkpoint_viewed_at from Checkpoint
-            .await
-            .extend()
+        TransactionBlock::paginate(
+            ctx.data_unchecked(),
+            page,
+            filter,
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 }
 
@@ -158,64 +176,114 @@ impl Checkpoint {
     /// Look up a `Checkpoint` in the database, filtered by either sequence number or digest. If
     /// both filters are supplied they will both be applied. If none are supplied, the latest
     /// checkpoint is fetched.
-    pub(crate) async fn query(db: &Db, filter: CheckpointId) -> Result<Option<Self>, Error> {
+    pub(crate) async fn query(
+        db: &Db,
+        filter: CheckpointId,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Option<Self>, Error> {
         use checkpoints::dsl;
 
         let digest = filter.digest.map(|d| d.to_vec());
         let seq_num = filter.sequence_number.map(|n| n as i64);
 
-        let stored = db
-            .execute(move |conn| {
-                conn.first(move || {
-                    let mut query = dsl::checkpoints
-                        .order_by(dsl::sequence_number.desc())
-                        .into_boxed();
+        let (stored, checkpoint_viewed_at): (Option<StoredCheckpoint>, u64) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
 
-                    if let Some(digest) = digest.clone() {
-                        query = query.filter(dsl::checkpoint_digest.eq(digest));
-                    }
+                let stored = conn
+                    .first(move || {
+                        let mut query = dsl::checkpoints
+                            .order_by(dsl::sequence_number.desc())
+                            .into_boxed();
 
-                    if let Some(seq_num) = seq_num {
-                        query = query.filter(dsl::sequence_number.eq(seq_num));
-                    }
+                        if let Some(digest) = digest.clone() {
+                            query = query.filter(dsl::checkpoint_digest.eq(digest));
+                        }
 
-                    query
-                })
-                .optional()
+                        if let Some(seq_num) = seq_num {
+                            query = query.filter(dsl::sequence_number.eq(seq_num));
+                        }
+
+                        query
+                    })
+                    .optional()?;
+
+                Ok::<_, diesel::result::Error>((stored, checkpoint_viewed_at))
             })
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch checkpoint: {e}")))?;
 
-        Ok(stored.map(|stored| Checkpoint { stored }))
+        Ok(stored.map(|stored| Checkpoint {
+            stored,
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+        }))
     }
 
-    /// Query the database for a `page` of checkpoints. The Page uses checkpoint sequence numbers as
-    /// the cursor, and can optionally be further `filter`-ed by an epoch number (to only return
-    /// checkpoints within that epoch).
+    /// Query the database for a `page` of checkpoints. The Page uses the checkpoint sequence number
+    /// of the stored checkpoint and the checkpoint at which this was viewed at as the cursor, and
+    /// can optionally be further `filter`-ed by an epoch number (to only return checkpoints within
+    /// that epoch).
+    ///
+    /// The `checkpoint_viewed_at` parameter is an Option<u64> representing the
+    /// checkpoint_sequence_number at which this page was queried for, or `None` if the data was
+    /// requested at the latest checkpoint. Each entity returned in the connection will inherit this
+    /// checkpoint, so that when viewing that entity's state, it will be from the reference of this
+    /// checkpoint_viewed_at parameter.
+    ///
+    /// If the `Page<Cursor>` is set, then this function will defer to the `checkpoint_viewed_at` in
+    /// the cursor if they are consistent.
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<Cursor>,
         filter: Option<u64>,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Checkpoint>, Error> {
         use checkpoints::dsl;
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                // TODO (wlmyng) the None value will be replaced by self.checkpoint_viewed_at
-                page.paginate_query::<StoredCheckpoint, _, _, _>(conn, None, move || {
-                    let mut query = dsl::checkpoints.into_boxed();
-                    if let Some(epoch) = filter {
-                        query = query.filter(dsl::epoch.eq(epoch as i64));
-                    }
-                    query
-                })
+        let ((prev, next, results), rhs) = db
+            .execute_repeatable(move |conn| {
+                let checkpoint_viewed_at = match checkpoint_viewed_at {
+                    Some(value) => Ok(value),
+                    None => Checkpoint::available_range(conn).map(|(_, rhs)| rhs),
+                }?;
+
+                let result = page.paginate_query::<StoredCheckpoint, _, _, _>(
+                    conn,
+                    Some(checkpoint_viewed_at),
+                    move || {
+                        let mut query = dsl::checkpoints.into_boxed();
+                        query = query.filter(dsl::sequence_number.le(checkpoint_viewed_at as i64));
+                        if let Some(epoch) = filter {
+                            query = query.filter(dsl::epoch.eq(epoch as i64));
+                        }
+                        query
+                    },
+                )?;
+
+                Ok::<_, diesel::result::Error>((result, checkpoint_viewed_at))
             })
             .await?;
 
+        // Defer to the provided checkpoint_viewed_at, but if it is not provided, use the
+        // current available range. This sets a consistent upper bound for the nested queries.
         let mut conn = Connection::new(prev, next);
+        let checkpoint_viewed_at = checkpoint_viewed_at.unwrap_or(rhs);
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            conn.edges.push(Edge::new(cursor, Checkpoint { stored }));
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+            conn.edges.push(Edge::new(
+                cursor,
+                Checkpoint {
+                    stored,
+                    checkpoint_viewed_at: Some(checkpoint_viewed_at),
+                },
+            ));
         }
 
         Ok(conn)
@@ -257,11 +325,11 @@ impl Paginated<Cursor> for StoredCheckpoint {
     type Source = checkpoints::table;
 
     fn filter_ge<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.ge(**cursor as i64))
+        query.filter(checkpoints::dsl::sequence_number.ge(cursor.sequence_number as i64))
     }
 
     fn filter_le<ST, GB>(cursor: &Cursor, query: Query<ST, GB>) -> Query<ST, GB> {
-        query.filter(checkpoints::dsl::sequence_number.le(**cursor as i64))
+        query.filter(checkpoints::dsl::sequence_number.le(cursor.sequence_number as i64))
     }
 
     fn order<ST, GB>(asc: bool, query: Query<ST, GB>) -> Query<ST, GB> {
@@ -276,6 +344,36 @@ impl Paginated<Cursor> for StoredCheckpoint {
 
 impl Target<Cursor> for StoredCheckpoint {
     fn cursor(&self) -> Cursor {
-        Cursor::new(self.sequence_number as u64)
+        Cursor::new(CheckpointCursor {
+            sequence_number: self.sequence_number as u64,
+            checkpoint_viewed_at: None,
+        })
+    }
+
+    fn consistent_cursor(&self, checkpoint_viewed_at: u64) -> Cursor {
+        Cursor::new(CheckpointCursor {
+            checkpoint_viewed_at: Some(checkpoint_viewed_at),
+            sequence_number: self.sequence_number as u64,
+        })
+    }
+}
+
+pub(crate) fn validate_cursor_consistency(
+    after: Option<&Cursor>,
+    before: Option<&Cursor>,
+) -> Result<Option<u64>, Error> {
+    match (after, before) {
+        (Some(after_cursor), Some(before_cursor)) => {
+            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
+                Ok(after_cursor.checkpoint_viewed_at)
+            } else {
+                Err(Error::Client(
+                    "Cursors are inconsistent and cannot be used together in the same query."
+                        .to_string(),
+                ))
+            }
+        }
+        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
+        (None, None) => Ok(None),
     }
 }

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -89,7 +89,7 @@ impl Epoch {
     async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
-            None => Checkpoint::query(ctx.data_unchecked(), CheckpointId::default())
+            None => Checkpoint::query(ctx.data_unchecked(), CheckpointId::default(), None)
                 .await
                 .extend()?
                 .map_or(self.stored.first_checkpoint_id as u64, |c| {
@@ -200,7 +200,7 @@ impl Epoch {
     ) -> Result<Connection<String, Checkpoint>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         let epoch = self.stored.epoch as u64;
-        Checkpoint::paginate(ctx.data_unchecked(), page, Some(epoch))
+        Checkpoint::paginate(ctx.data_unchecked(), page, Some(epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -237,9 +237,13 @@ impl Query {
         ctx: &Context<'_>,
         id: Option<CheckpointId>,
     ) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(ctx.data_unchecked(), id.unwrap_or_default())
-            .await
-            .extend()
+        Checkpoint::query(
+            ctx.data_unchecked(),
+            id.unwrap_or_default(),
+            /* checkpoint_viewed_at */ None,
+        )
+        .await
+        .extend()
     }
 
     /// Fetch a transaction block by its transaction digest.
@@ -289,9 +293,14 @@ impl Query {
         before: Option<checkpoint::Cursor>,
     ) -> Result<Connection<String, Checkpoint>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        Checkpoint::paginate(ctx.data_unchecked(), page, None)
-            .await
-            .extend()
+        Checkpoint::paginate(
+            ctx.data_unchecked(),
+            page,
+            /* epoch */ None,
+            /* checkpoint_viewed_at */ None,
+        )
+        .await
+        .extend()
     }
 
     /// The transaction blocks that exist in the network.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -377,6 +377,7 @@ impl TransactionBlockEffects {
         Checkpoint::query(
             ctx.data_unchecked(),
             CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()


### PR DESCRIPTION
## Description 

Add `checkpoint_viewed_at` to `Checkpoint` and its cursor for consistent pagination and querying. This is needed because `Checkpoint` has a resolve field for `TransactionBlock`s, which further resolve out to fields like `Address` which would need checkpoint sequence number context for consistency.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
