### PR TITLE
[suiop-cli] check go installation and run go mod tidy by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13993,7 +13993,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.1.6"
+version = "0.1.7"
 
 [lib]
 name = "suioplib"

--- a/crates/suiop-cli/src/cli/pulumi/setup.rs
+++ b/crates/suiop-cli/src/cli/pulumi/setup.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info};
 
 const PULUMI: &str = "pulumi";
-const POETRY: &str = "poetry";
+const GO: &str = "go";
 
 fn get_current_time() -> std::time::Duration {
     SystemTime::now()
@@ -53,7 +53,7 @@ fn is_binary_in_path(binary: &str) -> bool {
 }
 
 fn ensure_prereqs() -> Result<()> {
-    let binaries = [PULUMI, POETRY];
+    let binaries = [PULUMI, GO];
     let mut missing_binaries = vec![];
     for binary in binaries.iter() {
         if !is_binary_in_path(binary) {
@@ -63,10 +63,7 @@ fn ensure_prereqs() -> Result<()> {
 
     let install_guide = HashMap::from([
         (PULUMI, "https://www.pulumi.com/docs/install/"),
-        (
-            POETRY,
-            "https://python-poetry.org/docs/#installing-with-the-official-installer",
-        ),
+        (GO, "`brew install go`"),
     ]);
 
     if missing_binaries.is_empty() {
@@ -167,7 +164,7 @@ pub fn ensure_setup() -> Result<()> {
         // our work here is done, it's set up!
         Ok(())
     } else {
-        ensure_prereqs()?; // make sure poetry and pulumi are installed
+        ensure_prereqs()?; // make sure golang and pulumi are installed
         ensure_pulumi_authed()?;
         // create marker file
         let prefix = setup_marker.parent().unwrap();


### PR DESCRIPTION
## Description 

suiop-cli should:
1. check whether Go is installed
2. run `go mod tidy` by default after creating a new pulumi project
3. print out the `pulumi new` command for easier debugging

## Test Plan 
ran `suiop pulumi init --app` locally and seeing expected output

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
