### PR TITLE
[Doc] fix advice for ephemeral key pair and the ZK proof storage

### DIFF
--- a/docs/content/concepts/cryptography/zklogin.mdx
+++ b/docs/content/concepts/cryptography/zklogin.mdx
@@ -527,8 +527,7 @@ You might want to cache the ephemeral key pair along with the ZKP for future use
 
 However, the ephemeral key pair needs to be treated as a secret akin to a key pair in a traditional wallet. This is because if both the ephemeral private key and ZK proof are revealed to an attacker, then they can typically sign any transaction on behalf of the user (using the same process described previously).
 
-Consequently, you should choose the storage of the ephemeral key pair and the ZK proof carefully. For example, a web browser provides both session and local storage. Data in local storage persists until you explicitly clear your browser cache (remains across browser sessions), whereas session storage persists only until you close the tab or bowser. Using local storage for this data is preferable to safeguard against the loss of funds should the session end unexpectedly.
-
+Consequently, you should not store them persistently in an unsecure storage location, on any platform. For example, on browsers, use session storage instead of local storage to store the ephemeral key pair and the ZK proof. This is because session storage automatically clears its data when the browser session ends, while data in local storage persists indefinitely.
 
 ## How zkLogin Works {#how-zklogin-works}
 


### PR DESCRIPTION
## Description 

This restores the advice to the previous wording.

## Test Plan 

n/a

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
