### PR TITLE
[cli][easy] Replace Replay related command result type with NoOutput type

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -753,8 +753,8 @@ impl SuiClientCommands {
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
-
-                SuiClientCommandResult::ProfileTransaction
+                // this will be displayed via trace info, so no output is needed here
+                SuiClientCommandResult::NoOutput
             }
             SuiClientCommands::ReplayTransaction {
                 tx_digest,
@@ -772,7 +772,8 @@ impl SuiClientCommands {
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
-                SuiClientCommandResult::ReplayTransaction
+                // this will be displayed via trace info, so no output is needed here
+                SuiClientCommandResult::NoOutput
             }
             SuiClientCommands::ReplayBatch {
                 path,
@@ -786,7 +787,8 @@ impl SuiClientCommands {
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
-                SuiClientCommandResult::ReplayBatch
+                // this will be displayed via trace info, so no output is needed here
+                SuiClientCommandResult::NoOutput
             }
             SuiClientCommands::ReplayCheckpoints {
                 start,
@@ -802,7 +804,8 @@ impl SuiClientCommands {
                 let rpc = context.config.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, cmd).await?;
-                SuiClientCommandResult::ReplayCheckpoints
+                // this will be displayed via trace info, so no output is needed here
+                SuiClientCommandResult::NoOutput
             }
             SuiClientCommands::Addresses { sort_by_alias } => {
                 let active_address = context.active_address()?;
@@ -1901,10 +1904,6 @@ impl Display for SuiClientCommandResult {
                 table.with(tabled::settings::style::BorderSpanCorrection);
                 writeln!(f, "{}", table)?;
             }
-            SuiClientCommandResult::ProfileTransaction => {}
-            SuiClientCommandResult::ReplayTransaction => {}
-            SuiClientCommandResult::ReplayBatch => {}
-            SuiClientCommandResult::ReplayCheckpoints => {}
             SuiClientCommandResult::NoOutput => {}
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
@@ -2186,10 +2185,6 @@ pub enum SuiClientCommandResult {
         used_module_ticks: u128,
     },
     VerifySource,
-    ProfileTransaction,
-    ReplayTransaction,
-    ReplayBatch,
-    ReplayCheckpoints,
 }
 
 #[derive(Serialize, Clone)]


### PR DESCRIPTION
## Description 

This cleans up commands that have no output to use the NoOutput type. In particular, the replay commands' output is shown through trace info, and thus no output is passed here and thus we don't need to have their own special command result types. 

## Test Plan 

Existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
