### PR TITLE
[move-ide] Added virtualized source file reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6908,6 +6908,7 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "derivative",
  "itertools 0.10.5",
  "move-binary-format",
  "move-bytecode-source-map",

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -415,6 +415,7 @@ pub fn build_test_modules_with_dep_addr(
     for (addr_name, obj_id) in dep_original_addresses {
         build_config
             .config
+            .build_info
             .additional_named_addresses
             .insert(addr_name.to_string(), AccountAddress::from(obj_id));
     }
@@ -461,6 +462,7 @@ pub async fn publish_package_on_single_authority(
     for (addr_name, obj_id) in dep_original_addresses {
         build_config
             .config
+            .build_info
             .additional_named_addresses
             .insert(addr_name.to_string(), AccountAddress::from(obj_id));
     }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5375,6 +5375,7 @@ async fn test_publish_transitive_dependencies_ok() {
     let mut build_config = BuildConfig::new_for_testing();
     build_config
         .config
+        .build_info
         .additional_named_addresses
         .insert("c".to_string(), AccountAddress::ZERO);
 
@@ -5407,10 +5408,14 @@ async fn test_publish_transitive_dependencies_ok() {
     package_b_path.extend(["src", "unit_tests", "data", "transitive_dependencies", "b"]);
 
     let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.additional_named_addresses.extend([
-        ("b".to_string(), AccountAddress::ZERO),
-        ("c".to_string(), (package_c_id).into()),
-    ]);
+    build_config
+        .config
+        .build_info
+        .additional_named_addresses
+        .extend([
+            ("b".to_string(), AccountAddress::ZERO),
+            ("c".to_string(), (package_c_id).into()),
+        ]);
 
     let modules = build_config
         .build(package_b_path)
@@ -5443,11 +5448,15 @@ async fn test_publish_transitive_dependencies_ok() {
     package_a_path.extend(["src", "unit_tests", "data", "transitive_dependencies", "a"]);
 
     let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.additional_named_addresses.extend([
-        ("a".to_string(), AccountAddress::ZERO),
-        ("b".to_string(), (package_b_id).into()),
-        ("c".to_string(), (package_c_id).into()),
-    ]);
+    build_config
+        .config
+        .build_info
+        .additional_named_addresses
+        .extend([
+            ("a".to_string(), AccountAddress::ZERO),
+            ("b".to_string(), (package_b_id).into()),
+            ("c".to_string(), (package_c_id).into()),
+        ]);
 
     let modules = build_config
         .build(package_a_path)
@@ -5486,12 +5495,16 @@ async fn test_publish_transitive_dependencies_ok() {
     ]);
 
     let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.additional_named_addresses.extend([
-        ("examples".to_string(), AccountAddress::ZERO),
-        ("a".to_string(), (package_a_id).into()),
-        ("b".to_string(), (package_b_id).into()),
-        ("c".to_string(), (package_c_id).into()),
-    ]);
+    build_config
+        .config
+        .build_info
+        .additional_named_addresses
+        .extend([
+            ("examples".to_string(), AccountAddress::ZERO),
+            ("a".to_string(), (package_a_id).into()),
+            ("b".to_string(), (package_b_id).into()),
+            ("c".to_string(), (package_c_id).into()),
+        ]);
 
     let modules = build_config
         .build(package_root_path)

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2774,7 +2774,7 @@ fn ascii_tag() -> TypeTag {
 #[cfg_attr(msim, ignore)]
 async fn test_object_no_id_error() {
     let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.test_mode = true;
+    build_config.config.build_info.test_mode = true;
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // in this package object struct (NotObject) is defined incorrectly and publishing should
     // fail (it's defined in test-only code hence cannot be checked by transactional testing

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -197,7 +197,7 @@ async fn test_generate_lock_file() {
     let lock_file_path = tmp.path().join("Move.lock");
 
     let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.lock_file = Some(lock_file_path.clone());
+    build_config.config.build_info.lock_file = Some(lock_file_path.clone());
     build_config
         .clone()
         .build(path.clone())
@@ -205,6 +205,7 @@ async fn test_generate_lock_file() {
     // Update the lock file with placeholder compiler version so this isn't bumped every release.
     build_config
         .config
+        .build_info
         .update_lock_file_toolchain_version(&path, "0.0.1".into())
         .expect("Could not update lock file");
 
@@ -288,7 +289,7 @@ async fn test_custom_property_parse_published_at() {
 #[tokio::test]
 #[cfg_attr(msim, ignore)]
 async fn test_custom_property_check_unpublished_dependencies() {
-    let build_config = BuildConfig::new_for_testing();
+    let mut build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend([
         "src",

--- a/crates/sui-framework-tests/src/metered_verifier.rs
+++ b/crates/sui-framework-tests/src/metered_verifier.rs
@@ -16,7 +16,7 @@ use sui_verifier::{default_verifier_config, meter::SuiVerifierMeter};
 
 fn build(path: PathBuf) -> SuiResult<CompiledPackage> {
     let mut config = sui_move_build::BuildConfig::new_for_testing();
-    config.config.warnings_are_errors = true;
+    config.config.build_info.warnings_are_errors = true;
     config.build(path)
 }
 

--- a/crates/sui-framework-tests/src/unit_tests.rs
+++ b/crates/sui-framework-tests/src/unit_tests.rs
@@ -87,12 +87,12 @@ fn run_docs_examples_move_unit_tests() -> io::Result<()> {
 /// Ensure packages build outside of test mode.
 fn check_package_builds(path: PathBuf) {
     let mut config = BuildConfig::new_for_testing();
-    config.config.dev_mode = true;
+    config.config.build_info.dev_mode = true;
     config.run_bytecode_verifier = true;
     config.print_diags_to_stderr = true;
-    config.config.warnings_are_errors = true;
-    config.config.silence_warnings = false;
-    config.config.no_lint = false;
+    config.config.build_info.warnings_are_errors = true;
+    config.config.build_info.silence_warnings = false;
+    config.config.build_info.no_lint = false;
     config
         .build(path.clone())
         .unwrap_or_else(|e| panic!("Building package {}.\nWith error {e}", path.display()));
@@ -101,13 +101,13 @@ fn check_package_builds(path: PathBuf) {
 fn check_move_unit_tests(path: PathBuf) {
     let mut config = BuildConfig::new_for_testing();
     // Make sure to verify tests
-    config.config.dev_mode = true;
-    config.config.test_mode = true;
+    config.config.build_info.dev_mode = true;
+    config.config.build_info.test_mode = true;
     config.run_bytecode_verifier = true;
     config.print_diags_to_stderr = true;
-    config.config.warnings_are_errors = true;
-    config.config.silence_warnings = false;
-    config.config.no_lint = false;
+    config.config.build_info.warnings_are_errors = true;
+    config.config.build_info.silence_warnings = false;
+    config.config.build_info.no_lint = false;
     let move_config = config.config.clone();
     let mut testing_config = UnitTestingConfig::default_with_bound(Some(3_000_000));
     testing_config.filter = std::env::var(FILTER_ENV).ok().map(|s| s.to_string());

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use move_binary_format::CompiledModule;
-use move_package::BuildConfig as MoveBuildConfig;
+use move_package::{BuildConfig as MoveBuildConfig, BuildInfo};
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -88,13 +88,16 @@ fn build_packages(
     out_dir: PathBuf,
 ) {
     let config = MoveBuildConfig {
-        generate_docs: true,
-        warnings_are_errors: true,
-        install_dir: Some(PathBuf::from(".")),
-        no_lint: true,
-        ..Default::default()
+        build_info: BuildInfo {
+            generate_docs: true,
+            warnings_are_errors: true,
+            install_dir: Some(PathBuf::from(".")),
+            no_lint: true,
+            ..Default::default()
+        },
+        file_reader: None,
     };
-    debug_assert!(!config.test_mode);
+    debug_assert!(!config.build_info.test_mode);
     build_packages_with_move_config(
         bridge_path.clone(),
         deepbook_path.clone(),
@@ -110,12 +113,15 @@ fn build_packages(
         true,
     );
     let config = MoveBuildConfig {
-        generate_docs: true,
-        test_mode: true,
-        warnings_are_errors: true,
-        install_dir: Some(PathBuf::from(".")),
-        no_lint: true,
-        ..Default::default()
+        build_info: BuildInfo {
+            generate_docs: true,
+            test_mode: true,
+            warnings_are_errors: true,
+            install_dir: Some(PathBuf::from(".")),
+            no_lint: true,
+            ..Default::default()
+        },
+        file_reader: None,
     };
     build_packages_with_move_config(
         bridge_path,

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -127,7 +127,7 @@ impl BuildConfig {
     ) -> anyhow::Result<(MoveCompiledPackage, FnInfoMap)> {
         let build_plan = BuildPlan::create(resolution_graph)?;
         let mut fn_info = None;
-        let compiled_pkg = build_plan.compile_with_driver(None, writer, |compiler| {
+        let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
             let (files, units_res) = compiler.build()?;
             match units_res {
                 Ok((units, warning_diags)) => {

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -127,7 +127,7 @@ impl BuildConfig {
     ) -> anyhow::Result<(MoveCompiledPackage, FnInfoMap)> {
         let build_plan = BuildPlan::create(resolution_graph)?;
         let mut fn_info = None;
-        let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
+        let compiled_pkg = build_plan.compile_with_driver(None, writer, |compiler| {
             let (files, units_res) = compiler.build()?;
             match units_res {
                 Ok((units, warning_diags)) => {

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -98,10 +98,10 @@ pub fn resolve_lock_file_path(
     mut build_config: MoveBuildConfig,
     package_path: Option<PathBuf>,
 ) -> Result<MoveBuildConfig, anyhow::Error> {
-    if build_config.lock_file.is_none() {
+    if build_config.build_info.lock_file.is_none() {
         let package_root = base::reroot_path(package_path)?;
         let lock_file_path = package_root.join(SourcePackageLayout::Lock.path());
-        build_config.lock_file = Some(lock_file_path);
+        build_config.build_info.lock_file = Some(lock_file_path);
     }
     Ok(build_config)
 }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -158,8 +158,8 @@ pub async fn verify_package(
         MoveBuildConfig::default(),
         Some(package_path.as_ref().to_path_buf()),
     )?;
-    config.no_lint = true;
-    config.silence_warnings = true;
+    config.build_info.no_lint = true;
+    config.build_info.silence_warnings = true;
     let build_config = BuildConfig {
         config,
         run_bytecode_verifier: false, /* no need to run verifier if code is on-chain */

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -178,7 +178,7 @@ async fn run_publish(
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path: package_path.clone(),
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -208,7 +208,7 @@ async fn run_upgrade(
     let resp = SuiClientCommands::Upgrade {
         package_path: upgrade_pkg_path,
         upgrade_capability: cap.reference.object_id,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -396,7 +396,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
         skip_dependency_verification: false,
@@ -617,7 +617,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -684,7 +684,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -791,7 +791,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -917,7 +917,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1043,7 +1043,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1171,7 +1171,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1239,7 +1239,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
     let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1285,7 +1285,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
     let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1340,7 +1340,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
     let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1382,7 +1382,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
     let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1421,11 +1421,11 @@ async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
     package_path.push("module_publish_with_nonexistent_dependency");
     let mut build_config: MoveBuildConfig = BuildConfig::new_for_testing().config;
     // this would have been the result of calling `sui client publish --test`
-    build_config.test_mode = true;
+    build_config.build_info.test_mode = true;
 
     let result = SuiClientCommands::Publish {
         package_path,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1480,7 +1480,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path: package_path.clone(),
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
@@ -1552,7 +1552,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Upgrade {
         package_path: upgrade_pkg_path,
         upgrade_capability: cap.reference.object_id,
-        build_config,
+        build_info: build_config.build_info,
         gas: Some(gas_obj_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -376,6 +376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chashmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
+dependencies = [
+ "owning_ref",
+ "parking_lot 0.4.8",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1566,7 @@ name = "move-analyzer"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "chashmap",
  "clap 4.4.1",
  "codespan-reporting",
  "crossbeam",
@@ -2077,7 +2100,7 @@ dependencies = [
  "move-vm-types",
  "sha2",
  "sha3",
- "smallvec",
+ "smallvec 1.10.0",
  "tempfile",
  "walkdir",
 ]
@@ -2213,7 +2236,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "proptest",
  "sha3",
- "smallvec",
+ "smallvec 1.10.0",
  "tracing",
 ]
 
@@ -2248,7 +2271,7 @@ dependencies = [
  "move-vm-profiler",
  "proptest",
  "serde",
- "smallvec",
+ "smallvec 1.10.0",
 ]
 
 [[package]]
@@ -2426,6 +2449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2485,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
+dependencies = [
+ "owning_ref",
+ "parking_lot_core 0.2.14",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
@@ -2474,6 +2516,18 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+ "smallvec 0.6.14",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
@@ -2482,7 +2536,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "winapi",
 ]
 
@@ -2495,7 +2549,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "windows-sys 0.45.0",
 ]
 
@@ -2771,6 +2825,19 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2812,6 +2879,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2878,6 +2960,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3241,6 +3332,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
@@ -3254,6 +3354,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
@@ -3624,7 +3730,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.10.0",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "clap 4.4.1",
  "colored",
  "datatest-stable",
+ "derivative",
  "expect-test",
  "itertools",
  "move-binary-format",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -16,6 +16,7 @@ better_any = "0.1.1"
 bitvec = "0.19.4"
 byteorder = "1.4.3"
 bytes = "1.0.1"
+chashmap = "2.2.2"
 chrono = "0.4.19"
 clap = { version = "4", features = ["derive"] }
 codespan = "0.11.1"

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+chashmap.workspace = true
 codespan-reporting.workspace = true
 derivative.workspace = true
 dunce.workspace = true

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -192,6 +192,7 @@ fn main() {
                         }
                     },
                     Err(error) => {
+                        assert!(false);
                         eprintln!("symbolicator message error: {:?}", error);
                     },
                 }

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -193,7 +193,6 @@ fn main() {
                     },
                     Err(error) => {
                         eprintln!("symbolicator message error: {:?}", error);
-                        assert!(false);
                     },
                 }
             },

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{context::Context, symbols::Symbols};
+use chashmap::CHashMap;
 use lsp_server::Request;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, Position};
 use move_command_line_common::files::FileHash;
@@ -14,7 +15,7 @@ use move_compiler::{
     },
 };
 use move_symbol_pool::Symbol;
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 /// Constructs an `lsp_types::CompletionItem` with the given `label` and `kind`.
 fn completion_item(label: &str, kind: CompletionItemKind) -> CompletionItem {
@@ -149,7 +150,12 @@ fn get_cursor_token(buffer: &str, position: &Position) -> Option<Tok> {
 /// Sends the given connection a response to a completion request.
 ///
 /// The completions returned depend upon where the user's cursor is positioned.
-pub fn on_completion_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_completion_request(
+    context: &Context,
+    request: &Request,
+    files: Arc<CHashMap<PathBuf, String>>,
+    symbols: &Symbols,
+) {
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
@@ -160,38 +166,40 @@ pub fn on_completion_request(context: &Context, request: &Request, symbols: &Sym
         .uri
         .to_file_path()
         .unwrap();
-    let buffer = context.files.get(&path);
-    if buffer.is_none() {
-        eprintln!(
-            "Could not read '{:?}' when handling completion request",
-            path
-        );
-    }
-
-    // The completion items we provide depend upon where the user's cursor is positioned.
-    let cursor =
-        buffer.and_then(|buf| get_cursor_token(buf, &parameters.text_document_position.position));
 
     let mut items = vec![];
-    match cursor {
-        Some(Tok::Colon) => {
-            items.extend_from_slice(&primitive_types());
+    match files.get(&path) {
+        Some(buffer) => {
+            let buf = buffer.as_str();
+            let cursor = get_cursor_token(buf, &parameters.text_document_position.position);
+            match cursor {
+                Some(Tok::Colon) => {
+                    items.extend_from_slice(&primitive_types());
+                }
+                Some(Tok::Period) | Some(Tok::ColonColon) => {
+                    // `.` or `::` must be followed by identifiers, which are added to the completion items
+                    // below.
+                }
+                _ => {
+                    // If the user's cursor is positioned anywhere other than following a `.`, `:`, or `::`,
+                    // offer them Move's keywords, operators, and builtins as completion items.
+                    items.extend_from_slice(&keywords());
+                    items.extend_from_slice(&builtins());
+                }
+            }
+
+            let identifiers = identifiers(buf, symbols, &path);
+            items.extend_from_slice(&identifiers);
         }
-        Some(Tok::Period) | Some(Tok::ColonColon) => {
-            // `.` or `::` must be followed by identifiers, which are added to the completion items
-            // below.
-        }
-        _ => {
-            // If the user's cursor is positioned anywhere other than following a `.`, `:`, or `::`,
-            // offer them Move's keywords, operators, and builtins as completion items.
+        None => {
+            eprintln!(
+                "Could not read '{:?}' when handling completion request",
+                path
+            );
+            // no file found so jus add keywords and builtins
             items.extend_from_slice(&keywords());
             items.extend_from_slice(&builtins());
         }
-    }
-
-    if let Some(buffer) = &buffer {
-        let identifiers = identifiers(buffer, symbols, &path);
-        items.extend_from_slice(&identifiers);
     }
 
     let result = serde_json::to_value(items).expect("could not serialize completion response");

--- a/external-crates/move/crates/move-analyzer/src/context.rs
+++ b/external-crates/move/crates/move-analyzer/src/context.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{symbols::Symbols, vfs::VirtualFileSystem};
+use crate::symbols::Symbols;
 use lsp_server::Connection;
 use std::sync::{Arc, Mutex};
 
@@ -10,8 +10,6 @@ use std::sync::{Arc, Mutex};
 pub struct Context {
     /// The connection with the language server's client.
     pub connection: Connection,
-    /// The files that the language server is providing information about.
-    pub files: VirtualFileSystem,
     /// Symbolication information
     pub symbols: Arc<Mutex<Symbols>>,
 }

--- a/external-crates/move/crates/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/crates/move-analyzer/src/diagnostics.rs
@@ -28,11 +28,6 @@ pub fn lsp_diagnostics(
 ) -> BTreeMap<PathBuf, Vec<Diagnostic>> {
     let mut lsp_diagnostics = BTreeMap::new();
     for (s, _, (loc, msg), labels, _) in diagnostics {
-        if file_name_mapping.get(&loc.file_hash()).is_none() {
-            eprintln!("HASH: {}", loc.file_hash());
-            eprintln!("FILES: {:#?}", file_id_mapping);
-            eprintln!("MSG {}", msg);
-        }
         let fpath = file_name_mapping.get(&loc.file_hash()).unwrap();
         if let Some(start) = get_loc(&loc.file_hash(), loc.start(), files, file_id_mapping) {
             if let Some(end) = get_loc(&loc.file_hash(), loc.end(), files, file_id_mapping) {

--- a/external-crates/move/crates/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/crates/move-analyzer/src/diagnostics.rs
@@ -28,6 +28,11 @@ pub fn lsp_diagnostics(
 ) -> BTreeMap<PathBuf, Vec<Diagnostic>> {
     let mut lsp_diagnostics = BTreeMap::new();
     for (s, _, (loc, msg), labels, _) in diagnostics {
+        if file_name_mapping.get(&loc.file_hash()).is_none() {
+            eprintln!("HASH: {}", loc.file_hash());
+            eprintln!("FILES: {:#?}", file_id_mapping);
+            eprintln!("MSG {}", msg);
+        }
         let fpath = file_name_mapping.get(&loc.file_hash()).unwrap();
         if let Some(start) = get_loc(&loc.file_hash(), loc.start(), files, file_id_mapping) {
             if let Some(end) = get_loc(&loc.file_hash(), loc.end(), files, file_id_mapping) {

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -58,8 +58,10 @@ use crate::{
     context::Context,
     diagnostics::{lsp_diagnostics, lsp_empty_diagnostics},
     utils::get_loc,
+    vfs::VirtualFileSystem,
 };
 use anyhow::{anyhow, Result};
+use chashmap::CHashMap;
 use codespan_reporting::files::SimpleFiles;
 use crossbeam::channel::Sender;
 use derivative::*;
@@ -88,7 +90,7 @@ use move_compiler::{
     expansion::ast::{self as E, Fields, ModuleIdent, ModuleIdent_, Value, Value_, Visibility},
     naming::ast::{StructDefinition, StructFields, TParam, Type, TypeName_, Type_, UseFuns},
     parser::ast::{self as P, StructName},
-    shared::{Identifier, Name},
+    shared::{Identifier, Name, SourceFileReader},
     typing::ast::{
         BuiltinFunction_, Exp, ExpListItem, Function, FunctionBody_, LValue, LValueList, LValue_,
         ModuleCall, ModuleDefinition, SequenceItem, SequenceItem_, UnannotatedExp_,
@@ -96,7 +98,10 @@ use move_compiler::{
     PASS_PARSER, PASS_TYPING,
 };
 use move_ir_types::location::*;
-use move_package::compilation::build_plan::BuildPlan;
+use move_package::{
+    compilation::build_plan::BuildPlan, resolution::resolution_graph::ResolvedGraph,
+    source_package::parsed_manifest::FileName,
+};
 use move_symbol_pool::Symbol;
 
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
@@ -652,6 +657,7 @@ impl SymbolicatorRunner {
 
     /// Create a new runner
     pub fn new(
+        files: Arc<CHashMap<PathBuf, String>>,
         symbols: Arc<Mutex<Symbols>>,
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: bool,
@@ -711,7 +717,7 @@ impl SymbolicatorRunner {
                             continue;
                         }
                         eprintln!("symbolication started");
-                        match get_symbols(root_dir.unwrap().as_path(), lint) {
+                        match get_symbols(files.clone(), root_dir.unwrap().as_path(), lint) {
                             Ok((symbols_opt, lsp_diagnostics)) => {
                                 eprintln!("symbolication finished");
                                 if let Some(new_symbols) = symbols_opt {
@@ -949,6 +955,7 @@ impl Symbols {
 /// actually (re)computed and the diagnostics are returned, the old symbolic information should
 /// be retained even if it's getting out-of-date.
 pub fn get_symbols(
+    virtual_files: Arc<CHashMap<PathBuf, String>>,
     pkg_path: &Path,
     lint: bool,
 ) -> Result<(Option<Symbols>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
@@ -966,14 +973,19 @@ pub fn get_symbols(
     // vector as the writer
     let resolution_graph = build_config.resolution_graph_for_package(pkg_path, &mut Vec::new())?;
 
+    let mut vfs = VirtualFileSystem {
+        ide_files: virtual_files.clone(),
+        all_files: HashMap::new(),
+    };
+
     // get source files to be able to correlate positions (in terms of byte offsets) with actual
     // file locations (in terms of line/column numbers)
-    let source_files = &resolution_graph.file_sources();
-    let mut files = SimpleFiles::new();
+    let source_files = file_sources(&resolution_graph, &mut vfs);
+    let mut files: SimpleFiles<Symbol, String> = SimpleFiles::new();
     let mut file_id_mapping = HashMap::new();
     let mut file_id_to_lines = HashMap::new();
     let mut file_name_mapping = BTreeMap::new();
-    for (fhash, (fname, source)) in source_files {
+    for (fhash, (fname, source)) in &source_files {
         let id = files.add(*fname, source.clone());
         file_id_mapping.insert(*fhash, id);
         file_name_mapping.insert(
@@ -988,7 +1000,7 @@ pub fn get_symbols(
     let mut parsed_ast = None;
     let mut typed_ast = None;
     let mut diagnostics = None;
-    build_plan.compile_with_driver(&mut std::io::sink(), |compiler| {
+    build_plan.compile_with_driver(Some(Box::new(vfs)), &mut std::io::sink(), |compiler| {
         // extract expansion AST
         let (files, compilation_result) = compiler.run::<PASS_PARSER>()?;
         let (_, compiler) = match compilation_result {
@@ -1180,6 +1192,28 @@ fn expansion_mod_ident_to_map_key(mod_ident: &E::ModuleIdent_) -> String {
             format!("{n}::{}", mod_ident.module).to_string()
         }
     }
+}
+
+pub fn file_sources(
+    resolved_graph: &ResolvedGraph,
+    vfs: &mut VirtualFileSystem,
+) -> BTreeMap<FileHash, (FileName, String)> {
+    resolved_graph
+        .package_table
+        .iter()
+        .flat_map(|(_, rpkg)| {
+            rpkg.get_sources(&resolved_graph.build_options)
+                .unwrap()
+                .iter()
+                .map(|fname| {
+                    let mut contents = String::new();
+                    let _ = vfs.read_to_string(&PathBuf::from(fname.as_str()), &mut contents);
+                    let fhash = FileHash::new(&contents);
+                    (fhash, (*fname, contents))
+                })
+                .collect::<BTreeMap<_, _>>()
+        })
+        .collect()
 }
 
 /// Get empty symbols
@@ -3468,7 +3502,7 @@ fn docstring_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -3738,7 +3772,7 @@ fn symbols_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -4778,7 +4812,7 @@ fn const_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5017,7 +5051,7 @@ fn imports_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5218,7 +5252,7 @@ fn module_access_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5372,7 +5406,7 @@ fn parse_error_test() {
 
     path.push("tests/parse-error");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5456,7 +5490,7 @@ fn parse_error_with_deps_test() {
 
     path.push("tests/parse-error-dep");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5504,7 +5538,7 @@ fn pretype_error_test() {
 
     path.push("tests/pre-type-error");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5538,7 +5572,7 @@ fn pretype_error_with_deps_test() {
 
     path.push("tests/pre-type-error-dep");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5635,7 +5669,7 @@ fn dot_call_test() {
 
     path.push("tests/move-2024");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5964,7 +5998,7 @@ fn mod_ident_uniform_test() {
 
     path.push("tests/mod-ident-uniform");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let (symbols_opt, _) = get_symbols(Arc::new(CHashMap::new()), path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -90,7 +90,7 @@ use move_compiler::{
     expansion::ast::{self as E, Fields, ModuleIdent, ModuleIdent_, Value, Value_, Visibility},
     naming::ast::{StructDefinition, StructFields, TParam, Type, TypeName_, Type_, UseFuns},
     parser::ast::{self as P, StructName},
-    shared::{Identifier, Name, SourceFileReader},
+    shared::{FileReader, Identifier, Name},
     typing::ast::{
         BuiltinFunction_, Exp, ExpListItem, Function, FunctionBody_, LValue, LValueList, LValue_,
         ModuleCall, ModuleDefinition, SequenceItem, SequenceItem_, UnannotatedExp_,

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -17,7 +17,7 @@ use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
-use move_compiler::shared::SourceFileReader;
+use move_compiler::shared::FileReader;
 use std::{
     collections::HashMap,
     io::Read,
@@ -38,7 +38,7 @@ pub struct VirtualFileSystem {
     pub all_files: HashMap<PathBuf, String>,
 }
 
-impl SourceFileReader for VirtualFileSystem {
+impl FileReader for VirtualFileSystem {
     fn read_to_string(&mut self, fpath: &Path, buf: &mut String) -> std::io::Result<usize> {
         // We may have a race here between a file being pushed by the IDE (and available in
         // `ide_files`) and files only available in the file system. This should be OK, though, as

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -11,76 +11,108 @@
 //! saved) to its textual contents.
 
 use crate::symbols;
+use chashmap::CHashMap;
 use lsp_server::Notification;
 use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
-use std::path::PathBuf;
+use move_compiler::shared::SourceFileReader;
+use std::{
+    collections::HashMap,
+    io::Read,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
+
+/// Virtual file system that serves the same version of the file each time it's queried,
+/// whether this file comes from the IDE message (file open or update notification) or
+/// it comes from the file system.
 pub struct VirtualFileSystem {
-    files: std::collections::HashMap<PathBuf, String>,
+    /// Files pushed to the LSP server by the IDE via file open or update notifications
+    pub ide_files: Arc<CHashMap<PathBuf, String>>,
+    /// Files served by this VFS (populated on demand from IDE files or from the file system)
+    pub all_files: HashMap<PathBuf, String>,
 }
 
-impl VirtualFileSystem {
-    /// Returns a reference to the buffer corresponding to the given identifier, or `None` if it
-    /// is not present in the system.
-    pub fn get(&self, identifier: &PathBuf) -> Option<&str> {
-        self.files.get(identifier).map(|s| s.as_str())
-    }
-
-    /// Inserts or overwrites the buffer corresponding to the given identifier.
-    ///
-    /// TODO: A far more efficient "virtual file system" would update its buffers with changes sent
-    /// from the client, instead of completely replacing them each time. The rust-analyzer has a
-    /// 'vfs' module that is capable of doing just that, but it is not published on crates.io. If
-    /// we could help get it published, we could use it here.
-    pub fn update(&mut self, identifier: PathBuf, content: &str) {
-        self.files.insert(identifier, content.to_string());
-    }
-
-    /// Removes the buffer and its identifier from the system.
-    pub fn remove(&mut self, identifier: &PathBuf) {
-        self.files.remove(identifier);
+impl SourceFileReader for VirtualFileSystem {
+    fn read_to_string(&mut self, fpath: &Path, buf: &mut String) -> std::io::Result<usize> {
+        // We may have a race here between a file being pushed by the IDE (and available in
+        // `ide_files`) and files only available in the file system. This should be OK, though, as
+        // in the worst case, we can always read from a file:
+        // - if we attempt to get `ide_files` file but the window closes in the meantime and it's no
+        // longer available, we still get up-to-date data from the file system (the file was saved
+        // or not before window closing but it does not matter)
+        // - if we attempt to read from file and the window opens in the meantime, the only
+        // consequence is that we will temporarily build symbols for a slightly out-of-date data,
+        // but this will quickly get updated once the user starts typing
+        match self.all_files.get(fpath) {
+            Some(s) => {
+                buf.push_str(s.as_str());
+                Ok(s.len())
+            }
+            None => match self.ide_files.remove(fpath) {
+                Some(s) => {
+                    buf.push_str(s.as_str());
+                    let len = s.len();
+                    self.all_files.insert(fpath.to_path_buf(), s);
+                    Ok(len)
+                }
+                None => {
+                    let mut f = std::fs::File::open(fpath).map_err(|err| {
+                        std::io::Error::new(err.kind(), format!("{}: {:?}", err, fpath))
+                    })?;
+                    let len = f.read_to_string(buf)?;
+                    self.all_files.insert(fpath.to_path_buf(), buf.clone());
+                    Ok(len)
+                }
+            },
+        }
     }
 }
 
 /// Updates the given virtual file system based on the text document sync notification that was sent.
 pub fn on_text_document_sync_notification(
-    files: &mut VirtualFileSystem,
+    files: Arc<CHashMap<PathBuf, String>>,
     symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
+    // TODO: A far more efficient "virtual file system" would update its buffers with changes sent
+    // from the client, instead of completely replacing them each time. The rust-analyzer has a
+    // 'vfs' module that is capable of doing just that, but it is not published on crates.io. If
+    // we could help get it published, we could use it here.
     eprintln!("text document notification");
     match notification.method.as_str() {
         lsp_types::notification::DidOpenTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidOpenTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
+            files.insert(
                 parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.text_document.text,
+                parameters.text_document.text,
             );
             symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
-            let parameters =
+            let mut parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
+            files.insert(
                 parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.content_changes.last().unwrap().text,
+                parameters.content_changes.pop().unwrap().text,
             );
+            symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
         }
         lsp_types::notification::DidSaveTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidSaveTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
+            files.insert(
                 parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.text.unwrap(),
+                parameters.text.unwrap(),
             );
             symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
         }

--- a/external-crates/move/crates/move-cli/src/base/build.rs
+++ b/external-crates/move/crates/move-cli/src/base/build.rs
@@ -14,10 +14,10 @@ pub struct Build;
 impl Build {
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
-        if config.fetch_deps_only {
+        if config.build_info.fetch_deps_only {
             let mut config = config;
-            if config.test_mode {
-                config.dev_mode = true;
+            if config.build_info.test_mode {
+                config.build_info.dev_mode = true;
             }
             config.download_deps_for_package(&rerooted_path, &mut std::io::stdout())?;
             return Ok(());

--- a/external-crates/move/crates/move-cli/src/base/info.rs
+++ b/external-crates/move/crates/move-cli/src/base/info.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 pub struct Info;
 
 impl Info {
-    pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+    pub fn execute(self, path: Option<PathBuf>, mut config: BuildConfig) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
         config
             .resolution_graph_for_package(&rerooted_path, &mut std::io::stdout())?

--- a/external-crates/move/crates/move-cli/src/base/migrate.rs
+++ b/external-crates/move/crates/move-cli/src/base/migrate.rs
@@ -14,10 +14,10 @@ pub struct Migrate;
 impl Migrate {
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
-        if config.fetch_deps_only {
+        if config.build_info.fetch_deps_only {
             let mut config = config;
-            if config.test_mode {
-                config.dev_mode = true;
+            if config.build_info.test_mode {
+                config.build_info.dev_mode = true;
             }
             config.download_deps_for_package(&rerooted_path, &mut std::io::stdout())?;
             return Ok(());

--- a/external-crates/move/crates/move-cli/src/base/prove.rs
+++ b/external-crates/move/crates/move-cli/src/base/prove.rs
@@ -162,7 +162,7 @@ pub fn run_move_prover(
     mut options: move_prover::cli::Options,
 ) -> anyhow::Result<()> {
     // Always run the prover in dev mode, so addresses get default assignments
-    config.dev_mode = true;
+    config.build_info.dev_mode = true;
 
     if !options.move_sources.is_empty() {
         bail!(

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -182,7 +182,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
     // then save it, before resuming the rest of the compilation and returning the results and
     // control back to the Move package system.
     let mut warning_diags = None;
-    build_plan.compile_with_driver(writer, |compiler| {
+    build_plan.compile_with_driver(None, writer, |compiler| {
         let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
         let (_, compiler) =
             diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -139,8 +139,8 @@ pub fn run_move_unit_tests<W: Write + Send>(
     writer: &mut W,
 ) -> Result<(UnitTestResult, Option<Diagnostics>)> {
     let mut test_plan = None;
-    build_config.test_mode = true;
-    build_config.dev_mode = true;
+    build_config.build_info.test_mode = true;
+    build_config.build_info.dev_mode = true;
 
     // Build the resolution graph (resolution graph diagnostics are only needed for CLI commands so
     // ignore them by passing a vector as the writer)
@@ -176,7 +176,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
         })
         .collect();
     let root_package = resolution_graph.root_package();
-    let mut build_plan = BuildPlan::create(resolution_graph)?;
+    let mut build_plan = BuildPlan::create(resolution_graph, None)?;
     // Compile the package. We need to intercede in the compilation, process being performed by the
     // Move package system, to first grab the compilation env, construct the test plan from it, and
     // then save it, before resuming the rest of the compilation and returning the results and

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -176,13 +176,13 @@ pub fn run_move_unit_tests<W: Write + Send>(
         })
         .collect();
     let root_package = resolution_graph.root_package();
-    let build_plan = BuildPlan::create(resolution_graph)?;
+    let mut build_plan = BuildPlan::create(resolution_graph)?;
     // Compile the package. We need to intercede in the compilation, process being performed by the
     // Move package system, to first grab the compilation env, construct the test plan from it, and
     // then save it, before resuming the rest of the compilation and returning the results and
     // control back to the Move package system.
     let mut warning_diags = None;
-    build_plan.compile_with_driver(None, writer, |compiler| {
+    build_plan.compile_with_driver(writer, |compiler| {
         let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
         let (_, compiler) =
             diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);

--- a/external-crates/move/crates/move-cli/src/sandbox/cli.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/cli.rs
@@ -270,6 +270,7 @@ impl SandboxCommand {
                 let build_dir = Path::new(
                     &move_args
                         .build_config
+                        .build_info
                         .install_dir
                         .as_ref()
                         .unwrap_or(&PathBuf::from(DEFAULT_BUILD_DIR)),

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
@@ -15,7 +15,7 @@ use move_package::{
     compilation::{compiled_package::OnDiskCompiledPackage, package_layout::CompiledPackageLayout},
     resolution::resolution_graph::ResolvedGraph,
     source_package::{layout::SourcePackageLayout, manifest_parser::parse_move_manifest_from_file},
-    BuildConfig,
+    BuildConfig, BuildInfo,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -129,8 +129,11 @@ fn copy_deps(tmp_dir: &Path, pkg_dir: &Path) -> anyhow::Result<PathBuf> {
     // don't need to nest at all. Resolution graph diagnostics are only needed for CLI commands so
     // ignore them by passing a vector as the writer.
     let package_resolution = match (BuildConfig {
-        dev_mode: true,
-        ..Default::default()
+        build_info: BuildInfo {
+            dev_mode: true,
+            ..Default::default()
+        },
+        file_reader: None,
     })
     .resolution_graph_for_package(pkg_dir, &mut Vec::new())
     {

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/package_context.rs
@@ -18,6 +18,7 @@ impl PackageContext {
     pub fn new(path: &Option<PathBuf>, build_config: &BuildConfig) -> Result<Self> {
         let path = path.as_deref().unwrap_or_else(|| Path::new("."));
         let build_dir = build_config
+            .build_info
             .install_dir
             .as_ref()
             .unwrap_or(&PathBuf::from(DEFAULT_BUILD_DIR))

--- a/external-crates/move/crates/move-cli/tests/build_tests/unbound_dependency/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/unbound_dependency/args.exp
@@ -3,4 +3,4 @@ Error: Failed to resolve dependencies for package 'A'
 
 Caused by:
     0: Parsing manifest for 'Foo'
-    1: No such file or directory (os error 2)
+    1: No such file or directory (os error 2): "./foo/Move.toml"

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -19,11 +19,7 @@ use anyhow::anyhow;
 use comments::*;
 use move_command_line_common::files::{find_move_filenames, FileHash};
 use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeSet, HashMap},
-    fs::File,
-    io::Read,
-};
+use std::collections::{BTreeSet, HashMap};
 
 pub(crate) fn parse_program(
     compilation_env: &mut CompilationEnv,
@@ -152,10 +148,8 @@ fn parse_file(
     MatchedFileCommentMap,
     FileHash,
 )> {
-    let mut f = File::open(fname.as_str())
-        .map_err(|err| std::io::Error::new(err.kind(), format!("{}: {}", err, fname)))?;
     let mut source_buffer = String::new();
-    f.read_to_string(&mut source_buffer)?;
+    compilation_env.read_to_string(std::path::Path::new(fname.as_str()), &mut source_buffer)?;
     let file_hash = FileHash::new(&source_buffer);
     let buffer = match verify_string(file_hash, &source_buffer) {
         Err(ds) => {

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -878,7 +878,7 @@ pub(crate) use process_binops;
 // Source file reader
 //**************************************************************************************************
 
-pub trait FileReader {
+pub trait FileReader: 'static {
     fn read_to_string(&mut self, fpath: &Path, buf: &mut String) -> std::io::Result<usize>;
 }
 

--- a/external-crates/move/crates/move-package/Cargo.toml
+++ b/external-crates/move/crates/move-package/Cargo.toml
@@ -24,6 +24,7 @@ treeline.workspace = true
 once_cell.workspace = true
 named-lock.workspace = true
 itertools.workspace = true
+derivative.workspace = true
 
 move-binary-format.workspace = true
 move-compiler.workspace = true

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -18,6 +18,7 @@ use move_compiler::{
         report_diagnostics_to_color_buffer, report_warnings, FilesSourceText, Migration,
     },
     editions::Edition,
+    shared::SourceFileReader,
     Compiler,
 };
 use std::{
@@ -68,7 +69,7 @@ impl BuildPlan {
 
     /// Compilation results in the process exit upon warning/failure
     pub fn compile<W: Write>(&self, writer: &mut W) -> Result<CompiledPackage> {
-        self.compile_with_driver(writer, |compiler| compiler.build_and_report())
+        self.compile_with_driver(None, writer, |compiler| compiler.build_and_report())
     }
 
     /// Compilation results in the process exit upon warning/failure
@@ -96,7 +97,7 @@ impl BuildPlan {
 
     /// Compilation process does not exit even if warnings/failures are encountered
     pub fn compile_no_exit<W: Write>(&self, writer: &mut W) -> Result<CompiledPackage> {
-        self.compile_with_driver(writer, |compiler| {
+        self.compile_with_driver(None, writer, |compiler| {
             let (files, units_res) = compiler.build()?;
             match units_res {
                 Ok((units, warning_diags)) => {
@@ -170,6 +171,7 @@ impl BuildPlan {
 
     pub fn compile_with_driver<W: Write>(
         &self,
+        source_file_reader: Option<Box<dyn SourceFileReader>>,
         writer: &mut W,
         mut compiler_driver: impl FnMut(
             Compiler,
@@ -188,6 +190,7 @@ impl BuildPlan {
             root_package,
             transitive_dependencies,
             &self.resolution_graph,
+            source_file_reader,
             &mut compiler_driver,
         )?;
 

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -121,7 +121,7 @@ impl BuildPlan {
         })
     }
 
-    fn compute_dependencies<'a>(&'a mut self) -> (CompilationDependencies, &'a mut BuildConfig) {
+    fn compute_dependencies(&mut self) -> (CompilationDependencies, &mut BuildConfig) {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {
             Some(under_path) => under_path.clone(),

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -18,7 +18,7 @@ use move_compiler::{
         report_diagnostics_to_color_buffer, report_warnings, FilesSourceText, Migration,
     },
     editions::Edition,
-    shared::SourceFileReader,
+    shared::FileReader,
     Compiler,
 };
 use std::{
@@ -171,7 +171,7 @@ impl BuildPlan {
 
     pub fn compile_with_driver<W: Write>(
         &self,
-        source_file_reader: Option<Box<dyn SourceFileReader>>,
+        source_file_reader: Option<Box<dyn FileReader>>,
         writer: &mut W,
         mut compiler_driver: impl FnMut(
             Compiler,

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -533,7 +533,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
-        source_file_reader: Option<Box<dyn FileReader>>,
+        file_reader: Option<Box<dyn FileReader>>,
         compiler_driver: impl FnMut(Compiler) -> Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let BuildResult {
@@ -547,7 +547,7 @@ impl CompiledPackage {
             resolved_package.clone(),
             transitive_dependencies,
             resolution_graph,
-            source_file_reader,
+            file_reader,
             compiler_driver,
         )?;
         let (file_map, all_compiled_units) = result;

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -28,7 +28,7 @@ use move_compiler::{
     compiled_unit::{AnnotatedCompiledUnit, CompiledUnit, NamedCompiledModule},
     diagnostics::FilesSourceText,
     editions::Flavor,
-    shared::{NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths},
+    shared::{NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths, SourceFileReader},
     sui_mode::linters::{known_filters, linter_visitors},
     Compiler,
 };
@@ -437,6 +437,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
+        source_file_reader: Option<Box<dyn SourceFileReader>>,
         mut compiler_driver: impl FnMut(Compiler) -> Result<T>,
     ) -> Result<BuildResult<T>> {
         let immediate_dependencies = transitive_dependencies
@@ -489,6 +490,9 @@ impl CompiledPackage {
         let mut compiler = Compiler::from_package_paths(paths, bytecode_deps)
             .unwrap()
             .set_flags(flags);
+        if let Some(file_reader) = source_file_reader {
+            compiler = compiler.set_source_file_reader(file_reader);
+        }
         if sui_mode {
             let (filter_attr_name, filters) = known_filters();
             compiler = compiler.add_custom_known_filters(filter_attr_name, filters);
@@ -517,6 +521,7 @@ impl CompiledPackage {
             resolved_package,
             transitive_dependencies,
             resolution_graph,
+            None,
             compiler_driver,
         )?;
         Ok(build_result.result)
@@ -528,6 +533,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
+        source_file_reader: Option<Box<dyn SourceFileReader>>,
         compiler_driver: impl FnMut(Compiler) -> Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let BuildResult {
@@ -541,6 +547,7 @@ impl CompiledPackage {
             resolved_package.clone(),
             transitive_dependencies,
             resolution_graph,
+            source_file_reader,
             compiler_driver,
         )?;
         let (file_map, all_compiled_units) = result;

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -28,7 +28,7 @@ use move_compiler::{
     compiled_unit::{AnnotatedCompiledUnit, CompiledUnit, NamedCompiledModule},
     diagnostics::FilesSourceText,
     editions::Flavor,
-    shared::{NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths, SourceFileReader},
+    shared::{FileReader, NamedAddressMap, NumericalAddress, PackageConfig, PackagePaths},
     sui_mode::linters::{known_filters, linter_visitors},
     Compiler,
 };
@@ -437,7 +437,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
-        source_file_reader: Option<Box<dyn SourceFileReader>>,
+        source_file_reader: Option<Box<dyn FileReader>>,
         mut compiler_driver: impl FnMut(Compiler) -> Result<T>,
     ) -> Result<BuildResult<T>> {
         let immediate_dependencies = transitive_dependencies
@@ -491,7 +491,7 @@ impl CompiledPackage {
             .unwrap()
             .set_flags(flags);
         if let Some(file_reader) = source_file_reader {
-            compiler = compiler.set_source_file_reader(file_reader);
+            compiler = compiler.set_file_reader(file_reader);
         }
         if sui_mode {
             let (filter_attr_name, filters) = known_filters();
@@ -533,7 +533,7 @@ impl CompiledPackage {
         resolved_package: Package,
         transitive_dependencies: Vec<DependencyInfo>,
         resolution_graph: &ResolvedGraph,
-        source_file_reader: Option<Box<dyn SourceFileReader>>,
+        source_file_reader: Option<Box<dyn FileReader>>,
         compiler_driver: impl FnMut(Compiler) -> Result<(FilesSourceText, Vec<AnnotatedCompiledUnit>)>,
     ) -> Result<CompiledPackage> {
         let BuildResult {

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -840,7 +840,7 @@ pub(crate) fn make_source_and_deps_for_compiler(
     let source_package_paths = PackagePaths {
         name: Some((
             root.source_package.package.name,
-            root.compiler_config(/* is_dependency */ false, &build_info),
+            root.compiler_config(/* is_dependency */ false, build_info),
         )),
         paths: sources,
         named_address_map: root_named_addrs,

--- a/external-crates/move/crates/move-package/src/compilation/model_builder.rs
+++ b/external-crates/move/crates/move-package/src/compilation/model_builder.rs
@@ -83,7 +83,7 @@ impl ModelBuilder {
             .collect::<Result<Vec<_>>>()?;
 
         let (target, deps) = make_source_and_deps_for_compiler(
-            &mut self.resolution_graph.build_options,
+            &self.resolution_graph.build_options,
             &root_package,
             deps_source_info,
         )?;

--- a/external-crates/move/crates/move-package/src/compilation/model_builder.rs
+++ b/external-crates/move/crates/move-package/src/compilation/model_builder.rs
@@ -32,7 +32,7 @@ impl ModelBuilder {
     // across all packages and build the Move model from that.
     // TODO: In the future we will need a better way to do this to support renaming in packages
     // where we want to support building a Move model.
-    pub fn build_model(&self) -> Result<GlobalEnv> {
+    pub fn build_model(&mut self) -> Result<GlobalEnv> {
         // Make sure no renamings have been performed
         if let Some(pkg_name) = self.resolution_graph.contains_renaming() {
             anyhow::bail!(
@@ -83,7 +83,7 @@ impl ModelBuilder {
             .collect::<Result<Vec<_>>>()?;
 
         let (target, deps) = make_source_and_deps_for_compiler(
-            &self.resolution_graph,
+            &mut self.resolution_graph.build_options,
             &root_package,
             deps_source_info,
         )?;

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -39,7 +39,7 @@ use crate::{
     package_lock::PackageLock,
 };
 
-#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+#[allow(clippy::non_canonical_partial_ord_impl)]
 #[derive(Derivative, Parser, Serialize, Deserialize, Default)]
 #[derivative(Debug, Eq, PartialEq, PartialOrd, Clone)]
 #[clap(about)]

--- a/external-crates/move/crates/move-package/src/resolution/mod.rs
+++ b/external-crates/move/crates/move-package/src/resolution/mod.rs
@@ -30,13 +30,14 @@ pub fn download_dependency_repos<Progress: Write>(
     progress_output: &mut Progress,
 ) -> Result<()> {
     let install_dir = build_options
+        .build_info
         .install_dir
         .as_ref()
         .unwrap_or(&root_path.to_path_buf())
         .to_owned();
     let file_reader = std::mem::take(&mut build_options.file_reader);
     let mut dep_graph_builder = DependencyGraphBuilder::new(
-        build_options.skip_fetch_latest_git_deps,
+        build_options.build_info.skip_fetch_latest_git_deps,
         progress_output,
         install_dir,
         file_reader,
@@ -54,7 +55,7 @@ pub fn download_dependency_repos<Progress: Write>(
             continue;
         }
 
-        if !(build_options.dev_mode || graph.always_deps.contains(&pkg_id)) {
+        if !(build_options.build_info.dev_mode || graph.always_deps.contains(&pkg_id)) {
             continue;
         }
 

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -12,7 +12,6 @@ use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -309,7 +308,7 @@ impl ResolvedGraph {
             .into_iter()
     }
 
-    pub fn file_sources(&self) -> BTreeMap<FileHash, (FileName, String)> {
+    pub fn file_sources(&mut self) -> BTreeMap<FileHash, (FileName, String)> {
         self.package_table
             .iter()
             .flat_map(|(_, rpkg)| {
@@ -317,7 +316,10 @@ impl ResolvedGraph {
                     .unwrap()
                     .iter()
                     .map(|fname| {
-                        let contents = fs::read_to_string(fname.as_str()).unwrap();
+                        let mut contents = String::new();
+                        self.build_options
+                            .read_to_string(&PathBuf::from(fname.as_str()), &mut contents)
+                            .unwrap();
                         let fhash = FileHash::new(&contents);
                         (fhash, (*fname, contents))
                     })

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -108,7 +108,7 @@ impl ResolvedGraph {
                 graph.root_path.join(local_path(&pkg.kind))
             };
 
-            let mut resolved_pkg = Package::new(package_path, &build_options)
+            let mut resolved_pkg = Package::new(package_path, build_options)
                 .with_context(|| format!("Resolving package '{pkg_id}'"))?;
 
             // Check dependencies package names from manifest are consistent with ther names

--- a/external-crates/move/crates/move-package/tests/package_hash_skips_non_move_files.rs
+++ b/external-crates/move/crates/move-package/tests/package_hash_skips_non_move_files.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_package::BuildConfig;
+use move_package::{BuildConfig, BuildInfo};
 use std::{io::Write, path::Path};
 use tempfile::tempdir;
 
@@ -14,8 +14,11 @@ fn package_hash_skips_non_move_files() {
     // passing a vector as the writer
 
     let pkg1 = BuildConfig {
-        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-        ..Default::default()
+        build_info: BuildInfo {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        },
+        file_reader: None,
     }
     .resolution_graph_for_package(path, &mut Vec::new())
     .unwrap();
@@ -27,8 +30,11 @@ fn package_hash_skips_non_move_files() {
         .unwrap();
 
     let pkg2 = BuildConfig {
-        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-        ..Default::default()
+        build_info: BuildInfo {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        },
+        file_reader: None,
     }
     .resolution_graph_for_package(path, &mut Vec::new())
     .unwrap();

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -47,7 +47,7 @@ fn test_additonal_addresses() {
 
     assert!(RG::ResolvedGraph::resolve(
         dg.clone(),
-        BuildConfig {
+        &mut BuildConfig {
             build_info: BuildInfo {
                 install_dir: Some(tempdir().unwrap().path().to_path_buf()),
                 additional_named_addresses: BTreeMap::from([(
@@ -65,7 +65,7 @@ fn test_additonal_addresses() {
 
     assert!(RG::ResolvedGraph::resolve(
         dg,
-        BuildConfig {
+        &mut BuildConfig {
             build_info: BuildInfo {
                 install_dir: Some(tempdir().unwrap().path().to_path_buf()),
                 ..Default::default()
@@ -110,7 +110,7 @@ fn test_additonal_addresses_already_assigned_same_value() {
 
     assert!(RG::ResolvedGraph::resolve(
         dg,
-        BuildConfig {
+        &mut BuildConfig {
             build_info: BuildInfo {
                 install_dir: Some(tempdir().unwrap().path().to_path_buf()),
                 additional_named_addresses: BTreeMap::from([(
@@ -159,7 +159,7 @@ fn test_additonal_addresses_already_assigned_different_value() {
 
     assert!(RG::ResolvedGraph::resolve(
         dg,
-        BuildConfig {
+        &mut BuildConfig {
             build_info: BuildInfo {
                 install_dir: Some(tempdir().unwrap().path().to_path_buf()),
                 additional_named_addresses: BTreeMap::from([(

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -6,7 +6,7 @@ use move_core_types::account_address::AccountAddress;
 use move_package::{
     resolution::{dependency_graph as DG, resolution_graph as RG},
     source_package::{layout::SourcePackageLayout, parsed_manifest as PM},
-    BuildConfig,
+    BuildConfig, BuildInfo,
 };
 use std::{collections::BTreeMap, path::PathBuf};
 use tempfile::tempdir;
@@ -48,12 +48,15 @@ fn test_additonal_addresses() {
     assert!(RG::ResolvedGraph::resolve(
         dg.clone(),
         BuildConfig {
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            additional_named_addresses: BTreeMap::from([(
-                "A".to_string(),
-                AccountAddress::from_hex_literal("0x1").unwrap()
-            )]),
-            ..Default::default()
+            build_info: BuildInfo {
+                install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+                additional_named_addresses: BTreeMap::from([(
+                    "A".to_string(),
+                    AccountAddress::from_hex_literal("0x1").unwrap()
+                )]),
+                ..Default::default()
+            },
+            file_reader: None,
         },
         &mut dependency_cache,
         &mut progress_output,
@@ -63,8 +66,11 @@ fn test_additonal_addresses() {
     assert!(RG::ResolvedGraph::resolve(
         dg,
         BuildConfig {
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            ..Default::default()
+            build_info: BuildInfo {
+                install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+                ..Default::default()
+            },
+            file_reader: None,
         },
         &mut dependency_cache,
         &mut progress_output,
@@ -105,12 +111,15 @@ fn test_additonal_addresses_already_assigned_same_value() {
     assert!(RG::ResolvedGraph::resolve(
         dg,
         BuildConfig {
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            additional_named_addresses: BTreeMap::from([(
-                "A".to_string(),
-                AccountAddress::from_hex_literal("0x0").unwrap()
-            )]),
-            ..Default::default()
+            build_info: BuildInfo {
+                install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+                additional_named_addresses: BTreeMap::from([(
+                    "A".to_string(),
+                    AccountAddress::from_hex_literal("0x0").unwrap()
+                )]),
+                ..Default::default()
+            },
+            file_reader: None,
         },
         &mut dependency_cache,
         &mut progress_output,
@@ -151,12 +160,15 @@ fn test_additonal_addresses_already_assigned_different_value() {
     assert!(RG::ResolvedGraph::resolve(
         dg,
         BuildConfig {
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            additional_named_addresses: BTreeMap::from([(
-                "A".to_string(),
-                AccountAddress::from_hex_literal("0x1").unwrap()
-            )]),
-            ..Default::default()
+            build_info: BuildInfo {
+                install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+                additional_named_addresses: BTreeMap::from([(
+                    "A".to_string(),
+                    AccountAddress::from_hex_literal("0x1").unwrap()
+                )]),
+                ..Default::default()
+            },
+            file_reader: None,
         },
         &mut dependency_cache,
         &mut progress_output,

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -28,6 +28,7 @@ fn test_additonal_addresses() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(
@@ -84,6 +85,7 @@ fn test_additonal_addresses_already_assigned_same_value() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(
@@ -129,6 +131,7 @@ fn test_additonal_addresses_already_assigned_different_value() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(

--- a/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
+++ b/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
@@ -38,6 +38,7 @@ fn no_dep_graph() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(
@@ -154,6 +155,7 @@ fn always_deps() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(
@@ -563,6 +565,7 @@ fn immediate_dependencies() {
         /* skip_fetch_latest_git_deps */ true,
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
+        /* file reader */ None,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 use move_compiler::editions::{Edition, Flavor};
 use move_package::lock_file::schema::ToolchainVersion;
 use move_package::lock_file::LockFile;
-use move_package::BuildConfig;
+use move_package::{BuildConfig, BuildInfo};
 
 #[test]
 fn commit() {
@@ -79,13 +79,17 @@ fn update_lock_file_toolchain_version() {
     lock.commit(&lock_path).unwrap();
 
     let build_config = BuildConfig {
-        default_flavor: Some(Flavor::Sui),
-        default_edition: Some(Edition::E2024_ALPHA),
-        lock_file: Some(lock_path.clone()),
-        ..Default::default()
+        build_info: BuildInfo {
+            default_flavor: Some(Flavor::Sui),
+            default_edition: Some(Edition::E2024_ALPHA),
+            lock_file: Some(lock_path.clone()),
+            ..Default::default()
+        },
+        file_reader: None,
     };
-    let _ =
-        build_config.update_lock_file_toolchain_version(&pkg.path().to_path_buf(), "0.0.1".into());
+    let _ = build_config
+        .build_info
+        .update_lock_file_toolchain_version(&pkg.path().to_path_buf(), "0.0.1".into());
 
     let mut lock_file = File::open(lock_path).unwrap();
     let toolchain_version =

--- a/external-crates/move/crates/move-package/tests/test_removal_second_compilation.rs
+++ b/external-crates/move/crates/move-package/tests/test_removal_second_compilation.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_package::{compilation::package_layout::CompiledPackageLayout, BuildConfig};
+use move_package::{compilation::package_layout::CompiledPackageLayout, BuildConfig, BuildInfo};
 use std::path::Path;
 use tempfile::tempdir;
 
@@ -12,10 +12,13 @@ fn test_that_second_build_artifacts_removed() {
     let dir = tempdir().unwrap().path().to_path_buf();
 
     BuildConfig {
-        dev_mode: true,
-        test_mode: true,
-        install_dir: Some(dir.clone()),
-        ..Default::default()
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: true,
+            install_dir: Some(dir.clone()),
+            ..Default::default()
+        },
+        file_reader: None,
     }
     .compile_package(path, &mut Vec::new())
     .unwrap();
@@ -37,10 +40,13 @@ fn test_that_second_build_artifacts_removed() {
 
     // Now make sure the MoveStdlib still exists, but that the test-only code is removed
     BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        install_dir: Some(dir.clone()),
-        ..Default::default()
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            install_dir: Some(dir.clone()),
+            ..Default::default()
+        },
+        file_reader: None,
     }
     .compile_package(path, &mut Vec::new())
     .unwrap();
@@ -55,10 +61,13 @@ fn test_that_second_build_artifacts_removed() {
         .exists());
 
     BuildConfig {
-        dev_mode: false,
-        test_mode: false,
-        install_dir: Some(dir.clone()),
-        ..Default::default()
+        build_info: BuildInfo {
+            dev_mode: false,
+            test_mode: false,
+            install_dir: Some(dir.clone()),
+            ..Default::default()
+        },
+        file_reader: None,
     }
     .compile_package(path, &mut Vec::new())
     .unwrap();

--- a/external-crates/move/crates/move-package/tests/test_runner.rs
+++ b/external-crates/move/crates/move-package/tests/test_runner.rs
@@ -10,12 +10,10 @@ use move_package::{
     compilation::{
         build_plan::BuildPlan, compiled_package::CompiledPackageInfo, model_builder::ModelBuilder,
     },
-    package_hooks,
-    package_hooks::PackageHooks,
-    package_hooks::PackageIdentifier,
+    package_hooks::{self, PackageHooks, PackageIdentifier},
     resolution::resolution_graph::Package,
     source_package::parsed_manifest::{CustomDepInfo, PackageDigest, SourceManifest},
-    BuildConfig, ModelConfig,
+    BuildConfig, BuildInfo, ModelConfig,
 };
 use move_symbol_pool::Symbol;
 use std::{
@@ -121,15 +119,18 @@ impl Test<'_> {
         let lock_path = out_path.join("Move.lock");
 
         let config = BuildConfig {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(out_path),
-            force_recompilation: false,
-            lock_file: ["locked", "notlocked"]
-                .contains(&ext)
-                .then(|| lock_path.clone()),
-            ..Default::default()
+            build_info: BuildInfo {
+                dev_mode: true,
+                test_mode: false,
+                generate_docs: false,
+                install_dir: Some(out_path),
+                force_recompilation: false,
+                lock_file: ["locked", "notlocked"]
+                    .contains(&ext)
+                    .then(|| lock_path.clone()),
+                ..Default::default()
+            },
+            file_reader: None,
         };
 
         let mut progress = Vec::new();
@@ -170,7 +171,7 @@ impl Test<'_> {
                     scrub_resolved_package(package)
                 }
 
-                scrub_build_config(&mut resolved_package.build_options);
+                scrub_build_config(&mut resolved_package.build_options.build_info);
                 format!("{:#?}\n", resolved_package)
             }
 
@@ -179,7 +180,7 @@ impl Test<'_> {
     }
 }
 
-fn scrub_build_config(config: &mut BuildConfig) {
+fn scrub_build_config(config: &mut BuildInfo) {
     config.install_dir = Some(PathBuf::from("ELIDED_FOR_TEST"));
     config.lock_file = Some(PathBuf::from("ELIDED_FOR_TEST"));
 }

--- a/external-crates/move/crates/move-package/tests/test_runner.rs
+++ b/external-crates/move/crates/move-package/tests/test_runner.rs
@@ -118,7 +118,7 @@ impl Test<'_> {
         let out_path = self.output_dir.path().to_path_buf();
         let lock_path = out_path.join("Move.lock");
 
-        let config = BuildConfig {
+        let mut config = BuildConfig {
             build_info: BuildInfo {
                 dev_mode: true,
                 test_mode: false,
@@ -148,7 +148,7 @@ impl Test<'_> {
             "notlocked" => "Lock file uncommitted\n".to_string(),
 
             "compiled" => {
-                let mut pkg = BuildPlan::create(resolved_package?)?.compile(&mut progress)?;
+                let mut pkg = BuildPlan::create(resolved_package?, None)?.compile(&mut progress)?;
                 scrub_compiled_package(&mut pkg.compiled_package_info);
                 format!("{:#?}\n", pkg.compiled_package_info)
             }
@@ -171,7 +171,7 @@ impl Test<'_> {
                     scrub_resolved_package(package)
                 }
 
-                scrub_build_config(&mut resolved_package.build_options.build_info);
+                scrub_build_config(&mut resolved_package.build_options);
                 format!("{:#?}\n", resolved_package)
             }
 

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
@@ -4,7 +4,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "919A5B078B47AD46674F36E1605578927D5BC4536A7646D78D1320A25DDD57CC",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "151286C56FC37AEF93D980A892F558C8EE65FBF062991BDF23C9FC88478D3648",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "5FB1273C1E2450599D1BC004959D0340057A7B589D254601F2C4476F29B21D13",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -103,25 +103,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -102,28 +102,26 @@ ResolvedGraph {
         manifest_digest: "98BBCE8D1C29472825E598691218A0CBC5BDA1A56C4429F5C2311C245DEC28CE",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "A4DB860CC2BC78C04706A7383CA52121876F87057538DF814C66F7EE6025E644",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
@@ -7,7 +7,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -77,28 +77,26 @@ ResolvedGraph {
         manifest_digest: "4644801498736A1617863CD04105A53E729A60DBD4838D2F676196147E78C889",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -78,25 +78,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -83,28 +83,26 @@ ResolvedGraph {
         manifest_digest: "CB01A8B6F9859E70A0A5DA10F8547C13EDDD63E9EDF72E930DD37C8EFC41F3F3",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -84,25 +84,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -82,25 +82,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -81,28 +81,26 @@ ResolvedGraph {
         manifest_digest: "B06FCED8E0EF6B62EC0B572DC233C0D70206B1C10EEDEA0403CA64AFBB3E439B",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -87,28 +87,26 @@ ResolvedGraph {
         manifest_digest: "82E01E336DD3374BDC42CA355AB6ACA69E44DB65E36DC0A831F36B06F6832574",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -88,25 +88,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -103,28 +103,26 @@ ResolvedGraph {
         manifest_digest: "E1BD09BE802FCCF437672321DEBFD0C8000F9D4A0AC5E54ED432087ABACA9667",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -104,25 +104,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -129,28 +129,26 @@ ResolvedGraph {
         manifest_digest: "86DBE490660052E70AF19AEB6DB3CDFE90F770D67E008E12C753575AB346B43C",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -130,25 +130,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -86,25 +86,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -85,28 +85,26 @@ ResolvedGraph {
         manifest_digest: "F64B7E3BA42923C4AFD7490B03D34813BA434044DC83D46F869DD5BB9A6052B2",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -121,28 +121,26 @@ ResolvedGraph {
         manifest_digest: "B2F5516D0E0D7FC1D1A91EF42181BC28609979CA8D75F7EF01B473AF22303C1D",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -122,25 +122,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -138,25 +138,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -137,28 +137,26 @@ ResolvedGraph {
         manifest_digest: "88451CA3B87F330C2224714E02829B02787D5AEA4F9CCD9FF239ED0344CF0632",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -138,25 +138,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -137,28 +137,26 @@ ResolvedGraph {
         manifest_digest: "D91D5258B2367D3D997443497ADC70411B9936C70B2CFFEDB81466DD133BA63B",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -138,25 +138,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -137,28 +137,26 @@ ResolvedGraph {
         manifest_digest: "EE8E91AA52F0CF9E3BB13B169696C40E3F6E8EFBD9E612B06B124CD509CFCDB5",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
@@ -7,7 +7,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -77,28 +77,26 @@ ResolvedGraph {
         manifest_digest: "2CE4CA7B1785FEAE60C59A993DB1182E09DB665E694C6104DF566E065752C030",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -78,25 +78,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -113,28 +113,26 @@ ResolvedGraph {
         manifest_digest: "0A80C25B25B48880831BFCCC1EDF50CC05B33E5855777F8F119538F2FB7B7601",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -114,25 +114,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -113,28 +113,26 @@ ResolvedGraph {
         manifest_digest: "29407D5EEB9708B0005BD2BB6ED487E03C55AA23B440DAB7A0C4F8588239D4F6",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -114,25 +114,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -78,25 +78,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -77,28 +77,26 @@ ResolvedGraph {
         manifest_digest: "373B3598A66D05FBD7DE398D2F588C9C79C9F38757140E8717C1D851CBC5C15F",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.progress
@@ -1,5 +1,5 @@
-[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
-[31m../resolvers/successful.sh stderr:[0m
+RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
+../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external
 Type:    dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.progress
@@ -1,5 +1,5 @@
-RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
+[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
+[31m../resolvers/successful.sh stderr:[0m
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external
 Type:    dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -56,25 +56,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -55,28 +55,26 @@ ResolvedGraph {
         manifest_digest: "8D09D19521F36950C0698F14ED09FE4F6175C022796F1E401F2F5A1BCA6FCE98",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.progress
@@ -1,11 +1,11 @@
-RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
+[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
+[31m../resolvers/successful.sh stderr:[0m
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dependencies
 Package: A
-RESOLVING DEV-DEPENDENCIES IN B FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
+[1;32mRESOLVING DEV-DEPENDENCIES IN[0m B [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
+[31m../resolvers/successful.sh stderr:[0m
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dev-dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.progress
@@ -1,11 +1,11 @@
-[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
-[31m../resolvers/successful.sh stderr:[0m
+RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
+../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dependencies
 Package: A
-[1;32mRESOLVING DEV-DEPENDENCIES IN[0m B [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/successful.sh
-[31m../resolvers/successful.sh stderr:[0m
+RESOLVING DEV-DEPENDENCIES IN B FROM Root WITH ../resolvers/successful.sh
+../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dev-dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -93,28 +93,26 @@ ResolvedGraph {
         manifest_digest: "84A0B503BE9F9B341AC66860713D12704876E5C2425891E3B94626B12E4313E5",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -94,25 +94,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move.progress
@@ -1,3 +1,3 @@
-[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/failing.sh
-[31m../resolvers/failing.sh stderr:[0m
+RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/failing.sh
+../resolvers/failing.sh stderr:
 Failed to resolve dependencies for A

--- a/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move.progress
@@ -1,3 +1,3 @@
-RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/failing.sh
-../resolvers/failing.sh stderr:
+[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/failing.sh
+[31m../resolvers/failing.sh stderr:[0m
 Failed to resolve dependencies for A

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -64,25 +64,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -63,28 +63,26 @@ ResolvedGraph {
         manifest_digest: "2401A97D2FE979752E0726963BFC3F677A4FA8041F3C6FAE5A4302401B165463",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_silent/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_silent/Move.progress
@@ -1,1 +1,1 @@
-[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/silent.sh
+RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/silent.sh

--- a/external-crates/move/crates/move-package/tests/test_sources/external_silent/Move.progress
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_silent/Move.progress
@@ -1,1 +1,1 @@
-RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/silent.sh
+[1;32mRESOLVING DEPENDENCIES IN[0m A [1;32mFROM[0m Root [1;32mWITH[0m ../resolvers/silent.sh

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -52,25 +52,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -51,28 +51,26 @@ ResolvedGraph {
         manifest_digest: "9DB26BA0BAD462FDDF65A0EDFF4C77DB02930DF5610D82F97B38FA6CC6EBEDA6",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -52,25 +52,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -51,28 +51,26 @@ ResolvedGraph {
         manifest_digest: "AA7756B3B213FDC25613CEA73598686AD82A71AE040693F919D582DE22C8FEF7",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -52,25 +52,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -51,28 +51,26 @@ ResolvedGraph {
         manifest_digest: "16BB782949D226228DAF21045B45585AD7D7C8F6468D6ED504C0B5302C9CA861",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
@@ -8,7 +8,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_bad_parent/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_bad_parent/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'NestedDeps': Parsing manifest for 'Nested': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'NestedDeps': Parsing manifest for 'Nested': No such file or directory (os error 2): "/Users/adamwelc/.move/_________ed613ee8e/language/tools/move-package/tests/test_sources/nested_deps_bad_parent/deps_only/nested/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -59,28 +59,26 @@ ResolvedGraph {
         manifest_digest: "598DCC919F7378E59F328E1B448D1AAC70B8F34894146860B3ABF46600F9F79B",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -60,25 +60,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -93,28 +93,26 @@ ResolvedGraph {
         manifest_digest: "5005BF461ECC5281FE314371B38D8C163C5395D7455B91BEA0F63C1BCFD57551",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "More": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -94,25 +94,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "More": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -77,28 +77,26 @@ ResolvedGraph {
         manifest_digest: "0157AC19D24D39641693161A0A6A0A4E3C424C337419209BBCD31C7C8BC34D18",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -78,25 +78,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "0C66C2C067539518C3189E86B5A09D478C872C0F97ACE6D707AE9753319E56AA",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "D1ED8F4323C1E149A29AEDE1E73EC97B117A39132914F088144621C5CD2E6059",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "0C66C2C067539518C3189E86B5A09D478C872C0F97ACE6D707AE9753319E56AA",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "340302CAC58F9844D483E9F19F08D9578B90043E621D953A62A4B679F8D98896",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "31285FC133B1449F5013BA29028EB9FD6518907FB5CC2EE4E6B601B4EB4D271D",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -34,25 +34,27 @@ ResolvedGraph {
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -33,28 +33,26 @@ ResolvedGraph {
         manifest_digest: "0C66C2C067539518C3189E86B5A09D478C872C0F97ACE6D707AE9753319E56AA",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "ED0F3693A744272C975287D7B3CB4B7E9E1C186E2D68CC6858DAD286347D1F7B",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "7BE8C17517DC6FC0EF6A05842A149B6B552A270E4F1B29DA846E41718C4CAC4B",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "4B5A39F0084184A337A86CB7E44DCB9DC4A42B22E8B9681B495B52A721B0B0B8",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "843626B76619D0C508D11EB76988677F42BF33AC853A0F44DA77BEAAF22AB355",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_full_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_full_manifest/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2): "tests/test_sources/parsing_full_manifest/../a/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_full_manifest_with_extra_field/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_full_manifest_with_extra_field/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2): "tests/test_sources/parsing_full_manifest_with_extra_field/../a/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_hex_address_in_subst/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_hex_address_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2): "tests/test_sources/parsing_invalid_hex_address_in_subst/a/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "D107C27F4F0CCCEA32AAA8A2CBCA3041764F6920DA7EEF69C4B0D55E4D80D5D6",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -14,25 +14,27 @@ ResolvedGraph {
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -13,28 +13,26 @@ ResolvedGraph {
         manifest_digest: "510F9FB59C4AEDBB7F7FF005B7DC3C7D67E78E0CB1ABB573DE635B21B4BD00B6",
         deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_non_identifier_address_name_in_subst/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_non_identifier_address_name_in_subst/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2): "tests/test_sources/parsing_non_identifier_address_name_in_subst/a/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_unknown_toplevel_field/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_unknown_toplevel_field/Move.resolved
@@ -1,1 +1,1 @@
-Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2)
+Failed to resolve dependencies for package 'name': Parsing manifest for 'A': No such file or directory (os error 2): "tests/test_sources/parsing_unknown_toplevel_field/../a/Move.toml"

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
@@ -7,7 +7,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -77,28 +77,26 @@ ResolvedGraph {
         manifest_digest: "6F18190939664D7ECC8F2DC327E079037A743E0CFF3FA5F72DABD2B6B5C3D200",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -78,25 +78,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -86,25 +86,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -85,28 +85,26 @@ ResolvedGraph {
         manifest_digest: "6C8AB032D245517996BC9E218500AF7471360346649D91F8858488AF631742A8",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
@@ -56,25 +56,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
@@ -55,28 +55,26 @@ ResolvedGraph {
         manifest_digest: "A152DBB11C386226B7A6435D66090103E0CC19330A38251784E4D2D0C0EF57A5",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
@@ -84,25 +84,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
@@ -83,28 +83,26 @@ ResolvedGraph {
         manifest_digest: "88C81CA573217383E355274A37F0C6171DDE43ED835A166B0D6446C294788F65",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
@@ -101,28 +101,26 @@ ResolvedGraph {
         manifest_digest: "66CAE9439801A11D189DACA1182DFEF8BF0CA1C5F043F966D466CD7E7C486FB3",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
@@ -102,25 +102,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
@@ -104,25 +104,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
@@ -103,28 +103,26 @@ ResolvedGraph {
         manifest_digest: "E301B66162FDBFF21CE0504F64D66F3F9CFE1FC85B6675A3D91C417A41284EEA",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
@@ -84,25 +84,27 @@ ResolvedGraph {
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
@@ -83,28 +83,26 @@ ResolvedGraph {
         manifest_digest: "99C31161E1ED00C7621A2403D3513580715CA556C77C3C26FB1233B0778291AF",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
@@ -91,28 +91,26 @@ ResolvedGraph {
         manifest_digest: "84867C472017C20EFC5FF536C440568833A0F592C104B9F9EF5CD5A27D109CDB",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
-    build_options: BuildConfig {
-        build_info: BuildInfo {
-            dev_mode: true,
-            test_mode: false,
-            generate_docs: false,
-            install_dir: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            force_recompilation: false,
-            lock_file: Some(
-                "ELIDED_FOR_TEST",
-            ),
-            fetch_deps_only: false,
-            skip_fetch_latest_git_deps: false,
-            default_flavor: None,
-            default_edition: None,
-            deps_as_root: false,
-            silence_warnings: false,
-            warnings_are_errors: false,
-            additional_named_addresses: {},
-            no_lint: false,
-        },
+    build_options: BuildInfo {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
@@ -92,25 +92,27 @@ ResolvedGraph {
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        lock_file: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        default_flavor: None,
-        default_edition: None,
-        deps_as_root: false,
-        silence_warnings: false,
-        warnings_are_errors: false,
-        additional_named_addresses: {},
-        no_lint: false,
+        build_info: BuildInfo {
+            dev_mode: true,
+            test_mode: false,
+            generate_docs: false,
+            install_dir: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            force_recompilation: false,
+            lock_file: Some(
+                "ELIDED_FOR_TEST",
+            ),
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: false,
+            default_flavor: None,
+            default_edition: None,
+            deps_as_root: false,
+            silence_warnings: false,
+            warnings_are_errors: false,
+            additional_named_addresses: {},
+            no_lint: false,
+        },
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
@@ -6,7 +6,7 @@ CompiledPackageInfo {
     source_digest: Some(
         "ELIDED_FOR_TEST",
     ),
-    build_flags: BuildConfig {
+    build_flags: BuildInfo {
         dev_mode: true,
         test_mode: false,
         generate_docs: false,

--- a/external-crates/move/crates/move-stdlib/tests/move_unit_test.rs
+++ b/external-crates/move/crates/move-stdlib/tests/move_unit_test.rs
@@ -29,9 +29,12 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
     let result = run_move_unit_tests(
         &pkg_path,
         move_package::BuildConfig {
-            test_mode: true,
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            ..Default::default()
+            build_info: move_package::BuildInfo {
+                test_mode: true,
+                install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+                ..Default::default()
+            },
+            file_reader: None,
         },
         UnitTestingConfig::default_with_bound(Some(1_000_000_000)),
         natives,


### PR DESCRIPTION
## Description 

This PR adds support for virtualized source file reader, allowing the compiler to build a package from files kept by the IDE in memory.

It also fixes an existing bug (https://github.com/move-language/move/issues/1082) where source files used in the symbolicator (obtained from resolution graph) and source files used by the compiler could be modified between the two uses resulting in different file hashes which can ultimately lead to crash when translating diagnostics (generated by the compiler and using "compiler file hashes") using symbolicator source files (and "symbolicator file hashes")

## Test Plan 

All existing tests must pass.
