### PR TITLE
add config option to sui-test-validator for reading genesis from path

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -5,6 +5,7 @@ use super::config::{ClusterTestOpt, Env};
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use std::path::Path;
+use sui_config::node::Genesis;
 use sui_config::Config;
 use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG};
 use sui_graphql_rpc::config::ConnectionConfig;
@@ -196,6 +197,12 @@ impl Cluster for LocalNewCluster {
             cluster_builder = cluster_builder.set_network_config(network_config);
             cluster_builder = cluster_builder.with_config_dir(config_dir);
         } else {
+            if let Some(genesis_file) = &options.genesis {
+                let binding = Genesis::new_from_file(genesis_file);
+                let genesis = binding.genesis()?;
+                cluster_builder = cluster_builder.set_genesis(genesis.clone());
+            }
+
             // Let the faucet account hold 1000 gas objects on genesis
             let genesis_config = GenesisConfig::custom_genesis(1, 100);
             // Custom genesis should be build here where we add the extra accounts

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -46,6 +46,9 @@ pub struct ClusterTestOpt {
     /// URL for the indexer RPC server
     #[clap(long)]
     pub graphql_address: Option<String>,
+    /// Path to genesis file
+    #[clap(long)]
+    pub genesis: Option<PathBuf>,
 }
 
 fn obfuscated_pg_address(val: &Option<String>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -76,6 +79,7 @@ impl ClusterTestOpt {
             config_dir: None,
             graphql_address: None,
             use_indexer_v2: false,
+            genesis: None,
         }
     }
 }

--- a/crates/sui-cluster-test/tests/local_cluster_test.rs
+++ b/crates/sui-cluster-test/tests/local_cluster_test.rs
@@ -35,6 +35,7 @@ async fn test_sui_cluster() {
         config_dir: None,
         graphql_address: Some(graphql_address),
         use_indexer_v2: true,
+        genesis: None,
     };
 
     let _cluster = LocalNewCluster::start(&opts).await.unwrap();

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -121,8 +121,9 @@ impl SimpleFaucet {
         let wal = WriteAheadLog::open(wal_path);
         let mut pending = vec![];
 
-        let (producer, consumer) = mpsc::channel(coins.len());
-        let (batch_producer, batch_consumer) = mpsc::channel(coins.len());
+        let channel_size = std::cmp::max(coins.len(), 1);
+        let (producer, consumer) = mpsc::channel(channel_size);
+        let (batch_producer, batch_consumer) = mpsc::channel(channel_size);
 
         let (sender, mut receiver) =
             mpsc::channel::<(Uuid, SuiAddress, Vec<u64>)>(config.max_request_queue_length as usize);

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -91,12 +91,17 @@ struct Args {
     /// If we should use the new version of the indexer
     #[clap(long)]
     pub use_indexer_v2: bool,
+
+    /// The directory location of the genesis file to use for  running a forked version of a pre-existing chain
+    #[clap(long)]
+    pub genesis: Option<std::path::PathBuf>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let (_guard, _filter_handle) = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
+        //.with_log_file("start_output.txt")
         .init();
 
     let args = Args::parse();
@@ -116,6 +121,7 @@ async fn main() -> Result<()> {
         with_indexer,
         use_indexer_experimental_methods,
         use_indexer_v2,
+        genesis,
     } = args;
 
     // We don't pass epoch duration if we have a genesis config.
@@ -148,6 +154,7 @@ async fn main() -> Result<()> {
         config_dir,
         graphql_address: graphql_port.map(|p| format!("{}:{}", graphql_host, p)),
         use_indexer_v2,
+        genesis,
     };
 
     println!("Starting Sui validator with config: {:#?}", cluster_config);


### PR DESCRIPTION
## Description 

Updates test-validator command to accept an optional path to a genesis file to create a local forked cluster. This cluster so far is not able to sync data, as it doesn't have information about seed peers or state snapshots, but runs successfully without panics. 

Next step is to load data from a state snapshot. 


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
