### PR TITLE
[easy][sui-package-resolver] Switch package resolver tests to using insta test for expected value tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13091,7 +13091,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bcs",
- "expect-test",
  "eyre",
  "hyper",
  "insta",

--- a/crates/sui-package-resolver/Cargo.toml
+++ b/crates/sui-package-resolver/Cargo.toml
@@ -23,7 +23,6 @@ lru.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-expect-test.workspace = true
 hyper.workspace = true
 insta.workspace = true
 move-compiler.workspace = true

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__cross_module.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__cross_module.snap
@@ -1,0 +1,14 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa0::n::T0 {
+    t: struct 0xa0::m::T1<u16, u32> {
+        a: address,
+        p: u16,
+        q: vector<u32>,
+    },
+    u: struct 0xa0::m::T2 {
+        x: u8,
+    },
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__cross_package.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__cross_package.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xb0::m::T0 {
+    m: struct 0xa0::m::T2 {
+        x: u8,
+    },
+    n: struct 0xa0::n::T0 {
+        t: struct 0xa0::m::T1<u16, u32> {
+            a: address,
+            p: u16,
+            q: vector<u32>,
+        },
+        u: struct 0xa0::m::T2 {
+            x: u8,
+        },
+    },
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__functions.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__functions.snap
@@ -1,0 +1,71 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"c0::m::foo: {foo:#?}\\n\\\n             c0::m::bar: {bar:#?}\\n\\\n             c0::m::baz: {baz:#?}\")"
+---
+c0::m::foo: FunctionDef {
+    visibility: Public,
+    is_entry: false,
+    type_params: [],
+    parameters: [],
+    return_: [],
+}
+c0::m::bar: FunctionDef {
+    visibility: Friend,
+    is_entry: false,
+    type_params: [],
+    parameters: [
+        OpenSignature {
+            ref_: Some(
+                Immutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000c0,
+                    module: "m",
+                    name: "T0",
+                },
+                [],
+            ),
+        },
+        OpenSignature {
+            ref_: Some(
+                Mutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000a0,
+                    module: "n",
+                    name: "T1",
+                },
+                [],
+            ),
+        },
+    ],
+    return_: [
+        OpenSignature {
+            ref_: None,
+            body: U64,
+        },
+    ],
+}
+c0::m::baz: FunctionDef {
+    visibility: Private,
+    is_entry: false,
+    type_params: [],
+    parameters: [
+        OpenSignature {
+            ref_: None,
+            body: U8,
+        },
+    ],
+    return_: [
+        OpenSignature {
+            ref_: None,
+            body: U16,
+        },
+        OpenSignature {
+            ref_: None,
+            body: U32,
+        },
+    ],
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__multiple_linkage_contexts.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__multiple_linkage_contexts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa0::m::T1<0xa0::m::T0, 0xa1::m::T3> {
+    a: address,
+    p: struct 0xa0::m::T0 {
+        b: bool,
+        v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+            a: address,
+            p: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            q: vector<u128>,
+        }>,
+    },
+    q: vector<struct 0xa1::m::T3 {
+        y: u16,
+    }>,
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__relinking.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__relinking.snap
@@ -1,0 +1,49 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xc0::m::T0 {
+    t: struct 0xa0::n::T0 {
+        t: struct 0xa0::m::T1<u16, u32> {
+            a: address,
+            p: u16,
+            q: vector<u32>,
+        },
+        u: struct 0xa0::m::T2 {
+            x: u8,
+        },
+    },
+    u: struct 0xa1::n::T1 {
+        t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+            a: address,
+            p: struct 0xa1::m::T3 {
+                y: u16,
+            },
+            q: vector<u32>,
+        },
+        u: struct 0xa1::m::T4 {
+            z: u32,
+        },
+    },
+    v: struct 0xa0::m::T2 {
+        x: u8,
+    },
+    w: struct 0xa1::m::T3 {
+        y: u16,
+    },
+    x: struct 0xb0::m::T0 {
+        m: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        n: struct 0xa0::n::T0 {
+            t: struct 0xa0::m::T1<u16, u32> {
+                a: address,
+                p: u16,
+                q: vector<u32>,
+            },
+            u: struct 0xa0::m::T2 {
+                x: u8,
+            },
+        },
+    },
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__simple_type.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__simple_type.snap
@@ -1,0 +1,14 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa0::m::T0 {
+    b: bool,
+    v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+        a: address,
+        p: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        q: vector<u128>,
+    }>,
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__structs.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__structs.snap
@@ -1,0 +1,83 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"a0::m::T0: {t0:#?}\\n\\\n             a0::m::T1: {t1:#?}\\n\\\n             a0::m::T2: {t2:#?}\",)"
+---
+a0::m::T0: StructDef {
+    defining_id: 00000000000000000000000000000000000000000000000000000000000000a0,
+    abilities: [],
+    type_params: [],
+    fields: [
+        (
+            "b",
+            Bool,
+        ),
+        (
+            "v",
+            Vector(
+                Datatype(
+                    DatatypeRef {
+                        package: 00000000000000000000000000000000000000000000000000000000000000a0,
+                        module: "m",
+                        name: "T1",
+                    },
+                    [
+                        Datatype(
+                            DatatypeRef {
+                                package: 00000000000000000000000000000000000000000000000000000000000000a0,
+                                module: "m",
+                                name: "T2",
+                            },
+                            [],
+                        ),
+                        U128,
+                    ],
+                ),
+            ),
+        ),
+    ],
+}
+a0::m::T1: StructDef {
+    defining_id: 00000000000000000000000000000000000000000000000000000000000000a0,
+    abilities: [],
+    type_params: [
+        StructTypeParameter {
+            constraints: [],
+            is_phantom: false,
+        },
+        StructTypeParameter {
+            constraints: [],
+            is_phantom: false,
+        },
+    ],
+    fields: [
+        (
+            "a",
+            Address,
+        ),
+        (
+            "p",
+            TypeParameter(
+                0,
+            ),
+        ),
+        (
+            "q",
+            Vector(
+                TypeParameter(
+                    1,
+                ),
+            ),
+        ),
+    ],
+}
+a0::m::T2: StructDef {
+    defining_id: 00000000000000000000000000000000000000000000000000000000000000a0,
+    abilities: [],
+    type_params: [],
+    fields: [
+        (
+            "x",
+            U8,
+        ),
+    ],
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__system_package_invalidation.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__system_package_invalidation.snap
@@ -1,0 +1,7 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0x1::m::T1 {
+    x: u256,
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__upgraded_package.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__upgraded_package.snap
@@ -1,0 +1,16 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa1::n::T1 {
+    t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+        a: address,
+        p: struct 0xa1::m::T3 {
+            y: u16,
+        },
+        q: vector<u32>,
+    },
+    u: struct 0xa1::m::T4 {
+        z: u32,
+    },
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__upgraded_package_non_defining_id.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__upgraded_package_non_defining_id.snap
@@ -1,0 +1,20 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa0::m::T1<0xa1::m::T3, 0xa0::m::T0> {
+    a: address,
+    p: struct 0xa1::m::T3 {
+        y: u16,
+    },
+    q: vector<struct 0xa0::m::T0 {
+        b: bool,
+        v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+            a: address,
+            p: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            q: vector<u128>,
+        }>,
+    }>,
+}

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__value_nesting_boundary.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__value_nesting_boundary.snap
@@ -1,0 +1,9 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"{layout:#}\")"
+---
+struct 0xa0::m::T1<u8, u8> {
+    a: address,
+    p: u8,
+    q: vector<u8>,
+}


### PR DESCRIPTION
## Description 

Converts the expected value tests in the sui-package-resolver crate to using insta test. This makes it easier to update/review and also to have larger resolution tests.

Note that I kept alternate display formatting for the layouts since that makes things easier to read in the snapshots. 

## Test Plan 

Make sure existing tests pass, and that the new expected insta snapshots match the old ones.

