### PR TITLE
move-package: make `nested_deps_git_local` use sui repo for dep

### DIFF
--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.locked
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.locked
@@ -2,7 +2,7 @@
 
 [move]
 version = 0
-manifest_digest = "EE966AF65A364E10F79C8D04690C10863F8B1084F45A4480A1F421D4A592A659"
+manifest_digest = "598DCC919F7378E59F328E1B448D1AAC70B8F34894146860B3ABF46600F9F79B"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 
 dependencies = [
@@ -11,8 +11,7 @@ dependencies = [
 
 [[move.package]]
 name = "MoveNursery"
-source = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib/nursery" }
-version = "1.5.0"
+source = { git = "https://github.com/MystenLabs/sui", rev = "5d8a867", subdir = "external-crates/move/crates/move-stdlib/nursery" }
 
 dependencies = [
   { name = "MoveStdlib" },
@@ -20,5 +19,4 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib" }
-version = "1.5.0"
+source = { git = "https://github.com/MystenLabs/sui", rev = "5d8a867", subdir = "external-crates/move/crates/move-stdlib" }

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -31,27 +31,23 @@ ResolvedGraph {
             "MoveNursery": Package {
                 kind: Git(
                     GitInfo {
-                        git_url: "https://github.com/move-language/move",
-                        git_rev: "781c844",
-                        subdir: "language/move-stdlib/nursery",
+                        git_url: "https://github.com/MystenLabs/sui",
+                        git_rev: "5d8a867",
+                        subdir: "external-crates/move/crates/move-stdlib/nursery",
                     },
                 ),
-                version: Some(
-                    "1.5.0",
-                ),
+                version: None,
                 resolver: None,
             },
             "MoveStdlib": Package {
                 kind: Git(
                     GitInfo {
-                        git_url: "https://github.com/move-language/move",
-                        git_rev: "781c844",
-                        subdir: "language/move-stdlib",
+                        git_url: "https://github.com/MystenLabs/sui",
+                        git_rev: "5d8a867",
+                        subdir: "external-crates/move/crates/move-stdlib",
                     },
                 ),
-                version: Some(
-                    "1.5.0",
-                ),
+                version: None,
                 resolver: None,
             },
         },
@@ -60,7 +56,7 @@ ResolvedGraph {
             "MoveStdlib",
             "NestedDeps",
         },
-        manifest_digest: "EE966AF65A364E10F79C8D04690C10863F8B1084F45A4480A1F421D4A592A659",
+        manifest_digest: "598DCC919F7378E59F328E1B448D1AAC70B8F34894146860B3ABF46600F9F79B",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
@@ -93,9 +89,7 @@ ResolvedGraph {
                     license: None,
                     edition: None,
                     flavor: None,
-                    custom_properties: {
-                        "version": "1.5.0",
-                    },
+                    custom_properties: {},
                 },
                 addresses: None,
                 dev_address_assignments: Some(
@@ -133,9 +127,7 @@ ResolvedGraph {
                     license: None,
                     edition: None,
                     flavor: None,
-                    custom_properties: {
-                        "version": "1.5.0",
-                    },
+                    custom_properties: {},
                 },
                 addresses: Some(
                     {
@@ -182,9 +174,9 @@ ResolvedGraph {
                         InternalDependency {
                             kind: Git(
                                 GitInfo {
-                                    git_url: "https://github.com/move-language/move",
-                                    git_rev: "781c844",
-                                    subdir: "language/move-stdlib/nursery",
+                                    git_url: "https://github.com/MystenLabs/sui",
+                                    git_rev: "5d8a867",
+                                    subdir: "external-crates/move/crates/move-stdlib/nursery",
                                 },
                             ),
                             subst: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml
@@ -2,7 +2,7 @@
 name = "NestedDeps"
 
 [dependencies]
-MoveNursery = { git = "https://github.com/move-language/move", rev = "781c844", subdir = "language/move-stdlib/nursery" }
+MoveNursery = { git = "https://github.com/MystenLabs/sui", rev = "5d8a867", subdir = "external-crates/move/crates/move-stdlib/nursery" }
 
 [addresses]
 std = "0x1"


### PR DESCRIPTION
## Description 

Forgot this yesterday with the nits. It's related to this https://github.com/MystenLabs/sui/pull/15867/files/3ee2e7f1df0cfea267a0b25896b46a5d6c61629b#r1466324788

@rvantonder @amnn 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
