### PR TITLE
[data ingestion] http based remote reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,7 +376,7 @@ ntest = "0.9.0"
 num-bigint = "0.4.4"
 num_cpus = "1.15.0"
 num_enum = "0.6.1"
-object_store = { version = "0.7", features = ["aws", "gcp", "azure"] }
+object_store = { version = "0.7", features = ["aws", "gcp", "azure", "http"] }
 once_cell = "1.18.0"
 ouroboros = "0.17"
 parking_lot = "0.12.1"

--- a/crates/sui-data-ingestion/src/reader.rs
+++ b/crates/sui-data-ingestion/src/reader.rs
@@ -164,12 +164,21 @@ impl CheckpointReader {
         let (processed_sender, processed_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let (exit_sender, exit_receiver) = oneshot::channel();
         let remote_store = remote_store_url.map(|url| {
-            parse_url_opts(
-                &Url::parse(&url).expect("failed to parse remote store url"),
-                remote_store_options,
-            )
-            .expect("failed to parse remote store config")
-            .0
+            if remote_store_options.is_empty() {
+                let builder = object_store::http::HttpBuilder::new().with_url(url);
+                Box::new(
+                    builder
+                        .build()
+                        .expect("failed to parse remote store config"),
+                )
+            } else {
+                parse_url_opts(
+                    &Url::parse(&url).expect("failed to parse remote store url"),
+                    remote_store_options,
+                )
+                .expect("failed to parse remote store config")
+                .0
+            }
         });
         let reader = Self {
             path,


### PR DESCRIPTION
add support for http based remote reader. 
Workload can be enabled by just specifying following setting in config:
```remote_store_url: https://checkpoints.testnet.sui.io``` 