### PR TITLE
[move] Make most ICEs diagnostics

### DIFF
--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -513,15 +513,25 @@ macro_rules! diag {
     }};
 }
 
+pub const ICE_BUG_REPORT_MESSAGE: &str =
+    "The Move compiler has encountered an internal compiler error.\n \
+    Please report this this issue to the Mysten Labs Move language team,\n \
+    including this error and any relevant code, to the Mysten Labs issue tracker\n \
+    at : https://github.com/MystenLabs/sui/issues";
+
 #[macro_export]
 macro_rules! ice {
     ($primary: expr $(,)?) => {{
         $crate::diagnostics::print_stack_trace();
-        diag!($crate::diagnostics::codes::Bug::ICE, $primary)
+        let mut diag = diag!($crate::diagnostics::codes::Bug::ICE, $primary);
+        diag.add_note($crate::diagnostics::ICE_BUG_REPORT_MESSAGE.to_string());
+        diag
     }};
     ($primary: expr, $($secondary: expr),+ $(,)?) => {{
         $crate::diagnostics::print_stack_trace();
-        diag!($crate::diagnostics::codes::Bug::ICE, $primary, $($secondary, )*)
+        let mut diag = diag!($crate::diagnostics::codes::Bug::ICE, $primary, $($secondary, )*);
+        diag.add_note($crate::diagnostics::ICE_BUG_REPORT_MESSAGE.to_string());
+        diag
     }}
 }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -4,6 +4,7 @@
 use crate::{
     diag,
     expansion::ast::ModuleIdent,
+    ice,
     naming::ast::{self as N, BlockLabel},
     parser::ast::BinOp_,
     shared::{unique_map::UniqueMap, *},
@@ -363,7 +364,13 @@ fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option<
         match last_exp {
             None => None,
             Some(sp!(_, S::Seq(last))) => tail(context, last),
-            Some(_) => panic!("ICE last sequence item should be an exp"),
+            Some(sp!(loc, _)) => {
+                context.env.add_diag(ice!((
+                    *loc,
+                    "ICE last sequence item should have been an exp in dead code analysis"
+                )));
+                None
+            }
         }
     }
 }
@@ -445,7 +452,13 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
                                 return next;
                             }
                         }
-                        T::ExpListItem::Splat(_, _, _) => panic!("ICE splat is unsupported."),
+                        T::ExpListItem::Splat(_, _, _) => {
+                            context.env.add_diag(ice!((
+                                *eloc,
+                                "ICE splat exp unsupported by dead code analysis"
+                            )));
+                            return None;
+                        }
                     }
                 }
                 None
@@ -502,7 +515,13 @@ fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option
         match last_exp {
             None => None,
             Some(sp!(_, S::Seq(last))) => value(context, last),
-            Some(_) => panic!("ICE last sequence item should be an exp"),
+            Some(sp!(loc, _)) => {
+                context.env.add_diag(ice!((
+                    *loc,
+                    "ICE last sequence item should have been an exp in dead code analysis"
+                )));
+                None
+            }
         }
     }
 }
@@ -638,7 +657,12 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         // -----------------------------------------------------------------------------------------
         // odds and ends -- things we need to deal with but that don't do much
         // -----------------------------------------------------------------------------------------
-        E::Use(_) => panic!("ICE unexpanded use"),
+        E::Use(_) => {
+            context
+                .env
+                .add_diag(ice!((*eloc, "ICE found unexpanded use")));
+            None
+        }
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::diag;
 use crate::expansion::ast::{self as E, ModuleIdent};
 use crate::naming::ast as N;
 use crate::parser::ast::{FunctionName, Visibility};
 use crate::shared::{program_info::NamingProgramInfo, unique_map::UniqueMap, *};
 use crate::typing::core;
+use crate::{diag, ice};
 use move_ir_types::location::*;
 
 //**************************************************************************************************
@@ -126,7 +126,13 @@ fn use_funs(context: &mut Context, uf: &mut N::UseFuns) {
             if is_valid {
                 if let Some(public_loc) = nuf.is_public {
                     let defining_module = match &tn.value {
-                        N::TypeName_::Multiple(_) => panic!("ICE unexpected tuple type"),
+                        N::TypeName_::Multiple(_) => {
+                            context.env.add_diag(ice!((
+                                tn.loc,
+                                "ICE tuple type should not be reachable from use fun"
+                            )));
+                            return None;
+                        }
                         N::TypeName_::Builtin(sp!(_, bt_)) => context.env.primitive_definer(*bt_),
                         N::TypeName_::ModuleType(m, _) => Some(m),
                     };

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -4,9 +4,10 @@
 
 use super::core::{self, Context};
 use crate::{
-    diag,
+    debug_display, diag,
     editions::FeatureGate,
     expansion::ast::Value_,
+    ice,
     naming::ast::{BuiltinTypeName_, FunctionSignature, Type, TypeName_, Type_},
     parser::ast::Ability_,
     typing::ast as T,
@@ -57,7 +58,14 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             let ty_tvar = sp(ty.loc, Var(*tvar));
             let replacement = core::unfold_type(&context.subst, ty_tvar);
             let replacement = match replacement {
-                sp!(_, Var(_)) => panic!("ICE unfold_type_base failed to expand"),
+                sp!(loc, Var(_)) => {
+                    let diag = ice!((
+                        ty.loc,
+                        "ICE unfold_type_base failed to expand type inf. var"
+                    ));
+                    context.env.add_diag(diag);
+                    sp(loc, UnresolvedError)
+                }
                 sp!(loc, Anything) => {
                     let msg = "Could not infer this type. Try adding an annotation";
                     context
@@ -76,7 +84,14 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             type_(context, ty);
         }
         Apply(Some(_), sp!(_, TypeName_::Builtin(_)), tys) => types(context, tys),
-        Apply(Some(_), _, _) => panic!("ICE expanding pre expanded type"),
+        aty @ Apply(Some(_), _, _) => {
+            let diag = ice!((
+                ty.loc,
+                format!("ICE expanding pre-expanded type {}", debug_display!(aty))
+            ));
+            context.env.add_diag(diag);
+            *ty = sp(ty.loc, UnresolvedError)
+        }
         Apply(None, _, _) => {
             let abilities = core::infer_abilities(&context.modules, &context.subst, ty.clone());
             match &mut ty.value {
@@ -84,7 +99,11 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
                     *abilities_opt = Some(abilities);
                     types(context, tys);
                 }
-                _ => panic!("ICE impossible. tapply switched to nontapply"),
+                _ => {
+                    let diag = ice!((ty.loc, "ICE type-apply switched to non-apply"));
+                    context.env.add_diag(diag);
+                    *ty = sp(ty.loc, UnresolvedError)
+                }
             }
         }
         Fun(args, result) => {
@@ -181,7 +200,16 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             use BuiltinTypeName_ as BT;
             let bt = match e.ty.value.builtin_name() {
                 Some(sp!(_, bt)) if bt.is_numeric() => bt,
-                _ => panic!("ICE inferred num failed {:?}", &e.ty.value),
+                _ => {
+                    let diag = ice!((
+                        e.exp.loc,
+                        format!("ICE failed to infer number type for {}", debug_display!(e))
+                    ));
+                    context.env.add_diag(diag);
+                    let _ = std::mem::replace(&mut e.ty.value, Type_::UnresolvedError);
+                    let _ = std::mem::replace(&mut e.exp.value, E::UnresolvedError);
+                    return;
+                }
             };
             let v = *v;
             let u8_max = U256::from(std::u8::MAX);


### PR DESCRIPTION
## Description 

The compiler has a number of panics when things have gone wrong. This tries to remediate a large number of them to return some sort of error to allow compilation to continue, plus report it as a bug.

It's unclear if this will make development easier, but I think it is overall a situation we should move toward to helps when users stumble into these. If there are any specific panics we'd like to reinstate, please call them out.

## Test Plan 

The test suite behavior should not change. 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
