### PR TITLE
Update to allow address aliases that use `.`s in them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11583,6 +11583,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-package",
+ "move-symbol-pool",
  "move-vm-profiler",
  "num-bigint 0.4.4",
  "petgraph 0.5.1",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -56,6 +56,7 @@ shared-crypto.workspace = true
 sui-replay.workspace = true
 sui-transaction-builder.workspace = true
 move-binary-format.workspace = true
+move-symbol-pool.workspace = true
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true

--- a/crates/sui/src/ptb/ptb_parser/argument.rs
+++ b/crates/sui/src/ptb/ptb_parser/argument.rs
@@ -25,7 +25,7 @@ pub enum Argument {
     U256(move_core_types::u256::U256),
     Gas,
     Identifier(String),
-    VariableAccess(Spanned<String>, Vec<Spanned<u16>>),
+    VariableAccess(Spanned<String>, Vec<Spanned<String>>),
     Address(NumericalAddress),
     String(String),
     Vector(Vec<Spanned<Argument>>),

--- a/crates/sui/src/ptb/ptb_parser/context.rs
+++ b/crates/sui/src/ptb/ptb_parser/context.rs
@@ -3,15 +3,18 @@
 
 use std::collections::BTreeMap;
 
+use move_symbol_pool::Symbol;
+
 use crate::ptb::ptb_parser::errors::PTBError;
 
-use super::errors::PTBResult;
+use super::errors::{PTBResult, Span};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileScope {
     pub file_command_index: usize,
-    pub name: String,
-    // Since the same filename may appear twice this disambiguates between first, second, etc.
+    /// Intern names
+    pub name: Symbol,
+    /// Since the same filename may appear twice this disambiguates between first, second, etc.
     pub name_index: usize,
 }
 
@@ -19,7 +22,7 @@ pub struct FileScope {
 pub struct PTBContext {
     current_file_scope: FileScope,
     file_scopes: Vec<FileScope>,
-    seen_scopes: BTreeMap<String, usize>,
+    seen_scopes: BTreeMap<Symbol, usize>,
 }
 
 impl PTBContext {
@@ -27,27 +30,28 @@ impl PTBContext {
         Self {
             current_file_scope: FileScope {
                 file_command_index: 0,
-                name: "console".to_owned(),
+                name: Symbol::from("console"),
                 name_index: 0,
             },
             file_scopes: vec![],
-            seen_scopes: [("console".to_owned(), 0)].into_iter().collect(),
+            seen_scopes: [(Symbol::from("console"), 0)].into_iter().collect(),
         }
     }
 
     pub fn push_file_scope(&mut self, name: String) {
         // Account for the `--file` command itself in the index
         self.increment_file_command_index();
+        let name_symbol = Symbol::from(name);
         let name_index = self
             .seen_scopes
-            .entry(name.clone())
+            .entry(name_symbol)
             .and_modify(|i| *i += 1)
             .or_insert(0);
         let scope = std::mem::replace(
             &mut self.current_file_scope,
             FileScope {
                 file_command_index: 0,
-                name,
+                name: name_symbol,
                 name_index: *name_index,
             },
         );
@@ -55,29 +59,28 @@ impl PTBContext {
     }
 
     pub fn pop_file_scope(&mut self, name: &str) -> PTBResult<()> {
-        if self.current_file_scope.name != name {
+        let name_symbol = Symbol::from(name);
+        if self.current_file_scope.name != name_symbol {
             return Err(PTBError::WithSource {
-                file_scope: self.current_file_scope.clone(),
                 message: format!(
                     "ICE: Expected file scope '{}' but got '{}'",
-                    name, self.current_file_scope.name
+                    name_symbol, self.current_file_scope.name
                 ),
-                span: None,
+                span: Span::cmd_span(0, self.current_file_scope()),
                 help: None,
             });
         }
         let scope = self.file_scopes.pop().ok_or_else(|| PTBError::WithSource {
-            file_scope: self.current_file_scope.clone(),
             message: "ICE: No file scopes to pop".to_owned(),
-            span: None,
+            span: Span::cmd_span(0, self.current_file_scope()),
             help: None,
         })?;
         self.current_file_scope = scope;
         Ok(())
     }
 
-    pub fn current_file_scope(&self) -> &FileScope {
-        &self.current_file_scope
+    pub fn current_file_scope(&self) -> FileScope {
+        self.current_file_scope
     }
 
     pub fn current_command_index(&self) -> usize {


### PR DESCRIPTION
Also fixes an issue in error reporting and spans due to the delayed resolution of arguments.
