### PR TITLE
[cherry-pick-graphql] Add CORS support (#16100)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12446,6 +12446,7 @@ dependencies = [
  "tokio",
  "toml 0.7.4",
  "tower",
+ "tower-http",
  "tracing",
  "uuid 1.2.2",
  "workspace-hack",

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -77,6 +77,10 @@ Headers: {
     "content-type": "application/json",
     "content-length": "157",
     "x-sui-rpc-version": "2024.1.1",
+    "access-control-allow-origin": "*",
+    "vary": "origin",
+    "vary": "access-control-request-method",
+    "vary": "access-control-request-headers",
 }
 Service version: 2024.1.1
 Response: {

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -50,6 +50,7 @@ tracing.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tower.workspace = true
+tower-http.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 


### PR DESCRIPTION
## Description 

This PR cherry-picks the RPC2.0 CORS implementation for the new release.

## Test Plan 

Existing tests & CI.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added support for CORS in RPC 2.0 server.