### PR TITLE
[shared-object-deletion] Turn on shared object deletion in mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -106,6 +106,7 @@ const MAX_PROTOCOL_VERSION: u64 = 36;
 // Version 35: Add poseidon hash function.
 //             Enable coin deny list.
 // Version 36: Enable group operations native functions in devnet.
+//             Enable shared object deletion in mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1868,6 +1869,8 @@ impl ProtocolConfig {
                         cfg.group_ops_bls12381_msm_max_len = Some(32);
                         cfg.group_ops_bls12381_pairing_cost = Some(52);
                     }
+                    // Enable shared object deletion on all networks.
+                    cfg.feature_flags.shared_object_deletion = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_36.snap
@@ -24,6 +24,7 @@ feature_flags:
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
   narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   enable_jwk_consensus_updates: true


### PR DESCRIPTION
## Description 

Turn on shared object deletion in mainnet. This is a flag-only PR (+ updates) that adds a new protocol version (version 36).

## Test Plan 

Existing tests + has been running in devnet/testnet for the past couple months.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [X] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Enable shared object deletion in mainnet.
