### PR TITLE
[CLI] Better manifest, more comments, more love

### DIFF
--- a/crates/sui-framework/packages/sui-framework/Move.toml
+++ b/crates/sui-framework/packages/sui-framework/Move.toml
@@ -4,10 +4,7 @@ version = "0.0.1"
 published-at = "0x2"
 
 [dependencies]
-# Using a local dep for the Move stdlib instead of a git dep to avoid the overhead of fetching the git dep in
-# CI. The local dep is an unmodified version of the upstream stdlib
 MoveStdlib = { local = "../move-stdlib" }
-#MoveStdlib = { git = "https://github.com/diem/diem.git", subdir="language/move-stdlib", rev = "346301f33b3489bb4e486ae6c0aa5e030223b492" }
 
 [addresses]
 sui = "0x2"

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -62,6 +62,10 @@ impl New {
             "[package]
 name = \"{name}\"
 
+# version = \"0.1.1\"  # semver \"maj.min.patch\"
+# license = \"\"       # e.g., \"MIT\", \"GPL\", \"Apache 2.0\"
+# authors = [\"...\"]  # e.g., [\"Joe Smith (joesmith@noemail.com)\", \"John Snow (johnsnow@noemail.com)\"]
+
 [dependencies]"
         )?;
         for (dep_name, dep_val) in deps {
@@ -69,15 +73,14 @@ name = \"{name}\"
         }
 
         writeln!(w, "
-# For remote import, use the `git = \"URL\"`. With this type of import you can
-# specify the path to Move.toml `subdir = \"...\"` and the revision using
-# `rev = \"...\"`. Revision can be a branch, a tag, and a commit hash.
-# MyRemotePackage = {{ git = \"https://some.remote/host.git\", subdir = \"remote/path\", rev = \"01Move....\" }}
+# For remote import, use the `{{ git = \"...\", subdir = \"...\", rev = \"...\" }}`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = {{ git = \"https://some.remote/host.git\", subdir = \"remote/path\", rev = \"main\" }}
 
 # For local dependencies use `local = path`. Path is relative to the package root
 # Local = {{ local = \"../path/to\" }}
 
-# To resolve version conflict and force a specific version for dependency
+# To resolve a version conflict and force a specific version for dependency
 # override use `override = true`
 # Override = {{ override = true, local = \"../conflicting/version\" }}
 

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -59,53 +59,59 @@ impl New {
         let mut w = std::fs::File::create(path.join(SourcePackageLayout::Manifest.path()))?;
         writeln!(
             w,
-            "[package]
-name = \"{name}\"
+            r#"[package]
+name = "{name}"
 
-# version = \"0.1.1\"  # semver \"maj.min.patch\"
-# license = \"\"       # e.g., \"MIT\", \"GPL\", \"Apache 2.0\"
-# authors = [\"...\"]  # e.g., [\"Joe Smith (joesmith@noemail.com)\", \"John Snow (johnsnow@noemail.com)\"]
+# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
-[dependencies]"
+[dependencies]"#
         )?;
         for (dep_name, dep_val) in deps {
             writeln!(w, "{dep_name} = {dep_val}")?;
         }
 
-        writeln!(w, "
-# For remote import, use the `{{ git = \"...\", subdir = \"...\", rev = \"...\" }}`.
+        writeln!(
+            w,
+            r#"
+# For remote import, use the `{{ git = "...", subdir = "...", rev = "..." }}`.
 # Revision can be a branch, a tag, and a commit hash.
-# MyRemotePackage = {{ git = \"https://some.remote/host.git\", subdir = \"remote/path\", rev = \"main\" }}
+# MyRemotePackage = {{ git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }}
 
 # For local dependencies use `local = path`. Path is relative to the package root
-# Local = {{ local = \"../path/to\" }}
+# Local = {{ local = "../path/to" }}
 
 # To resolve a version conflict and force a specific version for dependency
 # override use `override = true`
-# Override = {{ override = true, local = \"../conflicting/version\" }}
+# Override = {{ local = "../conflicting/version", override = true }}
 
-[addresses]")?;
+[addresses]"#
+        )?;
 
         // write named addresses
         for (addr_name, addr_val) in addrs {
             writeln!(w, "{addr_name} = \"{addr_val}\"")?;
         }
 
-        writeln!(w,"
+        writeln!(
+            w,
+            r#"
 # Named addresses will be accessible in Move as `@name`. They're also exported:
-# for example, `std = \"0x1\"` is exported by the Standard Library.
-# alice = \"0xA11CE\"
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
 
 [dev-dependencies]
 # The dev-dependencies section allows overriding dependencies for `--test` and
-# `--dev` modes. New dependencies cannot be introduced
-# Local = {{ local = \"../path/to/dev-build\" }}
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = {{ local = "../path/to/dev-build" }}
 
 [dev-addresses]
-# The dev-addresses section allows overloading named addresses for the `--test`
+# The dev-addresses section allows overwriting named addresses for the `--test`
 # and `--dev` modes.
-# alice = \"0xB0B\"
-")?;
+# alice = "0xB0B"
+"#
+        )?;
 
         // custom addition in the end
         if !custom.is_empty() {

--- a/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
@@ -3,14 +3,74 @@ External Command `cat P1/Move.toml`:
 [package]
 name = "P1"
 
+# version = "0.1.1"  # semver "maj.min.patch"
+# license = ""       # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]  # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
 [dependencies]
 
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { override = true, local = "../conflicting/version" }
+
 [addresses]
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. New dependencies cannot be introduced
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overloading named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+
 Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
 name = "P2"
 
+# version = "0.1.1"  # semver "maj.min.patch"
+# license = ""       # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]  # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+
 [dependencies]
 
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { override = true, local = "../conflicting/version" }
+
 [addresses]
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. New dependencies cannot be introduced
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overloading named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
+

--- a/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
@@ -3,9 +3,9 @@ External Command `cat P1/Move.toml`:
 [package]
 name = "P1"
 
-# version = "0.1.1"  # semver "maj.min.patch"
-# license = ""       # e.g., "MIT", "GPL", "Apache 2.0"
-# authors = ["..."]  # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
 
@@ -18,7 +18,7 @@ name = "P1"
 
 # To resolve a version conflict and force a specific version for dependency
 # override use `override = true`
-# Override = { override = true, local = "../conflicting/version" }
+# Override = { local = "../conflicting/version", override = true }
 
 [addresses]
 
@@ -28,11 +28,11 @@ name = "P1"
 
 [dev-dependencies]
 # The dev-dependencies section allows overriding dependencies for `--test` and
-# `--dev` modes. New dependencies cannot be introduced
+# `--dev` modes. You can introduce test-only dependencies here.
 # Local = { local = "../path/to/dev-build" }
 
 [dev-addresses]
-# The dev-addresses section allows overloading named addresses for the `--test`
+# The dev-addresses section allows overwriting named addresses for the `--test`
 # and `--dev` modes.
 # alice = "0xB0B"
 
@@ -41,9 +41,9 @@ External Command `cat other_dir/Move.toml`:
 [package]
 name = "P2"
 
-# version = "0.1.1"  # semver "maj.min.patch"
-# license = ""       # e.g., "MIT", "GPL", "Apache 2.0"
-# authors = ["..."]  # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
+# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
 
@@ -56,7 +56,7 @@ name = "P2"
 
 # To resolve a version conflict and force a specific version for dependency
 # override use `override = true`
-# Override = { override = true, local = "../conflicting/version" }
+# Override = { local = "../conflicting/version", override = true }
 
 [addresses]
 
@@ -66,11 +66,11 @@ name = "P2"
 
 [dev-dependencies]
 # The dev-dependencies section allows overriding dependencies for `--test` and
-# `--dev` modes. New dependencies cannot be introduced
+# `--dev` modes. You can introduce test-only dependencies here.
 # Local = { local = "../path/to/dev-build" }
 
 [dev-addresses]
-# The dev-addresses section allows overloading named addresses for the `--test`
+# The dev-addresses section allows overwriting named addresses for the `--test`
 # and `--dev` modes.
 # alice = "0xB0B"
 


### PR DESCRIPTION
## Description 

Here's what it looks like!

```toml
[package]
name = "love"

# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]

[dependencies]

# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
# Revision can be a branch, a tag, and a commit hash.
# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }

# For local dependencies use `local = path`. Path is relative to the package root
# Local = { local = "../path/to" }

# To resolve a version conflict and force a specific version for dependency
# override use `override = true`
# Override = { local = "../conflicting/version", override = true }

[addresses]

# Named addresses will be accessible in Move as `@name`. They're also exported:
# for example, `std = "0x1"` is exported by the Standard Library.
# alice = "0xA11CE"

[dev-dependencies]
# The dev-dependencies section allows overriding dependencies for `--test` and
# `--dev` modes. You can introduce test-only dependencies here.
# Local = { local = "../path/to/dev-build" }

[dev-addresses]
# The dev-addresses section allows overwriting named addresses for the `--test`
# and `--dev` modes.
# alice = "0xB0B"
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
