### PR TITLE
[move] Fix spec modules being an error

### DIFF
--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -555,6 +555,10 @@ fn module(
     module_def: P::ModuleDefinition,
 ) {
     assert!(context.address.is_none());
+    if module_def.is_spec_module {
+        context.spec_deprecated(module_def.name.0.loc, /* is_error */ false);
+        return;
+    }
     let (mident, mod_) = module_(context, package_name, module_address, module_def);
     if let Err((mident, old_loc)) = module_map.add(mident, mod_) {
         duplicate_module(context, module_map, mident, old_loc)
@@ -595,13 +599,10 @@ fn module_(
         attributes,
         loc,
         address,
-        is_spec_module,
+        is_spec_module: _,
         name,
         members,
     } = mdef;
-    if is_spec_module {
-        context.spec_deprecated(name.0.loc, /* is_error */ true)
-    }
     let attributes = flatten_attributes(context, AttributePosition::Module, attributes);
     let mut warning_filter = module_warning_filter(context, &attributes);
     let config = context.env().package_config(package_name);
@@ -858,7 +859,7 @@ fn unique_attributes(
             name_,
             E::AttributeName_::Known(KnownAttribute::Verification(_))
         ) {
-            context.spec_deprecated(loc, /* is_error */ true)
+            context.spec_deprecated(loc, /* is_error */ false)
         }
         if let Err((_, old_loc)) = attr_map.add(sp(nloc, name_), sp(loc, attr_)) {
             let msg = format!("Duplicate attribute '{}' attached to the same item", name_);

--- a/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.exp
@@ -1,0 +1,18 @@
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/verification/specs_are_not_errors.move:4:5
+  │
+4 │     spec foo {}
+  │     ^^^^^^^^^^^ Specification blocks are deprecated
+
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/verification/specs_are_not_errors.move:7:7
+  │
+7 │     #[verify_only]
+  │       ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks
+
+warning[W00001]: DEPRECATED. will be removed
+   ┌─ tests/move_check/verification/specs_are_not_errors.move:12:9
+   │
+12 │ spec a::m {
+   │         ^ Specification blocks are deprecated
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.move
@@ -1,0 +1,14 @@
+module a::m {
+
+    // not an error
+    spec foo {}
+
+    // not an error
+    #[verify_only]
+    fun foo() {}
+}
+
+// not a duplicate module, not an error
+spec a::m {
+
+}


### PR DESCRIPTION
## Description 

- `spec` modules were erroneously marked as errors, and could also trigger duplicate module errors

## Test Plan 

- new test

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fixed an issue where the Move compiler would error when hitting module spec blocks. The error is now a warning, as specs are no longer supported.
