### PR TITLE
[CheckpointExecutor] Reduce checkpoint scheduling timeout log spam

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -68,11 +68,7 @@ type CheckpointExecutionBuffer = FuturesOrdered<JoinHandle<VerifiedCheckpoint>>;
 /// The interval to log checkpoint progress, in # of checkpoints processed.
 const CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL: u64 = 5000;
 
-#[cfg(msim)]
-const SCHEDULING_EVENT_FUTURE_TIMEOUT_MS: u64 = 200;
-
-#[cfg(not(msim))]
-const SCHEDULING_EVENT_FUTURE_TIMEOUT_MS: u64 = 1000;
+const SCHEDULING_EVENT_FUTURE_TIMEOUT_MS: u64 = 1200;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum StopReason {


### PR DESCRIPTION
## Description 

Causing log spam due to timeout being too small for some simtests. 

## Test Plan 

Existing simtests
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
