### PR TITLE
[Indexer] add barebones health/ready endpoints for k8s

### DIFF
--- a/crates/sui-indexer/src/health_check.rs
+++ b/crates/sui-indexer/src/health_check.rs
@@ -1,0 +1,10 @@
+use axum::{http::StatusCode, Json};
+use serde_json::json;
+
+pub async fn health_check_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(json!({"status": "ok"})))
+}
+
+pub async fn ready_check_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(json!({"status": "ok"})))
+}

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -39,6 +39,7 @@ pub mod apis;
 pub mod errors;
 pub mod framework;
 mod handlers;
+pub mod health_check;
 pub mod indexer_reader;
 pub mod indexer_v2;
 pub mod metrics;


### PR DESCRIPTION
## Description 
We need to add health/ready http endpoints to better support k8s. This PR only adds the barebones dummy endpoints. We need to add more comprehensive checks to better signal app health.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
