### PR TITLE
[move-2024] Enable Move 2024 optimizations

### DIFF
--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
@@ -76,7 +76,9 @@ fn find_forwarding_jump_destinations(blocks: &BasicBlocks) -> LabelMap {
     let mut final_jumps: LabelMap = BTreeMap::new();
 
     for start in forwarding_jumps.keys() {
-        if final_jumps.contains_key(start) { break };
+        if final_jumps.contains_key(start) {
+            break;
+        };
         let mut target = *start;
         let mut seen = BTreeSet::new();
         while let Some(next_target) = forwarding_jumps.get(&target) {

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -118,6 +118,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::BlockLabels,
     FeatureGate::Move2024Paths,
     FeatureGate::MacroFuns,
+    FeatureGate::Move2024Optimizations,
 ];
 
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    public struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &S) {
+        let mut f;
+        if (cond) f = &s.f else f = &other.f;
+        freeze(s);
+        *f;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let mut f;
+        if (cond) f = &s.f else f = &s.g;
+        freeze(s);
+        *f;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &S) {
+        let mut x;
+        if (cond) x = freeze(s) else x = other;
+        freeze(s);
+        *x;
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo_invalid.exp
@@ -1,0 +1,26 @@
+error[E07002]: mutable ownership violated
+   ┌─ tests/move_2024/borrows/freeze_combo_invalid.move:13:9
+   │
+12 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       -------- Field 'f' is still being mutably borrowed by this reference
+13 │         freeze(s);
+   │         ^^^^^^^^^ Invalid freeze.
+
+error[E07002]: mutable ownership violated
+   ┌─ tests/move_2024/borrows/freeze_combo_invalid.move:20:9
+   │
+19 │         if (cond) f = &mut s.f else f = &mut s.g;
+   │                       --------          -------- Field 'g' is still being mutably borrowed by this reference
+   │                       │                  
+   │                       Field 'f' is still being mutably borrowed by this reference
+20 │         freeze(s);
+   │         ^^^^^^^^^ Invalid freeze.
+
+error[E07002]: mutable ownership violated
+   ┌─ tests/move_2024/borrows/freeze_combo_invalid.move:27:9
+   │
+26 │         if (cond) x = s else x = other;
+   │                       - It is still being mutably borrowed by this reference
+27 │         freeze(s);
+   │         ^^^^^^^^^ Invalid freeze.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_combo_invalid.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    public struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &mut S) {
+        let mut f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        freeze(s);
+        *f;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let mut f;
+        if (cond) f = &mut s.f else f = &mut s.g;
+        freeze(s);
+        *f;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &mut S) {
+        let mut x;
+        if (cond) x = s else x = other;
+        freeze(s);
+        *x;
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field.move
@@ -1,0 +1,22 @@
+module 0x8675309::M {
+    public struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        *f;
+        freeze(s);
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        freeze(s);
+        *f;
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field_invalid.exp
@@ -1,0 +1,16 @@
+error[E07002]: mutable ownership violated
+   ┌─ tests/move_2024/borrows/freeze_field_invalid.move:12:9
+   │
+11 │         let f = &mut s.f;
+   │                 -------- Field 'f' is still being mutably borrowed by this reference
+12 │         freeze(s);
+   │         ^^^^^^^^^ Invalid freeze.
+
+error[E07002]: mutable ownership violated
+   ┌─ tests/move_2024/borrows/freeze_field_invalid.move:19:9
+   │
+18 │         let g = &mut s.f;
+   │                 -------- Field 'f' is still being mutably borrowed by this reference
+19 │         freeze(s);
+   │         ^^^^^^^^^ Invalid freeze.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_field_invalid.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    public struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        freeze(s);
+        *f;
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        let g = &mut s.f;
+        freeze(s);
+        *f;
+        *g;
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_full.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_full.move
@@ -1,0 +1,18 @@
+module 0x8675309::M {
+    public struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        freeze(x);
+
+        let x = id_mut(&mut 0);
+        freeze(x);
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_full_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/borrows/freeze_full_invalid.move
@@ -1,0 +1,20 @@
+module 0x8675309::M {
+    public struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        freeze(x);
+        *x = 0;
+
+        let x = id_mut(&mut 0);
+        freeze(x);
+        *x = 0;
+    }
+
+}


### PR DESCRIPTION
## Description 

The Move 2024 optimizations got disabled from alpha at some point. This re-enables them.

## Test Plan 

The test suite still works, plus more tests to ensure the new freeze mechanisms work.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
