### PR TITLE
Add support for quoted values in ptb files

### DIFF
--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -240,7 +240,15 @@ impl PTB {
             return Err(anyhow!("{filename} does not exist"));
         }
 
-        let file_content = std::fs::read_to_string(file_path.clone())?.replace("\\", "");
+        // NB: The following replacements are necessary. In order to handle quoted values in PTB
+        // files (i.e., to support command-line syntax in PTB files), we need to handle escaped
+        // quotes replacing them with the alternate syntax for inner strings ('), we then remove
+        // any remaining quotes.
+        let file_content = std::fs::read_to_string(file_path.clone())?
+            .replace("\\\"", "'") // Handle escaped quotes \" and replace with '
+            .replace("\"", "") // Remove quotes
+            .replace("\\", ""); // Remove newlines
+
         let ignore_comments = file_content
             .lines()
             .filter(|x| !x.starts_with("#"))


### PR DESCRIPTION
## Description 

Adds support for quoted values in PTB values. Note that non-quoted values are also still supported.

## Test Plan 

Manually tested, but will add tests once we have the testing framework :) 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
