### PR TITLE
[move-2024] Correctly recompute breaks under named blocks

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/control_flow/named_block_nesting.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/control_flow/named_block_nesting.exp
@@ -1,0 +1,19 @@
+processed 28 tasks
+
+task 22 'run'. lines 249-249:
+return values: 0
+
+task 23 'run'. lines 251-251:
+return values: 0
+
+task 24 'run'. lines 253-253:
+return values: 0
+
+task 25 'run'. lines 255-255:
+return values: 0
+
+task 26 'run'. lines 257-257:
+return values: 0
+
+task 27 'run'. lines 259-259:
+return values: 0

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/control_flow/named_block_nesting.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/control_flow/named_block_nesting.move
@@ -1,0 +1,260 @@
+//# init --edition 2024.alpha
+
+//# publish
+
+#[allow(dead_code,unused_assignment)]
+module 42::m {
+
+    entry fun t00() {
+        loop 'a: {
+            loop { break 'a }
+        }
+    }
+
+    entry fun t01() {
+        loop 'a: {
+            'b: { break 'a }
+        }
+    }
+
+    entry fun t02() {
+        loop 'a: {
+            (loop { break 'a } : ())
+        }
+    }
+
+    entry fun t03() {
+        loop 'a: {
+            ('b: { break 'a } : ())
+        }
+    }
+
+    entry fun t04() {
+        let x = loop 'a: {
+            (loop { break 'a 0 } : ())
+        };
+        assert!(x == 0, 42);
+    }
+
+    entry fun t05() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            (loop { continue 'a } : ())
+        };
+    }
+
+    entry fun t06() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            'b: { continue 'a }
+        };
+    }
+
+    entry fun t07() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            ('b: { continue 'a } : ())
+        };
+    }
+
+    entry fun t08() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            'b: { break 'a }
+        };
+    }
+
+    entry fun t09() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            ('b: { break 'a } : ())
+        };
+    }
+
+    entry fun t10() {
+        loop 'a: {
+            'b: {
+                'c: { loop 'd: { break 'a } }
+            }
+        }
+    }
+
+    entry fun t11() {
+        let _x = loop 'a: {
+            (loop { break 'a 0 } : ())
+        };
+    }
+
+    entry fun t12() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            (loop { continue 'a } : ())
+        }
+    }
+
+    entry fun t13() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            'b: { continue 'a }
+        }
+    }
+
+    entry fun t14() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            ('b: { continue 'a } : ())
+        }
+    }
+
+    entry fun t15() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            'b: { break 'a }
+        }
+    }
+
+    entry fun t16() {
+        let mut i = 0;
+        while (i < 10) 'a: {
+            i = i + 1;
+            ('b: { break 'a } : ())
+        }
+    }
+
+    entry fun t17() {
+        loop 'a: {
+            ('b: {
+                'c: { loop 'd: { break 'a } }
+            }: ())
+        }
+    }
+
+    entry fun t18() {
+        loop 'a: {
+            'b: {
+                ('c: { loop 'd: { break 'a } } : ())
+            }
+        }
+    }
+
+    entry fun t19() {
+        loop 'a: {
+            ('b: {
+                 ('c: { loop 'd: { break 'a } } : ())
+            } : ())
+        }
+    }
+
+    entry fun t20(): u64 {
+        loop 'a: {
+            ('b: {
+                'c: { loop 'd: { break 'a 0 } }
+            }: ())
+        }
+    }
+
+    entry fun t21(): u64 {
+        loop 'a: {
+            'b: {
+                ('c: { loop 'd: { break 'a 0 } } : ())
+            }
+        }
+    }
+
+    entry fun t22(): u64 {
+        loop 'a: {
+            ('b: {
+                 ('c: { loop 'd: { break 'a 0 } } : ())
+            } : ())
+        }
+    }
+
+    entry fun t23(): u64 {
+        let x = loop 'a: {
+            ('b: {
+                'c: { loop 'd: { break 'a 0 } }
+            }: ())
+        };
+        x
+    }
+
+    entry fun t24(): u64 {
+        let x = loop 'a: {
+            'b: {
+                ('c: { loop 'd: { break 'a 0 } } : ())
+            }
+        };
+        x
+    }
+
+    entry fun t25(): u64 {
+        let x = loop 'a: {
+            ('b: {
+                 ('c: { loop 'd: { break 'a 0 } } : ())
+            } : ())
+        };
+        x
+    }
+}
+
+//# run 42::m::t00
+
+//# run 42::m::t01
+
+//# run 42::m::t02
+
+//# run 42::m::t03
+
+//# run 42::m::t04
+
+//# run 42::m::t05
+
+//# run 42::m::t06
+
+//# run 42::m::t07
+
+//# run 42::m::t08
+
+//# run 42::m::t09
+
+//# run 42::m::t10
+
+//# run 42::m::t11
+
+//# run 42::m::t12
+
+//# run 42::m::t13
+
+//# run 42::m::t14
+
+//# run 42::m::t15
+
+//# run 42::m::t16
+
+//# run 42::m::t17
+
+//# run 42::m::t18
+
+//# run 42::m::t19
+
+//# run 42::m::t20
+
+//# run 42::m::t21
+
+//# run 42::m::t22
+
+//# run 42::m::t23
+
+//# run 42::m::t24
+
+//# run 42::m::t25
+

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -829,10 +829,8 @@ fn statement(
 
             let entry_block = VecDeque::from([make_jump(sloc, start_label, false)]);
 
-            let (body_entry_block, body_blocks) = block_(
-                context,
-                with_last(body, make_jump(sloc, end_label, false)),
-            );
+            let (body_entry_block, body_blocks) =
+                block_(context, with_last(body, make_jump(sloc, end_label, false)));
 
             context.exit_named_block(&name);
 

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1671,8 +1671,9 @@ fn still_has_break(name: &BlockLabel, block: &Block) -> bool {
             } => has_break_block(name, if_block) || has_break_block(name, else_block),
             S::While { block, .. } => has_break_block(name, block),
             S::Loop { block, .. } => has_break_block(name, block),
+            S::NamedBlock { block, .. } => has_break_block(name, block),
             hcmd!(C::Break(break_name)) => break_name == name,
-            _ => false,
+            S::Command(_) => false,
         }
     }
 
@@ -2201,8 +2202,18 @@ fn needs_freeze(context: &Context, sp!(_, actual): &H::Type, sp!(_, expected): &
                 Freeze::NotNeeded
             }
         }
+        (T::Single(sp!(_, H::SingleType_::Base(sp!(_, H::BaseType_::Unreachable)))), _expected) => {
+            Freeze::NotNeeded
+        }
         (_actual, _expected) => {
-            assert!(context.env.has_errors());
+            if !context.env.has_errors() {
+                println!("typing produced the following actual and expected types: ");
+                print!("actual: ");
+                _actual.print();
+                print!("expected: ");
+                _expected.print();
+                panic!("ICE HLIR freezing went wrong")
+            }
             Freeze::NotNeeded
         }
     }


### PR DESCRIPTION
## Description 

Due to a wildcard match, recompuing `loop` breaks did not proceed under them in HLIR lowering. This fixes that and revises HLIR lowering to always exhaustively match the forms when looking for breaks.

Also, the testing found cases where we had `annot((x: _|_): T)`, causing freeze operations to fail. This modified freeze checking to pass when we find `x: _|_` because that expression is unreachable and will be removed, plus typing was fine with it.

## Test Plan 

A very long test for all these forms.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
