### PR TITLE
[docs] Remove the graphql MVP launch date info

### DIFF
--- a/docs/content/concepts/graphql-rpc.mdx
+++ b/docs/content/concepts/graphql-rpc.mdx
@@ -5,9 +5,6 @@ title: Sui GraphQL RPC
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-{@include: ../snippets/info-graphql-release.mdx}
-
-
 This section explains some of the common concepts when working with GraphQL, such as altering behavior using [HTTP headers](./graphql-rpc/headers), re-using query snippets with [variables](./graphql-rpc/variables) and [fragments](./graphql-rpc/fragments), consuming [paginated queries](./graphql-rpc/pagination), and understanding and working within the [limits](./graphql-rpc/limits) enforced by the service.
 
 For more details on GraphQL fundamentals, see the introductory documentation from [GraphQL](https://graphql.org/learn/) and [GitHub](https://docs.github.com/en/graphql/guides/introduction-to-graphql).

--- a/docs/content/concepts/graphql-rpc/fragments.mdx
+++ b/docs/content/concepts/graphql-rpc/fragments.mdx
@@ -2,8 +2,6 @@
 title: Fragments
 ---
 
-{@include: ../../snippets/info-graphql-release.mdx}
-
 Fragments are reusable units that can be included in queries as needed. To learn more, consult the official GraphQL [documentation](https://graphql.org/learn/queries/#fragments). The following example uses fragments to factor out a reusable snippet representing a Move Value.
 
 ```graphql

--- a/docs/content/concepts/graphql-rpc/headers.mdx
+++ b/docs/content/concepts/graphql-rpc/headers.mdx
@@ -5,8 +5,6 @@ title: Headers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-{@include: ../../snippets/info-graphql-release.mdx}
-
 The service accepts the following optional headers:
 
 - `x-sui-rpc-version` to specify which RPC version to use (note that currently only one version is supported),

--- a/docs/content/concepts/graphql-rpc/limits.mdx
+++ b/docs/content/concepts/graphql-rpc/limits.mdx
@@ -2,8 +2,6 @@
 title: Limits
 ---
 
-{@include: ../../snippets/info-graphql-release.mdx}
-
 The Sui GraphQL RPC service is rate-limited on all available instances to keep network throughput optimized and to protect against excessive or abusive calls to the service.
 
 ## Rate limits

--- a/docs/content/concepts/graphql-rpc/pagination.mdx
+++ b/docs/content/concepts/graphql-rpc/pagination.mdx
@@ -2,8 +2,6 @@
 title: Pagination
 ---
 
-{@include: ../../snippets/info-graphql-release.mdx}
-
 GraphQL supports queries that fetch multiple kinds of data, potentially nested. For example, the following query retrieves the first 20 transaction blocks (along with the digest, the sender's address, the gas object used to pay for the transaction, the gas price, and the gas budget) after a specific transaction block at epoch `97`.
 
 ```graphql

--- a/docs/content/concepts/graphql-rpc/variables.mdx
+++ b/docs/content/concepts/graphql-rpc/variables.mdx
@@ -5,8 +5,6 @@ title: Variables
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-{@include: ../../snippets/info-graphql-release.mdx}
-
 Variables offer a way to introduce dynamic inputs to a re-usable/static query. A variable is declared in the parameters to a `query` or `mutation`, using the `$` symbol and its type (in this example `Int`) which must be a `scalar`, `enum`, or `input` type. In the query body, it is referred to by its name (again prefixed with the `$` symbol).
 
 If a variable is declared but not used in the query or not defined (supplied a value), the query will fail to execute.

--- a/docs/content/guides/developer/advanced/graphql-migration.mdx
+++ b/docs/content/guides/developer/advanced/graphql-migration.mdx
@@ -5,8 +5,6 @@ title: Migrating to GraphQL
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-{@include: ../../../snippets/info-graphql-release.mdx}
-
 This guide compares JSON-RPC queries to their equivalent GraphQL counterpart. While it is possible to systematically rewrite JSON-RPC queries (for example, `sui_getTotalTransactionBlocks`) to their GraphQL counterparts using this guide, it is recommended that you revisit your application's query patterns to take full advantage of the flexibility that GraphQL offers in serving queries that touch multiple potentially nested endpoints (for example transactions, balances, coins), and use the following examples to get a flavor of how the two APIs express similar concepts.
 
 For a comprehensive list of all available GraphQL APIs, consult the [reference](../../../references/sui-graphql).

--- a/docs/content/guides/developer/getting-started/graphql-rpc.mdx
+++ b/docs/content/guides/developer/getting-started/graphql-rpc.mdx
@@ -3,8 +3,6 @@ title: Querying Sui GraphQL RPC
 description: Sui is currently developing a GraphQL RPC service for interacting with the network.
 ---
 
-{@include: ../../../snippets/info-graphql-release.mdx}
-
 The quickest way to access the Sui GraphQL service is through the online IDE that provides a complete toolbox for fetching data and executing transactions on the network. The online IDE provides features such as auto-completion (use Ctrl+Space or just start typing), built-in documentation (Book icon, top-left), multi-tabs, and more.
 
 The online IDE is available for [mainnet](https://sui-mainnet.mystenlabs.com/graphql) and [testnet](https://sui-testnet.mystenlabs.com/graphql). This guide contains various queries that you can try directly in the IDE.

--- a/docs/content/snippets/info-graphql-release.mdx
+++ b/docs/content/snippets/info-graphql-release.mdx
@@ -1,5 +1,0 @@
-:::info
-
-The GraphQL RPC service is currently under development. The MVP is scheduled to be launched at the end of January 2024.
-
-:::


### PR DESCRIPTION
## Description 

Removes the top info banner explaining that the launch is near.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
