### PR TITLE
[graphql] Improve the health check

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/logger.rs
+++ b/crates/sui-graphql-rpc/src/extensions/logger.rs
@@ -84,7 +84,7 @@ impl Extension for LoggerExtension {
             .any(|(_, operation)| operation.node.selection_set.node.items.iter().any(|selection| matches!(&selection.node, Selection::Field(field) if field.node.name.node == "__schema")));
         let query_id: &Uuid = ctx.data_unchecked();
         let session_id: &SocketAddr = ctx.data_unchecked();
-        if !is_schema && self.config.log_request_query && !is_health_check_request(query_id) {
+        if !is_schema && self.config.log_request_query {
             info!(
                 %query_id,
                 %session_id,
@@ -103,7 +103,7 @@ impl Extension for LoggerExtension {
         let res = next.run(ctx).await?;
         let query_id: &Uuid = ctx.data_unchecked();
         let session_id: &SocketAddr = ctx.data_unchecked();
-        if self.config.log_complexity && !is_health_check_request(query_id) {
+        if self.config.log_complexity {
             info!(
                 %query_id,
                 %session_id,
@@ -187,7 +187,7 @@ impl Extension for LoggerExtension {
                     )
                 }
             }
-        } else if self.config.log_response && !is_health_check_request(query_id) {
+        } else if self.config.log_response {
             match operation_name {
                 Some("IntrospectionQuery") => {
                     debug!(
@@ -205,9 +205,4 @@ impl Extension for LoggerExtension {
         }
         resp
     }
-}
-
-/// Check if the request comes from the `health` endpoint, which has the nil uuid
-fn is_health_check_request(id: &Uuid) -> bool {
-    id.is_nil()
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -6,6 +6,7 @@ use crate::config::{
 };
 use crate::context_data::package_cache::DbPackageStore;
 use crate::data::Db;
+
 use crate::metrics::Metrics;
 use crate::mutation::Mutation;
 use crate::types::move_object::IMoveObject;
@@ -41,7 +42,7 @@ use hyper::server::conn::AddrIncoming as HyperAddrIncoming;
 use hyper::Body;
 use hyper::Server as HyperServer;
 use std::convert::Infallible;
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::{any::Any, net::SocketAddr, time::Instant};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use sui_sdk::SuiClientBuilder;
@@ -49,8 +50,6 @@ use tokio::sync::OnceCell;
 use tower::{Layer, Service};
 use tracing::{info, warn};
 use uuid::Uuid;
-
-const HEALTH_UUID: Uuid = Uuid::nil();
 
 pub struct Server {
     pub server: HyperServer<HyperAddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>,
@@ -72,7 +71,7 @@ pub(crate) struct ServerBuilder {
 }
 
 #[derive(Clone)]
-struct AppState {
+pub(crate) struct AppState {
     connection: ConnectionConfig,
     metrics: Metrics,
 }
@@ -447,7 +446,7 @@ pub mod tests {
             let db = Db::new(reader.clone(), cfg.limits, metrics.clone());
             let pg_conn_pool = PgManager::new(reader);
             let state = AppState::new(connection_config.clone(), metrics.clone());
-            let mut schema = ServerBuilder::new(state)
+            let schema = ServerBuilder::new(state)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(cfg)
@@ -502,7 +501,7 @@ pub mod tests {
             let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
             let pg_conn_pool = PgManager::new(reader);
             let state = AppState::new(connection_config.clone(), metrics.clone());
-            let mut schema = ServerBuilder::new(state)
+            let schema = ServerBuilder::new(state)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(service_config)
@@ -576,7 +575,7 @@ pub mod tests {
             let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
             let pg_conn_pool = PgManager::new(reader);
             let state = AppState::new(connection_config.clone(), metrics.clone());
-            let mut schema = ServerBuilder::new(state)
+            let schema = ServerBuilder::new(state)
                 .context_data(db)
                 .context_data(pg_conn_pool)
                 .context_data(service_config)
@@ -650,7 +649,7 @@ pub mod tests {
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
         let state = AppState::new(connection_config.clone(), metrics.clone());
-        let mut schema = ServerBuilder::new(state)
+        let schema = ServerBuilder::new(state)
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(service_config)
@@ -704,7 +703,7 @@ pub mod tests {
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
         let state = AppState::new(connection_config.clone(), metrics.clone());
-        let mut schema = ServerBuilder::new(state)
+        let schema = ServerBuilder::new(state)
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(service_config)
@@ -747,7 +746,7 @@ pub mod tests {
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
         let state = AppState::new(connection_config.clone(), metrics.clone());
-        let mut schema = ServerBuilder::new(state)
+        let schema = ServerBuilder::new(state)
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(service_config)

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -337,7 +337,7 @@ async fn health_checks(State(connection): State<ConnectionConfig>) -> StatusCode
     let tcp_url = if let Some(port) = url.port() {
         format!("{host}:{port}")
     } else {
-        host.to_string();
+        host.to_string()
     };
 
     if TcpStream::connect(tcp_url).is_err() {


### PR DESCRIPTION
## Description 

Improve the health check by removing the query to the DB and replacing it with a status code 200 if all is OK, or 500 on error. It also cleans up the previous health check checks in the logging logic.

It also moves metrics and connection under a `AppState` struct as `axum` does not allow states with different types on the router, so we need to bundle them under one state and then have `FromRef` implementations for the substates.

## Test Plan 

Existing tests, manually analyzing the logs.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
