### PR TITLE
[move][move-2024] Automatic borrowing for Eq / Neq

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.move
@@ -1,0 +1,268 @@
+//# init --edition 2024.alpha
+
+//# publish
+module 0x42::m {
+
+    public struct S has copy, drop { t: u64 }
+
+    public fun make_s(t: u64): S {
+        S { t }
+    }
+
+        public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun tnum_0(): bool {
+       0 == &0
+    }
+
+    public fun tnum_1(): bool {
+       &0 == &0
+    }
+
+    public fun tnum_2(): bool {
+        let a = 0;
+        let b = &mut 0;
+        let c = &0;
+        a == b && b == c && a == c
+    }
+
+
+}
+
+//# run
+module 0x42::main {
+
+    fun main() {
+        let s_val = 0x42::m::make_s(42);
+        let s_ref = &(0x42::m::make_s(42));
+        let s_mut = &mut (0x42::m::make_s(42));
+
+        assert!(0x42::m::test_0(s_val, s_val), 0);
+        assert!(0x42::m::test_1(s_val, s_ref), 1);
+        assert!(0x42::m::test_2(s_val, s_mut), 2);
+        assert!(0x42::m::test_3(s_ref, s_val), 3);
+        assert!(0x42::m::test_4(s_ref, s_ref), 4);
+        assert!(0x42::m::test_5(s_ref, s_mut), 5);
+        assert!(0x42::m::test_6(s_mut, s_val), 6);
+        assert!(0x42::m::test_7(s_mut, s_ref), 7);
+        // assert!(0x42::m::test_8(s_mut, s_mut), 8);
+        assert!(0x42::m::test_9(s_val, s_val, s_val), 9);
+        assert!(0x42::m::test_10(s_val, s_val, s_ref), 10);
+        assert!(0x42::m::test_11(s_val, s_val, s_mut), 11);
+        assert!(0x42::m::test_12(s_val, s_ref, s_val), 12);
+        assert!(0x42::m::test_13(s_val, s_ref, s_ref), 13);
+        assert!(0x42::m::test_14(s_val, s_ref, s_mut), 14);
+        assert!(0x42::m::test_15(s_val, s_mut, s_val), 15);
+        assert!(0x42::m::test_16(s_val, s_mut, s_ref), 16);
+        // assert!(0x42::m::test_17(s_val, s_mut, s_mut), 17);
+        assert!(0x42::m::test_18(s_ref, s_val, s_val), 18);
+        assert!(0x42::m::test_19(s_ref, s_val, s_ref), 19);
+        assert!(0x42::m::test_20(s_ref, s_val, s_mut), 20);
+        assert!(0x42::m::test_21(s_ref, s_ref, s_val), 21);
+        assert!(0x42::m::test_22(s_ref, s_ref, s_ref), 22);
+        assert!(0x42::m::test_23(s_ref, s_ref, s_mut), 23);
+        assert!(0x42::m::test_24(s_ref, s_mut, s_val), 24);
+        assert!(0x42::m::test_25(s_ref, s_mut, s_ref), 25);
+        // assert!(0x42::m::test_26(s_ref, s_mut, s_mut), 26);
+        assert!(0x42::m::test_27(s_mut, s_val, s_val), 27);
+        assert!(0x42::m::test_28(s_mut, s_val, s_ref), 28);
+        // assert!(0x42::m::test_29(s_mut, s_val, s_mut), 29);
+        assert!(0x42::m::test_30(s_mut, s_ref, s_val), 30);
+        assert!(0x42::m::test_31(s_mut, s_ref, s_ref), 31);
+        // assert!(0x42::m::test_32(s_mut, s_ref, s_mut), 32);
+        // assert!(0x42::m::test_33(s_mut, s_mut, s_val), 33);
+        // assert!(0x42::m::test_34(s_mut, s_mut, s_ref), 34);
+        // assert!(0x42::m::test_35(s_mut, s_mut, s_mut), 35);
+
+        let s2_val = 0x42::m::make_s(2);
+        let s2_ref = &(0x42::m::make_s(2));
+        let s2_mut = &mut (0x42::m::make_s(2));
+
+        let s3_val = 0x42::m::make_s(3);
+        let s3_ref = &(0x42::m::make_s(3));
+        let s3_mut = &mut (0x42::m::make_s(3));
+
+        assert!(!0x42::m::test_0(s_val, s2_val), 36);
+        assert!(!0x42::m::test_1(s_val, s2_ref), 37);
+        assert!(!0x42::m::test_2(s_val, s2_mut), 38);
+        assert!(!0x42::m::test_3(s_ref, s2_val), 39);
+        assert!(!0x42::m::test_4(s_ref, s2_ref), 40);
+        assert!(!0x42::m::test_5(s_ref, s2_mut), 41);
+        assert!(!0x42::m::test_6(s_mut, s2_val), 42);
+        assert!(!0x42::m::test_7(s_mut, s2_ref), 43);
+        assert!(!0x42::m::test_8(s_mut, s2_mut), 44);
+        assert!(!0x42::m::test_9(s_val, s2_val, s3_val), 45);
+        assert!(!0x42::m::test_10(s_val, s2_val, s3_ref), 46);
+        assert!(!0x42::m::test_11(s_val, s2_val, s3_mut), 47);
+        assert!(!0x42::m::test_12(s_val, s2_ref, s3_val), 48);
+        assert!(!0x42::m::test_13(s_val, s2_ref, s3_ref), 49);
+        assert!(!0x42::m::test_14(s_val, s2_ref, s3_mut), 50);
+        assert!(!0x42::m::test_15(s_val, s2_mut, s3_val), 51);
+        assert!(!0x42::m::test_16(s_val, s2_mut, s3_ref), 52);
+        assert!(!0x42::m::test_17(s_val, s2_mut, s3_mut), 53);
+        assert!(!0x42::m::test_18(s_ref, s2_val, s3_val), 54);
+        assert!(!0x42::m::test_19(s_ref, s2_val, s3_ref), 55);
+        assert!(!0x42::m::test_20(s_ref, s2_val, s3_mut), 56);
+        assert!(!0x42::m::test_21(s_ref, s2_ref, s3_val), 57);
+        assert!(!0x42::m::test_22(s_ref, s2_ref, s3_ref), 58);
+        assert!(!0x42::m::test_23(s_ref, s2_ref, s3_mut), 59);
+        assert!(!0x42::m::test_24(s_ref, s2_mut, s3_val), 60);
+        assert!(!0x42::m::test_25(s_ref, s2_mut, s3_ref), 61);
+        assert!(!0x42::m::test_26(s_ref, s2_mut, s3_mut), 62);
+        assert!(!0x42::m::test_27(s_mut, s2_val, s3_val), 63);
+        assert!(!0x42::m::test_28(s_mut, s2_val, s3_ref), 64);
+        assert!(!0x42::m::test_29(s_mut, s2_val, s3_mut), 65);
+        assert!(!0x42::m::test_30(s_mut, s2_ref, s3_val), 66);
+        assert!(!0x42::m::test_31(s_mut, s2_ref, s3_ref), 67);
+        assert!(!0x42::m::test_32(s_mut, s2_ref, s3_mut), 68);
+        assert!(!0x42::m::test_33(s_mut, s2_mut, s3_val), 69);
+        assert!(!0x42::m::test_34(s_mut, s2_mut, s3_ref), 70);
+        assert!(!0x42::m::test_35(s_mut, s2_mut, s3_mut), 71);
+
+        assert!(0x42::m::tnum_0(), 101);
+        assert!(0x42::m::tnum_1(), 102);
+        assert!(0x42::m::tnum_2(), 103);
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -41,6 +41,7 @@ pub enum FeatureGate {
     MacroFuns,
     Move2024Migration,
     SyntaxMethods,
+    Autoborrow,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -122,6 +123,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::MacroFuns,
     FeatureGate::Move2024Optimizations,
     FeatureGate::SyntaxMethods,
+    FeatureGate::Autoborrow,
 ];
 
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
@@ -217,6 +219,7 @@ impl FeatureGate {
             FeatureGate::MacroFuns => "'macro' functions are",
             FeatureGate::Move2024Migration => "Move 2024 migration is",
             FeatureGate::SyntaxMethods => "'syntax' methods are",
+            FeatureGate::Autoborrow => "Automatic borrowing is",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -41,7 +41,7 @@ pub enum FeatureGate {
     MacroFuns,
     Move2024Migration,
     SyntaxMethods,
-    Autoborrow,
+    AutoborrowEq,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -123,7 +123,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::MacroFuns,
     FeatureGate::Move2024Optimizations,
     FeatureGate::SyntaxMethods,
-    FeatureGate::Autoborrow,
+    FeatureGate::AutoborrowEq,
 ];
 
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
@@ -219,7 +219,7 @@ impl FeatureGate {
             FeatureGate::MacroFuns => "'macro' functions are",
             FeatureGate::Move2024Migration => "Move 2024 migration is",
             FeatureGate::SyntaxMethods => "'syntax' methods are",
-            FeatureGate::Autoborrow => "Automatic borrowing is",
+            FeatureGate::AutoborrowEq => "Automatic borrowing is",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2092,7 +2092,6 @@ fn join_impl(
             subst.insert(new_tvar, other.clone());
             join_tvar(subst, case, other.loc, new_tvar, *loc, *id)
         }
-
         (sp!(_, UnresolvedError), other) | (other, sp!(_, UnresolvedError)) => {
             Ok((subst, other.clone()))
         }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2092,6 +2092,7 @@ fn join_impl(
             subst.insert(new_tvar, other.clone());
             join_tvar(subst, case, other.loc, new_tvar, *loc, *id)
         }
+
         (sp!(_, UnresolvedError), other) | (other, sp!(_, UnresolvedError)) => {
             Ok((subst, other.clone()))
         }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -28,8 +28,8 @@ use crate::{
     typing::{
         ast as T,
         core::{
-            self, make_tvar, public_testing_visibility, ready_tvars, Context, Local,
-            PublicForTesting, ResolvedFunctionType, Subst,
+            self, make_tvar, public_testing_visibility, Context, Local, PublicForTesting,
+            ResolvedFunctionType, Subst,
         },
         dependency_ordering, expand, infinite_instantiations, macro_expand, recursive_structs,
         syntax_methods::validate_syntax_methods,
@@ -1645,9 +1645,9 @@ fn binop(
             (Type_::bool(loc), operand_ty)
         }
 
-        Eq | Neq => {
-            let lhs_type = ready_tvars(&context.subst, el.ty.clone());
-            let rhs_type = ready_tvars(&context.subst, er.ty.clone());
+        Eq | Neq if context.env.supports_feature(context.current_package(), FeatureGate::AutoborrowEq) => {
+            let lhs_type = core::ready_tvars(&context.subst, el.ty.clone());
+            let rhs_type = core::ready_tvars(&context.subst, er.ty.clone());
             let (lhs_ref, lhs_inner, rhs_ref, rhs_inner) = match (lhs_type, rhs_type) {
                 (sp!(_, Type_::Ref(lhs_mut, lhs)), sp!(_, Type_::Ref(rhs_mut, rhs))) => {
                     (Some(lhs_mut), *lhs, Some(rhs_mut), *rhs)
@@ -1684,18 +1684,18 @@ fn binop(
                     // If the RHS is mutable, we reborrow it as immutable so avoid requiring the
                     // LHS to be mutable.
                     if rhs_mut {
-                        er = exp_to_ref(context, loc, false, er);
+                        er = exp_to_ref(context, er.exp.loc, false, er);
                     }
-                    el = exp_to_ref(context, loc, false, el);
+                    el = exp_to_ref(context, el.exp.loc, false, el);
                     sp(bop.loc, Type_::Ref(false, Box::new(ty)))
                 }
                 (Some(lhs_mut), None) => {
                     // If the LHS is mutable, we reborrow it as immutable so avoid requiring the
                     // RHS to be mutable.
                     if lhs_mut {
-                        el = exp_to_ref(context, loc, false, el);
+                        el = exp_to_ref(context, el.exp.loc, false, el);
                     }
-                    er = exp_to_ref(context, loc, false, er);
+                    er = exp_to_ref(context, er.exp.loc, false, er);
                     sp(bop.loc, Type_::Ref(false, Box::new(ty)))
                 }
                 (Some(lhs_mut), Some(rhs_mut)) => {
@@ -1703,16 +1703,34 @@ fn binop(
                         sp(bop.loc, Type_::Ref(lhs_mut, Box::new(ty)))
                     } else {
                         if lhs_mut {
-                            el = exp_to_ref(context, loc, false, el)
+                            el = exp_to_ref(context, el.exp.loc, false, el)
                         };
                         if rhs_mut {
-                            er = exp_to_ref(context, loc, false, er)
+                            er = exp_to_ref(context, er.exp.loc, false, er)
                         };
                         sp(bop.loc, Type_::Ref(false, Box::new(ty)))
                     }
                 }
             };
             (Type_::bool(loc), eq_ty)
+        }
+        Eq | Neq => {
+            let ability_msg = Some(format!(
+                "'{}' requires the '{}' ability as the value is consumed. Try \
+                         borrowing the values with '&' first.'",
+                &bop,
+                Ability_::Drop,
+            ));
+            context.add_ability_constraint(
+                el.exp.loc,
+                ability_msg.clone(),
+                el.ty.clone(),
+                Ability_::Drop,
+            );
+            context.add_ability_constraint(er.exp.loc, ability_msg, er.ty.clone(), Ability_::Drop);
+            let ty = join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
+            context.add_single_type_constraint(loc, msg(), ty.clone());
+            (Type_::bool(loc), ty)
         }
 
         And | Or => {

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -28,8 +28,8 @@ use crate::{
     typing::{
         ast as T,
         core::{
-            self, make_tvar, public_testing_visibility, Context, Local, PublicForTesting,
-            ResolvedFunctionType, Subst,
+            self, make_tvar, public_testing_visibility, ready_tvars, Context, Local,
+            PublicForTesting, ResolvedFunctionType, Subst,
         },
         dependency_ordering, expand, infinite_instantiations, macro_expand, recursive_structs,
         syntax_methods::validate_syntax_methods,
@@ -1607,10 +1607,10 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
 
 fn binop(
     context: &mut Context,
-    el: Box<T::Exp>,
+    mut el: Box<T::Exp>,
     bop: BinOp,
     loc: Loc,
-    er: Box<T::Exp>,
+    mut er: Box<T::Exp>,
 ) -> Box<T::Exp> {
     use BinOp_::*;
     use T::UnannotatedExp_ as TE;
@@ -1646,22 +1646,73 @@ fn binop(
         }
 
         Eq | Neq => {
-            let ability_msg = Some(format!(
-                "'{}' requires the '{}' ability as the value is consumed. Try \
-                         borrowing the values with '&' first.'",
-                &bop,
-                Ability_::Drop,
-            ));
-            context.add_ability_constraint(
-                el.exp.loc,
-                ability_msg.clone(),
-                el.ty.clone(),
-                Ability_::Drop,
-            );
-            context.add_ability_constraint(er.exp.loc, ability_msg, er.ty.clone(), Ability_::Drop);
-            let ty = join(context, bop.loc, msg, el.ty.clone(), er.ty.clone());
+            let lhs_type = ready_tvars(&context.subst, el.ty.clone());
+            let rhs_type = ready_tvars(&context.subst, er.ty.clone());
+            let (lhs_ref, lhs_inner, rhs_ref, rhs_inner) = match (lhs_type, rhs_type) {
+                (sp!(_, Type_::Ref(lhs_mut, lhs)), sp!(_, Type_::Ref(rhs_mut, rhs))) => {
+                    (Some(lhs_mut), *lhs, Some(rhs_mut), *rhs)
+                }
+                (sp!(_, Type_::Ref(lhs_mut, lhs)), rhs) => (Some(lhs_mut), *lhs, None, rhs),
+                (lhs, sp!(_, Type_::Ref(rhs_mut, rhs))) => (None, lhs, Some(rhs_mut), *rhs),
+                (lhs, rhs) => (None, lhs, None, rhs),
+            };
+            let ty = join(context, bop.loc, msg, lhs_inner.clone(), rhs_inner.clone());
             context.add_single_type_constraint(loc, msg(), ty.clone());
-            (Type_::bool(loc), ty)
+            let eq_ty = match (lhs_ref, rhs_ref) {
+                (None, None) => {
+                    let ability_msg = Some(format!(
+                        "'{}' requires the '{}' ability as the value is consumed. Try \
+                                 borrowing the values with '&' first.'",
+                        &bop,
+                        Ability_::Drop,
+                    ));
+                    context.add_ability_constraint(
+                        el.exp.loc,
+                        ability_msg.clone(),
+                        lhs_inner,
+                        Ability_::Drop,
+                    );
+                    context.add_ability_constraint(
+                        er.exp.loc,
+                        ability_msg,
+                        rhs_inner,
+                        Ability_::Drop,
+                    );
+                    ty
+                }
+                (None, Some(rhs_mut)) => {
+                    // If the RHS is mutable, we reborrow it as immutable so avoid requiring the
+                    // LHS to be mutable.
+                    if rhs_mut {
+                        er = exp_to_ref(context, loc, false, er);
+                    }
+                    el = exp_to_ref(context, loc, false, el);
+                    sp(bop.loc, Type_::Ref(false, Box::new(ty)))
+                }
+                (Some(lhs_mut), None) => {
+                    // If the LHS is mutable, we reborrow it as immutable so avoid requiring the
+                    // RHS to be mutable.
+                    if lhs_mut {
+                        el = exp_to_ref(context, loc, false, el);
+                    }
+                    er = exp_to_ref(context, loc, false, er);
+                    sp(bop.loc, Type_::Ref(false, Box::new(ty)))
+                }
+                (Some(lhs_mut), Some(rhs_mut)) => {
+                    if lhs_mut == rhs_mut {
+                        sp(bop.loc, Type_::Ref(lhs_mut, Box::new(ty)))
+                    } else {
+                        if lhs_mut {
+                            el = exp_to_ref(context, loc, false, el)
+                        };
+                        if rhs_mut {
+                            er = exp_to_ref(context, loc, false, er)
+                        };
+                        sp(bop.loc, Type_::Ref(false, Box::new(ty)))
+                    }
+                }
+            };
+            (Type_::bool(loc), eq_ty)
         }
 
         And | Or => {
@@ -1723,6 +1774,33 @@ fn loop_body(
     } else {
         // if it was a while loop, the `if` case ran, so we can simply make a type var for the loop
         (false, context.named_block_type(name, eloc), eloop)
+    }
+}
+
+fn exp_to_ref(context: &mut Context, loc: Loc, mut_: bool, e: Box<T::Exp>) -> Box<T::Exp> {
+    let ety = &e.ty;
+    let current_ty = core::unfold_type(&context.subst, ety.clone());
+    match current_ty.value {
+        Type_::Ref(false, _t) => {
+            if mut_ {
+                make_error_exp(context, loc)
+            } else {
+                e
+            }
+        }
+        Type_::Ref(true, t) => {
+            if mut_ {
+                e
+            } else {
+                let freeze_type = sp(loc, Type_::Ref(false, Box::new(*t)));
+                let freeze_exp = sp(
+                    loc,
+                    T::UnannotatedExp_::Annotate(e, Box::new(freeze_type.clone())),
+                );
+                Box::new(T::exp(freeze_type, freeze_exp))
+            }
+        }
+        _ => exp_to_borrow(context, loc, mut_, e, current_ty),
     }
 }
 
@@ -2692,7 +2770,7 @@ fn exp_to_borrow(
     loc: Loc,
     mut_: bool,
     eb: Box<T::Exp>,
-    cur_ty: Type,
+    base_type: Type,
 ) -> Box<T::Exp> {
     use Type_::*;
     use T::UnannotatedExp_ as TE;
@@ -2716,7 +2794,7 @@ fn exp_to_borrow(
             TE::TempBorrow(mut_, Box::new(T::exp(eb_ty, sp(ebloc, eb_))))
         }
     };
-    let ty = sp(loc, Ref(mut_, Box::new(cur_ty)));
+    let ty = sp(loc, Ref(mut_, Box::new(base_type)));
     Box::new(T::exp(ty, sp(loc, e_)))
 }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.exp
@@ -1,0 +1,132 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:12:17
+   │
+12 │         (0: u8) == (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '=='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:13:11
+   │
+13 │         0 == false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '=='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:21:9
+   │
+ 3 │     public struct R has key {
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+20 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+21 │         r == r;
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:21:14
+   │
+ 3 │     public struct R has key {
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+20 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+21 │         r == r;
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:25:9
+   │
+25 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │
+   │         │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:25:35
+   │
+25 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^
+   │                                   │  │
+   │                                   │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │                                   '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                   The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/eq_invalid.move:27:9
+   │
+27 │         G2{} == G2{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/eq_invalid.move:27:17
+   │
+27 │         G2{} == G2{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:28:9
+   │
+ 7 │     public struct G1<T: key> { f: T }
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G1{ f: t } == G1{ f: t };
+   │         ^^^^^^^^^^
+   │         │
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<T>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:28:23
+   │
+ 7 │     public struct G1<T: key> { f: T }
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G1{ f: t } == G1{ f: t };
+   │                       ^^^^^^^^^^
+   │                       │
+   │                       '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                       The type '0x8675309::M::G1<T>' does not have the ability 'drop'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/eq_invalid.move:32:9
+   │
+32 │         () == ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Incompatible arguments to '=='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/eq_invalid.move:33:9
+   │
+33 │         (0, 1) == (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:34:19
+   │
+34 │         (1, 2, 3) == (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '=='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:35:16
+   │
+35 │         (0, 1) == (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '=='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
@@ -1,0 +1,37 @@
+module 0x8675309::M {
+    public struct S { u: u64 }
+    public struct R has key {
+        f: u64
+    }
+    public struct G0<T> has drop { f: T }
+    public struct G1<T: key> { f: T }
+    public struct G2<phantom T> has drop {}
+
+
+    fun t0(mut s: S, s_ref: &S, s_mut: &mut S) {
+        (0: u8) == (1: u128);
+        0 == false;
+        &0 == 1;
+        1 == &0;
+        s == s_ref;
+        s_mut == s;
+    }
+
+    fun t1(r: R) {
+        r == r;
+    }
+
+    fun t3<T: copy + key>(t: T) {
+        G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+        // can be dropped, but cannot infer type
+        G2{} == G2{};
+        G1{ f: t } == G1{ f: t };
+    }
+
+    fun t4() {
+        () == ();
+        (0, 1) == (0, 1);
+        (1, 2, 3) == (0, 1);
+        (0, 1) == (1, 2, 3);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
@@ -8,7 +8,7 @@ module 0x8675309::M {
     public struct G2<phantom T> has drop {}
 
 
-    fun t0(mut s: S, s_ref: &S, s_mut: &mut S) {
+    fun t0(s: S, s_ref: &S, s_mut: &mut S) {
         (0: u8) == (1: u128);
         0 == false;
         &0 == 1;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
@@ -1,0 +1,74 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:18:11
+   │
+15 │         let x: T<u64> = any();
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+16 │         let y: &T<bool> = abort 0;
+   │                   ---- Found: 'bool'. It is not compatible with the other type.
+17 │         let z: &mut T<bool> = abort 0;
+18 │         x == y && x == z
+   │           ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:18:21
+   │
+15 │         let x: T<u64> = any();
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+16 │         let y: &T<bool> = abort 0;
+17 │         let z: &mut T<bool> = abort 0;
+   │                       ---- Found: 'bool'. It is not compatible with the other type.
+18 │         x == y && x == z
+   │                     ^^ Incompatible arguments to '=='
+
+error[E04024]: invalid usage of immutable variable
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:33:19
+   │
+30 │         let x = any();
+   │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+   ·
+33 │         x == y && x == z;
+   │                   ^ Invalid mutable borrow of immutable variable 'x'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:31
+   │
+45 │         let a: &T<u64> = abort 0;
+   │                   --- Found: 'u64'. It is not compatible with the other type.
+46 │         let b: &mut T<u64> = abort 0;
+47 │         let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+   │                             ---- Found: 'bool'. It is not compatible with the other type.
+48 │         a == b && c == d && a == c && b == d
+   │                               ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:41
+   │
+46 │         let b: &mut T<u64> = abort 0;
+   │                       --- Found: 'u64'. It is not compatible with the other type.
+47 │         let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+   │                                       ---- Found: 'bool'. It is not compatible with the other type.
+48 │         a == b && c == d && a == c && b == d
+   │                                         ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:73:11
+   │
+72 │         let x: T<u64> = option_take(&mut c);
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+73 │         x == &mut T { q: false };
+   │           ^^             ----- Found: 'bool'. It is not compatible with the other type.
+   │           │               
+   │           Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:74:9
+   │
+72 │         let x: T<u64> = option_take(&mut c);
+   │                  --- Expected: 'u64'
+73 │         x == &mut T { q: false };
+74 │         option_fill(&mut c, T { q: false });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                          │
+   │         │                          Given: 'bool'
+   │         Invalid call of 'a::m::option_fill'. Invalid argument for parameter '_e'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
@@ -20,15 +20,6 @@ error[E04007]: incompatible types
 18 │         x == y && x == z
    │                     ^^ Incompatible arguments to '=='
 
-error[E04024]: invalid usage of immutable variable
-   ┌─ tests/move_2024/typing/eq_ref_tvars.move:33:19
-   │
-30 │         let x = any();
-   │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
-   ·
-33 │         x == y && x == z;
-   │                   ^ Invalid mutable borrow of immutable variable 'x'
-
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:31
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
@@ -1,0 +1,98 @@
+module a::m {
+
+    public struct T<Q> has drop { q: Q }
+
+    fun any<T>(): T { abort 0 }
+
+    fun globals00(): bool {
+        let mut x: T<u64> = any();
+        let y: &T<u64> = abort 0;
+        let z: &mut T<u64> = abort 0;
+        x == y && x == z
+    }
+
+    fun globals01(): bool {
+        let x: T<u64> = any();
+        let y: &T<bool> = abort 0;
+        let z: &mut T<bool> = abort 0;
+        x == y && x == z
+    }
+
+    fun globals02(): u64 {
+        let mut x = any();
+        let y = &any();
+        let z = &mut any();
+        x == y && x == z;
+        (x : u64)
+    }
+
+    fun globals03(): u64 {
+        let x = any();
+        let y = &any();
+        let z = &mut any();
+        x == y && x == z;
+        (x : u64)
+    }
+
+    fun locals00(): bool {
+        let a: &T<u64> = abort 0;
+        let b: &mut T<u64> = abort 0;
+        let (c, d): (&mut T<u64>, &T<u64>) = abort 0;
+        a == b && c == d && a == c && b == d
+    }
+
+    fun locals01(): bool {
+        let a: &T<u64> = abort 0;
+        let b: &mut T<u64> = abort 0;
+        let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+        a == b && c == d && a == c && b == d
+    }
+
+    fun locals02(): bool {
+        let mut x = abort 0;
+        let y = &(abort 0);
+        let z = &mut (abort 0);
+        x == y && x == z;
+        let _ = (x : u64);
+        x == y && x == z
+    }
+
+    fun options00(): bool {
+        let mut c = option_none();
+        c == c;
+        let mut x: T<u64> = option_take(&mut c);
+        x == &mut T { q: 5 };
+        option_fill(&mut c, T { q: 10 });
+        x == x
+    }
+
+    fun options01(): bool {
+        let mut c = option_none();
+        c == c;
+        let x: T<u64> = option_take(&mut c);
+        x == &mut T { q: false };
+        option_fill(&mut c, T { q: false });
+        x == x
+    }
+
+    fun options02(): T<u64> {
+        let mut c = option_none();
+        c == c;
+        let mut x = option_take(&mut c);
+        x == &mut T { q: 5 };
+        option_fill(&mut c, T { q: 10 });
+        x == x;
+        x
+    }
+
+    // Approximation of options for typing
+
+    public struct Option<T> has copy, drop { value: T }
+
+    public fun option_none<Element>(): Option<Element> { abort 0 }
+
+    public fun option_fill<Element>(_t: &mut Option<Element>, _e: Element) { abort 0 }
+
+    public fun option_take<Element>(_t: &mut Option<Element>): Element { abort 0 }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
@@ -5,7 +5,7 @@ module a::m {
     fun any<T>(): T { abort 0 }
 
     fun globals00(): bool {
-        let mut x: T<u64> = any();
+        let x: T<u64> = any();
         let y: &T<u64> = abort 0;
         let z: &mut T<u64> = abort 0;
         x == y && x == z
@@ -19,7 +19,7 @@ module a::m {
     }
 
     fun globals02(): u64 {
-        let mut x = any();
+        let x = any();
         let y = &any();
         let z = &mut any();
         x == y && x == z;
@@ -49,7 +49,7 @@ module a::m {
     }
 
     fun locals02(): bool {
-        let mut x = abort 0;
+        let x = abort 0;
         let y = &(abort 0);
         let z = &mut (abort 0);
         x == y && x == z;
@@ -60,7 +60,7 @@ module a::m {
     fun options00(): bool {
         let mut c = option_none();
         c == c;
-        let mut x: T<u64> = option_take(&mut c);
+        let x: T<u64> = option_take(&mut c);
         x == &mut T { q: 5 };
         option_fill(&mut c, T { q: 10 });
         x == x
@@ -78,7 +78,7 @@ module a::m {
     fun options02(): T<u64> {
         let mut c = option_none();
         c == c;
-        let mut x = option_take(&mut c);
+        let x = option_take(&mut c);
         x == &mut T { q: 5 };
         option_fill(&mut c, T { q: 10 });
         x == x;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct.move
@@ -1,0 +1,149 @@
+module 0x42::a {
+
+    public struct S has drop, copy {}
+
+    public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.exp
@@ -1,0 +1,623 @@
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:6:9
+  │
+3 │     public struct S has copy {}
+  │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+4 │ 
+5 │     public fun test_0(a: S, b: S): bool {
+  │                          - The type '0x42::a::S' does not have the ability 'drop'
+6 │         a == b
+  │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:6:14
+  │
+3 │     public struct S has copy {}
+  │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+4 │ 
+5 │     public fun test_0(a: S, b: S): bool {
+  │                                - The type '0x42::a::S' does not have the ability 'drop'
+6 │         a == b
+  │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:10:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 9 │     public fun test_1(a: S, b: &S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+10 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:14:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     public fun test_2(a: S, b: &mut S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+14 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:18:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+17 │     public fun test_3(a: &S, b: S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+18 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:22:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     public fun test_6(a: &mut S, b: S): bool {
+   │                                  -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                  │   
+   │                                  The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+22 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                          - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                             -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                             │   
+   │                             The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                          - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+30 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                                 - The type '0x42::a::S' does not have the ability 'drop'
+30 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+30 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+30 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+34 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                                 - The type '0x42::a::S' does not have the ability 'drop'
+34 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+34 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+34 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+38 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                                     -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                     │   
+   │                                     The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+38 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+38 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                                        - The type '0x42::a::S' does not have the ability 'drop'
+38 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:42:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+41 │     public fun test_13(a: S, b: &S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+42 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:46:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+45 │     public fun test_14(a: S, b: &S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+46 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+50 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                                         -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                         │   
+   │                                         The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+50 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+50 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                                            - The type '0x42::a::S' does not have the ability 'drop'
+50 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:54:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+53 │     public fun test_16(a: S, b: &mut S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+54 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:58:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+57 │     public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+58 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                  - The type '0x42::a::S' does not have the ability 'drop'
+62 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                        - The type '0x42::a::S' does not have the ability 'drop'
+62 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+62 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                     -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                     │   
+   │                                     The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+62 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:66:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+65 │     public fun test_19(a: &S, b: S, c: &S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+66 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:70:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+69 │     public fun test_20(a: &S, b: S, c: &mut S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+70 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:74:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+73 │     public fun test_21(a: &S, b: &S, c: S): bool {
+   │                                      -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                      │   
+   │                                      The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+74 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:78:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+77 │     public fun test_24(a: &S, b: &mut S, c: S): bool {
+   │                                          -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                          │   
+   │                                          The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+78 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+82 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                            - The type '0x42::a::S' does not have the ability 'drop'
+82 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+82 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                         -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                         │   
+   │                                         The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+82 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:86:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+85 │     public fun test_28(a: &mut S, b: S, c: &S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+86 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:90:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+89 │     public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+90 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:94:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+93 │     public fun test_30(a: &mut S, b: &S, c: S): bool {
+   │                                          -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                          │   
+   │                                          The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+94 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:98:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+97 │     public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+   │                                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                              │   
+   │                                              The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+98 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move
@@ -1,0 +1,101 @@
+module 0x42::a {
+
+    public struct S has copy {}
+
+    public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_no_drop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_no_drop.move
@@ -1,0 +1,53 @@
+module 0x42::a {
+
+    public struct S has copy {}
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
@@ -1,0 +1,209 @@
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:2:5
+  │
+2 │     struct S { u: u64 }
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:3:5
+  │
+3 │     struct R {
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:6:5
+  │
+6 │     struct G0<phantom T> has drop {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:7:5
+  │
+7 │     struct G1<phantom T: key> {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:8:5
+  │
+8 │     struct G2<phantom T> {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:13:17
+   │
+13 │         (0: u8) != (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '!='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:14:11
+   │
+14 │         0 != false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '!='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E04024]: invalid usage of immutable variable
+   ┌─ tests/move_2024/typing/neq_invalid.move:18:18
+   │
+12 │     fun t0(s: S, s_ref: &S, s_mut: &mut S) {
+   │            - To use the variable mutably, it must be declared 'mut', e.g. 'mut s'
+   ·
+18 │         s_mut != s;
+   │                  ^ Invalid mutable borrow of immutable variable 's'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │         ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:14
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │              ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:26:9
+   │
+26 │         G0{} != G0{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:26:17
+   │
+26 │         G0{} != G0{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   │
+ 7 │     struct G1<phantom T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │         ^^^^
+   │         │
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   │
+27 │         G1{} != G1{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   │
+ 7 │     struct G1<phantom T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   │
+27 │         G1{} != G1{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
+   │
+ 8 │     struct G2<phantom T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │         ^^^^
+   │         │
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
+   │
+28 │         G2{} != G2{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
+   │
+ 8 │     struct G2<phantom T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
+   │
+28 │         G2{} != G2{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/neq_invalid.move:32:9
+   │
+32 │         () != ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Incompatible arguments to '!='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/neq_invalid.move:33:9
+   │
+33 │         (0, 1) != (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Incompatible arguments to '!='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:34:19
+   │
+34 │         (1, 2, 3) != (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '!='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:35:16
+   │
+35 │         (0, 1) != (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '!='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
@@ -56,15 +56,6 @@ error[E04007]: incompatible types
    │         │ Incompatible arguments to '!='
    │         Found: integer. It is not compatible with the other type.
 
-error[E04024]: invalid usage of immutable variable
-   ┌─ tests/move_2024/typing/neq_invalid.move:18:18
-   │
-12 │     fun t0(s: S, s_ref: &S, s_mut: &mut S) {
-   │            - To use the variable mutably, it must be declared 'mut', e.g. 'mut s'
-   ·
-18 │         s_mut != s;
-   │                  ^ Invalid mutable borrow of immutable variable 's'
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_2024/typing/neq_invalid.move:22:9
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
@@ -1,0 +1,37 @@
+module 0x8675309::M {
+    struct S { u: u64 }
+    struct R {
+        f: u64
+    }
+    struct G0<phantom T> has drop {}
+    struct G1<phantom T: key> {}
+    struct G2<phantom T> {}
+
+
+
+    fun t0(s: S, s_ref: &S, s_mut: &mut S) {
+        (0: u8) != (1: u128);
+        0 != false;
+        &0 != 1;
+        1 != &0;
+        s != s_ref;
+        s_mut != s;
+    }
+
+    fun t1(r: R) {
+        r != r;
+    }
+
+    fun t3() {
+        G0{} != G0{};
+        G1{} != G1{};
+        G2{} != G2{};
+    }
+
+    fun t4() {
+        () != ();
+        (0, 1) != (0, 1);
+        (1, 2, 3) != (0, 1);
+        (0, 1) != (1, 2, 3);
+    }
+}


### PR DESCRIPTION
## Description 

This considers refs during typechecking Eq/Neq binops, and does automatic referencing when possible to allow equality to work a bit easier.

Note this is not currently Move 2024 feature gated, but can become so upon request.

## Test Plan 

New tests, plus updated expected output for old ones.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
