### PR TITLE
[bridge 37/n] add governance action verifier and logic for handling governance actions

### DIFF
--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -78,7 +78,7 @@ impl EthBridgeEvent {
 }
 
 // Sanity checked version of TokensBridgedToSuiFilter
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
 pub struct EthToSuiTokenBridgeV1 {
     pub nonce: u64,
     pub sui_chain_id: BridgeChainId,

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -98,10 +98,15 @@ impl BridgeClient {
                 let nonce = a.nonce.to_string();
                 let proxy_address = Hex::encode(a.proxy_address.as_bytes());
                 let new_impl_address = Hex::encode(a.new_impl_address.as_bytes());
-                let call_data = Hex::encode(a.call_data.clone());
-                format!(
-                    "sign/upgrade_evm_contract/{chain_id}/{nonce}/{proxy_address}/{new_impl_address}/{call_data}"
-                )
+                let path = format!(
+                    "sign/upgrade_evm_contract/{chain_id}/{nonce}/{proxy_address}/{new_impl_address}"
+                );
+                if a.call_data.is_empty() {
+                    path
+                } else {
+                    let call_data = Hex::encode(a.call_data.clone());
+                    format!("{}/{}", path, call_data)
+                }
             }
         }
     }
@@ -471,7 +476,7 @@ mod tests {
             });
         assert_eq!(
             BridgeClient::bridge_action_to_path(&action),
-            "sign/upgrade_evm_contract/12/123/0606060606060606060606060606060606060606/0909090909090909090909090909090909090909/",
+            "sign/upgrade_evm_contract/12/123/0606060606060606060606060606060606060606/0909090909090909090909090909090909090909",
         );
 
         let function_signature = "initializeV2()";

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::crypto::BridgeAuthorityPublicKeyBytes;
+use crate::{crypto::BridgeAuthorityPublicKeyBytes, types::BridgeAction};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BridgeError {
@@ -41,14 +41,20 @@ pub enum BridgeError {
     InvalidBridgeAuthority(BridgeAuthorityPublicKeyBytes),
     // Authority's base_url is invalid
     InvalidAuthorityUrl(BridgeAuthorityPublicKeyBytes),
+    // Invalid Bridge Client request
+    InvalidBridgeClientRequest(String),
     // Message is signed by mismatched authority
     MismatchedAuthoritySigner,
     // Signature is over a mismatched action
     MismatchedAction,
+    // Action is not a governance action
+    ActionIsNotGovernanceAction(BridgeAction),
+    // Client requested an non-approved governace action
+    GovernanceActionIsNotApproved,
     // Authority has invalid url
     AuthoirtyUrlInvalid,
     // Action is not token transfer
-    NotTokenTransferAction,
+    ActionIsNotTokenTransferAction,
     // Sui transaction failure due to generic error
     SuiTxFailureGeneric(String),
     // Storage Error

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -40,7 +40,7 @@ pub struct MoveTokenBridgeEvent {
 }
 
 // Sanitized version of MoveTokenBridgeEvent
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
 pub struct EmittedSuiToEthTokenBridgeV1 {
     pub nonce: u64,
     pub sui_chain_id: BridgeChainId,

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
             server_config.key,
             server_config.sui_client,
             server_config.eth_client,
+            server_config.approved_governance_actions,
         ),
     )
     .await;

--- a/crates/sui-bridge/src/server/governance_verifier.rs
+++ b/crates/sui-bridge/src/server/governance_verifier.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::error::{BridgeError, BridgeResult};
+use crate::server::handler::ActionVerifier;
+use crate::types::{BridgeAction, BridgeActionDigest};
+
+#[derive(Debug)]
+pub struct GovernanceVerifier {
+    approved_goverance_actions: HashMap<BridgeActionDigest, BridgeAction>,
+}
+
+impl GovernanceVerifier {
+    pub fn new(approved_actions: Vec<BridgeAction>) -> BridgeResult<Self> {
+        // TOOD(audit-blocking): verify chain ids
+        let mut approved_goverance_actions = HashMap::new();
+        for action in approved_actions {
+            if !action.is_governace_action() {
+                return Err(BridgeError::ActionIsNotGovernanceAction(action));
+            }
+            approved_goverance_actions.insert(action.digest(), action);
+        }
+        Ok(Self {
+            approved_goverance_actions,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl ActionVerifier<BridgeAction> for GovernanceVerifier {
+    async fn verify(&self, key: BridgeAction) -> BridgeResult<BridgeAction> {
+        // TODO: an optimization would be to check the current nonce on chain and err for older ones
+        if !key.is_governace_action() {
+            return Err(BridgeError::ActionIsNotGovernanceAction(key));
+        }
+        if let Some(approved_action) = self.approved_goverance_actions.get(&key.digest()) {
+            assert_eq!(
+                &key, approved_action,
+                "Mismatched action found in approved_actions"
+            );
+            return Ok(key);
+        }
+        return Err(BridgeError::GovernanceActionIsNotApproved);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::get_test_sui_to_eth_bridge_action,
+        types::{
+            BridgeAction, BridgeChainId, EmergencyAction, EmergencyActionType, LimitUpdateAction,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_governance_verifier() {
+        let action_1 = BridgeAction::EmergencyAction(EmergencyAction {
+            chain_id: BridgeChainId::EthLocalTest,
+            nonce: 1,
+            action_type: EmergencyActionType::Pause,
+        });
+        let action_2 = BridgeAction::LimitUpdateAction(LimitUpdateAction {
+            chain_id: BridgeChainId::EthLocalTest,
+            sending_chain_id: BridgeChainId::SuiLocalTest,
+            nonce: 1,
+            new_usd_limit: 10000,
+        });
+
+        let verifier = GovernanceVerifier::new(vec![action_1.clone(), action_2.clone()]).unwrap();
+        assert_eq!(
+            verifier.verify(action_1.clone()).await.unwrap(),
+            action_1.clone()
+        );
+        assert_eq!(
+            verifier.verify(action_2.clone()).await.unwrap(),
+            action_2.clone()
+        );
+
+        let action_3 = BridgeAction::LimitUpdateAction(LimitUpdateAction {
+            chain_id: BridgeChainId::EthLocalTest,
+            sending_chain_id: BridgeChainId::SuiLocalTest,
+            nonce: 2,
+            new_usd_limit: 10000,
+        });
+        assert_eq!(
+            verifier.verify(action_3).await.unwrap_err(),
+            BridgeError::GovernanceActionIsNotApproved
+        );
+
+        // Token transfer action is not allowed
+        let action_4 = get_test_sui_to_eth_bridge_action(None, None, None, None);
+        assert!(matches!(
+            GovernanceVerifier::new(vec![action_1, action_2, action_4.clone()]).unwrap_err(),
+            BridgeError::ActionIsNotGovernanceAction(..)
+        ));
+
+        // Token transfer action will be rejected
+        assert!(matches!(
+            verifier.verify(action_4).await.unwrap_err(),
+            BridgeError::ActionIsNotGovernanceAction(..)
+        ));
+    }
+}

--- a/crates/sui-bridge/src/server/mock_handler.rs
+++ b/crates/sui-bridge/src/server/mock_handler.rs
@@ -9,9 +9,12 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
+use crate::crypto::BridgeAuthorityKeyPair;
+use crate::crypto::BridgeAuthoritySignInfo;
 use crate::error::BridgeError;
 use crate::error::BridgeResult;
 use crate::types::SignedBridgeAction;
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use axum::Json;
 use sui_types::digests::TransactionDigest;
@@ -20,8 +23,9 @@ use super::handler::BridgeRequestHandlerTrait;
 use super::make_router;
 
 #[allow(clippy::type_complexity)]
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct BridgeRequestMockHandler {
+    signer: Arc<ArcSwap<Option<BridgeAuthorityKeyPair>>>,
     sui_token_events:
         Arc<Mutex<HashMap<(TransactionDigest, u16), BridgeResult<SignedBridgeAction>>>>,
     sui_token_events_requested: Arc<Mutex<HashMap<(TransactionDigest, u16), u64>>>,
@@ -29,7 +33,11 @@ pub struct BridgeRequestMockHandler {
 
 impl BridgeRequestMockHandler {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            signer: Arc::new(ArcSwap::new(Arc::new(None))),
+            sui_token_events: Arc::new(Mutex::new(HashMap::new())),
+            sui_token_events_requested: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 
     pub fn add_sui_event_response(
@@ -55,6 +63,10 @@ impl BridgeRequestMockHandler {
             .unwrap()
             .get(&(tx_digest, event_index))
             .unwrap_or(&0)
+    }
+
+    pub fn set_signer(&self, signer: BridgeAuthorityKeyPair) {
+        self.signer.store(Arc::new(Some(signer)));
     }
 }
 
@@ -95,6 +107,16 @@ impl BridgeRequestHandlerTrait for BridgeRequestMockHandler {
             crate::crypto::BridgeAuthoritySignInfo,
         > = result.as_ref().unwrap();
         Ok(Json(signed_action.clone()))
+    }
+
+    async fn handle_governance_action(
+        &self,
+        action: crate::types::BridgeAction,
+    ) -> Result<Json<SignedBridgeAction>, BridgeError> {
+        let sig =
+            BridgeAuthoritySignInfo::new(&action, self.signer.load().as_ref().as_ref().unwrap());
+        let signed_action = SignedBridgeAction::new_from_data_and_sig(action, sig);
+        Ok(Json(signed_action))
     }
 }
 

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -1,20 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::{http::StatusCode, routing::get, Router};
-use std::net::SocketAddr;
-use std::sync::Arc;
+#![allow(clippy::inconsistent_digit_grouping)]
 
 use crate::{
+    crypto::BridgeAuthorityPublicKeyBytes,
     error::BridgeError,
     server::handler::{BridgeRequestHandler, BridgeRequestHandlerTrait},
-    types::SignedBridgeAction,
+    types::{
+        AssetPriceUpdateAction, BlocklistCommitteeAction, BlocklistType, BridgeAction,
+        BridgeChainId, EmergencyAction, EmergencyActionType, EvmContractUpgradeAction,
+        LimitUpdateAction, SignedBridgeAction, TokenId,
+    },
 };
 use axum::{
     extract::{Path, State},
     Json,
 };
+use axum::{http::StatusCode, routing::get, Router};
+use ethers::types::Address as EthAddress;
+use fastcrypto::{
+    encoding::{Encoding, Hex},
+    traits::ToFromBytes,
+};
+use std::net::SocketAddr;
+use std::sync::Arc;
 
+pub mod governance_verifier;
 pub mod handler;
 
 #[cfg(test)]
@@ -28,6 +40,14 @@ pub const SUI_TO_ETH_TX_PATH: &str = "/sign/bridge_tx/sui/eth/:tx_digest/:event_
 pub const COMMITTEE_BLOCKLIST_UPDATE_PATH: &str =
     "/sign/update_committee_blocklist/:chain_id/:nonce/:type/:keys";
 pub const EMERGENCY_BUTTON_PATH: &str = "/sign/emergency_button/:chain_id/:nonce/:type";
+pub const LIMIT_UPDATE_PATH: &str =
+    "/sign/update_limit/:chain_id/:nonce/:sending_chain_id/:new_usd_limit";
+pub const ASSET_PRICE_UPDATE_PATH: &str =
+    "/sign/update_asset_price/:chain_id/:nonce/:token_id/:new_usd_price";
+pub const EVM_CONTRACT_UPGRADE_PATH_WITH_CALLDATA: &str =
+    "/sign/upgrade_evm_contract/:chain_id/:nonce/:proxy_address/:new_impl_address/:calldata";
+pub const EVM_CONTRACT_UPGRADE_PATH: &str =
+    "/sign/upgrade_evm_contract/:chain_id/:nonce/:proxy_address/:new_impl_address";
 
 pub async fn run_server(socket_address: &SocketAddr, handler: BridgeRequestHandler) {
     axum::Server::bind(socket_address)
@@ -43,8 +63,21 @@ pub(crate) fn make_router(
         .route("/", get(health_check))
         .route(ETH_TO_SUI_TX_PATH, get(handle_eth_tx_hash))
         .route(SUI_TO_ETH_TX_PATH, get(handle_sui_tx_digest))
-        // TODO: handle COMMITTEE_BLOCKLIST_UPDATE_PATH
-        // TODO: handle EMERGENCY_BUTTON_PATH
+        .route(
+            COMMITTEE_BLOCKLIST_UPDATE_PATH,
+            get(handle_update_committee_blocklist_action),
+        )
+        .route(EMERGENCY_BUTTON_PATH, get(handle_emergecny_action))
+        .route(LIMIT_UPDATE_PATH, get(handle_limit_update_action))
+        .route(
+            ASSET_PRICE_UPDATE_PATH,
+            get(handle_asset_price_update_action),
+        )
+        .route(EVM_CONTRACT_UPGRADE_PATH, get(handle_evm_contract_upgrade))
+        .route(
+            EVM_CONTRACT_UPGRADE_PATH_WITH_CALLDATA,
+            get(handle_evm_contract_upgrade_with_calldata),
+        )
         .with_state(handler)
 }
 
@@ -84,13 +117,245 @@ async fn handle_sui_tx_digest(
     Path((tx_digest_base58, event_idx)): Path<(String, u16)>,
     State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
 ) -> Result<Json<SignedBridgeAction>, BridgeError> {
-    let sig: Json<
-        sui_types::message_envelope::Envelope<
-            crate::types::BridgeAction,
-            crate::crypto::BridgeAuthoritySignInfo,
-        >,
-    > = handler
+    let sig: Json<SignedBridgeAction> = handler
         .handle_sui_tx_digest(tx_digest_base58, event_idx)
         .await?;
     Ok(sig)
+}
+
+async fn handle_update_committee_blocklist_action(
+    Path((chain_id, nonce, blocklist_type, keys)): Path<(u8, u64, u8, String)>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let blocklist_type = BlocklistType::try_from(blocklist_type).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid blocklist action type: {:?}", err))
+    })?;
+    let blocklisted_members = keys
+        .split(',')
+        .map(|s| {
+            let bytes = Hex::decode(s).map_err(|e| anyhow::anyhow!("{:?}", e))?;
+            BridgeAuthorityPublicKeyBytes::from_bytes(&bytes)
+                .map_err(|e| anyhow::anyhow!("{:?}", e))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| BridgeError::InvalidBridgeClientRequest(format!("{:?}", e)))?;
+    let action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+        chain_id,
+        nonce,
+        blocklist_type,
+        blocklisted_members,
+    });
+
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+async fn handle_emergecny_action(
+    Path((chain_id, nonce, action_type)): Path<(u8, u64, u8)>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let action_type = EmergencyActionType::try_from(action_type).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid emergency action type: {:?}", err))
+    })?;
+    let action = BridgeAction::EmergencyAction(EmergencyAction {
+        chain_id,
+        nonce,
+        action_type,
+    });
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+async fn handle_limit_update_action(
+    Path((chain_id, nonce, sending_chain_id, new_usd_limit)): Path<(u8, u64, u8, u64)>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let sending_chain_id = BridgeChainId::try_from(sending_chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let action = BridgeAction::LimitUpdateAction(LimitUpdateAction {
+        chain_id,
+        nonce,
+        sending_chain_id,
+        new_usd_limit,
+    });
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+async fn handle_asset_price_update_action(
+    Path((chain_id, nonce, token_id, new_usd_price)): Path<(u8, u64, u8, u64)>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let token_id = TokenId::try_from(token_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid token id: {:?}", err))
+    })?;
+    let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
+        chain_id,
+        nonce,
+        token_id,
+        new_usd_price,
+    });
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+async fn handle_evm_contract_upgrade_with_calldata(
+    Path((chain_id, nonce, proxy_address, new_impl_address, calldata)): Path<(
+        u8,
+        u64,
+        EthAddress,
+        EthAddress,
+        String,
+    )>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let call_data = Hex::decode(&calldata).map_err(|e| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid call data: {:?}", e))
+    })?;
+    let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+        chain_id,
+        nonce,
+        proxy_address,
+        new_impl_address,
+        call_data,
+    });
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+async fn handle_evm_contract_upgrade(
+    Path((chain_id, nonce, proxy_address, new_impl_address)): Path<(
+        u8,
+        u64,
+        EthAddress,
+        EthAddress,
+    )>,
+    State(handler): State<Arc<impl BridgeRequestHandlerTrait + Sync + Send>>,
+) -> Result<Json<SignedBridgeAction>, BridgeError> {
+    let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
+        BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
+    })?;
+    let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+        chain_id,
+        nonce,
+        proxy_address,
+        new_impl_address,
+        call_data: vec![],
+    });
+    let sig: Json<SignedBridgeAction> = handler.handle_governance_action(action).await?;
+    Ok(sig)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::bridge_client::BridgeClient;
+    use crate::server::mock_handler::BridgeRequestMockHandler;
+    use crate::test_utils::get_test_authorities_and_run_mock_bridge_server;
+    use crate::types::BridgeCommittee;
+
+    #[tokio::test]
+    async fn test_bridge_server_handle_blocklist_update_action_path() {
+        let client = setup();
+
+        let pub_key_bytes = BridgeAuthorityPublicKeyBytes::from_bytes(
+            &Hex::decode("02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4")
+                .unwrap(),
+        )
+        .unwrap();
+        let action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+            nonce: 129,
+            chain_id: BridgeChainId::SuiLocalTest,
+            blocklist_type: BlocklistType::Blocklist,
+            blocklisted_members: vec![pub_key_bytes.clone()],
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_server_handle_emergency_action_path() {
+        let client = setup();
+
+        let action = BridgeAction::EmergencyAction(EmergencyAction {
+            nonce: 55,
+            chain_id: BridgeChainId::SuiLocalTest,
+            action_type: EmergencyActionType::Pause,
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_server_handle_limit_update_action_path() {
+        let client = setup();
+
+        let action = BridgeAction::LimitUpdateAction(LimitUpdateAction {
+            nonce: 15,
+            chain_id: BridgeChainId::SuiLocalTest,
+            sending_chain_id: BridgeChainId::EthLocalTest,
+            new_usd_limit: 1_000_000_0000, // $1M USD
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_server_handle_asset_price_update_action_path() {
+        let client = setup();
+
+        let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
+            nonce: 266,
+            chain_id: BridgeChainId::SuiLocalTest,
+            token_id: TokenId::BTC,
+            new_usd_price: 100_000_0000, // $100k USD
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_server_handle_evm_contract_upgrade_action_path() {
+        let client = setup();
+
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data: vec![],
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data: vec![12, 34, 56],
+        });
+        client.request_sign_bridge_action(action).await.unwrap();
+    }
+
+    fn setup() -> BridgeClient {
+        let mock = BridgeRequestMockHandler::new();
+        let (_handles, authorities, mut secrets) =
+            get_test_authorities_and_run_mock_bridge_server(vec![10000], vec![mock.clone()]);
+        mock.set_signer(secrets.swap_remove(0));
+        let committee = BridgeCommittee::new(authorities).unwrap();
+        let pub_key = committee.members().keys().next().unwrap();
+        BridgeClient::new(pub_key.clone(), Arc::new(committee)).unwrap()
+    }
 }

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -313,7 +313,7 @@ impl SuiClientInner for SuiSdkClient {
     ) -> Result<BridgeActionStatus, BridgeError> {
         match &action {
             BridgeAction::SuiToEthBridgeAction(_) | BridgeAction::EthToSuiBridgeAction(_) => (),
-            _ => return Err(BridgeError::NotTokenTransferAction),
+            _ => return Err(BridgeError::ActionIsNotTokenTransferAction),
         };
         let package_id = *get_bridge_package_id();
         let key = serde_json::json!(


### PR DESCRIPTION
## Description 

This PR adds the logic for server to handle governance action requests:
1. adds `approved_governance_actions` in `BridgeNodeConfig`. Validators add approved actions there to show support. It is then passed to `GovernanceVerifier`
2. add `GovernanceVerifier` which checks if the requested action is in `approved_governance_actions`, and only signs the action if it is.

More unit tests will come in next PR, to keep this one small. 

## Test Plan 

unit tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
