### PR TITLE
[Bridge 33/n] add emergency action and encoding

### DIFF
--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -73,6 +73,12 @@ impl BridgeClient {
                     .join(",");
                 format!("sign/update_committee_blocklist/{chain_id}/{nonce}/{type_}/{keys}")
             }
+            BridgeAction::EmergencyAction(a) => {
+                let chain_id = (a.chain_id as u8).to_string();
+                let nonce = a.nonce.to_string();
+                let type_ = (a.action_type as u8).to_string();
+                format!("sign/emergency_button/{chain_id}/{nonce}/{type_}")
+            }
         }
     }
 
@@ -396,6 +402,16 @@ mod tests {
         assert_eq!(
             BridgeClient::bridge_action_to_path(&action),
             "sign/update_committee_blocklist/11/1/0/027f1178ff417fc9f5b8290bd8876f0a157a505a6c52db100a8492203ddd1d4279,02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4",
+        );
+
+        let action = BridgeAction::EmergencyAction(crate::types::EmergencyAction {
+            chain_id: BridgeChainId::SuiLocalTest,
+            nonce: 5,
+            action_type: crate::types::EmergencyActionType::Pause,
+        });
+        assert_eq!(
+            BridgeClient::bridge_action_to_path(&action),
+            "sign/emergency_button/3/5/0",
         );
     }
 }

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -27,6 +27,7 @@ pub const ETH_TO_SUI_TX_PATH: &str = "/sign/bridge_tx/eth/sui/:tx_hash/:event_in
 pub const SUI_TO_ETH_TX_PATH: &str = "/sign/bridge_tx/sui/eth/:tx_digest/:event_index";
 pub const COMMITTEE_BLOCKLIST_UPDATE_PATH: &str =
     "/sign/update_committee_blocklist/:chain_id/:nonce/:type/:keys";
+pub const EMERGENCY_BUTTON_PATH: &str = "/sign/emergency_button/:chain_id/:nonce/:type";
 
 pub async fn run_server(socket_address: &SocketAddr, handler: BridgeRequestHandler) {
     axum::Server::bind(socket_address)
@@ -43,6 +44,7 @@ pub(crate) fn make_router(
         .route(ETH_TO_SUI_TX_PATH, get(handle_eth_tx_hash))
         .route(SUI_TO_ETH_TX_PATH, get(handle_sui_tx_digest))
         // TODO: handle COMMITTEE_BLOCKLIST_UPDATE_PATH
+        // TODO: handle EMERGENCY_BUTTON_PATH
         .with_state(handler)
 }
 

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -95,6 +95,10 @@ pub fn build_transaction(
             // TODO: handle this case
             unimplemented!()
         }
+        BridgeAction::EmergencyAction(_) => {
+            // TODO: handle this case
+            unimplemented!()
+        }
     }
 }
 

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -342,6 +342,37 @@ impl BlocklistCommitteeAction {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+pub enum EmergencyActionType {
+    Pause = 0,
+    Unpause = 1,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmergencyAction {
+    pub nonce: u64,
+    pub chain_id: BridgeChainId,
+    pub action_type: EmergencyActionType,
+}
+
+impl EmergencyAction {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::EmergencyButton as u8);
+        // Add message version
+        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+        // Add action type
+        bytes.push(self.action_type as u8);
+        bytes
+    }
+}
+
 /// The type of actions Bridge Committee verify and sign off to execution.
 /// Its relationship with BridgeEvent is similar to the relationship between
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -351,11 +382,13 @@ pub enum BridgeAction {
     /// Eth to sui bridge action
     EthToSuiBridgeAction(EthToSuiBridgeAction),
     BlocklistCommitteeAction(BlocklistCommitteeAction),
+    EmergencyAction(EmergencyAction),
     // TODO: add other bridge actions such as blocklist & emergency button
 }
 
 pub const TOKEN_TRANSFER_MESSAGE_VERSION: u8 = 1;
 pub const COMMITTEE_BLOCKLIST_MESSAGE_VERSION: u8 = 1;
+pub const EMERGENCY_BUTTON_MESSAGE_VERSION: u8 = 1;
 
 impl BridgeAction {
     /// Convert to message bytes that are verified in Move and Solidity
@@ -371,6 +404,9 @@ impl BridgeAction {
                 bytes.extend_from_slice(&a.to_bytes());
             }
             BridgeAction::BlocklistCommitteeAction(a) => {
+                bytes.extend_from_slice(&a.to_bytes());
+            }
+            BridgeAction::EmergencyAction(a) => {
                 bytes.extend_from_slice(&a.to_bytes());
             } // TODO add formats for other events
         }
@@ -389,6 +425,7 @@ impl BridgeAction {
             BridgeAction::SuiToEthBridgeAction(a) => a.sui_bridge_event.sui_chain_id,
             BridgeAction::EthToSuiBridgeAction(a) => a.eth_bridge_event.eth_chain_id,
             BridgeAction::BlocklistCommitteeAction(a) => a.chain_id,
+            BridgeAction::EmergencyAction(a) => a.chain_id,
         }
     }
 
@@ -398,6 +435,7 @@ impl BridgeAction {
             BridgeAction::SuiToEthBridgeAction(_) => BridgeActionType::TokenTransfer,
             BridgeAction::EthToSuiBridgeAction(_) => BridgeActionType::TokenTransfer,
             BridgeAction::BlocklistCommitteeAction(_) => BridgeActionType::UpdateCommitteeBlocklist,
+            BridgeAction::EmergencyAction(_) => BridgeActionType::EmergencyButton,
         }
     }
 
@@ -407,6 +445,7 @@ impl BridgeAction {
             BridgeAction::SuiToEthBridgeAction(a) => a.sui_bridge_event.nonce,
             BridgeAction::EthToSuiBridgeAction(a) => a.eth_bridge_event.nonce,
             BridgeAction::BlocklistCommitteeAction(a) => a.nonce,
+            BridgeAction::EmergencyAction(a) => a.nonce,
         }
     }
 }
@@ -776,6 +815,47 @@ mod tests {
         ]: blocklisted members abi-encoded
         */
         assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000005e0b010268b43fd906c0b8f024a18c56e06744f7c6157c65acaef39832cb995c4e049437a3e2ec6a7bad1ab5").unwrap());
+    }
+
+    #[test]
+    fn test_emergency_action_encoding() {
+        let action = BridgeAction::EmergencyAction(EmergencyAction {
+            nonce: 55,
+            chain_id: BridgeChainId::SuiLocalTest,
+            action_type: EmergencyActionType::Pause,
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        02: msg type
+        01: msg version
+        0000000000000037: nonce
+        03: chain id
+        00: action type
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000370300").unwrap()
+        );
+
+        let action = BridgeAction::EmergencyAction(EmergencyAction {
+            nonce: 56,
+            chain_id: BridgeChainId::EthSepolia,
+            action_type: EmergencyActionType::Unpause,
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        02: msg type
+        01: msg version
+        0000000000000038: nonce
+        0b: chain id
+        01: action type
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000380b01").unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description 

As title

## Test Plan 

unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
