### PR TITLE
[Consensus 2.0] move transactions size check to consumer/client

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -101,10 +101,10 @@ mod tests {
     use consensus_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
     use fastcrypto::traits::ToFromBytes;
     use prometheus::Registry;
-    use sui_protocol_config::ProtocolConfig;
 
     use crate::authority_node::AuthorityNode;
     use crate::block_verifier::TestBlockVerifier;
+    use crate::context::Context;
 
     #[tokio::test]
     async fn start_and_stop() {
@@ -121,7 +121,7 @@ mod tests {
             own_index,
             committee,
             parameters,
-            ProtocolConfig::get_for_min_version(),
+            Context::default_protocol_config_for_testing(),
             block_signer,
             signer,
             block_verifier,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -46,18 +46,8 @@ impl AuthorityNode {
         let start_time = Instant::now();
 
         // Create the transactions client and the transactions consumer
-        let (client, tx_receiver) = TransactionsClient::new(
-            context.clone(),
-            context
-                .protocol_config
-                .consensus_max_transaction_size_bytes(),
-        );
-        let tx_consumer = TransactionsConsumer::new(
-            tx_receiver,
-            context
-                .protocol_config
-                .consensus_max_block_transactions_size_bytes(),
-        );
+        let (client, tx_receiver) = TransactionsClient::new(context.clone());
+        let tx_consumer = TransactionsConsumer::new(tx_receiver, context.clone(), None);
 
         // Construct Core
         let (core_signals, _signals_receivers) = CoreSignals::new();

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 use sui_protocol_config::ProtocolConfig;
+#[cfg(test)]
+use sui_protocol_config::{Chain, ProtocolVersion};
 
 use crate::metrics::Metrics;
 
@@ -54,14 +56,20 @@ impl Context {
     ) -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {
         let (committee, keypairs) = Committee::new_for_test(0, vec![1; committee_size]);
         let metrics = test_metrics();
+
         let context = Context::new(
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters::default(),
-            ProtocolConfig::get_for_min_version(),
+            Self::default_protocol_config_for_testing(),
             metrics,
         );
         (context, keypairs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn default_protocol_config_for_testing() -> ProtocolConfig {
+        ProtocolConfig::get_for_version(ProtocolVersion::from(36), Chain::Unknown)
     }
 
     #[cfg(test)]

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use consensus_config::{AuthorityIndex, Committee, Parameters};
 use sui_protocol_config::ProtocolConfig;
-#[cfg(test)]
-use sui_protocol_config::{Chain, ProtocolVersion};
 
 use crate::metrics::Metrics;
 
@@ -69,7 +67,7 @@ impl Context {
 
     #[cfg(test)]
     pub(crate) fn default_protocol_config_for_testing() -> ProtocolConfig {
-        ProtocolConfig::get_for_version(ProtocolVersion::from(36), Chain::Unknown)
+        ProtocolConfig::get_for_max_version_UNSAFE()
     }
 
     #[cfg(test)]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -359,7 +359,7 @@ mod test {
     async fn test_core_propose_after_genesis() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_consensus_max_transaction_size_bytes(2_000);
-            config.set_consensus_max_block_transactions_size_bytes(2_000);
+            config.set_consensus_max_transactions_in_block_bytes(2_000);
             config
         });
 
@@ -414,7 +414,7 @@ mod test {
             total
                 <= context
                     .protocol_config
-                    .consensus_max_block_transactions_size_bytes()
+                    .consensus_max_transactions_in_block_bytes()
         );
 
         // genesis blocks should be referenced

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -366,18 +366,8 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_manager = BlockManager::new();
-        let (transactions_client, tx_receiver) = TransactionsClient::new(
-            context.clone(),
-            context
-                .protocol_config
-                .consensus_max_transaction_size_bytes(),
-        );
-        let transactions_consumer = TransactionsConsumer::new(
-            tx_receiver,
-            context
-                .protocol_config
-                .consensus_max_block_transactions_size_bytes(),
-        );
+        let (transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
+        let transactions_consumer = TransactionsConsumer::new(tx_receiver, context.clone(), None);
         let (signals, _signal_receivers) = CoreSignals::new();
 
         let mut core = Core::new(
@@ -422,7 +412,7 @@ mod test {
         }
         assert!(
             total
-                < context
+                <= context
                     .protocol_config
                     .consensus_max_block_transactions_size_bytes()
         );
@@ -448,18 +438,8 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_manager = BlockManager::new();
-        let (_transactions_client, tx_receiver) = TransactionsClient::new(
-            context.clone(),
-            context
-                .protocol_config
-                .consensus_max_transaction_size_bytes(),
-        );
-        let transactions_consumer = TransactionsConsumer::new(
-            tx_receiver,
-            context
-                .protocol_config
-                .consensus_max_block_transactions_size_bytes(),
-        );
+        let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
+        let transactions_consumer = TransactionsConsumer::new(tx_receiver, context.clone(), None);
         let (signals, _signal_receivers) = CoreSignals::new();
 
         let mut core = Core::new(
@@ -665,18 +645,9 @@ mod test {
             let context = Arc::new(context);
 
             let block_manager = BlockManager::new();
-            let (_transactions_client, tx_receiver) = TransactionsClient::new(
-                context.clone(),
-                context
-                    .protocol_config
-                    .consensus_max_transaction_size_bytes(),
-            );
-            let transactions_consumer = TransactionsConsumer::new(
-                tx_receiver,
-                context
-                    .protocol_config
-                    .consensus_max_block_transactions_size_bytes(),
-            );
+            let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
+            let transactions_consumer =
+                TransactionsConsumer::new(tx_receiver, context.clone(), None);
             let (signals, signal_receivers) = CoreSignals::new();
 
             let block_signer = signers.remove(index).0;

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -154,7 +154,7 @@ mod test {
     use super::*;
     use crate::block_manager::BlockManager;
     use crate::context::Context;
-    use crate::core::{CoreOptions, CoreSignals};
+    use crate::core::CoreSignals;
     use crate::transactions_client::{TransactionsClient, TransactionsConsumer};
 
     #[tokio::test]
@@ -162,15 +162,24 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_manager = BlockManager::new();
-        let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
-        let transactions_consumer = TransactionsConsumer::new(tx_receiver);
+        let (_transactions_client, tx_receiver) = TransactionsClient::new(
+            context.clone(),
+            context
+                .protocol_config
+                .consensus_max_transaction_size_bytes(),
+        );
+        let transactions_consumer = TransactionsConsumer::new(
+            tx_receiver,
+            context
+                .protocol_config
+                .consensus_max_block_transactions_size_bytes(),
+        );
         let (signals, _signal_receivers) = CoreSignals::new();
         let core = Core::new(
             context.clone(),
             transactions_consumer,
             block_manager,
             signals,
-            CoreOptions::default(),
             key_pairs.remove(context.own_index.value()).0,
         );
 

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -162,18 +162,8 @@ mod test {
         let (context, mut key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_manager = BlockManager::new();
-        let (_transactions_client, tx_receiver) = TransactionsClient::new(
-            context.clone(),
-            context
-                .protocol_config
-                .consensus_max_transaction_size_bytes(),
-        );
-        let transactions_consumer = TransactionsConsumer::new(
-            tx_receiver,
-            context
-                .protocol_config
-                .consensus_max_block_transactions_size_bytes(),
-        );
+        let (_transactions_client, tx_receiver) = TransactionsClient::new(context.clone());
+        let transactions_consumer = TransactionsConsumer::new(tx_receiver, context.clone(), None);
         let (signals, _signal_receivers) = CoreSignals::new();
         let core = Core::new(
             context.clone(),

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_trait::async_trait;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -22,6 +23,7 @@ where
 }
 
 /// Network client for communicating with peers.
+#[async_trait]
 pub(crate) trait NetworkClient: Send + Sync {
     /// Sends a serialized SignedBlock to a peer.
     async fn send_block(&self, peer: AuthorityIndex, block: &Bytes) -> ConsensusResult<()>;
@@ -35,6 +37,7 @@ pub(crate) trait NetworkClient: Send + Sync {
 }
 
 /// Network service for handling requests from peers.
+#[async_trait]
 pub(crate) trait NetworkService: Send + Sync {
     async fn handle_send_block(&self, peer: AuthorityIndex, block: Bytes) -> ConsensusResult<()>;
     async fn handle_fetch_blocks(

--- a/consensus/core/src/transactions_client.rs
+++ b/consensus/core/src/transactions_client.rs
@@ -36,7 +36,7 @@ impl TransactionsConsumer {
             tx_receiver,
             max_consumed_bytes_per_request: context
                 .protocol_config
-                .consensus_max_block_transactions_size_bytes(),
+                .consensus_max_transactions_in_block_bytes(),
             max_consumed_transactions_per_request: max_consumed_transactions_per_request
                 .unwrap_or(MAX_CONSUMED_TRANSACTIONS_PER_REQUEST),
             pending_transaction: None,
@@ -138,7 +138,7 @@ mod tests {
     async fn basic_submit_and_consume() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_consensus_max_transaction_size_bytes(2_000); // 2KB
-            config.set_consensus_max_block_transactions_size_bytes(2_000);
+            config.set_consensus_max_transactions_in_block_bytes(2_000);
             config
         });
 
@@ -173,7 +173,7 @@ mod tests {
     async fn submit_over_max_fetch_size_and_consume() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_consensus_max_transaction_size_bytes(100);
-            config.set_consensus_max_block_transactions_size_bytes(100);
+            config.set_consensus_max_transactions_in_block_bytes(100);
             config
         });
 
@@ -202,11 +202,11 @@ mod tests {
             total_size
                 <= context
                     .protocol_config
-                    .consensus_max_block_transactions_size_bytes(),
+                    .consensus_max_transactions_in_block_bytes(),
             "Should have fetched transactions up to {}",
             context
                 .protocol_config
-                .consensus_max_block_transactions_size_bytes()
+                .consensus_max_transactions_in_block_bytes()
         );
         all_transactions.extend(transactions);
 
@@ -220,11 +220,11 @@ mod tests {
             total_size
                 <= context
                     .protocol_config
-                    .consensus_max_block_transactions_size_bytes(),
+                    .consensus_max_transactions_in_block_bytes(),
             "Should have fetched transactions up to {}",
             context
                 .protocol_config
-                .consensus_max_block_transactions_size_bytes()
+                .consensus_max_transactions_in_block_bytes()
         );
         all_transactions.extend(transactions);
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1444,8 +1444,8 @@
                 "check_zklogin_id_cost_base": null,
                 "check_zklogin_issuer_cost_base": null,
                 "consensus_bad_nodes_stake_threshold": null,
-                "consensus_max_block_transactions_size_bytes": null,
                 "consensus_max_transaction_size_bytes": null,
+                "consensus_max_transactions_in_block_bytes": null,
                 "crypto_invalid_arguments_cost": {
                   "u64": "100"
                 },

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1444,6 +1444,8 @@
                 "check_zklogin_id_cost_base": null,
                 "check_zklogin_issuer_cost_base": null,
                 "consensus_bad_nodes_stake_threshold": null,
+                "consensus_max_block_transactions_size_bytes": null,
+                "consensus_max_transaction_size_bytes": null,
                 "crypto_invalid_arguments_cost": {
                   "u64": "100"
                 },

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -107,7 +107,7 @@ const MAX_PROTOCOL_VERSION: u64 = 36;
 //             Enable coin deny list.
 // Version 36: Enable group operations native functions in devnet.
 //             Enable shared object deletion in mainnet.
-
+//             Set the consensus accepted transaction size and the included transactions size in the proposed block.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -922,6 +922,11 @@ pub struct ProtocolConfig {
     /// Maximum allowed precision loss when reducing voting weights for the random beacon
     /// protocol.
     random_beacon_reduction_allowed_delta: Option<u16>,
+
+    /// The maximum serialised transaction size (in bytes) accepted by consensus
+    consensus_max_transaction_size_bytes: Option<u64>,
+    /// The maximum size of transactions included in a consensus proposed block
+    consensus_max_block_transactions_size_bytes: Option<u64>,
 }
 
 // feature flags
@@ -1554,8 +1559,11 @@ impl ProtocolConfig {
             max_age_of_jwk_in_epochs: None,
 
             random_beacon_reduction_allowed_delta: None,
-            // When adding a new constant, set it to None in the earliest version, like this:
-            // new_constant: None,
+
+            consensus_max_transaction_size_bytes: None,
+
+            consensus_max_block_transactions_size_bytes: None, // When adding a new constant, set it to None in the earliest version, like this:
+                                                               // new_constant: None,
         };
         for cur in 2..=version.0 {
             match cur {
@@ -1871,6 +1879,9 @@ impl ProtocolConfig {
                     }
                     // Enable shared object deletion on all networks.
                     cfg.feature_flags.shared_object_deletion = true;
+
+                    cfg.consensus_max_transaction_size_bytes = Some(6 * 1_024 * 1024);
+                    cfg.consensus_max_block_transactions_size_bytes = Some(6 * 1_024 * 1024);
                 }
                 // Use this template when making changes:
                 //
@@ -1957,6 +1968,12 @@ impl ProtocolConfig {
     }
     pub fn set_enable_effects_v2(&mut self, val: bool) {
         self.feature_flags.enable_effects_v2 = val;
+    }
+    pub fn set_consensus_max_transaction_size_bytes(&mut self, val: u64) {
+        self.consensus_max_transaction_size_bytes = Some(val);
+    }
+    pub fn set_consensus_max_block_transactions_size_bytes(&mut self, val: u64) {
+        self.consensus_max_block_transactions_size_bytes = Some(val);
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1883,7 +1883,8 @@ impl ProtocolConfig {
                     cfg.feature_flags.shared_object_deletion = true;
 
                     cfg.consensus_max_transaction_size_bytes = Some(256 * 1024); // 256KB
-                    cfg.consensus_max_transactions_in_block_bytes = Some(6 * 1_024 * 1024); // 6 MB
+                    cfg.consensus_max_transactions_in_block_bytes = Some(6 * 1_024 * 1024);
+                    // 6 MB
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1883,8 +1883,7 @@ impl ProtocolConfig {
                     cfg.feature_flags.shared_object_deletion = true;
 
                     cfg.consensus_max_transaction_size_bytes = Some(256 * 1024); // 256KB
-                    cfg.consensus_max_transactions_in_block_bytes = Some(6 * 1_024 * 1024);
-                    // 6 MB
+                    cfg.consensus_max_transactions_in_block_bytes = Some(6 * 1_024 * 1024); // 6 MB
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -923,10 +923,11 @@ pub struct ProtocolConfig {
     /// protocol.
     random_beacon_reduction_allowed_delta: Option<u16>,
 
-    /// The maximum serialised transaction size (in bytes) accepted by consensus
+    /// The maximum serialised transaction size (in bytes) accepted by consensus. That should be bigger than the
+    /// `max_tx_size_bytes` with some additional headroom.
     consensus_max_transaction_size_bytes: Option<u64>,
     /// The maximum size of transactions included in a consensus proposed block
-    consensus_max_block_transactions_size_bytes: Option<u64>,
+    consensus_max_transactions_in_block_bytes: Option<u64>,
 }
 
 // feature flags
@@ -1562,7 +1563,7 @@ impl ProtocolConfig {
 
             consensus_max_transaction_size_bytes: None,
 
-            consensus_max_block_transactions_size_bytes: None,
+            consensus_max_transactions_in_block_bytes: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -1881,8 +1882,9 @@ impl ProtocolConfig {
                     // Enable shared object deletion on all networks.
                     cfg.feature_flags.shared_object_deletion = true;
 
-                    cfg.consensus_max_transaction_size_bytes = Some(6 * 1_024 * 1024);
-                    cfg.consensus_max_block_transactions_size_bytes = Some(6 * 1_024 * 1024);
+                    cfg.consensus_max_transaction_size_bytes = Some(256 * 1024); // 256KB
+                    cfg.consensus_max_transactions_in_block_bytes = Some(6 * 1_024 * 1024);
+                    // 6 MB
                 }
                 // Use this template when making changes:
                 //
@@ -1973,8 +1975,8 @@ impl ProtocolConfig {
     pub fn set_consensus_max_transaction_size_bytes(&mut self, val: u64) {
         self.consensus_max_transaction_size_bytes = Some(val);
     }
-    pub fn set_consensus_max_block_transactions_size_bytes(&mut self, val: u64) {
-        self.consensus_max_block_transactions_size_bytes = Some(val);
+    pub fn set_consensus_max_transactions_in_block_bytes(&mut self, val: u64) {
+        self.consensus_max_transactions_in_block_bytes = Some(val);
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1562,8 +1562,9 @@ impl ProtocolConfig {
 
             consensus_max_transaction_size_bytes: None,
 
-            consensus_max_block_transactions_size_bytes: None, // When adding a new constant, set it to None in the earliest version, like this:
-                                                               // new_constant: None,
+            consensus_max_block_transactions_size_bytes: None,
+            // When adding a new constant, set it to None in the earliest version, like this:
+            // new_constant: None,
         };
         for cur in 2..=version.0 {
             match cur {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
@@ -210,5 +210,6 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-consensus_max_transaction_size_bytes: 6291456
-consensus_max_block_transactions_size_bytes: 6291456
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
@@ -210,4 +210,5 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-
+consensus_max_transaction_size_bytes: 6291456
+consensus_max_block_transactions_size_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
@@ -211,5 +211,6 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-consensus_max_transaction_size_bytes: 6291456
-consensus_max_block_transactions_size_bytes: 6291456
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_36.snap
@@ -211,4 +211,5 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-
+consensus_max_transaction_size_bytes: 6291456
+consensus_max_block_transactions_size_bytes: 6291456

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
@@ -206,7 +206,6 @@ hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
 poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 10
-<<<<<<< HEAD
 group_ops_bls12381_decode_scalar_cost: 52
 group_ops_bls12381_decode_g1_cost: 52
 group_ops_bls12381_decode_g2_cost: 52

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
@@ -248,5 +248,6 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-consensus_max_transaction_size_bytes: 6291456
-consensus_max_block_transactions_size_bytes: 6291456
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_36.snap
@@ -206,6 +206,7 @@ hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
 poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 10
+<<<<<<< HEAD
 group_ops_bls12381_decode_scalar_cost: 52
 group_ops_bls12381_decode_g1_cost: 52
 group_ops_bls12381_decode_g2_cost: 52
@@ -248,4 +249,5 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
-
+consensus_max_transaction_size_bytes: 6291456
+consensus_max_block_transactions_size_bytes: 6291456


### PR DESCRIPTION
## Description 

This PR is:
* Moving the block transactions size checks to the TransactionsConsumer/Client.
* Introducing the `consensus_max_transaction_size_bytes` and `consensus_max_block_transactions_size_bytes` properties to the ProtocolConfig.
* Bumping the protocol config version to 36.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
