### PR TITLE
move: simplify TestPlan::new interface (refactor)

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -194,7 +194,12 @@ pub fn run_move_unit_tests<W: Write + Send>(
         let (units, warnings) =
             diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
         diagnostics::report_warnings(&files, warnings.clone());
-        test_plan = Some((built_test_plan, files.clone(), units.clone()));
+        let named_units: Vec<_> = units
+            .clone()
+            .into_iter()
+            .map(|unit| unit.named_module)
+            .collect();
+        test_plan = Some((built_test_plan, files.clone(), named_units));
         warning_diags = Some(warnings);
         Ok((files, units))
     })?;

--- a/external-crates/move/crates/move-compiler/src/unit_test/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/mod.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    compiled_unit::{AnnotatedCompiledUnit, NamedCompiledModule},
-    diagnostics::FilesSourceText,
-    shared::NumericalAddress,
+    compiled_unit::NamedCompiledModule, diagnostics::FilesSourceText, shared::NumericalAddress,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
@@ -77,7 +75,7 @@ impl TestPlan {
     pub fn new(
         tests: Vec<ModuleTestPlan>,
         files: FilesSourceText,
-        units: Vec<AnnotatedCompiledUnit>,
+        units: Vec<NamedCompiledModule>,
     ) -> Self {
         let module_tests: BTreeMap<_, _> = tests
             .into_iter()
@@ -86,7 +84,7 @@ impl TestPlan {
 
         let module_info = units
             .into_iter()
-            .map(|unit| (unit.named_module.module.self_id(), unit.named_module))
+            .map(|unit| (unit.module.self_id(), unit))
             .collect();
 
         Self {

--- a/external-crates/move/crates/move-unit-test/src/lib.rs
+++ b/external-crates/move/crates/move-unit-test/src/lib.rs
@@ -161,6 +161,7 @@ impl UnitTestingConfig {
         let (units, warnings) =
             diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
         diagnostics::report_warnings(&files, warnings);
+        let units: Vec<_> = units.into_iter().map(|unit| unit.named_module).collect();
         test_plan.map(|tests| TestPlan::new(tests, files, units))
     }
 


### PR DESCRIPTION
## Description 

When I was digging around in `TestPlan` code I noticed `TestPlan::new` takes `AnnotatedCompiledUnit` when it only needs a subvalue `NamedCompiledModule`. So I'm making the interface change that simplifies this (Y/n)?

## Test Plan 

Just a refactor.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
