### PR TITLE
[gql] add owner_type to balance query

### DIFF
--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -251,7 +251,11 @@ fn filter(mut query: RawQuery, owner: SuiAddress, coin_type: Option<TypeTag>) ->
 
     query = filter!(
         query,
-        format!("owner_id = '\\x{}'::bytea", hex::encode(owner.into_vec()))
+        format!(
+            "owner_id = '\\x{}'::bytea AND owner_type = {}",
+            hex::encode(owner.into_vec()),
+            OwnerType::Address as i16
+        )
     );
 
     if let Some(coin_type) = coin_type {

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -16,6 +16,7 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use sui_indexer::types_v2::OwnerType;
 use sui_types::{parse_sui_type_tag, TypeTag};
 
 /// The total balance for a particular coin type.


### PR DESCRIPTION
## Description 

Filtering on owner_id is only efficient if we specify the `owner_type`. Balances consist of coin objects, which will be owned by an `AddressOwner`.

## Test Plan 

Existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
