### PR TITLE
[TS SDK] Fix  WebSocket constructor miss in Browser

### DIFF
--- a/.changeset/young-mayflies-sit.md
+++ b/.changeset/young-mayflies-sit.md
@@ -2,4 +2,4 @@
 '@mysten/sui.js': patch
 ---
 
-Fix WebSocket constructor miss in Browser
+Fix WebSocket constructor not being properly assigned in SuiClient HTTP transport

--- a/.changeset/young-mayflies-sit.md
+++ b/.changeset/young-mayflies-sit.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Fix WebSocket constructor miss in Browser

--- a/sdk/typescript/src/client/http-transport.ts
+++ b/sdk/typescript/src/client/http-transport.ts
@@ -76,7 +76,7 @@ export class SuiHTTPTransport implements SuiTransport {
 			this.#websocketClient = new WebsocketClient(
 				this.#options.websocket?.url ?? this.#options.url,
 				{
-					WebSocketConstructor: this.#options.WebSocketConstructor,
+					WebSocketConstructor,
 					...this.#options.websocket,
 				},
 			);


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

Reason: 

When using WebSocket in the browser, the value in option is still used by default.

This will result in an error: 
```
Uncaught Error: Missing WebSocket constructor
```

But in the documentation, it is not mentioned that the constructor needs to be set to window.WebSocket

So this should be fixed

