### PR TITLE
move: use source package layout to resolve Move.lock path

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use move_cli::base;
+use move_package::source_package::layout::SourcePackageLayout;
 use move_package::BuildConfig as MoveBuildConfig;
 use serde_json::json;
 use std::{fs, path::PathBuf};
@@ -99,7 +100,7 @@ pub fn resolve_lock_file_path(
 ) -> Result<MoveBuildConfig, anyhow::Error> {
     if build_config.lock_file.is_none() {
         let package_root = base::reroot_path(package_path)?;
-        let lock_file_path = package_root.join("Move.lock");
+        let lock_file_path = package_root.join(SourcePackageLayout::Lock.path());
         build_config.lock_file = Some(lock_file_path);
     }
     Ok(build_config)

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -511,7 +511,7 @@ fn units_for_toolchain(
         }
 
         let package_root = SourcePackageLayout::try_find_root(&local_unit.source_path)?;
-        let lock_file = package_root.join("Move.lock");
+        let lock_file = package_root.join(SourcePackageLayout::Lock.path());
         if !lock_file.exists() {
             // No lock file implies current compiler for this package.
             package_version_map.insert(*package, (current_toolchain(), vec![local_unit.clone()]));


### PR DESCRIPTION
## Description 

Tidying up some lock file logic and spotted this

## Test Plan 

Covered by existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
