### PR TITLE
[Consensus 2.0] introduce the leader timeout task component

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -299,7 +299,7 @@ pub(crate) struct CoreSignals {
 
 impl CoreSignals {
     #[allow(dead_code)]
-    pub(crate) fn new() -> (Self, CoreSignalsReceivers) {
+    pub fn new() -> (Self, CoreSignalsReceivers) {
         let (block_ready_sender, block_ready_receiver) = watch::channel(None);
         let (new_round_sender, new_round_receiver) = watch::channel(0);
 
@@ -317,13 +317,13 @@ impl CoreSignals {
     }
 
     /// Sends a signal to all the waiters that a new block has been produced.
-    fn new_block_ready(&mut self, block: BlockRef) {
+    pub fn new_block_ready(&mut self, block: BlockRef) {
         self.block_ready_sender.send(Some(block)).ok();
     }
 
     /// Sends a signal that threshold clock has advanced to new round. The `round_number` is the round at which the
     /// threshold clock has advanced to.
-    fn new_round(&mut self, round_number: Round) {
+    pub fn new_round(&mut self, round_number: Round) {
         self.new_round_sender.send(round_number).ok();
     }
 }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -18,6 +18,7 @@ use crate::{
 
 const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 32;
 
+/// The interface to adhere the implementations of the core thread dispatcher. Also allows the easier mocking during unit tests.
 #[async_trait]
 pub(crate) trait CoreThreadDispatcherInterface: Sync + Send + 'static {
     async fn add_blocks(&self, blocks: Vec<VerifiedBlock>) -> Result<Vec<BlockRef>, CoreError>;

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -1,0 +1,208 @@
+use std::sync::Arc;
+use std::time::Duration;
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::block::Round;
+use crate::context::Context;
+use crate::core::CoreSignalsReceivers;
+use crate::core_thread::CoreThreadDispatcherInterface;
+use tokio::sync::oneshot::{Receiver, Sender};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep_until, Instant};
+use tracing::{debug, warn};
+
+pub(crate) struct LeaderTimeoutTaskHandle {
+    handle: JoinHandle<()>,
+    stop: Sender<()>,
+}
+
+impl LeaderTimeoutTaskHandle {
+    pub async fn stop(self) {
+        self.stop.send(()).ok();
+        self.handle.await.ok();
+    }
+}
+
+pub(crate) struct LeaderTimeoutTask<D> {
+    dispatcher: D,
+    signals_receivers: CoreSignalsReceivers,
+    leader_timeout: Duration,
+    stop: Receiver<()>,
+}
+
+impl<D: CoreThreadDispatcherInterface> LeaderTimeoutTask<D> {
+    pub fn start(
+        dispatcher: D,
+        signals_receivers: CoreSignalsReceivers,
+        context: Arc<Context>,
+    ) -> LeaderTimeoutTaskHandle {
+        let (stop_sender, stop) = tokio::sync::oneshot::channel();
+        let mut me = Self {
+            dispatcher,
+            stop,
+            signals_receivers,
+            leader_timeout: context.parameters.leader_timeout,
+        };
+        let handle = tokio::spawn(async move { me.run().await });
+
+        LeaderTimeoutTaskHandle {
+            handle,
+            stop: stop_sender,
+        }
+    }
+
+    async fn run(&mut self) {
+        let mut new_round = self.signals_receivers.new_round_receiver();
+        let mut leader_round: Round = *new_round.borrow_and_update();
+        let mut leader_round_timed_out = false;
+        let timer_start = Instant::now();
+        let leader_timeout = sleep_until(timer_start + self.leader_timeout);
+
+        tokio::pin!(leader_timeout);
+
+        loop {
+            tokio::select! {
+                // when leader timer expires then we attempt to trigger the creation of a new block.
+                // If we already timed out before then the branch gets disabled so we don't attempt
+                // all the time to produce already produced blocks for that round.
+                () = &mut leader_timeout, if !leader_round_timed_out => {
+                    if let Err(err) = self.dispatcher.force_new_block(leader_round).await {
+                        warn!("Error received while calling dispatcher, probably dispatcher is shutting down, will now exit: {err:?}");
+                        return;
+                    }
+                    leader_round_timed_out = true;
+                }
+
+                // a new round has been produced. Reset the leader timeout.
+                Ok(_) = new_round.changed() => {
+                    leader_round = *new_round.borrow_and_update();
+                    debug!("New round has been received {leader_round}, resetting timer");
+
+                    leader_round_timed_out = false;
+
+                    leader_timeout
+                    .as_mut()
+                    .reset(Instant::now() + self.leader_timeout);
+                },
+                _ = &mut self.stop => {
+                    debug!("Stop signal has been received, now shutting down");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::block::{BlockRef, Round, VerifiedBlock};
+    use crate::context::Context;
+    use crate::core::CoreSignals;
+    use crate::core_thread::{CoreError, CoreThreadDispatcherInterface};
+    use crate::leader_timeout::LeaderTimeoutTask;
+    use async_trait::async_trait;
+    use consensus_config::Parameters;
+    use parking_lot::Mutex;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::{sleep, Instant};
+
+    #[derive(Clone, Default)]
+    struct MockCoreThreadDispatcher {
+        force_new_block_calls: Arc<Mutex<Vec<(Round, Instant)>>>,
+    }
+
+    impl MockCoreThreadDispatcher {
+        async fn get_force_new_block_calls(&self) -> Vec<(Round, Instant)> {
+            let mut binding = self.force_new_block_calls.lock();
+            let all_calls = binding.drain(0..);
+            all_calls.into_iter().collect()
+        }
+    }
+
+    #[async_trait]
+    impl CoreThreadDispatcherInterface for MockCoreThreadDispatcher {
+        async fn add_blocks(
+            &self,
+            _blocks: Vec<VerifiedBlock>,
+        ) -> Result<Vec<BlockRef>, CoreError> {
+            todo!()
+        }
+
+        async fn force_new_block(&self, round: Round) -> Result<(), CoreError> {
+            self.force_new_block_calls
+                .lock()
+                .push((round, Instant::now()));
+            Ok(())
+        }
+
+        async fn get_missing_blocks(&self) -> Result<Vec<HashSet<BlockRef>>, CoreError> {
+            todo!()
+        }
+    }
+
+    #[tokio::test]
+    async fn basic_leader_timeout() {
+        let (context, _signers) = Context::new_for_test(4);
+        let dispatcher = MockCoreThreadDispatcher::default();
+        let leader_timeout = Duration::from_millis(500);
+        let parameters = Parameters { leader_timeout };
+        let context = Arc::new(context.with_parameters(parameters));
+        let now = Instant::now();
+
+        let (mut signals, signal_receivers) = CoreSignals::new();
+
+        // spawn the task
+        let _handle = LeaderTimeoutTask::start(dispatcher.clone(), signal_receivers, context);
+
+        // send a signal that a new round has been produced.
+        signals.new_round(10);
+
+        // wait enough until a force_new_block has been received
+        sleep(2 * leader_timeout).await;
+        let all_calls = dispatcher.get_force_new_block_calls().await;
+
+        assert_eq!(all_calls.len(), 1);
+
+        let (round, timestamp) = all_calls[0];
+        assert_eq!(round, 10);
+        assert!(leader_timeout < timestamp - now);
+
+        // now wait another 2 * leader_timeout, no other call should be received
+        sleep(2 * leader_timeout).await;
+        let all_calls = dispatcher.get_force_new_block_calls().await;
+
+        assert_eq!(all_calls.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn multiple_leader_timeouts() {
+        let (context, _signers) = Context::new_for_test(4);
+        let dispatcher = MockCoreThreadDispatcher::default();
+        let leader_timeout = Duration::from_millis(500);
+        let parameters = Parameters { leader_timeout };
+        let context = Arc::new(context.with_parameters(parameters));
+        let now = Instant::now();
+
+        let (mut signals, signal_receivers) = CoreSignals::new();
+
+        // spawn the task
+        let _handle = LeaderTimeoutTask::start(dispatcher.clone(), signal_receivers, context);
+
+        // now send some signals with some small delay between them, but not enough so every round
+        // manages to timeout and call the force new block method.
+        signals.new_round(13);
+        sleep(leader_timeout / 2).await;
+        signals.new_round(14);
+        sleep(leader_timeout / 2).await;
+        signals.new_round(15);
+        sleep(2 * leader_timeout).await;
+
+        // only the last one should be received
+        let all_calls = dispatcher.get_force_new_block_calls().await;
+        let (round, timestamp) = all_calls[0];
+        assert_eq!(round, 15);
+        assert!(leader_timeout < timestamp - now);
+    }
+}

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
-use std::time::Duration;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::block::Round;
 use crate::context::Context;
 use crate::core::CoreSignalsReceivers;
 use crate::core_thread::CoreThreadDispatcherInterface;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep_until, Instant};

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -22,5 +22,6 @@ mod threshold_clock;
 mod transactions_client;
 mod universal_committer;
 
+mod leader_timeout;
 #[cfg(test)]
 mod test_dag;


### PR DESCRIPTION
## Description 

Introduces a dedicated component to timeout the leader based on the new produced round signal from Core. An interface has been added for the core thread dispatcher so we can more easily unit test the component without having to spin up the actual core - we can do this separately as an integration test.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
