### PR TITLE
Get PTB results available in transaction displays

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -236,7 +236,10 @@ impl SuiJsonValue {
         }
     }
 
-    fn to_move_value(val: &JsonValue, ty: &MoveTypeLayout) -> Result<R::MoveValue, anyhow::Error> {
+    pub fn to_move_value(
+        val: &JsonValue,
+        ty: &MoveTypeLayout,
+    ) -> Result<R::MoveValue, anyhow::Error> {
         Ok(match (val, ty) {
             // Bool to Bool is simple
             (JsonValue::Bool(b), MoveTypeLayout::Bool) => R::MoveValue::Bool(*b),

--- a/crates/sui-replay/src/displays/mod.rs
+++ b/crates/sui-replay/src/displays/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod gas_status_displays;
-mod transaction_displays;
+pub mod transaction_displays;
 
 pub struct Pretty<'a, T>(pub &'a T);
+
+pub struct PrettyM<'a, T>(pub &'a mut T);

--- a/crates/sui-replay/src/displays/mod.rs
+++ b/crates/sui-replay/src/displays/mod.rs
@@ -5,5 +5,3 @@ mod gas_status_displays;
 pub mod transaction_displays;
 
 pub struct Pretty<'a, T>(pub &'a T);
-
-pub struct PrettyM<'a, T>(pub &'a mut T);

--- a/crates/sui-replay/src/displays/transaction_displays.rs
+++ b/crates/sui-replay/src/displays/transaction_displays.rs
@@ -5,12 +5,22 @@ use crate::displays::Pretty;
 use std::fmt::{Display, Formatter};
 use sui_types::transaction::CallArg::Pure;
 use sui_types::transaction::{
-    write_sep, Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
+    write_sep, Argument, CallArg, Command, FullPTB, ObjectArg, ProgrammableMoveCall,
+    ProgrammableTransaction,
 };
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{style::HorizontalLine, Panel as TablePanel, Style as TableStyle},
 };
+
+impl<'a> Display for Pretty<'a, FullPTB> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(full_ptb) = self;
+        let (ptb, _results) = full_ptb;
+        // todo: format results and write
+        write!(f, "{}", Pretty(ptb))
+    }
+}
 
 /// These Display implementations provide alternate displays that are used to format info contained
 /// in these Structs when calling the CLI replay command with an additional provided flag.

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -779,6 +779,7 @@ impl LocalExec {
 
         trace!(target: "replay_gas_info", "{}", Pretty(&gas_status));
 
+        let skip_checks = true;
         if let ProgrammableTransaction(ref pt) = transaction_kind {
             trace!(target: "replay_ptb_info", "{}", Pretty(&(pt.clone(), executor.dev_inspect_transaction(&self, protocol_config,
                 metrics,
@@ -792,7 +793,7 @@ impl LocalExec {
                 transaction_kind.clone(),
                 tx_info.sender,
                 *tx_digest,
-                true
+                skip_checks
             ).3.unwrap_or_else(|e| panic!("Error executing this transaction in dev-inspect mode, {e}")))));
         };
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -793,7 +793,7 @@ impl LocalExec {
                 tx_info.sender,
                 *tx_digest,
                 true
-            ).3)));
+            ).3.unwrap_or_else(|e| panic!("Error executing this transaction in dev-inspect mode, {e}")))));
         };
 
         let all_required_objects = self.storage.all_objects();

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -788,7 +788,7 @@ impl LocalExec {
         if let ProgrammableTransaction(ref pt) = transaction_kind {
             trace!(target: "replay_ptb_info", "{}",
                 Pretty(
-                    &mut FullPTB {
+                    &FullPTB {
                         ptb: pt.clone(),
                         results: transform_command_results_to_annotated(
                             &executor,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -761,12 +761,12 @@ impl LocalExec {
             executor.execute_transaction_to_effects(
                 &self,
                 protocol_config,
-                metrics,
+                metrics.clone(),
                 expensive_checks,
                 &certificate_deny_set,
                 &tx_info.executed_epoch,
                 epoch_start_timestamp,
-                CheckedInputObjects::new_for_replay(input_objects),
+                CheckedInputObjects::new_for_replay(input_objects.clone()),
                 tx_info.gas.clone(),
                 gas_status,
                 transaction_kind.clone(),
@@ -779,8 +779,21 @@ impl LocalExec {
 
         trace!(target: "replay_gas_info", "{}", Pretty(&gas_status));
 
-        if let ProgrammableTransaction(pt) = transaction_kind {
-            trace!(target: "replay_ptb_info", "{}", Pretty(&pt));
+        if let ProgrammableTransaction(ref pt) = transaction_kind {
+            trace!(target: "replay_ptb_info", "{}", Pretty(&(pt.clone(), executor.dev_inspect_transaction(&self, protocol_config,
+                metrics,
+                expensive_checks,
+                &certificate_deny_set,
+                &tx_info.executed_epoch,
+                epoch_start_timestamp,
+                CheckedInputObjects::new_for_replay(input_objects),
+                tx_info.gas.clone(),
+                SuiGasStatus::new(tx_info.gas_budget, tx_info.gas_price, rgp, protocol_config)?,
+                transaction_kind.clone(),
+                tx_info.sender,
+                *tx_digest,
+                true
+            ).3)));
         };
 
         let all_required_objects = self.storage.all_objects();

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -47,7 +47,6 @@ use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
 use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_sdk::{SuiClient, SuiClientBuilder};
-use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::transaction::TransactionKind::ProgrammableTransaction;
 use sui_types::{
@@ -695,10 +694,6 @@ impl LocalExec {
             succeeded += 1;
         }
         Ok((succeeded, num as u64))
-    }
-
-    pub fn type_layout_store_factory(&self) -> Box<dyn TypeLayoutStore> {
-        Box::new(self.clone())
     }
 
     pub async fn execution_engine_execute_with_tx_info_impl(

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -12,9 +12,7 @@ use crate::crypto::{
 };
 use crate::digests::ConsensusCommitDigest;
 use crate::digests::{CertificateDigest, SenderSignedDataDigest};
-use crate::error::ExecutionError;
 use crate::execution::SharedInput;
-use crate::execution_mode::ExecutionResult;
 use crate::message_envelope::{
     AuthenticatedMessage, Envelope, Message, TrustedEnvelope, VerifiedEnvelope,
 };
@@ -642,11 +640,6 @@ fn add_type_tag_packages(packages: &mut BTreeSet<ObjectID>, type_argument: &Type
         }
     }
 }
-
-pub type FullPTB = (
-    ProgrammableTransaction,
-    Result<Vec<ExecutionResult>, ExecutionError>,
-);
 
 /// A series of commands where the results of one command can be used in future
 /// commands

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -12,7 +12,9 @@ use crate::crypto::{
 };
 use crate::digests::ConsensusCommitDigest;
 use crate::digests::{CertificateDigest, SenderSignedDataDigest};
+use crate::error::ExecutionError;
 use crate::execution::SharedInput;
+use crate::execution_mode::ExecutionResult;
 use crate::message_envelope::{
     AuthenticatedMessage, Envelope, Message, TrustedEnvelope, VerifiedEnvelope,
 };
@@ -640,6 +642,11 @@ fn add_type_tag_packages(packages: &mut BTreeSet<ObjectID>, type_argument: &Type
         }
     }
 }
+
+pub type FullPTB = (
+    ProgrammableTransaction,
+    Result<Vec<ExecutionResult>, ExecutionError>,
+);
 
 /// A series of commands where the results of one command can be used in future
 /// commands


### PR DESCRIPTION
## Description 

This makes a call to `dev_inspect_transaction` and forwards the PTB intermediate results to the transaction display where it can be formatted and output, if and only if the `--ptb-info` flag was supplied. This approach doesn't change any code in the main path of execution. 

The tabled library does not support displaying such large values so we omit the table for this new section.

example output 1:
<img width="1672" alt="Screenshot 2024-02-27 at 4 57 18 PM" src="https://github.com/MystenLabs/sui/assets/51134415/70b55b89-8185-4853-92ff-7c6451238ef9">
<img width="1673" alt="Screenshot 2024-02-27 at 4 57 34 PM" src="https://github.com/MystenLabs/sui/assets/51134415/ec24fb1b-4d2e-4b71-8f3d-648039ce1931">

example output 2:
<img width="1670" alt="Screenshot 2024-02-27 at 5 11 29 PM" src="https://github.com/MystenLabs/sui/assets/51134415/a43bfb04-1808-4a06-af8d-bbb5a2705d51">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
<img width="1670" alt="Screenshot 2024-02-27 at 5 11 29 PM" src="https://github.com/MystenLabs/sui/assets/51134415/0a3f913e-c008-433f-bbcf-f50bab6cb044">
