### PR TITLE
[Multi-sig Toolkit] Introduce user-friendly effects preview

### DIFF
--- a/dapps/multisig-toolkit/package.json
+++ b/dapps/multisig-toolkit/package.json
@@ -33,6 +33,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-hook-form": "^7.45.2",
+		"react-hot-toast": "^2.4.1",
 		"react-router-dom": "^6.14.2",
 		"tailwind-merge": "^1.14.0",
 		"zod": "^3.21.4"

--- a/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DryRunTransactionBlockResponse, SuiClient } from '@mysten/sui.js/src/client';
+import { DryRunTransactionBlockResponse } from '@mysten/sui.js/src/client';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useState } from 'react';
 
@@ -12,14 +12,7 @@ import { ObjectChanges } from './partials/ObjectChanges';
 import { Overview } from './partials/Overview';
 import { Transactions } from './partials/Transactions';
 
-// SPDX-License-Identifier: Apache-2.0
-export function EffectsPreview({
-	output,
-	client,
-}: {
-	output: DryRunTransactionBlockResponse;
-	client: SuiClient | undefined;
-}) {
+export function EffectsPreview({ output }: { output: DryRunTransactionBlockResponse }) {
 	const [tab, setTab] = useState('balance-changes');
 
 	const { objectChanges, balanceChanges } = output;

--- a/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
@@ -43,7 +43,7 @@ export function EffectsPreview({ output }: { output: DryRunTransactionBlockRespo
 		},
 		{
 			name: 'json',
-			title: 'Pure JSON',
+			title: 'Raw JSON',
 		},
 	];
 

--- a/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/EffectsPreview.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DryRunTransactionBlockResponse, SuiClient } from '@mysten/sui.js/src/client';
+import * as Tabs from '@radix-ui/react-tabs';
+import { useState } from 'react';
+
+import { Textarea } from '../ui/textarea';
+import { BalanceChanges } from './partials/BalanceChanges';
+import { Events } from './partials/Events';
+import { ObjectChanges } from './partials/ObjectChanges';
+import { Overview } from './partials/Overview';
+import { Transactions } from './partials/Transactions';
+
+// SPDX-License-Identifier: Apache-2.0
+export function EffectsPreview({
+	output,
+	client,
+}: {
+	output: DryRunTransactionBlockResponse;
+	client: SuiClient | undefined;
+}) {
+	const [tab, setTab] = useState('balance-changes');
+
+	const { objectChanges, balanceChanges } = output;
+
+	const tabs = [
+		{
+			name: 'balance-changes',
+			title: 'Balance Changes',
+			count: balanceChanges?.length,
+		},
+		{
+			name: 'object-changes',
+			title: 'Object Changes',
+			count: objectChanges?.length,
+		},
+		{
+			name: 'events',
+			title: 'Events',
+			count: output.events.length,
+		},
+		{
+			name: 'transactions',
+			title: 'Transactions',
+			count:
+				output.input.transaction.kind === 'ProgrammableTransaction'
+					? output.input.transaction.transactions.length
+					: 0,
+		},
+		{
+			name: 'json',
+			title: 'Pure JSON',
+		},
+	];
+
+	return (
+		<>
+			<Overview output={output} />
+			<Tabs.Root value={tab} onValueChange={setTab} className="w-full">
+				<Tabs.List className="flex overflow-x-auto border-b ">
+					{tabs.map((tab, index) => {
+						return (
+							<Tabs.Trigger
+								key={index}
+								className="border-transparent data-[state=active]:bg-gray-100 px-3 py-1 rounded-t-sm data-[state=active]:text-black"
+								value={tab.name}
+							>
+								{tab.title} {!!tab.count && Number(tab.count) > 0 && `(${tab.count})`}
+							</Tabs.Trigger>
+						);
+					})}
+				</Tabs.List>
+
+				<Tabs.Content className="py-6 " value="balance-changes">
+					<BalanceChanges changes={balanceChanges} />
+				</Tabs.Content>
+
+				<Tabs.Content className="py-6" value="object-changes">
+					<ObjectChanges objects={objectChanges} />
+				</Tabs.Content>
+
+				<Tabs.Content className="py-6" value="events">
+					<Events events={output.events} />
+				</Tabs.Content>
+
+				<Tabs.Content className="py-6" value="transactions">
+					<Transactions inputs={output.input} />
+				</Tabs.Content>
+
+				<Tabs.Content className="py-6" value="json">
+					<Textarea value={JSON.stringify(output, null, 4)} rows={20} />
+				</Tabs.Content>
+			</Tabs.Root>
+		</>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/ObjectLink.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/ObjectLink.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { useSuiClientContext } from '@mysten/dapp-kit';
+import { ObjectOwner, SuiObjectChange } from '@mysten/sui.js/src/client';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+
+import { formatAddress } from './utils';
+
+type OwnerDisplay = string | { address: string } | { object: string };
+
+const getOwnerDisplay = (owner: ObjectOwner): OwnerDisplay => {
+	if (owner === 'Immutable') return 'Immutable';
+	if ('Shared' in owner) return 'Shared';
+	if ('AddressOwner' in owner) return { address: owner.AddressOwner };
+	return { object: owner.ObjectOwner };
+};
+
+export function ObjectLink({
+	owner,
+	type,
+	object,
+	inputObject,
+	...tags
+}: {
+	inputObject?: string;
+	type?: string;
+	owner?: ObjectOwner;
+	object?: SuiObjectChange;
+} & React.HTMLAttributes<HTMLAnchorElement> &
+	React.ComponentPropsWithoutRef<'a'>) {
+	const [copied, setCopied] = useState(false);
+
+	const { network } = useSuiClientContext();
+
+	let objectId: string | undefined;
+	let display: string | undefined;
+
+	const ownerDisplay = owner ? getOwnerDisplay(owner) : undefined;
+
+	if (ownerDisplay) {
+		if (typeof ownerDisplay !== 'string') {
+			objectId = 'address' in ownerDisplay ? ownerDisplay.address : ownerDisplay.object;
+			display = formatAddress(objectId);
+		} else {
+			display = ownerDisplay;
+		}
+	}
+
+	if (type) {
+		display = type;
+	}
+
+	if (inputObject) {
+		objectId = inputObject;
+		display = formatAddress(inputObject);
+	}
+
+	if (object) {
+		if ('objectId' in object) {
+			objectId = object.objectId;
+			display = formatAddress(objectId);
+		}
+
+		if ('packageId' in object) {
+			objectId = object.packageId;
+			display = formatAddress(objectId);
+		}
+	}
+
+	const link = objectId
+		? `https://suiexplorer.com/${ownerDisplay ? 'address' : 'object'}/${objectId}?network=${
+				network.split(':')[1]
+		  }`
+		: undefined;
+
+	const copy = () => {
+		if (!objectId && !display) return;
+
+		navigator.clipboard.writeText(objectId || display || '');
+		setCopied(true);
+		toast.success('Copied to clipboard!');
+
+		setTimeout(() => {
+			setCopied(false);
+		}, 1_000);
+	};
+
+	return (
+		<>
+			{copied ? (
+				<CheckIcon width={10} height={10} className="" />
+			) : display ? (
+				<CopyIcon width={10} height={10} className="cursor-pointer" onClick={copy} />
+			) : null}
+
+			{link ? (
+				<>
+					<a
+						href={link}
+						target="_blank"
+						className="underline break-words pl-2"
+						{...tags}
+						rel="noreferrer"
+					>
+						{display}
+					</a>
+				</>
+			) : (
+				<span>{display || '-'}</span>
+			)}
+		</>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/PreviewCard.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/PreviewCard.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ObjectOwner } from '@mysten/sui.js/src/client';
+import { ReactNode } from 'react';
+
+import { ObjectLink } from './ObjectLink';
+
+type HeaderProps = {
+	children?: ReactNode;
+};
+type RootProps = {
+	children: ReactNode;
+	className?: string;
+};
+
+type BodyProps = {
+	children: ReactNode;
+};
+
+type FooterProps = {
+	children?: ReactNode;
+};
+
+function Root({ children, className }: RootProps) {
+	return (
+		<div className={`border flex flex-col  rounded-lg shadow overflow-hidden ${className}`}>
+			{children}
+		</div>
+	);
+}
+
+function Body({ children }: BodyProps) {
+	return <div className="p-3 overflow-x-auto">{children}</div>;
+}
+
+function Header({ children }: HeaderProps) {
+	return (
+		<div className="bg-gray-900 py-3 px-2 text-sm overflow-x-auto break-words">{children}</div>
+	);
+}
+function Footer({ children, owner }: FooterProps & { owner?: ObjectOwner }) {
+	return (
+		<div className="mt-auto bg-gray-900 py-3 px-2 text-sm overflow-x-auto break-words">
+			{children}
+			{owner && (
+				<div className="flex items-center ">
+					<div>Owner</div>
+					<div className="col-span-3 text-right flex items-center gap-1 ml-auto">
+						<ObjectLink owner={owner} />
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+const PreviewCard = {
+	Root,
+	Header,
+	Body,
+	Footer,
+};
+
+export default PreviewCard;

--- a/dapps/multisig-toolkit/src/components/preview-effects/context.ts
+++ b/dapps/multisig-toolkit/src/components/preview-effects/context.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-import { SuiClient } from '@mysten/sui.js/src/client';
-import { createContext } from 'react';
-
-export const EffectsPreviewContext = createContext<SuiClient | undefined>(undefined);

--- a/dapps/multisig-toolkit/src/components/preview-effects/context.ts
+++ b/dapps/multisig-toolkit/src/components/preview-effects/context.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiClient } from '@mysten/sui.js/src/client';
+import { createContext } from 'react';
+
+export const EffectsPreviewContext = createContext<SuiClient | undefined>(undefined);

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/BalanceChanges.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/BalanceChanges.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useSuiClientQuery } from '@mysten/dapp-kit';
+import { type BalanceChange } from '@mysten/sui.js/src/client';
+
+import PreviewCard from '../PreviewCard';
+import { onChainAmountToFloat } from '../utils';
+
+export function BalanceChanges({ changes }: { changes: BalanceChange[] }) {
+	return (
+		<div className="grid grid-cols-2 gap-4 even:bg-gray-900">
+			{changes.map((change, index) => (
+				<ChangedBalance key={index} change={change} />
+			))}
+		</div>
+	);
+}
+
+function ChangedBalance({ change }: { change: BalanceChange }) {
+	const { data: coinMetadata } = useSuiClientQuery('getCoinMetadata', {
+		coinType: change.coinType,
+	});
+
+	const amount = () => {
+		if (!coinMetadata) return '-';
+
+		return onChainAmountToFloat(change.amount, coinMetadata.decimals);
+	};
+	if (!coinMetadata) return <div>Loading...</div>;
+
+	return (
+		<PreviewCard.Root>
+			<PreviewCard.Body>
+				<>
+					{coinMetadata.iconUrl && (
+						<img src={coinMetadata.iconUrl as string} alt={coinMetadata.name} />
+					)}
+					<p>
+						<span className={`${Number(amount()) > 0.0 ? 'text-green-300' : 'text-red-700'}`}>
+							{amount()}{' '}
+						</span>{' '}
+						{coinMetadata.symbol} ({change.coinType})
+					</p>
+				</>
+			</PreviewCard.Body>
+			<PreviewCard.Footer owner={change.owner} />
+		</PreviewCard.Root>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/BalanceChanges.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/BalanceChanges.tsx
@@ -24,8 +24,9 @@ function ChangedBalance({ change }: { change: BalanceChange }) {
 
 	const amount = () => {
 		if (!coinMetadata) return '-';
+		const amt = onChainAmountToFloat(change.amount, coinMetadata.decimals);
 
-		return onChainAmountToFloat(change.amount, coinMetadata.decimals);
+		return `${amt && amt > 0.0 ? '+' : ''}${amt}`;
 	};
 	if (!coinMetadata) return <div>Loading...</div>;
 

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Events.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Events.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiEvent } from '@mysten/sui.js/src/client';
+import { ReactNode } from 'react';
+
+import { Textarea } from '@/components/ui/textarea';
+
+import { ObjectLink } from '../ObjectLink';
+import PreviewCard from '../PreviewCard';
+
+export function Events({ events }: { events: SuiEvent[] }) {
+	if (events.length === 0) {
+		return <div>No events were emitted.</div>;
+	}
+
+	return (
+		<div>
+			{events.map((event, index) => (
+				<Event key={index} event={event} />
+			))}
+		</div>
+	);
+}
+
+export function Event({ event }: { event: SuiEvent }) {
+	const fields: Record<string, ReactNode> = {
+		'Package ID': <ObjectLink inputObject={event.packageId} />,
+		Sender: <ObjectLink owner={{ AddressOwner: event.sender }} />,
+		Data: event.parsedJson ? (
+			<Textarea value={JSON.stringify(event.parsedJson, null, 2)} rows={6} readOnly />
+		) : (
+			'-'
+		),
+	};
+
+	return (
+		<PreviewCard.Root>
+			<PreviewCard.Body>
+				{Object.entries(fields).map(([key, value]) => (
+					<div key={key} className="flex items-center gap-3 mb-3 ">
+						<p className="capitalize min-w-[100px]">{key}: </p>
+						{value}
+					</div>
+				))}
+			</PreviewCard.Body>
+			<PreviewCard.Footer>
+				<p>
+					Event Type: <strong>{event.type}</strong>
+				</p>
+			</PreviewCard.Footer>
+		</PreviewCard.Root>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Events.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Events.tsx
@@ -36,6 +36,11 @@ export function Event({ event }: { event: SuiEvent }) {
 
 	return (
 		<PreviewCard.Root>
+			<PreviewCard.Header>
+				<p>
+					Event Type: <strong>{event.type}</strong>
+				</p>
+			</PreviewCard.Header>
 			<PreviewCard.Body>
 				{Object.entries(fields).map(([key, value]) => (
 					<div key={key} className="flex items-center gap-3 mb-3 ">
@@ -44,11 +49,6 @@ export function Event({ event }: { event: SuiEvent }) {
 					</div>
 				))}
 			</PreviewCard.Body>
-			<PreviewCard.Footer>
-				<p>
-					Event Type: <strong>{event.type}</strong>
-				</p>
-			</PreviewCard.Footer>
 		</PreviewCard.Root>
 	);
 }

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/ObjectChanges.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/ObjectChanges.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiObjectChange } from '@mysten/sui.js/src/client';
+
+import { ObjectLink } from '../ObjectLink';
+import PreviewCard from '../PreviewCard';
+
+const objectTypes: Record<string, Record<string, string>> = {
+	published: {
+		title: 'Published',
+		classes: 'text-green-800 bg-green-200',
+	},
+	created: {
+		title: 'Created',
+		classes: 'text-green-800 bg-green-200',
+	},
+	wrapped: {
+		title: 'Wrapped',
+		classes: 'text-gray-900 bg-gray-100',
+	},
+	mutated: {
+		title: 'Mutated',
+		classes: 'text-yellow-800 bg-yellow-50',
+	},
+	deleted: {
+		title: 'Deleted',
+		classes: 'text-red-800 bg-red-50',
+	},
+	transferred: {},
+};
+
+// SPDX-License-Identifier: Apache-2.0
+export function ObjectChanges({ objects }: { objects: SuiObjectChange[] }) {
+	return (
+		<div className="grid grid-cols-1 gap-5">
+			{objects.map((object, index) => (
+				<ChangedObject key={index} object={object} />
+			))}
+		</div>
+	);
+}
+
+function ChangedObject({ object }: { object: SuiObjectChange }) {
+	const objectType = objectTypes[object.type];
+
+	return (
+		<PreviewCard.Root>
+			<PreviewCard.Body>
+				<>
+					<span className={`${objectType?.classes} px-2 py-0.5 rounded`}>{objectType?.title}</span>
+					<div className="flex gap-3 items-center break-words my-2">
+						Type:{' '}
+						<ObjectLink
+							type={'objectType' in object ? object.objectType : ''}
+							className="break-words"
+						/>
+					</div>
+
+					<label className="flex gap-3 items-center flex-wrap break-words">
+						Object ID: <ObjectLink object={object} />
+					</label>
+				</>
+			</PreviewCard.Body>
+
+			<PreviewCard.Footer owner={'owner' in object ? object.owner : undefined} />
+		</PreviewCard.Root>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Overview.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Overview.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useSuiClientContext } from '@mysten/dapp-kit';
 import { DryRunTransactionBlockResponse, GasCostSummary } from '@mysten/sui.js/src/client';
 import { ReactNode } from 'react';
 
@@ -23,7 +24,9 @@ const calculateGas = (gas: GasCostSummary, gasPrice: string): string => {
 };
 
 export function Overview({ output }: { output: DryRunTransactionBlockResponse }) {
+	const { network } = useSuiClientContext();
 	const metadata: Record<string, ReactNode> = {
+		network,
 		status:
 			output.effects.status?.status === 'success'
 				? '✅ Transaction dry run executed succesfully!'

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Overview.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Overview.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DryRunTransactionBlockResponse, GasCostSummary } from '@mysten/sui.js/src/client';
+import { ReactNode } from 'react';
+
+import { ObjectLink } from '../ObjectLink';
+import { onChainAmountToFloat } from '../utils';
+
+const calculateGas = (gas: GasCostSummary, gasPrice: string): string => {
+	return (
+		onChainAmountToFloat(
+			(
+				BigInt(gasPrice) +
+				BigInt(gas.computationCost) +
+				BigInt(gas.nonRefundableStorageFee) +
+				BigInt(gas.storageCost) -
+				BigInt(gas.storageRebate)
+			).toString(),
+			9,
+		)?.toString() || '-'
+	);
+};
+
+export function Overview({ output }: { output: DryRunTransactionBlockResponse }) {
+	const metadata: Record<string, ReactNode> = {
+		status:
+			output.effects.status?.status === 'success'
+				? '✅ Transaction dry run executed succesfully!'
+				: output.effects.status?.status === 'failure'
+				? '❌ Transaction failed to execute!'
+				: null,
+
+		sender: (
+			<span className="flex gap-2 items-center">
+				<ObjectLink
+					owner={{
+						AddressOwner: output.input.sender,
+					}}
+				/>
+			</span>
+		),
+		epoch: output.effects.executedEpoch,
+		gas: calculateGas(output.effects.gasUsed, output.input.gasData.price) + ' SUI',
+	};
+
+	return (
+		<div className="border p-3 w-full rounded">
+			{Object.entries(metadata).map(([key, value]) => (
+				<div key={key} className="flex items-center gap-3 ">
+					<span className="capitalize">{key}: </span>
+					{value}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Transactions.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Transactions.tsx
@@ -91,8 +91,9 @@ const FOOTERS: Record<string, string> = {
 	TransferObjects: 'TransferObjects (transfers the list of objects to the specified address)',
 	SplitCoins: 'SplitCoins (splits the coin into multiple coins)',
 	MergeCoins: 'MergeCoins (merges the coins into a single coin)',
-	Publish: 'Publishes a new package',
-	Upgrade: 'Upgrades a package',
+	Publish: 'Publish (publishes a new package)',
+	Upgrade: 'Upgrade (upgrades a package)',
+	MakeMoveVec: 'MakeMoveVec (creates a vector of Move objects)',
 };
 
 function Transaction({
@@ -179,6 +180,16 @@ function Transaction({
 
 					{('Publish' in transaction || 'Upgrade' in transaction) && (
 						<>{JSON.stringify(transaction)}</>
+					)}
+
+					{'MakeMoveVec' in transaction && (
+						<>
+							{/* TODO: Create a sample tx with MakeMoveVec to render this better. */}
+							<div>
+								<label>Objects: </label>
+								{JSON.stringify(transaction.MakeMoveVec)}
+							</div>
+						</>
 					)}
 				</>
 			</PreviewCard.Body>

--- a/dapps/multisig-toolkit/src/components/preview-effects/partials/Transactions.tsx
+++ b/dapps/multisig-toolkit/src/components/preview-effects/partials/Transactions.tsx
@@ -1,0 +1,187 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	SuiArgument,
+	SuiCallArg,
+	SuiTransaction,
+	TransactionBlockData,
+} from '@mysten/sui.js/src/client';
+import { ReactNode } from 'react';
+
+import { ObjectLink } from '../ObjectLink';
+import PreviewCard from '../PreviewCard';
+
+export function Transactions({ inputs }: { inputs: TransactionBlockData }) {
+	if (inputs.transaction.kind !== 'ProgrammableTransaction') return null;
+
+	return (
+		<div className="">
+			{inputs.transaction.transactions.map((transaction, index) => (
+				<Transaction key={index} transaction={transaction} inputs={inputs} index={index} />
+			))}
+		</div>
+	);
+}
+
+const getCallArgDisplay = (argument: SuiCallArg | undefined) => {
+	if (!argument) return null;
+	if (typeof argument === 'string') return argument;
+
+	return (
+		<PreviewCard.Root>
+			<PreviewCard.Body>
+				{Object.entries(argument)
+					.filter(([key, value]) => value !== null)
+					.map(([key, value]) => (
+						<div key={key} className="flex items-center flex-shrink-0 gap-3 mb-3 justify-stretch ">
+							<p className="capitalize min-w-[100px] flex-shrink-0">{key}: </p>
+							{key === 'objectId' ? (
+								<ObjectLink inputObject={value as string} />
+							) : typeof value === 'object' ? (
+								JSON.stringify(value)
+							) : (
+								(value as ReactNode)
+							)}
+						</div>
+					))}
+			</PreviewCard.Body>
+		</PreviewCard.Root>
+	);
+};
+
+const getSuiArgumentDisplay = (argument: SuiArgument, inputs: SuiCallArg[]) => {
+	if (typeof argument === 'string') return argument;
+
+	if ('Input' in argument) {
+		return getCallArgDisplay(inputs[argument.Input]);
+	}
+
+	return (
+		<PreviewCard.Root>
+			<PreviewCard.Body>{JSON.stringify(argument)}</PreviewCard.Body>
+		</PreviewCard.Root>
+	);
+};
+
+const renderArguments = (callArgs: SuiArgument[], inputs: SuiCallArg[]) => {
+	return (
+		<div className="flex overflow-x-auto gap-3 my-3">
+			{callArgs.map((arg, index) => (
+				<div key={index} className="flex-shrink-0">
+					{getSuiArgumentDisplay(arg, inputs)}
+				</div>
+			))}
+		</div>
+	);
+};
+
+const renderFooter = (type: string, index: number) => {
+	return (
+		<PreviewCard.Header>
+			<p>
+				{index}. Type: <strong>{type}</strong>
+			</p>
+		</PreviewCard.Header>
+	);
+};
+
+const FOOTERS: Record<string, string> = {
+	MoveCall: "MoveCall (Direct Call to a Smart Contract's function)",
+	TransferObjects: 'TransferObjects (transfers the list of objects to the specified address)',
+	SplitCoins: 'SplitCoins (splits the coin into multiple coins)',
+	MergeCoins: 'MergeCoins (merges the coins into a single coin)',
+	Publish: 'Publishes a new package',
+	Upgrade: 'Upgrades a package',
+};
+
+function Transaction({
+	transaction,
+	inputs,
+	index,
+}: {
+	transaction: SuiTransaction;
+	inputs: TransactionBlockData;
+	index: number;
+}) {
+	const inputList = () => {
+		if (inputs.transaction.kind === 'ProgrammableTransaction') {
+			return inputs.transaction.inputs;
+		}
+		return [];
+	};
+
+	return (
+		<PreviewCard.Root className="mb-6">
+			{renderFooter(FOOTERS[Object.keys(transaction)[0]], index)}
+			<PreviewCard.Body>
+				<>
+					{'MoveCall' in transaction && (
+						<>
+							<div className="mb-3">
+								Target:{' '}
+								{`${transaction.MoveCall.package}::${transaction.MoveCall.module}::${transaction.MoveCall.function}`}
+							</div>
+							{transaction.MoveCall.type_arguments &&
+								transaction.MoveCall.type_arguments.length > 0 && (
+									<div className="mb-3">
+										<label>Type Arguments: </label>[{transaction.MoveCall.type_arguments.join(', ')}
+										]
+									</div>
+								)}
+
+							{transaction.MoveCall.arguments && transaction.MoveCall.arguments.length > 0 && (
+								<div>
+									<label>Inputs: </label>
+									{renderArguments(transaction.MoveCall.arguments, inputList())}
+								</div>
+							)}
+						</>
+					)}
+
+					{'TransferObjects' in transaction && (
+						<>
+							<div>
+								<label>Objects: </label>
+								{renderArguments(transaction.TransferObjects[0], inputList())}
+
+								<label>Transfer to:</label>
+								{renderArguments([transaction.TransferObjects[1]], inputList())}
+							</div>
+						</>
+					)}
+
+					{'SplitCoins' in transaction && (
+						<>
+							<div>
+								<label>From Coin: </label>
+								{renderArguments([transaction.SplitCoins[0]], inputList())}
+							</div>
+							<div>
+								<label>Splits into: </label>
+								{renderArguments(transaction.SplitCoins[1], inputList())}
+							</div>
+						</>
+					)}
+
+					{'MergeCoins' in transaction && (
+						<>
+							<div>
+								<label>To Coin: </label>
+								{renderArguments([transaction.MergeCoins[0]], inputList())}
+							</div>
+							<div>
+								<label>From coins: </label>
+								{renderArguments(transaction.MergeCoins[1], inputList())}
+							</div>
+						</>
+					)}
+
+					{('Publish' in transaction || 'Upgrade' in transaction) && (
+						<>{JSON.stringify(transaction)}</>
+					)}
+				</>
+			</PreviewCard.Body>
+		</PreviewCard.Root>
+	);
+}

--- a/dapps/multisig-toolkit/src/components/preview-effects/utils.ts
+++ b/dapps/multisig-toolkit/src/components/preview-effects/utils.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+export const onChainAmountToFloat = (amount: string, decimals: number) => {
+	if (!decimals) return undefined;
+	const total = parseFloat(amount);
+
+	return total / Math.pow(10, decimals);
+};
+
+export const formatAddress = (address: string) => {
+	return `${address.substring(0, 4)}...${address.slice(-10)}`;
+};

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -43,6 +43,7 @@ export default function OfflineSigner() {
 		if (!currentAccount?.chains[0]) return;
 
 		selectNetwork(currentAccount?.chains[0]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [currentAccount]);
 
 	// runs a dry-run for the transaction based on the connected wallet.
@@ -111,7 +112,7 @@ export default function OfflineSigner() {
 						</div>
 						{dryRunData && (
 							<>
-								<EffectsPreview client={client} output={dryRunData} />
+								<EffectsPreview output={dryRunData} />
 							</>
 						)}
 					</div>

--- a/dapps/multisig-toolkit/src/routes/offline-signer.tsx
+++ b/dapps/multisig-toolkit/src/routes/offline-signer.tsx
@@ -1,14 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCurrentAccount, useSignTransactionBlock } from '@mysten/dapp-kit';
-import { getFullnodeUrl, SuiClient, SuiClientOptions } from '@mysten/sui.js/client';
+import {
+	useCurrentAccount,
+	useSignTransactionBlock,
+	useSuiClient,
+	useSuiClientContext,
+} from '@mysten/dapp-kit';
 import { TransactionBlock } from '@mysten/sui.js/transactions';
 import { useMutation } from '@tanstack/react-query';
 import { AlertCircle, Terminal } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ConnectWallet } from '@/components/connect';
+import { EffectsPreview } from '@/components/preview-effects/EffectsPreview';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -16,6 +21,10 @@ import { Textarea } from '@/components/ui/textarea';
 
 export default function OfflineSigner() {
 	const currentAccount = useCurrentAccount();
+
+	const client = useSuiClient();
+	const { selectNetwork } = useSuiClientContext();
+
 	const { mutateAsync: signTransactionBlock } = useSignTransactionBlock();
 	const [tab, setTab] = useState<'transaction' | 'signature'>('transaction');
 	const [bytes, setBytes] = useState('');
@@ -30,12 +39,11 @@ export default function OfflineSigner() {
 		},
 	});
 
-	// supported networks.
-	const clientOptions: Record<`${string}:${string}`, SuiClientOptions> = {
-		'sui:testnet': { url: getFullnodeUrl('testnet') },
-		'sui:mainnet': { url: getFullnodeUrl('mainnet') },
-		'sui:devnet': { url: getFullnodeUrl('devnet') },
-	};
+	useEffect(() => {
+		if (!currentAccount?.chains[0]) return;
+
+		selectNetwork(currentAccount?.chains[0]);
+	}, [currentAccount]);
 
 	// runs a dry-run for the transaction based on the connected wallet.
 	const {
@@ -43,14 +51,10 @@ export default function OfflineSigner() {
 		data: dryRunData,
 		isPending: dryRunLoading,
 		error,
-		reset,
 	} = useMutation({
 		mutationKey: ['dry-run'],
 		mutationFn: async () => {
-			if (!currentAccount?.chains[0]) throw new Error('No chain detected for the account.');
-			const client = new SuiClient(
-				clientOptions[currentAccount?.chains.filter((x) => x.startsWith('sui'))[0]],
-			);
+			if (!client) throw new Error('No chain detected for the account.');
 
 			return await client.dryRunTransactionBlock({
 				transactionBlock: bytes,
@@ -91,8 +95,8 @@ export default function OfflineSigner() {
 
 				<TabsContent value="transaction">
 					<div className="flex flex-col items-start gap-4">
-						<Textarea value={bytes} onChange={(e) => setBytes(e.target.value)} />
-						<div className="flex gap-4">
+						<Textarea value={bytes} onChange={(e) => setBytes(e.target.value.trim())} />
+						<div className="flex gap-4 mb-3">
 							<ConnectWallet />
 							<Button disabled={!currentAccount || !bytes || isPending} onClick={() => mutate()}>
 								Sign Transaction
@@ -107,10 +111,7 @@ export default function OfflineSigner() {
 						</div>
 						{dryRunData && (
 							<>
-								<Button variant="link" size="sm" onClick={() => reset()}>
-									Hide
-								</Button>
-								<Textarea value={JSON.stringify(dryRunData, null, 4)} rows={20} />
+								<EffectsPreview client={client} output={dryRunData} />
 							</>
 						)}
 					</div>

--- a/dapps/multisig-toolkit/src/routes/root.tsx
+++ b/dapps/multisig-toolkit/src/routes/root.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Toaster } from 'react-hot-toast';
 import { Outlet } from 'react-router-dom';
 
 import { Header } from '@/components/header';
@@ -9,6 +10,7 @@ import { Warning } from '@/components/warning';
 export function Root() {
 	return (
 		<div>
+			<Toaster position="bottom-center" />
 			<Header />
 			<div className="container py-8">
 				<Outlet />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1029,6 +1029,9 @@ importers:
       react-hook-form:
         specifier: ^7.45.2
         version: 7.45.2(react@18.2.0)
+      react-hot-toast:
+        specifier: ^2.4.1
+        version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
       react-router-dom:
         specifier: ^6.14.2
         version: 6.14.2(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## Description 

Introduces effects preview in an easy to read way in the offline signer.

Before:
<img width="1271" alt="Screenshot 2024-02-05 at 8 27 55 PM" src="https://github.com/MystenLabs/sui/assets/44404359/c3439024-d70f-4617-929e-f99d25f74dcc">

After:
<img width="1324" alt="Screenshot 2024-02-05 at 8 28 16 PM" src="https://github.com/MystenLabs/sui/assets/44404359/65050922-e60b-4fcc-8eef-8d63f775bd62">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
