### PR TITLE
Client side change for handling ValidatorOverloadedRetryAfter error

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -306,6 +306,7 @@ struct ProcessTransactionState {
     object_or_package_not_found_stake: StakeUnit,
     // Validators that are overloaded with txns pending execution.
     overloaded_stake: StakeUnit,
+    // Validators that are overloaded and request client to retry.
     retryable_overloaded_stake: StakeUnit,
     // If there are conflicting transactions, we note them down and may attempt to retry
     conflicting_tx_digests:
@@ -1232,6 +1233,7 @@ where
 
         if state.tx_signatures.total_votes() + state.retryable_overloaded_stake >= quorum_threshold
         {
+            // TODO: make use of retry_after_secs, which is currently not used.
             return AggregatorProcessTransactionError::SystemOverloadRetryAfter {
                 overload_stake: state.retryable_overloaded_stake,
                 errors: group_errors(state.errors),

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -33,6 +33,8 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
     pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
     pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
+    pub(crate) total_retryable_overload_errors: IntCounter,
+    pub(crate) transaction_retry_count: Histogram,
 
     pub(crate) settlement_finality_latency: HistogramVec,
 }
@@ -100,6 +102,17 @@ impl QuorumDriverMetrics {
                 registry,
             )
             .unwrap(),
+            total_retryable_overload_errors: register_int_counter_with_registry!(
+                "quorum_driver_total_retryable_overload_errors",
+                "Total number of times the conflicting transaction is already finalized when retrying",
+                registry,
+            )
+            .unwrap(),
+            transaction_retry_count: Histogram::new_in_registry(
+                "quorum_driver_transaction_retry_count",
+                "Histogram of transaction retry count",
+                registry,
+            ),
             settlement_finality_latency: register_histogram_vec_with_registry!(
                 "quorum_driver_settlement_finality_latency",
                 "Settlement finality latency observed from quorum driver",

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -104,7 +104,7 @@ impl QuorumDriverMetrics {
             .unwrap(),
             total_retryable_overload_errors: register_int_counter_with_registry!(
                 "quorum_driver_total_retryable_overload_errors",
-                "Total number of times the conflicting transaction is already finalized when retrying",
+                "Total number of transactions experiencing retryable overload error",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -4,6 +4,7 @@
 use crate::quorum_driver::reconfig_observer::DummyReconfigObserver;
 use crate::quorum_driver::{AuthorityAggregator, QuorumDriverHandlerBuilder};
 use crate::test_authority_clients::LocalAuthorityClient;
+use crate::test_authority_clients::LocalAuthorityClientFaultConfig;
 use crate::test_utils::make_transfer_sui_transaction;
 use crate::{quorum_driver::QuorumDriverMetrics, test_utils::init_local_authorities};
 use mysten_common::sync::notify_read::{NotifyRead, Registration};
@@ -16,6 +17,7 @@ use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::{generate_test_gas_objects, Object};
 use sui_types::quorum_driver_types::{QuorumDriverError, QuorumDriverResponse, QuorumDriverResult};
 use sui_types::transaction::Transaction;
+use tokio::time::timeout;
 
 async fn setup() -> (AuthorityAggregator<LocalAuthorityClient>, Transaction) {
     let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
@@ -444,4 +446,57 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_quorum_driver_handling_overload_and_retry() {
+    telemetry_subscribers::init_for_testing();
+
+    // Setup
+    let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let (mut aggregator, authorities, genesis, _) =
+        init_local_authorities(4, vec![gas_object.clone()]).await;
+
+    let fault_config = LocalAuthorityClientFaultConfig {
+        overload_retry_after_handle_transaction: true,
+        ..Default::default()
+    };
+
+    let mut clients = aggregator.clone_inner_clients_test_only();
+    for client in &mut clients.values_mut() {
+        client.authority_client_mut().fault_config = fault_config;
+    }
+    let clients = clients.into_iter().map(|(k, v)| (k, Arc::new(v))).collect();
+    aggregator.authority_clients = Arc::new(clients);
+
+    let rgp = authorities
+        .first()
+        .unwrap()
+        .reference_gas_price_for_testing()
+        .unwrap();
+    let gas_object = genesis
+        .objects()
+        .iter()
+        .find(|o| o.id() == gas_object.id())
+        .unwrap();
+
+    let tx = make_tx(gas_object, sender, &keypair, rgp);
+    let arc_aggregator = Arc::new(aggregator.clone());
+
+    let quorum_driver_handler = Arc::new(
+        QuorumDriverHandlerBuilder::new(
+            arc_aggregator.clone(),
+            Arc::new(QuorumDriverMetrics::new_for_tests()),
+        )
+        .with_reconfig_observer(Arc::new(DummyReconfigObserver {}))
+        .with_max_retry_times(0)
+        .start(),
+    );
+
+    let ticket = quorum_driver_handler.submit_transaction(tx).await.unwrap();
+    match timeout(Duration::from_secs(300), ticket).await {
+        Ok(result) => assert!(false, "Process transaction should timeout! {:?}", result),
+        Err(_) => eprintln!("Waiting for txn timed out!"),
+    }
 }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -35,6 +35,7 @@ pub struct LocalAuthorityClientFaultConfig {
     pub fail_after_handle_transaction: bool,
     pub fail_before_handle_confirmation: bool,
     pub fail_after_handle_confirmation: bool,
+    pub overload_retry_after_handle_transaction: bool,
 }
 
 impl LocalAuthorityClientFaultConfig {
@@ -69,6 +70,9 @@ impl AuthorityAPI for LocalAuthorityClient {
             return Err(SuiError::GenericAuthorityError {
                 error: "Mock error after handle_transaction".to_owned(),
             });
+        }
+        if self.fault_config.overload_retry_after_handle_transaction {
+            return Err(SuiError::ValidatorOverloadedRetryAfter { retry_after_sec: 0 });
         }
         result
     }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -72,7 +72,9 @@ impl AuthorityAPI for LocalAuthorityClient {
             });
         }
         if self.fault_config.overload_retry_after_handle_transaction {
-            return Err(SuiError::ValidatorOverloadedRetryAfter { retry_after_sec: 0 });
+            return Err(SuiError::ValidatorOverloadedRetryAfter {
+                retry_after_secs: 0,
+            });
         }
         result
     }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1965,7 +1965,9 @@ async fn test_handle_overload_retry_response() {
         666, // this is a dummy value which does not matter
     );
 
-    let overload_error = SuiError::ValidatorOverloadedRetryAfter { retry_after_sec: 0 };
+    let overload_error = SuiError::ValidatorOverloadedRetryAfter {
+        retry_after_secs: 0,
+    };
     let rpc_error = SuiError::RpcError("RPC".into(), "Error".into());
 
     // Have 2f + 1 validators return the overload error and we should get the `SystemOverload` error.

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1939,6 +1939,8 @@ async fn test_handle_overload_response() {
     .await;
 }
 
+// Tests that authority aggregator can aggregate SuiError::ValidatorOverloadedRetryAfter into
+// AggregatorProcessTransactionError::SystemOverloadRetryAfter.
 #[tokio::test]
 async fn test_handle_overload_retry_response() {
     let mut authorities = BTreeMap::new();

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1940,6 +1940,84 @@ async fn test_handle_overload_response() {
 }
 
 #[tokio::test]
+async fn test_handle_overload_retry_response() {
+    let mut authorities = BTreeMap::new();
+    let mut clients = BTreeMap::new();
+    let mut authority_keys = Vec::new();
+    for _ in 0..4 {
+        let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
+        let name: AuthorityName = sec.public().into();
+        authorities.insert(name, 1);
+        authority_keys.push((name, sec));
+        clients.insert(name, HandleTransactionTestAuthorityClient::new());
+    }
+
+    let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = random_object_ref();
+    let txn = make_transfer_sui_transaction(
+        gas_object,
+        SuiAddress::default(),
+        None,
+        sender,
+        &sender_kp,
+        666, // this is a dummy value which does not matter
+    );
+
+    let overload_error = SuiError::ValidatorOverloadedRetryAfter { retry_after_sec: 0 };
+    let rpc_error = SuiError::RpcError("RPC".into(), "Error".into());
+
+    // Have 2f + 1 validators return the overload error and we should get the `SystemOverload` error.
+    set_retryable_tx_info_response_error(&mut clients, &authority_keys);
+    set_tx_info_response_with_error(&mut clients, authority_keys.iter().skip(1), overload_error);
+
+    let agg = get_genesis_agg(authorities.clone(), clients.clone());
+    assert_resp_err(
+        &agg,
+        txn.clone(),
+        |e| {
+            matches!(
+                e,
+                AggregatorProcessTransactionError::SystemOverloadRetryAfter { .. }
+            )
+        },
+        |e| {
+            matches!(
+                e,
+                SuiError::ValidatorOverloadedRetryAfter { .. } | SuiError::RpcError(..)
+            )
+        },
+    )
+    .await;
+
+    // Change one of the valdiators' errors to RPC error so the system is considered not overloaded now and a `RetryableTransaction`
+    // should be returned.
+    clients
+        .get_mut(&authority_keys[1].0)
+        .unwrap()
+        .set_tx_info_response_error(rpc_error);
+
+    let agg = get_genesis_agg(authorities.clone(), clients.clone());
+
+    assert_resp_err(
+        &agg,
+        txn.clone(),
+        |e| {
+            matches!(
+                e,
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
+            )
+        },
+        |e| {
+            matches!(
+                e,
+                SuiError::ValidatorOverloadedRetryAfter { .. } | SuiError::RpcError(..)
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_early_exit_with_too_many_conflicts() {
     let mut authorities = BTreeMap::new();
     let mut clients = BTreeMap::new();
@@ -2250,6 +2328,10 @@ async fn assert_resp_err<E, F>(
             }
 
             AggregatorProcessTransactionError::SystemOverload { errors, .. } => {
+                assert!(errors.iter().map(|e| &e.0).all(sui_err_checker));
+            }
+
+            AggregatorProcessTransactionError::SystemOverloadRetryAfter { errors, .. } => {
                 assert!(errors.iter().map(|e| &e.0).all(sui_err_checker));
             }
         },

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -242,7 +242,8 @@ impl From<Error> for RpcError {
                         );
                         RpcError::Call(CallError::Custom(error_object))
                     }
-                    QuorumDriverError::SystemOverload { .. } => {
+                    QuorumDriverError::SystemOverload { .. }
+                    | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
                             ErrorObject::owned(TRANSIENT_ERROR_CODE, err.to_string(), None::<()>);
                         RpcError::Call(CallError::Custom(error_object))

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -329,9 +329,7 @@ pub enum SuiError {
         threshold: u64,
     },
 
-    #[error(
-        "Validator cannot handle the request at the moment, and requests the client to retry."
-    )]
+    #[error("Validator cannot handle the request at the moment. Please retry later.")]
     ValidatorPushbackAndRetry,
 
     // Signature verification

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -329,6 +329,11 @@ pub enum SuiError {
         threshold: u64,
     },
 
+    #[error(
+        "Validator cannot handle the request at the moment, and requests the client to retry."
+    )]
+    ValidatorPushbackAndRetry,
+
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -329,9 +329,6 @@ pub enum SuiError {
         threshold: u64,
     },
 
-    #[error("Validator cannot handle the request at the moment. Please retry later.")]
-    ValidatorPushbackAndRetry,
-
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },
@@ -817,6 +814,10 @@ impl SuiError {
                 | SuiError::TooOldTransactionPendingOnObject { .. }
                 | SuiError::TooManyTransactionsPendingConsensus
         )
+    }
+
+    pub fn is_retryable_overload(&self) -> bool {
+        matches!(self, SuiError::ValidatorOverloadedRetryAfter { .. })
     }
 }
 

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -58,6 +58,12 @@ pub enum QuorumDriverError {
     },
     #[error("Transaction is already finalized but with different user signatures")]
     TxAlreadyFinalizedWithDifferentUserSignatures,
+    #[error("Transaction is not processed because {overload_stake} of validators are overloaded and asked client to retry after {retry_after_secs}.")]
+    SystemOverloadRetryAfter {
+        overload_stake: StakeUnit,
+        errors: GroupedErrors,
+        retry_after_secs: u64,
+    },
 }
 
 pub type GroupedErrors = Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;


### PR DESCRIPTION
## Description 

This PR implements the client side change for handling ValidatorOverloadedRetryAfter error. Upon receiving more than 2f+1 such error, the client performs exponential backoff and retry. Different from other retryable errors, the retry in this case ignores the max_retry_times constraints to make sure that locked objects can be eventually unlocked.

Caveat in this PR:
- ValidatorOverloadedRetryAfter error contains a suggestion about the minimum duration to wait until the next retry. This is currently ignored on the client side to make the PR managable.

## Test Plan 

Unit test + integration tests added.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
