### PR TITLE
Support shared object deletion in test scenario

### DIFF
--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -336,6 +336,26 @@ module sui::test_scenario_tests {
     }
 
     #[test]
+    fun test_delete_shared() {
+        let sender = @0x0;
+        let scenario = ts::begin(sender);
+        let uid1 = ts::new_object(&mut scenario);
+        {
+            let obj1 = Object { id: uid1, value: 10 };
+            transfer::public_share_object(obj1);
+        };
+        ts::next_tx(&mut scenario, sender);
+        {
+            assert!(ts::has_most_recent_shared<Object>(), 1);
+            let obj1 = ts::take_shared<Object>(&scenario);
+            assert!(obj1.value == 10, EValueMismatch);
+            let Object { id, value: _ } = obj1;
+            object::delete(id);
+        };
+        ts::end(scenario);
+    }
+
+    #[test]
     fun test_take_immutable_by_id() {
         let sender = @0x0;
         let scenario = ts::begin(sender);

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -157,8 +157,11 @@ pub fn end_transaction(
     // deletions already handled above, but we drop the delete kind for the effects
     let mut deleted = vec![];
     for id in deleted_object_ids {
-        incorrect_shared_or_imm_handling =
-            incorrect_shared_or_imm_handling || taken_shared_or_imm.contains_key(&id);
+        // Mark as "incorrect" if a imm object was deleted. Allow shared objects to be deleted though.
+        incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling
+            || taken_shared_or_imm
+                .get(&id)
+                .is_some_and(|owner| matches!(owner, Owner::Immutable));
         deleted.push(id);
     }
     // find all wrapped objects


### PR DESCRIPTION
## Description 

Adds support for shared object deletion in the test scenario -- mainly making sure that we don't raise an error if a shared object was deleted, whereas before it would complain.

This change was previously landed into https://github.com/MystenLabs/sui/pull/14598 but there's a desire/need for this in main sooner so putting this change up separately. 

## Test Plan 

This adds a test case to make sure the test scenario handles shared object deletion properly.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Add support for shared object deletion in test scenario.