### PR TITLE
[CLI] Better error messages and source tracking for commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,7 +2407,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
+ "terminal_size 0.2.6",
 ]
 
 [[package]]
@@ -5767,6 +5776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6411,6 +6426,38 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size 0.1.17",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -11269,6 +11316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snafu"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11523,6 +11576,7 @@ dependencies = [
  "inquire",
  "jemalloc-ctl",
  "json_to_table",
+ "miette",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
@@ -14026,6 +14080,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
 name = "symbolic-common"
 version = "10.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14255,6 +14337,16 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
@@ -14356,6 +14448,17 @@ dependencies = [
  "serde",
  "sha-1 0.10.1",
  "test-fuzz-internal",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -15197,6 +15300,12 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -16783,7 +16892,7 @@ dependencies = [
  "tempfile",
  "term",
  "termcolor",
- "terminal_size",
+ "terminal_size 0.2.6",
  "termtree",
  "test-fuzz",
  "test-fuzz-internal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,6 +520,7 @@ x509-parser = "0.14.0"
 zstd = "0.12.3"
 zeroize = "1.6.0"
 versions = "4.1.0"
+miette = {version = "5.10.0", features = ["fancy"] }
 
 # Move dependencies
 move-binary-format = { path = "external-crates/move/crates/move-binary-format" }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -36,6 +36,7 @@ reqwest.workspace = true
 im.workspace = true
 async-recursion.workspace = true
 thiserror.workspace = true
+miette.workspace = true
 
 sui-config.workspace = true
 sui-execution = { path = "../../sui-execution" }

--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -64,10 +64,10 @@ pub struct PTB {
     #[clap(long, num_args(2))]
     transfer_objects: Vec<String>,
     /// Publish the move package. It takes as input the folder where the package exists.
-    #[clap(long, num_args(1), required=false)]
+    #[clap(long, num_args(1), required = false)]
     publish: String,
     /// Upgrade the move package. It takes as input the folder where the package exists.
-    #[clap(long, num_args(2), required=false)]
+    #[clap(long, num_args(2), required = false)]
     upgrade: String,
     /// Preview the PTB instead of executing it
     #[clap(long)]
@@ -347,11 +347,13 @@ impl PTB {
         let (parsed, errors) = parser.finish();
 
         if !errors.is_empty() {
+            let suffix = if errors.len() > 1 { "s" } else { "" };
             let rendered = render_errors(commands, errors);
+            eprintln!("Encountered error{suffix} when parsing PTB:");
             for e in rendered.iter() {
-                println!("{:?}", e);
+                eprintln!("{:?}", e);
             }
-            anyhow::bail!("Encountered errors when parsing the PTB",);
+            anyhow::bail!("Could not build PTB due to previous error{suffix}");
         }
 
         // We need to resolve object IDs, so we need a fullnode to access
@@ -367,11 +369,13 @@ impl PTB {
 
         let (ptb, budget, _preview) = match builder.finish() {
             Err(errors) => {
+                let suffix = if errors.len() > 1 { "s" } else { "" };
+                eprintln!("Encountered error{suffix} when building PTB:");
                 let rendered = render_errors(commands, errors);
                 for e in rendered.iter() {
-                    println!("{:?}", e);
+                    eprintln!("{:?}", e);
                 }
-                anyhow::bail!("Encountered errors when building the PTB",);
+                anyhow::bail!("Could not build PTB due to previous error{suffix}");
             }
             Ok(x) => x,
         };

--- a/crates/sui/src/ptb/ptb_parser/build_ptb.rs
+++ b/crates/sui/src/ptb/ptb_parser/build_ptb.rs
@@ -38,7 +38,7 @@ use crate::{
     err, error,
     ptb::ptb_parser::{
         argument::Argument as PTBArg,
-        command_token::{CommandToken, ASSIGN, GAS_BUDGET, MOVE_CALL, WARN_SHADOWS},
+        command_token::{CommandToken, ASSIGN, GAS_BUDGET, MOVE_CALL},
         context::{FileScope, PTBContext},
         errors::{span, PTBError, PTBResult, Span, Spanned},
         parser::ParsedPTBCommand,
@@ -220,7 +220,7 @@ pub struct PTBBuilder<'a> {
     pub arguments_to_resolve: BTreeMap<Identifier, Spanned<PTBArg>>,
     /// The arguments that we have resolved. This is a map from identifiers to the actual
     /// transaction arguments.
-    /// TODO(tzakian): Maybe make these spanned as well.
+    // TODO(tzakian): Maybe make these spanned as well.
     pub resolved_arguments: BTreeMap<Identifier, Tx::Argument>,
     /// The actual PTB that we are building up.
     pub ptb: ProgrammableTransactionBuilder,
@@ -361,8 +361,7 @@ impl<'a> PTBBuilder<'a> {
                                 ident, i + 1
                             ),
                             span: Some(*command_loc),
-                            help: Some(format!("You can either rename this variable, or not use the '{WARN_SHADOWS}' \
-                                               command to not warn on these types of errors.")),
+                            help: Some(format!("You can either rename this variable, or do not pass the `warn-shadows` flag to ignore these types of errors.")),
                         });
                     }
                 }
@@ -744,7 +743,7 @@ impl<'a> PTBBuilder<'a> {
                         sp: ident_loc,
                         help: {
                            "This is most likely because the previous command did not \
-                           produce a result, e.g., an '{ASSIGN}' or '{GAS_BUDGET}' command."
+                           produce a result, e.g., '{ASSIGN}' or '{GAS_BUDGET}' commands do not produce results.."
 
                         },
                         self,

--- a/crates/sui/src/ptb/ptb_parser/command_token.rs
+++ b/crates/sui/src/ptb/ptb_parser/command_token.rs
@@ -91,102 +91,21 @@ impl FromStr for CommandToken {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Copy)]
-pub enum Arity {
-    Exact(usize),
-    Range(usize, usize),
-    Variable,
-}
-
-#[derive(Eq, PartialEq, Debug, Clone, Copy)]
-pub struct CommandArity {
-    types: Arity,
-    args: Arity,
-}
-
-impl CommandToken {
-    pub fn arity(&self) -> CommandArity {
-        match self {
-            CommandToken::TransferObjects => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(2),
-            },
-            CommandToken::SplitCoins => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(2),
-            },
-            CommandToken::MergeCoins => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(2),
-            },
-            CommandToken::MakeMoveVec => CommandArity {
-                types: Arity::Exact(1),
-                args: Arity::Exact(1),
-            },
-            CommandToken::MoveCall => CommandArity {
-                types: Arity::Range(0, 1),
-                args: Arity::Variable,
-            },
-            CommandToken::Publish => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::Upgrade => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::Assign => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Range(1, 3),
-            },
-            CommandToken::File => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::WarnShadows => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(0),
-            },
-            CommandToken::Preview => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(0),
-            },
-            CommandToken::PickGasBudget => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::GasBudget => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::FileStart => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-            CommandToken::FileEnd => CommandArity {
-                types: Arity::Exact(0),
-                args: Arity::Exact(1),
-            },
-        }
-    }
-    pub fn all() -> Vec<&'static str> {
-        vec![
-            TRANSFER_OBJECTS,
-            SPLIT_COINS,
-            MERGE_COINS,
-            MAKE_MOVE_VEC,
-            MOVE_CALL,
-            PUBLISH,
-            UPGRADE,
-            ASSIGN,
-            FILE,
-            PREVIEW,
-            WARN_SHADOWS,
-            PICK_GAS_BUDGET,
-            GAS_BUDGET,
-        ]
-    }
-}
+pub const ALL_PUBLIC_COMMAND_TOKENS: &[&'static str] = &[
+    TRANSFER_OBJECTS,
+    SPLIT_COINS,
+    MERGE_COINS,
+    MAKE_MOVE_VEC,
+    MOVE_CALL,
+    PUBLISH,
+    UPGRADE,
+    ASSIGN,
+    FILE,
+    PREVIEW,
+    WARN_SHADOWS,
+    PICK_GAS_BUDGET,
+    GAS_BUDGET,
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/sui/src/ptb/ptb_parser/command_token.rs
+++ b/crates/sui/src/ptb/ptb_parser/command_token.rs
@@ -169,6 +169,23 @@ impl CommandToken {
             },
         }
     }
+    pub fn all() -> Vec<&'static str> {
+        vec![
+            TRANSFER_OBJECTS,
+            SPLIT_COINS,
+            MERGE_COINS,
+            MAKE_MOVE_VEC,
+            MOVE_CALL,
+            PUBLISH,
+            UPGRADE,
+            ASSIGN,
+            FILE,
+            PREVIEW,
+            WARN_SHADOWS,
+            PICK_GAS_BUDGET,
+            GAS_BUDGET,
+        ]
+    }
 }
 
 #[cfg(test)]

--- a/crates/sui/src/ptb/ptb_parser/context.rs
+++ b/crates/sui/src/ptb/ptb_parser/context.rs
@@ -1,20 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use crate::ptb::ptb_parser::errors::PTBError;
 
 use super::errors::PTBResult;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileScope {
     pub file_command_index: usize,
     pub name: String,
+    // Since the same filename may appear twice this disambiguates between first, second, etc.
+    pub name_index: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct PTBContext {
     current_file_scope: FileScope,
     file_scopes: Vec<FileScope>,
+    seen_scopes: BTreeMap<String, usize>,
 }
 
 impl PTBContext {
@@ -23,23 +28,33 @@ impl PTBContext {
             current_file_scope: FileScope {
                 file_command_index: 0,
                 name: "console".to_owned(),
+                name_index: 0,
             },
             file_scopes: vec![],
+            seen_scopes: [("console".to_owned(), 0)].into_iter().collect(),
         }
     }
 
     pub fn push_file_scope(&mut self, name: String) {
+        // Account for the `--file` command itself in the index
+        self.increment_file_command_index();
+        let name_index = self
+            .seen_scopes
+            .entry(name.clone())
+            .and_modify(|i| *i += 1)
+            .or_insert(0);
         let scope = std::mem::replace(
             &mut self.current_file_scope,
             FileScope {
                 file_command_index: 0,
                 name,
+                name_index: *name_index,
             },
         );
         self.file_scopes.push(scope);
     }
 
-    pub fn pop_file_scope(&mut self, name: String) -> PTBResult<()> {
+    pub fn pop_file_scope(&mut self, name: &str) -> PTBResult<()> {
         if self.current_file_scope.name != name {
             return Err(PTBError::WithSource {
                 file_scope: self.current_file_scope.clone(),
@@ -47,11 +62,15 @@ impl PTBContext {
                     "ICE: Expected file scope '{}' but got '{}'",
                     name, self.current_file_scope.name
                 ),
+                span: None,
+                help: None,
             });
         }
         let scope = self.file_scopes.pop().ok_or_else(|| PTBError::WithSource {
             file_scope: self.current_file_scope.clone(),
             message: "ICE: No file scopes to pop".to_owned(),
+            span: None,
+            help: None,
         })?;
         self.current_file_scope = scope;
         Ok(())

--- a/crates/sui/src/ptb/ptb_parser/errors.rs
+++ b/crates/sui/src/ptb/ptb_parser/errors.rs
@@ -1,27 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use miette::{miette, LabeledSpan};
 use thiserror::Error;
 
-use super::context::FileScope;
+use crate::ptb::ptb::PTBCommand;
 
-pub type PTBResult<T> = Result<T, PTBError>;
-
-/// An error that occurred while working with a PTB. This error contains an error message along
-/// with the file scope (file name and command index) where the error occurred.
-#[derive(Debug, Clone, Error)]
-pub enum PTBError {
-    #[error("{message} at command {} in file '{}'", file_scope.file_command_index, file_scope.name)]
-    WithSource {
-        file_scope: FileScope,
-        message: String,
-    },
-}
+use super::{
+    command_token::{FILE_END, FILE_START},
+    context::FileScope,
+};
 
 #[macro_export]
 macro_rules! error {
     ($x:expr, $($arg:tt)*) => {
         return Err($crate::err!($x, $($arg)*))
+    };
+    (sp: $l:expr, $x:expr, $($arg:tt)*) => {
+        return Err($crate::err!(sp: $l, $x, $($arg)*))
+    };
+    (sp: $l:expr, help: { $($h:expr),* }, $x:expr, $($arg:tt)*) => {
+        return Err($crate::err!(sp: $l, help: { $($h),* }, $x, $($arg)*))
     };
 }
 
@@ -31,6 +33,289 @@ macro_rules! err {
         $crate::ptb::ptb_parser::errors::PTBError::WithSource {
             file_scope: $x.context.current_file_scope().clone(),
             message: format!($($arg)*),
+            span: None,
+            help: None,
         }
     };
+    (sp: $l:expr, $x:expr, $($arg:tt)*) => {
+        $crate::ptb::ptb_parser::errors::PTBError::WithSource {
+            file_scope: $x.context.current_file_scope().clone(),
+            message: format!($($arg)*),
+            span: Some($l),
+            help: None,
+        }
+    };
+    (sp: $l:expr, help: { $($h:expr),* }, $x:expr, $($arg:tt)*) => {
+        $crate::ptb::ptb_parser::errors::PTBError::WithSource {
+            file_scope: $x.context.current_file_scope().clone(),
+            message: format!($($arg)*),
+            span: Some($l),
+            help: Some(format!($($h),*)),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! sp {
+    (_, $value:pat) => {
+        $crate::ptb::ptb_parser::errors::Spanned { value: $value, .. }
+    };
+    ($loc:pat, _) => {
+        $crate::ptb::ptb_parser::errors::Spanned { span: $loc, .. }
+    };
+    ($loc:pat, $value:pat) => {
+        $crate::ptb::ptb_parser::errors::Spanned {
+            span: $loc,
+            value: $value,
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! bind {
+    ($loc:pat, $value:pat = $rhs:expr, $err:expr) => {
+        let x = $rhs;
+        let loc = x.span;
+        let ($loc, $value) = (loc.clone(), x.value) else {
+            return $err(loc);
+        };
+    };
+}
+
+pub type PTBResult<T> = Result<T, PTBError>;
+
+/// An error that occurred while working with a PTB. This error contains an error message along
+/// with the file scope (file name and command index) where the error occurred.
+#[derive(Debug, Clone, Error)]
+pub enum PTBError {
+    #[error("{message} at command {} in file '{}' {:?}", file_scope.file_command_index, file_scope.name, span)]
+    WithSource {
+        file_scope: FileScope,
+        message: String,
+        span: Option<Span>,
+        help: Option<String>,
+    },
+}
+
+/// Represents a span of a command in a PTB file. The span is represented as a character range
+/// where the `arg_idx` field indicates which argument the span is within.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+    pub arg_idx: usize,
+}
+
+/// Represents a value in a PTB file along with its span.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Spanned<T: Debug + Clone + PartialEq + Eq> {
+    pub span: Span,
+    pub value: T,
+}
+
+impl PTBError {
+    /// Add a help message to an error.
+    pub fn with_help(self, help: String) -> Self {
+        match self {
+            PTBError::WithSource {
+                file_scope,
+                message,
+                span,
+                ..
+            } => PTBError::WithSource {
+                file_scope,
+                message,
+                span,
+                help: Some(help),
+            },
+        }
+    }
+}
+
+/// A map from file scope to a list of commands in that file scope. Note that these commands are
+/// the original commands from the PTB file and not the commands that were parsed -- we will use
+/// the string representation of the original commands to render errors.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileIndexedErrors(pub BTreeMap<(String, usize), Vec<PTBCommand>>);
+
+impl FileIndexedErrors {
+    /// Take a set of commands and index them by file scope.
+    pub fn new(commands: &BTreeMap<usize, PTBCommand>) -> Self {
+        let mut file_indexed_commands = BTreeMap::new();
+        let mut name_collision_count: BTreeMap<_, _> =
+            [("console".to_owned(), 0)].into_iter().collect();
+        let mut scope_stack = vec![];
+        let mut current_scope = ("console".to_string(), 0);
+        for (_, command) in commands {
+            if command.name == FILE_START {
+                // Push a dummy command to keep indices in line with the usage of the `--file`
+                // command.
+                file_indexed_commands
+                    .entry(current_scope.clone())
+                    .or_insert_with(Vec::new)
+                    .push(command.clone());
+                scope_stack.push(current_scope.clone());
+                let name_index = name_collision_count
+                    .entry(command.values[0].clone())
+                    .and_modify(|i| *i += 1)
+                    .or_insert(0);
+                current_scope = (command.values[0].clone(), *name_index);
+                continue;
+            }
+
+            if command.name == FILE_END {
+                current_scope = scope_stack.pop().unwrap();
+                continue;
+            }
+
+            file_indexed_commands
+                .entry(current_scope.clone())
+                .or_insert_with(Vec::new)
+                .push(command.clone());
+        }
+
+        Self(file_indexed_commands)
+    }
+
+    pub fn get(&self, file_scope: &FileScope) -> Option<&PTBCommand> {
+        self.0
+            .get(&(file_scope.name.clone(), file_scope.name_index))
+            .and_then(|commands| commands.get(file_scope.file_command_index))
+    }
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize, arg_idx: usize) -> Self {
+        Self {
+            start,
+            end,
+            arg_idx,
+        }
+    }
+
+    /// Return the union of this span with a set of other spans.
+    pub fn union_with(&self, others: impl IntoIterator<Item = Span>) -> Span {
+        let mut start = self.start;
+        let mut end = self.end;
+
+        for s in others {
+            start = start.min(s.start);
+            end = end.max(s.end);
+        }
+        Span {
+            start,
+            end,
+            arg_idx: self.arg_idx,
+        }
+    }
+}
+
+pub fn span<T: Debug + Clone + PartialEq + Eq>(loc: Span, value: T) -> Spanned<T> {
+    Spanned { span: loc, value }
+}
+
+// If no span we point to the command name
+// If there is a span, we convert the span range to the appropriate offset in the whole string for
+// the command
+fn convert_span(
+    original_command: PTBCommand,
+    error: PTBError,
+) -> (String, LabeledSpan, String, Option<String>) {
+    let PTBError::WithSource {
+        span,
+        file_scope,
+        message,
+        help,
+    } = error;
+    let (range, command_string) = match span {
+        // No span -- point to the command name
+        None => (
+            0..original_command.name.len(),
+            original_command.name + " " + &original_command.values.join(" "),
+        ),
+        Some(span) => {
+            // Conver the character offset within the given argument index to the offset in the
+            // whole string.
+            let mut offset = original_command.name.len();
+            let mut final_string = original_command.name.clone();
+            let mut range = (span.start, span.end);
+            for (i, arg) in original_command.values.iter().enumerate() {
+                offset += 1;
+                final_string.push_str(" ");
+                if i != span.arg_idx {
+                    offset += arg.len();
+                    final_string.push_str(arg);
+                } else {
+                    range.0 += offset;
+                    range.1 += offset;
+                    offset += arg.len();
+                    final_string.push_str(arg);
+                }
+            }
+
+            // Handle range boundaries for e.g., unexpected tokens at the end of the token stream
+            // by pushing on a space at the end of the string. This will capture any unexpected
+            // token errors and allow us to point "to the end" of the argument.
+            final_string.push_str(" ");
+            (range.0..range.1, final_string)
+        }
+    };
+    let label = LabeledSpan::at(range, message.clone());
+    let error_string = format!(
+        "{} {}",
+        file_scope.file_command_index,
+        if file_scope.name == "console" {
+            "from console input".to_string()
+        } else {
+            let usage_string = if file_scope.name_index == 0 {
+                "".to_string()
+            } else {
+                format!("(usage {} of file)", file_scope.name_index + 1)
+            };
+            format!("in PTB file '{}' {usage_string}", file_scope.name)
+        }
+    );
+
+    (command_string, label, error_string, help)
+}
+
+pub fn convert_to_displayable_error(
+    original_command: PTBCommand,
+    error: PTBError,
+) -> miette::Report {
+    let (command_string, label, formatted_error, help_msg) = convert_span(original_command, error);
+    match help_msg {
+        Some(help_msg) => miette!(
+            labels = vec![label],
+            help = help_msg,
+            "Error at command {}",
+            formatted_error
+        ),
+        None => miette!(labels = vec![label], "Error at command {}", formatted_error),
+    }
+    .with_source_code(command_string)
+}
+
+pub fn render_errors(
+    commands: BTreeMap<usize, PTBCommand>,
+    errors: Vec<PTBError>,
+) -> Vec<miette::Report> {
+    let file_indexed_commands = FileIndexedErrors::new(&commands);
+    let mut rendered = vec![];
+    for error in errors {
+        let file_scope = match &error {
+            PTBError::WithSource { file_scope, .. } => file_scope,
+        };
+        match file_indexed_commands.get(&file_scope) {
+            Some(command) => rendered.push(convert_to_displayable_error(command.clone(), error)),
+            None => rendered.push(miette!(
+                labels = vec![],
+                "Error at command {} in PTB file '{}': {}",
+                file_scope.file_command_index,
+                file_scope.name,
+                error
+            )),
+        }
+    }
+    rendered
 }

--- a/crates/sui/src/ptb/ptb_parser/mod.rs
+++ b/crates/sui/src/ptb/ptb_parser/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod argument;
 pub mod argument_token;
 pub mod build_ptb;
@@ -5,3 +8,4 @@ pub mod command_token;
 pub mod context;
 pub mod errors;
 pub mod parser;
+pub mod utils;

--- a/crates/sui/src/ptb/ptb_parser/parser.rs
+++ b/crates/sui/src/ptb/ptb_parser/parser.rs
@@ -16,7 +16,7 @@ use anyhow::{anyhow, bail, Context, Result as AResult};
 
 use super::{
     argument::Argument,
-    command_token::CommandToken,
+    command_token::{CommandToken, ALL_PUBLIC_COMMAND_TOKENS},
     context::PTBContext,
     errors::{span, PTBError, Span, Spanned},
 };
@@ -71,7 +71,7 @@ impl PTBParser {
                 span: None,
                 help: Some(format!(
                     "Valid commands are: {}",
-                    CommandToken::all().join(", ")
+                    ALL_PUBLIC_COMMAND_TOKENS.join(", ")
                 )),
             });
             return;

--- a/crates/sui/src/ptb/ptb_parser/parser.rs
+++ b/crates/sui/src/ptb/ptb_parser/parser.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ptb::ptb::PTBCommand;
+use crate::{ptb::ptb::PTBCommand, sp};
 
 use move_command_line_common::{
     address::NumericalAddress,
@@ -9,33 +9,28 @@ use move_command_line_common::{
     types::TypeToken,
 };
 use move_core_types::identifier::Identifier;
-use std::{borrow::BorrowMut, marker::PhantomData, str::FromStr};
+use std::{error::Error, fmt::Debug, str::FromStr};
 
 use crate::ptb::ptb_parser::argument_token::ArgumentToken;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result as AResult};
 
 use super::{
-    argument::Argument, command_token::CommandToken, context::PTBContext, errors::PTBError,
+    argument::Argument,
+    command_token::CommandToken,
+    context::PTBContext,
+    errors::{span, PTBError, Span, Spanned},
 };
 
 /// A parsed PTB command consisting of the command and the parsed arguments to the command.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ParsedPTBCommand {
     pub name: CommandToken,
-    pub args: Vec<Argument>,
+    pub args: Vec<Spanned<Argument>>,
 }
 
 /// The parser for PTB command arguments.
-pub struct ValueParser<
-    'a,
-    I: Iterator<Item = (ArgumentToken, &'a str)>,
-    P: BorrowMut<Parser<'a, ArgumentToken, I>>,
-> {
-    inner: P,
-    // The current argument index that we are parsing. This is used for error reporting.
-    arg_index: usize,
-    _a: PhantomData<&'a ()>,
-    _i: PhantomData<I>,
+pub struct ValueParser<'a> {
+    inner: Spanner<'a>,
 }
 
 /// The PTB parsing context used when parsing PTB commands. This consists of:
@@ -73,6 +68,11 @@ impl PTBParser {
             self.errors.push(PTBError::WithSource {
                 file_scope: self.context.current_file_scope().clone(),
                 message: format!("Failed to parse command name: {e}"),
+                span: None,
+                help: Some(format!(
+                    "Valid commands are: {}",
+                    CommandToken::all().join(", ")
+                )),
             });
             return;
         };
@@ -80,18 +80,26 @@ impl PTBParser {
 
         match name {
             CommandToken::FileEnd => {
-                let name = cmd.values.pop().unwrap();
-                if let Err(e) = self.context.pop_file_scope(name) {
+                let fname = cmd.values.pop().unwrap();
+                if let Err(e) = self.context.pop_file_scope(&fname) {
                     self.errors.push(e);
                 }
+                self.parsed.push(ParsedPTBCommand {
+                    name,
+                    args: vec![span(Span::new(0, fname.len(), 0), Argument::String(fname))],
+                });
                 return;
             }
             CommandToken::FileStart => {
-                let name = cmd.values.pop().unwrap();
-                self.context.push_file_scope(name);
+                let fname = cmd.values.pop().unwrap();
+                self.context.push_file_scope(fname.clone());
+                self.parsed.push(ParsedPTBCommand {
+                    name,
+                    args: vec![span(Span::new(0, fname.len(), 0), Argument::String(fname))],
+                });
                 return;
             }
-            CommandToken::Publish | CommandToken::Upgrade => {
+            CommandToken::Publish => {
                 if cmd.values.len() != 1 {
                     self.errors.push(PTBError::WithSource {
                         file_scope: self.context.current_file_scope().clone(),
@@ -99,14 +107,66 @@ impl PTBParser {
                             "Invalid command -- expected 1 argument, got {}",
                             cmd.values.len()
                         ),
+                        span: None,
+                        help: None,
                     });
+                    self.context.increment_file_command_index();
                     return;
                 }
-                self.context.increment_file_command_index();
                 self.parsed.push(ParsedPTBCommand {
                     name,
-                    args: vec![Argument::String(cmd.values[0].clone())],
+                    args: vec![Spanned {
+                        span: Span {
+                            start: 0,
+                            end: cmd.values[0].len(),
+                            arg_idx: 0,
+                        },
+                        value: Argument::String(cmd.values[0].clone()),
+                    }],
                 });
+                self.context.increment_file_command_index();
+                return;
+            }
+            CommandToken::Upgrade => {
+                if cmd.values.len() != 2 {
+                    self.errors.push(PTBError::WithSource {
+                        file_scope: self.context.current_file_scope().clone(),
+                        message: format!(
+                            "Invalid command -- expected 2 arguments, got {}",
+                            cmd.values.len()
+                        ),
+                        span: None,
+                        help: None,
+                    });
+                    self.context.increment_file_command_index();
+                    return;
+                }
+                let mut upgrade_args = match Self::parse_values(&cmd.values[0], 0) {
+                    Err(e) => {
+                        self.errors.push(PTBError::WithSource {
+                            file_scope: self.context.current_file_scope().clone(),
+                            message: format!("Failed to parse argument command. {}", e.message,),
+                            span: Some(e.span),
+                            help: e.help,
+                        });
+                        self.context.increment_file_command_index();
+                        return;
+                    }
+                    Ok(parsed) => parsed,
+                };
+                upgrade_args.push(Spanned {
+                    span: Span {
+                        start: 0,
+                        end: cmd.values[1].len(),
+                        arg_idx: 1,
+                    },
+                    value: Argument::String(cmd.values[1].clone()),
+                });
+                self.parsed.push(ParsedPTBCommand {
+                    name,
+                    args: upgrade_args,
+                });
+                self.context.increment_file_command_index();
                 return;
             }
             _ => (),
@@ -114,11 +174,17 @@ impl PTBParser {
         let args = cmd
             .values
             .iter()
-            .map(|v| Self::parse_values(&v))
-            .collect::<Result<Vec<_>>>()
+            .enumerate()
+            .map(|(i, v)| Self::parse_values(&v, i))
+            .collect::<ParsingResult<Vec<_>>>()
             .map_err(|e| PTBError::WithSource {
                 file_scope: self.context.current_file_scope().clone(),
-                message: format!("Failed to parse arguments for '{}' command. {e}", cmd.name),
+                message: format!(
+                    "Failed to parse arguments for '{}' command. {}",
+                    cmd.name, e.message
+                ),
+                span: Some(e.span),
+                help: e.help,
             });
 
         self.context.increment_file_command_index();
@@ -135,62 +201,121 @@ impl PTBParser {
     }
 
     /// Parse a string to a list of values. Values are separated by whitespace.
-    pub fn parse_values(s: &str) -> Result<Vec<Argument>> {
-        let tokens: Vec<_> = ArgumentToken::tokenize(s)?;
-        let mut parser = ValueParser::new(tokens);
+    pub fn parse_values(s: &str, arg_idx: usize) -> ParsingResult<Vec<Spanned<Argument>>> {
+        let tokens: Vec<_> = ArgumentToken::tokenize(s).map_err(|e| ParsingErr {
+            span: Span::new(0, s.len(), arg_idx),
+            message: e.into(),
+            help: None,
+        })?;
+        let stokens = Spanner::new(tokens, arg_idx);
+        let mut parser = ValueParser::new(stokens);
         let res = parser.parse_arguments()?;
-        if let Ok((_, contents)) = parser.inner().advance_any() {
-            bail!("Expected end of token stream. Got: {}", contents)
+        if let Ok(sp!(sp, (_, contents))) = parser.spanned(|p| p.advance_any()) {
+            return Err(ParsingErr {
+                span: sp,
+                message: anyhow!("Expected end of token stream. Got: {}", contents).into(),
+                help: None,
+            });
         }
         Ok(res)
     }
 }
 
-impl<'a, I: Iterator<Item = (ArgumentToken, &'a str)>>
-    ValueParser<'a, I, Parser<'a, ArgumentToken, I>>
-{
-    pub fn new<T: IntoIterator<Item = (ArgumentToken, &'a str), IntoIter = I>>(v: T) -> Self {
-        Self::from_parser(Parser::new(v))
-    }
+/// A simple wrapper around a peekable-iterator-type interface that keeps track of the current
+/// location in the input string that is being parsed. This is used to keep track of the location
+/// for generation spans when parsing PTB arguments.
+pub struct Spanner<'a> {
+    pub current_location: usize,
+    pub arg_idx: usize,
+    pub tokens: Vec<(ArgumentToken, &'a str)>,
 }
 
-impl<'a, I, P> ValueParser<'a, I, P>
-where
-    I: Iterator<Item = (ArgumentToken, &'a str)>,
-    P: BorrowMut<Parser<'a, ArgumentToken, I>>,
-{
-    pub fn from_parser(inner: P) -> Self {
+impl<'a> Spanner<'a> {
+    pub fn new(mut tokens: Vec<(ArgumentToken, &'a str)>, arg_idx: usize) -> Self {
+        tokens.reverse();
         Self {
-            inner,
-            arg_index: 0,
-            _a: PhantomData,
-            _i: PhantomData,
+            current_location: 0,
+            arg_idx,
+            tokens,
         }
     }
 
-    /// Parse a list of arguments separated by whitespace.
-    pub fn parse_arguments(&mut self) -> Result<Vec<Argument>> {
-        let args = self.inner().parse_list(
-            |p| ValueParser::from_parser(p).parse_argument_outer(),
-            ArgumentToken::Whitespace,
-            /* not checked */ ArgumentToken::Void,
-            /* allow_trailing_delim */ true,
-        )?;
-        Ok(args)
+    pub fn next(&mut self) -> Option<(ArgumentToken, &'a str)> {
+        if let Some((tok, contents)) = self.tokens.pop() {
+            self.current_location += contents.len();
+            Some((tok, contents))
+        } else {
+            None
+        }
     }
 
-    /// Parse a numerical address.
-    fn parse_address(contents: &str) -> Result<NumericalAddress> {
-        NumericalAddress::parse_str(contents)
-            .map_err(|s| anyhow!("Failed to parse address '{}'. Got error: {}", contents, s))
+    pub fn peek(&self) -> Option<(ArgumentToken, &'a str)> {
+        self.tokens.last().copied()
     }
 
-    /// Parse an argument. Used to keep track of the current argument index that we are at for
-    /// better error reporting.
-    pub fn parse_argument_outer(&mut self) -> Result<Argument> {
-        self.arg_index += 1;
-        self.parse_argument()
-            .with_context(|| format!("Failed to parse argument #{}", self.arg_index,))
+    pub fn current_location(&self) -> usize {
+        self.current_location
+    }
+}
+
+impl<'a> Iterator for Spanner<'a> {
+    type Item = (ArgumentToken, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+
+impl<'a> ValueParser<'a> {
+    pub fn new(v: Spanner<'a>) -> Self {
+        Self { inner: v }
+    }
+
+    pub fn advance_any(&mut self) -> AResult<(ArgumentToken, &'a str)> {
+        match self.inner.next() {
+            Some(tok) => Ok(tok),
+            None => bail!("unexpected end of tokens"),
+        }
+    }
+
+    pub fn advance(&mut self, expected_token: ArgumentToken) -> AResult<&'a str> {
+        let (t, contents) = self.advance_any()?;
+        if t != expected_token {
+            bail!("expected token '{}', but got '{}'", expected_token, t)
+        }
+        Ok(contents)
+    }
+
+    pub fn peek(&mut self) -> Option<(ArgumentToken, &'a str)> {
+        self.inner.peek()
+    }
+
+    pub fn peek_tok(&mut self) -> Option<ArgumentToken> {
+        self.inner.peek().map(|(tok, _)| tok)
+    }
+
+    pub fn parse_list<R>(
+        &mut self,
+        parse_list_item: impl Fn(&mut Self) -> ParsingResult<R>,
+        delim: ArgumentToken,
+        end_token: ArgumentToken,
+        allow_trailing_delim: bool,
+    ) -> ParsingResult<Vec<R>> {
+        let is_end = |tok_opt: Option<ArgumentToken>| -> bool {
+            tok_opt.map(|tok| tok == end_token).unwrap_or(true)
+        };
+        let mut v = vec![];
+        while !is_end(self.peek_tok()) {
+            v.push(parse_list_item(self)?);
+            if is_end(self.peek_tok()) {
+                break;
+            }
+            self.spanned(|p| p.advance(delim))?;
+            if is_end(self.peek_tok()) && allow_trailing_delim {
+                break;
+            }
+        }
+        Ok(v)
     }
 
     /// Parses a list of items separated by `delim` and terminated by `end_token`, skipping any
@@ -199,18 +324,17 @@ where
     /// we're using is space-sensitive so we want to `skip` whitespace, and `delim` by ','.
     pub fn parse_list_skip<R>(
         &mut self,
-        parse_list_item: impl Fn(&mut Self) -> Result<R>,
+        parse_list_item: impl Fn(&mut Self) -> ParsingResult<R>,
         delim: ArgumentToken,
         end_token: ArgumentToken,
         skip: ArgumentToken,
         allow_trailing_delim: bool,
-    ) -> Result<Vec<R>> {
-        let is_end = |parser: &mut Self| -> Result<bool> {
-            while parser.inner().peek_tok() == Some(skip) {
-                parser.inner().advance(skip)?;
+    ) -> ParsingResult<Vec<R>> {
+        let is_end = |parser: &mut Self| -> ParsingResult<bool> {
+            while parser.peek_tok() == Some(skip) {
+                parser.spanned(|p| p.advance(skip))?;
             }
             let is_end = parser
-                .inner()
                 .peek_tok()
                 .map(|tok| tok == end_token)
                 .unwrap_or(true);
@@ -224,86 +348,179 @@ where
             if is_end(self)? {
                 break;
             }
-            self.inner().advance(delim)?;
+            self.spanned(|p| p.advance(delim))?;
             if is_end(self)? && allow_trailing_delim {
                 break;
             }
         }
         Ok(v)
     }
+}
+
+pub struct ParsingErr {
+    pub span: Span,
+    pub message: Box<dyn Error>,
+    pub help: Option<String>,
+}
+
+type ParsingResult<T> = Result<T, ParsingErr>;
+
+impl<'a> ValueParser<'a> {
+    /// Parse a list of arguments separated by whitespace.
+    pub fn parse_arguments(&mut self) -> ParsingResult<Vec<Spanned<Argument>>> {
+        let args = self.parse_list(
+            |p| p.parse_argument(),
+            ArgumentToken::Whitespace,
+            /* not checked */ ArgumentToken::Void,
+            /* allow_trailing_delim */ true,
+        )?;
+        Ok(args)
+    }
+
+    pub fn spanned<T: Debug + Clone + Eq + PartialEq, E: Into<Box<dyn Error>>>(
+        &mut self,
+        parse: impl Fn(&mut Self) -> Result<T, E>,
+    ) -> ParsingResult<Spanned<T>> {
+        let start = self.inner.current_location();
+        let arg = parse(self);
+        let end = self.inner.current_location();
+        let sp = Span {
+            start,
+            end,
+            arg_idx: self.inner.arg_idx,
+        };
+        let arg = arg.map_err(|e| ParsingErr {
+            span: sp,
+            message: e.into(),
+            help: None,
+        })?;
+        Ok(span(sp, arg))
+    }
+
+    pub fn with_span<T: Debug + Clone + Eq + PartialEq, E: Into<Box<dyn Error>>>(
+        &mut self,
+        sp: Span,
+        parse: impl Fn(&mut Self) -> Result<T, E>,
+    ) -> ParsingResult<Spanned<T>> {
+        let arg = parse(self);
+        let arg = arg.map_err(|e| ParsingErr {
+            span: sp,
+            message: e.into(),
+            help: None,
+        })?;
+        Ok(span(sp, arg))
+    }
+
+    pub fn sp<T: Debug + Clone + Eq + PartialEq>(&mut self, start_loc: usize, x: T) -> Spanned<T> {
+        let end = self.inner.current_location();
+        span(
+            Span {
+                start: start_loc,
+                end,
+                arg_idx: self.inner.arg_idx,
+            },
+            x,
+        )
+    }
+
+    /// Parse a numerical address.
+    fn parse_address(sp: Span, contents: &str) -> ParsingResult<Spanned<NumericalAddress>> {
+        let parsed = NumericalAddress::parse_str(contents)
+            .map_err(|s| anyhow!("Failed to parse address '{}'. Got error: {}", contents, s));
+        parsed.map(|addr| span(sp, addr)).map_err(|e| ParsingErr {
+            span: sp,
+            message: e.into(),
+            help: None,
+        })
+    }
 
     /// Parse a single PTB argument. This is the main parsing function for PTB arguments.
-    pub fn parse_argument(&mut self) -> Result<Argument> {
+    pub fn parse_argument(&mut self) -> ParsingResult<Spanned<Argument>> {
         use super::argument_token::ArgumentToken as Tok;
         use Argument as V;
-        Ok(match self.inner().advance_any()? {
-            (Tok::Ident, "true") => V::Bool(true),
-            (Tok::Ident, "false") => V::Bool(false),
-            (Tok::Number, contents) if matches!(self.inner().peek_tok(), Some(Tok::ColonColon)) => {
-                let address = Self::parse_address(contents)
-                    .with_context(|| format!("Unable to parse address '{contents}'"))?;
-                self.inner().advance(Tok::ColonColon)?;
-                let module_name = Identifier::new(
-                    self.inner()
-                        .advance(Tok::Ident)
-                        .with_context(|| format!("Unable to parse module name"))?,
+        let begin_loc = self.inner.current_location();
+        let sp!(tl_loc, arg) = self.spanned(|p| p.advance_any())?;
+        Ok(match arg {
+            (Tok::Ident, "true") => span(tl_loc, V::Bool(true)),
+            (Tok::Ident, "false") => span(tl_loc, V::Bool(false)),
+            (Tok::Number, contents) if matches!(self.peek_tok(), Some(Tok::ColonColon)) => {
+                let address = Self::parse_address(tl_loc, contents)?;
+                self.spanned(|p| p.advance(Tok::ColonColon))?;
+                let module_name = self.spanned(|parser| {
+                    Identifier::new(
+                        parser
+                            .advance(Tok::Ident)
+                            .with_context(|| format!("Unable to parse module name"))?,
+                    )
+                    .with_context(|| format!("Unable to parse module name"))
+                    .into()
+                })?;
+                self.spanned(|p| {
+                    p.advance(Tok::ColonColon)
+                        .with_context(|| format!("Missing '::' after module name"))
+                })?;
+                let function_name = self.spanned(|p| {
+                    Identifier::new(
+                        p.advance(Tok::Ident)
+                            .with_context(|| format!("Unable to parse function name"))?,
+                    )
+                })?;
+                self.sp(
+                    begin_loc,
+                    V::ModuleAccess {
+                        address,
+                        module_name,
+                        function_name,
+                    },
                 )
-                .with_context(|| format!("Unable to parse module name"))?;
-                self.inner()
-                    .advance(Tok::ColonColon)
-                    .with_context(|| format!("Missing '::' after module name"))?;
-                let function_name = Identifier::new(
-                    self.inner()
-                        .advance(Tok::Ident)
-                        .with_context(|| format!("Unable to parse function name"))?,
-                )?;
-                V::ModuleAccess {
-                    address,
-                    module_name,
-                    function_name,
-                }
             }
             (Tok::Number, contents) => {
-                let num = u64::from_str(contents).context("Invalid number")?;
-                V::U64(num)
+                let num = self.with_span(tl_loc, |_| {
+                    u64::from_str(contents).context("Invalid number")
+                })?;
+                span(num.span, V::U64(num.value))
             }
             (Tok::NumberTyped, contents) => {
-                if let Some(s) = contents.strip_suffix("u8") {
-                    let (u, _) = parse_u8(s)?;
-                    V::U8(u)
-                } else if let Some(s) = contents.strip_suffix("u16") {
-                    let (u, _) = parse_u16(s)?;
-                    V::U16(u)
-                } else if let Some(s) = contents.strip_suffix("u32") {
-                    let (u, _) = parse_u32(s)?;
-                    V::U32(u)
-                } else if let Some(s) = contents.strip_suffix("u64") {
-                    let (u, _) = parse_u64(s)?;
-                    V::U64(u)
-                } else if let Some(s) = contents.strip_suffix("u128") {
-                    let (u, _) = parse_u128(s)?;
-                    V::U128(u)
-                } else {
-                    let (u, _) = parse_u256(contents.strip_suffix("u256").unwrap())?;
-                    V::U256(u)
-                }
+                self.with_span::<Argument, anyhow::Error>(tl_loc, |_| {
+                    Ok(if let Some(s) = contents.strip_suffix("u8") {
+                        let (u, _) = parse_u8(s)?;
+                        V::U8(u)
+                    } else if let Some(s) = contents.strip_suffix("u16") {
+                        let (u, _) = parse_u16(s)?;
+                        V::U16(u)
+                    } else if let Some(s) = contents.strip_suffix("u32") {
+                        let (u, _) = parse_u32(s)?;
+                        V::U32(u)
+                    } else if let Some(s) = contents.strip_suffix("u64") {
+                        let (u, _) = parse_u64(s)?;
+                        V::U64(u)
+                    } else if let Some(s) = contents.strip_suffix("u128") {
+                        let (u, _) = parse_u128(s)?;
+                        V::U128(u)
+                    } else {
+                        let (u, _) = parse_u256(contents.strip_suffix("u256").unwrap())?;
+                        V::U256(u)
+                    })
+                })?
             }
             (Tok::At, _) => {
-                let (_, contents) = self.inner().advance_any()?;
-                let address = Self::parse_address(contents)?;
-                V::Address(address)
+                let sp!(addr_span, (_, contents)) = self.spanned(|p| p.advance_any())?;
+                let sp = tl_loc.union_with([addr_span]);
+                let address = Self::parse_address(sp, contents)?;
+                span(address.span, V::Address(address.value))
             }
             (Tok::Some_, _) => {
-                self.inner().advance(Tok::LParen)?;
-                let arg = self.parse_argument()?;
-                self.inner().advance(Tok::RParen)?;
-                V::Option(Some(Box::new(arg)))
+                self.spanned(|p| p.advance(Tok::LParen))?;
+                let sp!(arg_span, arg) = self.parse_argument()?;
+                let sp!(end_span, _) = self.spanned(|p| p.advance(Tok::RParen))?;
+                let sp = tl_loc.union_with([arg_span, end_span]);
+                span(sp, V::Option(span(arg_span, Some(Box::new(arg)))))
             }
-            (Tok::None_, _) => V::Option(None),
-            (Tok::DoubleQuote, contents) => V::String(contents.to_owned()),
-            (Tok::SingleQuote, contents) => V::String(contents.to_owned()),
+            (Tok::None_, _) => span(tl_loc, V::Option(span(tl_loc, None))),
+            (Tok::DoubleQuote, contents) => span(tl_loc, V::String(contents.to_owned())),
+            (Tok::SingleQuote, contents) => span(tl_loc, V::String(contents.to_owned())),
             (Tok::Vector, _) => {
-                self.inner().advance(Tok::LBracket)?;
+                self.spanned(|p| p.advance(Tok::LBracket))?;
                 let values = self.parse_list_skip(
                     |p| p.parse_argument(),
                     ArgumentToken::Comma,
@@ -311,8 +528,9 @@ where
                     Tok::Whitespace,
                     /* allow_trailing_delim */ true,
                 )?;
-                self.inner().advance(Tok::RBracket)?;
-                V::Vector(values)
+                let sp!(end_span, _) = self.spanned(|p| p.advance(Tok::RBracket))?;
+                let total_span = tl_loc.union_with([end_span]);
+                span(total_span, V::Vector(values))
             }
             (Tok::LBracket, _) => {
                 let values = self.parse_list_skip(
@@ -322,27 +540,32 @@ where
                     Tok::Whitespace,
                     /* allow_trailing_delim */ true,
                 )?;
-                self.inner().advance(Tok::RBracket)?;
-                V::Array(values)
+                let sp!(end_span, _) = self.spanned(|p| p.advance(Tok::RBracket))?;
+                let total_span = tl_loc.union_with([end_span]);
+                span(total_span, V::Array(values))
             }
-            (Tok::Ident, contents) if matches!(self.inner().peek_tok(), Some(Tok::Dot)) => {
-                let prefix = Identifier::new(contents)?;
+            (Tok::Ident, contents) if matches!(self.peek_tok(), Some(Tok::Dot)) => {
+                let sp!(_, prefix) = self.with_span(tl_loc, |_| Identifier::new(contents))?;
                 let mut fields = vec![];
-                self.inner().advance(Tok::Dot)?;
-                while let Ok((_, contents)) = self.inner().advance_any() {
-                    fields.push(
-                        u16::from_str(contents)
-                            .context("Invalid field access -- expected a number")?,
-                    );
-                    if !matches!(self.inner().peek_tok(), Some(Tok::Dot)) {
+                self.spanned(|p| p.advance(Tok::Dot))?;
+                while let Ok(sp!(sp, (_, contents))) = self.spanned(|p| p.advance_any()) {
+                    let num = self.with_span(tl_loc, |_| {
+                        u16::from_str(contents).context("Invalid field access -- expected a number")
+                    })?;
+                    fields.push(span(sp, num.value));
+                    if !matches!(self.peek_tok(), Some(Tok::Dot)) {
                         break;
                     }
-                    self.inner().advance(Tok::Dot)?;
+                    self.spanned(|p| p.advance(Tok::Dot))?;
                 }
-                V::VariableAccess(prefix, fields)
+                let sp = tl_loc.union_with(fields.iter().map(|f| f.span).collect::<Vec<_>>());
+                span(sp, V::VariableAccess(span(tl_loc, prefix), fields))
             }
-            (Tok::Ident, contents) => V::Identifier(Identifier::new(contents)?),
-            (Tok::TypeArgString, contents) => {
+            (Tok::Ident, contents) => span(
+                tl_loc,
+                V::Identifier(self.with_span(tl_loc, |_| Identifier::new(contents))?.value),
+            ),
+            (Tok::TypeArgString, contents) => self.with_span(tl_loc, |_| {
                 let type_tokens: Vec<_> = TypeToken::tokenize(contents)?
                     .into_iter()
                     .filter(|(tok, _)| !tok.is_whitespace())
@@ -355,15 +578,13 @@ where
                 if let Ok((_, contents)) = parser.advance_any() {
                     bail!("Expected end of token stream. Got: {}", contents)
                 }
-                V::TyArgs(res)
-            }
-            (Tok::Gas, _) => V::Gas,
-            x => bail!("unexpected token {:?}, expected argument", x),
+                Ok(V::TyArgs(res))
+            })?,
+            (Tok::Gas, _) => span(tl_loc, V::Gas),
+            x => self.with_span(tl_loc, |_| {
+                bail!("unexpected token {:?}, expected argument", x)
+            })?,
         })
-    }
-
-    pub fn inner(&mut self) -> &mut Parser<'a, ArgumentToken, I> {
-        self.inner.borrow_mut()
     }
 }
 
@@ -387,7 +608,7 @@ mod tests {
             "none",
         ];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -400,7 +621,7 @@ mod tests {
             "true @0x0 false 1 1u8 some_ident another ident some(123) none vector[] [] [vector[]] [vector[1]] [vector[1,2]] [vector[1,2,]]",
         ];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -408,7 +629,7 @@ mod tests {
     fn parse_address() {
         let values = vec!["@0x0", "@1234"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -416,7 +637,7 @@ mod tests {
     fn parse_string() {
         let values = vec!["\"hello world\"", "'hello world'"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -424,7 +645,7 @@ mod tests {
     fn parse_vector() {
         let values = vec!["vector[]", "vector[1]", "vector[1,2]", "vector[1,2,]"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -432,7 +653,7 @@ mod tests {
     fn parse_vector_with_spaces() {
         let values = vec!["vector[ ]", "vector[1 ]", "vector[1, 2]", "vector[1, 2, ]"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -440,7 +661,7 @@ mod tests {
     fn parse_array() {
         let values = vec!["[]", "[1]", "[1,2]", "[1,2,]"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -448,7 +669,7 @@ mod tests {
     fn parse_array_with_spaces() {
         let values = vec!["[ ]", "[1 ]", "[1, 2]", "[1, 2, ]"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -456,7 +677,7 @@ mod tests {
     fn module_access() {
         let values = vec!["123::b::c", "0x0::b::c"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -464,7 +685,7 @@ mod tests {
     fn type_args() {
         let values = vec!["<u64>", "<0x0::b::c>", "<0x0::b::c, 1234::g::f>"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -476,7 +697,7 @@ mod tests {
             "1 2u32 vector[]",
         ];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -484,7 +705,7 @@ mod tests {
     fn dotted_accesses() {
         let values = vec!["a.0", "a.1.2", "a.0.1.2"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_ok());
+            assert!(PTBParser::parse_values(s, 0).is_ok());
         }
     }
 
@@ -492,7 +713,7 @@ mod tests {
     fn dotted_accesses_invalid() {
         let values = vec!["a.b.c", "a.b.c.d", "a.b.c.d.e", "a.1,2"];
         for s in &values {
-            assert!(dbg!(PTBParser::parse_values(s)).is_err());
+            assert!(PTBParser::parse_values(s, 0).is_err());
         }
     }
 }

--- a/crates/sui/src/ptb/ptb_parser/utils.rs
+++ b/crates/sui/src/ptb/ptb_parser/utils.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) fn edit_distance(a: &str, b: &str) -> usize {
+    let mut cache = vec![vec![0; b.len() + 1]; a.len() + 1];
+
+    for i in 0..=a.len() {
+        cache[i][0] = i;
+    }
+
+    for j in 0..=b.len() {
+        cache[0][j] = j;
+    }
+
+    for (i, char_a) in a.chars().enumerate().map(|(i, c)| (i + 1, c)) {
+        for (j, char_b) in b.chars().enumerate().map(|(j, c)| (j + 1, c)) {
+            if char_a == char_b {
+                cache[i][j] = cache[i - 1][j - 1];
+            } else {
+                let insert = cache[i][j - 1];
+                let delete = cache[i - 1][j];
+                let replace = cache[i - 1][j - 1];
+
+                cache[i][j] = 1 + std::cmp::min(insert, std::cmp::min(delete, replace));
+            }
+        }
+    }
+
+    cache[a.len()][b.len()]
+}
+
+pub fn find_did_you_means<'a>(
+    needle: &str,
+    haystack: impl IntoIterator<Item = &'a str>,
+) -> Vec<&'a str> {
+    let mut results = Vec::new();
+    let mut best_distance = usize::MAX;
+
+    for item in haystack {
+        let distance = edit_distance(needle, item.as_ref());
+
+        if distance < best_distance {
+            best_distance = distance;
+            results.clear();
+            results.push(item);
+        } else if distance == best_distance {
+            results.push(item);
+        }
+    }
+
+    results
+}
+
+pub fn display_did_you_mean(possibles: Vec<&str>) -> Option<String> {
+    if possibles.is_empty() {
+        return None;
+    }
+
+    let mut strs = vec![];
+
+    let preposition = if possibles.len() == 1 {
+        "Did you mean "
+    } else {
+        "Did you mean one of "
+    };
+
+    let len = possibles.len();
+    for (i, possible) in possibles.into_iter().enumerate() {
+        if i == len - 1 && len > 1 {
+            strs.push(format!("or '{}'", possible));
+        } else {
+            strs.push(format!("'{}'", possible));
+        }
+    }
+
+    Some(format!("{preposition}{}?", strs.join(", ")))
+}


### PR DESCRIPTION
## Description 

Updates parsing and building of the PTB so that we can generate nice errors.

This adds:
* A way for us to track source locations during parsing. This information is then used for error reporting throughout both parsing and PTB building.
* Updated errors so that we can generate accurate error reports. 


## Test Plan 

Ran a bunch of commands locally and verified they worked/errors appeared as expected.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
