### PR TITLE
[Cherry Pick v1.18] Fix CLI panic when there are no inputs in a PTB and table fails to be built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11502,7 +11502,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11691,7 +11691,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -11745,7 +11745,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer-derive"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -12274,7 +12274,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -12497,7 +12497,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12787,7 +12787,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -12829,7 +12829,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -12971,7 +12971,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -13022,7 +13022,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13060,7 +13060,7 @@ dependencies = [
 
 [[package]]
 name = "sui-oracle"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13297,7 +13297,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-loadgen"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13327,7 +13327,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -13449,7 +13449,7 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -13578,7 +13578,7 @@ dependencies = [
 
 [[package]]
 name = "sui-surfer"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -13726,7 +13726,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anemo",
  "anemo-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
-version = "1.18.0"
+version = "1.18.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
+++ b/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
@@ -16,61 +16,75 @@ use tabled::{
 
 impl<'a> Display for Pretty<'a, SuiProgrammableTransactionBlock> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut builder = TableBuilder::default();
-
         let Pretty(ptb) = self;
         let SuiProgrammableTransactionBlock { inputs, commands } = ptb;
-
-        for (i, input) in inputs.iter().enumerate() {
-            match input {
-                SuiCallArg::Pure(v) => {
-                    let pure_arg = if let Some(t) = v.value_type() {
-                        format!(
-                            "{i:<3} Pure Arg: Type: {}, Value: {}",
-                            t,
-                            v.value().to_json_value()
-                        )
-                    } else {
-                        format!("{i:<3} Pure Arg: {}", v.value().to_json_value())
-                    };
-                    builder.push_record(vec![pure_arg]);
-                }
-                SuiCallArg::Object(SuiObjectArg::ImmOrOwnedObject { object_id, .. }) => {
-                    builder.push_record(vec![format!("{i:<3} Imm/Owned Object ID: {}", object_id)]);
-                }
-                SuiCallArg::Object(SuiObjectArg::SharedObject { object_id, .. }) => {
-                    builder.push_record(vec![format!("{i:<3} Shared Object    ID: {}", object_id)]);
-                }
-                SuiCallArg::Object(SuiObjectArg::Receiving { object_id, .. }) => {
-                    builder.push_record(vec![format!("{i:<3} Receiving Object ID: {}", object_id)]);
+        if !inputs.is_empty() {
+            let mut builder = TableBuilder::default();
+            for (i, input) in inputs.iter().enumerate() {
+                match input {
+                    SuiCallArg::Pure(v) => {
+                        let pure_arg = if let Some(t) = v.value_type() {
+                            format!(
+                                "{i:<3} Pure Arg: Type: {}, Value: {}",
+                                t,
+                                v.value().to_json_value()
+                            )
+                        } else {
+                            format!("{i:<3} Pure Arg: {}", v.value().to_json_value())
+                        };
+                        builder.push_record(vec![pure_arg]);
+                    }
+                    SuiCallArg::Object(SuiObjectArg::ImmOrOwnedObject { object_id, .. }) => {
+                        builder.push_record(vec![format!(
+                            "{i:<3} Imm/Owned Object ID: {}",
+                            object_id
+                        )]);
+                    }
+                    SuiCallArg::Object(SuiObjectArg::SharedObject { object_id, .. }) => {
+                        builder.push_record(vec![format!(
+                            "{i:<3} Shared Object    ID: {}",
+                            object_id
+                        )]);
+                    }
+                    SuiCallArg::Object(SuiObjectArg::Receiving { object_id, .. }) => {
+                        builder.push_record(vec![format!(
+                            "{i:<3} Receiving Object ID: {}",
+                            object_id
+                        )]);
+                    }
                 }
             }
+
+            let mut table = builder.build();
+            table.with(TablePanel::header("Input Objects"));
+            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                1,
+                TableStyle::modern().get_horizontal(),
+            )]));
+            write!(f, "\n{}", table)?;
+        } else {
+            write!(f, "\n  No input objects for this transaction")?;
         }
 
-        let mut table = builder.build();
-        table.with(TablePanel::header("Input Objects"));
-        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
-            1,
-            TableStyle::modern().get_horizontal(),
-        )]));
-        write!(f, "\n{}", table)?;
-
-        let mut builder = TableBuilder::default();
-
-        for (i, c) in commands.iter().enumerate() {
-            if i == commands.len() - 1 {
-                builder.push_record(vec![format!("{i:<2} {}", Pretty(c))]);
-            } else {
-                builder.push_record(vec![format!("{i:<2} {}\n", Pretty(c))]);
+        if !commands.is_empty() {
+            let mut builder = TableBuilder::default();
+            for (i, c) in commands.iter().enumerate() {
+                if i == commands.len() - 1 {
+                    builder.push_record(vec![format!("{i:<2} {}", Pretty(c))]);
+                } else {
+                    builder.push_record(vec![format!("{i:<2} {}\n", Pretty(c))]);
+                }
             }
+            let mut table = builder.build();
+            table.with(TablePanel::header("Commands"));
+            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                1,
+                TableStyle::modern().get_horizontal(),
+            )]));
+            write!(f, "\n{}", table)
+        } else {
+            write!(f, "\n  No commands for this transaction")
         }
-        let mut table = builder.build();
-        table.with(TablePanel::header("Commands"));
-        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
-            1,
-            TableStyle::modern().get_horizontal(),
-        )]));
-        write!(f, "\n{}", table)
     }
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "1.18.0"
+    "version": "1.18.1"
   },
   "methods": [
     {


### PR DESCRIPTION
## Description 

Fixes a CLI panic when there are no inputs in a PTB and the output formatted table cannot be built as it does not have any data (inputs are empty).

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
