### PR TITLE
[GraphQL] Connection Timeout -> Statement Timeout

### DIFF
--- a/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
+++ b/crates/sui-graphql-rpc/src/context_data/db_data_provider.rs
@@ -44,7 +44,7 @@ impl PgManager {
     ) -> Result<IndexerReader, Error> {
         let mut config = PgConnectionPoolConfig::default();
         config.set_pool_size(pool_size);
-        config.set_connection_timeout(Duration::from_millis(timeout_ms));
+        config.set_statement_timeout(Duration::from_millis(timeout_ms));
         IndexerReader::new_with_config(db_url, config)
             .map_err(|e| Error::Internal(format!("Failed to create reader: {e}")))
     }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -258,7 +258,7 @@ impl ServerBuilder {
         let reader = PgManager::reader_with_config(
             config.connection.db_url.clone(),
             config.connection.db_pool_size,
-            // Bound each connection in a request with the overall request timeout, to bound DB
+            // Bound each statement in a request with the overall request timeout, to bound DB
             // utilisation (in the worst case we will use 2x the request timeout time in DB wall
             // time).
             config.service.limits.request_timeout_ms,


### PR DESCRIPTION
## Description

The connection timeout parameter is used to control how long we wait for a connection from the pool, rather than how long the connection is allowed to last for -- use the request timeout for the statement timeout instead (how long each request to the DB can take).

## Test Plan

```
sui-graphql-rpc$ cargo nextest run
sui-graphql-e2e-tests$ cargo nextest run --features pg_integration
```