### PR TITLE
[Consensus] add network interface

### DIFF
--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -15,6 +15,7 @@ mod dag_state;
 mod error;
 mod leader_schedule;
 mod metrics;
+mod network;
 mod stake_aggregator;
 mod storage;
 mod threshold_clock;

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use consensus_config::AuthorityIndex;
+
+use crate::block::BlockRef;
+
+/// An AuthorityNode will keep a NetworkManager until shutdown.
+pub(crate) trait NetworkManager<C, S>
+where
+    C: NetworkClient,
+    S: NetworkService,
+{
+    /// Returns the network client.
+    fn client(&self) -> Arc<C>;
+
+    /// Installs network service.
+    fn install_service(&self, service: Box<S>);
+}
+
+/// Network client for communicating with peers.
+pub(crate) trait NetworkClient: Send + Sync {
+    /// Sends a block to all connected peers.
+    async fn send_block(&self, target: AuthorityIndex, block: Bytes);
+
+    /// Fetches blocks from a peer.
+    async fn fetch_blocks(&self, target: AuthorityIndex, block_refs: Vec<BlockRef>);
+}
+
+/// Network service for handling requests from peers.
+pub(crate) trait NetworkService: Send + Sync {
+    async fn handle_send_block(&self, source: AuthorityIndex, block: Bytes);
+    async fn handle_fetch_blocks(&self, source: AuthorityIndex, block_refs: Vec<BlockRef>);
+}

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
 
-use crate::block::BlockRef;
+use crate::{block::BlockRef, error::ConsensusResult};
 
-/// An AuthorityNode will keep a NetworkManager until shutdown.
+/// An `AuthorityNode` holds a `NetworkManager` until shutdown.
 pub(crate) trait NetworkManager<C, S>
 where
     C: NetworkClient,
@@ -23,15 +23,23 @@ where
 
 /// Network client for communicating with peers.
 pub(crate) trait NetworkClient: Send + Sync {
-    /// Sends a block to all connected peers.
-    async fn send_block(&self, target: AuthorityIndex, block: Bytes);
+    /// Sends a serialized SignedBlock to a peer.
+    async fn send_block(&self, peer: AuthorityIndex, block: &Bytes) -> ConsensusResult<()>;
 
-    /// Fetches blocks from a peer.
-    async fn fetch_blocks(&self, target: AuthorityIndex, block_refs: Vec<BlockRef>);
+    /// Fetches serialized `SignedBlock`s from a peer.
+    async fn fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+    ) -> ConsensusResult<Vec<Bytes>>;
 }
 
 /// Network service for handling requests from peers.
 pub(crate) trait NetworkService: Send + Sync {
-    async fn handle_send_block(&self, source: AuthorityIndex, block: Bytes);
-    async fn handle_fetch_blocks(&self, source: AuthorityIndex, block_refs: Vec<BlockRef>);
+    async fn handle_send_block(&self, peer: AuthorityIndex, block: Bytes) -> ConsensusResult<()>;
+    async fn handle_fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+    ) -> ConsensusResult<Vec<Bytes>>;
 }


### PR DESCRIPTION
## Description 

Add the minimum network traits. In the beginning, implementations of the traits will just wrap anemo unicast RPCs. Later, streaming and connection management logic can be added inside `NetworkClient` and `NetworkServer` implementations.

## Test Plan 

n/a

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
