### PR TITLE
move-package: refactor `custom_resolve_pkg_name` to `custom_resolve_pkg_id` (pure refactor)

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -32,7 +32,7 @@ use move_package::{
     compilation::{
         build_plan::BuildPlan, compiled_package::CompiledPackage as MoveCompiledPackage,
     },
-    package_hooks::PackageHooks,
+    package_hooks::{PackageHooks, PackageIdentifier},
     resolution::resolution_graph::ResolvedGraph,
     BuildConfig as MoveBuildConfig,
 };
@@ -617,7 +617,10 @@ impl PackageHooks for SuiPackageHooks {
         Ok(())
     }
 
-    fn custom_resolve_pkg_name(&self, manifest: &SourceManifest) -> anyhow::Result<Symbol> {
+    fn custom_resolve_pkg_id(
+        &self,
+        manifest: &SourceManifest,
+    ) -> anyhow::Result<PackageIdentifier> {
         Ok(manifest.package.name)
     }
 

--- a/external-crates/move/crates/move-package/src/package_hooks.rs
+++ b/external-crates/move/crates/move-package/src/package_hooks.rs
@@ -7,6 +7,8 @@ use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
+pub type PackageIdentifier = Symbol;
+
 // TODO: remove static hooks and refactor this crate for better customizability
 
 /// A trait providing hooks to customize the package system for a particular Move application.
@@ -28,7 +30,8 @@ pub trait PackageHooks {
         info: &CustomDepInfo,
     ) -> anyhow::Result<()>;
 
-    fn custom_resolve_pkg_name(&self, manifest: &SourceManifest) -> anyhow::Result<Symbol>;
+    fn custom_resolve_pkg_id(&self, manifest: &SourceManifest)
+        -> anyhow::Result<PackageIdentifier>;
 
     fn resolve_version(&self, manifest: &SourceManifest) -> anyhow::Result<Option<Symbol>>;
 }
@@ -69,9 +72,11 @@ pub(crate) fn custom_package_info_fields() -> Vec<String> {
     }
 }
 
-pub(crate) fn custom_resolve_pkg_name(manifest: &SourceManifest) -> anyhow::Result<Symbol> {
+pub(crate) fn custom_resolve_pkg_id(
+    manifest: &SourceManifest,
+) -> anyhow::Result<PackageIdentifier> {
     if let Some(hooks) = &*HOOKS.lock().unwrap() {
-        hooks.custom_resolve_pkg_name(manifest)
+        hooks.custom_resolve_pkg_id(manifest)
     } else {
         Ok(manifest.package.name)
     }

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     lock_file::{schema, LockFile},
-    package_hooks::{self, custom_resolve_pkg_name, resolve_version},
+    package_hooks::{self, custom_resolve_pkg_id, resolve_version, PackageIdentifier},
     source_package::{
         layout::SourcePackageLayout,
         manifest_parser::{
@@ -66,21 +66,21 @@ use super::{
 pub struct DependencyGraph {
     /// Path to the root package and its name (according to its manifest)
     pub root_path: PathBuf,
-    pub root_package: PM::PackageName,
-    /// Root package name as defined in its manifest (can be different from the resolved name).
-    pub root_package_orig_name: PM::PackageName,
+    pub root_package_id: PackageIdentifier,
+    /// Root package name as defined in its manifest (can be different from the resolved identifier).
+    pub root_package_name: PM::PackageName,
 
     /// Transitive dependency graph, with dependency edges `P -> Q` labelled according to whether Q
     /// is always a dependency of P or only in dev-mode.
-    pub package_graph: DiGraphMap<PM::PackageName, Dependency>,
+    pub package_graph: DiGraphMap<PackageIdentifier, Dependency>,
 
     /// The dependency that each package (keyed by name) originates from.  The root package is the
     /// only node in `package_graph` that does not have an entry in `package_table`.
-    pub package_table: BTreeMap<PM::PackageName, Package>,
+    pub package_table: BTreeMap<PackageIdentifier, Package>,
 
     /// Packages that are transitive dependencies regardless of mode (the transitive closure of
     /// `DependencyMode::Always` edges in `package_graph`).
-    pub always_deps: BTreeSet<PM::PackageName>,
+    pub always_deps: BTreeSet<PackageIdentifier>,
 
     /// A hash of the manifest file content this lock file was generated from.
     pub manifest_digest: String,
@@ -155,8 +155,8 @@ pub struct Dependency {
     pub digest: Option<PM::PackageDigest>,
     pub dep_override: PM::DepOverride,
     /// Original dependency name as defined in parent manifest since it can be different from the
-    /// resolved name. Used for printing user-friendly error messages.
-    pub dep_orig_name: PM::PackageName,
+    /// resolved identifier. Used for printing user-friendly error messages.
+    pub dep_name: PM::PackageName,
 }
 
 impl PartialEq for Dependency {
@@ -182,7 +182,7 @@ pub enum DependencyMode {
 /// currently support serializing types as inline tables.
 struct PackageTOML<'a>(&'a Package);
 struct PackageWithResolverTOML<'a>(&'a Package);
-struct DependencyTOML<'a>(PM::PackageName, &'a Dependency);
+struct DependencyTOML<'a>(PackageIdentifier, &'a Dependency);
 struct SubstTOML<'a>(&'a PM::Substitution);
 
 /// A builder for `DependencyGraph`
@@ -192,7 +192,7 @@ pub struct DependencyGraphBuilder<Progress: Write> {
     /// Logger
     pub progress_output: Progress,
     /// A chain of visited dependencies used for cycle detection
-    visited_dependencies: VecDeque<(PM::PackageName, PM::InternalDependency)>,
+    visited_dependencies: VecDeque<(PackageIdentifier, PM::InternalDependency)>,
     /// Installation directory for compiled artifacts (from BuildConfig).
     install_dir: PathBuf,
 }
@@ -237,18 +237,18 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             .unwrap_or(None);
 
         // collect sub-graphs for "regular" and "dev" dependencies
-        let root_pkg_name = custom_resolve_pkg_name(&root_manifest).with_context(|| {
+        let root_pkg_id = custom_resolve_pkg_id(&root_manifest).with_context(|| {
             format!(
                 "Resolving package name for '{}'",
                 root_manifest.package.name
             )
         })?;
-        let root_pkg_orig_name = root_manifest.package.name;
-        let (mut dep_graphs, resolved_name_deps, mut dep_orig_names, mut overrides) = self
+        let root_pkg_name = root_manifest.package.name;
+        let (mut dep_graphs, resolved_id_deps, mut dep_names, mut overrides) = self
             .collect_graphs(
                 parent,
+                root_pkg_id,
                 root_pkg_name,
-                root_pkg_orig_name,
                 root_path.clone(),
                 DependencyMode::Always,
                 root_manifest.dependencies.clone(),
@@ -257,11 +257,11 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             .values()
             .map(|graph_info| graph_info.g.write_to_lock(self.install_dir.clone()))
             .collect::<Result<Vec<LockFile>>>()?;
-        let (dev_dep_graphs, dev_resolved_name_deps, dev_dep_orig_names, dev_overrides) = self
+        let (dev_dep_graphs, dev_resolved_id_deps, dev_dep_names, dev_overrides) = self
             .collect_graphs(
                 parent,
+                root_pkg_id,
                 root_pkg_name,
-                root_pkg_orig_name,
                 root_path.clone(),
                 DependencyMode::DevOnly,
                 root_manifest.dev_dependencies.clone(),
@@ -280,7 +280,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                 return Ok((
                     DependencyGraph::read_from_lock(
                         root_path,
-                        root_pkg_name,
+                        root_pkg_id,
                         &mut lock_string.as_bytes(), // safe since old_deps_digest exists
                         None,
                     )?,
@@ -291,12 +291,12 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         };
 
         dep_graphs.extend(dev_dep_graphs);
-        dep_orig_names.extend(dev_dep_orig_names);
+        dep_names.extend(dev_dep_names);
 
         let mut combined_graph = DependencyGraph {
             root_path,
-            root_package: root_pkg_name,
-            root_package_orig_name: root_pkg_orig_name,
+            root_package_id: root_pkg_id,
+            root_package_name: root_pkg_name,
             package_graph: DiGraphMap::new(),
             package_table: BTreeMap::new(),
             always_deps: BTreeSet::new(),
@@ -306,10 +306,10 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         // ensure there's always a root node, even if it has no edges
         combined_graph
             .package_graph
-            .add_node(combined_graph.root_package);
+            .add_node(combined_graph.root_package_id);
 
         for (
-            dep_name,
+            dep_id,
             DependencyGraphInfo {
                 g,
                 mode,
@@ -320,10 +320,10 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         ) in dep_graphs.iter_mut()
         {
             g.prune_subgraph(
+                root_pkg_id,
                 root_pkg_name,
-                root_pkg_orig_name,
-                *dep_name,
-                *dep_orig_names.get(dep_name).unwrap(),
+                *dep_id,
+                *dep_names.get(dep_id).unwrap(),
                 *is_override,
                 *mode,
                 &overrides,
@@ -331,8 +331,8 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             )?;
         }
 
-        let mut all_deps = resolved_name_deps;
-        all_deps.extend(dev_resolved_name_deps);
+        let mut all_deps = resolved_id_deps;
+        all_deps.extend(dev_resolved_id_deps);
 
         // we can mash overrides together as the sets cannot overlap (it's asserted during pruning)
         overrides.extend(dev_overrides);
@@ -342,8 +342,8 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             parent,
             &all_deps,
             &overrides,
-            &dep_orig_names,
-            root_pkg_orig_name,
+            &dep_names,
+            root_pkg_name,
         )?;
 
         combined_graph.check_acyclic()?;
@@ -357,39 +357,39 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
     fn collect_graphs(
         &mut self,
         parent: &PM::DependencyKind,
-        parent_pkg: PM::PackageName,
-        parent_pkg_orig_name: PM::PackageName,
+        parent_pkg_id: PackageIdentifier,
+        parent_pkg_name: PM::PackageName,
         root_path: PathBuf,
         mode: DependencyMode,
         dependencies: PM::Dependencies,
     ) -> Result<(
-        BTreeMap<PM::PackageName, DependencyGraphInfo>,
-        PM::Dependencies,
-        BTreeMap<Symbol, PM::PackageName>,
-        BTreeMap<Symbol, Package>,
+        BTreeMap<PackageIdentifier, DependencyGraphInfo>,
+        BTreeMap<PackageIdentifier, PM::Dependency>,
+        BTreeMap<PackageIdentifier, PM::PackageName>,
+        BTreeMap<PackageIdentifier, Package>,
     )> {
         let mut dep_graphs = BTreeMap::new();
-        let mut resolved_name_deps = PM::Dependencies::new();
+        let mut resolved_id_deps = BTreeMap::new();
         let mut dep_orig_names = BTreeMap::new();
         let mut overrides = BTreeMap::new();
         for (dep_pkg_name, dep) in dependencies {
-            let (pkg_graph, is_override, is_external, resolved_pkg_name, resolved_version) = self
+            let (pkg_graph, is_override, is_external, resolved_pkg_id, resolved_version) = self
                 .new_for_dep(
                     parent,
                     &dep,
                     mode,
-                    parent_pkg,
+                    parent_pkg_id,
                     dep_pkg_name,
                     root_path.clone(),
                 )
                 .with_context(|| {
                     format!(
                         "Failed to resolve dependencies for package '{}'",
-                        parent_pkg_orig_name
+                        parent_pkg_name
                     )
                 })?;
             dep_graphs.insert(
-                resolved_pkg_name,
+                resolved_pkg_id,
                 DependencyGraphInfo::new(
                     pkg_graph,
                     mode,
@@ -398,8 +398,8 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                     resolved_version,
                 ),
             );
-            resolved_name_deps.insert(resolved_pkg_name, dep.clone());
-            dep_orig_names.insert(resolved_pkg_name, dep_pkg_name);
+            resolved_id_deps.insert(resolved_pkg_id, dep.clone());
+            dep_orig_names.insert(resolved_pkg_id, dep_pkg_name);
 
             if is_override {
                 let kind = match dep {
@@ -415,10 +415,10 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                     version: resolved_version,
                 };
                 dep_pkg.kind.reroot(parent)?;
-                overrides.insert(resolved_pkg_name, dep_pkg);
+                overrides.insert(resolved_pkg_id, dep_pkg);
             }
         }
-        Ok((dep_graphs, resolved_name_deps, dep_orig_names, overrides))
+        Ok((dep_graphs, resolved_id_deps, dep_orig_names, overrides))
     }
 
     /// Given a dependency in the parent's manifest file, creates a sub-graph for this dependency.
@@ -427,7 +427,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         parent: &PM::DependencyKind,
         dep: &PM::Dependency,
         mode: DependencyMode,
-        parent_pkg: PM::PackageName,
+        parent_pkg_id: PackageIdentifier,
         dep_pkg_name: PM::PackageName,
         dep_pkg_path: PathBuf,
     ) -> Result<(DependencyGraph, bool, bool, Symbol, Option<Symbol>)> {
@@ -446,15 +446,15 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                 // resolve name and version
                 let manifest =
                     parse_source_manifest(parse_move_manifest_string(manifest_string.clone())?)?;
-                let resolved_pkg_name = custom_resolve_pkg_name(&manifest)
+                let resolved_pkg_id = custom_resolve_pkg_id(&manifest)
                     .with_context(|| format!("Resolving package name for '{}'", dep_pkg_name))?;
                 let resolved_version = resolve_version(&manifest)
                     .with_context(|| format!("Resolving version for '{}'", dep_pkg_name))?;
-                check_for_dep_cycles(d.clone(), resolved_pkg_name, &mut self.visited_dependencies)?;
+                check_for_dep_cycles(d.clone(), resolved_pkg_id, &mut self.visited_dependencies)?;
 
                 // save dependency for cycle detection
                 self.visited_dependencies
-                    .push_front((resolved_pkg_name, d.clone()));
+                    .push_front((resolved_pkg_id, d.clone()));
                 let (mut pkg_graph, modified) =
                     self.get_graph(&d.kind, pkg_path, manifest_string, lock_string)?;
                 self.visited_dependencies.pop_front();
@@ -475,14 +475,14 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                     pkg_graph,
                     d.dep_override,
                     false,
-                    resolved_pkg_name,
+                    resolved_pkg_id,
                     resolved_version,
                 )
             }
             PM::Dependency::External(resolver) => {
                 let pkg_graph = DependencyGraph::get_external(
                     mode,
-                    parent_pkg,
+                    parent_pkg_id,
                     dep_pkg_name,
                     *resolver,
                     &dep_pkg_path,
@@ -537,14 +537,14 @@ impl DependencyGraph {
     /// Main driver from sub-graph pruning based on information about overrides.
     fn prune_subgraph(
         &mut self,
-        root_package: PM::PackageName,
-        root_package_orig_name: PM::PackageName,
+        root_package_id: PackageIdentifier,
+        root_package_name: PM::PackageName,
+        dep_id: PackageIdentifier,
         dep_name: PM::PackageName,
-        dep_orig_name: PM::PackageName,
         is_override: bool,
         mode: DependencyMode,
-        overrides: &BTreeMap<PM::PackageName, Package>,
-        dev_overrides: &BTreeMap<PM::PackageName, Package>,
+        overrides: &BTreeMap<PackageIdentifier, Package>,
+        dev_overrides: &BTreeMap<PackageIdentifier, Package>,
     ) -> Result<()> {
         if is_override {
             // when pruning an overridden dependency, we must not prune the package actually
@@ -554,16 +554,16 @@ impl DependencyGraph {
             let mut o = overrides.clone();
             let mut dev_o = dev_overrides.clone();
             DependencyGraph::remove_dep_override(
-                root_package,
+                root_package_id,
+                dep_id,
                 dep_name,
-                dep_orig_name,
                 &mut o,
                 &mut dev_o,
                 mode == DependencyMode::DevOnly,
             )?;
-            self.prune_overriden_pkgs(root_package_orig_name, mode, &o, &dev_o)?;
+            self.prune_overriden_pkgs(root_package_name, mode, &o, &dev_o)?;
         } else {
-            self.prune_overriden_pkgs(root_package_orig_name, mode, overrides, dev_overrides)?;
+            self.prune_overriden_pkgs(root_package_name, mode, overrides, dev_overrides)?;
         }
         Ok(())
     }
@@ -574,9 +574,9 @@ impl DependencyGraph {
         &self,
         pruned_pkgs: &mut BTreeSet<PM::PackageName>,
         reachable_pkgs: &mut BTreeSet<PM::PackageName>,
-        root_pkg_orig_name: PM::PackageName,
+        root_pkg_name: PM::PackageName,
+        from_pkg_id: PackageIdentifier,
         from_pkg_name: PM::PackageName,
-        from_pkg_orig_name: PM::PackageName,
         mode: DependencyMode,
         overrides: &BTreeMap<PM::PackageName, Package>,
         dev_overrides: &BTreeMap<PM::PackageName, Package>,
@@ -584,9 +584,9 @@ impl DependencyGraph {
     ) -> Result<()> {
         if overridden_path {
             // we are on a path originating at the overridden package
-            if !reachable_pkgs.contains(&from_pkg_name) {
+            if !reachable_pkgs.contains(&from_pkg_id) {
                 // not (yet) reached via regular (non-overridden) path
-                pruned_pkgs.insert(from_pkg_name);
+                pruned_pkgs.insert(from_pkg_id);
             }
         }
         let mut override_found = overridden_path;
@@ -594,9 +594,9 @@ impl DependencyGraph {
         if !override_found {
             override_found = self
                 .get_dep_override(
-                    root_pkg_orig_name,
+                    root_pkg_name,
+                    from_pkg_id,
                     from_pkg_name,
-                    from_pkg_orig_name,
                     overrides,
                     dev_overrides,
                     mode == DependencyMode::DevOnly,
@@ -608,29 +608,29 @@ impl DependencyGraph {
                 // from other package graph nodes to the overridden package will be preserved (see
                 // the nested_pruned_override test for additional explanation how nodes are removed
                 // from the package graph)
-                pruned_pkgs.insert(from_pkg_name);
+                pruned_pkgs.insert(from_pkg_id);
             } else {
                 // we are on a regular path, not involving an override (overridden_path == false)
                 // and we did not find an override
-                reachable_pkgs.insert(from_pkg_name);
+                reachable_pkgs.insert(from_pkg_id);
             }
         }
 
-        for to_pkg_name in self
+        for to_pkg_id in self
             .package_graph
-            .neighbors_directed(from_pkg_name, Direction::Outgoing)
+            .neighbors_directed(from_pkg_id, Direction::Outgoing)
         {
             let dep = self
                 .package_graph
-                .edge_weight(from_pkg_name, to_pkg_name)
+                .edge_weight(from_pkg_id, to_pkg_id)
                 .unwrap();
-            let to_pkg_orig_name = dep.dep_orig_name;
+            let to_pkg_name = dep.dep_name;
             self.find_pruned_pkgs(
                 pruned_pkgs,
                 reachable_pkgs,
-                root_pkg_orig_name,
+                root_pkg_name,
+                to_pkg_id,
                 to_pkg_name,
-                to_pkg_orig_name,
                 mode,
                 overrides,
                 dev_overrides,
@@ -643,20 +643,20 @@ impl DependencyGraph {
     /// Prunes packages in a sub-graph based on the overrides information from the outer graph.
     fn prune_overriden_pkgs(
         &mut self,
-        root_pkg_orig_name: PM::PackageName,
+        root_pkg_name: PM::PackageName,
         mode: DependencyMode,
-        overrides: &BTreeMap<PM::PackageName, Package>,
-        dev_overrides: &BTreeMap<PM::PackageName, Package>,
+        overrides: &BTreeMap<PackageIdentifier, Package>,
+        dev_overrides: &BTreeMap<PackageIdentifier, Package>,
     ) -> Result<()> {
-        let from_pkg_name = self.root_package;
+        let from_pkg_id = self.root_package_id;
         let mut pruned_pkgs = BTreeSet::new();
         let mut reachable_pkgs = BTreeSet::new();
         self.find_pruned_pkgs(
             &mut pruned_pkgs,
             &mut reachable_pkgs,
-            root_pkg_orig_name,
-            from_pkg_name,
-            from_pkg_name,
+            root_pkg_name,
+            from_pkg_id,
+            from_pkg_id,
             mode,
             overrides,
             dev_overrides,
@@ -678,12 +678,12 @@ impl DependencyGraph {
     /// subgraphs to form the parent dependency graph.
     pub fn merge(
         &mut self,
-        mut dep_graphs: BTreeMap<PM::PackageName, DependencyGraphInfo>,
+        mut dep_graphs: BTreeMap<PackageIdentifier, DependencyGraphInfo>,
         parent: &PM::DependencyKind,
-        dependencies: &PM::Dependencies,
-        overrides: &BTreeMap<PM::PackageName, Package>,
-        dep_orig_names: &BTreeMap<Symbol, PM::PackageName>,
-        root_pkg_orig_name: Symbol,
+        dependencies: &BTreeMap<PackageIdentifier, PM::Dependency>,
+        overrides: &BTreeMap<PackageIdentifier, Package>,
+        dep_names: &BTreeMap<PackageIdentifier, PM::PackageName>,
+        root_pkg_name: PM::PackageName,
     ) -> Result<()> {
         if !self.always_deps.is_empty() {
             bail!("Merging dependencies into a graph after calculating its 'always' dependencies");
@@ -691,20 +691,20 @@ impl DependencyGraph {
 
         // insert direct dependency edges and (if necessary) packages for the remaining graph nodes
         // (not present in package table)
-        for (dep_name, graph_info) in &dep_graphs {
-            let dep_orig_name = dep_orig_names.get(dep_name).unwrap_or(dep_name);
+        for (dep_id, graph_info) in &dep_graphs {
+            let dep_name = dep_names.get(dep_id).unwrap_or(dep_id);
 
-            let Some(dep) = dependencies.get(dep_name) else {
+            let Some(dep) = dependencies.get(dep_id) else {
                 bail!(
                     "Can't merge dependencies for '{}' because nothing depends on it",
-                    dep_orig_name
+                    dep_name
                 );
             };
 
             let internally_resolved = self.insert_direct_dep(
                 dep,
+                *dep_id,
                 *dep_name,
-                *dep_orig_name,
                 graph_info.version,
                 &graph_info.g,
                 graph_info.mode,
@@ -716,9 +716,9 @@ impl DependencyGraph {
                 // internally resolved sub-graphs - due to how external graphs are constructed,
                 // edges between directly dependent packages and their neighbors are already in
                 // the sub-graph and would have been inserted in the first loop in this function
-                for (_, to_pkg_name, sub_dep) in graph_info.g.package_graph.edges(*dep_name) {
+                for (_, to_pkg_id, sub_dep) in graph_info.g.package_graph.edges(*dep_id) {
                     self.package_graph
-                        .add_edge(*dep_name, to_pkg_name, sub_dep.clone());
+                        .add_edge(*dep_id, to_pkg_id, sub_dep.clone());
                 }
             }
         }
@@ -731,66 +731,70 @@ impl DependencyGraph {
         }
 
         dep_graphs.insert(
-            self.root_package,
+            self.root_package_id,
             DependencyGraphInfo::new(self.clone(), DependencyMode::Always, false, false, None),
         );
 
         // analyze all packages to determine if any of these packages represent a conflicting
         // dependency; insert the packages and their respective edges into the combined graph along
         // the way
-        for pkg_name in all_packages {
-            let mut existing_pkg_info: Option<(Symbol, &DependencyGraph, &Package, bool)> = None;
-            for (dep_name, graph_info) in dep_graphs.iter() {
-                let Some(pkg) = graph_info.g.package_table.get(&pkg_name) else {
+        for pkg_id in all_packages {
+            let mut existing_pkg_info: Option<(
+                PackageIdentifier,
+                &DependencyGraph,
+                &Package,
+                bool,
+            )> = None;
+            for (dep_id, graph_info) in dep_graphs.iter() {
+                let Some(pkg) = graph_info.g.package_table.get(&pkg_id) else {
                     continue;
                 };
                 // graph g has a package with name pkg_name
                 let Some((
-                    existing_immediate_dep_name,
+                    existing_immediate_dep_id,
                     existing_graph,
                     existing_pkg,
                     existing_is_external,
                 )) = existing_pkg_info
                 else {
                     // first time this package was encountered
-                    existing_pkg_info =
-                        Some((*dep_name, &graph_info.g, pkg, graph_info.is_external));
+                    existing_pkg_info = Some((*dep_id, &graph_info.g, pkg, graph_info.is_external));
                     continue;
                 };
 
-                let existing_immediate_dep_orig_name = dep_orig_names
-                    .get(&existing_immediate_dep_name)
-                    .unwrap_or(&existing_immediate_dep_name);
-                let immediate_dep_orig_name = dep_orig_names.get(dep_name).unwrap_or(dep_name);
+                let existing_immediate_dep_name = dep_names
+                    .get(&existing_immediate_dep_id)
+                    .unwrap_or(&existing_immediate_dep_id);
+                let immediate_dep_name = dep_names.get(dep_id).unwrap_or(dep_id);
 
                 // it's the subsequent time package with pkg_name has been encountered
                 if pkg != existing_pkg {
                     let existing_conflict_dep_orig_name =
-                        get_original_dep_name(existing_graph, pkg_name).to_string();
+                        get_original_dep_name(existing_graph, pkg_id).to_string();
                     let conflict_dep_orig_name =
-                        get_original_dep_name(&graph_info.g, pkg_name).to_string();
+                        get_original_dep_name(&graph_info.g, pkg_id).to_string();
 
                     bail!(
-                        "When resolving dependencies for package {root_pkg_orig_name}, conflicting versions \
+                        "When resolving dependencies for package {root_pkg_name}, conflicting versions \
                          of package {conflict_dep_orig_name} found:\
                          \nAt {2}\n\t{existing_conflict_dep_orig_name} = {0}\
                          \nAt {3}\n\t{conflict_dep_orig_name} = {1}",
                         PackageWithResolverTOML(existing_pkg),
                         PackageWithResolverTOML(pkg),
                         dep_path_from_root(
-                            self.root_package,
-                            root_pkg_orig_name,
+                            self.root_package_id,
+                            root_pkg_name,
                             existing_graph,
-                            *existing_immediate_dep_orig_name,
-                            pkg_name,
+                            *existing_immediate_dep_name,
+                            pkg_id,
                             existing_is_external
                         )?,
                         dep_path_from_root(
-                            self.root_package,
-                            root_pkg_orig_name,
+                            self.root_package_id,
+                            root_pkg_name,
                             &graph_info.g,
-                            *immediate_dep_orig_name,
-                            pkg_name,
+                            *immediate_dep_name,
+                            pkg_id,
                             graph_info.is_external
                         )?
                     );
@@ -799,17 +803,17 @@ impl DependencyGraph {
                 // both packages are the same but we need to check if their dependencies
                 // are the same as well
                 match deps_equal(
-                    pkg_name,
+                    pkg_id,
                     existing_graph,
                     self.pkg_table_for_deps_compare(
-                        pkg_name,
+                        pkg_id,
                         existing_graph,
                         &dep_graphs,
                         existing_is_external,
                     ),
                     &graph_info.g,
                     self.pkg_table_for_deps_compare(
-                        pkg_name,
+                        pkg_id,
                         &graph_info.g,
                         &dep_graphs,
                         graph_info.is_external,
@@ -819,26 +823,26 @@ impl DependencyGraph {
                     Ok(_) => continue,
                     Err((existing_pkg_deps, pkg_deps)) => {
                         bail!(
-                            "When resolving dependencies for package {root_pkg_orig_name}, \
+                            "When resolving dependencies for package {root_pkg_name}, \
                              conflicting dependencies found:{}{}",
                             format_deps(
                                 dep_path_from_root(
-                                    self.root_package,
-                                    root_pkg_orig_name,
+                                    self.root_package_id,
+                                    root_pkg_name,
                                     existing_graph,
-                                    *existing_immediate_dep_orig_name,
-                                    pkg_name,
+                                    *existing_immediate_dep_name,
+                                    pkg_id,
                                     existing_is_external
                                 )?,
                                 existing_pkg_deps
                             ),
                             format_deps(
                                 dep_path_from_root(
-                                    self.root_package,
-                                    root_pkg_orig_name,
+                                    self.root_package_id,
+                                    root_pkg_name,
                                     &graph_info.g,
-                                    *immediate_dep_orig_name,
-                                    pkg_name,
+                                    *immediate_dep_name,
+                                    pkg_id,
                                     graph_info.is_external,
                                 )?,
                                 pkg_deps,
@@ -849,10 +853,10 @@ impl DependencyGraph {
             }
             if let Some((_, g, existing_pkg, _)) = existing_pkg_info {
                 // update combined graph with the new package and its dependencies
-                self.package_table.insert(pkg_name, existing_pkg.clone());
-                for (_, to_pkg_name, sub_dep) in g.package_graph.edges(pkg_name) {
+                self.package_table.insert(pkg_id, existing_pkg.clone());
+                for (_, to_pkg_name, sub_dep) in g.package_graph.edges(pkg_id) {
                     self.package_graph
-                        .add_edge(pkg_name, to_pkg_name, sub_dep.clone());
+                        .add_edge(pkg_id, to_pkg_name, sub_dep.clone());
                 }
             }
         }
@@ -887,10 +891,10 @@ impl DependencyGraph {
         &self,
         dep_name: Symbol,
         g: &'a DependencyGraph,
-        dep_graphs: &'a BTreeMap<PM::PackageName, DependencyGraphInfo>,
+        dep_graphs: &'a BTreeMap<PackageIdentifier, DependencyGraphInfo>,
         external: bool,
     ) -> &'a BTreeMap<PM::PackageName, Package> {
-        if !external && g.root_package == self.root_package {
+        if !external && g.root_package_id == self.root_package_id {
             // unwrap is safe since dep_graphs are actually built using information about
             // dependencies (including their name, represented here by dep_name) from the root
             // package
@@ -907,8 +911,8 @@ impl DependencyGraph {
     fn insert_direct_dep(
         &mut self,
         dep: &PM::Dependency,
-        dep_pkg_name: PM::PackageName,
-        dep_orig_name: PM::PackageName,
+        dep_pkg_id: PackageIdentifier,
+        dep_name: PM::PackageName,
         dep_version: Option<Symbol>,
         sub_graph: &DependencyGraph,
         mode: DependencyMode,
@@ -921,7 +925,7 @@ impl DependencyGraph {
                 digest,
                 dep_override,
             }) => {
-                if let Entry::Vacant(entry) = self.package_table.entry(dep_pkg_name) {
+                if let Entry::Vacant(entry) = self.package_table.entry(dep_pkg_id) {
                     let mut pkg = Package {
                         kind: kind.clone(),
                         resolver: None,
@@ -931,14 +935,14 @@ impl DependencyGraph {
                     entry.insert(pkg);
                 }
                 self.package_graph.add_edge(
-                    self.root_package,
-                    dep_pkg_name,
+                    self.root_package_id,
+                    dep_pkg_id,
                     Dependency {
                         mode,
                         subst: subst.clone(),
                         digest: *digest,
                         dep_override: *dep_override,
-                        dep_orig_name,
+                        dep_name,
                     },
                 );
                 Ok(true)
@@ -949,10 +953,10 @@ impl DependencyGraph {
                 // sub-graph
                 let d = sub_graph
                     .package_graph
-                    .edge_weight(self.root_package, dep_pkg_name)
+                    .edge_weight(self.root_package_id, dep_pkg_id)
                     .unwrap();
                 self.package_graph
-                    .add_edge(self.root_package, dep_pkg_name, d.clone());
+                    .add_edge(self.root_package_id, dep_pkg_id, d.clone());
                 Ok(false)
             }
         }
@@ -962,28 +966,28 @@ impl DependencyGraph {
     /// dependencies (`dev_only` is true).
     fn get_dep_override<'a>(
         &self,
-        root_pkg_orig_name: PM::PackageName,
+        root_pkg_name: PM::PackageName,
+        pkg_id: PackageIdentifier,
         pkg_name: PM::PackageName,
-        pkg_orig_name: PM::PackageName,
-        overrides: &'a BTreeMap<Symbol, Package>,
-        dev_overrides: &'a BTreeMap<Symbol, Package>,
+        overrides: &'a BTreeMap<PackageIdentifier, Package>,
+        dev_overrides: &'a BTreeMap<PackageIdentifier, Package>,
         dev_only: bool,
     ) -> Result<Option<&'a Package>> {
         // for "regular" dependencies override can come only from "regular" dependencies section,
         // but for "dev" dependencies override can come from "regular" or "dev" dependencies section
-        if let Some(pkg) = overrides.get(&pkg_name) {
+        if let Some(pkg) = overrides.get(&pkg_id) {
             // "regular" dependencies section case
-            if let Some(dev_pkg) = dev_overrides.get(&pkg_name) {
+            if let Some(dev_pkg) = dev_overrides.get(&pkg_id) {
                 bail!(
                     "Conflicting \"regular\" and \"dev\" overrides found in {0}:\n{1} = {2}\n{1} = {3}",
-                    root_pkg_orig_name,
-                    pkg_orig_name,
+                    root_pkg_name,
+                    pkg_name,
                     PackageWithResolverTOML(pkg),
                     PackageWithResolverTOML(dev_pkg),
                 );
             }
             return Ok(Some(pkg));
-        } else if let Some(dev_pkg) = dev_overrides.get(&pkg_name) {
+        } else if let Some(dev_pkg) = dev_overrides.get(&pkg_id) {
             // "dev" dependencies section case
             return Ok(dev_only.then_some(dev_pkg));
         }
@@ -993,29 +997,29 @@ impl DependencyGraph {
     /// Helper function to remove an override for a package with a given name for "regular"
     /// dependencies (`dev_only` is false) or "dev" dependencies (`dev_only` is true).
     fn remove_dep_override(
-        root_pkg_name: PM::PackageName,
+        root_pkg_id: PackageIdentifier,
+        pkg_id: PackageIdentifier,
         pkg_name: PM::PackageName,
-        pkg_orig_name: PM::PackageName,
         overrides: &mut BTreeMap<Symbol, Package>,
         dev_overrides: &mut BTreeMap<Symbol, Package>,
         dev_only: bool,
     ) -> Result<()> {
         // for "regular" dependencies override can come only from "regular" dependencies section,
         // but for "dev" dependencies override can come from "regular" or "dev" dependencies section
-        if let Some(pkg) = overrides.remove(&pkg_name) {
+        if let Some(pkg) = overrides.remove(&pkg_id) {
             // "regular" dependencies section case
-            if let Some(dev_pkg) = dev_overrides.get(&pkg_name) {
+            if let Some(dev_pkg) = dev_overrides.get(&pkg_id) {
                 bail!(
                     "Conflicting \"regular\" and \"dev\" overrides found in {0}:\n{1} = {2}\n{1} = {3}",
-                    root_pkg_name,
-                    pkg_orig_name,
+                    root_pkg_id,
+                    pkg_name,
                     PackageWithResolverTOML(&pkg),
                     PackageWithResolverTOML(dev_pkg),
                 );
             }
         } else if dev_only {
             // "dev" dependencies section case
-            dev_overrides.remove(&pkg_name);
+            dev_overrides.remove(&pkg_id);
         }
         Ok(())
     }
@@ -1030,7 +1034,7 @@ impl DependencyGraph {
     /// the `lock_file::schema` module).
     pub fn read_from_lock(
         root_path: PathBuf,
-        root_package: PM::PackageName,
+        root_package_id: PackageIdentifier,
         lock: &mut impl Read,
         resolver: Option<Symbol>,
     ) -> Result<DependencyGraph> {
@@ -1047,7 +1051,7 @@ impl DependencyGraph {
         ) = schema::Packages::read(lock)?;
 
         // Ensure there's always a root node, even if it has no edges.
-        package_graph.add_node(root_package);
+        package_graph.add_node(root_package_id);
 
         for schema::Dependency {
             name,
@@ -1056,14 +1060,14 @@ impl DependencyGraph {
         } in packages.root_dependencies.into_iter().flatten()
         {
             package_graph.add_edge(
-                root_package,
+                root_package_id,
                 Symbol::from(name.as_str()),
                 Dependency {
                     mode: DependencyMode::Always,
                     subst: subst.map(parse_substitution).transpose()?,
                     digest: digest.map(Symbol::from),
                     dep_override: false,
-                    dep_orig_name: PM::PackageName::from(name),
+                    dep_name: PM::PackageName::from(name),
                 },
             );
         }
@@ -1075,14 +1079,14 @@ impl DependencyGraph {
         } in packages.root_dev_dependencies.into_iter().flatten()
         {
             package_graph.add_edge(
-                root_package,
+                root_package_id,
                 Symbol::from(name.as_str()),
                 Dependency {
                     mode: DependencyMode::DevOnly,
                     subst: subst.map(parse_substitution).transpose()?,
                     digest: digest.map(Symbol::from),
                     dep_override: false,
-                    dep_orig_name: PM::PackageName::from(name.as_str()),
+                    dep_name: PM::PackageName::from(name.as_str()),
                 },
             );
         }
@@ -1153,7 +1157,7 @@ impl DependencyGraph {
                         subst: subst.map(parse_substitution).transpose()?,
                         digest: digest.map(Symbol::from),
                         dep_override: false,
-                        dep_orig_name: PM::PackageName::from(dep_name),
+                        dep_name: PM::PackageName::from(dep_name),
                     },
                 );
             }
@@ -1172,7 +1176,7 @@ impl DependencyGraph {
                         subst: subst.map(parse_substitution).transpose()?,
                         digest: digest.map(Symbol::from),
                         dep_override: false,
-                        dep_orig_name: PM::PackageName::from(dep_name),
+                        dep_name: PM::PackageName::from(dep_name),
                     },
                 );
             }
@@ -1180,8 +1184,8 @@ impl DependencyGraph {
 
         let mut graph = DependencyGraph {
             root_path,
-            root_package,
-            root_package_orig_name: root_package,
+            root_package_id,
+            root_package_name: root_package_id,
             package_graph,
             package_table,
             always_deps: BTreeSet::new(),
@@ -1207,18 +1211,18 @@ impl DependencyGraph {
         )?;
         let mut writer = BufWriter::new(&*lock);
 
-        self.write_dependencies_to_lock(self.root_package, &mut writer)?;
+        self.write_dependencies_to_lock(self.root_package_id, &mut writer)?;
 
-        for (name, pkg) in &self.package_table {
+        for (id, pkg) in &self.package_table {
             writeln!(writer, "\n[[move.package]]")?;
 
-            writeln!(writer, "name = {}", str_escape(name.as_str())?)?;
+            writeln!(writer, "name = {}", str_escape(id.as_str())?)?;
             writeln!(writer, "source = {}", PackageTOML(pkg))?;
             if let Some(version) = &pkg.version {
                 writeln!(writer, "version = {}", str_escape(version.as_str())?)?;
             }
 
-            self.write_dependencies_to_lock(*name, &mut writer)?;
+            self.write_dependencies_to_lock(*id, &mut writer)?;
         }
 
         writer.flush()?;
@@ -1231,12 +1235,12 @@ impl DependencyGraph {
     /// dependency graph, to the lock file under `writer`.
     fn write_dependencies_to_lock<W: Write>(
         &self,
-        name: PM::PackageName,
+        id: PackageIdentifier,
         writer: &mut W,
     ) -> Result<()> {
         let mut deps: Vec<_> = self
             .package_graph
-            .edges(name)
+            .edges(id)
             .map(|(_, pkg, dep)| (dep, pkg))
             .collect();
 
@@ -1299,7 +1303,7 @@ impl DependencyGraph {
     /// resolution.
     fn get_external<Progress: Write>(
         mode: DependencyMode,
-        from: PM::PackageName,
+        from_id: PackageIdentifier,
         to: PM::PackageName,
         resolver: Symbol,
         package_path: &Path,
@@ -1317,7 +1321,7 @@ impl DependencyGraph {
 
         writeln!(
             progress_output,
-            "{progress_label} {to} {} {from} {} {resolver}",
+            "{progress_label} {to} {} {from_id} {} {resolver}",
             "FROM".bold().green(),
             "WITH".bold().green(),
         )?;
@@ -1340,7 +1344,7 @@ impl DependencyGraph {
         if !output.status.success() {
             let err_msg = format!(
                 "'{resolver}' failed to resolve {mode_label} for dependency '{to}' of package \
-                 '{from}'"
+                 '{from_id}'"
             );
 
             if let Some(code) = output.status.code() {
@@ -1352,12 +1356,14 @@ impl DependencyGraph {
 
         let sub_graph = DependencyGraph::read_from_lock(
             package_path.to_path_buf(),
-            from,
+            from_id,
             &mut output.stdout.as_slice(),
             Some(resolver),
         )
         .with_context(|| {
-            format!("Parsing response from '{resolver}' for dependency '{to}' of package '{from}'")
+            format!(
+                "Parsing response from '{resolver}' for dependency '{to}' of package '{from_id}'"
+            )
         })?;
 
         Ok(sub_graph)
@@ -1367,7 +1373,7 @@ impl DependencyGraph {
     /// package table.
     fn check_consistency(&self) -> Result<()> {
         for package in self.package_graph.nodes() {
-            if package == self.root_package {
+            if package == self.root_package_id {
                 continue;
             }
 
@@ -1414,7 +1420,7 @@ impl DependencyGraph {
     /// to the `always_deps` set.  Assumes that if a package is already in the graph's `always_deps`
     /// set, then the sub-graph reachable from it has already been explored.
     fn discover_always_deps(&mut self) {
-        let mut frontier = vec![self.root_package];
+        let mut frontier = vec![self.root_package_id];
         while let Some(package) = frontier.pop() {
             let new_frontier = self.always_deps.insert(package);
             if !new_frontier {
@@ -1508,7 +1514,7 @@ impl<'a> fmt::Display for DependencyTOML<'a> {
                 subst,
                 digest,
                 dep_override: _,
-                dep_orig_name: _,
+                dep_name: _,
             },
         ) = self;
 
@@ -1594,9 +1600,9 @@ fn format_deps(
     let mut s = format!("\nAt {}", pkg_path);
     if !dependencies.is_empty() {
         for (dep, _, pkg) in dependencies {
-            let orig_pkg_name = dep.dep_orig_name;
+            let pkg_name = dep.dep_name;
             s.push_str("\n\t");
-            s.push_str(&format!("{orig_pkg_name} = "));
+            s.push_str(&format!("{pkg_name} = "));
             s.push_str("{ ");
             s.push_str(&format!("{pkg}"));
             if let Some(digest) = dep.digest {
@@ -1618,17 +1624,17 @@ fn format_deps(
 /// different). Returns Ok(()) if they are and the two parts of the symmetric different between
 /// dependencies inside Err if they aren't.
 fn deps_equal<'a>(
-    pkg_name: Symbol,
+    pkg_id: Symbol,
     graph1: &'a DependencyGraph,
-    graph1_pkg_table: &'a BTreeMap<PM::PackageName, Package>,
+    graph1_pkg_table: &'a BTreeMap<PackageIdentifier, Package>,
     graph2: &'a DependencyGraph,
-    graph2_pkg_table: &'a BTreeMap<PM::PackageName, Package>,
-    overrides: &'a BTreeMap<PM::PackageName, Package>,
+    graph2_pkg_table: &'a BTreeMap<PackageIdentifier, Package>,
+    overrides: &'a BTreeMap<PackageIdentifier, Package>,
 ) -> std::result::Result<
     (),
     (
-        Vec<(&'a Dependency, PM::PackageName, &'a Package)>,
-        Vec<(&'a Dependency, PM::PackageName, &'a Package)>,
+        Vec<(&'a Dependency, PackageIdentifier, &'a Package)>,
+        Vec<(&'a Dependency, PackageIdentifier, &'a Package)>,
     ),
 > {
     // Unwraps in the code below are safe as these edges (and target nodes) must exist either in the
@@ -1637,7 +1643,7 @@ fn deps_equal<'a>(
     // the algorithm so it's OK to panic here.
     let graph1_edges = graph1
         .package_graph
-        .edges(pkg_name)
+        .edges(pkg_id)
         .map(|(_, pkg, dep)| {
             (
                 pkg,
@@ -1653,7 +1659,7 @@ fn deps_equal<'a>(
         .collect::<BTreeMap<PM::PackageName, (&Dependency, &Package)>>();
     let graph2_edges = graph2
         .package_graph
-        .edges(pkg_name)
+        .edges(pkg_id)
         .map(|(_, pkg, dep)| {
             (
                 pkg,
@@ -1693,22 +1699,22 @@ fn deps_equal<'a>(
 /// sub-graphs, expecting to end recursion at leaf packages that have no dependencies.
 fn check_for_dep_cycles(
     dep: PM::InternalDependency,
-    dep_pkg_name: PM::PackageName,
+    dep_pkg_id: PackageIdentifier,
     internal_dependencies: &mut VecDeque<(PM::PackageName, PM::InternalDependency)>,
 ) -> Result<()> {
-    if internal_dependencies.contains(&(dep_pkg_name, dep.clone())) {
+    if internal_dependencies.contains(&(dep_pkg_id, dep.clone())) {
         let (mut processed_name, mut processed_dep) = internal_dependencies.pop_back().unwrap();
-        while processed_name != dep_pkg_name || processed_dep != dep {
+        while processed_name != dep_pkg_id || processed_dep != dep {
             (processed_name, processed_dep) = internal_dependencies.pop_back().unwrap();
         }
         // now the queue contains all intermediate dependencies
         let mut msg = "Found cycle between packages: ".to_string();
-        msg.push_str(format!("{} -> ", dep_pkg_name).as_str());
+        msg.push_str(format!("{} -> ", dep_pkg_id).as_str());
         while !internal_dependencies.is_empty() {
             let (p, _) = internal_dependencies.pop_back().unwrap();
             msg.push_str(format!("{} -> ", p).as_str());
         }
-        msg.push_str(format!("{}", dep_pkg_name).as_str());
+        msg.push_str(format!("{}", dep_pkg_id).as_str());
         bail!(msg);
     }
     Ok(())
@@ -1717,8 +1723,8 @@ fn check_for_dep_cycles(
 /// Find the shortest path from a root of the graph to a given dependency and return it in a string
 /// format.
 fn dep_path_from_root(
-    root_package: PM::PackageName,
-    root_package_orig_name: PM::PackageName,
+    root_package_id: PackageIdentifier,
+    root_package_name: PM::PackageName,
     graph: &DependencyGraph,
     orig_dep_name: PM::PackageName,
     pkg_name: PM::PackageName,
@@ -1726,7 +1732,7 @@ fn dep_path_from_root(
 ) -> Result<String> {
     match algo::astar(
         &graph.package_graph,
-        graph.root_package,
+        graph.root_package_id,
         |dst| dst == pkg_name,
         |_| 1,
         |_| 0,
@@ -1734,15 +1740,15 @@ fn dep_path_from_root(
         None => bail!(
             "When resolving dependencies for package {}, \
              expected a dependency path between {} and {} which does not exist",
-            root_package_orig_name,
-            graph.root_package,
+            root_package_name,
+            graph.root_package_id,
             pkg_name
         ),
         Some((_, p)) => {
             let mut path: Vec<&str> = vec![];
 
             let mut i = p.iter();
-            if !is_external && root_package != graph.root_package {
+            if !is_external && root_package_id != graph.root_package_id {
                 // Externally resolved graphs contain a path to the package in the enclosing graph.
                 // This package has to be removed from the path for the output to be consistent
                 // between internally and externally resolved graphs. We have a similar situation
@@ -1759,7 +1765,7 @@ fn dep_path_from_root(
                     Some(dep) => dep,
                     None => return Ok(String::from("")),
                 };
-                path.push(dep.dep_orig_name.as_str());
+                path.push(dep.dep_name.as_str());
                 current = next;
             }
 
@@ -1768,11 +1774,11 @@ fn dep_path_from_root(
     }
 }
 
-fn get_original_dep_name(graph: &DependencyGraph, resolved_name: Symbol) -> PM::PackageName {
+fn get_original_dep_name(graph: &DependencyGraph, id: PackageIdentifier) -> PM::PackageName {
     let map = graph
         .package_graph
-        .edges(graph.root_package)
-        .map(|(_, name, dep)| (name, dep.dep_orig_name))
+        .edges(graph.root_package_id)
+        .map(|(_, name, dep)| (name, dep.dep_name))
         .collect::<BTreeMap<_, _>>();
-    *map.get(&resolved_name).unwrap_or(&resolved_name)
+    *map.get(&id).unwrap_or(&id)
 }

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -75,7 +75,7 @@ pub struct DependencyGraph {
     /// is always a dependency of P or only in dev-mode.
     pub package_graph: DiGraphMap<PackageIdentifier, Dependency>,
 
-    /// The dependency that each package (keyed by name) originates from.  The root package is the
+    /// The dependency that each package (keyed by id) originates from. The root package is the
     /// only node in `package_graph` that does not have an entry in `package_table`.
     pub package_table: BTreeMap<PackageIdentifier, Package>,
 

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -66,6 +66,7 @@ use super::{
 pub struct DependencyGraph {
     /// Path to the root package and its name (according to its manifest)
     pub root_path: PathBuf,
+    /// Root package identifier as resolved by the package id resolution hook.
     pub root_package_id: PackageIdentifier,
     /// Root package name as defined in its manifest (can be different from the resolved identifier).
     pub root_package_name: PM::PackageName,

--- a/external-crates/move/crates/move-package/src/resolution/mod.rs
+++ b/external-crates/move/crates/move-package/src/resolution/mod.rs
@@ -46,18 +46,18 @@ pub fn download_dependency_repos<Progress: Write>(
         lock_string,
     )?;
 
-    for pkg_name in graph.topological_order() {
-        if pkg_name == graph.root_package {
+    for pkg_id in graph.topological_order() {
+        if pkg_id == graph.root_package_id {
             continue;
         }
 
-        if !(build_options.dev_mode || graph.always_deps.contains(&pkg_name)) {
+        if !(build_options.dev_mode || graph.always_deps.contains(&pkg_id)) {
             continue;
         }
 
         let package = graph
             .package_table
-            .get(&pkg_name)
+            .get(&pkg_id)
             .expect("Metadata for package");
 
         let DependencyGraphBuilder {
@@ -65,7 +65,7 @@ pub fn download_dependency_repos<Progress: Write>(
             ref mut progress_output,
             ..
         } = dep_graph_builder;
-        dependency_cache.download_and_update_if_remote(pkg_name, &package.kind, progress_output)?;
+        dependency_cache.download_and_update_if_remote(pkg_id, &package.kind, progress_output)?;
     }
 
     Ok(())

--- a/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
+++ b/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
@@ -49,11 +49,11 @@ fn no_dep_graph() {
         .expect("Creating DependencyGraph");
 
     assert!(
-        graph.package_graph.contains_node(graph.root_package),
+        graph.package_graph.contains_node(graph.root_package_id),
         "A graph for a package with no dependencies should still contain the root package",
     );
 
-    assert_eq!(graph.topological_order(), vec![graph.root_package]);
+    assert_eq!(graph.topological_order(), vec![graph.root_package_id]);
 }
 
 #[test]
@@ -70,11 +70,11 @@ fn no_dep_graph_from_lock() {
     .expect("Reading DependencyGraph");
 
     assert!(
-        graph.package_graph.contains_node(graph.root_package),
+        graph.package_graph.contains_node(graph.root_package_id),
         "A graph for a package with no dependencies should still contain the root package",
     );
 
-    assert_eq!(graph.topological_order(), vec![graph.root_package]);
+    assert_eq!(graph.topological_order(), vec![graph.root_package_id]);
 }
 
 #[test]

--- a/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
+++ b/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
@@ -64,6 +64,7 @@ fn no_dep_graph_from_lock() {
     let graph = DependencyGraph::read_from_lock(
         pkg,
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut File::open(snapshot).expect("Opening snapshot"),
         None,
     )
@@ -87,6 +88,7 @@ fn lock_file_roundtrip() {
 
     let graph = DependencyGraph::read_from_lock(
         pkg,
+        Symbol::from("Root"),
         Symbol::from("Root"),
         &mut File::open(&snapshot).expect("Opening snapshot"),
         None,
@@ -127,6 +129,7 @@ fn lock_file_missing_dependency() {
 
     let Err(err) = DependencyGraph::read_from_lock(
         pkg,
+        Symbol::from("Root"),
         Symbol::from("Root"),
         &mut File::open(&commit).expect("Opening empty lock file"),
         None,
@@ -180,6 +183,7 @@ fn always_deps_from_lock() {
     let graph = DependencyGraph::read_from_lock(
         pkg,
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut File::open(snapshot).expect("Opening snapshot"),
         None,
     )
@@ -202,6 +206,7 @@ fn merge_simple() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut A_LOCK.as_bytes(),
         None,
     )
@@ -213,6 +218,7 @@ fn merge_simple() {
 
     let inner = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("A"),
         Symbol::from("A"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
@@ -254,6 +260,7 @@ fn merge_into_root() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
     )
@@ -266,6 +273,7 @@ fn merge_into_root() {
     // The `inner` graph describes more dependencies for `outer`'s root package.
     let inner = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("Root"),
         Symbol::from("Root"),
         &mut A_LOCK.as_bytes(),
         None,
@@ -309,6 +317,7 @@ fn merge_detached() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
     )
@@ -320,6 +329,7 @@ fn merge_detached() {
 
     let inner = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("OtherDep"),
         Symbol::from("OtherDep"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
@@ -351,6 +361,7 @@ fn merge_after_calculating_always_deps() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut A_LOCK.as_bytes(),
         None,
     )
@@ -358,6 +369,7 @@ fn merge_after_calculating_always_deps() {
 
     let inner = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("A"),
         Symbol::from("A"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
@@ -390,6 +402,7 @@ fn merge_overlapping() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
     )
@@ -402,6 +415,7 @@ fn merge_overlapping() {
     let inner1 = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("C"),
+        Symbol::from("C"),
         &mut AB_LOCK.as_bytes(),
         None,
     )
@@ -409,6 +423,7 @@ fn merge_overlapping() {
 
     let inner2 = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("C"),
         Symbol::from("C"),
         &mut A_LOCK.as_bytes(),
         None,
@@ -465,6 +480,7 @@ fn merge_overlapping_different_deps() {
     let mut outer = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("Root"),
+        Symbol::from("Root"),
         &mut EMPTY_LOCK.as_bytes(),
         None,
     )
@@ -477,6 +493,7 @@ fn merge_overlapping_different_deps() {
     let inner1 = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
         Symbol::from("C"),
+        Symbol::from("C"),
         &mut A_DEP_B_LOCK.as_bytes(),
         None,
     )
@@ -484,6 +501,7 @@ fn merge_overlapping_different_deps() {
 
     let inner2 = DependencyGraph::read_from_lock(
         tmp.path().to_path_buf(),
+        Symbol::from("C"),
         Symbol::from("C"),
         &mut A_LOCK.as_bytes(),
         None,

--- a/external-crates/move/crates/move-package/tests/test_runner.rs
+++ b/external-crates/move/crates/move-package/tests/test_runner.rs
@@ -12,6 +12,7 @@ use move_package::{
     },
     package_hooks,
     package_hooks::PackageHooks,
+    package_hooks::PackageIdentifier,
     resolution::resolution_graph::Package,
     source_package::parsed_manifest::{CustomDepInfo, PackageDigest, SourceManifest},
     BuildConfig, ModelConfig,
@@ -220,7 +221,10 @@ impl PackageHooks for TestHooks {
         )
     }
 
-    fn custom_resolve_pkg_name(&self, manifest: &SourceManifest) -> anyhow::Result<Symbol> {
+    fn custom_resolve_pkg_id(
+        &self,
+        manifest: &SourceManifest,
+    ) -> anyhow::Result<PackageIdentifier> {
         let name = manifest.package.name.to_string();
         if name.ends_with("-rename") {
             Ok(Symbol::from(name.replace("-rename", "-resolved")))

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps_address_assigned",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/dep_dev_dep_diamond",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/dep_good_digest",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_backflow_resolution",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_dev_override_with_reg",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_no_conflict",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_external_override_root",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_nested_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_transitive_nested_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_two_nested_overrides",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dep_with_deps",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_dual_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_no_conflict",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_with_and_without_override_v1",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/diamond_problem_with_and_without_override_v2",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/direct_and_indirect_dep",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external_dev_dep",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/external_overlap",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_from_lock",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_from_lock_no_manifest",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/multiple_deps_rename",
-        root_package: "test",
-        root_package_orig_name: "test",
+        root_package_id: "test",
+        root_package_name: "test",
         package_graph: {
             "test": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_deps_git_local",
-        root_package: "NestedDeps",
-        root_package_orig_name: "NestedDeps",
+        root_package_id: "NestedDeps",
+        root_package_name: "NestedDeps",
         package_graph: {
             "NestedDeps": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_deps_shared_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/nested_pruned_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_assigned_address",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_multiple_of_same_name",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_reassigned_address",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/one_dep_unification_across_local_renamings",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_edition_2024_alpha",
-        root_package: "name",
-        root_package_orig_name: "name",
+        root_package_id: "name",
+        root_package_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_edition_legacy",
-        root_package: "name",
-        root_package_orig_name: "name",
+        root_package_id: "name",
+        root_package_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_flavor_global_storage",
-        root_package: "name",
-        root_package_orig_name: "name",
+        root_package_id: "name",
+        root_package_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_flavor_sui",
-        root_package: "name",
-        root_package_orig_name: "name",
+        root_package_id: "name",
+        root_package_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_invalid_identifier_package_name",
-        root_package: "®´∑œ",
-        root_package_orig_name: "®´∑œ",
+        root_package_id: "®´∑œ",
+        root_package_name: "®´∑œ",
         package_graph: {
             "®´∑œ": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/parsing_minimal_manifest",
-        root_package: "name",
-        root_package_orig_name: "name",
+        root_package_id: "name",
+        root_package_name: "name",
         package_graph: {
             "name": [],
         },

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_pkg_name",
-        root_package: "Root-resolved",
-        root_package_orig_name: "Root-rename",
+        root_package_id: "Root-resolved",
+        root_package_name: "Root-rename",
         package_graph: {
             "Root-resolved": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_pkg_name_override",
-        root_package: "Root-resolved",
-        root_package_orig_name: "Root-rename",
+        root_package_id: "Root-resolved",
+        root_package_name: "Root-rename",
         package_graph: {
             "Root-resolved": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version_diamond",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version_diamond_deep",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version_diamond_deep_success",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version_diamond_external",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
@@ -1,8 +1,8 @@
 ResolvedGraph {
     graph: DependencyGraph {
         root_path: "tests/test_sources/resolve_version_diamond_override",
-        root_package: "Root",
-        root_package_orig_name: "Root",
+        root_package_id: "Root",
+        root_package_name: "Root",
         package_graph: {
             "Root": [
                 (


### PR DESCRIPTION
## Description 

This is the famed rename from `name` to `identifier`, and boy am I glad we went for this because the code is 10x more readable now. In summary, it changes `*_pkg_name` -> `*_pkg_id` and `*_pkg_original_name` -> `*_pkg_name`.

In the second commit, I've found additional places where (what is now) `pkg_id` was being used in error messages instead of name so I switched those around. These don't show up in the unit tests because there aren't any that trigger those edge cases but it should be fine because it's clear from the code that these affect only error messages (in a good way) and not functionality of the resolver.

The only thing that remains is that we still use the `name = <...>` field in the lockfile for (what is now) `id`. I didn't want to touch this here because it would be a breaking change for the lockfile. In the next PR I'll be adding the additional fields to the lockfile that we discussed and switch this around.

This is part of the work to enable compiling against on-chain dependencies https://github.com/MystenLabs/sui/pull/14178.

cc @rvantonder @amnn

## Test Plan 

Unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
