### PR TITLE
move: tidy lock file header read interface

### DIFF
--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -106,7 +106,7 @@ impl Packages {
         let Schema { move_: packages } =
             toml::de::from_str::<Schema<Packages>>(&contents).context("Deserializing packages")?;
 
-        Ok((packages, read_header(&contents)?))
+        Ok((packages, Header::from_str(&contents)?))
     }
 }
 
@@ -133,32 +133,32 @@ impl ToolchainVersion {
 }
 
 impl Header {
+    /// Read lock file header after verifying that the version of the lock is not newer than the version
+    /// supported by this library.
     pub fn read(lock: &mut impl Read) -> Result<Header> {
         let contents = {
             let mut buf = String::new();
             lock.read_to_string(&mut buf).context("Reading lock file")?;
             buf
         };
-        read_header(&contents)
-    }
-}
-
-/// Read lock file header after verifying that the version of the lock is not newer than the version
-/// supported by this library.
-#[allow(clippy::ptr_arg)] // Allowed to avoid interface changes.
-pub fn read_header(contents: &String) -> Result<Header> {
-    let Schema { move_: header } =
-        toml::de::from_str::<Schema<Header>>(contents).context("Deserializing lock header")?;
-
-    if header.version > VERSION {
-        bail!(
-            "Lock file format is too new, expected version {} or below, found {}",
-            VERSION,
-            header.version
-        );
+        Self::from_str(&contents)
     }
 
-    Ok(header)
+    #[allow(clippy::ptr_arg)] // Allowed to avoid interface changes.
+    fn from_str(contents: &String) -> Result<Header> {
+        let Schema { move_: header } =
+            toml::de::from_str::<Schema<Header>>(contents).context("Deserializing lock header")?;
+
+        if header.version > VERSION {
+            bail!(
+                "Lock file format is too new, expected version {} or below, found {}",
+                VERSION,
+                header.version
+            );
+        }
+
+        Ok(header)
+    }
 }
 
 /// Write the initial part of the lock file.

--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -144,8 +144,7 @@ impl Header {
         Self::from_str(&contents)
     }
 
-    #[allow(clippy::ptr_arg)] // Allowed to avoid interface changes.
-    fn from_str(contents: &String) -> Result<Header> {
+    fn from_str(contents: &str) -> Result<Header> {
         let Schema { move_: header } =
             toml::de::from_str::<Schema<Header>>(contents).context("Deserializing lock header")?;
 

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -8,6 +8,7 @@ use petgraph::{algo, prelude::DiGraphMap, Direction};
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet, VecDeque},
     fmt,
+    fs::File,
     io::{BufWriter, Read, Write},
     path::{Path, PathBuf},
     process::Command,
@@ -201,17 +202,14 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         // compute digests eagerly as even if we can't reuse existing lock file, they need to become
         // part of the newly computed dependency graph
         let new_manifest_digest = digest_str(manifest_string.into_bytes().as_slice());
-        let (old_manifest_digest_opt, old_deps_digest_opt, lock_string) = match lock_string_opt {
-            Some(lock_string) => match schema::read_header(&lock_string) {
-                Ok(header) => (
-                    Some(header.manifest_digest),
-                    Some(header.deps_digest),
-                    Some(lock_string),
-                ),
-                Err(_) => (None, None, None), // malformed header - regenerate lock file
-            },
-            None => (None, None, None),
-        };
+        let lock_path = root_path.join(SourcePackageLayout::Lock.path());
+        let lock_file = File::open(lock_path);
+        let digest_and_lock_contents = lock_file
+            .map(|mut lock_file| match schema::Header::read(&mut lock_file) {
+                Ok(header) => Some((header.manifest_digest, header.deps_digest, lock_string_opt)),
+                Err(_) => None, // malformed header - regenerate lock file
+            })
+            .unwrap_or(None);
 
         // collect sub-graphs for "regular" and "dev" dependencies
         let root_pkg_name = custom_resolve_pkg_name(&root_manifest).with_context(|| {
@@ -249,24 +247,23 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             .map(|graph_info| graph_info.g.write_to_lock(self.install_dir.clone()))
             .collect::<Result<Vec<LockFile>>>()?;
         let new_deps_digest = self.dependency_digest(dep_lock_files, dev_dep_lock_files)?;
-        let (manifest_digest, deps_digest) =
-            match (old_manifest_digest_opt, old_deps_digest_opt, lock_string) {
-                (Some(old_manifest_digest), Some(old_deps_digest), Some(lock_string))
-                    if old_manifest_digest == new_manifest_digest
-                        && old_deps_digest == new_deps_digest =>
-                {
-                    return Ok((
-                        DependencyGraph::read_from_lock(
-                            root_path,
-                            root_pkg_name,
-                            &mut lock_string.as_bytes(), // safe since old_deps_digest exists
-                            None,
-                        )?,
-                        false,
-                    ));
-                }
-                _ => (new_manifest_digest, new_deps_digest),
-            };
+        let (manifest_digest, deps_digest) = match digest_and_lock_contents {
+            Some((old_manifest_digest, old_deps_digest, Some(lock_string)))
+                if old_manifest_digest == new_manifest_digest
+                    && old_deps_digest == new_deps_digest =>
+            {
+                return Ok((
+                    DependencyGraph::read_from_lock(
+                        root_path,
+                        root_pkg_name,
+                        &mut lock_string.as_bytes(), // safe since old_deps_digest exists
+                        None,
+                    )?,
+                    false,
+                ));
+            }
+            _ => (new_manifest_digest, new_deps_digest),
+        };
 
         dep_graphs.extend(dev_dep_graphs);
         dep_orig_names.extend(dev_dep_orig_names);


### PR DESCRIPTION
## Description 

Just a cleanup of how we do lock file header reads. See separate commits for a breakdown of the change, and inline comments for more.

Follow up of https://github.com/MystenLabs/sui/pull/15751#pullrequestreview-1829957061. 

## Test Plan 

Should not be changing anything functionally, covered by existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
