### PR TITLE
[consensus] Add Commit Observer

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -1,0 +1,549 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use crate::{
+    block::{timestamp_utc_ms, BlockAPI, VerifiedBlock},
+    commit::CommitIndex,
+    context::Context,
+    linearizer::{CommittedSubDag, Linearizer},
+    storage::Store,
+};
+
+/// Role of CommitObserver
+/// - Called by core when block is created via try_new_block or force_new_block
+/// and try_commit returns newly comitted leaders
+/// - The newly committed leaders are sent to commit observer and then commit observer
+/// gets subdags for each leader via the commit interpreter (linearizer)
+/// - The committed subdags are sent as consensus output via an unbounded tokio channel.
+/// No back pressure mechanism is needed as backpressure is handled as input into
+/// consenus.
+/// - Last commit index is persisted in store as soon as the subdag is sent to
+/// output channel.
+/// - When CommitObserver is initialized a last received commit index can be used
+/// to ensure any missing commits are re-sent.
+
+#[allow(unused)]
+pub(crate) struct CommitObserver {
+    context: Arc<Context>,
+    /// Component to deterministically collect subdags for committed leaders.
+    commit_interpreter: Linearizer,
+    /// An unbounded channel to send committed sub-dags to the consumer of consensus output.
+    sender: tokio::sync::mpsc::UnboundedSender<CommittedSubDag>,
+    /// Persistent storage for blocks, commits and other consensus data.
+    store: Arc<dyn Store>,
+}
+
+#[allow(unused)]
+impl CommitObserver {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        commit_interpreter: Linearizer,
+        sender: tokio::sync::mpsc::UnboundedSender<CommittedSubDag>,
+        // Last CommitIndex that has been successfully received by the output channel.
+        // First commit in the replayed sequence will have index last_received_index + 1.
+        // Set to 0 to replay from the start (as normal sequence starts at index = 1).
+        last_received_index: CommitIndex,
+        store: Arc<dyn Store>,
+    ) -> Self {
+        let mut observer = Self {
+            context,
+            commit_interpreter,
+            sender,
+            store,
+        };
+
+        observer.send_missing_commits(last_received_index);
+        observer
+    }
+
+    pub(crate) fn handle_commit(
+        &mut self,
+        committed_leaders: Vec<VerifiedBlock>,
+    ) -> Vec<CommittedSubDag> {
+        let commits = self.commit_interpreter.handle_commit(committed_leaders);
+        let mut sent_sub_dags = vec![];
+        let mut sent_commit_data = vec![];
+
+        for (commit_data, committed_sub_dag) in commits.into_iter() {
+            if let Err(err) = self.sender.send(committed_sub_dag.clone()) {
+                tracing::error!(
+                    "Failed to send committed sub-dag, probably due to shutdown: {err:?}"
+                );
+                break;
+            }
+            sent_sub_dags.push(committed_sub_dag);
+            sent_commit_data.push(commit_data);
+        }
+
+        // Persist sent commits to store
+        self.store
+            .write(
+                sent_sub_dags
+                    .iter()
+                    .flat_map(|subdag| subdag.blocks.clone())
+                    .collect::<Vec<_>>(),
+                sent_commit_data,
+            )
+            .expect("Writing commits to store should not fail");
+
+        self.report_metrics(&sent_sub_dags);
+        sent_sub_dags
+    }
+
+    fn send_missing_commits(&mut self, last_received_index: CommitIndex) {
+        let last_commit = self
+            .store
+            .read_last_commit()
+            .expect("Reading the last commit should not fail");
+
+        if let Some(last_commit) = last_commit {
+            let last_commit_index = last_commit.index;
+
+            assert!(last_commit_index >= last_received_index);
+            if last_commit_index == last_received_index {
+                return;
+            }
+        };
+
+        // We should not send the last received commit again, so last_received_index++
+        let unsent_commits = self
+            .store
+            .scan_commits(last_received_index + 1)
+            .expect("Scanning commits should not fail");
+
+        for commit in unsent_commits {
+            // Resend all the committed subdags to the consensus output channel
+            // for all the commits above the last received index.
+            assert!(commit.index > last_received_index);
+            let committed_subdag =
+                CommittedSubDag::new_from_commit_data(commit, self.store.clone());
+            if let Err(err) = self.sender.send(committed_subdag) {
+                tracing::error!(
+                    "Failed to send committed sub-dag, probably due to shutdown: {:?}",
+                    err
+                );
+            }
+        }
+    }
+
+    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+        let utc_now = timestamp_utc_ms();
+        let mut total = 0;
+        for block in committed.iter().flat_map(|dag| &dag.blocks) {
+            let latency_ms = utc_now
+                .checked_sub(block.timestamp_ms())
+                .unwrap_or_default();
+
+            total += 1;
+            self.context
+                .metrics
+                .node_metrics
+                .block_commit_latency
+                .observe(latency_ms as f64);
+        }
+        self.context
+            .metrics
+            .node_metrics
+            .blocks_per_commit_count
+            .observe(total as f64);
+        self.context
+            .metrics
+            .node_metrics
+            .sub_dags_per_commit_count
+            .observe(committed.len() as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use consensus_config::AuthorityIndex;
+    use parking_lot::RwLock;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+    use crate::{
+        block::{BlockRef, BlockTimestampMs, TestBlock},
+        commit::DEFAULT_WAVE_LENGTH,
+        context::Context,
+        dag_state::DagState,
+        leader_schedule::LeaderSchedule,
+        storage::mem_store::MemStore,
+    };
+
+    #[test]
+    fn test_handle_commit() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mem_store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let linearizer = Linearizer::new(dag_state.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone());
+        let last_received_index = 0;
+        #[allow(clippy::disallowed_methods)] // allow unbounded_channel()
+        let (sender, mut receiver) = unbounded_channel();
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            linearizer,
+            sender,
+            last_received_index,
+            mem_store.clone(),
+        );
+
+        // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
+        let num_rounds = 10;
+        let num_authorities = 4;
+        let leaders = setup_test(
+            context.clone(),
+            dag_state.clone(),
+            leader_schedule,
+            num_rounds,
+            num_authorities,
+        );
+
+        let commits = observer.handle_commit(leaders.clone());
+
+        // Check commits are returned by CommitObserver::handle_commit is accurate
+        let mut expected_stored_refs: Vec<BlockRef> = vec![];
+        for (idx, subdag) in commits.iter().enumerate() {
+            tracing::info!("{subdag:?}");
+            assert_eq!(subdag.leader, leaders[idx].reference());
+            assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
+            if idx == 0 {
+                // First subdag includes the leader block plus all ancestor blocks
+                // of the leader minus the genesis round blocks
+                assert_eq!(
+                    subdag.blocks.len(),
+                    (num_authorities * (DEFAULT_WAVE_LENGTH - 1)) as usize + 1
+                );
+            } else {
+                // Every subdag after will be missing the leader block from the previous
+                // committed subdag
+                assert_eq!(
+                    subdag.blocks.len(),
+                    (num_authorities * DEFAULT_WAVE_LENGTH) as usize
+                );
+            }
+            for block in subdag.blocks.iter() {
+                expected_stored_refs.push(block.reference());
+                assert!(block.round() <= leaders[idx].round());
+            }
+            assert_eq!(subdag.commit_index, idx as u64 + 1);
+        }
+
+        // Check commits sent over consensus output channel is accurate
+        let mut received_subdag_count = 0;
+        while let Ok(subdag) = receiver.try_recv() {
+            assert_eq!(subdag.leader, commits[received_subdag_count].leader);
+            assert_eq!(subdag.blocks, commits[received_subdag_count].blocks);
+            assert_eq!(
+                subdag.commit_index,
+                commits[received_subdag_count].commit_index
+            );
+            received_subdag_count += 1;
+
+            if received_subdag_count == leaders.len() {
+                break;
+            }
+        }
+
+        verify_channel_empty(&mut receiver);
+
+        // Check commits have been persisted to storage
+        let last_commit = mem_store.read_last_commit().unwrap().unwrap();
+        assert_eq!(last_commit.index, commits.last().unwrap().commit_index);
+        let all_stored_commits = mem_store.scan_commits(0).unwrap();
+        assert_eq!(all_stored_commits.len(), leaders.len());
+        let blocks_existence = mem_store.contains_blocks(&expected_stored_refs).unwrap();
+        assert!(blocks_existence.iter().all(|exists| *exists));
+    }
+
+    #[test]
+    fn test_send_missing_commits_from_index() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mem_store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let linearizer = Linearizer::new(dag_state.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone());
+        let last_received_index = 0;
+        #[allow(clippy::disallowed_methods)] // allow unbounded_channel()
+        let (sender, mut receiver) = unbounded_channel();
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            linearizer.clone(),
+            sender.clone(),
+            last_received_index,
+            mem_store.clone(),
+        );
+
+        // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
+        let num_rounds = 10;
+        let num_authorities = 4;
+        let leaders = setup_test(
+            context.clone(),
+            dag_state.clone(),
+            leader_schedule,
+            num_rounds,
+            num_authorities,
+        );
+
+        // Commit first batch of leaders (2) and "receive" the subdags as the
+        // consumer of the consensus output channel.
+        let expected_last_received_index = 2;
+        let mut commits = observer.handle_commit(
+            leaders
+                .clone()
+                .into_iter()
+                .take(expected_last_received_index)
+                .collect::<Vec<_>>(),
+        );
+
+        // Check commits sent over consensus output channel is accurate
+        let mut received_subdag_index = 0;
+        while let Ok(subdag) = receiver.try_recv() {
+            tracing::info!("Received {subdag}");
+            assert_eq!(subdag.leader, commits[received_subdag_index].leader);
+            assert_eq!(subdag.blocks, commits[received_subdag_index].blocks);
+            assert_eq!(
+                subdag.commit_index,
+                commits[received_subdag_index].commit_index
+            );
+            received_subdag_index = subdag.commit_index as usize;
+
+            if received_subdag_index == expected_last_received_index {
+                break;
+            }
+        }
+
+        verify_channel_empty(&mut receiver);
+
+        // Check last stored commit is correct
+        let last_commit = mem_store.read_last_commit().unwrap().unwrap();
+        assert_eq!(
+            last_commit.index,
+            expected_last_received_index as CommitIndex
+        );
+
+        // Handle next batch of leaders (1), these will be sent by consensus but not
+        // "received" by consensus output channel. Simulating something happened on
+        // the consumer side where the commits were not persisted.
+        commits.append(
+            &mut observer.handle_commit(
+                leaders
+                    .clone()
+                    .into_iter()
+                    .skip(expected_last_received_index)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+
+        let expected_last_sent_index = 3;
+        while let Ok(subdag) = receiver.try_recv() {
+            tracing::info!("{subdag} was sent but not received by consumer");
+            assert_eq!(subdag.leader, commits[received_subdag_index].leader);
+            assert_eq!(subdag.blocks, commits[received_subdag_index].blocks);
+            assert_eq!(
+                subdag.commit_index,
+                commits[received_subdag_index].commit_index
+            );
+            received_subdag_index = subdag.commit_index as usize;
+
+            if received_subdag_index == expected_last_sent_index {
+                break;
+            }
+        }
+
+        verify_channel_empty(&mut receiver);
+
+        // Check last stored commit is correct. We should persist the last commit
+        // that was sent over the channel regardless of how the consumer handled
+        // the commit on their end.
+        let last_commit = mem_store.read_last_commit().unwrap().unwrap();
+        assert_eq!(last_commit.index, expected_last_sent_index as CommitIndex);
+
+        // Re-create commit observer starting from index 2 which represents the
+        // last received index from the consumer over consensus output channel
+        let _observer = CommitObserver::new(
+            context.clone(),
+            linearizer,
+            sender,
+            expected_last_received_index as CommitIndex,
+            mem_store.clone(),
+        );
+
+        // Check commits sent over consensus output channel is accurate starting
+        // from last received index of 2 and finishing at last sent index of 3.
+        received_subdag_index = expected_last_received_index;
+        while let Ok(subdag) = receiver.try_recv() {
+            tracing::info!("Received {subdag} on resubmission");
+            assert_eq!(subdag.leader, commits[received_subdag_index].leader);
+            assert_eq!(subdag.blocks, commits[received_subdag_index].blocks);
+            assert_eq!(
+                subdag.commit_index,
+                commits[received_subdag_index].commit_index
+            );
+            received_subdag_index = subdag.commit_index as usize;
+
+            if received_subdag_index == expected_last_sent_index {
+                break;
+            }
+        }
+
+        verify_channel_empty(&mut receiver);
+    }
+
+    #[test]
+    fn test_send_no_missing_commits() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let mem_store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            mem_store.clone(),
+        )));
+        let linearizer = Linearizer::new(dag_state.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone());
+        let last_received_index = 0;
+        #[allow(clippy::disallowed_methods)] // allow unbounded_channel()
+        let (sender, mut receiver) = unbounded_channel();
+
+        let mut observer = CommitObserver::new(
+            context.clone(),
+            linearizer.clone(),
+            sender.clone(),
+            last_received_index,
+            mem_store.clone(),
+        );
+
+        // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
+        let num_rounds = 10;
+        let num_authorities = 4;
+        let leaders = setup_test(
+            context.clone(),
+            dag_state.clone(),
+            leader_schedule,
+            num_rounds,
+            num_authorities,
+        );
+
+        // Commit all of the leaders and "receive" the subdags as the consumer of
+        // the consensus output channel.
+        let expected_last_received_index = 3;
+        let commits = observer.handle_commit(leaders.clone());
+
+        // Check commits sent over consensus output channel is accurate
+        let mut received_subdag_index = 0;
+        while let Ok(subdag) = receiver.try_recv() {
+            tracing::info!("Received {subdag}");
+            assert_eq!(subdag.leader, commits[received_subdag_index].leader);
+            assert_eq!(subdag.blocks, commits[received_subdag_index].blocks);
+            assert_eq!(
+                subdag.commit_index,
+                commits[received_subdag_index].commit_index
+            );
+            received_subdag_index = subdag.commit_index as usize;
+
+            if received_subdag_index == expected_last_received_index {
+                break;
+            }
+        }
+
+        verify_channel_empty(&mut receiver);
+
+        // Check last stored commit is correct
+        let last_commit = mem_store.read_last_commit().unwrap().unwrap();
+        assert_eq!(
+            last_commit.index,
+            expected_last_received_index as CommitIndex
+        );
+
+        // Re-create commit observer starting from index 3 which represents the
+        // last received index from the consumer over consensus output channel
+        let _observer = CommitObserver::new(
+            context.clone(),
+            linearizer,
+            sender,
+            expected_last_received_index as CommitIndex,
+            mem_store.clone(),
+        );
+
+        // No commits should be resubmitted as consensus store's last commit index
+        // is equal to last received index by consumer
+        verify_channel_empty(&mut receiver);
+    }
+
+    /// Populate fully connected test blocks for round & authorities provided.
+    fn setup_test(
+        context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
+        leader_schedule: LeaderSchedule,
+        num_rounds: u32,
+        num_authorities: u32,
+    ) -> Vec<VerifiedBlock> {
+        let mut leaders = vec![];
+
+        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlock::new(0, author_idx).build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        dag_state.write().accept_blocks(genesis);
+
+        let mut ancestors = genesis_references;
+        for round in 1..=num_rounds {
+            let mut new_ancestors = vec![];
+            for author in 0..num_authorities {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+                dag_state.write().accept_block(block.clone());
+                new_ancestors.push(block.reference());
+
+                if round % DEFAULT_WAVE_LENGTH == 0
+                    && AuthorityIndex::new_for_test(author)
+                        == leader_schedule.elect_leader(round, 0)
+                {
+                    leaders.push(block.clone());
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        leaders
+    }
+
+    /// After receiving all expected subdags, ensure channel is empty
+    fn verify_channel_empty(receiver: &mut UnboundedReceiver<CommittedSubDag>) {
+        match receiver.try_recv() {
+            Ok(_) => {
+                panic!("Expected the consensus output channel to be empty, but found more subdags.")
+            }
+            Err(e) => match e {
+                tokio::sync::mpsc::error::TryRecvError::Empty => {}
+                tokio::sync::mpsc::error::TryRecvError::Disconnected => {
+                    panic!("The consensus output channel was unexpectedly closed.")
+                }
+            },
+        }
+    }
+}

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -243,6 +243,7 @@ mod tests {
                 break;
             }
         }
+        assert_eq!(processed_subdag_index, leaders.len());
 
         verify_channel_empty(&mut receiver);
 
@@ -312,6 +313,7 @@ mod tests {
                 break;
             }
         }
+        assert_eq!(processed_subdag_index, expected_last_processed_index);
 
         verify_channel_empty(&mut receiver);
 
@@ -344,6 +346,7 @@ mod tests {
                 break;
             }
         }
+        assert_eq!(processed_subdag_index, expected_last_sent_index);
 
         verify_channel_empty(&mut receiver);
 
@@ -374,6 +377,7 @@ mod tests {
                 break;
             }
         }
+        assert_eq!(processed_subdag_index, expected_last_sent_index);
 
         verify_channel_empty(&mut receiver);
     }
@@ -429,6 +433,7 @@ mod tests {
                 break;
             }
         }
+        assert_eq!(processed_subdag_index, expected_last_processed_index);
 
         verify_channel_empty(&mut receiver);
 

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -283,7 +283,25 @@ impl DagState {
         }
     }
 
+    // Write commits to store. Commits should be provided in commit order, meaning
+    // the last element in commits is the new last_commit.
+    pub(crate) fn write_commits(
+        &mut self,
+        commits: Vec<Commit>,
+        committed_blocks: Vec<VerifiedBlock>,
+    ) {
+        assert!(!commits.is_empty());
+        let last_commit = commits.last().unwrap().clone();
+        self.store
+            .write(committed_blocks, commits)
+            .expect("Writing commits to store should not fail");
+        self.set_last_commit(last_commit);
+    }
+
     pub(crate) fn set_last_commit(&mut self, commit: Commit) {
+        if let Some(last_commit) = &self.last_commit {
+            assert!(commit.index >= last_commit.index);
+        }
         self.last_commit = Some(commit);
     }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -7,6 +7,7 @@ mod block;
 mod block_manager;
 mod block_verifier;
 mod commit;
+mod commit_observer;
 mod context;
 mod core;
 mod core_thread;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -18,7 +18,7 @@ use crate::{
 
 /// The output of consensus is an ordered list of [`CommittedSubDag`]. The application
 /// can arbitrarily sort the blocks within each sub-dag (but using a deterministic algorithm).
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct CommittedSubDag {
     /// A reference to the leader of the sub-dag
     pub leader: BlockRef,
@@ -178,13 +178,12 @@ impl Linearizer {
     }
 
     // This function should be called whenever a new commit is observed. This will
-    // iterate over the sequence of committed leaders and produce a list of commit
-    // data & committed sub-dags.
-    pub fn handle_commit(
-        &mut self,
-        committed_leaders: Vec<VerifiedBlock>,
-    ) -> Vec<(Commit, CommittedSubDag)> {
+    // iterate over the sequence of committed leaders and produce a list of committed
+    // sub-dags.
+    pub fn handle_commit(&mut self, committed_leaders: Vec<VerifiedBlock>) -> Vec<CommittedSubDag> {
+        let mut committed_sub_dags = vec![];
         let mut commits = vec![];
+        let mut committed_blocks = vec![];
 
         for leader_block in committed_leaders {
             // Grab latest commit state from dag state
@@ -221,9 +220,14 @@ impl Linearizer {
             self.dag_state
                 .write()
                 .set_last_commit(last_commit_data.clone());
-            commits.push((last_commit_data, sub_dag));
+            commits.push(last_commit_data);
+            committed_blocks.extend(sub_dag.blocks.clone());
+            committed_sub_dags.push(sub_dag);
         }
-        commits
+        self.dag_state
+            .write()
+            .write_commits(commits, committed_blocks);
+        committed_sub_dags
     }
 }
 
@@ -231,20 +235,20 @@ impl Linearizer {
 mod tests {
     use super::*;
 
-    use consensus_config::AuthorityIndex;
-
     use crate::{
         block::{BlockTimestampMs, TestBlock},
         commit::DEFAULT_WAVE_LENGTH,
         context::Context,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
+        test_dag::{build_dag, get_all_leader_blocks},
     };
 
     #[test]
     fn test_handle_commit() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             Arc::new(MemStore::new()),
@@ -254,47 +258,18 @@ mod tests {
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
-        let num_authorities: u32 = 4;
-        let mut leaders = vec![];
-
-        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
-            .committee
-            .authorities()
-            .map(|index| {
-                let author_idx = index.0.value() as u32;
-                let block = TestBlock::new(0, author_idx).build();
-                VerifiedBlock::new_for_test(block)
-            })
-            .map(|block| (block.reference(), block))
-            .unzip();
-        dag_state.write().accept_blocks(genesis);
-
-        let mut ancestors = genesis_references;
-        for round in 1..=num_rounds {
-            let mut new_ancestors = vec![];
-            for author in 0..num_authorities {
-                let base_ts = round as BlockTimestampMs * 1000;
-                let block = VerifiedBlock::new_for_test(
-                    TestBlock::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
-                        .set_ancestors(ancestors.clone())
-                        .build(),
-                );
-                dag_state.write().accept_block(block.clone());
-                new_ancestors.push(block.reference());
-
-                if round % DEFAULT_WAVE_LENGTH == 0
-                    && AuthorityIndex::new_for_test(author)
-                        == leader_schedule.elect_leader(round, 0)
-                {
-                    leaders.push(block.clone());
-                }
-            }
-            ancestors = new_ancestors;
-        }
+        build_dag(context.clone(), dag_state.clone(), None, num_rounds);
+        let leaders = get_all_leader_blocks(
+            dag_state.clone(),
+            leader_schedule,
+            num_rounds,
+            DEFAULT_WAVE_LENGTH,
+            false,
+            1,
+        );
 
         let commits = linearizer.handle_commit(leaders.clone());
-        for (idx, (_commit_data, subdag)) in commits.into_iter().enumerate() {
+        for (idx, subdag) in commits.into_iter().enumerate() {
             tracing::info!("{subdag:?}");
             assert_eq!(subdag.leader, leaders[idx].reference());
             assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
@@ -303,14 +278,14 @@ mod tests {
                 // of the leader minus the genesis round blocks
                 assert_eq!(
                     subdag.blocks.len(),
-                    (num_authorities * (DEFAULT_WAVE_LENGTH - 1)) as usize + 1
+                    (num_authorities * (DEFAULT_WAVE_LENGTH - 1) as usize) + 1
                 );
             } else {
                 // Every subdag after will be missing the leader block from the previous
                 // committed subdag
                 assert_eq!(
                     subdag.blocks.len(),
-                    (num_authorities * DEFAULT_WAVE_LENGTH) as usize
+                    (num_authorities * DEFAULT_WAVE_LENGTH as usize)
                 );
             }
             for block in subdag.blocks.iter() {
@@ -323,115 +298,120 @@ mod tests {
     #[test]
     fn test_handle_already_committed() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+        let num_authorities = 4;
+        let context = Arc::new(Context::new_for_test(num_authorities).0);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
             Arc::new(MemStore::new()),
         )));
+        let leader_schedule = LeaderSchedule::new(context.clone());
         let mut linearizer = Linearizer::new(dag_state.clone());
         let wave_length = DEFAULT_WAVE_LENGTH;
 
-        // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
-        let first_wave_rounds: u32 = wave_length;
-        let num_authorities: u32 = 4;
+        let mut blocks = vec![];
+        let mut ancestors = None;
+        let leader_round_wave_1 = 3;
 
-        let mut blocks = Vec::new();
-        let (genesis_references, _genesis): (Vec<_>, Vec<_>) = context
-            .committee
-            .authorities()
-            .map(|index| {
-                let author_idx = index.0.value() as u32;
-                let block = TestBlock::new(0, author_idx).build();
-                VerifiedBlock::new_for_test(block)
-            })
-            .map(|block| (block.reference(), block))
-            .unzip();
-        blocks.append(&mut genesis_references.clone());
-
-        let mut ancestors = genesis_references;
-        let mut last_committed_rounds = vec![0; num_authorities as usize];
-        for round in 1..=first_wave_rounds {
-            let mut new_ancestors = vec![];
-            for author in 0..num_authorities {
-                let base_ts = round as BlockTimestampMs * 1000;
-                let block = VerifiedBlock::new_for_test(
-                    TestBlock::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
-                        .set_ancestors(ancestors.clone())
-                        .build(),
-                );
-                new_ancestors.push(block.reference());
-                blocks.push(block.reference());
-                last_committed_rounds[block.author().value()] = block.round();
-
-                // only write one block for the final round, which is the leader
-                // of the committed subdag.
-                if round == first_wave_rounds {
-                    break;
-                }
-            }
-            ancestors = new_ancestors;
+        // Build dag layers for rounds 0 ~ 2 and maintain list of blocks to be included
+        // in the subdag of the leader of wave 1.
+        for n in 0..leader_round_wave_1 {
+            ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, n));
+            blocks.extend(ancestors.clone().unwrap());
         }
 
-        let first_leader = *blocks.last().unwrap();
+        // Build dag layer for round 3 which is the leader round of wave 1
+        ancestors = Some(build_dag(
+            context.clone(),
+            dag_state.clone(),
+            ancestors,
+            leader_round_wave_1,
+        ));
+
+        let leaders = get_all_leader_blocks(
+            dag_state.clone(),
+            leader_schedule.clone(),
+            leader_round_wave_1,
+            wave_length,
+            false,
+            1,
+        );
+
+        // Add leader block to first committed subdag blocks
+        blocks.push(leaders[0].reference());
+
+        let mut last_committed_rounds = vec![0; num_authorities];
+        for block in blocks.iter() {
+            let last_committed_round = last_committed_rounds[block.author];
+            last_committed_rounds[block.author] = std::cmp::max(last_committed_round, block.round);
+        }
+
+        let first_leader = leaders[0].clone();
         let mut last_commit_index = 1;
         let first_commit_data = Commit {
             index: last_commit_index,
-            leader: first_leader,
+            leader: first_leader.reference(),
             blocks: blocks.clone(),
             last_committed_rounds,
         };
         dag_state.write().set_last_commit(first_commit_data);
 
         blocks.clear();
-        let second_wave_rounds = first_wave_rounds + wave_length;
-        for round in first_wave_rounds..=second_wave_rounds {
-            let mut new_ancestors = vec![];
-            for author in 0..num_authorities {
-                // skip leader of last committed subdag as it was already written
-                if round == first_leader.round && author == first_leader.author.value() as u32 {
-                    continue;
-                }
-                let base_ts = round as BlockTimestampMs * 1000;
-                let block = VerifiedBlock::new_for_test(
-                    TestBlock::new(round, author)
-                        .set_timestamp_ms(base_ts + (author + round) as u64)
-                        .set_ancestors(ancestors.clone())
-                        .build(),
-                );
-                new_ancestors.push(block.reference());
-                blocks.push(block.reference());
-                dag_state.write().accept_block(block);
+        let leader_round_wave_2 = leader_round_wave_1 + wave_length;
 
-                // only write one block for the final round, which is the leader
-                // of the next committed subdag.
-                if round == second_wave_rounds {
-                    break;
-                }
-            }
-            ancestors = new_ancestors;
+        // Add all nonleader blocks from round 3 to the blocks which will be part
+        // of the second committed subdag
+        blocks.extend(
+            ancestors
+                .clone()
+                .unwrap()
+                .into_iter()
+                .filter(|block_ref| block_ref.author != first_leader.author())
+                .collect::<Vec<_>>(),
+        );
+
+        // Build dag layers for rounds 4 ~ 5 and maintain list of blocks to be included
+        // in the subdag of the leader of wave 1.
+        for n in leader_round_wave_1 + 1..leader_round_wave_2 {
+            ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, n));
+            blocks.extend(ancestors.clone().unwrap());
         }
 
+        // Build dag layer for round 6 which is the leader round of wave 2
+        build_dag(
+            context.clone(),
+            dag_state.clone(),
+            ancestors,
+            leader_round_wave_2,
+        );
+
+        let leaders = get_all_leader_blocks(
+            dag_state.clone(),
+            leader_schedule,
+            leader_round_wave_2,
+            wave_length,
+            false,
+            1,
+        );
+
+        // Add leader block to second committed subdag blocks
+        blocks.push(leaders[1].reference());
+
         last_commit_index += 1;
-        let second_leader = *blocks.last().unwrap();
+        let second_leader = leaders[1].clone();
         let expected_second_commit_data = Commit {
             index: last_commit_index,
-            leader: second_leader,
+            leader: second_leader.reference(),
             blocks: blocks.clone(),
             last_committed_rounds: vec![],
         };
 
-        let second_leader_block = dag_state
-            .read()
-            .get_uncommitted_block(&second_leader)
-            .unwrap();
-        let commit = linearizer.handle_commit(vec![second_leader_block.clone()]);
+        let commit = linearizer.handle_commit(vec![second_leader.clone()]);
         assert_eq!(commit.len(), 1);
 
-        let (_commit_data, subdag) = &commit[0];
+        let subdag = &commit[0];
         tracing::info!("{subdag:?}");
-        assert_eq!(subdag.leader, second_leader);
-        assert_eq!(subdag.timestamp_ms, second_leader_block.timestamp_ms());
+        assert_eq!(subdag.leader, second_leader.reference());
+        assert_eq!(subdag.timestamp_ms, second_leader.timestamp_ms());
         assert_eq!(subdag.commit_index, expected_second_commit_data.index);
 
         // Using the same sorting as used in CommittedSubDag::sort

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -224,6 +224,7 @@ impl Linearizer {
             committed_blocks.extend(sub_dag.blocks.clone());
             committed_sub_dags.push(sub_dag);
         }
+        // TODO: Revisit this after refactor of dag state
         self.dag_state
             .write()
             .write_commits(commits, committed_blocks);

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -37,8 +37,6 @@ pub(crate) fn test_metrics() -> Arc<Metrics> {
 pub(crate) struct NodeMetrics {
     pub uptime: Histogram,
     pub quorum_receive_latency: Histogram,
-    #[allow(unused)]
-    pub committed_leaders_total: IntCounterVec,
     pub core_lock_enqueued: IntCounter,
     pub core_lock_dequeued: IntCounter,
     pub leader_timeout_total: IntCounter,
@@ -46,6 +44,13 @@ pub(crate) struct NodeMetrics {
     pub suspended_blocks: IntCounterVec,
     pub unsuspended_blocks: IntCounterVec,
     pub invalid_blocks: IntCounterVec,
+
+    // Commit Metrics
+    #[allow(unused)]
+    pub committed_leaders_total: IntCounterVec,
+    pub blocks_per_commit_count: Histogram,
+    pub sub_dags_per_commit_count: Histogram,
+    pub block_commit_latency: Histogram,
 }
 
 impl NodeMetrics {
@@ -62,13 +67,6 @@ impl NodeMetrics {
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
                 registry
-            )
-            .unwrap(),
-            committed_leaders_total: register_int_counter_vec_with_registry!(
-                "committed_leaders_total",
-                "Total number of (direct or indirect) committed leaders per authority",
-                &["authority", "commit_type"],
-                registry,
             )
             .unwrap(),
             core_lock_enqueued: register_int_counter_with_registry!(
@@ -111,6 +109,33 @@ impl NodeMetrics {
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
                 &["authority"],
+                registry,
+            )
+            .unwrap(),
+
+            // Commit Metrics
+            committed_leaders_total: register_int_counter_vec_with_registry!(
+                "committed_leaders_total",
+                "Total number of (direct or indirect) committed leaders per authority",
+                &["authority", "commit_type"],
+                registry,
+            )
+            .unwrap(),
+            block_commit_latency: register_histogram_with_registry!(
+                "block_commit_latency",
+                "The time taken between block creation and block commit.",
+                registry,
+            )
+            .unwrap(),
+            blocks_per_commit_count: register_histogram_with_registry!(
+                "blocks_per_commit_count",
+                "The number of blocks per commit.",
+                registry,
+            )
+            .unwrap(),
+            sub_dags_per_commit_count: register_histogram_with_registry!(
+                "sub_dags_per_commit_count",
+                "The number of subdags per commit.",
                 registry,
             )
             .unwrap(),

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -7,9 +7,10 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use crate::{
-    block::{Block, BlockRef, Round, TestBlock, VerifiedBlock},
+    block::{Block, BlockRef, BlockTimestampMs, Round, Slot, TestBlock, VerifiedBlock},
     context::Context,
     dag_state::DagState,
+    leader_schedule::LeaderSchedule,
 };
 
 /// Build a fully interconnected dag up to the specified round. This function
@@ -47,8 +48,10 @@ pub(crate) fn build_dag(
             .authorities()
             .map(|authority| {
                 let author_idx = authority.0.value() as u32;
+                let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlock::new_for_test(
                     TestBlock::new(round, author_idx)
+                        .set_timestamp_ms(base_ts + (author_idx + round) as u64)
                         .set_ancestors(ancestors.clone())
                         .build(),
                 );
@@ -83,4 +86,26 @@ pub(crate) fn build_dag_layer(
         dag_state.write().accept_block(block);
     }
     references
+}
+
+// TODO: confirm pipelined & multi-leader cases work properly
+pub(crate) fn get_all_leader_blocks(
+    dag_state: Arc<RwLock<DagState>>,
+    leader_schedule: LeaderSchedule,
+    num_rounds: u32,
+    wave_length: u32,
+    pipelined: bool,
+    num_leaders: u32,
+) -> Vec<VerifiedBlock> {
+    let mut blocks = Vec::new();
+    for round in 1..=num_rounds {
+        for leader_offset in 0..num_leaders {
+            if pipelined || round % wave_length == 0 {
+                let slot = Slot::new(round, leader_schedule.elect_leader(round, leader_offset));
+                let uncommitted_blocks = dag_state.read().get_uncommitted_blocks_at_slot(slot);
+                blocks.extend(uncommitted_blocks);
+            }
+        }
+    }
+    blocks
 }


### PR DESCRIPTION
Copying comment from PR

```
/// Role of CommitObserver
/// - Called by core when block is created via try_new_block or force_new_block
/// and try_commit returns newly comitted leaders
/// - The newly committed leaders are sent to commit observer and then commit observer
/// gets subdags for each leader via the commit interpreter (linearizer)
/// - The committed subdags are sent as consensus output via an unbounded tokio channel.
/// No back pressure mechanism is needed as backpressure is handled as input into
/// consenus.
/// - Last commit index is persisted in store as soon as the subdag is sent to
/// output channel.
/// - When CommitObserver is initialized a last received commit index can be used
/// to ensure any missing commits are re-sent.
```