### PR TITLE
update homebrew sui install

### DIFF
--- a/docs/content/guides/developer/getting-started/sui-install.mdx
+++ b/docs/content/guides/developer/getting-started/sui-install.mdx
@@ -18,11 +18,10 @@ Sui supports the following operating systems:
 
 ## Install using Homebrew {#install-homebrew}
 
-If you use [Homebrew](https://brew.sh/), you can install Sui with the following commands:
+If you use [Homebrew](https://brew.sh/), you can install Sui with the following command:
 
 ```bash
-brew tap mystenlabs/tap
-brew install mystenlabs/tap/sui
+brew install sui
 ```
 
 ## Install from binaries {#install-binaries}


### PR DESCRIPTION
## Description 

sui is available as a homebrew-core library now: https://github.com/Homebrew/homebrew-core/pull/161424

I have another PR to mark the older mysten-tap sui formula as deprecated to encourage people to migrate to the core library

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
