### PR TITLE
[gql][consistent-reads][last???/n] Add context to MovePackage and peripherals, clean up Validator

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -30,7 +30,7 @@
 
 //# create-checkpoint 12
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -44,7 +44,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6} {"checkpoint_viewed_at":null,"sequence_number":8}
+//# run-graphql --cursors {"c":12,"s":6} {"c":12,"s":8}
 {
   checkpoints(first: 4, after: "@{cursor_0}", before: "@{cursor_1}") {
     pageInfo {
@@ -58,7 +58,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":6}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -72,7 +72,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":3} {"c":12,"s":6}
 {
   checkpoints(first: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -86,7 +86,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3}
+//# run-graphql --cursors {"c":12,"s":3}
 {
   checkpoints(first: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -100,7 +100,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -114,7 +114,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
+//# run-graphql --cursors {"c":12,"s":4}
 {
   checkpoints(before: "@{cursor_0}") {
     pageInfo {
@@ -128,7 +128,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":4}
+//# run-graphql --cursors {"c":12,"s":4}
 {
   checkpoints(after: "@{cursor_0}") {
     pageInfo {
@@ -142,7 +142,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":6}
 {
   checkpoints(last: 4, before: "@{cursor_0}") {
     pageInfo {
@@ -156,7 +156,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":3} {"checkpoint_viewed_at":null,"sequence_number":6}
+//# run-graphql --cursors {"c":12,"s":3} {"c":12,"s":6}
 {
   checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
@@ -170,7 +170,7 @@
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":null,"sequence_number":9}
+//# run-graphql --cursors {"c":12,"s":9}
 {
   checkpoints(last: 4, after: "@{cursor_0}") {
     pageInfo {
@@ -229,6 +229,21 @@
 //# run-graphql
 {
   checkpoints(first: 4, last: 2) {
+    pageInfo {
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      cursor
+      node { sequenceNumber }
+    }
+  }
+}
+
+//# run-graphql --cursors {"c":10,"s":3} {"c":12,"s":6}
+# Should throw a client error about inconsistent cursors.
+{
+  checkpoints(last: 4, after: "@{cursor_0}" before: "@{cursor_1}") {
     pageInfo {
       hasPreviousPage
       hasNextPage

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -78,7 +78,7 @@ module P0::fake {
 
 //# create-checkpoint
 
-//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":2,"t":1}
 # Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -101,7 +101,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":3,"t":1}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -124,7 +124,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":4,"t":1}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -149,7 +149,7 @@ module P0::fake {
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 3
 
-//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":2,"t":1}
 # Emulating viewing transaction blocks at checkpoint 2. Fake coin balance should be 700.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -172,7 +172,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":3,"t":1}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -195,7 +195,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":4,"t":1}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -220,7 +220,7 @@ module P0::fake {
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 4
 
-//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":2,"t":1}
 # Outside available range
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -243,7 +243,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":3,"t":1}
 # Emulating viewing transaction blocks at checkpoint 3. Fake coin balance should be 500.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -266,7 +266,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":4,"t":1}
 # Emulating viewing transaction blocks at checkpoint 4. Fake coin balance should be 400.
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -292,7 +292,7 @@ module P0::fake {
 
 //# force-object-snapshot-catchup --start-cp 0 --end-cp 6
 
-//# run-graphql --cursors {"checkpoint_viewed_at":2,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":2,"t":1}
 # Outside available range
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -315,7 +315,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":3,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":3,"t":1}
 # Outside available range
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
@@ -338,7 +338,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors {"checkpoint_viewed_at":4,"tx_sequence_number":1}
+//# run-graphql --cursors {"c":4,"t":1}
 # Outside available range
 {
   transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.exp
@@ -1,0 +1,333 @@
+processed 16 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 13-30:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 32-32:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 34-34:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'run'. lines 36-36:
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'run'. lines 38-38:
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'create-checkpoint'. lines 40-40:
+Checkpoint created: 1
+
+task 7 'run'. lines 42-42:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'run'. lines 44-44:
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9 'run'. lines 46-46:
+created: object(9,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10 'create-checkpoint'. lines 48-48:
+Checkpoint created: 2
+
+task 11 'run'. lines 50-50:
+created: object(11,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12 'run'. lines 52-52:
+created: object(12,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 13 'create-checkpoint'. lines 54-54:
+Checkpoint created: 3
+
+task 14 'run-graphql'. lines 56-80:
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 0,
+          "transactionBlocks": {
+            "edges": []
+          }
+        },
+        {
+          "sequenceNumber": 1,
+          "transactionBlocks": {
+            "edges": [
+              {
+                "cursor": "eyJjIjozLCJ0IjoyfQ",
+                "node": {
+                  "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0IjozfQ",
+                "node": {
+                  "digest": "5nPZdTNXfSpMAh9aZSZv1X3gALhquiMXqCXLazM7KrEX",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0Ijo0fQ",
+                "node": {
+                  "digest": "3pGWbtcYaaJh2UP1QMmFQm4EaSxkhRrbprdtcMnY8m7o",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0Ijo1fQ",
+                "node": {
+                  "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "sequenceNumber": 2,
+          "transactionBlocks": {
+            "edges": [
+              {
+                "cursor": "eyJjIjozLCJ0Ijo2fQ",
+                "node": {
+                  "digest": "5qTN5frbR8zMR8fLt1kSTZMxcNRsZX29dfwBqFEah6Dq",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0Ijo3fQ",
+                "node": {
+                  "digest": "Ecqfh146tDVR4hnN5XNaYJoMLCmgGNt5ft7BVQJoq5c3",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0Ijo4fQ",
+                "node": {
+                  "digest": "J1nDq1YDGM84f4iQLWUtWAPnxf8GGYrMF794NDKrC6Qj",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "sequenceNumber": 3,
+          "transactionBlocks": {
+            "edges": [
+              {
+                "cursor": "eyJjIjozLCJ0Ijo5fQ",
+                "node": {
+                  "digest": "7ixKWaN2khH5824iXGAwP7VoYCUumYixvGzyaKavq9vw",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "cursor": "eyJjIjozLCJ0IjoxMH0",
+                "node": {
+                  "digest": "6z6Sk5gXrMmfnSeovGfqt7AaLMVxjSQK3Gu2nG87WZwT",
+                  "sender": {
+                    "objects": {
+                      "edges": [
+                        {
+                          "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUAwAAAAAAAAA="
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 82-97:
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "sequenceNumber": 0,
+          "epoch": {
+            "epochId": 0,
+            "checkpoints": {
+              "nodes": [
+                {
+                  "sequenceNumber": 0
+                },
+                {
+                  "sequenceNumber": 1
+                },
+                {
+                  "sequenceNumber": 2
+                },
+                {
+                  "sequenceNumber": 3
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sequenceNumber": 1,
+          "epoch": {
+            "epochId": 0,
+            "checkpoints": {
+              "nodes": [
+                {
+                  "sequenceNumber": 0
+                },
+                {
+                  "sequenceNumber": 1
+                },
+                {
+                  "sequenceNumber": 2
+                },
+                {
+                  "sequenceNumber": 3
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sequenceNumber": 2,
+          "epoch": {
+            "epochId": 0,
+            "checkpoints": {
+              "nodes": [
+                {
+                  "sequenceNumber": 0
+                },
+                {
+                  "sequenceNumber": 1
+                },
+                {
+                  "sequenceNumber": 2
+                },
+                {
+                  "sequenceNumber": 3
+                }
+              ]
+            }
+          }
+        },
+        {
+          "sequenceNumber": 3,
+          "epoch": {
+            "epochId": 0,
+            "checkpoints": {
+              "nodes": [
+                {
+                  "sequenceNumber": 0
+                },
+                {
+                  "sequenceNumber": 1
+                },
+                {
+                  "sequenceNumber": 2
+                },
+                {
+                  "sequenceNumber": 3
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// checkpoint | transactions from A
+// -----------+--------------------
+// 0          | 0
+// 1          | 4
+// 2          | 3
+// 3          | 2
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+# Each transaction block's sender's last object resolves to the same last object at the latest
+# state
+{
+  checkpoints {
+    nodes {
+      sequenceNumber
+      transactionBlocks(filter: { signAddress: "@{A}"}) {
+        edges {
+          cursor
+          node {
+            digest
+            sender {
+                objects(last: 1) {
+                    edges {
+                        cursor
+                    }
+                }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Similarly, resolving the checkpoint's epoch will return the epoch the checkpoint belongs in, but
+# the nested checkpoints connection will behave as if it was made on the top-level.
+{
+  checkpoints {
+    nodes {
+      sequenceNumber
+      epoch {
+        epochId
+        checkpoints {
+          nodes {
+            sequenceNumber
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.exp
@@ -1,0 +1,289 @@
+processed 16 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'create-checkpoint'. lines 13-13:
+Checkpoint created: 1
+
+task 2 'create-checkpoint'. lines 15-15:
+Checkpoint created: 2
+
+task 3 'advance-epoch'. lines 17-17:
+Epoch advanced: 0
+
+task 4 'run-graphql'. lines 19-34:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 3
+    },
+    "epoch": {
+      "epochId": 0,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 0
+          },
+          {
+            "sequenceNumber": 1
+          },
+          {
+            "sequenceNumber": 2
+          },
+          {
+            "sequenceNumber": 3
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 5 'create-checkpoint'. lines 36-36:
+Checkpoint created: 4
+
+task 6 'create-checkpoint'. lines 38-38:
+Checkpoint created: 5
+
+task 7 'create-checkpoint'. lines 40-40:
+Checkpoint created: 6
+
+task 8 'advance-epoch'. lines 42-42:
+Epoch advanced: 1
+
+task 9 'create-checkpoint'. lines 44-44:
+Checkpoint created: 8
+
+task 10 'create-checkpoint'. lines 46-46:
+Checkpoint created: 9
+
+task 11 'run-graphql'. lines 48-87:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 9
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "checkpoints": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJzIjowfQ",
+            "node": {
+              "sequenceNumber": 0
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjoxfQ",
+            "node": {
+              "sequenceNumber": 1
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjoyfQ",
+            "node": {
+              "sequenceNumber": 2
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjozfQ",
+            "node": {
+              "sequenceNumber": 3
+            }
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "checkpoints": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJzIjo0fQ",
+            "node": {
+              "sequenceNumber": 4
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjo1fQ",
+            "node": {
+              "sequenceNumber": 5
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjo2fQ",
+            "node": {
+              "sequenceNumber": 6
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjo3fQ",
+            "node": {
+              "sequenceNumber": 7
+            }
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "checkpoints": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJzIjo4fQ",
+            "node": {
+              "sequenceNumber": 8
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJzIjo5fQ",
+            "node": {
+              "sequenceNumber": 9
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 12 'create-checkpoint'. lines 89-89:
+Checkpoint created: 10
+
+task 13 'run-graphql'. lines 91-122:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 0
+          },
+          {
+            "sequenceNumber": 1
+          },
+          {
+            "sequenceNumber": 2
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 4
+          },
+          {
+            "sequenceNumber": 5
+          },
+          {
+            "sequenceNumber": 6
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 8
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14 'run-graphql'. lines 124-155:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 1
+          },
+          {
+            "sequenceNumber": 2
+          },
+          {
+            "sequenceNumber": 3
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 5
+          },
+          {
+            "sequenceNumber": 6
+          },
+          {
+            "sequenceNumber": 7
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 9
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 15 'run-graphql'. lines 157-188:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 2
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 6
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "checkpoints": {
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
@@ -1,0 +1,188 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// epoch | checkpoints
+// ------+-------------
+// 0     | 4
+// 1     | 4
+// 2     | 2
+// An additional checkpoint is created at the end.
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+# Even though the epoch has advanced, we will not see it until indexer indexes the next checkpoint
+# in the new epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch {
+    epochId
+    checkpoints {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+}
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql
+# Get latest state
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    checkpoints {
+      edges {
+        cursor
+        node {
+          sequenceNumber
+        }
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    checkpoints {
+      edges {
+        cursor
+        node {
+          sequenceNumber
+        }
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    checkpoints {
+      edges {
+        cursor
+        node {
+          sequenceNumber
+        }
+      }
+    }
+  }
+}
+
+//# create-checkpoint
+
+//# run-graphql --cursors {"s":3,"c":4} {"s":7,"c":8} {"s":9,"c":10}
+# View checkpoints before the last checkpoint in each epoch, from the perspective of the first
+# checkpoint in the next epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    checkpoints(before: "@{cursor_0}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    checkpoints(before: "@{cursor_1}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    checkpoints(before: "@{cursor_2}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"s":0,"c":3} {"s":4,"c":7} {"s":8,"c":9}
+# View checkpoints after the first checkpoint in each epoch, from the perspective of the last
+# checkpoint in each epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    checkpoints(after: "@{cursor_0}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    checkpoints(after: "@{cursor_1}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    checkpoints(after: "@{cursor_2}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"s":1,"c":2} {"s":5,"c":6} {"s":9,"c":9}
+# View checkpoints after the second checkpoint in each epoch, from the perspective of a checkpoint
+# around the middle of each epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    checkpoints(after: "@{cursor_0}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    checkpoints(after: "@{cursor_1}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    checkpoints(after: "@{cursor_2}") {
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.exp
@@ -1,0 +1,547 @@
+processed 25 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 12-29:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'create-checkpoint'. lines 31-31:
+Checkpoint created: 1
+
+task 3 'run'. lines 33-33:
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4 'create-checkpoint'. lines 35-35:
+Checkpoint created: 2
+
+task 5 'advance-epoch'. lines 37-37:
+Epoch advanced: 0
+
+task 6 'run-graphql'. lines 39-55:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 3
+    },
+    "epoch": {
+      "epochId": 0,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjozLCJ0IjowfQ",
+            "node": {
+              "digest": "ABuYqibX1jCzX9JVsxEVmcFJevRXpxznqhpSs5xd1ah7"
+            }
+          },
+          {
+            "cursor": "eyJjIjozLCJ0IjoxfQ",
+            "node": {
+              "digest": "3z8vrWFCZgrGNVz2eqpijsgGQNvdto2RLgk6nzyN1qAJ"
+            }
+          },
+          {
+            "cursor": "eyJjIjozLCJ0IjoyfQ",
+            "node": {
+              "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy"
+            }
+          },
+          {
+            "cursor": "eyJjIjozLCJ0IjozfQ",
+            "node": {
+              "digest": "AF43j1x2yErUGqNRFANyDsCMPs2LRBzdi8t4Qa8mPvHP"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 7 'run'. lines 57-57:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'create-checkpoint'. lines 59-59:
+Checkpoint created: 4
+
+task 9 'run'. lines 61-61:
+created: object(9,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10 'create-checkpoint'. lines 63-63:
+Checkpoint created: 5
+
+task 11 'run'. lines 65-65:
+created: object(11,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12 'create-checkpoint'. lines 67-67:
+Checkpoint created: 6
+
+task 13 'advance-epoch'. lines 69-69:
+Epoch advanced: 1
+
+task 14 'run'. lines 71-71:
+created: object(14,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 15 'create-checkpoint'. lines 73-73:
+Checkpoint created: 8
+
+task 16 'run'. lines 75-75:
+created: object(16,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 17 'create-checkpoint'. lines 77-77:
+Checkpoint created: 9
+
+task 18 'run-graphql'. lines 79-118:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 9
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJ0IjowfQ",
+            "node": {
+              "digest": "ABuYqibX1jCzX9JVsxEVmcFJevRXpxznqhpSs5xd1ah7"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0IjoxfQ",
+            "node": {
+              "digest": "3z8vrWFCZgrGNVz2eqpijsgGQNvdto2RLgk6nzyN1qAJ"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0IjoyfQ",
+            "node": {
+              "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0IjozfQ",
+            "node": {
+              "digest": "AF43j1x2yErUGqNRFANyDsCMPs2LRBzdi8t4Qa8mPvHP"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo0fQ",
+            "node": {
+              "digest": "5nPZdTNXfSpMAh9aZSZv1X3gALhquiMXqCXLazM7KrEX"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo1fQ",
+            "node": {
+              "digest": "3pGWbtcYaaJh2UP1QMmFQm4EaSxkhRrbprdtcMnY8m7o"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo2fQ",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo3fQ",
+            "node": {
+              "digest": "ALWqSMZk4AGtw6fDczxqTLeRwCzU14rZUQ84CYbBXQQh"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo4fQ",
+            "node": {
+              "digest": "5qTN5frbR8zMR8fLt1kSTZMxcNRsZX29dfwBqFEah6Dq"
+            }
+          },
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo5fQ",
+            "node": {
+              "digest": "Ecqfh146tDVR4hnN5XNaYJoMLCmgGNt5ft7BVQJoq5c3"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 19 'run'. lines 120-120:
+created: object(19,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 20 'create-checkpoint'. lines 122-122:
+Checkpoint created: 10
+
+task 21 'run-graphql'. lines 124-164:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo0LCJ0IjowfQ",
+            "node": {
+              "digest": "ABuYqibX1jCzX9JVsxEVmcFJevRXpxznqhpSs5xd1ah7"
+            }
+          },
+          {
+            "cursor": "eyJjIjo0LCJ0IjoxfQ",
+            "node": {
+              "digest": "3z8vrWFCZgrGNVz2eqpijsgGQNvdto2RLgk6nzyN1qAJ"
+            }
+          },
+          {
+            "cursor": "eyJjIjo0LCJ0IjoyfQ",
+            "node": {
+              "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo4LCJ0Ijo0fQ",
+            "node": {
+              "digest": "5nPZdTNXfSpMAh9aZSZv1X3gALhquiMXqCXLazM7KrEX"
+            }
+          },
+          {
+            "cursor": "eyJjIjo4LCJ0Ijo1fQ",
+            "node": {
+              "digest": "3pGWbtcYaaJh2UP1QMmFQm4EaSxkhRrbprdtcMnY8m7o"
+            }
+          },
+          {
+            "cursor": "eyJjIjo4LCJ0Ijo2fQ",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjoxMCwidCI6OH0",
+            "node": {
+              "digest": "5qTN5frbR8zMR8fLt1kSTZMxcNRsZX29dfwBqFEah6Dq"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 22 'run-graphql'. lines 166-206:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjozLCJ0IjoxfQ",
+            "node": {
+              "digest": "3z8vrWFCZgrGNVz2eqpijsgGQNvdto2RLgk6nzyN1qAJ"
+            }
+          },
+          {
+            "cursor": "eyJjIjozLCJ0IjoyfQ",
+            "node": {
+              "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy"
+            }
+          },
+          {
+            "cursor": "eyJjIjozLCJ0IjozfQ",
+            "node": {
+              "digest": "AF43j1x2yErUGqNRFANyDsCMPs2LRBzdi8t4Qa8mPvHP"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo3LCJ0Ijo1fQ",
+            "node": {
+              "digest": "3pGWbtcYaaJh2UP1QMmFQm4EaSxkhRrbprdtcMnY8m7o"
+            }
+          },
+          {
+            "cursor": "eyJjIjo3LCJ0Ijo2fQ",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus"
+            }
+          },
+          {
+            "cursor": "eyJjIjo3LCJ0Ijo3fQ",
+            "node": {
+              "digest": "ALWqSMZk4AGtw6fDczxqTLeRwCzU14rZUQ84CYbBXQQh"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo5LCJ0Ijo5fQ",
+            "node": {
+              "digest": "Ecqfh146tDVR4hnN5XNaYJoMLCmgGNt5ft7BVQJoq5c3"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 23 'run-graphql'. lines 208-248:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "epoch_0": {
+      "epochId": 0,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjoyLCJ0IjoyfQ",
+            "node": {
+              "digest": "5aWuRSbWjig25LEXbB8BAJYHhLDWkDD5pmvVN5VPNFPy"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_1": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo2LCJ0Ijo2fQ",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus"
+            }
+          }
+        ]
+      }
+    },
+    "epoch_2": {
+      "epochId": 2,
+      "transactionBlocks": {
+        "edges": []
+      }
+    }
+  }
+}
+
+task 24 'run-graphql'. lines 250-294:
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 10
+    },
+    "with_cursor": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjo2LCJ0Ijo2fQ",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus",
+              "sender": {
+                "objects": {
+                  "edges": [
+                    {
+                      "cursor": "ICRXWtegdf7XtibW4GO5PLDNDGOAPSTK3WuYSHeby2fJBgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "ICci3gY0bJbYdGZSsWlGEC2yukFFqssE9x56HKNP7Ke5BgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IJqZ8Sc8Y3P5YJbzDNp21xvB+SlJGKxetJVpw2OkiIwWBgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IL87TIy3OdKryjRG2nNGDL5aFIp6PqzSiXAmuAR77YoLBgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IMSbVwss+wcPWs9sQaRM2H2wtrgnpmUT5DXsdm3knALEBgAAAAAAAAA="
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "without_cursor": {
+      "epochId": 1,
+      "transactionBlocks": {
+        "edges": [
+          {
+            "cursor": "eyJjIjoxMCwidCI6NH0",
+            "node": {
+              "digest": "5nPZdTNXfSpMAh9aZSZv1X3gALhquiMXqCXLazM7KrEX",
+              "sender": {
+                "objects": {
+                  "edges": [
+                    {
+                      "cursor": "ICRXWtegdf7XtibW4GO5PLDNDGOAPSTK3WuYSHeby2fJCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "ICci3gY0bJbYdGZSsWlGEC2yukFFqssE9x56HKNP7Ke5CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IElqWqkUj4KBBw8E+OZ3S7j3gK7Hu8LT/ezuocHEKXgiCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IFvKXhvjy9+LBIH8tMyQfQgJSi8LhN8YVVG2Z+WpUG/8CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IJqZ8Sc8Y3P5YJbzDNp21xvB+SlJGKxetJVpw2OkiIwWCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IL87TIy3OdKryjRG2nNGDL5aFIp6PqzSiXAmuAR77YoLCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IMSbVwss+wcPWs9sQaRM2H2wtrgnpmUT5DXsdm3knALECgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUCgAAAAAAAAA="
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "cursor": "eyJjIjoxMCwidCI6NX0",
+            "node": {
+              "digest": "3pGWbtcYaaJh2UP1QMmFQm4EaSxkhRrbprdtcMnY8m7o",
+              "sender": {
+                "objects": {
+                  "edges": [
+                    {
+                      "cursor": "ICRXWtegdf7XtibW4GO5PLDNDGOAPSTK3WuYSHeby2fJCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "ICci3gY0bJbYdGZSsWlGEC2yukFFqssE9x56HKNP7Ke5CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IElqWqkUj4KBBw8E+OZ3S7j3gK7Hu8LT/ezuocHEKXgiCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IFvKXhvjy9+LBIH8tMyQfQgJSi8LhN8YVVG2Z+WpUG/8CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IJqZ8Sc8Y3P5YJbzDNp21xvB+SlJGKxetJVpw2OkiIwWCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IL87TIy3OdKryjRG2nNGDL5aFIp6PqzSiXAmuAR77YoLCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IMSbVwss+wcPWs9sQaRM2H2wtrgnpmUT5DXsdm3knALECgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUCgAAAAAAAAA="
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "cursor": "eyJjIjoxMCwidCI6Nn0",
+            "node": {
+              "digest": "a2tWbUVMMYfj6kU7NU9sUHdJZycLcnrQJKZNYvJfeus",
+              "sender": {
+                "objects": {
+                  "edges": [
+                    {
+                      "cursor": "ICRXWtegdf7XtibW4GO5PLDNDGOAPSTK3WuYSHeby2fJCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "ICci3gY0bJbYdGZSsWlGEC2yukFFqssE9x56HKNP7Ke5CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IElqWqkUj4KBBw8E+OZ3S7j3gK7Hu8LT/ezuocHEKXgiCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IFvKXhvjy9+LBIH8tMyQfQgJSi8LhN8YVVG2Z+WpUG/8CgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IJqZ8Sc8Y3P5YJbzDNp21xvB+SlJGKxetJVpw2OkiIwWCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IL87TIy3OdKryjRG2nNGDL5aFIp6PqzSiXAmuAR77YoLCgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IMSbVwss+wcPWs9sQaRM2H2wtrgnpmUT5DXsdm3knALECgAAAAAAAAA="
+                    },
+                    {
+                      "cursor": "IM5DqnzKeu0xB+PJnpCp2mONWDw2LyLx4xq5nRhAQKAUCgAAAAAAAAA="
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
@@ -1,0 +1,294 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// epoch | transactions
+// ------+-------------
+// 0     | 4
+// 1     | 4
+// 2     | 2
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch {
+    epochId
+    transactionBlocks {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+# Get latest state
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    transactionBlocks {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    transactionBlocks {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    transactionBlocks {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::create --args 0 @A --sender A
+
+//# create-checkpoint
+
+//# run-graphql --cursors {"t":3,"c":4} {"t":7,"c":8} {"t":9,"c":10}
+# View transactions before the last transaction in each epoch, from the perspective of the first
+# checkpoint in the next epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    transactionBlocks(before: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    transactionBlocks(before: "@{cursor_1}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    transactionBlocks(before: "@{cursor_2}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"t":0,"c":3} {"t":4,"c":7} {"t":8,"c":9}
+# View transactions after the first transaction in each epoch, from the perspective of the last
+# checkpoint in the next epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    transactionBlocks(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    transactionBlocks(after: "@{cursor_1}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    transactionBlocks(after: "@{cursor_2}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"t":1,"c":2} {"t":5,"c":6} {"t":9,"c":9}
+# View transactions after the second transaction in each epoch, from the perspective of a checkpoint
+# around the middle of each epoch.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  epoch_0: epoch(id: 0) {
+    epochId
+    transactionBlocks(after: "@{cursor_0}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_1: epoch(id: 1) {
+    epochId
+    transactionBlocks(after: "@{cursor_1}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+  epoch_2: epoch(id: 2) {
+    epochId
+    transactionBlocks(after: "@{cursor_2}") {
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors {"t":1,"c":2} {"t":5,"c":6} {"t":9,"c":9}
+# Verify that with a cursor, we are locked into a view as if we were at the checkpoint stored in
+# the cursor. Compare against `without_cursor`, which should show the latest state at the actual
+# latest checkpoint.
+{
+  checkpoint {
+    sequenceNumber
+  }
+  with_cursor: epoch(id: 1) {
+    epochId
+    transactionBlocks(after: "@{cursor_1}", filter: {signAddress: "@{A}"}) {
+      edges {
+        cursor
+        node {
+          digest
+          sender {
+            objects {
+              edges {
+                cursor
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  without_cursor: epoch(id: 1) {
+    epochId
+    transactionBlocks(filter: {signAddress: "@{A}"}) {
+      edges {
+        cursor
+        node {
+          digest
+          sender {
+            objects {
+              edges {
+                cursor
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -53,7 +53,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":2,"e":0,"checkpoint_viewed_at":null}
+//# run-graphql --cursors {"tx":2,"e":0,"c":1}
 {
   events(first: 2 after: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {
@@ -79,7 +79,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors {"tx":3,"e":1,"checkpoint_viewed_at":null}
+//# run-graphql --cursors {"tx":3,"e":1,"c":1}
 {
   events(last: 2 before: "@{cursor_0}", filter: {sender: "@{A}"}) {
     pageInfo {

--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.move
@@ -18,7 +18,7 @@ module P0::n {
 
 //# create-checkpoint
 
-//# run-graphql --cursors 0 2
+//# run-graphql --cursors {"i":0,"c":1} {"i":2,"c":1}
 
 fragment ModuleFriends on Object {
     asMovePackage {
@@ -110,7 +110,7 @@ fragment ModuleFriends on Object {
     }
 }
 
-//# run-graphql --cursors 0 2
+//# run-graphql --cursors {"i":0,"c":1} {"i":2,"c":1}
 
 fragment ModuleFriends on Object {
     asMovePackage {

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.move
@@ -135,7 +135,7 @@ fragment Functions on Object {
     }
 }
 
-//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
+//# run-graphql --cursors {"n":"consensus_commit_prologue","c":2} {"n":"timestamp_ms","c":2}
 
 fragment Signatures on MoveFunctionConnection {
     edges {
@@ -172,7 +172,7 @@ fragment Signatures on MoveFunctionConnection {
     }
 }
 
-//# run-graphql --cursors "consensus_commit_prologue" "timestamp_ms"
+//# run-graphql --cursors {"n":"consensus_commit_prologue","c":2} {"n":"timestamp_ms","c":2}
 
 fragment Signatures on MoveFunctionConnection {
     edges {

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.move
@@ -64,7 +64,7 @@ fragment Modules on Object {
     }
 }
 
-//# run-graphql --cursors "m" "o"
+//# run-graphql --cursors {"n":"m","c":1} {"n":"o","c":1}
 fragment NodeNames on MoveModuleConnection {
     edges {
         cursor
@@ -103,7 +103,7 @@ fragment Modules on Object {
     }
 }
 
-//# run-graphql --cursors "m" "o"
+//# run-graphql --cursors {"n":"m","c":1} {"n":"o","c":1}
 fragment NodeNames on MoveModuleConnection {
     edges {
         cursor

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -208,7 +208,7 @@ fragment Structs on Object {
 }
 
 
-//# run-graphql --cursors "Coin" "TreasuryCap"
+//# run-graphql --cursors {"n":"Coin","c":2} {"n":"TreasuryCap","c":2}
 {
     object(address: "0x2") {
         asMovePackage {
@@ -250,7 +250,7 @@ fragment Structs on Object {
     }
 }
 
-//# run-graphql --cursors "Coin" "TreasuryCap"
+//# run-graphql --cursors {"n":"Coin","c":2} {"n":"TreasuryCap","c":2}
 fragment NodeNames on MoveStructConnection {
     edges {
         cursor

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
@@ -44,7 +44,7 @@
   }
 }
 
-//# run-graphql --cursors 2
+//# run-graphql --cursors {"i":2,"c":1}
 {
   address(address: "@{C}") {
     transactionBlocks(last: 1) {
@@ -70,7 +70,7 @@
   }
 }
 
-//# run-graphql --cursors 3
+//# run-graphql --cursors {"i":3,"c":1}
 {
   address(address: "@{C}") {
     transactionBlocks(last: 1) {

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
@@ -95,7 +95,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors 0
+//# run-graphql --cursors {"i":0,"c":1}
 {
   transactionBlocks(last: 1) {
     nodes {

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
@@ -90,7 +90,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors 0
+//# run-graphql --cursors {"i":0,"c":1}
 {
   transactionBlocks(last: 1, filter: { signAddress: "@{A}" }) {
     nodes {

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
@@ -52,7 +52,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors 10
+//# run-graphql --cursors {"i":10,"c":1}
 {
   transactionBlocks(first: 1) {
     nodes {

--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -123,7 +123,7 @@ impl PgManager {
 pub(crate) fn convert_to_validators(
     validators: Vec<SuiValidatorSummary>,
     system_state: Option<NativeSuiSystemStateSummary>,
-    checkpoint_viewed_at: Option<u64>,
+    checkpoint_viewed_at: u64,
 ) -> Vec<Validator> {
     let (at_risk, reports) = if let Some(NativeSuiSystemStateSummary {
         at_risk_validators,
@@ -149,7 +149,7 @@ pub(crate) fn convert_to_validators(
                     .cloned()
                     .map(|a| Address {
                         address: SuiAddress::from(a),
-                        checkpoint_viewed_at,
+                        checkpoint_viewed_at: Some(checkpoint_viewed_at),
                     })
                     .collect()
             });

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::cursor::{self, Checkpointed, Page, RawPaginated, Target};
+use super::cursor::{self, Page, RawPaginated, Target};
 use super::{big_int::BigInt, move_type::MoveType, sui_address::SuiAddress};
-use crate::consistency::consistent_range;
+use crate::consistency::{consistent_range, Checkpointed};
 use crate::data::{Db, DbConnection, QueryExecutor};
 use crate::error::Error;
 use crate::raw_query::RawQuery;

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -3,13 +3,14 @@
 
 use super::{
     base64::Base64,
-    cursor::{self, Checkpointed, Page, Paginated, Target},
+    cursor::{self, Page, Paginated, Target},
     date_time::DateTime,
     digest::Digest,
     epoch::Epoch,
     gas::GasCostSummary,
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
 };
+use crate::consistency::Checkpointed;
 use crate::{
     data::{self, Conn, Db, DbConnection, QueryExecutor},
     error::Error,

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -8,6 +8,7 @@ use move_binary_format::binary_views::BinaryIndexedView;
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Loc;
 
+use crate::consistency::{ConsistentIndexCursor, ConsistentNamedCursor};
 use crate::data::Db;
 use crate::error::Error;
 use sui_package_resolver::Module as ParsedMoveModule;
@@ -23,11 +24,13 @@ pub(crate) struct MoveModule {
     pub storage_id: SuiAddress,
     pub native: Vec<u8>,
     pub parsed: ParsedMoveModule,
+    /// The checkpoint sequence number this was viewed at.
+    pub checkpoint_viewed_at: u64,
 }
 
-pub(crate) type CFriend = JsonCursor<usize>;
-pub(crate) type CStruct = JsonCursor<String>;
-pub(crate) type CFunction = JsonCursor<String>;
+pub(crate) type CFriend = JsonCursor<ConsistentIndexCursor>;
+pub(crate) type CStruct = JsonCursor<ConsistentNamedCursor>;
+pub(crate) type CFunction = JsonCursor<ConsistentNamedCursor>;
 
 /// Represents a module in Move, a library that defines struct types
 /// and functions that operate on these types.
@@ -38,7 +41,7 @@ impl MoveModule {
         MovePackage::query(
             ctx.data_unchecked(),
             self.storage_id,
-            ObjectLookupKey::Latest,
+            ObjectLookupKey::LatestAt(self.checkpoint_viewed_at),
         )
         .await
         .extend()?
@@ -76,7 +79,9 @@ impl MoveModule {
         let bytecode = self.parsed.bytecode();
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_indices(bytecode.friend_decls.len()) else {
+        let Some((prev, next, checkpoint_viewed_at, cs)) = page
+            .paginate_consistent_indices(bytecode.friend_decls.len(), self.checkpoint_viewed_at)?
+        else {
             return Ok(connection);
         };
 
@@ -87,7 +92,7 @@ impl MoveModule {
         let Some(package) = MovePackage::query(
             ctx.data_unchecked(),
             self.storage_id,
-            ObjectLookupKey::Latest,
+            ObjectLookupKey::LatestAt(checkpoint_viewed_at),
         )
         .await
         .extend()?
@@ -102,7 +107,7 @@ impl MoveModule {
         // Select `friend_decls[lo..hi]` using iterators to enumerate before taking a sub-sequence
         // from it, to get pairs `(i, friend_decls[i])`.
         for c in cs {
-            let decl = &bytecode.friend_decls[*c];
+            let decl = &bytecode.friend_decls[c.ix];
             let friend_pkg = bytecode.address_identifier_at(decl.address);
             let friend_mod = bytecode.identifier_at(decl.name);
 
@@ -148,9 +153,12 @@ impl MoveModule {
         before: Option<CStruct>,
     ) -> Result<Option<Connection<String, MoveStruct>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(|a| (*a).as_str());
-        let before = page.before().map(|b| (*b).as_str());
+        let after = page.after().map(|a| a.name.as_str());
+        let before = page.before().map(|b| b.name.as_str());
         let struct_range = self.parsed.structs(after, before);
+
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(self.checkpoint_viewed_at);
 
         let mut connection = Connection::new(false, false);
         let struct_names = if page.is_from_front() {
@@ -179,7 +187,11 @@ impl MoveModule {
                 .extend();
             };
 
-            let cursor = JsonCursor::new(name.to_string()).encode_cursor();
+            let cursor = JsonCursor::new(ConsistentNamedCursor {
+                name: name.to_string(),
+                c: checkpoint_viewed_at,
+            })
+            .encode_cursor();
             connection.edges.push(Edge::new(cursor, struct_));
         }
 
@@ -205,9 +217,12 @@ impl MoveModule {
         before: Option<CFunction>,
     ) -> Result<Option<Connection<String, MoveFunction>>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let after = page.after().map(|a| (*a).as_str());
-        let before = page.before().map(|b| (*b).as_str());
+        let after = page.after().map(|a| a.name.as_str());
+        let before = page.before().map(|b| b.name.as_str());
         let function_range = self.parsed.functions(after, before);
+
+        let cursor_viewed_at = page.validate_cursor_consistency()?;
+        let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(self.checkpoint_viewed_at);
 
         let mut connection = Connection::new(false, false);
         let function_names = if page.is_from_front() {
@@ -236,7 +251,11 @@ impl MoveModule {
                 .extend();
             };
 
-            let cursor = JsonCursor::new(name.to_string()).encode_cursor();
+            let cursor = JsonCursor::new(ConsistentNamedCursor {
+                name: name.to_string(),
+                c: checkpoint_viewed_at,
+            })
+            .encode_cursor();
             connection.edges.push(Edge::new(cursor, function));
         }
 
@@ -278,6 +297,7 @@ impl MoveModule {
             self.parsed.name().to_string(),
             name,
             def,
+            self.checkpoint_viewed_at,
         )))
     }
 
@@ -293,6 +313,7 @@ impl MoveModule {
             self.parsed.name().to_string(),
             name,
             def,
+            self.checkpoint_viewed_at,
         )))
     }
 
@@ -300,8 +321,12 @@ impl MoveModule {
         db: &Db,
         address: SuiAddress,
         name: &str,
+        checkpoint_viewed_at: u64,
     ) -> Result<Option<Self>, Error> {
-        let Some(package) = MovePackage::query(db, address, ObjectLookupKey::Latest).await? else {
+        let Some(package) =
+            MovePackage::query(db, address, ObjectLookupKey::LatestAt(checkpoint_viewed_at))
+                .await?
+        else {
             return Ok(None);
         };
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -27,6 +27,7 @@ use sui_types::{
 };
 
 use crate::{
+    consistency::Checkpointed,
     data::{self, Db, DbConnection, QueryExecutor},
     error::Error,
     types::intersect,
@@ -36,7 +37,7 @@ use super::{
     address::Address,
     base64::Base64,
     checkpoint::Checkpoint,
-    cursor::{self, Checkpointed, Page, Paginated, Target},
+    cursor::{self, Page, Paginated, Target},
     digest::Digest,
     epoch::Epoch,
     gas::GasInput,

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -155,7 +155,7 @@ impl TransactionBlockEffects {
 
         let dependencies = self.native().dependencies();
 
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(dependencies.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -215,7 +215,7 @@ impl TransactionBlockEffects {
 
         let input_shared_objects = self.native().input_shared_objects();
 
-        let Some((prev, next, cs)) = page
+        let Some((prev, next, _, cs)) = page
             .paginate_consistent_indices(input_shared_objects.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -253,7 +253,7 @@ impl TransactionBlockEffects {
 
         let object_changes = self.native().object_changes();
 
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(object_changes.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -293,7 +293,7 @@ impl TransactionBlockEffects {
             return Ok(connection);
         };
 
-        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
             stored_tx.balance_changes.len(),
             self.checkpoint_viewed_at,
         )?
@@ -334,7 +334,7 @@ impl TransactionBlockEffects {
             TransactionBlockEffectsKind::Executed { events, .. }
             | TransactionBlockEffectsKind::DryRun { events, .. } => events.len(),
         };
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(len, self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -346,13 +346,13 @@ impl TransactionBlockEffects {
         for c in cs {
             let event = match &self.kind {
                 TransactionBlockEffectsKind::Stored { stored_tx, .. } => {
-                    Event::try_from_stored_transaction(stored_tx, c.ix, Some(c.c)).extend()?
+                    Event::try_from_stored_transaction(stored_tx, c.ix, c.c).extend()?
                 }
                 TransactionBlockEffectsKind::Executed { events, .. }
                 | TransactionBlockEffectsKind::DryRun { events, .. } => Event {
                     stored: None,
                     native: events[c.ix].clone(),
-                    checkpoint_viewed_at: Some(c.c),
+                    checkpoint_viewed_at: c.c,
                 },
             };
             connection.edges.push(Edge::new(c.encode_cursor(), event));

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -66,7 +66,7 @@ impl AuthenticatorStateUpdateTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
             self.native.new_active_jwks.len(),
             self.checkpoint_viewed_at,
         )?

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -98,7 +98,7 @@ impl EndOfEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(self.native.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -179,7 +179,7 @@ impl ChangeEpochTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page.paginate_consistent_indices(
+        let Some((prev, next, _, cs)) = page.paginate_consistent_indices(
             self.native.system_packages.len(),
             self.checkpoint_viewed_at,
         )?
@@ -208,7 +208,7 @@ impl ChangeEpochTransaction {
 
             let runtime_id = native.id();
             let object = Object::from_native(SuiAddress::from(runtime_id), native, Some(c.c));
-            let package = MovePackage::try_from(&object)
+            let package = MovePackage::try_from(&object, self.checkpoint_viewed_at)
                 .map_err(|_| Error::Internal("Failed to create system package".to_string()))
                 .extend()?;
 

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -44,7 +44,7 @@ impl GenesisTransaction {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(self.native.objects.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -215,7 +215,7 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) =
+        let Some((prev, next, _, cs)) =
             page.paginate_consistent_indices(self.native.inputs.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -244,7 +244,7 @@ impl ProgrammableTransactionBlock {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
 
         let mut connection = Connection::new(false, false);
-        let Some((prev, next, cs)) = page
+        let Some((prev, next, _, cs)) = page
             .paginate_consistent_indices(self.native.commands.len(), self.checkpoint_viewed_at)?
         else {
             return Ok(connection);
@@ -287,6 +287,7 @@ impl MoveCallTransaction {
             self.native.package.into(),
             self.native.module.as_str(),
             self.native.function.as_str(),
+            self.checkpoint_viewed_at,
         )
         .await
         .extend()


### PR DESCRIPTION
## Description 

To handle consistency for `MovePackage` and related `Move` types, when querying for `MovePackage`, we set the `checkpoint_viewed_at` field to a value to make it easier to pass the context back and forth.

Move the consistent cursors into the `consistency` module.

Replaces last usage of `paginate_indices` with `paginate_consistent_indices`, which allows us to drop the function. 

Also clean up consistency on `Validator` side - when instantiating `ValidatorSet`, populate it with a non-null `checkpoint_viewed_at`.

## Test Plan 

Potentially rehauling tests - this is intended to be the last PR and will test all about consistency.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
