### PR TITLE
[SuiNS Indexer] Dynamic config & edge case fix

### DIFF
--- a/crates/suins-indexer/.env.sample
+++ b/crates/suins-indexer/.env.sample
@@ -1,6 +1,6 @@
 DATABASE_URL=postgres://<pg_user>:<pg_password>@localhost:5432/<db_name>
 REMOTE_STORAGE=https://checkpoints.mainnet.sui.io
-BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress
+BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress # expects a file in the format { "suins_indexing": <checkpoint> }
 CHECKPOINTS_DIR=/tmp/checkpoints
 REGISTRY_ID=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106
 SUBDOMAIN_WRAPPER_TYPE=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106::subdomain_registration::SubDomainRegistration

--- a/crates/suins-indexer/.env.sample
+++ b/crates/suins-indexer/.env.sample
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://<pg_user>:<pg_password>@localhost:5432/<db_name>
 REMOTE_STORAGE=https://checkpoints.mainnet.sui.io
-BACKFILL_PROGRESS_FILE_PATH=/Users/manosliolios/tmp/backfill_progress
-CHECKPOINTS_DIR=/Users/manosliolios/tmp/checkpoints
+BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress
+CHECKPOINTS_DIR=/tmp/checkpoints
 REGISTRY_ID=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106
 SUBDOMAIN_WRAPPER_TYPE=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106::subdomain_registration::SubDomainRegistration
 

--- a/crates/suins-indexer/.env.sample
+++ b/crates/suins-indexer/.env.sample
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://<pg_user>:<pg_password>@localhost:5432/<db_name>
-AWS_S3_ENDPOINT=https://s3.<region>.amazonaws.com/<bucket_name>
-AWS_ACCESS_KEY_ID=
-AWS_ACCESS_SECRET_KEY=
-AWS_SESSION_TOKEN=
-BACKFILL_PROGRESS_FILE_PATH=/tmp/backfill_progress # expects a file in the format { "indexing_name": <checkpoint> }
-CHECKPOINTS_DIR=/tmp/backfill_progress
+REMOTE_STORAGE=https://checkpoints.mainnet.sui.io
+BACKFILL_PROGRESS_FILE_PATH=/Users/manosliolios/tmp/backfill_progress
+CHECKPOINTS_DIR=/Users/manosliolios/tmp/checkpoints
+REGISTRY_ID=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106
+SUBDOMAIN_WRAPPER_TYPE=0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106::subdomain_registration::SubDomainRegistration
+

--- a/crates/suins-indexer/src/indexer.rs
+++ b/crates/suins-indexer/src/indexer.rs
@@ -19,7 +19,7 @@ use crate::models::VerifiedDomain;
 
 const REGISTRY_TABLE_ID: &str =
     "0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106";
-/// TODO(manos): Hardcode mainnet type once we publish the subdomains package.
+/// TODO(manos): Hardcode mainnet once we publish the subdomains package.
 const SUBDOMAIN_REGISTRATION_TYPE: &str =
     "0xPackageIdTBD::subdomain_registration::SubDomainRegistration";
 
@@ -149,8 +149,9 @@ impl SuinsIndexer {
     /// - `Vec<String>`: A list of IDs to be deleted from the database (`field_id` is the matching column)
     pub fn process_checkpoint(
         &self,
-        checkpoint: CheckpointData,
+        checkpoint: &CheckpointData,
     ) -> (Vec<VerifiedDomain>, Vec<String>) {
+        // Gather a list of name records, subdomain wrappers and removals on that checkpoint.
         let mut name_records: HashMap<ObjectID, NameRecordChange> = HashMap::new();
         let mut subdomain_wrappers: HashMap<String, String> = HashMap::new();
         let mut removals: HashSet<ObjectID> = HashSet::new();

--- a/crates/suins-indexer/src/indexer.rs
+++ b/crates/suins-indexer/src/indexer.rs
@@ -95,7 +95,6 @@ impl SuinsIndexer {
             checkpoint.parse_record_deletions(self, transaction);
         }
 
-        // let
         (
             // Convert our name_records & wrappers into a list of updates for the DB.
             checkpoint.prepare_db_updates(),

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -80,8 +80,9 @@ impl SuinsIndexerWorker {
             }
 
             if !removals.is_empty() {
+                let field_ids: Vec<_> = removals.keys().map(|x| x.to_string()).collect();
                 diesel::delete(domains::table)
-                    .filter(domains::field_id.eq_any(removals.keys().map(|x| x.to_string())))
+                    .filter(domains::field_id.eq_any(field_ids))
                     .execute(tx)
                     .unwrap_or_else(|_| panic!("Failed to process deletions: {:?}", removals));
             }

--- a/crates/suins-indexer/tests/checkpoint_process_tests.rs
+++ b/crates/suins-indexer/tests/checkpoint_process_tests.rs
@@ -100,6 +100,10 @@ fn process_22279944_checkpoint() {
         addition.subdomain_wrapper_id,
         Some("0x9ca93181d093598b55787e82f69296819e9f779f25f1cc5226d2cd4d07126790".to_string())
     );
+    assert_eq!(
+        addition.field_id,
+        "0x79b123c73d073ba73c9e6f0817e63270d716db3c7945ecde477b22df7d026e43".to_string()
+    )
 }
 
 #[test]
@@ -121,6 +125,11 @@ fn process_22280030_checkpoint() {
         addition.subdomain_wrapper_id,
         Some("0x48de1a7eef5956c4f3478849654abd94dcf5b206c631328c50518091b0eee9b0".to_string())
     );
+
+    assert_eq!(
+        addition.field_id,
+        "0x79b123c73d073ba73c9e6f0817e63270d716db3c7945ecde477b22df7d026e43".to_string()
+    )
 }
 
 /// Reads a checkpoint from a given file in the `/tests/data` directory.

--- a/crates/suins-indexer/tests/checkpoint_process_tests.rs
+++ b/crates/suins-indexer/tests/checkpoint_process_tests.rs
@@ -24,7 +24,7 @@ fn process_22279187_checkpoint() {
     let checkpoint = read_checkpoint_from_file(include_bytes!("data/22279187.chk"));
     let indexer = get_test_indexer();
 
-    let (updates, removals) = indexer.process_checkpoint(checkpoint.clone());
+    let (updates, removals) = indexer.process_checkpoint(&checkpoint);
 
     // This checkpoint has no removals and adds 3 names.
     assert_eq!(removals.len(), 0);
@@ -41,7 +41,7 @@ fn process_22279187_checkpoint() {
 fn process_22279365_checkpoint() {
     let checkpoint = read_checkpoint_from_file(include_bytes!("data/22279365.chk"));
     let indexer = get_test_indexer();
-    let (updates, removals) = indexer.process_checkpoint(checkpoint.clone());
+    let (updates, removals) = indexer.process_checkpoint(&checkpoint);
 
     // This checkpoint has 1 removal and 1 addition.
     assert_eq!(removals.len(), 1);
@@ -62,7 +62,7 @@ fn process_22279365_checkpoint() {
 fn process_22279496_checkpoint() {
     let checkpoint = read_checkpoint_from_file(include_bytes!("data/22279496.chk"));
     let indexer = get_test_indexer();
-    let (updates, removals) = indexer.process_checkpoint(checkpoint.clone());
+    let (updates, removals) = indexer.process_checkpoint(&checkpoint);
 
     assert_eq!(removals.len(), 0);
     assert_eq!(updates.len(), 1);
@@ -85,7 +85,7 @@ fn process_22279496_checkpoint() {
 fn process_22279944_checkpoint() {
     let checkpoint = read_checkpoint_from_file(include_bytes!("data/22279944.chk"));
     let indexer = get_test_indexer();
-    let (updates, removals) = indexer.process_checkpoint(checkpoint.clone());
+    let (updates, removals) = indexer.process_checkpoint(&checkpoint);
 
     assert_eq!(removals.len(), 0);
     assert_eq!(updates.len(), 1);
@@ -106,7 +106,7 @@ fn process_22279944_checkpoint() {
 fn process_22280030_checkpoint() {
     let checkpoint = read_checkpoint_from_file(include_bytes!("data/22280030.chk"));
     let indexer = get_test_indexer();
-    let (updates, removals) = indexer.process_checkpoint(checkpoint.clone());
+    let (updates, removals) = indexer.process_checkpoint(&checkpoint);
 
     assert_eq!(removals.len(), 0);
     assert_eq!(updates.len(), 1);


### PR DESCRIPTION
## Description 

This PR:
1. Allows dynamic config for registry + subdomain wrapper ID from env file (so we can deploy in diff networks)
2. Gets rid of any S3 related envs, we can just use the public endpoint.
3. Rewrites the logic to use a single loop over all transactions in a sequenced way (so we make sure that in the end of each checkpoint, we only have the LAST state for updates/deletions per name record).

## Test Plan 

Re-run the existing tests 
```
crates/suins-indexer$ cargo test
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
