### PR TITLE
Overload monitor simulation tests

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -711,6 +711,8 @@ pub struct OverloadThresholdConfig {
     #[serde(default = "default_min_load_shedding_percentage_above_hard_limit")]
     pub min_load_shedding_percentage_above_hard_limit: u32,
 
+    // If transaction ready rate is below this rate, we consider the validator
+    // is well under used, and will not enter load shedding mode.
     #[serde(default = "default_safe_transaction_ready_rate")]
     pub safe_transaction_ready_rate: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -710,6 +710,9 @@ pub struct OverloadThresholdConfig {
     // transactions to shed.
     #[serde(default = "default_min_load_shedding_percentage_above_hard_limit")]
     pub min_load_shedding_percentage_above_hard_limit: u32,
+
+    #[serde(default = "default_safe_transaction_ready_rate")]
+    pub safe_transaction_ready_rate: u32,
     // TODO: Move other thresholds here as well, including `MAX_TM_QUEUE_LENGTH`
     // and `MAX_PER_OBJECT_QUEUE_LENGTH`.
 }
@@ -738,6 +741,10 @@ fn default_min_load_shedding_percentage_above_hard_limit() -> u32 {
     50
 }
 
+fn default_safe_transaction_ready_rate() -> u32 {
+    100
+}
+
 impl Default for OverloadThresholdConfig {
     fn default() -> Self {
         Self {
@@ -748,6 +755,7 @@ impl Default for OverloadThresholdConfig {
             max_load_shedding_percentage: default_max_load_shedding_percentage(),
             min_load_shedding_percentage_above_hard_limit:
                 default_min_load_shedding_percentage_above_hard_limit(),
+            safe_transaction_ready_rate: default_safe_transaction_ready_rate(),
         }
     }
 }

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -533,7 +533,7 @@ mod tests {
         let (stop_tx, stop_rx) = oneshot::channel();
         let executor = start_executor(executor_rate, rx, stop_rx, state.clone());
 
-        sleep_and_print_stats(state.clone(), 50).await;
+        sleep_and_print_stats(state.clone(), 300).await;
 
         stop_tx.send(()).unwrap();
         let _ = tokio::join!(load_generator, executor);
@@ -545,8 +545,7 @@ mod tests {
     }
 
     // Tests that when request generation rate is slower than execution rate, no requests should be dropped.
-    #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(msim, ignore)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_workload_consistent_no_overload() {
         telemetry_subscribers::init_for_testing();
         run_consistent_workload_test(900.0, 1000.0, 0.0, 0.0).await;
@@ -554,8 +553,7 @@ mod tests {
 
     // Tests that when request generation rate is slightly above execution rate, a small portion of
     // requests should be dropped.
-    #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(msim, ignore)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_workload_consistent_slightly_overload() {
         telemetry_subscribers::init_for_testing();
         // Dropping rate should be around 15%.
@@ -564,8 +562,7 @@ mod tests {
 
     // Tests that when request generation rate is much higher than execution rate, a large portion of
     // requests should be dropped.
-    #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(msim, ignore)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_workload_consistent_overload() {
         telemetry_subscribers::init_for_testing();
         // Dropping rate should be around 70%.
@@ -573,8 +570,7 @@ mod tests {
     }
 
     // Tests that when there is a very short single spike, no request should be dropped.
-    #[tokio::test(flavor = "current_thread")]
-    #[cfg_attr(msim, ignore)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_workload_single_spike() {
         telemetry_subscribers::init_for_testing();
         let state = TestAuthorityBuilder::new().build().await;
@@ -610,8 +606,7 @@ mod tests {
 
     // Tests that when there are regular spikes that keep queueing latency consistently high,
     // overload monitor should kick in and shed load.
-    #[tokio::test(flavor = "current_thread")]
-    #[cfg_attr(msim, ignore)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_workload_consistent_short_spike() {
         telemetry_subscribers::init_for_testing();
         let state = TestAuthorityBuilder::new().build().await;

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -123,6 +123,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -243,6 +244,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -363,6 +365,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -483,6 +486,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -603,6 +607,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -723,6 +728,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -843,6 +849,7 @@ validator_configs:
         nanos: 0
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
+      safe-transaction-ready-rate: 100
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=


### PR DESCRIPTION
## Description 

Create a simulation test to test overload monitor. Particularly, it tests 5 scenarios
- No overload
- Slightly overload
- Heavy overload
- Single spike
- Consistent spikes

The tests use a simple load generator and executor. Both use a AuthorityState.overload_info to keep track of requests. The overload monitor inside the same AuthorityState can be used as an overload monitor for the load generator.

This test discovered several improvements from the previous load generator. Some notable ones are:
- When we are already in shedding mode, say 50%, and decide to shed 10%, previously the new shedding percentage will be 10% but it really should be 50% + 50% * 10% = 55%.
- When txn ready rate < execution rate, it doesn't mean that the overload is over. We need to protect against future spikes by only gradually reduce shedding percentage.

## Test Plan 

Simulation tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
