### PR TITLE
Hide all access to AuthorityStore behind the execution cache traits

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -11,6 +11,7 @@
 //! [`Simulacrum`]: crate::Simulacrum
 
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use fastcrypto::traits::Signer;
@@ -472,8 +473,8 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     fn get_transaction(
         &self,
         tx_digest: &sui_types::digests::TransactionDigest,
-    ) -> sui_types::storage::error::Result<Option<VerifiedTransaction>> {
-        Ok(self.store().get_transaction(tx_digest))
+    ) -> sui_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
+        Ok(self.store().get_transaction(tx_digest).map(Arc::new))
     }
 
     fn get_transaction_effects(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_store_types::{StoreObject, StoreObjectWrapper};
+use crate::in_mem_execution_cache::NotifyReadWrapper;
 use crate::transaction_outputs::TransactionOutputs;
 use crate::verify_indexes::verify_indexes;
 use anyhow::anyhow;
@@ -12,7 +12,6 @@ use chrono::prelude::*;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::hash::MultisetHash;
-use futures::stream::FuturesUnordered;
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
 use move_core_types::annotated_value::MoveStructLayout;
@@ -31,13 +30,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
     fs,
     pin::Pin,
     sync::Arc,
-    thread, vec,
+    vec,
 };
 use sui_config::node::{OverloadThresholdConfig, StateDebugDumpConfig};
 use sui_config::NodeConfig;
@@ -99,7 +98,7 @@ use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents, CheckpointContentsDigest,
     CheckpointDigest, CheckpointRequest, CheckpointRequestV2, CheckpointResponse,
     CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSummary, CheckpointSummaryResponse,
-    CheckpointTimestamp, VerifiedCheckpoint,
+    CheckpointTimestamp, ECMHLiveObjectSetDigest, VerifiedCheckpoint,
 };
 use sui_types::messages_consensus::AuthorityCapabilities;
 use sui_types::messages_grpc::{
@@ -125,7 +124,7 @@ use sui_types::{
     SUI_SYSTEM_ADDRESS,
 };
 use sui_types::{is_system_package, TypeTag};
-use typed_store::{Map, TypedStoreError};
+use typed_store::TypedStoreError;
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
@@ -138,13 +137,16 @@ use crate::checkpoints::CheckpointStore;
 use crate::consensus_adapter::ConsensusAdapter;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::execution_driver::execution_process;
-use crate::in_mem_execution_cache::{ExecutionCache, ExecutionCacheRead, ExecutionCacheWrite};
+use crate::in_mem_execution_cache::{
+    CheckpointCache, ExecutionCache, ExecutionCacheRead, ExecutionCacheReconfigAPI,
+    ExecutionCacheWrite, StateSyncAPI,
+};
 use crate::metrics::LatencyObserver;
 use crate::metrics::RateTracker;
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::overload_monitor::{overload_monitor, AuthorityOverloadInfo};
 use crate::stake_aggregator::StakeAggregator;
-use crate::state_accumulator::{StateAccumulator, WrappedObject};
+use crate::state_accumulator::{AccumulatorStore, StateAccumulator, WrappedObject};
 use crate::subscription_handler::SubscriptionHandler;
 use crate::transaction_input_loader::TransactionInputLoader;
 use crate::transaction_manager::TransactionManager;
@@ -659,6 +661,34 @@ impl AuthorityMetrics {
 ///
 pub type StableSyncAuthoritySigner = Pin<Arc<dyn Signer<AuthoritySignature> + Send + Sync>>;
 
+struct ExecutionCacheTraitPointers {
+    cache_reader: Arc<dyn ExecutionCacheRead>,
+    backing_store: Arc<dyn BackingStore + Send + Sync>,
+    backing_package_store: Arc<dyn BackingPackageStore + Send + Sync>,
+    effects_notify_read: NotifyReadWrapper<ExecutionCache>,
+    object_store: Arc<dyn ObjectStore + Send + Sync>,
+    reconfig_api: Arc<dyn ExecutionCacheReconfigAPI>,
+    accumulator_store: Arc<dyn AccumulatorStore>,
+    checkpoint_cache: Arc<dyn CheckpointCache>,
+    state_sync_store: Arc<dyn StateSyncAPI>,
+}
+
+impl ExecutionCacheTraitPointers {
+    fn new(cache: &Arc<ExecutionCache>) -> Self {
+        Self {
+            cache_reader: cache.clone(),
+            backing_store: cache.clone(),
+            backing_package_store: cache.clone(),
+            effects_notify_read: cache.clone().as_notify_read_wrapper(),
+            object_store: cache.clone(),
+            reconfig_api: cache.clone(),
+            accumulator_store: cache.clone(),
+            checkpoint_cache: cache.clone(),
+            state_sync_store: cache.clone(),
+        }
+    }
+}
+
 pub struct AuthorityState {
     // Fixed size, static, identity of the authority
     /// The name of this authority.
@@ -669,8 +699,7 @@ pub struct AuthorityState {
     /// The database
     input_loader: TransactionInputLoader,
     execution_cache: Arc<ExecutionCache>,
-
-    pub database: Arc<AuthorityStore>, // TODO: remove pub
+    execution_cache_trait_pointers: ExecutionCacheTraitPointers,
 
     epoch_store: ArcSwap<AuthorityPerEpochStore>,
 
@@ -1098,7 +1127,7 @@ impl AuthorityState {
     }
 
     async fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        self.database
+        self.execution_cache
             .check_owned_object_locks_exist(owned_object_refs)
     }
 
@@ -1126,7 +1155,7 @@ impl AuthorityState {
             tx_digest,
             effects,
             expected_effects_digest,
-            &self.database,
+            &self.execution_cache,
             &epoch_store,
             inner_temporary_store,
             certificate,
@@ -1147,7 +1176,7 @@ impl AuthorityState {
         let digest = *certificate.digest();
         // The cert could have been processed by a concurrent attempt of the same cert, so check if
         // the effects have already been written.
-        if let Some(effects) = self.database.get_executed_effects(&digest)? {
+        if let Some(effects) = self.execution_cache.get_executed_effects(&digest)? {
             tx_guard.release();
             return Ok((effects, None));
         }
@@ -1253,7 +1282,7 @@ impl AuthorityState {
 
             // double check that the signature verifier always matches the authenticator state
             if cfg!(debug_assertions) {
-                let authenticator_state = get_authenticator_state(&self.database)
+                let authenticator_state = get_authenticator_state(&self.execution_cache)
                     .expect("Read cannot fail")
                     .expect("Authenticator state must exist");
 
@@ -2461,6 +2490,7 @@ impl AuthorityState {
             archive_readers,
         );
         let input_loader = TransactionInputLoader::new(execution_cache.clone());
+        let cache_pointers = ExecutionCacheTraitPointers::new(&execution_cache);
         let epoch = epoch_store.epoch();
         let state = Arc::new(AuthorityState {
             name,
@@ -2469,7 +2499,7 @@ impl AuthorityState {
             epoch_store: ArcSwap::new(epoch_store.clone()),
             input_loader,
             execution_cache,
-            database: store,
+            execution_cache_trait_pointers: cache_pointers,
             indexes,
             subscription_handler: Arc::new(SubscriptionHandler::new(prometheus_registry)),
             checkpoint_store,
@@ -2507,34 +2537,55 @@ impl AuthorityState {
         state
     }
 
-    // This method only exists for sui-replay. Normally you should get one of the specific
-    // traits (below) instead.
+    // Use this method only if one of the trait-specific methods below does not work.
+    // (For instance if you need an implementation of more than one of these traits
+    // simulatenously).
     pub fn get_execution_cache(&self) -> Arc<ExecutionCache> {
         self.execution_cache.clone()
     }
 
     // TODO: Consolidate our traits to reduce the number of methods here.
-    pub fn get_cache_reader(&self) -> Arc<dyn ExecutionCacheRead> {
-        self.execution_cache.clone()
+    pub fn get_cache_reader(&self) -> &Arc<dyn ExecutionCacheRead> {
+        &self.execution_cache_trait_pointers.cache_reader
     }
 
-    pub fn get_backing_store(&self) -> Arc<dyn BackingStore> {
-        self.execution_cache.clone()
+    pub fn get_backing_store(&self) -> &Arc<dyn BackingStore + Send + Sync> {
+        &self.execution_cache_trait_pointers.backing_store
     }
 
-    pub fn get_backing_package_store(&self) -> Arc<dyn BackingPackageStore> {
-        self.execution_cache.clone()
+    pub fn get_backing_package_store(&self) -> &Arc<dyn BackingPackageStore + Send + Sync> {
+        &self.execution_cache_trait_pointers.backing_package_store
     }
 
-    pub fn get_effects_notify_read(&self) -> Arc<dyn EffectsNotifyRead> {
-        Arc::new(self.execution_cache.clone().as_notify_read_wrapper())
+    pub fn get_effects_notify_read(&self) -> &NotifyReadWrapper<ExecutionCache> {
+        &self.execution_cache_trait_pointers.effects_notify_read
     }
 
-    pub fn get_object_store(&self) -> Arc<dyn ObjectStore> {
-        self.execution_cache.clone()
+    pub fn get_object_store(&self) -> &Arc<dyn ObjectStore + Send + Sync> {
+        &self.execution_cache_trait_pointers.object_store
     }
 
-    pub async fn prune_checkpoints_for_eligible_epochs(
+    pub fn get_reconfig_api(&self) -> &Arc<dyn ExecutionCacheReconfigAPI> {
+        &self.execution_cache_trait_pointers.reconfig_api
+    }
+
+    pub fn get_accumulator_store(&self) -> &Arc<dyn AccumulatorStore> {
+        &self.execution_cache_trait_pointers.accumulator_store
+    }
+
+    pub fn get_checkpoint_cache(&self) -> &Arc<dyn CheckpointCache> {
+        &self.execution_cache_trait_pointers.checkpoint_cache
+    }
+
+    pub fn get_state_sync_store(&self) -> &Arc<dyn StateSyncAPI> {
+        &self.execution_cache_trait_pointers.state_sync_store
+    }
+
+    pub fn database_for_testing(&self) -> &Arc<AuthorityStore> {
+        self.execution_cache.store_for_testing()
+    }
+
+    pub async fn prune_checkpoints_for_eligible_epochs_for_testing(
         &self,
         config: NodeConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
@@ -2542,9 +2593,9 @@ impl AuthorityState {
         let archive_readers =
             ArchiveReaderBalancer::new(config.archive_reader_config(), &Registry::default())?;
         AuthorityStorePruner::prune_checkpoints_for_eligible_epochs(
-            &self.database.perpetual_tables,
+            &self.execution_cache.store_for_testing().perpetual_tables,
             &self.checkpoint_store,
-            &self.database.objects_lock_table,
+            &self.execution_cache.store_for_testing().objects_lock_table,
             config.authority_store_pruning_config,
             metrics,
             config.indirect_objects_threshold,
@@ -2573,16 +2624,11 @@ impl AuthorityState {
     // guard as an argument to ensure that this is the case.
     fn clear_object_per_epoch_marker_table(
         &self,
-        _execution_guard: &ExecutionLockWriteGuard<'_>,
+        execution_guard: &ExecutionLockWriteGuard<'_>,
     ) -> SuiResult<()> {
-        // We can safely delete all entries in the per epoch marker table since this is only called
-        // at epoch boundaries (during reconfiguration). Therefore any entries that currently
-        // exist can be removed. Because of this we can use the `schedule_delete_all` method.
-        Ok(self
-            .database
-            .perpetual_tables
-            .object_per_epoch_marker_table
-            .schedule_delete_all()?)
+        self.execution_cache
+            .clear_object_per_epoch_marker_table(execution_guard);
+        Ok(())
     }
 
     fn create_owner_index_if_empty(
@@ -2689,9 +2735,8 @@ impl AuthorityState {
                 .protocol_version(),
         );
         self.clear_object_per_epoch_marker_table(&execution_lock)?;
-        self.db()
-            .set_epoch_start_configuration(&epoch_start_configuration)
-            .await?;
+        self.execution_cache
+            .set_epoch_start_configuration(&epoch_start_configuration)?;
         if let Some(checkpoint_path) = &self.db_checkpoint_config.checkpoint_path {
             if self
                 .db_checkpoint_config
@@ -2737,138 +2782,8 @@ impl AuthorityState {
         cur_epoch_store: &AuthorityPerEpochStore,
         new_protocol_version: ProtocolVersion,
     ) {
-        let old_simplified_unwrap_then_delete = cur_epoch_store
-            .protocol_config()
-            .simplified_unwrap_then_delete();
-        let new_simplified_unwrap_then_delete = ProtocolConfig::get_for_version(
-            new_protocol_version,
-            cur_epoch_store.get_chain_identifier().chain(),
-        )
-        .simplified_unwrap_then_delete();
-        // If in the new epoch the simplified_unwrap_then_delete is enabled for the first time,
-        // we re-accumulate state root.
-        let should_reaccumulate =
-            !old_simplified_unwrap_then_delete && new_simplified_unwrap_then_delete;
-        if !should_reaccumulate {
-            return;
-        }
-        info!("[Re-accumulate] simplified_unwrap_then_delete is enabled in the new protocol version, re-accumulating state hash");
-        let cur_time = Instant::now();
-        thread::scope(|s| {
-            let pending_tasks = FuturesUnordered::new();
-            // Shard the object IDs into different ranges so that we can process them in parallel.
-            // We divide the range into 2^BITS number of ranges. To do so we use the highest BITS bits
-            // to mark the starting/ending point of the range. For example, when BITS = 5, we
-            // divide the range into 32 ranges, and the first few ranges are:
-            // 00000000_.... to 00000111_....
-            // 00001000_.... to 00001111_....
-            // 00010000_.... to 00010111_....
-            // and etc.
-            const BITS: u8 = 5;
-            for index in 0u8..(1 << BITS) {
-                pending_tasks.push(s.spawn(move || {
-                    let mut id_bytes = [0; ObjectID::LENGTH];
-                    id_bytes[0] = index << (8 - BITS);
-                    let start_id = ObjectID::new(id_bytes);
-
-                    id_bytes[0] |= (1 << (8 - BITS)) - 1;
-                    for element in id_bytes.iter_mut().skip(1) {
-                        *element = u8::MAX;
-                    }
-                    let end_id = ObjectID::new(id_bytes);
-
-                    info!(
-                        "[Re-accumulate] Scanning object ID range {:?}..{:?}",
-                        start_id, end_id
-                    );
-                    let mut prev = (
-                        ObjectKey::min_for_id(&ObjectID::ZERO),
-                        StoreObjectWrapper::V1(StoreObject::Deleted),
-                    );
-                    let mut object_scanned: u64 = 0;
-                    let mut wrapped_objects_to_remove = vec![];
-                    for db_result in self.database.perpetual_tables.objects.safe_range_iter(
-                        ObjectKey::min_for_id(&start_id)..=ObjectKey::max_for_id(&end_id),
-                    ) {
-                        match db_result {
-                            Ok((object_key, object)) => {
-                                object_scanned += 1;
-                                if object_scanned % 100000 == 0 {
-                                    info!(
-                                        "[Re-accumulate] Task {}: object scanned: {}",
-                                        index, object_scanned,
-                                    );
-                                }
-                                if matches!(prev.1.inner(), StoreObject::Wrapped)
-                                    && object_key.0 != prev.0 .0
-                                {
-                                    wrapped_objects_to_remove
-                                        .push(WrappedObject::new(prev.0 .0, prev.0 .1));
-                                }
-
-                                prev = (object_key, object);
-                            }
-                            Err(err) => {
-                                warn!("Object iterator encounter RocksDB error {:?}", err);
-                                return Err(err);
-                            }
-                        }
-                    }
-                    if matches!(prev.1.inner(), StoreObject::Wrapped) {
-                        wrapped_objects_to_remove.push(WrappedObject::new(prev.0 .0, prev.0 .1));
-                    }
-                    info!(
-                        "[Re-accumulate] Task {}: object scanned: {}, wrapped objects: {}",
-                        index,
-                        object_scanned,
-                        wrapped_objects_to_remove.len(),
-                    );
-                    Ok((wrapped_objects_to_remove, object_scanned))
-                }));
-            }
-            let (last_checkpoint_of_epoch, cur_accumulator) = self
-                .database
-                .get_root_state_accumulator(cur_epoch_store.epoch());
-            let (accumulator, total_objects_scanned, total_wrapped_objects) =
-                pending_tasks.into_iter().fold(
-                    (cur_accumulator, 0u64, 0usize),
-                    |(mut accumulator, total_objects_scanned, total_wrapped_objects), task| {
-                        let (wrapped_objects_to_remove, object_scanned) =
-                            task.join().unwrap().unwrap();
-                        accumulator.remove_all(
-                            wrapped_objects_to_remove
-                                .iter()
-                                .map(|wrapped| bcs::to_bytes(wrapped).unwrap().to_vec())
-                                .collect::<Vec<Vec<u8>>>(),
-                        );
-                        (
-                            accumulator,
-                            total_objects_scanned + object_scanned,
-                            total_wrapped_objects + wrapped_objects_to_remove.len(),
-                        )
-                    },
-                );
-            info!(
-                "[Re-accumulate] Total objects scanned: {}, total wrapped objects: {}",
-                total_objects_scanned, total_wrapped_objects,
-            );
-            info!(
-                "[Re-accumulate] New accumulator value: {:?}",
-                accumulator.digest()
-            );
-            self.database
-                .perpetual_tables
-                .root_state_hash_by_epoch
-                .insert(
-                    &cur_epoch_store.epoch(),
-                    &(last_checkpoint_of_epoch, accumulator),
-                )
-                .unwrap();
-        });
-        info!(
-            "[Re-accumulate] Re-accumulating took {}seconds",
-            cur_time.elapsed().as_secs()
-        );
+        self.execution_cache
+            .maybe_reaccumulate_state_hash(cur_epoch_store, new_protocol_version);
     }
 
     #[instrument(level = "error", skip_all)]
@@ -2885,7 +2800,7 @@ impl AuthorityState {
         );
 
         if let Err(err) = self
-            .database
+            .execution_cache
             .expensive_check_sui_conservation(cur_epoch_store)
         {
             if cfg!(debug_assertions) {
@@ -2905,7 +2820,7 @@ impl AuthorityState {
                 "Performing state consistency check for epoch {}",
                 cur_epoch_store.epoch()
             );
-            self.database.expensive_check_is_consistent_state(
+            self.expensive_check_is_consistent_state(
                 checkpoint_executor,
                 accumulator,
                 cur_epoch_store,
@@ -2915,14 +2830,54 @@ impl AuthorityState {
 
         if expensive_safety_check_config.enable_secondary_index_checks() {
             if let Some(indexes) = self.indexes.clone() {
-                verify_indexes(self.database.clone(), indexes)
+                verify_indexes(&*self.execution_cache, indexes)
                     .expect("secondary indexes are inconsistent");
             }
         }
     }
 
-    pub fn db(&self) -> Arc<AuthorityStore> {
-        self.database.clone()
+    fn expensive_check_is_consistent_state(
+        &self,
+        checkpoint_executor: &CheckpointExecutor,
+        accumulator: Arc<StateAccumulator>,
+        cur_epoch_store: &AuthorityPerEpochStore,
+        panic: bool,
+    ) {
+        let live_object_set_hash = accumulator.digest_live_object_set(
+            !cur_epoch_store
+                .protocol_config()
+                .simplified_unwrap_then_delete(),
+        );
+
+        let root_state_hash: ECMHLiveObjectSetDigest = self
+            .execution_cache
+            .get_root_state_accumulator_for_epoch(cur_epoch_store.epoch())
+            .expect("Retrieving root state hash cannot fail")
+            .expect("Root state hash for epoch must exist")
+            .1
+            .digest()
+            .into();
+
+        let is_inconsistent = root_state_hash != live_object_set_hash;
+        if is_inconsistent {
+            if panic {
+                panic!(
+                    "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
+                    root_state_hash, live_object_set_hash
+                );
+            } else {
+                error!(
+                    "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
+                    root_state_hash, live_object_set_hash
+                );
+            }
+        } else {
+            info!("State consistency check passed");
+        }
+
+        if !panic {
+            checkpoint_executor.set_inconsistent_state(is_inconsistent);
+        }
     }
 
     pub fn current_epoch_for_testing(&self) -> EpochId {
@@ -2962,9 +2917,9 @@ impl AuthorityState {
         self.checkpoint_store
             .checkpoint_db(&checkpoint_path_tmp.join("checkpoints"))?;
 
-        self.database
-            .perpetual_tables
+        self.execution_cache
             .checkpoint_db(&store_checkpoint_path_tmp.join("perpetual"))?;
+
         self.committee_store
             .checkpoint_db(&checkpoint_path_tmp.join("epochs"))?;
 
@@ -3275,7 +3230,7 @@ impl AuthorityState {
             .collect::<Vec<_>>();
         let mut move_objects = vec![];
 
-        let objects = self.execution_cache.multi_get_object_by_key(&object_ids)?;
+        let objects = self.execution_cache.multi_get_objects_by_key(&object_ids)?;
 
         for (o, id) in objects.into_iter().zip(object_ids) {
             let object = o.ok_or_else(|| {
@@ -3452,8 +3407,8 @@ impl AuthorityState {
     }
 
     #[cfg(msim)]
-    pub fn get_highest_pruned_checkpoint(&self) -> SuiResult<CheckpointSequenceNumber> {
-        self.database
+    pub fn get_highest_pruned_checkpoint_for_testing(&self) -> SuiResult<CheckpointSequenceNumber> {
+        self.database_for_testing()
             .perpetual_tables
             .get_highest_pruned_checkpoint()
     }
@@ -3724,7 +3679,8 @@ impl AuthorityState {
     }
 
     pub async fn insert_genesis_object(&self, object: Object) {
-        self.database
+        // TODO(cache)
+        self.execution_cache
             .insert_genesis_object(object)
             .expect("Cannot insert genesis object")
     }
@@ -4063,7 +4019,7 @@ impl AuthorityState {
                 .unwrap_or(modules);
 
             let Some(obj_ref) = sui_framework::compare_system_package(
-                self.database.as_ref(),
+                &self.execution_cache,
                 system_package.id(),
                 &modules,
                 system_package.dependencies().to_vec(),
@@ -4515,7 +4471,8 @@ impl AuthorityState {
         // We must write tx and effects to the state sync tables so that state sync is able to
         // deliver to the transaction to CheckpointExecutor after it is included in a certified
         // checkpoint.
-        self.database
+        // TODO(cache) - state sync trait pls
+        self.execution_cache
             .insert_transaction_and_effects(&tx, &effects)
             .map_err(|err| {
                 let err: anyhow::Error = err.into();
@@ -4564,7 +4521,7 @@ impl AuthorityState {
                 continue;
             }
             info!("Reverting {:?} at the end of epoch", digest);
-            self.database.revert_state_update(&digest).await?;
+            self.execution_cache.revert_state_update(&digest)?;
         }
         info!("All uncommitted local transactions reverted");
         Ok(())
@@ -4590,7 +4547,7 @@ impl AuthorityState {
                 }
             })
             .collect::<BTreeSet<_>>();
-        DenyList::check_coin_deny_list(sender, coin_types, &self.database)?;
+        DenyList::check_coin_deny_list(sender, coin_types, &self.execution_cache)?;
         Ok(())
     }
 
@@ -4630,7 +4587,8 @@ impl AuthorityState {
             .epoch_store_for_testing()
             .protocol_config()
             .simplified_unwrap_then_delete();
-        self.database.iter_live_object_set(include_wrapped_object)
+        self.execution_cache
+            .iter_live_object_set(include_wrapped_object)
     }
 
     #[cfg(test)]
@@ -4644,25 +4602,14 @@ impl AuthorityState {
     }
 
     pub async fn prune_objects_and_compact_for_testing(&self) {
-        let pruning_config = AuthorityStorePruningConfig {
-            num_epochs_to_retain: 0,
-            ..Default::default()
-        };
-        let _ = AuthorityStorePruner::prune_objects_for_eligible_epochs(
-            &self.database.perpetual_tables,
-            &self.checkpoint_store,
-            &self.database.objects_lock_table,
-            pruning_config,
-            AuthorityStorePruningMetrics::new_for_test(),
-            usize::MAX,
-        )
-        .await;
-        let _ = AuthorityStorePruner::compact(&self.database.perpetual_tables);
+        self.execution_cache
+            .prune_objects_and_compact_for_testing(&self.checkpoint_store)
+            .await
     }
 
     /// NOTE: this function is only to be used for fuzzing and testing. Never use in prod
     pub async fn insert_objects_unsafe_for_testing_only(&self, objects: &[Object]) -> SuiResult {
-        self.database.bulk_insert_genesis_objects(objects).await?;
+        self.execution_cache.bulk_insert_genesis_objects(objects)?;
         self.execution_cache
             .force_reload_system_packages(&BuiltInFramework::all_package_ids());
         Ok(())
@@ -4762,9 +4709,9 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> SuiResult<Option<CheckpointSequenceNumber>> {
-        self.database
+        self.execution_cache
             .deprecated_get_transaction_checkpoint(&digest)
-            .map(|maybe| maybe.map(|(_epoch, checkpoint)| checkpoint))
+            .map(|res| res.map(|(_epoch, checkpoint)| checkpoint))
     }
 
     async fn get_object(
@@ -4782,7 +4729,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<CheckpointSequenceNumber>>> {
         let res = self
-            .database
+            .execution_cache
             .deprecated_multi_get_transaction_checkpoint(digests)?;
 
         Ok(res
@@ -4931,7 +4878,7 @@ impl NodeStateDump {
         tx_digest: &TransactionDigest,
         effects: &TransactionEffects,
         expected_effects_digest: TransactionEffectsDigest,
-        authority_store: &Arc<AuthorityStore>,
+        object_store: &dyn ObjectStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         inner_temporary_store: &InnerTemporaryStore,
         certificate: &VerifiedExecutableTransaction,
@@ -4946,7 +4893,7 @@ impl NodeStateDump {
         // Record all system packages at this version
         let mut relevant_system_packages = Vec::new();
         for sys_package_id in BuiltInFramework::all_package_ids() {
-            if let Some(w) = authority_store.get_object(&sys_package_id)? {
+            if let Some(w) = object_store.get_object(&sys_package_id)? {
                 relevant_system_packages.push(w)
             }
         }
@@ -4956,7 +4903,7 @@ impl NodeStateDump {
         for kind in effects.input_shared_objects() {
             match kind {
                 InputSharedObject::Mutate(obj_ref) | InputSharedObject::ReadOnly(obj_ref) => {
-                    if let Some(w) = authority_store.get_object_by_key(&obj_ref.0, obj_ref.1)? {
+                    if let Some(w) = object_store.get_object_by_key(&obj_ref.0, obj_ref.1)? {
                         shared_objects.push(w)
                     }
                 }
@@ -4968,7 +4915,7 @@ impl NodeStateDump {
         // Child objects which are read but not mutated are not tracked anywhere else
         let mut loaded_child_objects = Vec::new();
         for (id, meta) in &inner_temporary_store.loaded_runtime_objects {
-            if let Some(w) = authority_store.get_object_by_key(id, meta.version)? {
+            if let Some(w) = object_store.get_object_by_key(id, meta.version)? {
                 loaded_child_objects.push(w)
             }
         }
@@ -4976,7 +4923,7 @@ impl NodeStateDump {
         // Record all modified objects
         let mut modified_at_versions = Vec::new();
         for (id, ver) in effects.modified_at_versions() {
-            if let Some(w) = authority_store.get_object_by_key(&id, ver)? {
+            if let Some(w) = object_store.get_object_by_key(&id, ver)? {
                 modified_at_versions.push(w)
             }
         }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -11,6 +11,7 @@ use crate::authority::authority_store_types::{
     get_store_object_pair, ObjectContentDigest, StoreObject, StoreObjectPair, StoreObjectWrapper,
 };
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
+use crate::state_accumulator::AccumulatorStore;
 use crate::transaction_outputs::TransactionOutputs;
 use either::Either;
 use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
@@ -21,6 +22,7 @@ use sui_storage::mutex_table::{MutexGuard, MutexTable, RwLockGuard, RwLockTable}
 use sui_types::accumulator::Accumulator;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::UserInputError;
+use sui_types::execution::TypeLayoutStore;
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::storage::{
@@ -145,9 +147,7 @@ impl AuthorityStore {
                 *genesis.checkpoint().digest(),
                 &genesis.objects(),
             )?;
-            perpetual_tables
-                .set_epoch_start_configuration(&epoch_start_configuration)
-                .await?;
+            perpetual_tables.set_epoch_start_configuration(&epoch_start_configuration)?;
             epoch_start_configuration
         } else {
             info!("Loading epoch start config from DB");
@@ -184,6 +184,21 @@ impl AuthorityStore {
                 .with_label_values(&[&flag.to_string()])
                 .set(1);
         }
+    }
+
+    // NB: This must only be called at time of reconfiguration. We take the execution lock write
+    // guard as an argument to ensure that this is the case.
+    pub fn clear_object_per_epoch_marker_table(
+        &self,
+        _execution_guard: &ExecutionLockWriteGuard<'_>,
+    ) -> SuiResult<()> {
+        // We can safely delete all entries in the per epoch marker table since this is only called
+        // at epoch boundaries (during reconfiguration). Therefore any entries that currently
+        // exist can be removed. Because of this we can use the `schedule_delete_all` method.
+        Ok(self
+            .perpetual_tables
+            .object_per_epoch_marker_table
+            .schedule_delete_all()?)
     }
 
     pub async fn open_with_committee_for_testing(
@@ -229,7 +244,6 @@ impl AuthorityStore {
         {
             store
                 .bulk_insert_genesis_objects(genesis.objects())
-                .await
                 .expect("Cannot bulk insert genesis objects");
 
             // insert txn and effects of genesis
@@ -262,24 +276,13 @@ impl AuthorityStore {
         Ok(store)
     }
 
-    pub fn get_root_state_hash(&self, epoch: EpochId) -> SuiResult<ECMHLiveObjectSetDigest> {
+    pub fn _get_root_state_hash(&self, epoch: EpochId) -> SuiResult<ECMHLiveObjectSetDigest> {
         let acc = self
             .perpetual_tables
             .root_state_hash_by_epoch
             .get(&epoch)?
             .expect("Root state hash for this epoch does not exist");
         Ok(acc.1.digest().into())
-    }
-
-    pub fn get_root_state_accumulator(
-        &self,
-        epoch: EpochId,
-    ) -> (CheckpointSequenceNumber, Accumulator) {
-        self.perpetual_tables
-            .root_state_hash_by_epoch
-            .get(&epoch)
-            .unwrap()
-            .unwrap()
     }
 
     pub fn get_recovery_epoch_at_restart(&self) -> SuiResult<EpochId> {
@@ -512,7 +515,7 @@ impl AuthorityStore {
             .collect())
     }
 
-    pub fn get_object_ref_prior_to_key(
+    fn get_object_ref_prior_to_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
@@ -536,7 +539,7 @@ impl AuthorityStore {
         Ok(None)
     }
 
-    pub fn multi_get_object_by_key(
+    pub fn multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, SuiError> {
@@ -641,7 +644,7 @@ impl AuthorityStore {
     }
 
     /// This function should only be used for initializing genesis and should remain private.
-    pub(super) async fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> SuiResult<()> {
+    pub(crate) fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> SuiResult<()> {
         let mut batch = self.perpetual_tables.objects.batch();
         let ref_and_objects: Vec<_> = objects
             .iter()
@@ -743,13 +746,12 @@ impl AuthorityStore {
         Ok(())
     }
 
-    pub async fn set_epoch_start_configuration(
+    pub fn set_epoch_start_configuration(
         &self,
         epoch_start_configuration: &EpochStartConfiguration,
     ) -> SuiResult {
         self.perpetual_tables
-            .set_epoch_start_configuration(epoch_start_configuration)
-            .await?;
+            .set_epoch_start_configuration(epoch_start_configuration)?;
         Ok(())
     }
 
@@ -1208,7 +1210,7 @@ impl AuthorityStore {
     /// so that when we receive the checkpoint that includes it from state
     /// sync, we are able to execute the checkpoint.
     /// TODO: implement GC for transactions that are no longer needed.
-    pub async fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
+    pub fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
         let Some(effects) = self.get_executed_effects(tx_digest)? else {
             debug!("Not reverting {:?} as it was not executed", tx_digest);
             return Ok(());
@@ -1439,26 +1441,17 @@ impl AuthorityStore {
         get_sui_system_state(self.perpetual_tables.as_ref())
     }
 
-    pub fn iter_live_object_set(
-        &self,
-        include_wrapped_object: bool,
-    ) -> impl Iterator<Item = LiveObject> + '_ {
-        self.perpetual_tables
-            .iter_live_object_set(include_wrapped_object)
-    }
-
-    pub fn expensive_check_sui_conservation(
+    pub fn expensive_check_sui_conservation<T>(
         self: &Arc<Self>,
+        type_layout_store: T,
         old_epoch_store: &AuthorityPerEpochStore,
-    ) -> SuiResult {
+    ) -> SuiResult
+    where
+        T: TypeLayoutStore + Send + Copy,
+    {
         if !self.enable_epoch_sui_conservation_check {
             return Ok(());
         }
-
-        // Note that this can only be called at reconfiguration time, at which time the
-        // db is fully consistent. Therefore the system cache (in AuthorityState) has no
-        // dirty data and is not needed.
-        let cache = Arc::new(ExecutionCache::new_with_no_metrics(self.clone()));
 
         let executor = old_epoch_store.executor();
         info!("Starting SUI conservation check. This may take a while..");
@@ -1477,10 +1470,9 @@ impl AuthorityStore {
                         if count % 1_000_000 == 0 {
                             let mut task_objects = vec![];
                             mem::swap(&mut pending_objects, &mut task_objects);
-                            let cache = cache.clone();
                             pending_tasks.push(s.spawn(move || {
                                 let mut layout_resolver =
-                                    executor.type_layout_resolver(Box::new(cache.as_ref()));
+                                    executor.type_layout_resolver(Box::new(type_layout_store));
                                 let mut total_storage_rebate = 0;
                                 let mut total_sui = 0;
                                 for object in task_objects {
@@ -1508,7 +1500,7 @@ impl AuthorityStore {
                 (init.0 + result.0, init.1 + result.1)
             })
         });
-        let mut layout_resolver = executor.type_layout_resolver(Box::new(cache.as_ref()));
+        let mut layout_resolver = executor.type_layout_resolver(Box::new(type_layout_store));
         for object in pending_objects {
             total_storage_rebate += object.storage_rebate;
             total_sui +=
@@ -1612,9 +1604,13 @@ impl AuthorityStore {
                 .simplified_unwrap_then_delete(),
         );
 
-        let root_state_hash = self
-            .get_root_state_hash(cur_epoch_store.epoch())
-            .expect("Retrieving root state hash cannot fail");
+        let root_state_hash: ECMHLiveObjectSetDigest = self
+            .get_root_state_accumulator_for_epoch(cur_epoch_store.epoch())
+            .expect("Retrieving root state hash cannot fail")
+            .expect("Root state hash not found")
+            .1
+            .digest()
+            .into();
 
         let is_inconsistent = root_state_hash != live_object_set_hash;
         if is_inconsistent {
@@ -1636,6 +1632,147 @@ impl AuthorityStore {
         if !panic {
             checkpoint_executor.set_inconsistent_state(is_inconsistent);
         }
+    }
+
+    /// This is a temporary method to be used when we enable simplified_unwrap_then_delete.
+    /// It re-accumulates state hash for the new epoch if simplified_unwrap_then_delete is enabled.
+    #[instrument(level = "error", skip_all)]
+    pub fn maybe_reaccumulate_state_hash(
+        &self,
+        cur_epoch_store: &AuthorityPerEpochStore,
+        new_protocol_version: ProtocolVersion,
+    ) {
+        let old_simplified_unwrap_then_delete = cur_epoch_store
+            .protocol_config()
+            .simplified_unwrap_then_delete();
+        let new_simplified_unwrap_then_delete = ProtocolConfig::get_for_version(
+            new_protocol_version,
+            cur_epoch_store.get_chain_identifier().chain(),
+        )
+        .simplified_unwrap_then_delete();
+        // If in the new epoch the simplified_unwrap_then_delete is enabled for the first time,
+        // we re-accumulate state root.
+        let should_reaccumulate =
+            !old_simplified_unwrap_then_delete && new_simplified_unwrap_then_delete;
+        if !should_reaccumulate {
+            return;
+        }
+        info!("[Re-accumulate] simplified_unwrap_then_delete is enabled in the new protocol version, re-accumulating state hash");
+        let cur_time = Instant::now();
+        std::thread::scope(|s| {
+            let pending_tasks = FuturesUnordered::new();
+            // Shard the object IDs into different ranges so that we can process them in parallel.
+            // We divide the range into 2^BITS number of ranges. To do so we use the highest BITS bits
+            // to mark the starting/ending point of the range. For example, when BITS = 5, we
+            // divide the range into 32 ranges, and the first few ranges are:
+            // 00000000_.... to 00000111_....
+            // 00001000_.... to 00001111_....
+            // 00010000_.... to 00010111_....
+            // and etc.
+            const BITS: u8 = 5;
+            for index in 0u8..(1 << BITS) {
+                pending_tasks.push(s.spawn(move || {
+                    let mut id_bytes = [0; ObjectID::LENGTH];
+                    id_bytes[0] = index << (8 - BITS);
+                    let start_id = ObjectID::new(id_bytes);
+
+                    id_bytes[0] |= (1 << (8 - BITS)) - 1;
+                    for element in id_bytes.iter_mut().skip(1) {
+                        *element = u8::MAX;
+                    }
+                    let end_id = ObjectID::new(id_bytes);
+
+                    info!(
+                        "[Re-accumulate] Scanning object ID range {:?}..{:?}",
+                        start_id, end_id
+                    );
+                    let mut prev = (
+                        ObjectKey::min_for_id(&ObjectID::ZERO),
+                        StoreObjectWrapper::V1(StoreObject::Deleted),
+                    );
+                    let mut object_scanned: u64 = 0;
+                    let mut wrapped_objects_to_remove = vec![];
+                    for db_result in self.perpetual_tables.objects.safe_range_iter(
+                        ObjectKey::min_for_id(&start_id)..=ObjectKey::max_for_id(&end_id),
+                    ) {
+                        match db_result {
+                            Ok((object_key, object)) => {
+                                object_scanned += 1;
+                                if object_scanned % 100000 == 0 {
+                                    info!(
+                                        "[Re-accumulate] Task {}: object scanned: {}",
+                                        index, object_scanned,
+                                    );
+                                }
+                                if matches!(prev.1.inner(), StoreObject::Wrapped)
+                                    && object_key.0 != prev.0 .0
+                                {
+                                    wrapped_objects_to_remove
+                                        .push(WrappedObject::new(prev.0 .0, prev.0 .1));
+                                }
+
+                                prev = (object_key, object);
+                            }
+                            Err(err) => {
+                                warn!("Object iterator encounter RocksDB error {:?}", err);
+                                return Err(err);
+                            }
+                        }
+                    }
+                    if matches!(prev.1.inner(), StoreObject::Wrapped) {
+                        wrapped_objects_to_remove.push(WrappedObject::new(prev.0 .0, prev.0 .1));
+                    }
+                    info!(
+                        "[Re-accumulate] Task {}: object scanned: {}, wrapped objects: {}",
+                        index,
+                        object_scanned,
+                        wrapped_objects_to_remove.len(),
+                    );
+                    Ok((wrapped_objects_to_remove, object_scanned))
+                }));
+            }
+            let (last_checkpoint_of_epoch, cur_accumulator) = self
+                .get_root_state_accumulator_for_epoch(cur_epoch_store.epoch())
+                .expect("read cannot fail")
+                .expect("accumulator must exist");
+            let (accumulator, total_objects_scanned, total_wrapped_objects) =
+                pending_tasks.into_iter().fold(
+                    (cur_accumulator, 0u64, 0usize),
+                    |(mut accumulator, total_objects_scanned, total_wrapped_objects), task| {
+                        let (wrapped_objects_to_remove, object_scanned) =
+                            task.join().unwrap().unwrap();
+                        accumulator.remove_all(
+                            wrapped_objects_to_remove
+                                .iter()
+                                .map(|wrapped| bcs::to_bytes(wrapped).unwrap().to_vec())
+                                .collect::<Vec<Vec<u8>>>(),
+                        );
+                        (
+                            accumulator,
+                            total_objects_scanned + object_scanned,
+                            total_wrapped_objects + wrapped_objects_to_remove.len(),
+                        )
+                    },
+                );
+            info!(
+                "[Re-accumulate] Total objects scanned: {}, total wrapped objects: {}",
+                total_objects_scanned, total_wrapped_objects,
+            );
+            info!(
+                "[Re-accumulate] New accumulator value: {:?}",
+                accumulator.digest()
+            );
+            self.insert_state_accumulator_for_epoch(
+                cur_epoch_store.epoch(),
+                &last_checkpoint_of_epoch,
+                &accumulator,
+            )
+            .unwrap();
+        });
+        info!(
+            "[Re-accumulate] Re-accumulating took {}seconds",
+            cur_time.elapsed().as_secs()
+        );
     }
 
     #[cfg(test)]
@@ -1685,6 +1822,63 @@ impl AuthorityStore {
             .collect::<Result<Vec<_>, _>>()
             .unwrap()
             .len()
+    }
+}
+
+impl AccumulatorStore for AuthorityStore {
+    fn get_object_ref_prior_to_key_deprecated(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> SuiResult<Option<ObjectRef>> {
+        self.get_object_ref_prior_to_key(object_id, version)
+    }
+
+    fn get_root_state_accumulator_for_epoch(
+        &self,
+        epoch: EpochId,
+    ) -> SuiResult<Option<(CheckpointSequenceNumber, Accumulator)>> {
+        self.perpetual_tables
+            .root_state_hash_by_epoch
+            .get(&epoch)
+            .map_err(Into::into)
+    }
+
+    fn get_root_state_accumulator_for_highest_epoch(
+        &self,
+    ) -> SuiResult<Option<(EpochId, (CheckpointSequenceNumber, Accumulator))>> {
+        Ok(self
+            .perpetual_tables
+            .root_state_hash_by_epoch
+            .safe_iter()
+            .skip_to_last()
+            .next()
+            .transpose()?)
+    }
+
+    fn insert_state_accumulator_for_epoch(
+        &self,
+        epoch: EpochId,
+        last_checkpoint_of_epoch: &CheckpointSequenceNumber,
+        acc: &Accumulator,
+    ) -> SuiResult {
+        self.perpetual_tables
+            .root_state_hash_by_epoch
+            .insert(&epoch, &(*last_checkpoint_of_epoch, acc.clone()))?;
+        self.root_state_notify_read
+            .notify(&epoch, &(*last_checkpoint_of_epoch, acc.clone()));
+
+        Ok(())
+    }
+
+    fn iter_live_object_set(
+        &self,
+        include_wrapped_object: bool,
+    ) -> Box<dyn Iterator<Item = LiveObject> + '_> {
+        Box::new(
+            self.perpetual_tables
+                .iter_live_object_set(include_wrapped_object),
+        )
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -291,7 +291,7 @@ impl AuthorityPerpetualTables {
             .epoch())
     }
 
-    pub async fn set_epoch_start_configuration(
+    pub fn set_epoch_start_configuration(
         &self,
         epoch_start_configuration: &EpochStartConfiguration,
     ) -> SuiResult {

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -88,7 +88,7 @@ pub async fn execute_certificate_with_execution_error(
     // for testing and regression detection.
     // We must do this before sending to consensus, otherwise consensus may already
     // lead to transaction execution and state change.
-    let state_acc = StateAccumulator::new(authority.database.clone());
+    let state_acc = StateAccumulator::new(authority.execution_cache.clone());
     let include_wrapped_tombstone = !authority
         .epoch_store_for_testing()
         .protocol_config()

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -6,6 +6,7 @@ use crate::authority_client::{
     make_authority_clients_with_timeout_config, make_network_authority_clients_with_network_config,
     AuthorityAPI, NetworkAuthorityClient,
 };
+use crate::in_mem_execution_cache::ExecutionCacheRead;
 use crate::safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase};
 use fastcrypto::traits::ToFromBytes;
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
@@ -55,7 +56,6 @@ use sui_types::messages_grpc::{
 use sui_types::messages_safe_client::PlainTransactionInfoResponse;
 use tokio::time::{sleep, timeout};
 
-use crate::authority::AuthorityStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::stake_aggregator::{InsertResult, MultiStakeAggregator, StakeAggregator};
 
@@ -623,7 +623,7 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
     /// This function needs metrics parameters because registry will panic
     /// if we attempt to register already-registered metrics again.
     pub fn new_from_local_system_state(
-        store: &Arc<AuthorityStore>,
+        store: &Arc<dyn ExecutionCacheRead>,
         committee_store: &Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: AuthAggMetrics,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -591,7 +591,10 @@ impl Validator for ValidatorService {
         &self,
         _request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<SuiSystemState>, tonic::Status> {
-        let response = self.state.database.get_sui_system_state_object_unsafe()?;
+        let response = self
+            .state
+            .get_cache_reader()
+            .get_sui_system_state_object_unsafe()?;
 
         return Ok(tonic::Response::new(response));
     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -86,7 +86,7 @@ pub(crate) fn store_checkpoint_locally(
             .collect::<Vec<_>>();
 
         let input_objects = cache_reader
-            .multi_get_object_by_key(&input_object_keys)?
+            .multi_get_objects_by_key(&input_object_keys)?
             .into_iter()
             .zip(&input_object_keys)
             .map(|(object, object_key)| {
@@ -106,7 +106,7 @@ pub(crate) fn store_checkpoint_locally(
             .collect::<Vec<_>>();
 
         let output_objects = cache_reader
-            .multi_get_object_by_key(&output_object_keys)?
+            .multi_get_objects_by_key(&output_object_keys)?
             .into_iter()
             .zip(&output_object_keys)
             .map(|(object, object_key)| {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -106,7 +106,7 @@ impl CheckpointExecutor {
             mailbox,
             state: state.clone(),
             checkpoint_store,
-            cache_reader: state.get_cache_reader(),
+            cache_reader: state.get_cache_reader().clone(),
             tx_manager: state.transaction_manager().clone(),
             accumulator,
             config,
@@ -1100,11 +1100,13 @@ fn finalize_checkpoint(
         epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
     }
     // TODO remove once we no longer need to support this table for read RPC
-    state.database.deprecated_insert_finalized_transactions(
-        tx_digests,
-        epoch_store.epoch(),
-        checkpoint.sequence_number,
-    )?;
+    state
+        .get_checkpoint_cache()
+        .deprecated_insert_finalized_transactions(
+            tx_digests,
+            epoch_store.epoch(),
+            checkpoint.sequence_number,
+        )?;
 
     accumulator.accumulate_checkpoint(effects, checkpoint.sequence_number, epoch_store)?;
     if let Some(path) = data_ingestion_dir {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1912,7 +1912,7 @@ mod tests {
             }]);
         for i in 0..15 {
             state
-                .database
+                .database_for_testing()
                 .perpetual_tables
                 .transactions
                 .insert(&d(i), dummy_tx.serializable_ref())
@@ -1920,7 +1920,7 @@ mod tests {
         }
         for i in 15..20 {
             state
-                .database
+                .database_for_testing()
                 .perpetual_tables
                 .transactions
                 .insert(&d(i), dummy_tx_with_data.serializable_ref())
@@ -1990,7 +1990,7 @@ mod tests {
         let ckpt_dir = tempfile::tempdir().unwrap();
         let checkpoint_store = CheckpointStore::new(ckpt_dir.path());
 
-        let accumulator = StateAccumulator::new(state.database.clone());
+        let accumulator = StateAccumulator::new(state.get_accumulator_store().clone());
 
         let epoch_store = state.epoch_store_for_testing();
         let (checkpoint_service, _exit) = CheckpointService::spawn(

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -8,10 +8,10 @@ use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
 
 use crate::{
-    authority::AuthorityStore,
     authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     epoch::committee_store::CommitteeStore,
+    in_mem_execution_cache::ExecutionCacheRead,
     safe_client::SafeClientMetricsBase,
 };
 
@@ -27,7 +27,7 @@ pub trait ReconfigObserver<A: Clone> {
 /// This is used in TransactionOrchestrator.
 pub struct OnsiteReconfigObserver {
     reconfig_rx: tokio::sync::broadcast::Receiver<SuiSystemState>,
-    authority_store: Arc<AuthorityStore>,
+    execution_cache: Arc<dyn ExecutionCacheRead>,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
     auth_agg_metrics: AuthAggMetrics,
@@ -36,14 +36,14 @@ pub struct OnsiteReconfigObserver {
 impl OnsiteReconfigObserver {
     pub fn new(
         reconfig_rx: tokio::sync::broadcast::Receiver<SuiSystemState>,
-        authority_store: Arc<AuthorityStore>,
+        execution_cache: Arc<dyn ExecutionCacheRead>,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
         auth_agg_metrics: AuthAggMetrics,
     ) -> Self {
         Self {
             reconfig_rx,
-            authority_store,
+            execution_cache,
             committee_store,
             safe_client_metrics_base,
             auth_agg_metrics,
@@ -54,7 +54,7 @@ impl OnsiteReconfigObserver {
         &self,
     ) -> AuthorityAggregator<NetworkAuthorityClient> {
         AuthorityAggregator::new_from_local_system_state(
-            &self.authority_store,
+            &self.execution_cache,
             &self.committee_store,
             self.safe_client_metrics_base.clone(),
             self.auth_agg_metrics.clone(),
@@ -73,7 +73,7 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<NetworkAuthorityClient> + Send + Sync> {
         Box::new(Self {
             reconfig_rx: self.reconfig_rx.resubscribe(),
-            authority_store: self.authority_store.clone(),
+            execution_cache: self.execution_cache.clone(),
             committee_store: self.committee_store.clone(),
             safe_client_metrics_base: self.safe_client_metrics_base.clone(),
             auth_agg_metrics: self.auth_agg_metrics.clone(),

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -59,7 +59,7 @@ impl RocksDbStore {
     }
 
     pub fn get_objects(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>, SuiError> {
-        self.execution_cache.multi_get_object_by_key(object_keys)
+        self.execution_cache.multi_get_objects_by_key(object_keys)
     }
 
     pub fn get_last_executed_checkpoint(&self) -> Result<Option<VerifiedCheckpoint>, SuiError> {
@@ -160,8 +160,10 @@ impl ReadStore for RocksDbStore {
                             .get(&tx.effects)
                             .map_err(sui_types::storage::error::Error::custom)?,
                     ) {
-                        transactions
-                            .push(sui_types::base_types::ExecutionData::new(t.into_inner(), e))
+                        transactions.push(sui_types::base_types::ExecutionData::new(
+                            (*t).clone().into_inner(),
+                            e,
+                        ))
                     } else {
                         return Result::<
                             Option<FullCheckpointContents>,
@@ -191,10 +193,9 @@ impl ReadStore for RocksDbStore {
     fn get_transaction(
         &self,
         digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedTransaction>, StorageError> {
+    ) -> Result<Option<Arc<VerifiedTransaction>>, StorageError> {
         self.execution_cache
             .get_transaction_block(digest)
-            .map(|tx| tx.map(|tx| (*tx).clone()))
             .map_err(StorageError::custom)
     }
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -79,7 +79,7 @@ pub async fn send_and_confirm_transaction(
     //
     // We also check the incremental effects of the transaction on the live object set against StateAccumulator
     // for testing and regression detection
-    let state_acc = StateAccumulator::new(authority.database.clone());
+    let state_acc = StateAccumulator::new(authority.get_execution_cache().clone());
     let include_wrapped_tombstone = !authority
         .epoch_store_for_testing()
         .protocol_config()

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -86,7 +86,7 @@ impl TransactionInputLoader {
 
         let objects = self
             .cache
-            .multi_get_object_with_more_accurate_error_return(&object_refs)?;
+            .multi_get_objects_with_more_accurate_error_return(&object_refs)?;
         assert_eq!(objects.len(), object_refs.len());
         for (index, object) in fetch_indices.into_iter().zip(objects.into_iter()) {
             input_results[index] = Some(ObjectReadResult {
@@ -234,7 +234,7 @@ impl TransactionInputLoader {
             }
         }
 
-        let objects = self.cache.multi_get_object_by_key(&object_keys)?;
+        let objects = self.cache.multi_get_objects_by_key(&object_keys)?;
 
         assert!(objects.len() == object_keys.len() && objects.len() == fetches.len());
 

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -71,7 +71,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
         let safe_client_metrics_base = SafeClientMetricsBase::new(prometheus_registry);
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
         let validators = AuthorityAggregator::new_from_local_system_state(
-            &validator_state.db(),
+            validator_state.get_cache_reader(),
             validator_state.committee_store(),
             safe_client_metrics_base.clone(),
             auth_agg_metrics.clone(),
@@ -79,7 +79,7 @@ impl TransactiondOrchestrator<NetworkAuthorityClient> {
 
         let observer = OnsiteReconfigObserver::new(
             reconfig_channel,
-            validator_state.db(),
+            validator_state.get_cache_reader().clone(),
             validator_state.clone_committee_store(),
             safe_client_metrics_base,
             auth_agg_metrics,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2074,7 +2074,7 @@ async fn test_conflicting_transactions() {
                 .auth_sig()
         );
 
-        authority_state.database.reset_locks_for_test(
+        authority_state.database_for_testing().reset_locks_for_test(
             &[*tx1.digest(), *tx2.digest()],
             &[
                 gas_object.compute_object_reference(),
@@ -3146,7 +3146,7 @@ async fn test_invalid_randomness_parameter() {
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
 
     let init_random_version =
-        get_randomness_state_obj_initial_shared_version(&authority_state.database)
+        get_randomness_state_obj_initial_shared_version(authority_state.get_object_store())
             .unwrap()
             .unwrap();
     let random_mut = CallArg::Object(ObjectArg::SharedObject {
@@ -3431,8 +3431,9 @@ async fn test_store_revert_transfer_sui() {
         .await
         .unwrap();
 
-    let db = &authority_state.database;
-    db.revert_state_update(&tx_digest).await.unwrap();
+    // TODO:
+    let db = &authority_state.database_for_testing();
+    db.revert_state_update(&tx_digest).unwrap();
 
     assert_eq!(
         db.get_object(&gas_object_id).unwrap().unwrap().owner,
@@ -3447,7 +3448,7 @@ async fn test_store_revert_transfer_sui() {
     // Transaction should not be deleted on revert in case it's needed
     // to execute a future state sync checkpoint.
     assert!(db.get_transaction_block(&tx_digest).unwrap().is_some());
-    assert!(!db.as_ref().is_tx_already_executed(&tx_digest).unwrap());
+    assert!(!db.is_tx_already_executed(&tx_digest).unwrap());
 }
 
 #[tokio::test]
@@ -3505,8 +3506,8 @@ async fn test_store_revert_wrap_move_call() {
 
     let wrapper_v0 = wrap_effects.created()[0].0;
 
-    let db = &authority_state.database;
-    db.revert_state_update(&wrap_digest).await.unwrap();
+    let db = &authority_state.database_for_testing();
+    db.revert_state_update(&wrap_digest).unwrap();
 
     // The wrapped object is unwrapped once again (accessible from storage).
     let object = db.get_object(&object_v0.0).unwrap().unwrap();
@@ -3592,9 +3593,9 @@ async fn test_store_revert_unwrap_move_call() {
     assert_eq!(unwrap_effects.unwrapped().len(), 1);
     assert_eq!(unwrap_effects.unwrapped()[0].0 .0, object_v0.0);
 
-    let db = &authority_state.database;
+    let db = &authority_state.database_for_testing();
 
-    db.revert_state_update(&unwrap_digest).await.unwrap();
+    db.revert_state_update(&unwrap_digest).unwrap();
 
     // The unwrapped object is wrapped once again
     assert!(db.get_object(&object_v0.0).unwrap().is_none());
@@ -3848,7 +3849,7 @@ async fn test_store_revert_add_ofield() {
     let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
     let inner_v1 = find_by_id(&add_effects.mutated(), inner_v0.0).unwrap();
 
-    let db = &authority_state.database;
+    let db = &authority_state.database_for_testing();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
@@ -3860,7 +3861,7 @@ async fn test_store_revert_add_ofield() {
     assert_eq!(inner.version(), inner_v1.1);
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
 
-    db.revert_state_update(&add_digest).await.unwrap();
+    db.revert_state_update(&add_digest).unwrap();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v0.1);
@@ -3961,7 +3962,7 @@ async fn test_store_revert_remove_ofield() {
     let outer_v2 = find_by_id(&remove_effects.mutated(), outer_v0.0).unwrap();
     let inner_v2 = find_by_id(&remove_effects.mutated(), inner_v0.0).unwrap();
 
-    let db = &authority_state.database;
+    let db = &authority_state.database_for_testing();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v2.1);
@@ -3970,7 +3971,7 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
     assert_eq!(inner.version(), inner_v2.1);
 
-    db.revert_state_update(&remove_ofield_digest).await.unwrap();
+    db.revert_state_update(&remove_ofield_digest).unwrap();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
@@ -4860,7 +4861,7 @@ async fn test_consensus_message_processed() {
                 .unwrap();
             authority2.try_execute_for_test(&certificate).await.unwrap();
             authority2
-                .database
+                .get_cache_reader()
                 .get_executed_effects(transaction_digest)
                 .unwrap()
                 .unwrap()

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3431,7 +3431,6 @@ async fn test_store_revert_transfer_sui() {
         .await
         .unwrap();
 
-    // TODO:
     let db = &authority_state.database_for_testing();
     db.revert_state_update(&tx_digest).unwrap();
 

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -3,6 +3,7 @@
 
 use crate::authority::authority_tests::{send_consensus, send_consensus_no_execution};
 use crate::authority::AuthorityState;
+use crate::authority::EffectsNotifyRead;
 use crate::authority_aggregator::authority_aggregator_tests::{
     create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
 };

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -352,7 +352,7 @@ async fn test_upgrade_introduces_type_then_uses_it() {
 
     let b = runner
         .authority_state
-        .database
+        .get_object_store()
         .get_object_by_key(&created.0, created.1)
         .unwrap()
         .unwrap();

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -69,7 +69,7 @@ async fn send_transactions(
 
 pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<CheckpointService> {
     let (output, _result) = mpsc::channel::<(CheckpointContents, CheckpointSummary)>(10);
-    let accumulator = StateAccumulator::new(state.database.clone());
+    let accumulator = StateAccumulator::new(state.get_execution_cache());
     let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
 
     let epoch_store = state.epoch_store_for_testing();
@@ -78,7 +78,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),
-        state.get_effects_notify_read(),
+        Arc::new(state.get_effects_notify_read().clone()),
         Arc::new(accumulator),
         Box::new(output),
         Box::new(certified_output),

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -112,8 +112,7 @@ impl TestRunner {
 
     pub fn get_object_latest_version(&mut self, obj_id: ObjectID) -> SequenceNumber {
         self.authority_state
-            .database
-            .perpetual_tables
+            .get_cache_reader()
             .get_latest_object_ref_or_tombstone(obj_id)
             .unwrap()
             .unwrap()

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -61,7 +61,7 @@ async fn reload_state_with_new_deny_config(
     TestAuthorityBuilder::new()
         .with_transaction_deny_config(config)
         .with_network_config(network_config)
-        .with_store(state.db())
+        .with_store(state.database_for_testing().clone())
         .build()
         .await
 }

--- a/crates/sui-core/src/verify_indexes.rs
+++ b/crates/sui-core/src/verify_indexes.rs
@@ -9,18 +9,18 @@ use sui_types::{base_types::ObjectInfo, object::Owner};
 use tracing::info;
 use typed_store::traits::Map;
 
-use crate::authority::{authority_store_tables::LiveObject, AuthorityStore};
+use crate::{authority::authority_store_tables::LiveObject, state_accumulator::AccumulatorStore};
 
 /// This is a very expensive function that verifies some of the secondary indexes. This is done by
 /// iterating through the live object set and recalculating these secodary indexes.
-pub fn verify_indexes(database: Arc<AuthorityStore>, indexes: Arc<IndexStore>) -> Result<()> {
+pub fn verify_indexes(store: &dyn AccumulatorStore, indexes: Arc<IndexStore>) -> Result<()> {
     info!("Begin running index verification checks");
 
     let mut owner_index = BTreeMap::new();
     let mut coin_index = BTreeMap::new();
 
     tracing::info!("Reading live objects set");
-    for object in database.iter_live_object_set(false) {
+    for object in store.iter_live_object_set(false) {
         let LiveObject::Normal(object) = object else {
             continue;
         };

--- a/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_deny_list_tests.rs
@@ -26,7 +26,10 @@ async fn test_coin_deny_list_creation() {
         .await;
     for handle in test_cluster.all_node_handles() {
         handle.with(|node| {
-            assert!(get_deny_list_obj_initial_shared_version(&node.state().database).is_none());
+            assert!(get_deny_list_obj_initial_shared_version(
+                node.state().get_object_store().as_ref()
+            )
+            .is_none());
             assert!(!node
                 .state()
                 .epoch_store_for_testing()
@@ -51,7 +54,8 @@ async fn test_coin_deny_list_creation() {
                 .coin_deny_list_obj_initial_shared_version()
                 .unwrap();
 
-            let deny_list_object = get_deny_list_root_object(&node.state().database).unwrap();
+            let deny_list_object =
+                get_deny_list_root_object(node.state().get_object_store().as_ref()).unwrap();
             assert_eq!(deny_list_object.version(), version);
             assert!(deny_list_object.owner.is_shared());
             let deny_list: DenyList = deny_list_object.to_rust().unwrap();
@@ -64,7 +68,8 @@ async fn test_coin_deny_list_creation() {
                 prev_tx = Some(deny_list_object.previous_transaction);
             }
 
-            let coin_deny_list = get_coin_deny_list(&node.state().database).unwrap();
+            let coin_deny_list =
+                get_coin_deny_list(node.state().get_object_store().as_ref()).unwrap();
             assert_eq!(coin_deny_list.denied_count.size, 0);
             assert_eq!(coin_deny_list.denied_addresses.size, 0);
         });
@@ -89,7 +94,7 @@ async fn test_coin_deny_list_creation() {
         handle.with(|node| {
             assert_eq!(
                 node.state()
-                    .database
+                    .get_object_store()
                     .get_object(&SUI_DENY_LIST_OBJECT_ID)
                     .unwrap()
                     .unwrap()

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use std::sync::Arc;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_config::node::RunWithRange;
+use sui_core::authority::EffectsNotifyRead;
 use sui_json_rpc_types::{
     type_and_fields_from_move_struct, EventPage, SuiEvent, SuiExecutionStatus,
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
@@ -1335,7 +1336,7 @@ async fn test_access_old_object_pruned() {
         state.prune_objects_and_compact_for_testing().await;
         // Make sure the old version of the object is already pruned.
         assert!(state
-            .db()
+            .get_object_store()
             .get_object_by_key(&gas_object.0, gas_object.1)
             .unwrap()
             .is_none());

--- a/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -31,7 +31,7 @@ async fn test_onsite_reconfig_observer_basic() {
     let registry = Registry::new();
     let mut observer = OnsiteReconfigObserver::new(
         rx,
-        fullnode.with(|node| node.clone_authority_store()),
+        fullnode.with(|node| node.state().get_cache_reader().clone()),
         fullnode.with(|node| node.clone_committee_store()),
         SafeClientMetricsBase::new(&registry),
         AuthAggMetrics::new(&registry),

--- a/crates/sui-e2e-tests/tests/randomness_tests.rs
+++ b/crates/sui-e2e-tests/tests/randomness_tests.rs
@@ -22,7 +22,7 @@ async fn test_create_randomness_state_object() {
         h.with(|node| {
             assert!(node
                 .state()
-                .database
+                .get_cache_reader()
                 .get_latest_object_ref_or_tombstone(SUI_RANDOMNESS_STATE_OBJECT_ID)
                 .unwrap()
                 .is_none());
@@ -38,7 +38,7 @@ async fn test_create_randomness_state_object() {
     for h in &handles {
         h.with(|node| {
             node.state()
-                .database
+                .get_cache_reader()
                 .get_latest_object_ref_or_tombstone(SUI_RANDOMNESS_STATE_OBJECT_ID)
                 .unwrap()
                 .expect("randomness state object should exist");

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -449,14 +449,14 @@ async fn test_validator_candidate_pool_read() {
             .unwrap();
         let system_state_summary = system_state.clone().into_sui_system_state_summary();
         let staking_pool_id = get_validator_from_table(
-            node.state().db().as_ref(),
+            node.state().get_object_store().as_ref(),
             system_state_summary.validator_candidates_id,
             &address,
         )
         .unwrap()
         .staking_pool_id;
         let validator = get_validator_by_pool_id(
-            node.state().db().as_ref(),
+            node.state().get_object_store().as_ref(),
             &system_state,
             &system_state_summary,
             staking_pool_id,
@@ -494,7 +494,7 @@ async fn test_inactive_validator_pool_read() {
         let system_state_summary = system_state.clone().into_sui_system_state_summary();
         // Validator is active. Check that we can find its summary by staking pool id.
         let validator = get_validator_by_pool_id(
-            node.state().db().as_ref(),
+            node.state().get_object_store().as_ref(),
             &system_state,
             &system_state_summary,
             staking_pool_id,
@@ -529,7 +529,7 @@ async fn test_inactive_validator_pool_read() {
         );
         let system_state_summary = system_state.clone().into_sui_system_state_summary();
         let validator = get_validator_by_pool_id(
-            node.state().db().as_ref(),
+            node.state().get_object_store().as_ref(),
             &system_state,
             &system_state_summary,
             staking_pool_id,
@@ -786,7 +786,7 @@ async fn execute_add_validator_transactions(
             .get_sui_system_state_object_for_testing()
             .unwrap();
         system_state
-            .get_pending_active_validators(node.state().db().as_ref())
+            .get_pending_active_validators(node.state().get_object_store().as_ref())
             .unwrap()
             .len()
     });
@@ -831,7 +831,7 @@ async fn execute_add_validator_transactions(
             .get_sui_system_state_object_for_testing()
             .unwrap();
         let pending_active_validators = system_state
-            .get_pending_active_validators(node.state().db().as_ref())
+            .get_pending_active_validators(node.state().get_object_store().as_ref())
             .unwrap();
         assert_eq!(pending_active_validators.len(), pending_active_count + 1);
         assert_eq!(

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -7,6 +7,7 @@ use rand::distributions::Distribution;
 use std::ops::Deref;
 use std::time::{Duration, SystemTime};
 use sui_config::node::OverloadThresholdConfig;
+use sui_core::authority::EffectsNotifyRead;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_macros::{register_fail_point_async, sim_test};

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -11,6 +11,7 @@ use rand::{
     Rng,
 };
 use std::collections::{HashMap, HashSet};
+use sui_core::authority::EffectsNotifyRead;
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::make_transfer_sui_transaction;
 use tokio::time::{sleep, Duration, Instant};

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -4,6 +4,7 @@
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_core::authority::EffectsNotifyRead;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -165,7 +165,7 @@ async fn test_create_authenticator_state_object() {
         h.with(|node| {
             assert!(node
                 .state()
-                .database
+                .get_cache_reader()
                 .get_latest_object_ref_or_tombstone(SUI_AUTHENTICATOR_STATE_OBJECT_ID)
                 .unwrap()
                 .is_none());
@@ -181,7 +181,7 @@ async fn test_create_authenticator_state_object() {
     for h in &handles {
         h.with(|node| {
             node.state()
-                .database
+                .get_cache_reader()
                 .get_latest_object_ref_or_tombstone(SUI_AUTHENTICATOR_STATE_OBJECT_ID)
                 .unwrap()
                 .expect("auth state object should exist");
@@ -222,7 +222,7 @@ async fn test_conflicting_jwks() {
             while let Some(tx) = txns.next().await {
                 let digest = *tx.transaction_digest();
                 let tx = state
-                    .database
+                    .get_cache_reader()
                     .get_transaction_block(&digest)
                     .unwrap()
                     .unwrap();

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use arc_swap::Guard;
 use async_trait::async_trait;
 use move_core_types::language_storage::TypeTag;
-use mysten_metrics::spawn_monitored_task;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -88,11 +87,11 @@ pub trait StateRead: Send + Sync {
         limit: usize,
     ) -> StateReadResult<Vec<(ObjectID, DynamicFieldInfo)>>;
 
-    fn get_cache_reader(&self) -> Arc<dyn ExecutionCacheRead>;
+    fn get_cache_reader(&self) -> &Arc<dyn ExecutionCacheRead>;
 
-    fn get_object_store(&self) -> Arc<dyn ObjectStore>;
+    fn get_object_store(&self) -> &Arc<dyn ObjectStore + Send + Sync>;
 
-    fn get_backing_package_store(&self) -> Arc<dyn BackingPackageStore>;
+    fn get_backing_package_store(&self) -> &Arc<dyn BackingPackageStore + Send + Sync>;
 
     fn get_owner_objects(
         &self,
@@ -307,15 +306,15 @@ impl StateRead for AuthorityState {
         Ok(self.get_dynamic_fields(owner, cursor, limit)?)
     }
 
-    fn get_cache_reader(&self) -> Arc<dyn ExecutionCacheRead> {
+    fn get_cache_reader(&self) -> &Arc<dyn ExecutionCacheRead> {
         self.get_cache_reader()
     }
 
-    fn get_object_store(&self) -> Arc<dyn ObjectStore> {
+    fn get_object_store(&self) -> &Arc<dyn ObjectStore + Send + Sync> {
         self.get_object_store()
     }
 
-    fn get_backing_package_store(&self) -> Arc<dyn BackingPackageStore> {
+    fn get_backing_package_store(&self) -> &Arc<dyn BackingPackageStore + Send + Sync> {
         self.get_backing_package_store()
     }
 
@@ -428,7 +427,9 @@ impl StateRead for AuthorityState {
             .await?)
     }
     fn get_system_state(&self) -> StateReadResult<SuiSystemState> {
-        Ok(self.database.get_sui_system_state_object_unsafe()?)
+        Ok(self
+            .get_cache_reader()
+            .get_sui_system_state_object_unsafe()?)
     }
     fn get_or_latest_committee(&self, epoch: Option<BigInt<u64>>) -> StateReadResult<Committee> {
         Ok(self
@@ -520,7 +521,7 @@ impl StateRead for AuthorityState {
         digests: &[TransactionDigest],
     ) -> StateReadResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
         Ok(self
-            .database
+            .get_checkpoint_cache()
             .deprecated_multi_get_transaction_checkpoint(digests)?)
     }
 
@@ -529,7 +530,7 @@ impl StateRead for AuthorityState {
         digest: &TransactionDigest,
     ) -> StateReadResult<Option<(EpochId, CheckpointSequenceNumber)>> {
         Ok(self
-            .database
+            .get_checkpoint_cache()
             .deprecated_get_transaction_checkpoint(digest)?)
     }
 
@@ -588,12 +589,9 @@ impl<S: ?Sized + StateRead> ObjectProvider for Arc<S> {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Option<Object>, Self::Error> {
-        let cache = self.get_cache_reader();
-        let id = *id;
-        let version = *version;
-        spawn_monitored_task!(async move { cache.find_object_lt_or_eq_version(id, version) })
-            .await
-            .map_err(StateReadError::from)
+        Ok(self
+            .get_cache_reader()
+            .find_object_lt_or_eq_version(*id, *version))
     }
 }
 
@@ -623,12 +621,10 @@ impl<S: ?Sized + StateRead> ObjectProvider for (Arc<S>, Arc<TransactionKeyValueS
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Option<Object>, Self::Error> {
-        let cache = self.0.get_cache_reader();
-        let id = *id;
-        let version = *version;
-        spawn_monitored_task!(async move { cache.find_object_lt_or_eq_version(id, version) })
-            .await
-            .map_err(StateReadError::from)
+        Ok(self
+            .0
+            .get_cache_reader()
+            .find_object_lt_or_eq_version(*id, *version))
     }
 }
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -2147,7 +2147,7 @@ async fn create_epoch_store(
     let epoch_start_config = EpochStartConfiguration::new(
         sys_state,
         CheckpointDigest::random(),
-        &authority_state.database,
+        &authority_state.get_object_store(),
     )
     .unwrap();
 

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -321,8 +321,8 @@ impl BenchmarkContext {
                 .insert_verified_checkpoint(&checkpoint)
                 .unwrap();
             state
-                .database
-                .multi_insert_transaction_and_effects(contents.iter())
+                .get_state_sync_store()
+                .multi_insert_transaction_and_effects(contents.transactions())
                 .unwrap();
             state
                 .get_checkpoint_store()

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -15,6 +15,7 @@ use sui_core::checkpoints::checkpoint_executor::CheckpointExecutor;
 use sui_core::consensus_adapter::{
     ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
 };
+use sui_core::state_accumulator::AccumulatorStore;
 use sui_core::state_accumulator::StateAccumulator;
 use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress, TransactionDigest};
@@ -286,7 +287,7 @@ impl SingleValidator {
             ckpt_receiver,
             validator.get_checkpoint_store().clone(),
             validator.clone(),
-            Arc::new(StateAccumulator::new(validator.db())),
+            Arc::new(StateAccumulator::new(validator.get_execution_cache())),
         );
         (checkpoint_executor, ckpt_sender)
     }
@@ -294,7 +295,7 @@ impl SingleValidator {
     pub(crate) fn create_in_memory_store(&self) -> InMemoryObjectStore {
         let objects: HashMap<_, _> = self
             .get_validator()
-            .database
+            .get_execution_cache()
             .iter_live_object_set(false)
             .map(|o| match o {
                 LiveObject::Normal(object) => (object.id(), object),

--- a/crates/sui-snapshot/src/lib.rs
+++ b/crates/sui-snapshot/src/lib.rs
@@ -233,9 +233,7 @@ pub async fn setup_db_state(
         &perpetual_db,
     )
     .unwrap();
-    perpetual_db
-        .set_epoch_start_configuration(&epoch_start_configuration)
-        .await?;
+    perpetual_db.set_epoch_start_configuration(&epoch_start_configuration)?;
     perpetual_db.insert_root_state_hash(epoch, last_checkpoint.sequence_number, accumulator)?;
     perpetual_db.set_highest_pruned_checkpoint_without_wb(last_checkpoint.sequence_number)?;
     committee_store.insert_new_committee(&next_epoch_committee)?;

--- a/crates/sui-surfer/src/surfer_task.rs
+++ b/crates/sui-surfer/src/surfer_task.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use sui_core::authority::authority_store_tables::LiveObject;
+use sui_core::state_accumulator::AccumulatorStore;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     object::Owner,
@@ -45,8 +46,12 @@ impl SurferTask {
             .unwrap()
             .get_node_handle()
             .unwrap();
-        let all_live_objects: Vec<_> =
-            validator.with(|node| node.state().db().iter_live_object_set(false).collect());
+        let all_live_objects: Vec<_> = validator.with(|node| {
+            node.state()
+                .get_execution_cache()
+                .iter_live_object_set(false)
+                .collect()
+        });
         for obj in all_live_objects {
             match obj {
                 LiveObject::Normal(obj) => {

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -276,10 +276,10 @@ impl ReadStore for ValidatorWithFullnode {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> sui_types::storage::error::Result<Option<sui_types::transaction::VerifiedTransaction>>
+    ) -> sui_types::storage::error::Result<Option<Arc<sui_types::transaction::VerifiedTransaction>>>
     {
         self.validator
-            .database
+            .get_cache_reader()
             .get_transaction_block(tx_digest)
             .map_err(sui_types::storage::error::Error::custom)
     }
@@ -289,7 +289,7 @@ impl ReadStore for ValidatorWithFullnode {
         tx_digest: &TransactionDigest,
     ) -> sui_types::storage::error::Result<Option<TransactionEffects>> {
         self.validator
-            .database
+            .get_cache_reader()
             .get_executed_effects(tx_digest)
             .map_err(sui_types::storage::error::Error::custom)
     }
@@ -299,7 +299,7 @@ impl ReadStore for ValidatorWithFullnode {
         event_digest: &TransactionEventsDigest,
     ) -> sui_types::storage::error::Result<Option<TransactionEvents>> {
         self.validator
-            .database
+            .get_cache_reader()
             .get_events(event_digest)
             .map_err(sui_types::storage::error::Error::custom)
     }
@@ -328,7 +328,7 @@ impl ObjectStore for ValidatorWithFullnode {
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, sui_types::storage::error::Error> {
-        self.validator.database.get_object(object_id)
+        self.validator.get_object_store().get_object(object_id)
     }
 
     fn get_object_by_key(
@@ -337,7 +337,7 @@ impl ObjectStore for ValidatorWithFullnode {
         version: VersionNumber,
     ) -> Result<Option<Object>, sui_types::storage::error::Error> {
         self.validator
-            .database
+            .get_object_store()
             .get_object_by_key(object_id, version)
     }
 }

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::PathBuf, time::Duration};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
@@ -649,7 +649,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> sui_types::storage::error::Result<Option<VerifiedTransaction>> {
+    ) -> sui_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
         self.sync();
 
         Ok(self
@@ -657,7 +657,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .transactions
             .get(tx_digest)
             .expect("Fatal: DB read failed")
-            .map(|transaction| transaction.into()))
+            .map(|transaction| Arc::new(transaction.into())))
     }
 
     fn get_transaction_effects(

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -2193,7 +2193,7 @@ impl ReadStore for SuiTestAdapter<'_> {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> sui_types::storage::error::Result<Option<VerifiedTransaction>> {
+    ) -> sui_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
         self.executor.get_transaction(tx_digest)
     }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -534,7 +534,7 @@ impl FullCheckpointContents {
                 store.get_transaction(&tx.transaction)?,
                 store.get_transaction_effects(&tx.transaction)?,
             ) {
-                transactions.push(ExecutionData::new(t.into_inner(), e))
+                transactions.push(ExecutionData::new((*t).clone().into_inner(), e))
             } else {
                 return Ok(None);
             }
@@ -650,6 +650,10 @@ impl VerifiedCheckpointContents {
 
     pub fn iter(&self) -> Iter<'_, VerifiedExecutionData> {
         self.transactions.iter()
+    }
+
+    pub fn transactions(&self) -> &[VerifiedExecutionData] {
+        &self.transactions
     }
 
     pub fn into_inner(self) -> FullCheckpointContents {

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -82,13 +82,15 @@ pub trait ReadStore: ObjectStore {
     // Transaction Getters
     //
 
-    fn get_transaction(&self, tx_digest: &TransactionDigest)
-        -> Result<Option<VerifiedTransaction>>;
+    fn get_transaction(
+        &self,
+        tx_digest: &TransactionDigest,
+    ) -> Result<Option<Arc<VerifiedTransaction>>>;
 
     fn multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
-    ) -> Result<Vec<Option<VerifiedTransaction>>> {
+    ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
         tx_digests
             .iter()
             .map(|digest| self.get_transaction(digest))
@@ -258,7 +260,7 @@ pub trait ReadStore: ObjectStore {
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             let full_transaction = CheckpointTransaction {
-                transaction: tx.into(),
+                transaction: (*tx).clone().into(),
                 effects: fx,
                 events,
                 input_objects,
@@ -338,14 +340,14 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedTransaction>> {
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
         (*self).get_transaction(tx_digest)
     }
 
     fn multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
-    ) -> Result<Vec<Option<VerifiedTransaction>>> {
+    ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
         (*self).multi_get_transactions(tx_digests)
     }
 
@@ -460,14 +462,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedTransaction>> {
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
         (**self).get_transaction(tx_digest)
     }
 
     fn multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
-    ) -> Result<Vec<Option<VerifiedTransaction>>> {
+    ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
         (**self).multi_get_transactions(tx_digests)
     }
 
@@ -582,14 +584,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
     fn get_transaction(
         &self,
         tx_digest: &TransactionDigest,
-    ) -> Result<Option<VerifiedTransaction>> {
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
         (**self).get_transaction(tx_digest)
     }
 
     fn multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
-    ) -> Result<Vec<Option<VerifiedTransaction>>> {
+    ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
         (**self).multi_get_transactions(tx_digests)
     }
 

--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -114,8 +114,14 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_transaction(&self, digest: &TransactionDigest) -> Result<Option<VerifiedTransaction>> {
-        self.inner().get_transaction_block(digest).cloned().pipe(Ok)
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
+        self.inner()
+            .get_transaction_block(digest)
+            .map(|tx| Arc::new(tx.clone()))
+            .pipe(Ok)
     }
 
     fn get_transaction_effects(
@@ -527,7 +533,10 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
         self.0.get_committee(epoch)
     }
 
-    fn get_transaction(&self, digest: &TransactionDigest) -> Result<Option<VerifiedTransaction>> {
+    fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<Arc<VerifiedTransaction>>> {
         self.0.get_transaction(digest)
     }
 

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -175,7 +175,7 @@ pub trait SuiSystemStateTrait {
     fn safe_mode(&self) -> bool;
     fn advance_epoch_safe_mode(&mut self, params: &AdvanceEpochParams);
     fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata;
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError>;
@@ -384,12 +384,12 @@ pub fn get_validators_from_table_vec<S, ValidatorType>(
     table_size: u64,
 ) -> Result<Vec<ValidatorType>, SuiError>
 where
-    S: ObjectStore,
+    S: ObjectStore + ?Sized,
     ValidatorType: Serialize + DeserializeOwned,
 {
     let mut validators = vec![];
     for i in 0..table_size {
-        let validator: ValidatorType = get_dynamic_field_from_store(object_store, table_id, &i)
+        let validator: ValidatorType = get_dynamic_field_from_store(&object_store, table_id, &i)
             .map_err(|err| {
                 SuiError::SuiSystemStateReadError(format!(
                     "Failed to load validator from table: {:?}",

--- a/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
+++ b/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
@@ -184,7 +184,7 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerV1 {
         }
     }
 
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         _object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
@@ -298,7 +298,7 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerShallowV2 {
         }
     }
 
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         _object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
@@ -441,7 +441,7 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerDeepV2 {
         }
     }
 
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         _object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError> {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -563,7 +563,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
         }
     }
 
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError> {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
@@ -140,14 +140,14 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV2 {
         }
     }
 
-    fn get_pending_active_validators<S: ObjectStore>(
+    fn get_pending_active_validators<S: ObjectStore + ?Sized>(
         &self,
         object_store: &S,
     ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
         let table_id = self.validators.pending_active_validators.contents.id;
         let table_size = self.validators.pending_active_validators.contents.size;
         let validators: Vec<ValidatorV1> =
-            get_validators_from_table_vec(object_store, table_id, table_size)?;
+            get_validators_from_table_vec(&object_store, table_id, table_size)?;
         Ok(validators
             .into_iter()
             .map(|v| v.into_sui_validator_summary())

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -416,7 +416,7 @@ pub fn get_validator_by_pool_id<S>(
     pool_id: ObjectID,
 ) -> Result<SuiValidatorSummary, SuiError>
 where
-    S: ObjectStore,
+    S: ObjectStore + ?Sized,
 {
     // First try to find in active validator set.
     let active_validator = system_state_summary
@@ -437,13 +437,13 @@ where
     // After that try to find in inactive pools.
     let inactive_table_id = system_state_summary.inactive_pools_id;
     if let Ok(inactive) =
-        get_validator_from_table(object_store, inactive_table_id, &ID::new(pool_id))
+        get_validator_from_table(&object_store, inactive_table_id, &ID::new(pool_id))
     {
         return Ok(inactive);
     }
     // Finally look up the candidates pool.
     let candidate_address: SuiAddress = get_dynamic_field_from_store(
-        object_store,
+        &object_store,
         system_state_summary.staking_pool_mappings_id,
         &ID::new(pool_id),
     )
@@ -454,5 +454,5 @@ where
         ))
     })?;
     let candidate_table_id = system_state_summary.validator_candidates_id;
-    get_validator_from_table(object_store, candidate_table_id, &candidate_address)
+    get_validator_from_table(&object_store, candidate_table_id, &candidate_address)
 }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -241,7 +241,7 @@ impl TestCluster {
         self.fullnode_handle
             .sui_node
             .state()
-            .db()
+            .get_cache_reader()
             .get_latest_object_ref_or_tombstone(object_id)
             .unwrap()
             .unwrap()
@@ -470,7 +470,7 @@ impl TestCluster {
                 while let Some(tx) = txns.next().await {
                     let digest = *tx.transaction_digest();
                     let tx = state
-                        .database
+                        .get_cache_reader()
                         .get_transaction_block(&digest)
                         .unwrap()
                         .unwrap();


### PR DESCRIPTION
After this change there are essentially no direct uses of the db.

There are a few exceptions, which are for things that are clearly very db-specific, for instance pruning.