### PR TITLE
[move-compiler] Add receiving_object_id function to compiler

### DIFF
--- a/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/typing.rs
@@ -887,23 +887,6 @@ fn exp(context: &mut Context, e: &T::Exp) {
             if is_transfer_module && PRIVATE_TRANSFER_FUNCTIONS.contains(&name.value()) {
                 check_private_transfer(context, e.exp.loc, mcall)
             }
-            // TODO(tzakian): Temporary
-            if is_transfer_module && &*name.value() == "receiving_object_id" {
-                let diag = diag!(
-                    crate::diagnostics::codes::custom(
-                        SUI_DIAG_PREFIX,
-                        Severity::NonblockingError,
-                        TYPING,
-                        10,
-                        "Non-supported call"
-                    ),
-                    (
-                        e.exp.loc,
-                        "Calling 'receiving_object_id' is not supported at this time"
-                    ),
-                );
-                context.env.add_diag(diag);
-            }
         }
         T::UnannotatedExp_::Pack(m, s, _, _) => {
             if !context.in_test

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/private_generics/no_public_transfer.exp
@@ -30,9 +30,3 @@ error[Sui E02009]: invalid private transfer call
 21 │         transfer::receive(p, s)
    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid private transfer. The function 'sui::transfer::receive' is restricted to being called in the object's module, 'a::other'
 
-error[Sui E02010]: Non-supported call
-   ┌─ tests/sui_mode/private_generics/no_public_transfer.move:25:9
-   │
-25 │         transfer::receiving_object_id(s);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Calling 'receiving_object_id' is not supported at this time
-


### PR DESCRIPTION
## Description 

Allows calling this function in the compiler.

## Test Plan 

Ran existing tests + ran on local network.
