### PR TITLE
[cli] add summary and move displays

### DIFF
--- a/crates/sui/src/ptb/display/gas_cost_summary.rs
+++ b/crates/sui/src/ptb/display/gas_cost_summary.rs
@@ -15,17 +15,14 @@ impl<'a> Display for Pretty<'a, GasCostSummary> {
             storage_rebate,
             non_refundable_storage_fee,
         } = gcs;
-        write!(
-            f,
-            "{}",
-            format!(
-                "Gas Cost Summary:\n   \
+        let output = format!(
+            "Gas Cost Summary:\n   \
                  Storage Cost: {}\n   \
                  Computation Cost: {}\n   \
                  Storage Rebate: {}\n   \
                  Non-refundable Storage Fee: {}",
-                storage_cost, computation_cost, storage_rebate, non_refundable_storage_fee
-            )
-        )
+            storage_cost, computation_cost, storage_rebate, non_refundable_storage_fee
+        );
+        write!(f, "{}", output)
     }
 }

--- a/crates/sui/src/ptb/display/gas_cost_summary.rs
+++ b/crates/sui/src/ptb/display/gas_cost_summary.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ptb::display::Pretty;
+use std::fmt::{Display, Formatter};
+
+use sui_types::gas::GasCostSummary;
+
+impl<'a> Display for Pretty<'a, GasCostSummary> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(gcs) = self;
+        let GasCostSummary {
+            computation_cost,
+            storage_cost,
+            storage_rebate,
+            non_refundable_storage_fee,
+        } = gcs;
+        write!(
+            f,
+            "{}",
+            format!(
+                "Gas Cost Summary:\n   \
+                 Storage Cost: {}\n   \
+                 Computation Cost: {}\n   \
+                 Storage Rebate: {}\n   \
+                 Non-refundable Storage Fee: {}",
+                storage_cost, computation_cost, storage_rebate, non_refundable_storage_fee
+            )
+        )
+    }
+}

--- a/crates/sui/src/ptb/display/mod.rs
+++ b/crates/sui/src/ptb/display/mod.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod gas_cost_summary;
+mod status;
+mod summary;
+
+use crate::ptb::ptb::PTBGas;
+use crate::ptb::ptb::PTBPreview;
+use std::fmt::{Display, Formatter};
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{style::HorizontalLine, Panel as TablePanel, Style as TableStyle},
+};
+
+pub struct Pretty<'a, T>(pub &'a T);
+
+impl Display for PTBPreview {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut builder = TableBuilder::default();
+        let columns = vec!["command", "from", "value(s)"];
+        builder.set_header(columns);
+        let mut from = "console";
+        for cmd in &self.cmds {
+            if cmd.name == "file-include-start" {
+                from = cmd.values.get(0).unwrap();
+                continue;
+            } else if cmd.name == "file-include-end" {
+                from = "console";
+                continue;
+            } else if cmd.name == "preview" && cmd.is_preview_false() {
+                continue;
+            } else if cmd.name == "warn_shadows" && cmd.is_warn_shadows_false() {
+                continue;
+            }
+            builder.push_record([
+                cmd.name.to_string(),
+                from.to_string(),
+                cmd.values.join(" ").to_string(),
+            ]);
+        }
+        let mut table = builder.build();
+        table.with(TablePanel::header(format!("PTB Preview")));
+        table.with(TableStyle::rounded().horizontals([
+            HorizontalLine::new(1, TableStyle::modern().get_horizontal()),
+            HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
+            HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
+        ]));
+        table.with(tabled::settings::style::BorderSpanCorrection);
+
+        write!(f, "{}", table)
+    }
+}
+
+impl Display for PTBGas {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let r = match self {
+            PTBGas::MIN => "min",
+            PTBGas::MAX => "max",
+            PTBGas::SUM => "sum",
+        };
+        write!(f, "{}", r.to_string())
+    }
+}

--- a/crates/sui/src/ptb/display/mod.rs
+++ b/crates/sui/src/ptb/display/mod.rs
@@ -53,9 +53,9 @@ impl Display for PTBPreview {
 impl Display for PTBGas {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let r = match self {
-            PTBGas::MIN => "min",
-            PTBGas::MAX => "max",
-            PTBGas::SUM => "sum",
+            PTBGas::Min => "min",
+            PTBGas::Max => "max",
+            PTBGas::Sum => "sum",
         };
         write!(f, "{}", r)
     }

--- a/crates/sui/src/ptb/display/mod.rs
+++ b/crates/sui/src/ptb/display/mod.rs
@@ -23,14 +23,12 @@ impl Display for PTBPreview {
         let mut from = "console";
         for cmd in &self.cmds {
             if cmd.name == "file-include-start" {
-                from = cmd.values.get(0).unwrap();
+                from = cmd.values.first().unwrap();
                 continue;
             } else if cmd.name == "file-include-end" {
                 from = "console";
                 continue;
-            } else if cmd.name == "preview" && cmd.is_preview_false() {
-                continue;
-            } else if cmd.name == "warn_shadows" && cmd.is_warn_shadows_false() {
+            } else if cmd.is_preview_false() || cmd.is_warn_shadows_false() {
                 continue;
             }
             builder.push_record([
@@ -40,7 +38,7 @@ impl Display for PTBPreview {
             ]);
         }
         let mut table = builder.build();
-        table.with(TablePanel::header(format!("PTB Preview")));
+        table.with(TablePanel::header("PTB Preview"));
         table.with(TableStyle::rounded().horizontals([
             HorizontalLine::new(1, TableStyle::modern().get_horizontal()),
             HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
@@ -59,6 +57,6 @@ impl Display for PTBGas {
             PTBGas::MAX => "max",
             PTBGas::SUM => "sum",
         };
-        write!(f, "{}", r.to_string())
+        write!(f, "{}", r)
     }
 }

--- a/crates/sui/src/ptb/display/status.rs
+++ b/crates/sui/src/ptb/display/status.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ptb::display::Pretty;
+use std::fmt::{Display, Formatter};
+use sui_json_rpc_types::SuiExecutionStatus;
+use sui_json_rpc_types::SuiExecutionStatus::{Failure, Success};
+
+impl<'a> Display for Pretty<'a, SuiExecutionStatus> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(status) = self;
+
+        let output = match status {
+            Success => "success".to_string(),
+            Failure { error } => format!("failed due to {error}"),
+        };
+
+        write!(f, "{}", output)
+    }
+}

--- a/crates/sui/src/ptb/display/summary.rs
+++ b/crates/sui/src/ptb/display/summary.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ptb::display::Pretty;
+use crate::ptb::ptb::Summary;
+use std::fmt::{Display, Formatter};
+
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{style::HorizontalLine, Panel as TablePanel, Style as TableStyle},
+};
+impl<'a> Display for Pretty<'a, Summary> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut builder = TableBuilder::default();
+        let Pretty(summary) = self;
+        let Summary {
+            digest,
+            status,
+            gas_cost,
+        } = summary;
+
+        builder.push_record(vec![format!("Digest: {}", digest)]);
+        builder.push_record(vec![format!("Status: {}", Pretty(status))]);
+        builder.push_record(vec![format!("{}", Pretty(gas_cost))]);
+        let mut table = builder.build();
+        table.with(TablePanel::header("PTB Execution Summary"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        write!(f, "{}", table)
+    }
+}

--- a/crates/sui/src/ptb/mod.rs
+++ b/crates/sui/src/ptb/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod display;
 pub mod ptb;
 pub mod ptb_builder;

--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ptb::display::Pretty;
 use crate::ptb::ptb_builder::build_ptb::PTBBuilder;
 use crate::ptb::ptb_builder::errors::render_errors;
 use crate::ptb::ptb_builder::parse_ptb::PTBParser;
@@ -17,11 +18,14 @@ use shared_crypto::intent::Intent;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Display;
-use std::fmt::Formatter;
 use std::path::Path;
 use std::path::PathBuf;
+use sui_json_rpc_types::SuiExecutionStatus;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_sdk::SuiClient;
 use sui_types::base_types::ObjectID;
+use sui_types::digests::TransactionDigest;
+use sui_types::gas::GasCostSummary;
 use sui_types::transaction::ProgrammableTransaction;
 
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
@@ -32,13 +36,10 @@ use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
 
-use tabled::{
-    builder::Builder as TableBuilder,
-    settings::{style::HorizontalLine, Panel as TablePanel, Style as TableStyle},
-};
-
 use super::ptb_builder::errors::PTBError;
 use super::ptb_builder::parse_ptb::ParsedPTBCommand;
+
+const SKIP_ARGS: [&str; 3] = ["json", "gas", "summary"];
 
 /// The ProgrammableTransactionBlock structure used in the CLI ptb command
 #[derive(Parser, Debug, Default)]
@@ -89,6 +90,10 @@ pub struct PTB {
     /// Pick gas budget strategy if multiple gas-budgets are provided.
     #[clap(long)]
     pick_gas_budget: Option<PTBGas>,
+    /// Show only a short summary (digest, execution status, gas cost).
+    /// Do not use this flag when you need all the transaction data and the execution effects.
+    #[clap(long)]
+    summary: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -106,14 +111,21 @@ enum PTBGas {
 }
 
 pub struct PTBPreview {
-    cmds: Vec<PTBCommand>,
+    pub cmds: Vec<PTBCommand>,
+}
+
+#[derive(Serialize)]
+pub struct Summary {
+    pub digest: TransactionDigest,
+    pub status: SuiExecutionStatus,
+    pub gas_cost: GasCostSummary,
 }
 
 impl PTBCommand {
-    fn is_preview_false(&self) -> bool {
+    pub fn is_preview_false(&self) -> bool {
         self.name == "preview" && self.values == ["false".to_string()]
     }
-    fn is_warn_shadows_false(&self) -> bool {
+    pub fn is_warn_shadows_false(&self) -> bool {
         self.name == "warn_shadows" && self.values == ["false".to_string()]
     }
 }
@@ -135,8 +147,8 @@ impl PTB {
                 continue;
             }
 
-            // we need to skip the json as this is handled in the execute fn
-            if arg_name.as_str() == "json" || arg_name.as_str() == "gas" {
+            // we need to skip some args as these are handled in the execute fn
+            if SKIP_ARGS.contains(&arg_name.as_str()) {
                 continue;
             }
 
@@ -441,6 +453,7 @@ impl PTB {
             .subcommand_matches("ptb")
             .ok_or_else(|| anyhow!("Expected the ptb subcommand but got a different command"))?;
         let json = ptb_args_matches.get_flag("json");
+        let summary_flag = ptb_args_matches.get_flag("summary");
         let gas_coin = ptb_args_matches.get_one::<String>("gas");
         let cwd =
             std::env::current_dir().map_err(|_| anyhow!("Cannot get the working directory."))?;
@@ -544,7 +557,6 @@ impl PTB {
                 .sign_secure(&sender, &tx_data, Intent::sui_transaction())?;
 
         // execute the transaction
-        println!("Executing the transaction...");
         let transaction_response = context
             .get_client()
             .await?
@@ -556,63 +568,51 @@ impl PTB {
             )
             .await?;
 
-        println!("Transaction executed");
+        if let Some(effects) = transaction_response.effects.as_ref() {
+            if effects.status().is_err() {
+                return Err(anyhow!(
+                    "PTB execution {}. Transaction digest is: {}",
+                    Pretty(effects.status()),
+                    effects.transaction_digest()
+                ));
+            }
+        }
+
+        let summary = {
+            let effects = transaction_response.effects.clone();
+            Summary {
+                digest: transaction_response.digest,
+                status: effects
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("Error"))?
+                    .status()
+                    .clone(),
+                gas_cost: effects
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("Bail"))?
+                    .gas_cost_summary()
+                    .clone(),
+            }
+        };
+
         if json {
-            let json_string =
+            let json_string = if summary_flag {
+                serde_json::to_string_pretty(&serde_json::json!(summary))
+                    .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?
+            } else {
                 serde_json::to_string_pretty(&serde_json::json!(transaction_response))
-                    .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?;
+                    .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?
+            };
             println!("{}", json_string);
         } else {
-            println!("{}", transaction_response);
+            if summary_flag {
+                println!("{}", Pretty(&summary));
+            } else {
+                println!("{}", transaction_response);
+            }
         }
 
         Ok(())
-    }
-}
-
-impl Display for PTBPreview {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut builder = TableBuilder::default();
-        let columns = vec!["command", "from", "value(s)"];
-        builder.set_header(columns);
-        let mut from = "console";
-        for cmd in &self.cmds {
-            if cmd.name == "file-include-start" {
-                from = cmd.values.first().unwrap();
-                continue;
-            } else if cmd.name == "file-include-end" {
-                from = "console";
-                continue;
-            } else if cmd.is_preview_false() || cmd.is_warn_shadows_false() {
-                continue;
-            }
-            builder.push_record([
-                cmd.name.to_string(),
-                from.to_string(),
-                cmd.values.join(" ").to_string(),
-            ]);
-        }
-        let mut table = builder.build();
-        table.with(TablePanel::header("PTB Preview"));
-        table.with(TableStyle::rounded().horizontals([
-            HorizontalLine::new(1, TableStyle::modern().get_horizontal()),
-            HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
-            HorizontalLine::new(2, TableStyle::modern().get_horizontal()),
-        ]));
-        table.with(tabled::settings::style::BorderSpanCorrection);
-
-        write!(f, "{}", table)
-    }
-}
-
-impl Display for PTBGas {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let r = match self {
-            PTBGas::Min => "min",
-            PTBGas::Max => "max",
-            PTBGas::Sum => "sum",
-        };
-        write!(f, "{}", r)
     }
 }
 

--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -579,19 +579,13 @@ impl PTB {
         }
 
         let summary = {
-            let effects = transaction_response.effects.clone();
+            let effects = transaction_response.effects.as_ref().ok_or_else(|| {
+                anyhow!("Internal error: no transaction effects after PTB was executed.")
+            })?;
             Summary {
                 digest: transaction_response.digest,
-                status: effects
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("Error"))?
-                    .status()
-                    .clone(),
-                gas_cost: effects
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("Bail"))?
-                    .gas_cost_summary()
-                    .clone(),
+                status: effects.status().clone(),
+                gas_cost: effects.gas_cost_summary().clone(),
             }
         };
 

--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -604,12 +604,10 @@ impl PTB {
                     .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?
             };
             println!("{}", json_string);
+        } else if summary_flag {
+            println!("{}", Pretty(&summary));
         } else {
-            if summary_flag {
-                println!("{}", Pretty(&summary));
-            } else {
-                println!("{}", transaction_response);
-            }
+            println!("{}", transaction_response);
         }
 
         Ok(())

--- a/crates/sui/src/ptb/ptb.rs
+++ b/crates/sui/src/ptb/ptb.rs
@@ -103,7 +103,7 @@ pub struct PTBCommand {
 }
 
 #[derive(clap::ValueEnum, Clone, Debug, Serialize, Default)]
-enum PTBGas {
+pub enum PTBGas {
     Min,
     #[default]
     Max,


### PR DESCRIPTION
## Description 

Add the `--summary` flag and refactored our way to display different types.

## Test Plan 

<img width="2008" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/80b1eb3d-54a3-43f8-a3cb-9545e7715ad3">

<img width="2008" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/6782ad3d-cd1c-4535-93c2-4f6c9cb5f283">

<img width="2008" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/5ac9fdc1-f6bb-409b-a80b-30eece610c2c">


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
