### PR TITLE
I've revised the original example for calling `queryEvents` with the Sui TypeScript SDK.

### DIFF
--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -129,25 +129,6 @@ This example leverages the Sui TypeScript SDK to subscribe to events the package
 
 To create the event subscription, you can use a basic Node.js app. You need the Sui TypeScript SDK, so install the module using `npm install @mysten/sui.js` at the root of your project. In your TypeScript code, Use queryEvents within the executeMoveCall function below to query the events information for a Transaction.Below is an example of how to obtain the events information for the current transaction when calling a contract.
 
-Example transaction：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
-
-```json
-{
-  "id": {
-    "txDigest": "2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej",
-    "eventSeq": "0"
-  },
-  "packageId": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f",
-  "transactionModule": "sicbogame",
-  "sender": "0x3c54103db151f05f698705b76427cc03f80f1b3a092353bc84c2fd88a6b56c85",
-  "type": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f::sicbogame::Result",
-  "parsedJson": {
-    "msg": "You Win :)"
-  },
-  "bcs": "3ZrJhsA3GhA8gKr",
-  "timestampMs": "1707120095029"
-```
-
 Example code：
 
 ```ts
@@ -231,6 +212,25 @@ export function Creategame({
 ```
 
 ### Response
+
+Example transaction：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
+
+```json
+{
+  "id": {
+    "txDigest": "2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej",
+    "eventSeq": "0"
+  },
+  "packageId": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f",
+  "transactionModule": "sicbogame",
+  "sender": "0x3c54103db151f05f698705b76427cc03f80f1b3a092353bc84c2fd88a6b56c85",
+  "type": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f::sicbogame::Result",
+  "parsedJson": {
+    "msg": "You Win :)"
+  },
+  "bcs": "3ZrJhsA3GhA8gKr",
+  "timestampMs": "1707120095029"
+```
 
 I can get the value of parsedJson in the example below, and its final value is {"msg":"You Win :)"}.
 

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -147,6 +147,7 @@ Example transaction：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCA
   "bcs": "3ZrJhsA3GhA8gKr",
   "timestampMs": "1707120095029"
 ```
+
 Example code：
 
 ```ts
@@ -227,7 +228,6 @@ export function Creategame({
         </>
     );
 }
-
 ```
 
 ### Response

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -127,64 +127,112 @@ This example leverages the Sui TypeScript SDK to subscribe to events the package
 
 ### TypeScript
 
-To create the event subscription, you can use a basic Node.js app. You need the Sui TypeScript SDK, so install the module using `npm install @mysten/sui.js` at the root of your project. In your TypeScript code, import `JsonRpcProvider` and a connection from the library.
+To create the event subscription, you can use a basic Node.js app. You need the Sui TypeScript SDK, so install the module using `npm install @mysten/sui.js` at the root of your project. In your TypeScript code, Use queryEvents within the executeMoveCall function below to query the events information for a Transaction.Below is an example of how to obtain the events information for the current transaction when calling a contract.
+
+example：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
+```json
+{
+  "id": {
+    "txDigest": "2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej",
+    "eventSeq": "0"
+  },
+  "packageId": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f",
+  "transactionModule": "sicbogame",
+  "sender": "0x3c54103db151f05f698705b76427cc03f80f1b3a092353bc84c2fd88a6b56c85",
+  "type": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f::sicbogame::Result",
+  "parsedJson": {
+    "msg": "You Win :)"
+  },
+  "bcs": "3ZrJhsA3GhA8gKr",
+  "timestampMs": "1707120095029"
+
+```
+
 
 ```ts
-import { JsonRpcProvider, testnetConnection } from '@mysten/sui.js';
+import {
+    useSignAndExecuteTransactionBlock,
+    useSuiClient,
+  } from "@mysten/dapp-kit";
+import { TransactionBlock } from "@mysten/sui.js/transactions";
+import { Button, Flex, Heading } from "@radix-ui/themes";
+import { SICBOGAME_PACKAGE_ID } from "./constants";  
+  
+export function Creategame({ 
+    onCreated,
+}:{
+    onCreated: (id: string) => void;
+ }) {
+    const { mutate: signAndExecute } = useSignAndExecuteTransactionBlock();
+    const client = useSuiClient();
 
-// Package is on Testnet.
-const provider = new JsonRpcProvider(testnetConnection);
-const Package = '<PACKAGE_ID>';
+    const executeMoveCall = (method: "small" | "large") => {
+        const txb = new TransactionBlock();
 
-const MoveEventType = '<PACKAGE_ID>::<MODULE_NAME>::<METHOD_NAME>';
+        if (method === "small") {
+        txb.moveCall({
+            arguments: [txb.pure.u64(0)],
+            target: `${SICBOGAME_PACKAGE_ID}::sicbogame::create_game`,
+        });
+        } else {
+        txb.moveCall({
+            arguments: [txb.pure.u64(1)],
+            target: `${SICBOGAME_PACKAGE_ID}::sicbogame::create_game`,
+        });
+        }
 
-console.log(
-	await provider.getObject({
-		id: Package,
-		options: { showPreviousTransaction: true },
-	}),
-);
+        signAndExecute(
+        {
+            transactionBlock: txb,
+            options: {
+            showEffects: true,
+            showObjectChanges: true,
+            },
+        },
+        {
+            onSuccess: (tx) => {
+                client.
+                    queryEvents({
+                        query:{Transaction:tx.digest}
+                    }).then(PaginatedEvents=> {
+                        const events = JSON.stringify(PaginatedEvents.data[0].parsedJson);
+                    
+                        if (events.length > 0) {
+                          onCreated(events)
+                        } else {
+                          onCreated('No events found for the given criteria.');
+                        }
+                      })
+                      .catch(error => { 
+                        console.error('Error querying events:', error);
+                      });
+            },
+        },
+        );
+    };
+    return (
+        <>
+        <Heading size="3">Game Start</Heading>
 
-let unsubscribe = await provider.subscribeEvent({
-	filter: { Package },
-	onMessage: (event) => {
-		console.log('subscribeEvent', JSON.stringify(event, null, 2));
-	},
-});
+        <Flex direction="column" gap="2">
+            <Flex direction="row" gap="2">
+            <Button onClick={() => executeMoveCall("small")}>
+                small
+            </Button>
+            <Button onClick={() => executeMoveCall("large")}>
+                large
+            </Button>
+            </Flex>
+        </Flex>
+        </>
+    );
+}
 
-process.on('SIGINT', async () => {
-	console.log('Interrupted...');
-	if (unsubscribe) {
-		await unsubscribe();
-		unsubscribe = undefined;
-	}
-});
 ```
 
 ### Response
 
-When the subscribed to event fires, the example displays the following JSON representation of the event.
-
-```json
-subscribeEvent {
-  "id": {
-    "txDigest": "HkCBeBLQbpKBYXmuQeTM98zprUqaACRkjKmmtvC6MiP1",
-    "eventSeq": "0"
-  },
-  "packageId": "0x2d6733a32e957430324196dc5d786d7c839f3c7bbfd92b83c469448b988413b1",
-  "transactionModule": "coin_flip",
-  "sender": "0x46f184f2d68007e4344fffe603c4ccacd22f4f28c47f321826e83619dede558e",
-  "type": "0x2d6733a32e957430324196dc5d786d7c839f3c7bbfd92b83c469448b988413b1::coin_flip::Outcome",
-  "parsedJson": {
-    "bet_amount": "4000000000",
-    "game_id": "0xa7e1fb3c18a88d048b75532de219645410705fa48bfb8b13e8dbdbb7f4b9bbce",
-    "guess": 0,
-    "player_won": true
-  },
-  "bcs": "3oWWjWKRVu115bnnZphyDcJ8EyF9X4pgVguwhEtcsVpBf74B6RywQupm2X",
-  "timestampMs": "1687912116638"
-}
-```
+I can get the value of parsedJson in the example below, and its final value is {"msg":"You Win :)"}.
 
 ### Rust SDK
 

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -215,24 +215,7 @@ export function Creategame({
 
 Example transaction：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
 
-```json
-{
-  "id": {
-    "txDigest": "2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej",
-    "eventSeq": "0"
-  },
-  "packageId": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f",
-  "transactionModule": "sicbogame",
-  "sender": "0x3c54103db151f05f698705b76427cc03f80f1b3a092353bc84c2fd88a6b56c85",
-  "type": "0x4047ca9d7990e25abe3dea249e54eb5ed079212dd976f1ccc30700a96d01608f::sicbogame::Result",
-  "parsedJson": {
-    "msg": "You Win :)"
-  },
-  "bcs": "3ZrJhsA3GhA8gKr",
-  "timestampMs": "1707120095029"
-```
-
-I can get the value of parsedJson in the example below, and its final value is {"msg":"You Win :)"}.
+I can get the value of parsedJson in the example below, and its final value is {"msg":"You Win :)"} .
 
 ### Rust SDK
 

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -129,7 +129,8 @@ This example leverages the Sui TypeScript SDK to subscribe to events the package
 
 To create the event subscription, you can use a basic Node.js app. You need the Sui TypeScript SDK, so install the module using `npm install @mysten/sui.js` at the root of your project. In your TypeScript code, Use queryEvents within the executeMoveCall function below to query the events information for a Transaction.Below is an example of how to obtain the events information for the current transaction when calling a contract.
 
-example：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
+Example transaction：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRnpo29ej?network=testnet
+
 ```json
 {
   "id": {
@@ -145,9 +146,8 @@ example：https://suiexplorer.com/txblock/2hg7QQvNh7DnmmMaanAZ7hRYCAUimPJTN3bJRn
   },
   "bcs": "3ZrJhsA3GhA8gKr",
   "timestampMs": "1707120095029"
-
 ```
-
+Example code：
 
 ```ts
 import {


### PR DESCRIPTION
## Description 

I've revised the original example for calling `queryEvents` with the Sui TypeScript SDK.

## Test Plan 

I believe that the previous example of using queryEvents in the Sui TypeScript SDK is outdated, and the import statement import { JsonRpcProvider, testnetConnection } from '@mysten/sui.js'; is no longer valid. This can mislead beginners and make it difficult for them to learn. As a beginner myself, I was only able to successfully retrieve the events from a transaction by examining multiple layers of the source code through the client. Therefore, I hope the example can be updated so that beginners can simply and correctly use queryEvents to query the contents of events in a transaction.

https://docs.sui.io/guides/developer/sui-101/using-events

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
