### PR TITLE
Authority overload monitor

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -688,6 +688,11 @@ pub struct TransactionKeyValueStoreWriteConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OverloadThresholdConfig {
     pub max_txn_age_in_queue: Duration,
+    pub overload_monitor_interval: Duration,
+    pub execution_queue_latency_hard_limit: Duration,
+    pub execution_queue_latency_soft_limit: Duration,
+    pub max_load_shedding_percentage: u32,
+    pub min_load_shedding_percentage_above_hard_limit: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
     // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
 }
@@ -696,6 +701,11 @@ impl Default for OverloadThresholdConfig {
     fn default() -> Self {
         Self {
             max_txn_age_in_queue: Duration::from_secs(1), // 1 second
+            overload_monitor_interval: Duration::from_secs(10),
+            execution_queue_latency_hard_limit: Duration::from_secs(10),
+            execution_queue_latency_soft_limit: Duration::from_secs(1),
+            max_load_shedding_percentage: 99,
+            min_load_shedding_percentage_above_hard_limit: 50,
         }
     }
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -688,10 +688,21 @@ pub struct TransactionKeyValueStoreWriteConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OverloadThresholdConfig {
     pub max_txn_age_in_queue: Duration,
+
+    // The interval of checking overload signal.
     pub overload_monitor_interval: Duration,
-    pub execution_queue_latency_hard_limit: Duration,
+
+    // The execution queueing latency when entering load shedding mode.
     pub execution_queue_latency_soft_limit: Duration,
+
+    // The execution queueing latency when entering aggressive load shedding mode.
+    pub execution_queue_latency_hard_limit: Duration,
+
+    // The maximum percentage of transactions to shed in load shedding mode.
     pub max_load_shedding_percentage: u32,
+
+    // When in aggressive load shedding mode, the the minimum percentage of
+    // transactions to shed.
     pub min_load_shedding_percentage_above_hard_limit: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
     // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
@@ -702,9 +713,9 @@ impl Default for OverloadThresholdConfig {
         Self {
             max_txn_age_in_queue: Duration::from_secs(1), // 1 second
             overload_monitor_interval: Duration::from_secs(10),
-            execution_queue_latency_hard_limit: Duration::from_secs(10),
             execution_queue_latency_soft_limit: Duration::from_secs(1),
-            max_load_shedding_percentage: 99,
+            execution_queue_latency_hard_limit: Duration::from_secs(10),
+            max_load_shedding_percentage: 95,
             min_load_shedding_percentage_above_hard_limit: 50,
         }
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -274,7 +274,11 @@ pub struct AuthorityMetrics {
     // Tracks recent average txn queueing delay between when it is ready for execution
     // until it starts executing.
     pub execution_queueing_latency: LatencyObserver,
+
+    // Tracks the rate of transactions become ready for execution in transaction manager.
     pub txn_ready_rate_tracker: Arc<Mutex<RateTracker>>,
+
+    // Tracks the rate of transactions starts execution in execution driver.
     pub execution_rate_tracker: Arc<Mutex<RateTracker>>,
 }
 
@@ -704,6 +708,7 @@ pub struct AuthorityState {
     /// Config for when we consider the node overloaded.
     overload_threshold_config: OverloadThresholdConfig,
 
+    /// Current overload status in this authority. Updated periodically.
     pub overload_info: AuthorityOverloadInfo,
 }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -140,7 +140,9 @@ use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
 use crate::in_mem_execution_cache::{ExecutionCache, ExecutionCacheRead, ExecutionCacheWrite};
 use crate::metrics::LatencyObserver;
+use crate::metrics::RateTracker;
 use crate::module_cache_metrics::ResolverMetrics;
+use crate::overload_monitor::{overload_monitor, AuthorityOverloadInfo};
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::{StateAccumulator, WrappedObject};
 use crate::subscription_handler::SubscriptionHandler;
@@ -237,6 +239,9 @@ pub struct AuthorityMetrics {
     pub(crate) skipped_consensus_txns: IntCounter,
     pub(crate) skipped_consensus_txns_cache_hit: IntCounter,
 
+    pub(crate) authority_overload_status: IntGauge,
+    pub(crate) authority_load_shedding_percentage: IntGauge,
+
     /// Post processing metrics
     post_processing_total_events_emitted: IntCounter,
     post_processing_total_tx_indexed: IntCounter,
@@ -269,6 +274,8 @@ pub struct AuthorityMetrics {
     // Tracks recent average txn queueing delay between when it is ready for execution
     // until it starts executing.
     pub execution_queueing_latency: LatencyObserver,
+    pub txn_ready_rate_tracker: Arc<Mutex<RateTracker>>,
+    pub execution_rate_tracker: Arc<Mutex<RateTracker>>,
 }
 
 // Override default Prom buckets for positive numbers in 0-50k range
@@ -453,6 +460,16 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
+            authority_overload_status: register_int_gauge_with_registry!(
+                "authority_overload_status",
+                "Whether authority is current experiencing overload and enters load shedding mode.",
+                registry)
+            .unwrap(),
+            authority_load_shedding_percentage: register_int_gauge_with_registry!(
+                "authority_load_shedding_percentage",
+                "The percentage of transactions is shed when the authority is in load shedding mode.",
+                registry)
+            .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(
                 "transaction_manager_object_cache_misses",
                 "Number of object-availability cache misses in TransactionManager",
@@ -618,6 +635,8 @@ impl AuthorityMetrics {
                 registry
             ).unwrap(),
             execution_queueing_latency: LatencyObserver::new(),
+            txn_ready_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
+            execution_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
         }
     }
 }
@@ -684,6 +703,8 @@ pub struct AuthorityState {
 
     /// Config for when we consider the node overloaded.
     overload_threshold_config: OverloadThresholdConfig,
+
+    pub overload_info: AuthorityOverloadInfo,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -2452,7 +2473,8 @@ impl AuthorityState {
             transaction_deny_config,
             certificate_deny_config,
             debug_dump_config,
-            overload_threshold_config,
+            overload_threshold_config: overload_threshold_config.clone(),
+            overload_info: AuthorityOverloadInfo::default(),
         });
 
         // Start a task to execute ready certificates.
@@ -2460,8 +2482,11 @@ impl AuthorityState {
         spawn_monitored_task!(execution_process(
             authority_state,
             rx_ready_certificates,
-            rx_execution_shutdown
+            rx_execution_shutdown,
         ));
+
+        let authority_state = Arc::downgrade(&state);
+        spawn_monitored_task!(overload_monitor(authority_state, overload_threshold_config));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -276,9 +276,15 @@ pub struct AuthorityMetrics {
     pub execution_queueing_latency: LatencyObserver,
 
     // Tracks the rate of transactions become ready for execution in transaction manager.
+    // The need for the Mutex is that the tracker is updated in transaction manager and read
+    // in the overload_monitor. There should be low mutex contention because
+    // transaction manager is single threaded and the read rate in overload_monitor is
+    // low. In the case where transaction manager becomes multi-threaded, we can
+    // create one rate tracker per thread.
     pub txn_ready_rate_tracker: Arc<Mutex<RateTracker>>,
 
     // Tracks the rate of transactions starts execution in execution driver.
+    // Similar reason for using a Mutex here as to `txn_ready_rate_tracker`.
     pub execution_rate_tracker: Arc<Mutex<RateTracker>>,
 }
 

--- a/crates/sui-core/src/consensus_throughput_calculator.rs
+++ b/crates/sui-core/src/consensus_throughput_calculator.rs
@@ -469,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_calculator() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let max_observation_points: NonZeroU64 = NonZeroU64::new(3).unwrap();
@@ -513,6 +514,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_throughput_calculator_same_timestamp_observations() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let max_observation_points: NonZeroU64 = NonZeroU64::new(2).unwrap();
@@ -543,6 +545,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_interval: TimestampSecs = 5;
@@ -610,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler_update_interval() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_interval: TimestampSecs = 5;
@@ -662,6 +666,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler_cool_down() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_window: TimestampSecs = 3;

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -104,6 +104,8 @@ pub async fn execution_process(
             }
         }
 
+        authority.metrics.execution_rate_tracker.lock().record();
+
         // Certificate execution can take significant time, so run it in a separate task.
         spawn_monitored_task!(async move {
             let _scope = monitored_scope("ExecutionDriver::task");

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod in_mem_execution_cache;
 pub mod metrics;
 pub mod module_cache_metrics;
 pub mod mysticeti_adapter;
+mod overload_monitor;
 pub(crate) mod post_consensus_tx_reorder;
 pub mod quorum_driver;
 pub mod safe_client;

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -74,7 +74,7 @@ fn check_authority_overload(
     let execution_rate = authority.metrics.execution_rate_tracker.lock().rate();
 
     let (is_overload, load_shedding_percentage) =
-        check_overload_signals(&config, queueing_latency, txn_ready_rate, execution_rate);
+        check_overload_signals(config, queueing_latency, txn_ready_rate, execution_rate);
     if is_overload {
         authority
             .overload_info

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -1,0 +1,221 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::AuthorityState;
+use std::cmp::{max, min};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Weak;
+use std::time::Duration;
+use sui_config::node::OverloadThresholdConfig;
+use tokio::time::sleep;
+use tracing::info;
+
+#[derive(Default)]
+pub struct AuthorityOverloadInfo {
+    pub is_overload: AtomicBool,
+    pub load_shedding_percentage: AtomicU32,
+}
+
+impl AuthorityOverloadInfo {
+    pub fn set_overload(&self, load_shedding_percentage: u32) {
+        self.is_overload.store(true, Ordering::Relaxed);
+        self.load_shedding_percentage
+            .store(min(load_shedding_percentage, 100), Ordering::Relaxed);
+    }
+
+    pub fn clear_overload(&self) {
+        self.is_overload.store(false, Ordering::Relaxed);
+        self.load_shedding_percentage.store(0, Ordering::Relaxed);
+    }
+}
+
+pub async fn overload_monitor(
+    authority_state: Weak<AuthorityState>,
+    config: OverloadThresholdConfig,
+) {
+    info!("Starting system overload monitor.");
+    loop {
+        if let Some(authority) = authority_state.upgrade() {
+            let queueing_latency = authority
+                .metrics
+                .execution_queueing_latency
+                .latency()
+                .unwrap_or_default();
+            let txn_ready_rate = authority.metrics.txn_ready_rate_tracker.lock().rate();
+            let execution_rate = authority.metrics.execution_rate_tracker.lock().rate();
+
+            let (is_overload, load_shedding_percentage) =
+                check_system_overload(&config, queueing_latency, txn_ready_rate, execution_rate);
+            if is_overload {
+                authority
+                    .overload_info
+                    .set_overload(load_shedding_percentage);
+            } else {
+                authority.overload_info.clear_overload();
+            }
+
+            authority
+                .metrics
+                .authority_overload_status
+                .set(is_overload as i64);
+            authority
+                .metrics
+                .authority_load_shedding_percentage
+                .set(load_shedding_percentage as i64);
+        } else {
+            break;
+        }
+
+        sleep(config.overload_monitor_interval).await;
+    }
+
+    info!("Shut down system overload monitor.");
+}
+
+fn calculate_load_shedding_percentage(txn_ready_rate: f64, execution_rate: f64) -> u32 {
+    if execution_rate * 0.9 > txn_ready_rate {
+        return 0;
+    }
+
+    (((1.0 - execution_rate * 0.9 / txn_ready_rate) + 0.1).min(1.0) * 100.0).round() as u32
+}
+
+fn check_system_overload(
+    config: &OverloadThresholdConfig,
+    queueing_latency: Duration,
+    txn_ready_rate: f64,
+    execution_rate: f64,
+) -> (bool, u32) {
+    let overload_status;
+    let load_shedding_percentage;
+    if queueing_latency > config.execution_queue_latency_hard_limit {
+        overload_status = true;
+        load_shedding_percentage = max(
+            calculate_load_shedding_percentage(txn_ready_rate, execution_rate),
+            config.min_load_shedding_percentage_above_hard_limit,
+        );
+    } else if queueing_latency > config.execution_queue_latency_soft_limit {
+        load_shedding_percentage =
+            calculate_load_shedding_percentage(txn_ready_rate, execution_rate);
+        overload_status = load_shedding_percentage > 0;
+    } else {
+        overload_status = false;
+        load_shedding_percentage = 0;
+    }
+
+    let load_shedding_percentage = min(
+        load_shedding_percentage,
+        config.max_load_shedding_percentage,
+    );
+    (overload_status, load_shedding_percentage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_authority_overload_info() {
+        let overload_info = AuthorityOverloadInfo::default();
+        assert!(!overload_info.is_overload.load(Ordering::Relaxed));
+        assert_eq!(
+            overload_info
+                .load_shedding_percentage
+                .load(Ordering::Relaxed),
+            0
+        );
+
+        {
+            overload_info.set_overload(20);
+            assert!(overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                20
+            );
+        }
+
+        {
+            overload_info.set_overload(110);
+            assert!(overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                100
+            );
+        }
+
+        {
+            overload_info.clear_overload();
+            assert!(!overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                0
+            );
+        }
+    }
+
+    #[test]
+    pub fn test_calculate_load_shedding_ratio() {
+        assert_eq!(calculate_load_shedding_percentage(90.0, 100.1), 0);
+        assert_eq!(calculate_load_shedding_percentage(90.0, 100.0), 10);
+        assert_eq!(calculate_load_shedding_percentage(100.0, 100.0), 20);
+        assert_eq!(calculate_load_shedding_percentage(110.0, 100.0), 28);
+        assert_eq!(calculate_load_shedding_percentage(180.0, 100.0), 60);
+        assert_eq!(calculate_load_shedding_percentage(100.0, 0.0), 100);
+    }
+
+    #[test]
+    pub fn test_check_system_overload() {
+        let config = OverloadThresholdConfig {
+            execution_queue_latency_hard_limit: Duration::from_secs(10),
+            execution_queue_latency_soft_limit: Duration::from_secs(1),
+            max_load_shedding_percentage: 90,
+            ..Default::default()
+        };
+
+        // When execution queueing latency is within soft limit, don't start overload protection.
+        assert_eq!(
+            check_system_overload(&config, Duration::from_millis(500), 1000.0, 10.0),
+            (false, 0)
+        );
+
+        // When execution queueing latency hits soft limit and execution rate is higher, don't
+        // start overload protection.
+        assert_eq!(
+            check_system_overload(&config, Duration::from_secs(2), 100.0, 120.0),
+            (false, 0)
+        );
+
+        // When execution queueing latency hits soft limit, but not hard limit, start overload
+        // protection.
+        assert_eq!(
+            check_system_overload(&config, Duration::from_secs(2), 100.0, 100.0),
+            (true, 20)
+        );
+
+        // When execution queueing latency hits hard limit, start more aggressive overload
+        // protection.
+        assert_eq!(
+            check_system_overload(&config, Duration::from_secs(11), 100.0, 100.0),
+            (true, 50)
+        );
+
+        // When execution queueing latency hits hard limit and calculated shedding percentage
+        // is higher than
+        assert_eq!(
+            check_system_overload(&config, Duration::from_secs(11), 240.0, 100.0),
+            (true, 73)
+        );
+
+        // Maximum transactions shed is cap by `max_load_shedding_percentage` config.
+        assert_eq!(
+            check_system_overload(&config, Duration::from_secs(11), 100.0, 0.0),
+            (true, 90)
+        );
+    }
+}

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -97,6 +97,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_update_low_scoring_authorities() {
         // GIVEN
         // Total stake is 8 for this committee and every authority has equal stake = 1

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -12,7 +12,9 @@ use indexmap::IndexMap;
 use lru::LruCache;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use sui_types::{base_types::TransactionDigest, error::SuiResult, fp_ensure};
+use sui_types::{
+    base_types::TransactionDigest, error::SuiResult, fp_ensure, message_envelope::Message,
+};
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     committee::EpochId,
@@ -817,6 +819,7 @@ impl TransactionManager {
                 threshold: MAX_TM_QUEUE_LENGTH,
             }
         );
+        tx_data.digest();
 
         for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -756,6 +756,7 @@ impl TransactionManager {
         assert!(inner
             .executing_certificates
             .insert(*pending_certificate.certificate.digest()));
+        self.metrics.txn_ready_rate_tracker.lock().record();
         let _ = self.tx_ready_certificates.send(pending_certificate);
         self.metrics.transaction_manager_num_ready.inc();
         self.metrics.execution_driver_dispatch_queue.inc();

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -934,6 +934,7 @@ mod test {
     use prometheus::Registry;
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     fn test_available_objects_cache() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::default()));
         let mut cache = AvailableObjectsCache::new_with_size(metrics, 5);

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -588,6 +588,7 @@ async fn test_txn_age_overload() {
             gas_objects.clone(),
             OverloadThresholdConfig {
                 max_txn_age_in_queue: Duration::from_secs(5),
+                ..Default::default()
             },
         )
         .await;

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -535,6 +535,7 @@ async fn shared_object_sync() {
         // Set the threshold high enough so it won't be triggered.
         .with_overload_threshold_config(OverloadThresholdConfig {
             max_txn_age_in_queue: Duration::from_secs(60),
+            ..Default::default()
         })
         .build()
         .await;

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -112,6 +112,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -221,6 +232,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -330,6 +352,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -439,6 +472,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -548,6 +592,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -657,6 +712,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -766,6 +832,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=


### PR DESCRIPTION
## Description 

This PR implements overload monitor in AuthorityState.

Overload monitor periodically monitors 3 signals:
  - the execution queueing latency
  - txn enqueue rate
  - txn execution rate

to make a decision whether it should enter load shedding mode, and what percentage of traffic to shed.

Currently, we store the load shedding information in AuthorityState::overload_info struct, and expose it using
metrics. This PR doesn't implement any actions when an authority is in load shedding mode.

## Test Plan 

1. Added unit tests to test overload_monitor module

2. Single node benchmark `cargo run --release --bin sui-single-node-benchmark -- --component with-tx-manager no-move`

with this PR: `Execution finished in 24.127s, TPS=20723.670576532517`
before this PR: `Execution finished in 24.007s, TPS=20827.258716207773`

3. local cluster testing to show metrics
<img width="500" alt="Screenshot 2024-01-29 at 5 55 23 PM" src="https://github.com/MystenLabs/sui/assets/9200652/291ebfcd-82c1-4105-9272-e18204d22caf">


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
