### PR TITLE
[docs] Show how to use `sui client faucet` for getting tokens from faucet

### DIFF
--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -108,14 +108,13 @@ Use the active address to get test SUI to use on your local network. Use the `su
 
 Transactions on your local network require SUI coins to pay for gas fees just like other networks. To send coins to a Sui Wallet connected to your local network, see [Set up a local Sui Wallet](#set-up-a-local-sui-wallet). You can use the address for the local Sui Wallet with the faucet.
 
-Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to its faucet.
+Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server.
 
 There are two options for the command:
 `--url`, which is the URL to the gas faucet server
 `--address`, which can be either an address or the alias name corresponding to an address in the wallet.
 
 In the most simple case, just run `sui client faucet` and wait up to 60s for your tokens to reach your wallet. Use `sui client gas` to check for the new tokens. 
-
 
 ### Check the gas coin objects for the active address
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -108,9 +108,12 @@ Use the active address to get test SUI to use on your local network. Use the `su
 
 Transactions on your local network require SUI coins to pay for gas fees just like other networks. To send coins to a Sui Wallet connected to your local network, see [Set up a local Sui Wallet](#set-up-a-local-sui-wallet). You can use the address for the local Sui Wallet with the faucet.
 
-Sui CLI provides the `sui client faucet` command to get coins from the faucet. The `faucet` command uses the active address and the active network environment by default. If you need to pass in a different address or faucet server URL, check the `help` menu. If you're using a different network than the public ones (fullnode.network.sui.io) or than a local network, you will have to pass the URL to the faucet server.
+Sui CLI provides the `sui client faucet` command to get coins from the faucet. In the most basic case, run `sui client faucet` and wait up to 60 seconds for the coins to reach your wallet. Use `sui client gas` to check for the new coins.
 
-In the most basic case, run `sui client faucet` and wait up to 60 seconds for the coins to reach your wallet. Use `sui client gas` to check for the new coins.
+:::info
+The command uses the active address and the active network environment by default. If you need to pass in a different address or faucet server URL, check the `help` menu. If you're using a different network than a local network or the public ones (fullnode.network.sui.io), you will have to pass the URL to the faucet server.
+:::
+
 
 ### Check the gas coin objects for the active address
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -108,52 +108,14 @@ Use the active address to get test SUI to use on your local network. Use the `su
 
 Transactions on your local network require SUI coins to pay for gas fees just like other networks. To send coins to a Sui Wallet connected to your local network, see [Set up a local Sui Wallet](#set-up-a-local-sui-wallet). You can use the address for the local Sui Wallet with the faucet.
 
-Use the following cURL command to get test coins from the local faucet.
+Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to its faucet.
 
-```bash
-curl --location --request POST 'http://127.0.0.1:9123/gas' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "FixedAmountRequest": {
-        "recipient": "0xbc33e6e4818f9f2ef77d020b35c24be738213e64d9e58839ee7b4222029610de"
-    }
-}'
-```
+There are two options for the command:
+`--url`, which is the URL to the gas faucet server
+`--address`, which can be either an address or the alias name corresponding to an address in the wallet.
 
-If successful, the response resembles the following:
+In the most simple case, just run `sui client faucet` and wait up to 60s for your tokens to reach your wallet. Use `sui client gas` to check for the new tokens. 
 
-```json
-{
-    "transferredGasObjects": [
-        {
-            "amount": 200000000,
-            "id": "0x192ce62506ed8705b76e8423be1f6e011064a3f887ba924605f27a8c83c8c970",
-            "transferTxDigest": "7sp4fFPH2WaUgvN43kjDzCpEhKfifqjx5RTki74y8T3E"
-        },
-        {
-            "amount": 200000000,
-            "id": "0x31d003ade00675d1ab82b225bfcceaa60bb993f5d90e9d0aa88f81dc24ec14d6",
-            "transferTxDigest": "7sp4fFPH2WaUgvN43kjDzCpEhKfifqjx5RTki74y8T3E"
-        },
-        {
-            "amount": 200000000,
-            "id": "0x98cbdc93ae672110f91bc0c39c0c87bc66f36984c79218bb2c0bac967260970c",
-            "transferTxDigest": "7sp4fFPH2WaUgvN43kjDzCpEhKfifqjx5RTki74y8T3E"
-        },
-        {
-            "amount": 200000000,
-            "id": "0xba66aee6289cc6d0203c451bea442ad30d4cfe699e50b36fed0ff3e99ba51529",
-            "transferTxDigest": "7sp4fFPH2WaUgvN43kjDzCpEhKfifqjx5RTki74y8T3E"
-        },
-        {
-            "amount": 200000000,
-            "id": "0xd9f0b521443d66227eddc2aac2e16f667ca9caeef9f1b7afb4a6c2fc7dcb58d8",
-            "transferTxDigest": "7sp4fFPH2WaUgvN43kjDzCpEhKfifqjx5RTki74y8T3E"
-        }
-    ],
-    "error": null
-}
-```
 
 ### Check the gas coin objects for the active address
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -111,7 +111,7 @@ Transactions on your local network require SUI coins to pay for gas fees just li
 Sui CLI provides the `sui client faucet` command to get coins from the faucet. In the most basic case, run `sui client faucet` and wait up to 60 seconds for the coins to reach your wallet. Use `sui client gas` to check for the new coins.
 
 :::info
-The command uses the active address and the active network environment by default. If you need to pass in a different address or faucet server URL, check the `help` menu. If you're using a different network than a local network or the public ones (fullnode.network.sui.io), you will have to pass the URL to the faucet server.
+The `faucet` command uses the active address and the active network environment by default. If you need to pass in a different address or faucet server URL, check the `help` menu. If you're using a different network than a local network or the public ones (fullnode.network.sui.io), you will have to pass the URL to the faucet server.
 :::
 
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -110,7 +110,7 @@ Transactions on your local network require SUI coins to pay for gas fees just li
 
 Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server. By default, it will use the active address and the active network environment. If you need to pass in a different address or faucet server url, check the help menu.
 
-In the most simple case, run `sui client faucet` and wait up to 60s for your tokens to reach your wallet. Use `sui client gas` to check for the new tokens.
+In the most basic case, run `sui client faucet` and wait up to 60 seconds for the coins to reach your wallet. Use `sui client gas` to check for the new coins.
 
 ### Check the gas coin objects for the active address
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -110,7 +110,7 @@ Transactions on your local network require SUI coins to pay for gas fees just li
 
 Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server.
 
-There are two options for the command:
+There are two **optional** arguments for the command:
 `--url`, which is the URL to the gas faucet server
 `--address`, which can be either an address or the alias name corresponding to an address in the wallet.
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -108,7 +108,7 @@ Use the active address to get test SUI to use on your local network. Use the `su
 
 Transactions on your local network require SUI coins to pay for gas fees just like other networks. To send coins to a Sui Wallet connected to your local network, see [Set up a local Sui Wallet](#set-up-a-local-sui-wallet). You can use the address for the local Sui Wallet with the faucet.
 
-Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server. By default, it will use the active address and the active network environment. If you need to pass in a different address or faucet server url, check the help menu.
+Sui CLI provides the `sui client faucet` command to get coins from the faucet. The `faucet` command uses the active address and the active network environment by default. If you need to pass in a different address or faucet server URL, check the `help` menu. If you're using a different network than the public ones (fullnode.network.sui.io) or than a local network, you will have to pass the URL to the faucet server.
 
 In the most basic case, run `sui client faucet` and wait up to 60 seconds for the coins to reach your wallet. Use `sui client gas` to check for the new coins.
 

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -108,13 +108,9 @@ Use the active address to get test SUI to use on your local network. Use the `su
 
 Transactions on your local network require SUI coins to pay for gas fees just like other networks. To send coins to a Sui Wallet connected to your local network, see [Set up a local Sui Wallet](#set-up-a-local-sui-wallet). You can use the address for the local Sui Wallet with the faucet.
 
-Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server.
+Sui CLI provides the `sui client faucet` command to get tokens from the faucet. If a different network than the usual ones (fullnode.network.sui.io) is used, it will complain and ask to pass the url to the faucet server. By default, it will use the active address and the active network environment. If you need to pass in a different address or faucet server url, check the help menu.
 
-There are two **optional** arguments for the command:
-`--url`, which is the URL to the gas faucet server
-`--address`, which can be either an address or the alias name corresponding to an address in the wallet.
-
-In the most simple case, just run `sui client faucet` and wait up to 60s for your tokens to reach your wallet. Use `sui client gas` to check for the new tokens. 
+In the most simple case, run `sui client faucet` and wait up to 60s for your tokens to reach your wallet. Use `sui client gas` to check for the new tokens.
 
 ### Check the gas coin objects for the active address
 


### PR DESCRIPTION
## Description 

This PR updates the docs to show how to to use `sui client faucet` for getting tokens from faucet.

## Test Plan 

Docs, no tests needed.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR updates the docs to show how to to use `sui client faucet` for getting tokens from faucet.
