### PR TITLE
[move-package] Update `clean` to handle extranious files in `build` dir

### DIFF
--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -204,7 +204,11 @@ impl BuildPlan {
         for dir in std::fs::read_dir(build_root)? {
             let path = dir?.path();
             if !keep_paths.iter().any(|name| path.ends_with(name.as_str())) {
-                std::fs::remove_dir_all(&path)?;
+                if path.is_file() {
+                    std::fs::remove_file(&path)?;
+                } else {
+                    std::fs::remove_dir_all(&path)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Description 

Updates `clean` in the Move package system to handle extranious top-level files. If someone accidentally created a file there a `clean` would fail, and package builds would not be able to be run.

## Test Plan 

Tested case locally.

