### PR TITLE
[gql][consistent-reads][12/n] Consistent reads for epochs

### DIFF
--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -15,9 +15,7 @@ use super::display::DisplayEntry;
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::{MoveObject, MoveObjectImpl};
 use super::move_value::MoveValue;
-use super::object::{
-    self, validate_cursor_consistency, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus,
-};
+use super::object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus};
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
@@ -305,7 +303,7 @@ impl Coin {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let response = db

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -10,9 +10,7 @@ use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
 use super::cursor::{Page, Target};
-use super::object::{
-    self, deserialize_move_struct, validate_cursor_consistency, Object, ObjectKind, ObjectLookupKey,
-};
+use super::object::{self, deserialize_move_struct, Object, ObjectKind, ObjectLookupKey};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
@@ -201,7 +199,7 @@ impl DynamicField {
         // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
         // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
         // paginated queries are consistent with the previous query that created the cursor.
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let Some(((prev, next, results), checkpoint_viewed_at)) = db

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use super::checkpoint::Checkpoint;
-use super::cursor::{self, Page, Paginated, Target};
+use super::cursor::{self, Checkpointed, Page, Paginated, Target};
 use super::digest::Digest;
 use super::type_filter::{ModuleFilter, TypeFilter};
 use super::{
@@ -157,7 +157,7 @@ impl Event {
         filter: EventFilter,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, Event>, Error> {
-        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
         let ((prev, next, results), checkpoint_viewed_at) = db
@@ -169,7 +169,7 @@ impl Event {
 
                 let result = page.paginate_query::<StoredEvent, _, _, _>(
                     conn,
-                    Some(checkpoint_viewed_at),
+                    checkpoint_viewed_at,
                     move || {
                         let mut query = events::dsl::events.into_boxed();
 
@@ -361,22 +361,8 @@ impl Target<Cursor> for StoredEvent {
     }
 }
 
-pub(crate) fn validate_cursor_consistency(
-    after: Option<&Cursor>,
-    before: Option<&Cursor>,
-) -> Result<Option<u64>, Error> {
-    match (after, before) {
-        (Some(after_cursor), Some(before_cursor)) => {
-            if after_cursor.checkpoint_viewed_at == before_cursor.checkpoint_viewed_at {
-                Ok(after_cursor.checkpoint_viewed_at)
-            } else {
-                Err(Error::Client(
-                    "Cursors are inconsistent and cannot be used together in the same query."
-                        .to_string(),
-                ))
-            }
-        }
-        (Some(cursor), None) | (None, Some(cursor)) => Ok(cursor.checkpoint_viewed_at),
-        (None, None) => Ok(None),
+impl Checkpointed for Cursor {
+    fn checkpoint_viewed_at(&self) -> Option<u64> {
+        self.checkpoint_viewed_at
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -227,7 +227,7 @@ impl Query {
 
     /// Fetch epoch information by ID (defaults to the latest epoch).
     async fn epoch(&self, ctx: &Context<'_>, id: Option<u64>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), id).await.extend()
+        Epoch::query(ctx.data_unchecked(), id, None).await.extend()
     }
 
     /// Fetch checkpoint information by sequence number or digest (defaults to the latest available

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -304,16 +304,24 @@ impl StakedSui {
 
     /// The epoch at which this stake became active.
     async fn activated_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native.activation_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.activation_epoch()),
+            self.super_.super_.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The epoch at which this object was requested to join a stake pool.
     async fn requested_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native.request_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.request_epoch()),
+            self.super_.super_.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The object id of the validator staking pool this stake belongs to.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -362,9 +362,13 @@ impl TransactionBlockEffects {
 
     /// The epoch this transaction was finalized in.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.native().executed_epoch()))
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native().executed_epoch()),
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// The checkpoint this transaction was finalized in.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -31,7 +31,8 @@ struct ActiveJwk(NativeActiveJwk);
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }
@@ -110,7 +111,8 @@ impl ActiveJwk {
 
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -32,7 +32,8 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -112,7 +112,8 @@ impl EndOfEpochTransaction {
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
             .await
             .extend()
     }
@@ -202,7 +203,8 @@ impl ChangeEpochTransaction {
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch))
+        // TODO (wlmyng)
+        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch), None)
             .await
             .extend()
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -47,7 +47,10 @@ impl From<NativeTransactionKind> for TransactionBlockKind {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
             }
             K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
-            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction(rsu)),
+            K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
+                native: rsu,
+                checkpoint_viewed_at: None, // TODO (wlmyng)
+            }),
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -6,30 +6,40 @@ use async_graphql::*;
 use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
 
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct RandomnessStateUpdateTransaction(pub NativeRandomnessStateUpdate);
+pub(crate) struct RandomnessStateUpdateTransaction {
+    pub native: NativeRandomnessStateUpdate,
+    /// The checkpoint sequence number at which this was viewed at, or None if the data was
+    /// requested at the latest checkpoint.
+    pub checkpoint_viewed_at: Option<u64>,
+}
 
 /// System transaction to update the source of on-chain randomness.
 #[Object]
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch))
-            .await
-            .extend()
+        // TODO (wlmyng)
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            self.checkpoint_viewed_at,
+        )
+        .await
+        .extend()
     }
 
     /// Randomness round of the update.
     async fn randomness_round(&self) -> u64 {
-        self.0.randomness_round
+        self.native.randomness_round
     }
 
     /// Updated random bytes, encoded as Base64.
     async fn random_bytes(&self) -> Base64 {
-        Base64::from(&self.0.random_bytes)
+        Base64::from(&self.native.random_bytes)
     }
 
     /// The initial version the randomness object was shared at.
     async fn randomness_obj_initial_shared_version(&self) -> u64 {
-        self.0.randomness_obj_initial_shared_version.value()
+        self.native.randomness_obj_initial_shared_version.value()
     }
 }


### PR DESCRIPTION
## Description 

Add context to `Epoch`. Note that some `TransactionBlockKind`s do resolve `Epoch`, so that will be coming in a follow-up.

There's a lot of duplicate `validate_cursor_consistency` functions - introduce new `Checkpointed` trait for retrieving `checkpoint_viewed_at`, and add an implementation on `Page` to do this check instead of in each type module.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
