### PR TITLE
toolchain versioning: fix windows binary rename

### DIFF
--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -615,7 +615,7 @@ fn download_and_compile(
 
     if !dest_canonical_binary.exists() {
         // Check the platform and proceed if we can download a binary. If not, the user should follow error instructions to sideload the binary.
-        let platform = detect_platform(&root, compiler_version, &dest_canonical_binary)?;
+        let mut platform = detect_platform(&root, compiler_version, &dest_canonical_binary)?;
         // Download if binary does not exist.
         let mainnet_url = format!(
             "https://github.com/MystenLabs/sui/releases/download/mainnet-v{compiler_version}/sui-mainnet-v{compiler_version}-{platform}.tgz",
@@ -664,6 +664,9 @@ fn download_and_compile(
             .map_err(|e| anyhow!("failed to untar compiler binary: {e}"))?;
 
         let mut dest_binary = dest_version.clone();
+        if platform == "windows-x86_64" {
+            platform = format!("{platform}.exe");
+        }
         dest_binary.extend(["target", "release", &format!("sui-{platform}")]);
         let dest_binary_os = OsStr::new(dest_binary.as_path());
         set_executable_permission(dest_binary_os)?;


### PR DESCRIPTION
## Description 

On windows we have a step to rename the compiler binary like `sui-windows-x86_64` to `sui`. Except that, the windows release tarball names the source binary `sui-windows-x86_64.exe`, so we need to append the `.exe` for the rename to succeed.

Part of end-to-end testing on windows and ran into this.

## Test Plan 

Tested the fix with local source build--we don't have windows CI env for testing (yet?) so this will have to do for now!

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
