### PR TITLE
move: pause tracking a package in config.toml

### DIFF
--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -57,11 +57,11 @@ packages = [
     { path = "kiosk" },
 ]
 
-[[packages]]
-source = "Repository"
-[packages.values]
-repository = "https://github.com/kunalabs-io/sui-smart-contracts"
-branch = "master"
-packages = [
-    { path = "kai-finance" }
-]
+# [[packages]]
+# source = "Repository"
+# [packages.values]
+# repository = "https://github.com/kunalabs-io/sui-smart-contracts"
+# branch = "master"
+# packages = [
+#    { path = "kai-finance" }
+# ]


### PR DESCRIPTION
## Description 

The source for this package is moving on the `master` branch https://github.com/kunalabs-io/sui-smart-contracts/commit/e6fcbd69ed330de2824abb45c876f4b360923de2 which shouldn't happen when we're tracking it for bytecode verification. When it moves, but the published address stays the same, the bytecode no longer matches upstream and the service pauses.

I'll get in touch with package maintainers to figure out how we can pin the source to a branch that doesn't move or is being actively developed against, and will then re-enable. 

## Test Plan 

N/A, maintaining source service.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
