### PR TITLE
Authority overload monitor

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -687,6 +687,22 @@ pub struct TransactionKeyValueStoreWriteConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OverloadThresholdConfig {
     pub max_txn_age_in_queue: Duration,
+
+    // The interval of checking overload signal.
+    pub overload_monitor_interval: Duration,
+
+    // The execution queueing latency when entering load shedding mode.
+    pub execution_queue_latency_soft_limit: Duration,
+
+    // The execution queueing latency when entering aggressive load shedding mode.
+    pub execution_queue_latency_hard_limit: Duration,
+
+    // The maximum percentage of transactions to shed in load shedding mode.
+    pub max_load_shedding_percentage: u32,
+
+    // When in aggressive load shedding mode, the the minimum percentage of
+    // transactions to shed.
+    pub min_load_shedding_percentage_above_hard_limit: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
     // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
 }
@@ -695,6 +711,11 @@ impl Default for OverloadThresholdConfig {
     fn default() -> Self {
         Self {
             max_txn_age_in_queue: Duration::from_secs(1), // 1 second
+            overload_monitor_interval: Duration::from_secs(10),
+            execution_queue_latency_soft_limit: Duration::from_secs(1),
+            execution_queue_latency_hard_limit: Duration::from_secs(10),
+            max_load_shedding_percentage: 95,
+            min_load_shedding_percentage_above_hard_limit: 50,
         }
     }
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -685,37 +685,69 @@ pub struct TransactionKeyValueStoreWriteConfig {
 /// stop processing new transactions and/or certificates until the congestion
 /// resolves.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct OverloadThresholdConfig {
+    #[serde(default = "default_max_txn_age_in_queue")]
     pub max_txn_age_in_queue: Duration,
 
     // The interval of checking overload signal.
+    #[serde(default = "default_overload_monitor_interval")]
     pub overload_monitor_interval: Duration,
 
     // The execution queueing latency when entering load shedding mode.
+    #[serde(default = "default_execution_queue_latency_soft_limit")]
     pub execution_queue_latency_soft_limit: Duration,
 
     // The execution queueing latency when entering aggressive load shedding mode.
+    #[serde(default = "default_execution_queue_latency_hard_limit")]
     pub execution_queue_latency_hard_limit: Duration,
 
     // The maximum percentage of transactions to shed in load shedding mode.
+    #[serde(default = "default_max_load_shedding_percentage")]
     pub max_load_shedding_percentage: u32,
 
     // When in aggressive load shedding mode, the the minimum percentage of
     // transactions to shed.
+    #[serde(default = "default_min_load_shedding_percentage_above_hard_limit")]
     pub min_load_shedding_percentage_above_hard_limit: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
     // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
 }
 
+fn default_max_txn_age_in_queue() -> Duration {
+    Duration::from_secs(1)
+}
+
+fn default_overload_monitor_interval() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_execution_queue_latency_soft_limit() -> Duration {
+    Duration::from_secs(1)
+}
+
+fn default_execution_queue_latency_hard_limit() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_max_load_shedding_percentage() -> u32 {
+    95
+}
+
+fn default_min_load_shedding_percentage_above_hard_limit() -> u32 {
+    50
+}
+
 impl Default for OverloadThresholdConfig {
     fn default() -> Self {
         Self {
-            max_txn_age_in_queue: Duration::from_secs(1), // 1 second
-            overload_monitor_interval: Duration::from_secs(10),
-            execution_queue_latency_soft_limit: Duration::from_secs(1),
-            execution_queue_latency_hard_limit: Duration::from_secs(10),
-            max_load_shedding_percentage: 95,
-            min_load_shedding_percentage_above_hard_limit: 50,
+            max_txn_age_in_queue: default_max_txn_age_in_queue(),
+            overload_monitor_interval: default_overload_monitor_interval(),
+            execution_queue_latency_soft_limit: default_execution_queue_latency_soft_limit(),
+            execution_queue_latency_hard_limit: default_execution_queue_latency_hard_limit(),
+            max_load_shedding_percentage: default_max_load_shedding_percentage(),
+            min_load_shedding_percentage_above_hard_limit:
+                default_min_load_shedding_percentage_above_hard_limit(),
         }
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -140,7 +140,9 @@ use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
 use crate::in_mem_execution_cache::{ExecutionCache, ExecutionCacheRead, ExecutionCacheWrite};
 use crate::metrics::LatencyObserver;
+use crate::metrics::RateTracker;
 use crate::module_cache_metrics::ResolverMetrics;
+use crate::overload_monitor::{overload_monitor, AuthorityOverloadInfo};
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::{StateAccumulator, WrappedObject};
 use crate::subscription_handler::SubscriptionHandler;
@@ -237,6 +239,9 @@ pub struct AuthorityMetrics {
     pub(crate) skipped_consensus_txns: IntCounter,
     pub(crate) skipped_consensus_txns_cache_hit: IntCounter,
 
+    pub(crate) authority_overload_status: IntGauge,
+    pub(crate) authority_load_shedding_percentage: IntGauge,
+
     /// Post processing metrics
     post_processing_total_events_emitted: IntCounter,
     post_processing_total_tx_indexed: IntCounter,
@@ -269,6 +274,18 @@ pub struct AuthorityMetrics {
     // Tracks recent average txn queueing delay between when it is ready for execution
     // until it starts executing.
     pub execution_queueing_latency: LatencyObserver,
+
+    // Tracks the rate of transactions become ready for execution in transaction manager.
+    // The need for the Mutex is that the tracker is updated in transaction manager and read
+    // in the overload_monitor. There should be low mutex contention because
+    // transaction manager is single threaded and the read rate in overload_monitor is
+    // low. In the case where transaction manager becomes multi-threaded, we can
+    // create one rate tracker per thread.
+    pub txn_ready_rate_tracker: Arc<Mutex<RateTracker>>,
+
+    // Tracks the rate of transactions starts execution in execution driver.
+    // Similar reason for using a Mutex here as to `txn_ready_rate_tracker`.
+    pub execution_rate_tracker: Arc<Mutex<RateTracker>>,
 }
 
 // Override default Prom buckets for positive numbers in 0-50k range
@@ -453,6 +470,16 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
+            authority_overload_status: register_int_gauge_with_registry!(
+                "authority_overload_status",
+                "Whether authority is current experiencing overload and enters load shedding mode.",
+                registry)
+            .unwrap(),
+            authority_load_shedding_percentage: register_int_gauge_with_registry!(
+                "authority_load_shedding_percentage",
+                "The percentage of transactions is shed when the authority is in load shedding mode.",
+                registry)
+            .unwrap(),
             transaction_manager_object_cache_misses: register_int_counter_with_registry!(
                 "transaction_manager_object_cache_misses",
                 "Number of object-availability cache misses in TransactionManager",
@@ -618,6 +645,8 @@ impl AuthorityMetrics {
                 registry
             ).unwrap(),
             execution_queueing_latency: LatencyObserver::new(),
+            txn_ready_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
+            execution_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
         }
     }
 }
@@ -684,6 +713,9 @@ pub struct AuthorityState {
 
     /// Config for when we consider the node overloaded.
     overload_threshold_config: OverloadThresholdConfig,
+
+    /// Current overload status in this authority. Updated periodically.
+    pub overload_info: AuthorityOverloadInfo,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -2452,7 +2484,8 @@ impl AuthorityState {
             transaction_deny_config,
             certificate_deny_config,
             debug_dump_config,
-            overload_threshold_config,
+            overload_threshold_config: overload_threshold_config.clone(),
+            overload_info: AuthorityOverloadInfo::default(),
         });
 
         // Start a task to execute ready certificates.
@@ -2460,8 +2493,11 @@ impl AuthorityState {
         spawn_monitored_task!(execution_process(
             authority_state,
             rx_ready_certificates,
-            rx_execution_shutdown
+            rx_execution_shutdown,
         ));
+
+        let authority_state = Arc::downgrade(&state);
+        spawn_monitored_task!(overload_monitor(authority_state, overload_threshold_config));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/sui-core/src/consensus_throughput_calculator.rs
+++ b/crates/sui-core/src/consensus_throughput_calculator.rs
@@ -469,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_calculator() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let max_observation_points: NonZeroU64 = NonZeroU64::new(3).unwrap();
@@ -513,6 +514,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_throughput_calculator_same_timestamp_observations() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let max_observation_points: NonZeroU64 = NonZeroU64::new(2).unwrap();
@@ -543,6 +545,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_interval: TimestampSecs = 5;
@@ -610,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler_update_interval() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_interval: TimestampSecs = 5;
@@ -662,6 +666,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_consensus_throughput_profiler_cool_down() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput_profile_update_window: TimestampSecs = 3;

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -104,6 +104,8 @@ pub async fn execution_process(
             }
         }
 
+        authority.metrics.execution_rate_tracker.lock().record();
+
         // Certificate execution can take significant time, so run it in a separate task.
         spawn_monitored_task!(async move {
             let _scope = monitored_scope("ExecutionDriver::task");

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod in_mem_execution_cache;
 pub mod metrics;
 pub mod module_cache_metrics;
 pub mod mysticeti_adapter;
+mod overload_monitor;
 pub(crate) mod post_consensus_tx_reorder;
 pub mod quorum_driver;
 pub mod safe_client;

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -1,0 +1,292 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::AuthorityState;
+use std::cmp::{max, min};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Weak;
+use std::time::Duration;
+use sui_config::node::OverloadThresholdConfig;
+use tokio::time::sleep;
+use tracing::info;
+
+#[derive(Default)]
+pub struct AuthorityOverloadInfo {
+    /// Whether the authority is overloaded.
+    pub is_overload: AtomicBool,
+
+    /// The calculated percentage of transactions to drop.
+    pub load_shedding_percentage: AtomicU32,
+}
+
+impl AuthorityOverloadInfo {
+    pub fn set_overload(&self, load_shedding_percentage: u32) {
+        self.is_overload.store(true, Ordering::Relaxed);
+        self.load_shedding_percentage
+            .store(min(load_shedding_percentage, 100), Ordering::Relaxed);
+    }
+
+    pub fn clear_overload(&self) {
+        self.is_overload.store(false, Ordering::Relaxed);
+        self.load_shedding_percentage.store(0, Ordering::Relaxed);
+    }
+}
+
+// Monitors the overload signals in `authority_state` periodically, and updates its `overload_info`
+// when the signals indicates overload.
+pub async fn overload_monitor(
+    authority_state: Weak<AuthorityState>,
+    config: OverloadThresholdConfig,
+) {
+    info!("Starting system overload monitor.");
+
+    loop {
+        let authority_exist = check_authority_overload(&authority_state, &config);
+        if !authority_exist {
+            // `authority_state` doesn't exist anymore. Quit overload monitor.
+            break;
+        }
+        sleep(config.overload_monitor_interval).await;
+    }
+
+    info!("Shut down system overload monitor.");
+}
+
+// Checks authority overload signals, and updates authority's `overload_info`.
+// Returns whether the authority state exists.
+fn check_authority_overload(
+    authority_state: &Weak<AuthorityState>,
+    config: &OverloadThresholdConfig,
+) -> bool {
+    let authority_arc = authority_state.upgrade();
+    if authority_arc.is_none() {
+        // `authority_state` doesn't exist anymore.
+        return false;
+    }
+
+    let authority = authority_arc.unwrap();
+    let queueing_latency = authority
+        .metrics
+        .execution_queueing_latency
+        .latency()
+        .unwrap_or_default();
+    let txn_ready_rate = authority.metrics.txn_ready_rate_tracker.lock().rate();
+    let execution_rate = authority.metrics.execution_rate_tracker.lock().rate();
+
+    let (is_overload, load_shedding_percentage) =
+        check_overload_signals(config, queueing_latency, txn_ready_rate, execution_rate);
+    if is_overload {
+        authority
+            .overload_info
+            .set_overload(load_shedding_percentage);
+    } else {
+        authority.overload_info.clear_overload();
+    }
+
+    authority
+        .metrics
+        .authority_overload_status
+        .set(is_overload as i64);
+    authority
+        .metrics
+        .authority_load_shedding_percentage
+        .set(load_shedding_percentage as i64);
+    true
+}
+
+// Calculates the percentage of transactions to drop in order to reduce execution queue.
+// Returns the integer percentage between 0 and 100.
+fn calculate_load_shedding_percentage(txn_ready_rate: f64, execution_rate: f64) -> u32 {
+    // When transaction ready rate is practically 0, we aren't adding more load to the
+    // execution driver, so no shedding.
+    // TODO: consensus handler or transaction manager can also be overloaded.
+    if txn_ready_rate < 1e-10 {
+        return 0;
+    }
+
+    // Deflate the execution rate to account for the case that execution_rate is close to
+    // txn_ready_rate.
+    if execution_rate * 0.9 > txn_ready_rate {
+        return 0;
+    }
+
+    // In order to maintain execution queue length, we need to drop at least (1 - executionRate / readyRate).
+    // TO reduce the queue length, here we add 10% more transactions to drop.
+    (((1.0 - execution_rate * 0.9 / txn_ready_rate) + 0.1).min(1.0) * 100.0).round() as u32
+}
+
+// Given overload signals (`queueing_latency`, `txn_ready_rate`, `execution_rate`), return whether
+// the authority server should enter load shedding mode, and how much percentage of transactions to drop.
+fn check_overload_signals(
+    config: &OverloadThresholdConfig,
+    queueing_latency: Duration,
+    txn_ready_rate: f64,
+    execution_rate: f64,
+) -> (bool, u32) {
+    let overload_status;
+    let load_shedding_percentage;
+    if queueing_latency > config.execution_queue_latency_hard_limit {
+        overload_status = true;
+        load_shedding_percentage = max(
+            calculate_load_shedding_percentage(txn_ready_rate, execution_rate),
+            config.min_load_shedding_percentage_above_hard_limit,
+        );
+    } else if queueing_latency > config.execution_queue_latency_soft_limit {
+        load_shedding_percentage =
+            calculate_load_shedding_percentage(txn_ready_rate, execution_rate);
+        overload_status = load_shedding_percentage > 0;
+    } else {
+        overload_status = false;
+        load_shedding_percentage = 0;
+    }
+
+    let load_shedding_percentage = min(
+        load_shedding_percentage,
+        config.max_load_shedding_percentage,
+    );
+    (overload_status, load_shedding_percentage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::authority::test_authority_builder::TestAuthorityBuilder;
+    use std::sync::Arc;
+
+    #[test]
+    pub fn test_authority_overload_info() {
+        let overload_info = AuthorityOverloadInfo::default();
+        assert!(!overload_info.is_overload.load(Ordering::Relaxed));
+        assert_eq!(
+            overload_info
+                .load_shedding_percentage
+                .load(Ordering::Relaxed),
+            0
+        );
+
+        {
+            overload_info.set_overload(20);
+            assert!(overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                20
+            );
+        }
+
+        // Tests that load shedding percentage can't go beyond 100%.
+        {
+            overload_info.set_overload(110);
+            assert!(overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                100
+            );
+        }
+
+        {
+            overload_info.clear_overload();
+            assert!(!overload_info.is_overload.load(Ordering::Relaxed));
+            assert_eq!(
+                overload_info
+                    .load_shedding_percentage
+                    .load(Ordering::Relaxed),
+                0
+            );
+        }
+    }
+
+    #[test]
+    pub fn test_calculate_load_shedding_ratio() {
+        assert_eq!(calculate_load_shedding_percentage(90.0, 100.1), 0);
+        assert_eq!(calculate_load_shedding_percentage(90.0, 100.0), 10);
+        assert_eq!(calculate_load_shedding_percentage(100.0, 100.0), 20);
+        assert_eq!(calculate_load_shedding_percentage(110.0, 100.0), 28);
+        assert_eq!(calculate_load_shedding_percentage(180.0, 100.0), 60);
+        assert_eq!(calculate_load_shedding_percentage(100.0, 0.0), 100);
+        assert_eq!(calculate_load_shedding_percentage(0.0, 1.0), 0);
+    }
+
+    #[test]
+    pub fn test_check_overload_signals() {
+        let config = OverloadThresholdConfig {
+            execution_queue_latency_hard_limit: Duration::from_secs(10),
+            execution_queue_latency_soft_limit: Duration::from_secs(1),
+            max_load_shedding_percentage: 90,
+            ..Default::default()
+        };
+
+        // When execution queueing latency is within soft limit, don't start overload protection.
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_millis(500), 1000.0, 10.0),
+            (false, 0)
+        );
+
+        // When execution queueing latency hits soft limit and execution rate is higher, don't
+        // start overload protection.
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_secs(2), 100.0, 120.0),
+            (false, 0)
+        );
+
+        // When execution queueing latency hits soft limit, but not hard limit, start overload
+        // protection.
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_secs(2), 100.0, 100.0),
+            (true, 20)
+        );
+
+        // When execution queueing latency hits hard limit, start more aggressive overload
+        // protection.
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_secs(11), 100.0, 100.0),
+            (true, 50)
+        );
+
+        // When execution queueing latency hits hard limit and calculated shedding percentage
+        // is higher than
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_secs(11), 240.0, 100.0),
+            (true, 73)
+        );
+
+        // Maximum transactions shed is cap by `max_load_shedding_percentage` config.
+        assert_eq!(
+            check_overload_signals(&config, Duration::from_secs(11), 100.0, 0.0),
+            (true, 90)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    pub async fn test_check_authority_overload() {
+        let state = TestAuthorityBuilder::new().build().await;
+        let config = OverloadThresholdConfig::default();
+
+        // Creates a simple case to see if authority state overload_info can be updated
+        // correctly by check_authority_overload.
+        state
+            .metrics
+            .execution_queueing_latency
+            .report(Duration::from_secs(20));
+        let authority = Arc::downgrade(&state);
+        assert!(check_authority_overload(&authority, &config));
+        assert!(state.overload_info.is_overload.load(Ordering::Relaxed));
+        assert_eq!(
+            state
+                .overload_info
+                .load_shedding_percentage
+                .load(Ordering::Relaxed),
+            config.min_load_shedding_percentage_above_hard_limit
+        );
+
+        // Checks that check_authority_overload should return false when the input
+        // authority state doesn't exist.
+        let authority = Arc::downgrade(&state);
+        drop(state);
+        assert!(!check_authority_overload(&authority, &config));
+    }
+}

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -97,6 +97,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     pub fn test_update_low_scoring_authorities() {
         // GIVEN
         // Total stake is 8 for this committee and every authority has equal stake = 1

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -12,7 +12,9 @@ use indexmap::IndexMap;
 use lru::LruCache;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use sui_types::{base_types::TransactionDigest, error::SuiResult, fp_ensure};
+use sui_types::{
+    base_types::TransactionDigest, error::SuiResult, fp_ensure, message_envelope::Message,
+};
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     committee::EpochId,
@@ -756,6 +758,7 @@ impl TransactionManager {
         assert!(inner
             .executing_certificates
             .insert(*pending_certificate.certificate.digest()));
+        self.metrics.txn_ready_rate_tracker.lock().record();
         let _ = self.tx_ready_certificates.send(pending_certificate);
         self.metrics.transaction_manager_num_ready.inc();
         self.metrics.execution_driver_dispatch_queue.inc();
@@ -816,6 +819,7 @@ impl TransactionManager {
                 threshold: MAX_TM_QUEUE_LENGTH,
             }
         );
+        tx_data.digest();
 
         for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data
@@ -933,6 +937,7 @@ mod test {
     use prometheus::Registry;
 
     #[test]
+    #[cfg_attr(msim, ignore)]
     fn test_available_objects_cache() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::default()));
         let mut cache = AvailableObjectsCache::new_with_size(metrics, 5);

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -588,6 +588,7 @@ async fn test_txn_age_overload() {
             gas_objects.clone(),
             OverloadThresholdConfig {
                 max_txn_age_in_queue: Duration::from_secs(5),
+                ..Default::default()
             },
         )
         .await;

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -535,6 +535,7 @@ async fn shared_object_sync() {
         // Set the threshold high enough so it won't be triggered.
         .with_overload_threshold_config(OverloadThresholdConfig {
             max_txn_age_in_queue: Duration::from_secs(60),
+            ..Default::default()
         })
         .build()
         .await;

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -112,6 +112,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -221,6 +232,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -330,6 +352,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -439,6 +472,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -548,6 +592,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -657,6 +712,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -766,6 +832,17 @@ validator_configs:
       max_txn_age_in_queue:
         secs: 1
         nanos: 0
+      overload_monitor_interval:
+        secs: 10
+        nanos: 0
+      execution_queue_latency_soft_limit:
+        secs: 1
+        nanos: 0
+      execution_queue_latency_hard_limit:
+        secs: 10
+        nanos: 0
+      max_load_shedding_percentage: 95
+      min_load_shedding_percentage_above_hard_limit: 50
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -109,20 +109,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -229,20 +229,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -349,20 +349,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -469,20 +469,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -589,20 +589,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -709,20 +709,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -829,20 +829,20 @@ validator_configs:
         - Slack
         - Twitch
     overload-threshold-config:
-      max_txn_age_in_queue:
+      max-txn-age-in-queue:
         secs: 1
         nanos: 0
-      overload_monitor_interval:
+      overload-monitor-interval:
         secs: 10
         nanos: 0
-      execution_queue_latency_soft_limit:
+      execution-queue-latency-soft-limit:
         secs: 1
         nanos: 0
-      execution_queue_latency_hard_limit:
+      execution-queue-latency-hard-limit:
         secs: 10
         nanos: 0
-      max_load_shedding_percentage: 95
-      min_load_shedding_percentage_above_hard_limit: 50
+      max-load-shedding-percentage: 95
+      min-load-shedding-percentage-above-hard-limit: 50
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=


### PR DESCRIPTION
Roll forward #15981 

Previously, the PR was causing CI failure because `max_txn_age_in_queue` was used in the config. Therefore, although `overload_threshold_config` has a default, since `max_txn_age_in_queue` is specified, serde expects the rest of config to show up in the config file. Because we don't have a serde default set for the rest of the field, it crashes.

This PR added serde default for all the field in OverloadThresholdConfig in addition to the original #15981 .

I manually verified that it can parse the config correctly when only partial config is set.