### PR TITLE
[gql][consistent-reads][x/n] Make cursor's checkpoint non-null, add context from the input and transaction connections down to ObjectRead.

### DIFF
--- a/crates/sui-graphql-rpc/docs/examples.md
+++ b/crates/sui-graphql-rpc/docs/examples.md
@@ -416,10 +416,10 @@
 
 ### <a id=262141></a>
 ### First Ten After Checkpoint
-####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
+####  Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 0. Note that the cursor is opaque.
 
 ><pre>{
->  checkpoints(first: 10, after: "MTE=") {
+>  checkpoints(first: 10, after: "eyJjIjoyMjgwMDU4MCwicyI6MH0") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -432,7 +432,7 @@
 ####  Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 
 ><pre>{
->  checkpoints(last: 20, before: "MTAw") {
+>  checkpoints(last: 20, before: "eyJjIjoyMjgwMDY1MSwicyI6MjI4MDA2MzJ9") {
 >    nodes {
 >      sequenceNumber
 >      digest
@@ -587,12 +587,12 @@
 
 ### <a id=458748></a>
 ### With Tx Block Connection
-####  Fetch the first 20 transactions after 231220100 (encoded as a
+####  Fetch the first 20 transactions after 885733467 (encoded as a
 ####  cursor) in epoch 97.
 
 ><pre>{
 >  epoch(id: 97) {
->    transactionBlocks(first: 20, after:"MjMxMjIwMTAw") {
+>    transactionBlocks(first: 20, after:"eyJjIjoyMjgwMDY5MiwidCI6ODg1NzMzNDY3fQ") {
 >      pageInfo {
 >        hasNextPage
 >        endCursor
@@ -624,11 +624,11 @@
 ### <a id=458749></a>
 ### With Tx Block Connection Latest Epoch
 ####  the last checkpoint of epoch 97 is 8097645, and the last transaction
-####  number of the checkpoint is 261225985 (encoded as a cursor).
+####  number of the checkpoint is 261225985.
 
 ><pre>{
 >  epoch {
->    transactionBlocks(first: 20, after: "MjYxMjI1OTg1") {
+>    transactionBlocks(first: 20, after: "eyJjIjo4MDk3NjQ1LCJ0IjoyNjEyMjU5ODV9") {
 >      pageInfo {
 >        hasNextPage
 >        endCursor
@@ -691,7 +691,7 @@
 ><pre>query ByEmittingPackageModuleAndEventType {
 >  events(
 >    first: 1
->    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+>    after: "eyJ0eCI6Njc2MywiZSI6MCwiYyI6MjI4MDA3NDJ9"
 >    filter: {
 >      emittingModule: "0x3::sui_system",
 >      eventType: "0x3::validator::StakingRequestEvent"

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/first_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
-# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 11. Note that the cursor is opaque.
+# Fetch the digest and sequence number of the first 10 checkpoints after the cursor, which in this example is set to be checkpoint 0. Note that the cursor is opaque.
 {
-  checkpoints(first: 10, after: "MTE=") {
+  checkpoints(first: 10, after: "eyJjIjoyMjgwMDU4MCwicyI6MH0") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
+++ b/crates/sui-graphql-rpc/examples/checkpoint_connection/last_ten_after_checkpoint.graphql
@@ -1,6 +1,6 @@
 # Fetch the digest and the sequence number of the last 20 checkpoints before the cursor
 {
-  checkpoints(last: 20, before: "MTAw") {
+  checkpoints(last: 20, before: "eyJjIjoyMjgwMDY1MSwicyI6MjI4MDA2MzJ9") {
     nodes {
       sequenceNumber
       digest

--- a/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
@@ -1,8 +1,8 @@
-# Fetch the first 20 transactions after 231220100 (encoded as a
+# Fetch the first 20 transactions after 885733467 (encoded as a
 # cursor) in epoch 97.
 {
   epoch(id: 97) {
-    transactionBlocks(first: 20, after:"MjMxMjIwMTAw") {
+    transactionBlocks(first: 20, after:"eyJjIjoyMjgwMDY5MiwidCI6ODg1NzMzNDY3fQ") {
       pageInfo {
         hasNextPage
         endCursor

--- a/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection_latest_epoch.graphql
+++ b/crates/sui-graphql-rpc/examples/epoch/with_tx_block_connection_latest_epoch.graphql
@@ -1,8 +1,8 @@
 # the last checkpoint of epoch 97 is 8097645, and the last transaction
-# number of the checkpoint is 261225985 (encoded as a cursor).
+# number of the checkpoint is 261225985.
 {
   epoch {
-    transactionBlocks(first: 20, after: "MjYxMjI1OTg1") {
+    transactionBlocks(first: 20, after: "eyJjIjo4MDk3NjQ1LCJ0IjoyNjEyMjU5ODV9") {
       pageInfo {
         hasNextPage
         endCursor

--- a/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
+++ b/crates/sui-graphql-rpc/examples/event_connection/filter_by_emitting_package_module_and_event_type.graphql
@@ -1,7 +1,7 @@
 query ByEmittingPackageModuleAndEventType {
   events(
     first: 1
-    after: "eyJ0eCI6ODUxNzMsImUiOjB9"
+    after: "eyJ0eCI6Njc2MywiZSI6MCwiYyI6MjI4MDA3NDJ9"
     filter: {
       emittingModule: "0x3::sui_system",
       eventType: "0x3::validator::StakingRequestEvent"

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
+
 use crate::data::Conn;
 use crate::raw_query::RawQuery;
 use crate::types::checkpoint::Checkpoint;
@@ -13,6 +15,13 @@ pub(crate) enum View {
     /// Return objects that fulfill the filtering criteria and are the most recent version within
     /// the checkpoint range
     Consistent,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub(crate) struct ConsistentIndexCursor {
+    pub ix: usize,
+    /// The checkpoint sequence number at which the entity corresponding to this cursor was viewed at.
+    pub c: u64,
 }
 
 /// Constructs a `RawQuery` against the `objects_snapshot` and `objects_history` table to fetch

--- a/crates/sui-graphql-rpc/src/mutation.rs
+++ b/crates/sui-graphql-rpc/src/mutation.rs
@@ -131,7 +131,8 @@ impl Mutation {
                     native,
                     events,
                 },
-                checkpoint_viewed_at: None,
+                // set to u64::MAX, as the executed transaction has not been indexed yet
+                checkpoint_viewed_at: u64::MAX,
             },
         })
     }

--- a/crates/sui-graphql-rpc/src/types/balance_change.rs
+++ b/crates/sui-graphql-rpc/src/types/balance_change.rs
@@ -10,10 +10,8 @@ use crate::error::Error;
 
 pub(crate) struct BalanceChange {
     stored: StoredBalanceChange,
-
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
 }
 
 /// Effects to the balance (sum of coin values per coin type) owned by an address or object.
@@ -26,7 +24,7 @@ impl BalanceChange {
         match self.stored.owner {
             O::AddressOwner(addr) | O::ObjectOwner(addr) => Some(Owner {
                 address: SuiAddress::from(addr),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             }),
 
             O::Shared { .. } | O::Immutable => None,
@@ -49,7 +47,7 @@ impl BalanceChange {
     /// `BalanceChange` was queried for, or `None` if the data was requested at the latest
     /// checkpoint. This is stored on `BalanceChange` so that when viewing that entity's state, it
     /// will be as if it was read at the same checkpoint.
-    pub(crate) fn read(bytes: &[u8], checkpoint_viewed_at: Option<u64>) -> Result<Self, Error> {
+    pub(crate) fn read(bytes: &[u8], checkpoint_viewed_at: u64) -> Result<Self, Error> {
         let stored = bcs::from_bytes(bytes)
             .map_err(|e| Error::Internal(format!("Error deserializing BalanceChange: {e}")))?;
 

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -333,9 +333,7 @@ impl Coin {
         for stored in results {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
-            let cursor = stored
-                .consistent_cursor(checkpoint_viewed_at)
-                .encode_cursor();
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             let object =
                 Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -228,9 +228,7 @@ impl DynamicField {
         for stored in results {
             // To maintain consistency, the returned cursor should have the same upper-bound as the
             // checkpoint found on the cursor.
-            let cursor = stored
-                .consistent_cursor(checkpoint_viewed_at)
-                .encode_cursor();
+            let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
 
             let object =
                 Object::try_from_stored_history_object(stored, Some(checkpoint_viewed_at))?;

--- a/crates/sui-graphql-rpc/src/types/gas.rs
+++ b/crates/sui-graphql-rpc/src/types/gas.rs
@@ -40,9 +40,8 @@ pub(crate) struct GasEffects {
     pub summary: GasCostSummary,
     pub object_id: SuiAddress,
     pub object_version: u64,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Configuration for this transaction's gas price and the coins used to pay for gas.
@@ -136,7 +135,7 @@ impl GasEffects {
             self.object_id,
             ObjectLookupKey::VersionAt {
                 version: self.object_version,
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -153,10 +152,7 @@ impl GasEffects {
     /// was queried for, or `None` if the data was requested at the latest checkpoint. This is
     /// stored on `GasEffects` so that when viewing that entity's state, it will be as if it was
     /// read at the same checkpoint.
-    pub(crate) fn from(
-        effects: &NativeTransactionEffects,
-        checkpoint_viewed_at: Option<u64>,
-    ) -> Self {
+    pub(crate) fn from(effects: &NativeTransactionEffects, checkpoint_viewed_at: u64) -> Self {
         let ((id, version, _digest), _owner) = effects.gas_object();
         Self {
             summary: GasCostSummary::from(effects.gas_cost_summary()),

--- a/crates/sui-graphql-rpc/src/types/object_change.rs
+++ b/crates/sui-graphql-rpc/src/types/object_change.rs
@@ -11,9 +11,8 @@ use super::{
 
 pub(crate) struct ObjectChange {
     pub native: NativeObjectChange,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// Effect on an individual Object (keyed by its ID).
@@ -35,7 +34,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -53,7 +52,7 @@ impl ObjectChange {
             self.native.id.into(),
             ObjectLookupKey::VersionAt {
                 version: version.value(),
-                checkpoint_viewed_at: self.checkpoint_viewed_at,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await

--- a/crates/sui-graphql-rpc/src/types/object_read.rs
+++ b/crates/sui-graphql-rpc/src/types/object_read.rs
@@ -12,7 +12,11 @@ use super::{
 // A helper type representing the read of a specific version of an object. Intended to be
 // "flattened" into other GraphQL types.
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct ObjectRead(pub NativeObjectRef);
+pub(crate) struct ObjectRead {
+    pub native: NativeObjectRef,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[Object]
 impl ObjectRead {
@@ -29,7 +33,7 @@ impl ObjectRead {
     /// 32-byte hash that identifies the object's contents at this version, encoded as a Base58
     /// string.
     async fn digest(&self) -> String {
-        self.0 .2.base58_encode()
+        self.native.2.base58_encode()
     }
 
     /// The object at this version.  May not be available due to pruning.
@@ -39,7 +43,7 @@ impl ObjectRead {
             self.address_impl(),
             ObjectLookupKey::VersionAt {
                 version: self.version_impl(),
-                checkpoint_viewed_at: None,
+                checkpoint_viewed_at: Some(self.checkpoint_viewed_at),
             },
         )
         .await
@@ -49,10 +53,10 @@ impl ObjectRead {
 
 impl ObjectRead {
     fn address_impl(&self) -> SuiAddress {
-        SuiAddress::from(self.0 .0)
+        SuiAddress::from(self.native.0)
     }
 
     fn version_impl(&self) -> u64 {
-        self.0 .1.value()
+        self.native.1.value()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -11,35 +11,47 @@ use sui_types::{
     transaction::AuthenticatorStateUpdate as NativeAuthenticatorStateUpdateTransaction,
 };
 
-use crate::types::{
-    cursor::{JsonCursor, Page},
-    epoch::Epoch,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        cursor::{JsonCursor, Page},
+        epoch::Epoch,
+    },
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct AuthenticatorStateUpdateTransaction(
-    pub NativeAuthenticatorStateUpdateTransaction,
-);
+pub(crate) struct AuthenticatorStateUpdateTransaction {
+    pub native: NativeAuthenticatorStateUpdateTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CActiveJwk = JsonCursor<usize>;
+pub(crate) type CActiveJwk = JsonCursor<ConsistentIndexCursor>;
 
 /// The active JSON Web Key representing a set of public keys for an OpenID provider
-struct ActiveJwk(NativeActiveJwk);
+struct ActiveJwk {
+    native: NativeActiveJwk,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
+}
 
 /// System transaction for updating the on-chain state used by zkLogin.
 #[Object]
 impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// Consensus round of the authenticator state update.
     async fn round(&self) -> u64 {
-        self.0.round
+        self.native.round
     }
 
     /// Newly active JWKs (JSON Web Keys).
@@ -54,7 +66,11 @@ impl AuthenticatorStateUpdateTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.new_active_jwks.len()) else {
+        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+            self.native.new_active_jwks.len(),
+            self.checkpoint_viewed_at,
+        )?
+        else {
             return Ok(connection);
         };
 
@@ -62,7 +78,10 @@ impl AuthenticatorStateUpdateTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let active_jwk = ActiveJwk(self.0.new_active_jwks[*c].clone());
+            let active_jwk = ActiveJwk {
+                native: self.native.new_active_jwks[c.ix].clone(),
+                checkpoint_viewed_at: c.c,
+            };
             connection
                 .edges
                 .push(Edge::new(c.encode_cursor(), active_jwk));
@@ -73,7 +92,7 @@ impl AuthenticatorStateUpdateTransaction {
 
     /// The initial version of the authenticator object that it was shared at.
     async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.0.authenticator_obj_initial_shared_version.value()
+        self.native.authenticator_obj_initial_shared_version.value()
     }
 }
 
@@ -81,39 +100,42 @@ impl AuthenticatorStateUpdateTransaction {
 impl ActiveJwk {
     /// The string (Issuing Authority) that identifies the OIDC provider.
     async fn iss(&self) -> &str {
-        &self.0.jwk_id.iss
+        &self.native.jwk_id.iss
     }
 
     /// The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
     async fn kid(&self) -> &str {
-        &self.0.jwk_id.kid
+        &self.native.jwk_id.kid
     }
 
     /// The JWK key type parameter, (RFC 7517, Section 4.1).
     async fn kty(&self) -> &str {
-        &self.0.jwk.kty
+        &self.native.jwk.kty
     }
 
     /// The JWK RSA public exponent, (RFC 7517, Section 9.3).
     async fn e(&self) -> &str {
-        &self.0.jwk.e
+        &self.native.jwk.e
     }
 
     /// The JWK RSA modulus, (RFC 7517, Section 9.3).
     async fn n(&self) -> &str {
-        &self.0.jwk.n
+        &self.native.jwk.n
     }
 
     /// The JWK algorithm parameter, (RFC 7517, Section 4.4).
     async fn alg(&self) -> &str {
-        &self.0.jwk.alg
+        &self.native.jwk.alg
     }
 
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -24,6 +24,8 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
     round: u64,
     commit_timestamp_ms: CheckpointTimestamp,
     consensus_commit_digest: Option<ConsensusCommitDigest>,
+    /// The checkpoint sequence number this was viewed at.
+    checkpoint_viewed_at: u64,
 }
 
 /// System transaction that runs at the beginning of a checkpoint, and is responsible for setting
@@ -32,10 +34,13 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// Consensus round of the commit.
@@ -56,24 +61,30 @@ impl ConsensusCommitPrologueTransaction {
     }
 }
 
-impl From<NativeConsensusCommitPrologueTransactionV1> for ConsensusCommitPrologueTransaction {
-    fn from(ccp: NativeConsensusCommitPrologueTransactionV1) -> Self {
+impl ConsensusCommitPrologueTransaction {
+    pub(crate) fn from_v1(
+        ccp: NativeConsensusCommitPrologueTransactionV1,
+        checkpoint_viewed_at: u64,
+    ) -> Self {
         Self {
             epoch: ccp.epoch,
             round: ccp.round,
             commit_timestamp_ms: ccp.commit_timestamp_ms,
             consensus_commit_digest: None,
+            checkpoint_viewed_at,
         }
     }
-}
 
-impl From<NativeConsensusCommitPrologueTransactionV2> for ConsensusCommitPrologueTransaction {
-    fn from(ccp: NativeConsensusCommitPrologueTransactionV2) -> Self {
+    pub(crate) fn from_v2(
+        ccp: NativeConsensusCommitPrologueTransactionV2,
+        checkpoint_viewed_at: u64,
+    ) -> Self {
         Self {
             epoch: ccp.epoch,
             round: ccp.round,
             commit_timestamp_ms: ccp.commit_timestamp_ms,
             consensus_commit_digest: Some(ccp.consensus_commit_digest),
+            checkpoint_viewed_at,
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -15,6 +15,7 @@ use sui_types::{
     },
 };
 
+use crate::consistency::ConsistentIndexCursor;
 use crate::types::cursor::{JsonCursor, Page};
 use crate::types::sui_address::SuiAddress;
 use crate::{
@@ -26,7 +27,11 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct EndOfEpochTransaction(pub Vec<NativeEndOfEpochTransactionKind>);
+pub(crate) struct EndOfEpochTransaction {
+    pub native: Vec<NativeEndOfEpochTransactionKind>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[derive(Union, Clone, PartialEq, Eq)]
 pub(crate) enum EndOfEpochTransactionKind {
@@ -38,7 +43,11 @@ pub(crate) enum EndOfEpochTransactionKind {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct ChangeEpochTransaction(pub NativeChangeEpochTransaction);
+pub(crate) struct ChangeEpochTransaction {
+    pub native: NativeChangeEpochTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 /// System transaction for creating the on-chain state used by zkLogin.
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
@@ -49,9 +58,11 @@ pub(crate) struct AuthenticatorStateCreateTransaction {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct AuthenticatorStateExpireTransaction(
-    pub NativeAuthenticatorStateExpireTransaction,
-);
+pub(crate) struct AuthenticatorStateExpireTransaction {
+    pub native: NativeAuthenticatorStateExpireTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
 pub(crate) struct RandomnessStateCreateTransaction {
@@ -67,8 +78,8 @@ pub(crate) struct CoinDenyListStateCreateTransaction {
     dummy: Option<bool>,
 }
 
-pub(crate) type CTxn = JsonCursor<usize>;
-pub(crate) type CPackage = JsonCursor<usize>;
+pub(crate) type CTxn = JsonCursor<ConsistentIndexCursor>;
+pub(crate) type CPackage = JsonCursor<ConsistentIndexCursor>;
 
 /// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions
 /// at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other
@@ -87,7 +98,9 @@ impl EndOfEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -95,7 +108,7 @@ impl EndOfEpochTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let tx = EndOfEpochTransactionKind::from(self.0[*c].clone());
+            let tx = EndOfEpochTransactionKind::from(self.native[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), tx));
         }
 
@@ -112,41 +125,44 @@ impl EndOfEpochTransaction {
 impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// The protocol version in effect in the new epoch.
     async fn protocol_version(&self) -> u64 {
-        self.0.protocol_version.as_u64()
+        self.native.protocol_version.as_u64()
     }
 
     /// The total amount of gas charged for storage during the previous epoch (in MIST).
     async fn storage_charge(&self) -> BigInt {
-        BigInt::from(self.0.storage_charge)
+        BigInt::from(self.native.storage_charge)
     }
 
     /// The total amount of gas charged for computation during the previous epoch (in MIST).
     async fn computation_charge(&self) -> BigInt {
-        BigInt::from(self.0.computation_charge)
+        BigInt::from(self.native.computation_charge)
     }
 
     /// The SUI returned to transaction senders for cleaning up objects (in MIST).
     async fn storage_rebate(&self) -> BigInt {
-        BigInt::from(self.0.storage_rebate)
+        BigInt::from(self.native.storage_rebate)
     }
 
     /// The total gas retained from storage fees, that will not be returned by storage rebates when
     /// the relevant objects are cleaned up (in MIST).
     async fn non_refundable_storage_fee(&self) -> BigInt {
-        BigInt::from(self.0.non_refundable_storage_fee)
+        BigInt::from(self.native.non_refundable_storage_fee)
     }
 
     /// Time at which the next epoch will start.
     async fn start_timestamp(&self) -> Result<DateTime, Error> {
-        DateTime::from_ms(self.0.epoch_start_timestamp_ms as i64)
+        DateTime::from_ms(self.native.epoch_start_timestamp_ms as i64)
     }
 
     /// System packages (specifically framework and move stdlib) that are written before the new
@@ -163,7 +179,11 @@ impl ChangeEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.system_packages.len()) else {
+        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+            self.native.system_packages.len(),
+            self.checkpoint_viewed_at,
+        )?
+        else {
             return Ok(connection);
         };
 
@@ -171,7 +191,7 @@ impl ChangeEpochTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let (version, modules, deps) = &self.0.system_packages[*c];
+            let (version, modules, deps) = &self.native.system_packages[c.ix];
             let compiled_modules = modules
                 .iter()
                 .map(|bytes| CompiledModule::deserialize_with_defaults(bytes))
@@ -187,7 +207,7 @@ impl ChangeEpochTransaction {
             );
 
             let runtime_id = native.id();
-            let object = Object::from_native(SuiAddress::from(runtime_id), native, None);
+            let object = Object::from_native(SuiAddress::from(runtime_id), native, Some(c.c));
             let package = MovePackage::try_from(&object)
                 .map_err(|_| Error::Internal("Failed to create system package".to_string()))
                 .extend()?;
@@ -203,30 +223,39 @@ impl ChangeEpochTransaction {
 impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
-        Epoch::query(ctx.data_unchecked(), Some(self.0.min_epoch), None)
-            .await
-            .extend()
+        Epoch::query(
+            ctx.data_unchecked(),
+            Some(self.native.min_epoch),
+            Some(self.checkpoint_viewed_at),
+        )
+        .await
+        .extend()
     }
 
     /// The initial version that the AuthenticatorStateUpdate was shared at.
     async fn authenticator_obj_initial_shared_version(&self) -> u64 {
-        self.0.authenticator_obj_initial_shared_version.value()
+        self.native.authenticator_obj_initial_shared_version.value()
     }
 }
 
-impl From<NativeEndOfEpochTransactionKind> for EndOfEpochTransactionKind {
-    fn from(kind: NativeEndOfEpochTransactionKind) -> Self {
+impl EndOfEpochTransactionKind {
+    fn from(kind: NativeEndOfEpochTransactionKind, checkpoint_viewed_at: u64) -> Self {
         use EndOfEpochTransactionKind as K;
         use NativeEndOfEpochTransactionKind as N;
 
         match kind {
-            N::ChangeEpoch(ce) => K::ChangeEpoch(ChangeEpochTransaction(ce)),
+            N::ChangeEpoch(ce) => K::ChangeEpoch(ChangeEpochTransaction {
+                native: ce,
+                checkpoint_viewed_at,
+            }),
             N::AuthenticatorStateCreate => {
                 K::AuthenticatorStateCreate(AuthenticatorStateCreateTransaction { dummy: None })
             }
             N::AuthenticatorStateExpire(ase) => {
-                K::AuthenticatorStateExpire(AuthenticatorStateExpireTransaction(ase))
+                K::AuthenticatorStateExpire(AuthenticatorStateExpireTransaction {
+                    native: ase,
+                    checkpoint_viewed_at,
+                })
             }
             N::RandomnessStateCreate => {
                 K::RandomnessStateCreate(RandomnessStateCreateTransaction { dummy: None })

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -11,16 +11,23 @@ use sui_types::{
     transaction::{GenesisObject, GenesisTransaction as NativeGenesisTransaction},
 };
 
-use crate::types::{
-    cursor::{JsonCursor, Page},
-    object::Object,
-    sui_address::SuiAddress,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        cursor::{JsonCursor, Page},
+        object::Object,
+        sui_address::SuiAddress,
+    },
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct GenesisTransaction(pub NativeGenesisTransaction);
+pub(crate) struct GenesisTransaction {
+    pub native: NativeGenesisTransaction,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CObject = JsonCursor<usize>;
+pub(crate) type CObject = JsonCursor<ConsistentIndexCursor>;
 
 /// System transaction that initializes the network and writes the initial set of objects on-chain.
 #[Object]
@@ -37,7 +44,9 @@ impl GenesisTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.objects.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.objects.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -45,11 +54,11 @@ impl GenesisTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let GenesisObject::RawObject { data, owner } = self.0.objects[*c].clone();
+            let GenesisObject::RawObject { data, owner } = self.native.objects[c.ix].clone();
             let native =
                 NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
 
-            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(0));
+            let object = Object::from_native(SuiAddress::from(native.id()), native, Some(c.c));
             connection.edges.push(Edge::new(c.encode_cursor(), object));
         }
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -32,24 +32,43 @@ pub(crate) enum TransactionBlockKind {
     EndOfEpoch(EndOfEpochTransaction),
 }
 
-impl From<NativeTransactionKind> for TransactionBlockKind {
-    fn from(kind: NativeTransactionKind) -> Self {
+impl TransactionBlockKind {
+    pub(crate) fn from(kind: NativeTransactionKind, checkpoint_viewed_at: u64) -> Self {
         use NativeTransactionKind as K;
         use TransactionBlockKind as T;
 
         match kind {
-            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock(pt)),
-            K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction(ce)),
-            K::Genesis(g) => T::Genesis(GenesisTransaction(g)),
-            K::ConsensusCommitPrologue(ccp) => T::ConsensusCommitPrologue(ccp.into()),
-            K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(ccp.into()),
+            K::ProgrammableTransaction(pt) => T::Programmable(ProgrammableTransactionBlock {
+                native: pt,
+                checkpoint_viewed_at,
+            }),
+            K::ChangeEpoch(ce) => T::ChangeEpoch(ChangeEpochTransaction {
+                native: ce,
+                checkpoint_viewed_at,
+            }),
+            K::Genesis(g) => T::Genesis(GenesisTransaction {
+                native: g,
+                checkpoint_viewed_at,
+            }),
+            K::ConsensusCommitPrologue(ccp) => T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v1(ccp, checkpoint_viewed_at),
+            ),
+            K::ConsensusCommitPrologueV2(ccp) => T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v2(ccp, checkpoint_viewed_at),
+            ),
             K::AuthenticatorStateUpdate(asu) => {
-                T::AuthenticatorState(AuthenticatorStateUpdateTransaction(asu))
+                T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
+                    native: asu,
+                    checkpoint_viewed_at,
+                })
             }
-            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction(eoe)),
+            K::EndOfEpochTransaction(eoe) => T::EndOfEpoch(EndOfEpochTransaction {
+                native: eoe,
+                checkpoint_viewed_at,
+            }),
             K::RandomnessStateUpdate(rsu) => T::Randomness(RandomnessStateUpdateTransaction {
                 native: rsu,
-                checkpoint_viewed_at: None, // TODO (wlmyng)
+                checkpoint_viewed_at,
             }),
         }
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -1,13 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{
-    base64::Base64,
-    cursor::{JsonCursor, Page},
-    move_function::MoveFunction,
-    move_type::MoveType,
-    object_read::ObjectRead,
-    sui_address::SuiAddress,
+use crate::{
+    consistency::ConsistentIndexCursor,
+    types::{
+        base64::Base64,
+        cursor::{JsonCursor, Page},
+        move_function::MoveFunction,
+        move_type::MoveType,
+        object_read::ObjectRead,
+        sui_address::SuiAddress,
+    },
 };
 use async_graphql::{
     connection::{Connection, CursorType, Edge},
@@ -21,10 +24,14 @@ use sui_types::transaction::{
 };
 
 #[derive(Clone, Eq, PartialEq)]
-pub(crate) struct ProgrammableTransactionBlock(pub NativeProgrammableTransactionBlock);
+pub(crate) struct ProgrammableTransactionBlock {
+    pub native: NativeProgrammableTransactionBlock,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
+}
 
-pub(crate) type CInput = JsonCursor<usize>;
-pub(crate) type CTxn = JsonCursor<usize>;
+pub(crate) type CInput = JsonCursor<ConsistentIndexCursor>;
+pub(crate) type CTxn = JsonCursor<ConsistentIndexCursor>;
 
 #[derive(Union, Clone, Eq, PartialEq)]
 enum TransactionInput {
@@ -82,7 +89,10 @@ enum ProgrammableTransaction {
 }
 
 #[derive(Clone, Eq, PartialEq)]
-struct MoveCallTransaction(NativeMoveCallTransaction);
+struct MoveCallTransaction {
+    native: NativeMoveCallTransaction,
+    checkpoint_viewed_at: u64,
+}
 
 /// Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public
 /// transfer) and must not be previously immutable or shared.
@@ -205,7 +215,9 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.inputs.len()) else {
+        let Some((prev, next, cs)) =
+            page.paginate_consistent_indices(self.native.inputs.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -213,7 +225,7 @@ impl ProgrammableTransactionBlock {
         connection.has_next_page = next;
 
         for c in cs {
-            let input = TransactionInput::from(self.0.inputs[*c].clone());
+            let input = TransactionInput::from(self.native.inputs[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), input));
         }
 
@@ -232,7 +244,9 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(self.0.commands.len()) else {
+        let Some((prev, next, cs)) = page
+            .paginate_consistent_indices(self.native.commands.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -240,7 +254,7 @@ impl ProgrammableTransactionBlock {
         connection.has_next_page = next;
 
         for c in cs {
-            let txn = ProgrammableTransaction::from(self.0.commands[*c].clone());
+            let txn = ProgrammableTransaction::from(self.native.commands[c.ix].clone(), c.c);
             connection.edges.push(Edge::new(c.encode_cursor(), txn));
         }
 
@@ -253,26 +267,26 @@ impl ProgrammableTransactionBlock {
 impl MoveCallTransaction {
     /// The storage ID of the package the function being called is defined in.
     async fn package(&self) -> SuiAddress {
-        self.0.package.into()
+        self.native.package.into()
     }
 
     /// The name of the module the function being called is defined in.
     async fn module(&self) -> &str {
-        self.0.module.as_str()
+        self.native.module.as_str()
     }
 
     /// The name of the function being called.
     async fn function_name(&self) -> &str {
-        self.0.function.as_str()
+        self.native.function.as_str()
     }
 
     /// The function being called, resolved.
     async fn function(&self, ctx: &Context<'_>) -> Result<Option<MoveFunction>> {
         MoveFunction::query(
             ctx.data_unchecked(),
-            self.0.package.into(),
-            self.0.module.as_str(),
-            self.0.function.as_str(),
+            self.native.package.into(),
+            self.native.module.as_str(),
+            self.native.function.as_str(),
         )
         .await
         .extend()
@@ -280,7 +294,7 @@ impl MoveCallTransaction {
 
     /// The actual type parameters passed in for this move call.
     async fn type_arguments(&self) -> Vec<MoveType> {
-        self.0
+        self.native
             .type_arguments
             .iter()
             .map(|tag| MoveType::new(tag.clone()))
@@ -289,7 +303,7 @@ impl MoveCallTransaction {
 
     /// The actual function parameters passed in for this move call.
     async fn arguments(&self) -> Vec<TransactionArgument> {
-        self.0
+        self.native
             .arguments
             .iter()
             .map(|arg| TransactionArgument::from(*arg))
@@ -297,8 +311,8 @@ impl MoveCallTransaction {
     }
 }
 
-impl From<NativeCallArg> for TransactionInput {
-    fn from(argument: NativeCallArg) -> Self {
+impl TransactionInput {
+    fn from(argument: NativeCallArg, checkpoint_viewed_at: u64) -> Self {
         use NativeCallArg as N;
         use NativeObjectArg as O;
         use TransactionInput as I;
@@ -309,7 +323,10 @@ impl From<NativeCallArg> for TransactionInput {
             }),
 
             N::Object(O::ImmOrOwnedObject(oref)) => I::OwnedOrImmutable(OwnedOrImmutable {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             }),
 
             N::Object(O::SharedObject {
@@ -323,18 +340,24 @@ impl From<NativeCallArg> for TransactionInput {
             }),
 
             N::Object(O::Receiving(oref)) => I::Receiving(Receiving {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             }),
         }
     }
 }
 
-impl From<NativeProgrammableTransaction> for ProgrammableTransaction {
-    fn from(pt: NativeProgrammableTransaction) -> Self {
+impl ProgrammableTransaction {
+    fn from(pt: NativeProgrammableTransaction, checkpoint_viewed_at: u64) -> Self {
         use NativeProgrammableTransaction as N;
         use ProgrammableTransaction as P;
         match pt {
-            N::MoveCall(call) => P::MoveCall(MoveCallTransaction(*call)),
+            N::MoveCall(call) => P::MoveCall(MoveCallTransaction {
+                native: *call,
+                checkpoint_viewed_at,
+            }),
 
             N::TransferObjects(inputs, address) => P::TransferObjects(TransferObjectsTransaction {
                 inputs: inputs.into_iter().map(TransactionArgument::from).collect(),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -8,9 +8,8 @@ use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct RandomnessStateUpdateTransaction {
     pub native: NativeRandomnessStateUpdate,
-    /// The checkpoint sequence number at which this was viewed at, or None if the data was
-    /// requested at the latest checkpoint.
-    pub checkpoint_viewed_at: Option<u64>,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
 /// System transaction to update the source of on-chain randomness.
@@ -18,11 +17,10 @@ pub(crate) struct RandomnessStateUpdateTransaction {
 impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        // TODO (wlmyng)
         Epoch::query(
             ctx.data_unchecked(),
             Some(self.native.epoch),
-            self.checkpoint_viewed_at,
+            Some(self.checkpoint_viewed_at),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -42,10 +42,11 @@ pub(crate) struct SharedObjectDelete {
 /// Error for converting from an `InputSharedObject`.
 pub(crate) struct SharedObjectChanged;
 
-impl TryFrom<NativeInputSharedObject> for UnchangedSharedObject {
-    type Error = SharedObjectChanged;
-
-    fn try_from(input: NativeInputSharedObject) -> Result<Self, Self::Error> {
+impl UnchangedSharedObject {
+    pub fn try_from(
+        input: NativeInputSharedObject,
+        checkpoint_viewed_at: u64,
+    ) -> Result<Self, SharedObjectChanged> {
         use NativeInputSharedObject as I;
         use UnchangedSharedObject as U;
 
@@ -53,7 +54,10 @@ impl TryFrom<NativeInputSharedObject> for UnchangedSharedObject {
             I::Mutate(_) => Err(SharedObjectChanged),
 
             I::ReadOnly(oref) => Ok(U::Read(SharedObjectRead {
-                read: ObjectRead(oref),
+                read: ObjectRead {
+                    native: oref,
+                    checkpoint_viewed_at,
+                },
             })),
 
             I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {


### PR DESCRIPTION
## Description 

Adds a `ConsistentIndexCursor` to the `consistency` module - we have a good number of cursors that are just indices into a type's `Vec` field, so this is a quick way to handle consistency for all of them in one go.

Sets `checkpoint_viewed_at` field on cursors to non-null. `DryRun` and `Mutation` results now fetch the latest checkpoint sequence number so that we can set `TransactionBlock` and `TransactionBlockEffects` to a checkpoint value. This is so that pagination fields on types that do not make a db roundtrip will have the correct checkpoint context on hand already - thus we can set `checkpoint_viewed_at: u64` on fields like the transaction calls of a `PTB`. Actually, it's likely the case that all graphql types can have a non-null `checkpoint_viewed_at`, but this can be revisited later.

Removes `fn cursor` from `Target` trait. Adds a `paginate_consistent_indices` function - does exactly what `paginate_indices` does, with the one difference that this function also validates cursor consistency. The caller just needs to use `cursor.ix` to index into the data's `Vec` field, and use `cursor.c` which has been set to the correct `checkpoint_viewed_at`.

Shorten cursor fields to one letter to reduce size.

This leaves MoveModule and related types and Validator and related types.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
