### PR TITLE
[gql][consistent-reads][8/n] Consolidate queries that require historical object state into one module.

### DIFF
--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::Conn;
+use crate::raw_query::RawQuery;
+use crate::types::checkpoint::Checkpoint;
+use crate::{filter, query};
+
+pub(crate) enum View {
+    /// Return objects that fulfill the filtering criteria, even if there are more recent versions
+    /// of the object within the checkpoint range
+    Historical,
+    /// Return objects that fulfill the filtering criteria and are the most recent version within
+    /// the checkpoint range
+    Consistent,
+}
+
+/// Constructs a `RawQuery` against the `objects_snapshot` and `objects_history` table to fetch
+/// objects that satisfy some filtering criteria `filter_fn` within the provided checkpoint range
+/// `lhs` and `rhs`. If the `view` parameter is set to `Consistent`, the query additionally filters
+/// out objects that satisfy the provided filters, but are not the most recent version of the object
+/// within the checkpoint range. If the view parameter is set to `Historical`, this final filter is
+/// not applied.
+pub(crate) fn build_objects_query<F>(view: View, lhs: i64, rhs: i64, filter_fn: F) -> RawQuery
+where
+    F: Fn(RawQuery) -> RawQuery,
+{
+    // Construct the filtered inner query - apply the same filtering criteria to both
+    // objects_snapshot and objects_history tables.
+    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
+    snapshot_objs = filter_fn(snapshot_objs);
+
+    // Additionally filter objects_history table for results between the available range, or
+    // checkpoint_viewed_at, if provided.
+    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
+    history_objs = filter_fn(history_objs);
+    history_objs = filter!(
+        history_objs,
+        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+    );
+
+    // Combine the two queries, and select the most recent version of each object. The result set is
+    // the most recent version of objects from `objects_snapshot` and `objects_history` that match
+    // the filter criteria.
+    let candidates = query!(
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        snapshot_objs,
+        history_objs
+    )
+    .order_by("object_id")
+    .order_by("object_version DESC");
+
+    // The following conditions ensure that the version of object matching our filters is the latest
+    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
+    // `object_keys` field), then this extra check is not required (it will filter out correct
+    // results).
+    match view {
+        View::Consistent => {
+            let mut newer = query!("SELECT object_id, object_version FROM objects_history");
+            newer = filter!(
+                newer,
+                format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
+            );
+            let query = query!(
+                r#"SELECT candidates.*
+                FROM ({}) candidates
+                LEFT JOIN ({}) newer
+                ON (
+                    candidates.object_id = newer.object_id
+                    AND candidates.object_version < newer.object_version
+                )"#,
+                candidates,
+                newer
+            );
+            filter!(query, "newer.object_version IS NULL")
+        }
+        View::Historical => {
+            query!("SELECT * FROM ({}) candidates", candidates)
+        }
+    }
+}
+
+/// Given a `checkpoint_viewed_at` representing the checkpoint sequence number when the query was
+/// made, check whether the value falls under the current available range of the database. Returns
+/// `None` if the `checkpoint_viewed_at` lies outside the range, otherwise return a tuple consisting
+/// of the available range's lower bound and the `checkpoint_viewed_at`, or the upper bound of the
+/// database if `checkpoint_viewed_at` is `None`.
+pub(crate) fn consistent_range(
+    conn: &mut Conn,
+    checkpoint_viewed_at: Option<u64>,
+) -> Result<Option<(u64, u64)>, diesel::result::Error> {
+    let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
+
+    if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
+        if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
+            return Ok(None);
+        }
+        rhs = checkpoint_viewed_at;
+    }
+
+    Ok(Some((lhs, rhs)))
+}

--- a/crates/sui-graphql-rpc/src/lib.rs
+++ b/crates/sui-graphql-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 pub use sui_graphql_rpc_client as client;
 pub mod commands;
 pub mod config;
+pub(crate) mod consistency;
 pub mod context_data;
 pub(crate) mod data;
 mod error;

--- a/crates/sui-graphql-rpc/src/raw_query.rs
+++ b/crates/sui-graphql-rpc/src/raw_query.rs
@@ -186,11 +186,15 @@ macro_rules! or_filter {
 /// macro parameter. Subqueries are consumed into the new `RawQuery`.
 #[macro_export]
 macro_rules! query {
+    // Matches the case where no subqueries are provided. A `RawQuery` is constructed from the given
+    // select clause.
     ($select:expr) => {
         RawQuery::new($select, vec![])
     };
 
-    ($select:expr $(,$subquery:expr)*) => {{
+    // Expects a select clause and one or more subqueries. The select clause should contain curly
+    // braces for subqueries to be interpolated into.
+    ($select:expr $(,$subquery:expr)+) => {{
         use $crate::raw_query::RawQuery;
         let mut binds = vec![];
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -9,7 +9,6 @@ use sui_indexer::types_v2::OwnerType;
 use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
-use super::checkpoint::Checkpoint;
 use super::cursor::{Page, Target};
 use super::object::{
     self, deserialize_move_struct, validate_cursor_consistency, Object, ObjectKind, ObjectLookupKey,
@@ -18,11 +17,12 @@ use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
+use crate::consistency::{build_objects_query, consistent_range, View};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
+use crate::filter;
 use crate::raw_query::RawQuery;
-use crate::{filter, query};
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
@@ -202,14 +202,9 @@ impl DynamicField {
 
         let Some(((prev, next, results), checkpoint_viewed_at)) = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok::<_, diesel::result::Error>(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
@@ -320,57 +315,13 @@ pub fn extract_field_from_move_struct(
 }
 
 fn dynamic_fields_query(parent: SuiAddress, version: Option<u64>, lhs: i64, rhs: i64) -> RawQuery {
-    // Construct the filtered inner query - apply the same filtering criteria to both
-    // objects_snapshot and objects_history tables.
-    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
-    snapshot_objs = apply_filter(snapshot_objs, parent, version);
-
-    // Additionally filter objects_history table for results between the available range, or
-    // checkpoint_viewed_at, if provided.
-    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
-    history_objs = apply_filter(history_objs, parent, version);
-    history_objs = filter!(
-        history_objs,
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-
-    // Combine the two queries, and select the most recent version of each object.
-    let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
-        snapshot_objs,
-        history_objs
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
-
-    // The following conditions ensure that the version of object matching our filters is the latest
-    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
-    // `object_keys` field), then this extra check is not required (it will filter out correct
-    // results).
-    if version.is_none() {
-        // Objects that fulfill the filtering criteria may not be the most recent version available.
-        // Left join the candidates table on newer to filter out any objects that have a newer
-        // version.
-        let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-        newer = filter!(
-            newer,
-            format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-        );
-        let query = query!(
-            r#"SELECT candidates.*
-            FROM ({}) candidates
-            LEFT JOIN ({}) newer
-            ON (
-                candidates.object_id = newer.object_id
-                AND candidates.object_version < newer.object_version
-            )"#,
-            candidates,
-            newer
-        );
-        filter!(query, "newer.object_version IS NULL")
+    let view = if version.is_some() {
+        View::Historical
     } else {
-        query!("SELECT * FROM ({}) candidates", candidates)
-    }
+        View::Consistent
+    };
+
+    build_objects_query(view, lhs, rhs, |query| apply_filter(query, parent, version))
 }
 
 fn apply_filter(query: RawQuery, parent: SuiAddress, parent_version: Option<u64>) -> RawQuery {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -21,14 +21,14 @@ use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
+use crate::consistency::{build_objects_query, consistent_range, View};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::raw_query::RawQuery;
 use crate::types::base64::Base64;
-use crate::types::checkpoint::Checkpoint;
 use crate::types::intersect;
-use crate::{filter, or_filter, query};
+use crate::{filter, or_filter};
 use async_graphql::connection::{CursorType, Edge};
 use async_graphql::{connection::Connection, *};
 use diesel::{CombineDsl, ExpressionMethods, OptionalExtension, QueryDsl};
@@ -718,14 +718,9 @@ impl Object {
 
         let response = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok::<_, diesel::result::Error>(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
@@ -779,14 +774,9 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 conn.results(move || {
                     // If an object was created or mutated in a checkpoint outside the current
@@ -834,14 +824,9 @@ impl Object {
 
         let stored_objs: Option<Vec<StoredHistoryObject>> = db
             .execute_repeatable(move |conn| {
-                let (lhs, mut rhs) = Checkpoint::available_range(conn)?;
-
-                if let Some(checkpoint_viewed_at) = checkpoint_viewed_at {
-                    if checkpoint_viewed_at < lhs || rhs < checkpoint_viewed_at {
-                        return Ok(None);
-                    }
-                    rhs = checkpoint_viewed_at;
-                }
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
 
                 conn.results(move || {
                     // If an object was created or mutated in a checkpoint outside the current
@@ -1313,58 +1298,13 @@ pub(crate) fn validate_cursor_consistency(
 }
 
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64) -> RawQuery {
-    // Construct the filtered inner query - apply the same filtering criteria to both
-    // objects_snapshot and objects_history tables.
-    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
-    snapshot_objs = filter.apply(snapshot_objs);
-
-    // Additionally filter objects_history table for results between the available range, or
-    // checkpoint_viewed_at, if provided.
-    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
-    history_objs = filter.apply(history_objs);
-    history_objs = filter!(
-        history_objs,
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-
-    // Combine the two queries, and select the most recent version of each object.
-    let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
-        snapshot_objs,
-        history_objs
-    )
-    .order_by("object_id")
-    .order_by("object_version DESC");
-
-    // The following conditions ensure that the version of object matching our filters is the latest
-    // version at the checkpoint we are viewing at. If the filter includes version constraints (an
-    // `object_keys` field), then this extra check is not required (it will filter out correct
-    // results).
-    if filter.object_keys.is_none() {
-        // Objects that fulfill the filtering criteria may not be the most recent version available.
-        // Left join the candidates table on newer to filter out any objects that have a newer
-        // version.
-        let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-        newer = filter!(
-            newer,
-            format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-        );
-        let query = query!(
-            r#"SELECT candidates.*
-            FROM ({}) candidates
-            LEFT JOIN ({}) newer
-            ON (
-                candidates.object_id = newer.object_id
-                AND candidates.object_version < newer.object_version
-            )"#,
-            candidates,
-            newer
-        );
-
-        filter!(query, "newer.object_version IS NULL")
+    let view = if filter.object_keys.is_some() {
+        View::Historical
     } else {
-        query!("SELECT * FROM ({}) candidates", candidates)
-    }
+        View::Consistent
+    };
+
+    build_objects_query(view, lhs, rhs, move |query| filter.apply(query))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

Moves the various historical object queries into the `consistency` module to reduce copypasta. Unfortunately does not play well with Balance's query, since it has different select conditions. It is possible to rely on `build_objects_query` to construct the historical query, and then compose a new query starting from the customized select, but any pagination will throw the bindings order off.

Also centralizes the valid consistent range check into a top-level `consistent_range` function in the module. While it would be nice to return `Result<(u64, u64), Error>` here, because it is intended to be used in an `execute_repeatable`, the custom error gets converted into an `IndexerError`, and then into `sui-graphql-rpc::Error` - the many error conversions back and forth are not worth it.

## Test Plan 

Refactor - existing tests should pass.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
