### PR TITLE
Nikost/rosetta budget

### DIFF
--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -283,7 +283,7 @@ pub async fn metadata(
         }
     };
 
-    // Get budget for suggested fee.
+    // Get budget for suggested_fee and metadata.budget
     let budget = match budget {
         Some(budget) => budget,
         None => {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -171,7 +171,7 @@ pub async fn preprocess(
 
     let internal_operation = request.operations.into_internal()?;
     let sender = internal_operation.sender();
-    let budget = request.metadata.map(|m| m.budget).flatten();
+    let budget = request.metadata.and_then(|m| m.budget);
 
     Ok(ConstructionPreprocessResponse {
         options: Some(MetadataOptions {

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -558,14 +558,7 @@ pub struct ConstructionPreprocessRequest {
 
 #[derive(Serialize, Deserialize)]
 pub struct PreprocessMetadata {
-    pub internal_operation: InternalOperationRequest,
     pub budget: Option<u64>
-}
-
-#[derive(Serialize, Deserialize)]
-pub enum InternalOperationRequest {
-    PaySui,
-    Delegation,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -556,8 +556,9 @@ pub struct ConstructionPreprocessRequest {
     pub metadata: Option<PreprocessMetadata>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PreprocessMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<u64>
 }
 
@@ -572,6 +573,7 @@ pub struct ConstructionPreprocessResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataOptions {
     pub internal_operation: InternalOperation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<u64>
 }
 

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -556,7 +556,7 @@ pub struct ConstructionPreprocessRequest {
     pub metadata: Option<PreprocessMetadata>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct PreprocessMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<u64>,

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -557,7 +557,13 @@ pub struct ConstructionPreprocessRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum PreprocessMetadata {
+pub struct PreprocessMetadata {
+    pub internal_operation: InternalOperationRequest,
+    pub budget: Option<u64>
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum InternalOperationRequest {
     PaySui,
     Delegation,
 }
@@ -573,6 +579,7 @@ pub struct ConstructionPreprocessResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataOptions {
     pub internal_operation: InternalOperation,
+    pub budget: Option<u64>
 }
 
 impl IntoResponse for ConstructionPreprocessResponse {

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -559,7 +559,7 @@ pub struct ConstructionPreprocessRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PreprocessMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub budget: Option<u64>
+    pub budget: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -574,7 +574,7 @@ pub struct ConstructionPreprocessResponse {
 pub struct MetadataOptions {
     pub internal_operation: InternalOperation,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub budget: Option<u64>
+    pub budget: Option<u64>,
 }
 
 impl IntoResponse for ConstructionPreprocessResponse {

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -177,12 +177,12 @@ async fn test_pay_with_gas_budget_fail() {
             assert_eq!(
                 rosetta_submit_gas_error,
                 RosettaSubmitGasError {
-                    code: 10,
-                    message: "Transaction execution error".to_string(),
+                    code: 11,
+                    message: "Transaction dry run error".to_string(),
                     description: None,
                     retriable: false,
                     details: RosettaSubmitGasErrorDetails {
-                        error: "Error executing transaction: InsufficientGas".to_string()
+                        error: "InsufficientGas".to_string()
                     }
                 }
             )

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -1,0 +1,195 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use fastcrypto::encoding::{Encoding, Hex};
+use serde::Deserialize;
+use serde_json::json;
+
+use rosetta_client::start_rosetta_test_server;
+use sui_keys::keystore::AccountKeystore;
+use sui_rosetta::operations::Operations;
+use sui_rosetta::types::{
+    ConstructionCombineRequest, ConstructionCombineResponse, ConstructionMetadataRequest,
+    ConstructionMetadataResponse, ConstructionPayloadsRequest, ConstructionPayloadsResponse,
+    ConstructionPreprocessRequest, ConstructionPreprocessResponse, ConstructionSubmitRequest,
+    NetworkIdentifier, PreprocessMetadata, Signature, SignatureType, SuiEnv,
+    TransactionIdentifierResponse,
+};
+use sui_types::crypto::SuiSignature;
+use test_cluster::TestClusterBuilder;
+
+use crate::rosetta_client::RosettaEndpoint;
+
+#[allow(dead_code)]
+mod rosetta_client;
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum TransactionIdentifierResponseResult {
+    Success(TransactionIdentifierResponse),
+    Error(RosettaSubmitGasError),
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug)]
+struct RosettaSubmitGasError {
+    pub code: i32,
+    pub message: String,
+    pub description: Option<String>,
+    pub retriable: bool,
+    pub details: RosettaSubmitGasErrorDetails,
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug)]
+struct RosettaSubmitGasErrorDetails {
+    error: String,
+}
+
+async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let network_identifier = NetworkIdentifier {
+        blockchain: "sui".to_string(),
+        network: SuiEnv::LocalNet,
+    };
+
+    let ops: Operations = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"PaySui",
+            "account": { "address" : recipient.to_string() },
+            "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+        },{
+            "operation_identifier":{"index":1},
+            "type":"PaySui",
+            "account": { "address" : sender.to_string() },
+            "amount" : { "value": "-1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+        }]
+    ))
+    .unwrap();
+
+    let metadata = Some(PreprocessMetadata {
+        budget: Some(budget),
+    });
+
+    let preprocess: ConstructionPreprocessResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Preprocess,
+            &ConstructionPreprocessRequest {
+                network_identifier: network_identifier.clone(),
+                operations: ops.clone(),
+                metadata,
+            },
+        )
+        .await;
+    println!("Preprocess : {preprocess:?}");
+    assert_eq!(
+        preprocess.options.as_ref().unwrap().budget.unwrap(),
+        budget
+    );
+
+    let metadata: ConstructionMetadataResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Metadata,
+            &ConstructionMetadataRequest {
+                network_identifier: network_identifier.clone(),
+                options: preprocess.options,
+                public_keys: vec![],
+            },
+        )
+        .await;
+    println!("Metadata : {metadata:?}");
+    assert_eq!(metadata.metadata.budget, budget);
+
+    let payloads: ConstructionPayloadsResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Payloads,
+            &ConstructionPayloadsRequest {
+                network_identifier: network_identifier.clone(),
+                operations: ops.clone(),
+                metadata: Some(metadata.metadata),
+                public_keys: vec![],
+            },
+        )
+        .await;
+    println!("Payload : {payloads:?}");
+
+    // Combine
+    let signing_payload = payloads.payloads.first().unwrap();
+    let bytes = Hex::decode(&signing_payload.hex_bytes).unwrap();
+    let signer = signing_payload.account_identifier.address;
+    let signature = keystore.sign_hashed(&signer, &bytes).unwrap();
+    let public_key = keystore.get_key(&signer).unwrap().public();
+
+    let combine: ConstructionCombineResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Combine,
+            &ConstructionCombineRequest {
+                network_identifier: network_identifier.clone(),
+                unsigned_transaction: payloads.unsigned_transaction,
+                signatures: vec![Signature {
+                    signing_payload: signing_payload.clone(),
+                    public_key: public_key.into(),
+                    signature_type: SignatureType::Ed25519,
+                    hex_bytes: Hex::from_bytes(SuiSignature::signature_bytes(&signature)),
+                }],
+            },
+        )
+        .await;
+    println!("Combine : {combine:?}");
+
+    // Submit
+    let submit: TransactionIdentifierResponseResult = rosetta_client
+        .call(
+            RosettaEndpoint::Submit,
+            &ConstructionSubmitRequest {
+                network_identifier,
+                signed_transaction: combine.signed_transaction,
+            },
+        )
+        .await;
+    println!("Submit : {submit:?}");
+    submit
+}
+
+#[tokio::test]
+async fn test_pay_with_gas_budget() {
+    const TX_BUDGET_PASS: u64 = 5_000_000;
+    let submit = pay_with_gas_budget(TX_BUDGET_PASS).await;
+    match submit {
+        TransactionIdentifierResponseResult::Success(_) => {}
+        _ => panic!("Expected transaction to succeed"),
+    }
+}
+
+#[tokio::test]
+async fn test_pay_with_gas_budget_fail() {
+    const TX_BUDGET_FAIL: u64 = 1_100_000;
+    let submit = pay_with_gas_budget(TX_BUDGET_FAIL).await;
+    match submit {
+        TransactionIdentifierResponseResult::Error(rosetta_submit_gas_error) => {
+            assert_eq!(
+                rosetta_submit_gas_error,
+                RosettaSubmitGasError {
+                    code: 10,
+                    message: "Transaction execution error".to_string(),
+                    description: None,
+                    retriable: false,
+                    details: RosettaSubmitGasErrorDetails {
+                        error: "Error executing transaction: InsufficientGas".to_string()
+                    }
+                }
+            )
+        }
+        _ => panic!("Expected transaction to fail"),
+    }
+}

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -92,10 +92,7 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
         )
         .await;
     println!("Preprocess : {preprocess:?}");
-    assert_eq!(
-        preprocess.options.as_ref().unwrap().budget.unwrap(),
-        budget
-    );
+    assert_eq!(preprocess.options.as_ref().unwrap().budget.unwrap(), budget);
 
     let metadata: ConstructionMetadataResponse = rosetta_client
         .call(


### PR DESCRIPTION
## Description 

/construction/preprocess:
- Request: May or may not have metadata field and metadata may or may not have budget field.
- Response: May or may not have options field and options may or may not have budget field.

/construction/metadata:
- Request: May or may not have options field and options may or may not have budget field
- Response: Always has metadata field and metadata field always has budget field. If Request above included budget, this is returned. If not, computation_cost + storage_cost is used.

/construction/submit:
Dry run the transaction before executing it. On dry-run failure, fail early and not execute it.

## Test Plan 

Added /tests/gas_budget_tests.rs

---

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
