### PR TITLE
graphql: utilize a tower layer for more accurate tracking of graphql metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12411,6 +12411,7 @@ dependencies = [
  "move-disassembler",
  "move-ir-types",
  "mysten-metrics",
+ "mysten-network",
  "once_cell",
  "prometheus",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,7 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
+ "pin-project-lite",
  "serde",
  "snap",
  "tokio",
@@ -9007,9 +9008,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -23,5 +23,6 @@ tonic.workspace = true
 tonic-health.workspace = true
 tower.workspace = true
 tower-http.workspace = true
+pin-project-lite = "0.2.13"
 tracing.workspace = true
 workspace-hack.workspace = true

--- a/crates/mysten-network/src/callback/future.rs
+++ b/crates/mysten-network/src/callback/future.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::ResponseHandler;
+use http::Response;
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    /// Response future for [`Callback`].
+    ///
+    /// [`Callback`]: super::Callback
+    pub struct ResponseFuture<F, ResponseHandler> {
+        #[pin]
+        pub(crate) inner: F,
+        pub(crate) handler: Option<ResponseHandler>,
+    }
+}
+
+impl<Fut, B, E, ResponseHandlerT> Future for ResponseFuture<Fut, ResponseHandlerT>
+where
+    Fut: Future<Output = Result<Response<B>, E>>,
+    ResponseHandlerT: ResponseHandler,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let result = futures::ready!(this.inner.poll(cx));
+        let handler = this.handler.take().unwrap();
+
+        let result = match result {
+            Ok(response) => {
+                let (head, body) = response.into_parts();
+                handler.on_response(&head);
+                Ok(Response::from_parts(head, body))
+            }
+            Err(error) => {
+                handler.on_error(&error);
+                Err(error)
+            }
+        };
+
+        Poll::Ready(result)
+    }
+}

--- a/crates/mysten-network/src/callback/layer.rs
+++ b/crates/mysten-network/src/callback/layer.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Callback, MakeCallbackHandler};
+use tower::Layer;
+
+/// [`Layer`] that adds callbacks to a [`Service`].
+///
+/// See the [module docs](crate::callback) for more details.
+///
+/// [`Layer`]: tower::layer::Layer
+/// [`Service`]: tower::Service
+#[derive(Debug, Copy, Clone)]
+pub struct CallbackLayer<M> {
+    pub(crate) make_handler: M,
+}
+
+impl<M> CallbackLayer<M> {
+    /// Create a new [`CallbackLayer`] using the given [`MakeCallbackHandler`].
+    pub fn new(make_handler: M) -> Self
+    where
+        M: MakeCallbackHandler,
+    {
+        Self { make_handler }
+    }
+}
+
+impl<S, M> Layer<S> for CallbackLayer<M>
+where
+    M: Clone,
+{
+    type Service = Callback<S, M>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Callback {
+            inner,
+            make_callback_handler: self.make_handler.clone(),
+        }
+    }
+}

--- a/crates/mysten-network/src/callback/mod.rs
+++ b/crates/mysten-network/src/callback/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use http::{request, response};
+
+mod future;
+mod layer;
+mod service;
+
+pub use self::{future::ResponseFuture, layer::CallbackLayer, service::Callback};
+
+pub trait MakeCallbackHandler {
+    type Handler: ResponseHandler;
+
+    fn make_handler(&self, request: &request::Parts) -> Self::Handler;
+}
+
+pub trait ResponseHandler {
+    fn on_response(self, response: &response::Parts);
+    fn on_error<E>(self, error: &E);
+}

--- a/crates/mysten-network/src/callback/service.rs
+++ b/crates/mysten-network/src/callback/service.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{CallbackLayer, MakeCallbackHandler, ResponseFuture};
+use http::{Request, Response};
+use std::task::{Context, Poll};
+use tower::Service;
+
+/// Middleware that adds callbacks to a [`Service`].
+///
+/// See the [module docs](crate::callback) for an example.
+///
+/// [`Service`]: tower::Service
+#[derive(Debug, Clone, Copy)]
+pub struct Callback<S, M> {
+    pub(crate) inner: S,
+    pub(crate) make_callback_handler: M,
+}
+
+impl<S, M> Callback<S, M> {
+    /// Create a new [`Callback`].
+    pub fn new(inner: S, make_callback_handler: M) -> Self {
+        Self {
+            inner,
+            make_callback_handler,
+        }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a [`CallbackLayer`] middleware.
+    ///
+    /// [`Layer`]: tower::layer::Layer
+    pub fn layer(make_handler: M) -> CallbackLayer<M>
+    where
+        M: MakeCallbackHandler,
+    {
+        CallbackLayer::new(make_handler)
+    }
+
+    /// Gets a reference to the underlying service.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying service.
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes `self`, returning the underlying service.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S, M, RequestBody, ResponseBody> Service<Request<RequestBody>> for Callback<S, M>
+where
+    S: Service<Request<RequestBody>, Response = Response<ResponseBody>>,
+    M: MakeCallbackHandler,
+{
+    type Response = Response<ResponseBody>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, M::Handler>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<RequestBody>) -> Self::Future {
+        let (head, body) = request.into_parts();
+        let handler = self.make_callback_handler.make_handler(&head);
+        let request = Request::from_parts(head, body);
+
+        ResponseFuture {
+            inner: self.inner.call(request),
+            handler: Some(handler),
+        }
+    }
+}

--- a/crates/mysten-network/src/lib.rs
+++ b/crates/mysten-network/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+pub mod callback;
 pub mod client;
 pub mod codec;
 pub mod config;

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -29,6 +29,7 @@ move-disassembler.workspace = true
 move-ir-types.workspace = true
 markdown-gen.workspace = true
 mysten-metrics.workspace = true
+mysten-network.workspace = true
 move-core-types.workspace = true
 once_cell.workspace = true
 prometheus.workspace = true

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -123,9 +123,9 @@ impl Metrics {
 
     /// Use this function to increment the number of errors per path and per error type.
     /// The error type is detected automatically from the passed errors.
-    pub(crate) fn inc_errors(&self, errors: Vec<ServerError>) {
+    pub(crate) fn inc_errors(&self, errors: &[ServerError]) {
         for err in errors {
-            if let Some(ext) = err.extensions {
+            if let Some(ext) = &err.extensions {
                 if let Some(async_graphql_value::ConstValue::String(val)) = ext.get("code") {
                     self.request_metrics
                         .num_errors


### PR DESCRIPTION
## Description 

Implement a Callback tower layer, which is then used in the Graphql Axum server to be able to properly handle metrics. This way we are properly tracking in-flight requests, since we're using an RAII guard which will decrement when dropped.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
