### PR TITLE
[bridge 35/n] update function family get_action_onchain_status

### DIFF
--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -47,6 +47,8 @@ pub enum BridgeError {
     MismatchedAction,
     // Authority has invalid url
     AuthoirtyUrlInvalid,
+    // Action is not token transfer
+    NotTokenTransferAction,
     // Sui transaction failure due to generic error
     SuiTxFailureGeneric(String),
     // Storage Error

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -184,7 +184,7 @@ impl SuiClientInner for SuiMockClient {
         unimplemented!()
     }
 
-    async fn get_action_onchain_status(
+    async fn get_token_transfer_action_onchain_status(
         &self,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -492,7 +492,7 @@ impl BridgeAction {
         BridgeActionDigest::new(hasher.finalize().into())
     }
 
-    pub fn source_chain_id(&self) -> BridgeChainId {
+    pub fn chain_id(&self) -> BridgeChainId {
         match self {
             BridgeAction::SuiToEthBridgeAction(a) => a.sui_bridge_event.sui_chain_id,
             BridgeAction::EthToSuiBridgeAction(a) => a.eth_bridge_event.eth_chain_id,


### PR DESCRIPTION
## Description 

`source_chain_id` is a bit confusing concept. This PR de-ambiguates it and updates some functions to only handle token bridge actions.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
