### PR TITLE
push homebrew updates on testnet releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
     name: Push binaries to homebrew
     needs: release-build
     runs-on: ubuntu-latest
-    if: ${{ contains( inputs.sui_tag, 'mainnet') || contains( github.ref, 'mainnet') }}
+    if: ${{ contains( inputs.sui_tag, 'testnet') || contains( github.ref, 'testnet') }}
     steps:
       - name: Clean up tag name ${{ env.TAG_NAME }}
         shell: bash
@@ -211,7 +211,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: MystenLabs/homebrew-tap
-          # @john's PAT, needs to be rotated jan 5 2024
+          # @john's PAT, needs to be rotated jan 5 2025
           token: ${{ secrets.HOMEBREW_TAP_REPO_READ_WRITE }}
           ref: main
           fetch-depth: 0
@@ -242,7 +242,7 @@ jobs:
           template_env = jinja2.Environment(loader=template_loader)
           template = template_env.get_template("sui.rb.j2")
 
-          version = "${{ env.sui_tag }}".removeprefix("mainnet-v")
+          version = "${{ env.sui_tag }}".removeprefix("testnet-v")
 
           # Render the template with variables
           output = template.render(


### PR DESCRIPTION
## Description 

> Wondering if there is a quick win here (and will tag 
@Ştefan also) should we make homebrew build from the devnet or testnet branch by default? The average dev getting started via the brew install route is almost certainly going to be hitting devnet or testnet first, so the onboarding flow in the docs will always work

> My 2c would be testnet as a good balance between being leading edge and being stable.

## Test Plan 

@ebmifa I see there's already a `testnet` release for 1.17 - can we re-run this workflow for 1.17 or should I just manually update the homebrew tap for 1.17?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
