### PR TITLE
[move] Remove explicit stack size threads

### DIFF
--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -29,7 +29,6 @@ fn main() {
     let move_stdlib_path = packages_path.join("move-stdlib");
 
     Builder::new()
-        .stack_size(16 * 1024 * 1024) // build_packages require bigger stack size on windows.
         .spawn(move || {
             build_packages(
                 deepbook_path_clone,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -664,7 +664,6 @@ impl SymbolicatorRunner {
         let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::Builder::new()
-            .stack_size(STACK_SIZE_BYTES)
             .spawn(move || {
                 let (mtx, cvar) = &*thread_mtx_cvar;
                 // Locations opened in the IDE (files or directories) for which manifest file is missing


### PR DESCRIPTION
## Description 

- We added some explicit calls to `thread::Builder::new()` and `.stack_size` to try to fix Move stack issues
- This seemingly conflicts with the new usage of stacker, but who really knows

## Test Plan 

- If CI passes, we should be good. CI was broken sometimes

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
