### PR TITLE
[cli] fix missing clap macro which breaks the cli

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -620,6 +620,7 @@ pub enum SuiClientCommands {
         /// Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data
         /// (TransactionData) using base64 encoding, and print out the string <TX_BYTES>. The string can
         /// be used to execute transaction with `sui client execute-signed-tx --tx-bytes <TX_BYTES>`.
+        #[clap(long, required = false)]
         serialize_unsigned_transaction: bool,
 
         /// Instead of executing the transaction, serialize the bcs bytes of the signed transaction data


### PR DESCRIPTION
## Description 

This missing clap annotation leads to a panic if there is no subcommand requested, e.g., when `sui client` is called.

```
thread 'main' panicked at /Users/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.1/src/builder/debug_asserts.rs:747:9:
Argument 'serialize_unsigned_transaction` is positional, it must take a value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
