### PR TITLE
[gql][consistent-reads][6/n] Implement consistent reads for dynamic fields

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.exp
@@ -1,0 +1,298 @@
+processed 13 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 14-58:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8474000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 60-60:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 62-62:
+Owner: Account Address ( A )
+Version: 2
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 4 'run'. lines 64-64:
+created: object(4,0), object(4,1), object(4,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 8664000,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'view-object'. lines 66-66:
+Owner: Account Address ( A )
+Version: 3
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 6 'run'. lines 68-68:
+created: object(6,0), object(6,1), object(6,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 8664000,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7 'view-object'. lines 70-70:
+Owner: Account Address ( A )
+Version: 4
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 8 'run'. lines 72-72:
+mutated: object(0,0), object(2,0)
+deleted: object(4,0), object(4,1), object(4,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 8577360, non_refundable_storage_fee: 86640
+
+task 9 'run'. lines 74-74:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 10 'create-checkpoint'. lines 76-76:
+Checkpoint created: 1
+
+task 11 'run-graphql'. lines 78-141:
+Response: {
+  "data": {
+    "latest": {
+      "version": 6,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IGaEnJFkb4uC7Mz4R/hQ5XxOfJruJFLH9LhUawdiONa/AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg=="
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IMTgp9iawa8gNOypennDFZzq+vZmCgF0PwlftltbXt6qAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ=="
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IM1L38bOw52duDmzwWvdfrmWYjQHc72VYa0GSnsCq4QhAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA=="
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      },
+      "df1": null,
+      "df5": {
+        "name": {
+          "bcs": "A2RmNQ=="
+        },
+        "value": {
+          "json": "df5"
+        }
+      }
+    },
+    "df123_removed": {
+      "version": 5,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IGaEnJFkb4uC7Mz4R/hQ5XxOfJruJFLH9LhUawdiONa/AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg=="
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IMTgp9iawa8gNOypennDFZzq+vZmCgF0PwlftltbXt6qAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ=="
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IM1L38bOw52duDmzwWvdfrmWYjQHc72VYa0GSnsCq4QhAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA=="
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      },
+      "df1": null,
+      "df5": {
+        "name": {
+          "bcs": "A2RmNQ=="
+        },
+        "value": {
+          "json": "df5"
+        }
+      }
+    },
+    "df456_added": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IGaEnJFkb4uC7Mz4R/hQ5XxOfJruJFLH9LhUawdiONa/AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg=="
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IHJtTVw6aBHb4Yr8eLBNubAuuzYGXMNXIWxoZ/5ltjIBAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg=="
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "ILmnQzXAC3sO4SUSxfvlRTP2P4zpYsdiF+yvk2QekLftAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw=="
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          },
+          {
+            "cursor": "IMTgp9iawa8gNOypennDFZzq+vZmCgF0PwlftltbXt6qAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ=="
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IM1L38bOw52duDmzwWvdfrmWYjQHc72VYa0GSnsCq4QhAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA=="
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          },
+          {
+            "cursor": "IOa7H1KrCE4B1Ot4RT/7+PxpS0rpdMnKZPzJpU2t0SWcAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ=="
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          }
+        ]
+      },
+      "df1": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1"
+        }
+      },
+      "df5": {
+        "name": {
+          "bcs": "A2RmNQ=="
+        },
+        "value": {
+          "json": "df5"
+        }
+      }
+    }
+  }
+}
+
+task 12 'run-graphql'. lines 143-181:
+Response: {
+  "data": {
+    "latest_owner": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IGaEnJFkb4uC7Mz4R/hQ5XxOfJruJFLH9LhUawdiONa/AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg=="
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IMTgp9iawa8gNOypennDFZzq+vZmCgF0PwlftltbXt6qAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ=="
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IM1L38bOw52duDmzwWvdfrmWYjQHc72VYa0GSnsCq4QhAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA=="
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      },
+      "df1": null,
+      "df5": {
+        "name": {
+          "bcs": "A2RmNQ=="
+        },
+        "value": {
+          "json": "df5"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// version | status
+// --------|--------
+// 2       | created
+// 3       | added df1, df2, df3
+// 4       | added df4, df5, df6
+// 5       | removed df1, df2, df3
+// 6       | mutated parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_field as field;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use std::string::{String, utf8};
+
+    struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun mutate_parent(parent: &mut Parent) {
+        parent.count = parent.count + 42;
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<String, String>(id, utf8(b"df1"), utf8(b"df1"));
+        field::add<String, String>(id, utf8(b"df2"), utf8(b"df2"));
+        field::add<String, String>(id, utf8(b"df3"), utf8(b"df3"));
+    }
+
+    public entry fun remove_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::remove<String, String>(id, utf8(b"df1"));
+        field::remove<String, String>(id, utf8(b"df2"));
+        field::remove<String, String>(id, utf8(b"df3"));
+    }
+
+    public entry fun add_more_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<String, String>(id, utf8(b"df4"), utf8(b"df4"));
+        field::add<String, String>(id, utf8(b"df5"), utf8(b"df5"));
+        field::add<String, String>(id, utf8(b"df6"), utf8(b"df6"));
+    }
+}
+
+//# run Test::M1::parent --sender A --args @A
+
+//# view-object 2,0
+
+//# run Test::M1::add_df --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# run Test::M1::add_more_df --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# run Test::M1::remove_df --sender A --args object(2,0)
+
+//# run Test::M1::mutate_parent --sender A --args object(2,0)
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_0}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    df1: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+    df5: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmNQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  df123_removed: object(address: "@{obj_2_0}", version: 5) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    df1: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+    df5: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmNQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  df456_added: object(address: "@{obj_2_0}", version: 4) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    df1: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+    df5: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmNQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest_owner: owner(address: "@{obj_2_0}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    df1: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+    df5: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmNQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.exp
@@ -1,0 +1,219 @@
+processed 13 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 14-61:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7949600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 63-65:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 67-67:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'run'. lines 69-69:
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'create-checkpoint'. lines 71-71:
+Checkpoint created: 1
+
+task 6 'run-graphql'. lines 73-130:
+Response: {
+  "data": {
+    "latest": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "INdePH0mgYyKiKKTMQKXLB23QhffGfEJ5WOO1Q2f3LMkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "INdePH0mgYyKiKKTMQKXLB23QhffGfEJ5WOO1Q2f3LMkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "dof_added": {
+      "version": 3,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "before_dof_added": {
+      "version": 2,
+      "dynamicObjectField": null
+    }
+  }
+}
+
+task 7 'run'. lines 132-132:
+mutated: object(0,0), object(2,1)
+deleted: object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 8 'create-checkpoint'. lines 134-134:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 136-187:
+Response: {
+  "data": {
+    "latest": {
+      "version": 5,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "owner_view": {
+      "version": 5,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "before_delete_dof": {
+      "version": 4,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+task 10 'run'. lines 189-189:
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 11 'create-checkpoint'. lines 191-191:
+Checkpoint created: 3
+
+task 12 'run-graphql'. lines 193-256:
+Response: {
+  "data": {
+    "latest": {
+      "version": 6,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "owner_view": {
+      "version": 6,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "parent_version_6": {
+      "version": 6,
+      "dynamicObjectField": null
+    },
+    "parent_version_5": {
+      "version": 5,
+      "dynamicObjectField": null
+    },
+    "parent_version_4": {
+      "version": 4,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0xcc3f79badbde910cc6c1c31c8188ed5d1e29e1f55c24ec394cc8653f7ce51cf2",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
@@ -1,0 +1,256 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 3             | mutated parent
+// 5              |               | deleted child
+// 6              |               | mutated parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun mutate_parent(parent: &mut Parent) {
+        parent.count = parent.count + 42;
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun delete_child(parent: &mut Parent, name: u64) {
+        let Child { id, count: _ } = reclaim_child(parent, name);
+        object::delete(id);
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# run Test::M1::mutate_parent --sender A --args object(2,1)
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  dof_added: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_dof_added: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::delete_child --sender A --args object(2,1) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_delete_dof: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::mutate_parent --sender A --args object(2,1)
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_6: object(address: "@{obj_2_1}", version: 6) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_5: object(address: "@{obj_2_1}", version: 5) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.exp
@@ -1,0 +1,986 @@
+processed 34 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 12-85:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 11012400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 87-89:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3549200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 91-91:
+Owner: Account Address ( A )
+Version: 2
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}}
+
+task 4 'view-object'. lines 93-93:
+Owner: Account Address ( A )
+Version: 2
+Contents: Test::M1::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 5 'programmable'. lines 95-97:
+created: object(5,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6004000,  storage_rebate: 3513708, non_refundable_storage_fee: 35492
+
+task 6 'view-object'. lines 99-99:
+Owner: Account Address ( A )
+Version: 3
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}}
+
+task 7 'view-object'. lines 101-101:
+Owner: Object ID: ( fake(5,0) )
+Version: 3
+Contents: Test::M1::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 1u64}
+
+task 8 'create-checkpoint'. lines 103-103:
+Checkpoint created: 1
+
+task 9 'run-graphql'. lines 105-191:
+Response: {
+  "data": {
+    "parent_version_2_no_dof": {
+      "address": "0x25418846f7ffe5ee3bb2de5a600ee742d016159f0ecc9c24c88a4a17ad448dc3",
+      "dynamicFields": {
+        "edges": []
+      }
+    },
+    "parent_version_3_has_dof": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "child_dof_state_consistent": {
+        "value": {
+          "address": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+          "owner": {
+            "parent": {
+              "dynamicFields": {
+                "edges": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "child_version_2_no_parent": {
+      "address": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+      "owner": {}
+    },
+    "child_version_3_has_parent": {
+      "owner": {
+        "parent": {
+          "address": "0x474cb5cb10c38c5bd72f7e87a0dc4b4dd109440a17ec5ada98081c9a6a392383"
+        }
+      }
+    }
+  }
+}
+
+task 10 'programmable'. lines 193-195:
+created: object(10,0), object(10,1), object(10,2)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 9910400,  storage_rebate: 3513708, non_refundable_storage_fee: 35492
+
+task 11 'view-object'. lines 197-197:
+Owner: Account Address ( A )
+Version: 4
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}}
+
+task 12 'view-object'. lines 199-199:
+Owner: Object ID: ( fake(5,0) )
+Version: 4
+Contents: Test::M1::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 2u64}
+
+task 13 'create-checkpoint'. lines 201-201:
+Checkpoint created: 2
+
+task 14 'run-graphql'. lines 203-263:
+Response: {
+  "data": {
+    "parent_version_4_show_dof_and_dfs": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IEQIaFkdx7vqo7e+tEQHg2K3Nos2jyEMWQz39kFyRIdQAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_3_only_dof": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "use_dof_version_3_cursor_at_parent_version_4": {
+      "dynamicFields": {
+        "edges": []
+      }
+    },
+    "use_dof_version_4_cursor_at_parent_version_4": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "use_dof_version_3_cursor_at_parent_version_3": {
+      "dynamicFields": {
+        "edges": []
+      }
+    },
+    "use_dof_version_4_cursor_at_version_3": {
+      "dynamicFields": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 265-302:
+Response: {
+  "data": {
+    "parent_version_3": {
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "pAEAAAAAAAA=",
+          "type": {
+            "repr": "u64"
+          }
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+              "count": "1"
+            }
+          }
+        }
+      },
+      "dfNotAvailableYet": null
+    },
+    "parent_version_4": {
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "pAEAAAAAAAA=",
+          "type": {
+            "repr": "u64"
+          }
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+              "count": "1"
+            }
+          }
+        }
+      },
+      "dfAddedHere": {
+        "name": {
+          "bcs": "A2RmMQ==",
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+          }
+        },
+        "value": {
+          "json": "df1"
+        }
+      }
+    }
+  }
+}
+
+task 16 'programmable'. lines 305-306:
+created: object(16,0), object(16,1), object(16,2)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 8603200,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+
+task 17 'view-object'. lines 308-308:
+Owner: Account Address ( A )
+Version: 5
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}}
+
+task 18 'view-object'. lines 310-310:
+Owner: Object ID: ( fake(5,0) )
+Version: 4
+Contents: Test::M1::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 2u64}
+
+task 19 'create-checkpoint'. lines 312-312:
+Checkpoint created: 3
+
+task 20 'run-graphql'. lines 314-364:
+Response: {
+  "data": {
+    "parent_version_4_has_4_children": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IEQIaFkdx7vqo7e+tEQHg2K3Nos2jyEMWQz39kFyRIdQAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_4_paginated_on_dof_consistent": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_5_has_7_children": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "ID6P1eZZLHfFNjRyoLXEZ9B+t9XRi1Rd3Kmw1k4xndi8AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IEQIaFkdx7vqo7e+tEQHg2K3Nos2jyEMWQz39kFyRIdQAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_5_paginated_on_dof_consistent": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 21 'programmable'. lines 366-367:
+mutated: object(0,0), object(2,1)
+deleted: object(10,0), object(10,1), object(10,2)
+gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 8517168, non_refundable_storage_fee: 86032
+
+task 22 'view-object'. lines 369-369:
+Owner: Account Address ( A )
+Version: 6
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}}
+
+task 23 'view-object'. lines 371-371:
+Owner: Object ID: ( fake(5,0) )
+Version: 4
+Contents: Test::M1::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 2u64}
+
+task 24 'create-checkpoint'. lines 373-373:
+Checkpoint created: 4
+
+task 25 'run-graphql'. lines 375-425:
+Response: {
+  "data": {
+    "parent_version_4_has_df1_2_3": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IEQIaFkdx7vqo7e+tEQHg2K3Nos2jyEMWQz39kFyRIdQBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1BAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_4_paginated_on_dof_consistent": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IF2pqGcLv056m9dwzboKmSsrIw4m56KqTv0XefkEBuDgAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          },
+          {
+            "cursor": "IKfuuYBZoFmZiJgOfJccjObQ0g/NGr3ChZwNFH48cqW1AgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_6_no_df_1_2_3": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "ID6P1eZZLHfFNjRyoLXEZ9B+t9XRi1Rd3Kmw1k4xndi8BAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5fab7f2559f39354da23e6e963cf4e65f3720e1bd6d38730fc1d5f49a554a198",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99BAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_6_paginated_no_df_1_2_3": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99BAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 26 'run-graphql'. lines 427-458:
+Response: {
+  "data": {
+    "parent_version_4": {
+      "dfAtParentVersion4": {
+        "name": {
+          "bcs": "A2RmMQ==",
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+          }
+        },
+        "value": {
+          "json": "df1"
+        }
+      }
+    },
+    "parent_version_6": {
+      "dfAtParentVersion6": null
+    }
+  }
+}
+
+task 28 'create-checkpoint'. lines 462-462:
+Checkpoint created: 5
+
+task 30 'create-checkpoint'. lines 466-466:
+Checkpoint created: 6
+
+task 31 'force-object-snapshot-catchup'. lines 468-468:
+Objects snapshot updated to [0 to 5)
+
+task 32 'run-graphql'. lines 470-520:
+Response: {
+  "data": {
+    "parent_version_4_outside_consistent_range": null,
+    "parent_version_4_paginated_outside_consistent_range": null,
+    "parent_version_6_no_df_1_2_3": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "ID6P1eZZLHfFNjRyoLXEZ9B+t9XRi1Rd3Kmw1k4xndi8BgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNg==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df6"
+              }
+            }
+          },
+          {
+            "cursor": "IEdMtcsQw4xb1y9+h6DcS03RCUQKF+xa2pgIHJpqOSODBgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "pAEAAAAAAAA=",
+                "type": {
+                  "repr": "u64"
+                }
+              },
+              "value": null
+            }
+          },
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWBgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99BgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "parent_version_6_paginated_no_df_1_2_3": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IErIWASFvZ2bKCntxuOmGUX7pkmR8Ee9E3CBzHBrfLSWBAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNQ==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df5"
+              }
+            }
+          },
+          {
+            "cursor": "IJGnxMEs3n6Z9TGcRWP31gf/psqDyX7Ol9VYDGaRCr99BAAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmNA==",
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000001::string::String"
+                }
+              },
+              "value": {
+                "json": "df4"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 33 'run-graphql'. lines 522-553:
+Response: {
+  "data": {
+    "parent_version_4": null,
+    "parent_version_6": {
+      "dfAtParentVersion6": null
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
@@ -1,0 +1,553 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// chkpt1: create parent and child @ version 2
+// chkpt1: add dof to parent @ version 3
+// chkpt2: PTB(mutate dof, add df1, 2, 3) - parent and dof @ version 4
+// chkpt3: add df4, 5, 6 parent @ version 5, child @ version 4
+// chkpt4: remove df1, df2, df3 parent @ version 6, child @ version 4
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::dynamic_field as field;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use std::string::{String, utf8};
+
+    struct Parent has key, store {
+        id: UID,
+    }
+
+    struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx) },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun mutate_child(child: &mut Child) {
+        child.count = child.count + 1;
+    }
+
+    public fun mutate_child_via_parent(parent: &mut Parent, name: u64) {
+        mutate_child(ofield::borrow_mut(&mut parent.id, name))
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun delete_child(parent: &mut Parent, name: u64) {
+        let Child { id, count: _ } = reclaim_child(parent, name);
+        object::delete(id);
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<String, String>(id, utf8(b"df1"), utf8(b"df1"));
+        field::add<String, String>(id, utf8(b"df2"), utf8(b"df2"));
+        field::add<String, String>(id, utf8(b"df3"), utf8(b"df3"));
+    }
+
+    public entry fun remove_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::remove<String, String>(id, utf8(b"df1"));
+        field::remove<String, String>(id, utf8(b"df2"));
+        field::remove<String, String>(id, utf8(b"df3"));
+    }
+
+    public entry fun add_more_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<String, String>(id, utf8(b"df4"), utf8(b"df4"));
+        field::add<String, String>(id, utf8(b"df5"), utf8(b"df5"));
+        field::add<String, String>(id, utf8(b"df6"), utf8(b"df6"));
+    }
+}
+
+//# programmable --sender A --inputs @A 42
+//> 0: Test::M1::parent(Input(0));
+//> 1: Test::M1::child(Input(0));
+
+//# view-object 2,1
+
+//# view-object 2,0
+
+//# programmable --sender A --inputs object(2,1) object(2,0) 420
+//> Test::M1::add_child(Input(0), Input(1), Input(2));
+//> Test::M1::mutate_child_via_parent(Input(0), Input(2));
+
+//# view-object 2,1
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+fragment ParentSelect on Parent {
+  parent {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+}
+
+{
+  parent_version_2_no_dof: object(address: "@{obj_2_1}", version: 2) {
+    address
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_3_has_dof: object(address: "@{obj_2_1}", version: 3) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    child_dof_state_consistent: dynamicObjectField(name: {type: "u64", bcs: "pAEAAAAAAAA="}) {
+      value {
+        ... on MoveObject {
+          address
+          # When we look up a dynamic object field, the object retrieved is the `Field<Wrapper<K>,
+          # V>` which points to the expected parent object. To resolve the value of this dynamic
+          # object field, we look up the wrapped object(?) for the actual contents of the dynamic
+          # field. This move object will have its parent pointed to the wrapper, not the actual
+          # parent object.
+          owner {
+            ... on Parent {
+              ...ParentSelect
+            }
+          }
+        }
+      }
+    }
+  }
+  child_version_2_no_parent: object(address: "@{obj_2_0}", version: 2) {
+    address
+    owner {
+      ... on Parent {
+        parent {
+          address
+        }
+      }
+    }
+  }
+  # Likewise, the following error is expected
+  child_version_3_has_parent: object(address: "@{obj_2_0}", version: 3) {
+    owner {
+      ... on Parent {
+        parent {
+          address
+        }
+      }
+    }
+  }
+}
+
+//# programmable --sender A --inputs object(2,1) 420
+//> Test::M1::mutate_child_via_parent(Input(0), Input(1));
+//> Test::M1::add_df(Input(0));
+
+//# view-object 2,1
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_5_0,1} @{obj_5_0,2}
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  parent_version_4_show_dof_and_dfs: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_3_only_dof: object(address: "@{obj_2_1}", version: 3) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  use_dof_version_3_cursor_at_parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields(after: "@{cursor_0}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  use_dof_version_4_cursor_at_parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields(after: "@{cursor_1}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  use_dof_version_3_cursor_at_parent_version_3: object(address: "@{obj_2_1}", version: 3) {
+    dynamicFields(after: "@{cursor_0}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  use_dof_version_4_cursor_at_version_3: object(address: "@{obj_2_1}", version: 3) {
+    dynamicFields(after: "@{cursor_1}") {
+      ...DynamicFieldsSelect
+    }
+  }
+}
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+{
+  parent_version_3: object(address: "@{obj_2_1}", version: 3) {
+    dynamicObjectField(name: {type: "u64", bcs: "pAEAAAAAAAA="}) {
+      ...DynamicFieldSelect
+    }
+    dfNotAvailableYet: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+  parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    dynamicObjectField(name: {type: "u64", bcs: "pAEAAAAAAAA="}) {
+      ...DynamicFieldSelect
+    }
+    dfAddedHere: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+
+//# programmable --sender A --inputs object(2,1)
+//> Test::M1::add_more_df(Input(0));
+
+//# view-object 2,1
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,3}
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  parent_version_4_has_4_children: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_4_paginated_on_dof_consistent: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields(after: "@{cursor_0}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_5_has_7_children: object(address: "@{obj_2_1}", version: 5) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_5_paginated_on_dof_consistent: object(address: "@{obj_2_1}", version: 5) {
+    dynamicFields(after: "@{cursor_1}") {
+      ...DynamicFieldsSelect
+    }
+  }
+}
+
+//# programmable --sender A --inputs object(2,1) 420
+//> Test::M1::remove_df(Input(0));
+
+//# view-object 2,1
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  parent_version_4_has_df1_2_3: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_4_paginated_on_dof_consistent: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields(after: "@{cursor_0}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_6_no_df_1_2_3: object(address: "@{obj_2_1}", version: 6) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_6_paginated_no_df_1_2_3: object(address: "@{obj_2_1}", version: 6) {
+    dynamicFields(after: "@{cursor_1}") {
+      ...DynamicFieldsSelect
+    }
+  }
+}
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+{
+  parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    dfAtParentVersion4: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+  parent_version_6: object(address: "@{obj_2_1}", version: 6) {
+    dfAtParentVersion6: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# force-object-snapshot-catchup --start-cp 0 --end-cp 5
+
+//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  parent_version_4_outside_consistent_range: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_4_paginated_outside_consistent_range: object(address: "@{obj_2_1}", version: 4) {
+    dynamicFields(after: "@{cursor_0}") {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_6_no_df_1_2_3: object(address: "@{obj_2_1}", version: 6) {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+  }
+  parent_version_6_paginated_no_df_1_2_3: object(address: "@{obj_2_1}", version: 6) {
+    dynamicFields(after: "@{cursor_1}") {
+      ...DynamicFieldsSelect
+    }
+  }
+}
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+    type {
+      repr
+    }
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+{
+  parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    dfAtParentVersion4_outside_range: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+  parent_version_6: object(address: "@{obj_2_1}", version: 6) {
+    dfAtParentVersion6: dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+      ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.exp
@@ -1,0 +1,212 @@
+processed 17 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 14-48:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7828000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 50-50:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 52-52:
+Owner: Account Address ( A )
+Version: 2
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 4 'run'. lines 54-54:
+created: object(4,0), object(4,1), object(4,2)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 8664000,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'view-object'. lines 56-56:
+Owner: Account Address ( A )
+Version: 3
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 0u64}
+
+task 6 'run'. lines 58-58:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7 'view-object'. lines 60-60:
+Owner: Account Address ( A )
+Version: 4
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 42u64}
+
+task 8 'create-checkpoint'. lines 62-62:
+Checkpoint created: 1
+
+task 9 'run-graphql'. lines 64-112:
+Response: {
+  "data": {
+    "latest": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IAUAKOjfsm7M/R74AGg6BPxCyjeHgCN8OgJ2ZisROpe5AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg=="
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IBsWjE47qNcKcyOZvULWtjv0kLPiSGSzZk+KCFla6hdBAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw=="
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          },
+          {
+            "cursor": "IEQYIaQIVRMxJxs8T1+NIi42cSakAFSV+Qt0/xtlVEIRAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ=="
+              },
+              "value": {
+                "json": "df1"
+              }
+            }
+          }
+        ]
+      },
+      "dynamicField": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1"
+        }
+      }
+    },
+    "df_added": {
+      "version": 3,
+      "dynamicField": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1"
+        }
+      }
+    },
+    "before_df_added": {
+      "version": 2,
+      "dynamicField": null
+    }
+  }
+}
+
+task 10 'view-object'. lines 114-114:
+Owner: Account Address ( A )
+Version: 4
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 42u64}
+
+task 11 'run'. lines 116-116:
+mutated: object(0,0), object(2,0), object(4,2)
+gas summary: computation_cost: 1000000, storage_cost: 4484000,  storage_rebate: 4378968, non_refundable_storage_fee: 44232
+
+task 12 'view-object'. lines 118-118:
+Owner: Account Address ( A )
+Version: 5
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 42u64}
+
+task 13 'run'. lines 120-120:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 14 'view-object'. lines 122-122:
+Owner: Account Address ( A )
+Version: 6
+Contents: Test::M1::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, count: 84u64}
+
+task 15 'create-checkpoint'. lines 124-124:
+Checkpoint created: 2
+
+task 16 'run-graphql'. lines 126-174:
+Response: {
+  "data": {
+    "latest": {
+      "version": 6,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IAUAKOjfsm7M/R74AGg6BPxCyjeHgCN8OgJ2ZisROpe5AgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMg=="
+              },
+              "value": {
+                "json": "df2"
+              }
+            }
+          },
+          {
+            "cursor": "IBsWjE47qNcKcyOZvULWtjv0kLPiSGSzZk+KCFla6hdBAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMw=="
+              },
+              "value": {
+                "json": "df3"
+              }
+            }
+          },
+          {
+            "cursor": "IEQYIaQIVRMxJxs8T1+NIi42cSakAFSV+Qt0/xtlVEIRAgAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "A2RmMQ=="
+              },
+              "value": {
+                "json": "df1_mutated"
+              }
+            }
+          }
+        ]
+      },
+      "dynamicField": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1_mutated"
+        }
+      }
+    },
+    "df1_mutated": {
+      "version": 5,
+      "dynamicField": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1_mutated"
+        }
+      }
+    },
+    "before_df1_mutated": {
+      "version": 4,
+      "dynamicField": {
+        "name": {
+          "bcs": "A2RmMQ=="
+        },
+        "value": {
+          "json": "df1"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// version | status
+// --------|--------
+// 2       | created
+// 3       | added df1, df2, df3
+// 4       | mutated parent
+// 5       | mutated df1
+// 6       | mutated parent again
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_field as field;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    use std::string::{String, utf8};
+
+    struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun mutate_parent(parent: &mut Parent) {
+        parent.count = parent.count + 42;
+    }
+
+    public entry fun add_df(obj: &mut Parent) {
+        let id = &mut obj.id;
+        field::add<String, String>(id, utf8(b"df1"), utf8(b"df1"));
+        field::add<String, String>(id, utf8(b"df2"), utf8(b"df2"));
+        field::add<String, String>(id, utf8(b"df3"), utf8(b"df3"));
+    }
+
+    public entry fun mutate_df1(parent: &mut Parent) {
+        *field::borrow_mut(&mut parent.id, utf8(b"df1")) = utf8(b"df1_mutated");
+    }
+}
+
+//# run Test::M1::parent --sender A --args @A
+
+//# view-object 2,0
+
+//# run Test::M1::add_df --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# run Test::M1::mutate_parent --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_0}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  df_added: object(address: "@{obj_2_0}", version: 3) {
+    version
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_df_added: object(address: "@{obj_2_0}", version: 2) {
+    version
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# view-object 2,0
+
+//# run Test::M1::mutate_df1 --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# run Test::M1::mutate_parent --sender A --args object(2,0)
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_0}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  df1_mutated: object(address: "@{obj_2_0}", version: 5) {
+    version
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_df1_mutated: object(address: "@{obj_2_0}", version: 4) {
+    version
+    dynamicField(name: {type: "0x0000000000000000000000000000000000000000000000000000000000000001::string::String", bcs: "A2RmMQ=="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.exp
@@ -1,0 +1,279 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 15-65:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 8390400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 67-69:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 71-71:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'run'. lines 73-73:
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 5 'create-checkpoint'. lines 75-75:
+Checkpoint created: 1
+
+task 6 'run-graphql'. lines 77-134:
+Response: {
+  "data": {
+    "latest": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IENG08+K/pD0xqxmvJ+2UgkHKwV5Ja2YdF8JEUE/P+G4AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IENG08+K/pD0xqxmvJ+2UgkHKwV5Ja2YdF8JEUE/P+G4AQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "dof_added": {
+      "version": 3,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "before_dof_added": {
+      "version": 2,
+      "dynamicObjectField": null
+    }
+  }
+}
+
+task 7 'run'. lines 136-136:
+mutated: object(0,0), object(2,0), object(2,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 8 'create-checkpoint'. lines 138-138:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 140-191:
+Response: {
+  "data": {
+    "latest": {
+      "version": 5,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "owner_view": {
+      "version": 5,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "before_reclaim_dof": {
+      "version": 4,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+task 10 'run'. lines 193-193:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 11 'run'. lines 195-195:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 12 'create-checkpoint'. lines 197-197:
+Checkpoint created: 3
+
+task 13 'run-graphql'. lines 199-262:
+Response: {
+  "data": {
+    "latest": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IENG08+K/pD0xqxmvJ+2UgkHKwV5Ja2YdF8JEUE/P+G4AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "1"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IENG08+K/pD0xqxmvJ+2UgkHKwV5Ja2YdF8JEUE/P+G4AwAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+                    "count": "1"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "1"
+            }
+          }
+        }
+      }
+    },
+    "parent_version_6": null,
+    "parent_version_5": {
+      "version": 5,
+      "dynamicObjectField": null
+    },
+    "parent_version_4": {
+      "version": 4,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x43e47bdf3ddfb63059ac0a7999e8958f97e753efdca27796d1656778ef168d2d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
@@ -1,0 +1,262 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 3             | mutated parent
+// 5              | 5             | reclaimed child from parent
+// 5              | 6             | mutated child
+// 7              | 7             | add child back to parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun mutate_parent(parent: &mut Parent) {
+        parent.count = parent.count + 42;
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun mutate_child(child: &mut Child) {
+        child.count = child.count + 1;
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        transfer::public_transfer(reclaim_child(parent, name), recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# run Test::M1::mutate_parent --sender A --args object(2,1)
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  dof_added: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_dof_added: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,1) 42 @A
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_reclaim_dof: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::mutate_child --sender A --args object(2,0)
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_6: object(address: "@{obj_2_1}", version: 6) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_5: object(address: "@{obj_2_1}", version: 5) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  parent_version_4: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -241,7 +241,7 @@ impl Coin {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_field(ctx, name)
+            .dynamic_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -258,7 +258,7 @@ impl Coin {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_object_field(ctx, name)
+            .dynamic_object_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -275,7 +275,14 @@ impl Coin {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_fields(ctx, first, after, last, before)
+            .dynamic_fields(
+                ctx,
+                first,
+                after,
+                last,
+                before,
+                Some(self.super_.super_.version_impl()),
+            )
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -229,7 +229,7 @@ impl CoinMetadata {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_field(ctx, name)
+            .dynamic_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -246,7 +246,7 @@ impl CoinMetadata {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_object_field(ctx, name)
+            .dynamic_object_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -263,7 +263,14 @@ impl CoinMetadata {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_fields(ctx, first, after, last, before)
+            .dynamic_fields(
+                ctx,
+                first,
+                after,
+                last,
+                before,
+                Some(self.super_.super_.version_impl()),
+            )
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -3,27 +3,29 @@
 
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
-use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use move_core_types::annotated_value::{self as A, MoveStruct};
-use sui_indexer::models_v2::objects::StoredObject;
-use sui_indexer::schema_v2::objects;
-use sui_indexer::types_v2::OwnerType;
+use sui_indexer::models_v2::objects::StoredHistoryObject;
+use sui_indexer::types_v2::{ObjectStatus, OwnerType};
 use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
+use super::checkpoint::Checkpoint;
 use super::cursor::{Page, Target};
-use super::object::{self, deserialize_move_struct, ObjectLookupKey};
+use super::object::{
+    self, deserialize_move_struct, validate_cursor_consistency, Object, ObjectKind, ObjectLookupKey,
+};
 use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
 use crate::context_data::package_cache::PackageCache;
-use crate::data::{Db, DbConnection, QueryExecutor};
+use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
-use sui_types::object::Object as NativeObject;
+use crate::raw_query::RawQuery;
+use crate::{filter, query};
 
 pub(crate) struct DynamicField {
-    pub stored: StoredObject,
+    pub super_: MoveObject,
     pub df_object_id: SuiAddress,
     pub df_kind: DynamicFieldType,
 }
@@ -62,15 +64,8 @@ impl DynamicField {
             .data()
             .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
             .extend()?;
-        let native_object: NativeObject = bcs::from_bytes(&self.stored.serialized_object)
-            .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?;
-        let move_object = native_object
-            .data
-            .try_as_move()
-            .ok_or_else(|| Error::Internal("Failed to convert object into MoveObject".to_string()))
-            .extend()?;
 
-        let (struct_tag, move_struct) = deserialize_move_struct(move_object, resolver)
+        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
             .await
             .extend()?;
 
@@ -106,10 +101,18 @@ impl DynamicField {
     /// in which case it is also accessible off-chain via its address.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         if self.df_kind == DynamicFieldType::DynamicObject {
+            // If `df_kind` is a DynamicObject, the object we are currently on is the field object,
+            // and we must resolve one more level down to the value object. Becuase we only have
+            // checkpoint-level granularity, we may end up reading a later version of the value
+            // object. Thus, we use the version of the field object to bound the value object at the
+            // correct version.
             let obj = MoveObject::query(
                 ctx.data_unchecked(),
                 self.df_object_id,
-                ObjectLookupKey::Latest,
+                ObjectLookupKey::LatestAtParentVersion {
+                    version: self.super_.super_.version_impl(),
+                    checkpoint_viewed_at: self.super_.super_.checkpoint_viewed_at,
+                },
             )
             .await
             .extend()?;
@@ -119,17 +122,8 @@ impl DynamicField {
                 .data()
                 .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
                 .extend()?;
-            let native_object: NativeObject = bcs::from_bytes(&self.stored.serialized_object)
-                .map_err(|e| Error::Internal(format!("Failed to deserialize object: {e}")))?;
-            let move_object = native_object
-                .data
-                .try_as_move()
-                .ok_or_else(|| {
-                    Error::Internal("Failed to convert object into MoveObject".to_string())
-                })
-                .extend()?;
 
-            let (struct_tag, move_struct) = deserialize_move_struct(move_object, resolver)
+            let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
                 .await
                 .extend()?;
 
@@ -155,15 +149,18 @@ impl DynamicField {
 
 impl DynamicField {
     /// Fetch a single dynamic field entry from the `db`, on `parent` object, with field name
-    /// `name`, and kind `kind` (dynamic field or dynamic object field).
+    /// `name`, and kind `kind` (dynamic field or dynamic object field). The dynamic field is bound
+    /// by the `parent_version` if provided - the fetched field will be the latest version at or
+    /// before the provided version. If `parent_version` is not provided, the latest version of the
+    /// field is returned as bounded by the `checkpoint_viewed_at` parameter.
     pub(crate) async fn query(
         db: &Db,
         parent: SuiAddress,
+        parent_version: Option<u64>,
         name: DynamicFieldName,
         kind: DynamicFieldType,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<DynamicField>, Error> {
-        use objects::dsl;
-
         let type_ = match kind {
             DynamicFieldType::DynamicField => name.type_.0,
             DynamicFieldType::DynamicObject => {
@@ -172,66 +169,125 @@ impl DynamicField {
         };
 
         let field_id = derive_dynamic_field_id(parent, &type_, &name.bcs.0)
-            .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?
-            .to_vec();
+            .map_err(|e| Error::Internal(format!("Failed to derive dynamic field id: {e}")))?;
 
-        let stored: Option<StoredObject> = db
-            .execute(move |conn| {
-                conn.first(move || dsl::objects.filter(dsl::object_id.eq(field_id.clone())))
-                    .optional()
-            })
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to fetch object: {e}")))?;
+        use ObjectLookupKey as K;
+        let key = match (parent_version, checkpoint_viewed_at) {
+            (None, None) => K::Latest,
+            (None, Some(checkpoint_viewed_at)) => K::LatestAt(checkpoint_viewed_at),
+            (Some(version), checkpoint_viewed_at) => K::LatestAtParentVersion {
+                version,
+                checkpoint_viewed_at,
+            },
+        };
 
-        stored.map(Self::try_from).transpose()
+        let super_ = MoveObject::query(db, SuiAddress::from(field_id), key).await?;
+
+        super_.map(Self::try_from).transpose()
     }
 
-    /// Query the `db` for a `page` of dynamic fields attached to object with ID `parent`.
+    /// Query the `db` for a `page` of dynamic fields attached to object with ID `parent`. The
+    /// returned dynamic fields are bound by the `parent_version` if provided - each field will be
+    /// the latest version at or before the provided version. If `parent_version` is not provided,
+    /// the latest version of each field is returned as bounded by the `checkpoint_viewed-at`
+    /// parameter.`
     pub(crate) async fn paginate(
         db: &Db,
         page: Page<object::Cursor>,
         parent: SuiAddress,
+        parent_version: Option<u64>,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Connection<String, DynamicField>, Error> {
-        let (prev, next, results) = db
-            .execute(move |conn| {
-                page.paginate_query::<StoredObject, _, _, _>(conn, move || {
-                    use objects::dsl;
-                    dsl::objects
-                        .filter(dsl::owner_id.eq(parent.into_vec()))
-                        .filter(dsl::owner_type.eq(OwnerType::Object as i16))
-                        .filter(dsl::df_kind.is_not_null())
-                        .into_boxed()
-                })
-            })
-            .await?;
+        // If cursors are provided, defer to the `checkpoint_viewed_at` in the cursor if they are
+        // consistent. Otherwise, use the value from the parameter, or set to None. This is so that
+        // paginated queries are consistent with the previous query that created the cursor.
+        let cursor_viewed_at = validate_cursor_consistency(page.after(), page.before())?;
+        let checkpoint_viewed_at: Option<u64> = cursor_viewed_at.or(checkpoint_viewed_at);
 
-        let mut conn = Connection::new(prev, next);
+        let Some(((prev, next, results), checkpoint_viewed_at)) = db
+            .execute_repeatable(move |conn| {
+                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+                        return Ok::<_, diesel::result::Error>(None);
+                    }
+                    rhs = checkpoint_viewed_at;
+                }
+
+                let result = page.paginate_raw_query::<StoredHistoryObject>(
+                    conn,
+                    rhs,
+                    dynamic_fields_query(parent, parent_version, lhs as i64, rhs as i64),
+                )?;
+
+                Ok(Some((result, rhs)))
+            })
+            .await?
+        else {
+            return Err(Error::Client(
+                "Requested data is outside the available range".to_string(),
+            ));
+        };
+
+        let mut conn: Connection<String, DynamicField> = Connection::new(prev, next);
 
         for stored in results {
-            let cursor = stored.cursor().encode_cursor();
-            let field = DynamicField::try_from(stored)?;
-            conn.edges.push(Edge::new(cursor, field));
+            // To maintain consistency, the returned cursor should have the same upper-bound as the
+            // checkpoint found on the cursor.
+            let cursor = stored
+                .consistent_cursor(checkpoint_viewed_at)
+                .encode_cursor();
+
+            let object =
+                Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
+
+            let move_ = MoveObject::try_from(&object).map_err(|_| {
+                Error::Internal(format!(
+                    "Failed to deserialize as Move object: {}",
+                    object.address
+                ))
+            })?;
+
+            let dynamic_field = DynamicField::try_from(move_)?;
+
+            conn.edges.push(Edge::new(cursor, dynamic_field));
         }
 
         Ok(conn)
     }
 }
 
-impl TryFrom<StoredObject> for DynamicField {
+impl TryFrom<MoveObject> for DynamicField {
     type Error = Error;
 
-    fn try_from(stored: StoredObject) -> Result<Self, Error> {
-        let Some(df_object_id) = stored.df_object_id.as_ref() else {
-            return Err(Error::Internal(
-                "Object is not a dynamic field.".to_string(),
-            ));
+    fn try_from(stored: MoveObject) -> Result<Self, Error> {
+        let super_ = &stored.super_;
+
+        let (df_object_id, df_kind) = match &super_.kind {
+            ObjectKind::Live(_, stored) => stored
+                .df_object_id
+                .as_ref()
+                .map(|id| (id, stored.df_kind))
+                .ok_or_else(|| Error::Internal("Object is not a dynamic field.".to_string()))?,
+            ObjectKind::Historical(_, stored) => stored
+                .df_object_id
+                .as_ref()
+                .map(|id| (id, stored.df_kind))
+                .ok_or_else(|| Error::Internal("Object is not a dynamic field.".to_string()))?,
+            _ => {
+                return Err(Error::Internal(
+                    "A WrappedOrDeleted object cannot be converted into a DynamicField."
+                        .to_string(),
+                ))
+            }
         };
 
         let df_object_id = SuiAddress::from_bytes(df_object_id).map_err(|e| {
             Error::Internal(format!("Failed to deserialize dynamic field ID: {e}."))
         })?;
 
-        let df_kind = match stored.df_kind {
+        let df_kind = match df_kind {
             Some(0) => DynamicFieldType::DynamicField,
             Some(1) => DynamicFieldType::DynamicObject,
             Some(k) => {
@@ -243,7 +299,7 @@ impl TryFrom<StoredObject> for DynamicField {
         };
 
         Ok(DynamicField {
-            stored,
+            super_: stored,
             df_object_id,
             df_kind,
         })
@@ -265,4 +321,107 @@ pub fn extract_field_from_move_struct(
             }
         })
         .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)))
+}
+
+/// Builds the `RawQuery` for fetching dynamic fields attached to a parent object. If
+/// `parent_version` is null, the latest version of each field within the given checkpoint range
+/// [`lhs`, `rhs`] is returned, conditioned on the fact that there is not a more recent version of
+/// the field.
+///
+/// If `parent_version` is provided, the latest version that is less than or equal to the parent
+/// version is returned, conditioned on the fact that there is not a more recent `WrappedOrDeleted`
+/// version of the field that is greater than the matched child but less than or equal to the parent
+/// version.
+fn dynamic_fields_query(
+    parent: SuiAddress,
+    parent_version: Option<u64>,
+    lhs: i64,
+    rhs: i64,
+) -> RawQuery {
+    // Construct the filtered inner query - apply the same filtering criteria to both
+    // objects_snapshot and objects_history tables.
+    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
+    snapshot_objs = apply_filter(snapshot_objs, parent, parent_version);
+
+    // Additionally filter objects_history table for results between the available range, or
+    // checkpoint_viewed_at, if provided.
+    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
+    history_objs = apply_filter(history_objs, parent, parent_version);
+    history_objs = filter!(
+        history_objs,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Combine the two queries, and select the most recent version of each object.
+    let candidates = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        snapshot_objs,
+        history_objs
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    let mut newer = query!("SELECT object_id, object_version, object_status FROM objects_history");
+    newer = filter!(
+        newer,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Even though the `parent_version` is provided, because it serves as an upper bound instead of
+    // a strict equality, it is possible for the dynamic field to have been deleted but still show
+    // up in the results. This is because deleted objects only have `object_id`, `object_status, and
+    // `checkpoint_sequence_number`. We need to additionally left join on any objects that have a
+    // more recent version and where the `object_status` is `WrappedOrDeleted`. However, because we
+    // know the `parent_version`, we know that if a more recent deleted version exists, that it was
+    // deleted while a child of the parent.
+    if let Some(parent_version) = parent_version {
+        newer = filter!(newer, format!("object_version <= {}", parent_version));
+        newer = filter!(
+            newer,
+            format!("object_status = {}", ObjectStatus::WrappedOrDeleted as i16)
+        );
+
+        let query = query!(
+            r#"SELECT candidates.*
+                FROM ({}) candidates
+                LEFT JOIN ({}) newer
+                ON (
+                    candidates.object_id = newer.object_id
+                    AND candidates.object_version < newer.object_version
+                )"#,
+            candidates,
+            newer
+        );
+        return filter!(query, "newer.object_status IS NULL");
+    }
+
+    let query = query!(
+        r#"SELECT candidates.*
+            FROM ({}) candidates
+            LEFT JOIN ({}) newer
+            ON (
+                candidates.object_id = newer.object_id
+                AND candidates.object_version < newer.object_version
+            )"#,
+        candidates,
+        newer
+    );
+    filter!(query, "newer.object_version IS NULL")
+}
+
+fn apply_filter(query: RawQuery, parent: SuiAddress, parent_version: Option<u64>) -> RawQuery {
+    let query = filter!(
+        query,
+        format!(
+            "owner_id = '\\x{}'::bytea AND owner_type = {} AND df_kind IS NOT NULL",
+            hex::encode(parent.into_vec()),
+            OwnerType::Object as i16
+        )
+    );
+
+    if let Some(version) = parent_version {
+        filter!(query, format!("object_version <= {}", version))
+    } else {
+        query
+    }
 }

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -248,7 +248,7 @@ impl StakedSui {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_field(ctx, name)
+            .dynamic_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -265,7 +265,7 @@ impl StakedSui {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_object_field(ctx, name)
+            .dynamic_object_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -282,7 +282,14 @@ impl StakedSui {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_fields(ctx, first, after, last, before)
+            .dynamic_fields(
+                ctx,
+                first,
+                after,
+                last,
+                before,
+                Some(self.super_.super_.version_impl()),
+            )
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -256,7 +256,7 @@ impl SuinsRegistration {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_field(ctx, name)
+            .dynamic_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -273,7 +273,7 @@ impl SuinsRegistration {
         name: DynamicFieldName,
     ) -> Result<Option<DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_object_field(ctx, name)
+            .dynamic_object_field(ctx, name, Some(self.super_.super_.version_impl()))
             .await
     }
 
@@ -290,7 +290,14 @@ impl SuinsRegistration {
         before: Option<object::Cursor>,
     ) -> Result<Connection<String, DynamicField>> {
         OwnerImpl::from(&self.super_.super_)
-            .dynamic_fields(ctx, first, after, last, before)
+            .dynamic_fields(
+                ctx,
+                first,
+                after,
+                last,
+                before,
+                Some(self.super_.super_.version_impl()),
+            )
             .await
     }
 


### PR DESCRIPTION
## Description 

Implement a historical read query for `DynamicField`'s `query` and `paginate` against the `objects_snapshot` and `objects_history` tables, and bound this historical read by a `checkpoint_viewed_at` for consistency. 

Substitute `DynamicField`'s internal representation with the `MoveObject` graphql type instead of the `Object` type.

This led to an observation where `MoveObject::query` returns an error on encountering a `WrappedOrDeleted` object. The underlying conversion has been modified to return `MoveObjectDowncastError::WrappedOrDeleted`, which `MoveObject::query` will convert into an `Ok(None)`.

Additionally, in order to look up the correct dynamic object fields for a parent object, we need to bound them by its parent's version. The entrypoints to fetch a dynamic object and dynamic field have been updated with an additional `parent_version: Option<u64>` - this is used as the upper bound if provided. Note that for dynamic object fields, the resolved `DynamicField` is actually the field object - so to resolve the `value` of a field object, to the value object, we must use the field object's version as the upper bound to return the correct data.

Something to call out is that when we look up a dynamic object field, the object retrieved is the `Field<Wrapper<K>, V>` which points to the expected parent object. To resolve the value of this dynamic object field, we look up the wrapped object(?) for the actual contents of the dynamic field. This move object will have its parent pointed to the wrapper, not the actual parent object.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
