### PR TITLE
feat: add upper bound for max epoch in zklogin sig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12546,6 +12546,7 @@ dependencies = [
  "sui-rest-api",
  "sui-sdk",
  "sui-swarm-config",
+ "sui-test-transaction-builder",
  "sui-types",
  "tap",
  "telemetry-subscribers 0.2.0",

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -80,6 +80,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         ZkLoginEnv::Test,
                         true,
                         true,
+                        Some(2),
                     ));
 
                     b.iter(|| {

--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -80,7 +80,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         ZkLoginEnv::Test,
                         true,
                         true,
-                        Some(2),
+                        Some(30),
                     ));
 
                     b.iter(|| {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -884,6 +884,7 @@ impl AuthorityPerEpochStore {
             zklogin_env,
             protocol_config.verify_legacy_zklogin_address(),
             protocol_config.accept_zklogin_in_multisig(),
+            protocol_config.zklogin_max_epoch_upper_bound(),
         );
 
         let authenticator_state_exists = epoch_start_configuration

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -884,7 +884,7 @@ impl AuthorityPerEpochStore {
             zklogin_env,
             protocol_config.verify_legacy_zklogin_address(),
             protocol_config.accept_zklogin_in_multisig(),
-            protocol_config.zklogin_max_epoch_upper_bound(),
+            protocol_config.zklogin_max_epoch_upper_bound_delta(),
         );
 
         let authenticator_state_exists = epoch_start_configuration

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -360,7 +360,6 @@ impl SignatureVerifier {
         self.signed_data_cache.is_verified(
             signed_tx.full_message_digest(),
             || {
-                signed_tx.verify_epoch(self.committee.epoch())?;
                 signed_tx.verify_max_epoch_for_all_sigs(
                     self.committee.epoch(),
                     self.zk_login_params.zklogin_max_epoch_upper_bound,

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -116,8 +116,12 @@ struct ZkLoginParams {
     pub supported_providers: Vec<OIDCProvider>,
     /// The environment (prod/test) the code runs in. It decides which verifying key to use in fastcrypto.
     pub env: ZkLoginEnv,
+    /// Flag to determine whether legacy address (derived from padded address seed) should be verified.
     pub verify_legacy_zklogin_address: bool,
+    // Flag to determine whether zkLogin inside multisig is accepted.
     pub accept_zklogin_in_multisig: bool,
+    /// Value that sets the upper bound for max_epoch in zkLogin signature.
+    pub zklogin_max_epoch_upper_bound: Option<u64>,
 }
 
 impl SignatureVerifier {
@@ -129,6 +133,7 @@ impl SignatureVerifier {
         env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
+        zklogin_max_epoch_upper_bound: Option<u64>,
     ) -> Self {
         Self {
             committee,
@@ -155,6 +160,7 @@ impl SignatureVerifier {
                 env,
                 verify_legacy_zklogin_address,
                 accept_zklogin_in_multisig,
+                zklogin_max_epoch_upper_bound,
             },
         }
     }
@@ -166,6 +172,7 @@ impl SignatureVerifier {
         zklogin_env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
+        zklogin_max_epoch_upper_bound: Option<u64>,
     ) -> Self {
         Self::new_with_batch_size(
             committee,
@@ -175,6 +182,7 @@ impl SignatureVerifier {
             zklogin_env,
             verify_legacy_zklogin_address,
             accept_zklogin_in_multisig,
+            zklogin_max_epoch_upper_bound,
         )
     }
 
@@ -353,6 +361,10 @@ impl SignatureVerifier {
             signed_tx.full_message_digest(),
             || {
                 signed_tx.verify_epoch(self.committee.epoch())?;
+                signed_tx.verify_max_epoch_for_all_sigs(
+                    self.committee.epoch(),
+                    self.zk_login_params.zklogin_max_epoch_upper_bound,
+                )?;
                 let jwks = self.jwks.read().clone();
                 let verify_params = VerifyParams::new(
                     jwks,
@@ -360,6 +372,7 @@ impl SignatureVerifier {
                     self.zk_login_params.env,
                     self.zk_login_params.verify_legacy_zklogin_address,
                     self.zk_login_params.accept_zklogin_in_multisig,
+                    self.zk_login_params.zklogin_max_epoch_upper_bound,
                 );
                 signed_tx.verify_message_signature(&verify_params)
             },
@@ -509,6 +522,7 @@ pub fn batch_verify_certificates(
         Default::default(),
         true,
         true,
+        Some(2),
     );
     match batch_verify(committee, certs, &[]) {
         Ok(_) => vec![Ok(()); certs.len()],

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -121,7 +121,7 @@ struct ZkLoginParams {
     // Flag to determine whether zkLogin inside multisig is accepted.
     pub accept_zklogin_in_multisig: bool,
     /// Value that sets the upper bound for max_epoch in zkLogin signature.
-    pub zklogin_max_epoch_upper_bound: Option<u64>,
+    pub zklogin_max_epoch_upper_bound_delta: Option<u64>,
 }
 
 impl SignatureVerifier {
@@ -133,7 +133,7 @@ impl SignatureVerifier {
         env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
-        zklogin_max_epoch_upper_bound: Option<u64>,
+        zklogin_max_epoch_upper_bound_delta: Option<u64>,
     ) -> Self {
         Self {
             committee,
@@ -160,7 +160,7 @@ impl SignatureVerifier {
                 env,
                 verify_legacy_zklogin_address,
                 accept_zklogin_in_multisig,
-                zklogin_max_epoch_upper_bound,
+                zklogin_max_epoch_upper_bound_delta,
             },
         }
     }
@@ -172,7 +172,7 @@ impl SignatureVerifier {
         zklogin_env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
-        zklogin_max_epoch_upper_bound: Option<u64>,
+        zklogin_max_epoch_upper_bound_delta: Option<u64>,
     ) -> Self {
         Self::new_with_batch_size(
             committee,
@@ -182,7 +182,7 @@ impl SignatureVerifier {
             zklogin_env,
             verify_legacy_zklogin_address,
             accept_zklogin_in_multisig,
-            zklogin_max_epoch_upper_bound,
+            zklogin_max_epoch_upper_bound_delta,
         )
     }
 
@@ -362,7 +362,7 @@ impl SignatureVerifier {
             || {
                 signed_tx.verify_max_epoch_for_all_sigs(
                     self.committee.epoch(),
-                    self.zk_login_params.zklogin_max_epoch_upper_bound,
+                    self.zk_login_params.zklogin_max_epoch_upper_bound_delta,
                 )?;
                 let jwks = self.jwks.read().clone();
                 let verify_params = VerifyParams::new(
@@ -371,7 +371,7 @@ impl SignatureVerifier {
                     self.zk_login_params.env,
                     self.zk_login_params.verify_legacy_zklogin_address,
                     self.zk_login_params.accept_zklogin_in_multisig,
-                    self.zk_login_params.zklogin_max_epoch_upper_bound,
+                    self.zk_login_params.zklogin_max_epoch_upper_bound_delta,
                 );
                 signed_tx.verify_message_signature(&verify_params)
             },

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -521,7 +521,7 @@ pub fn batch_verify_certificates(
         Default::default(),
         true,
         true,
-        Some(2),
+        Some(30),
     );
     match batch_verify(committee, certs, &[]) {
         Ok(_) => vec![Ok(()); certs.len()],

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -121,6 +121,7 @@ async fn test_async_verifier() {
         ZkLoginEnv::Test,
         true,
         true,
+        Some(2),
     ));
 
     let tasks: Vec<_> = (0..32)

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -121,7 +121,7 @@ async fn test_async_verifier() {
         ZkLoginEnv::Test,
         true,
         true,
-        Some(2),
+        Some(30),
     ));
 
     let tasks: Vec<_> = (0..32)

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -667,7 +667,7 @@ async fn test_expired_epoch_zklogin_in_multisig() {
 async fn test_max_epoch_too_large_fail_zklogin_in_multisig() {
     use sui_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_zklogin_max_epoch_upper_bound(Some(1));
+        config.set_zklogin_max_epoch_upper_bound_delta(Some(1));
         config
     });
 

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -639,7 +639,7 @@ async fn test_multisig_with_zklogin_scenerios() {
 #[sim_test]
 async fn test_expired_epoch_zklogin_in_multisig() {
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(15000)
         .with_default_jwks()
         .build()
         .await;
@@ -770,7 +770,7 @@ async fn test_zklogin_inside_multisig_feature_deny() {
     });
     let test_cluster = TestClusterBuilder::new()
         .with_default_jwks()
-        .with_epoch_duration_ms(1000)
+        .with_epoch_duration_ms(15000)
         .build()
         .await;
     test_cluster.wait_for_authenticator_state_update().await;

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -679,10 +679,11 @@ async fn test_random_zklogin_in_multisig() {
     let test_vectors =
         &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1..11];
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(1000)
+        .with_epoch_duration_ms(15000)
         .with_default_jwks()
         .build()
         .await;
+    test_cluster.wait_for_authenticator_state_update().await;
 
     let rgp = test_cluster.get_reference_gas_price().await;
     let context = &test_cluster.wallet;

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -6,8 +6,10 @@ use shared_crypto::intent::Intent;
 use shared_crypto::intent::IntentMessage;
 use sui_core::authority_client::AuthorityAPI;
 use sui_macros::sim_test;
+use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::SuiAddress;
+use sui_types::committee::EpochId;
 use sui_types::crypto::Signature;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::signature::GenericSignature;
@@ -18,6 +20,7 @@ use sui_types::utils::{
 };
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::SUI_AUTHENTICATOR_STATE_OBJECT_ID;
+use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 
 async fn do_zklogin_test(address: SuiAddress, legacy: bool) -> SuiResult {
@@ -36,6 +39,31 @@ async fn do_zklogin_test(address: SuiAddress, legacy: bool) -> SuiResult {
         .map(|_| ())
 }
 
+async fn build_zklogin_tx(test_cluster: &TestCluster, max_epoch: EpochId) -> Transaction {
+    // load test vectors
+    let (kp, pk_zklogin, inputs) =
+        &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
+    let zklogin_addr = (pk_zklogin).into();
+
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let gas = test_cluster
+        .fund_address_and_return_gas(rgp, Some(20000000000), zklogin_addr)
+        .await;
+    let tx_data = TestTransactionBuilder::new(zklogin_addr, gas, rgp)
+        .transfer_sui(None, SuiAddress::ZERO)
+        .build();
+
+    let msg = IntentMessage::new(Intent::sui_transaction(), tx_data.clone());
+    let eph_sig = Signature::new_secure(&msg, kp);
+
+    // combine ephemeral sig with zklogin inputs.
+    let generic_sig = GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(
+        inputs.clone(),
+        max_epoch,
+        eph_sig.clone(),
+    ));
+    Transaction::from_generic_sig_data(tx_data.clone(), vec![generic_sig])
+}
 #[sim_test]
 async fn test_zklogin_feature_deny() {
     use sui_protocol_config::ProtocolConfig;
@@ -58,6 +86,7 @@ async fn test_zklogin_feature_legacy_address_deny() {
 
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_verify_legacy_zklogin_address(false);
+        config.set_zklogin_max_epoch_upper_bound(None);
         config
     });
 
@@ -69,7 +98,6 @@ async fn test_zklogin_feature_legacy_address_deny() {
 
 #[sim_test]
 async fn test_legacy_zklogin_address_accept() {
-    use sui_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_verify_legacy_zklogin_address(true);
         config
@@ -91,47 +119,43 @@ async fn zklogin_end_to_end_test() {
         .await;
 
     // trigger reconfiguration that advanced epoch to 1.
-    test_cluster.wait_for_epoch_all_nodes(1).await;
 
-    // load test vectors
-    let (kp, pk_zklogin, inputs) =
-        &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
-    let zklogin_addr = (pk_zklogin).into();
-
-    let rgp = test_cluster.get_reference_gas_price().await;
-    let gas = test_cluster
-        .fund_address_and_return_gas(rgp, Some(20000000000), zklogin_addr)
-        .await;
-    let tx_data = TestTransactionBuilder::new(zklogin_addr, gas, rgp)
-        .transfer_sui(None, SuiAddress::ZERO)
-        .build();
-
-    let msg = IntentMessage::new(Intent::sui_transaction(), tx_data.clone());
-    let eph_sig = Signature::new_secure(&msg, kp);
-
-    // combine ephemeral sig with zklogin inputs.
-    let generic_sig = GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(
-        inputs.clone(),
-        2,
-        eph_sig.clone(),
-    ));
-    let signed_txn = Transaction::from_generic_sig_data(tx_data.clone(), vec![generic_sig]);
+    test_cluster.trigger_reconfiguration().await;
+    let signed_txn = build_zklogin_tx(&test_cluster, 2).await;
     let context = &test_cluster.wallet;
     let res = context.execute_transaction_may_fail(signed_txn).await;
     assert!(res.is_ok());
 
     // a txn with max_epoch mismatch with proof, fails to execute.
-    let generic_sig = GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(
-        inputs.clone(),
-        1,
-        eph_sig,
-    ));
-    let signed_txn_with_wrong_max_epoch =
-        Transaction::from_generic_sig_data(tx_data, vec![generic_sig]);
+    let signed_txn_with_wrong_max_epoch = build_zklogin_tx(&test_cluster, 2).await;
     assert!(context
         .execute_transaction_may_fail(signed_txn_with_wrong_max_epoch)
         .await
         .is_err());
+}
+
+#[sim_test]
+async fn test_max_epoch_too_large_fail_tx() {
+    use sui_protocol_config::ProtocolConfig;
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_zklogin_max_epoch_upper_bound(Some(1));
+        config
+    });
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(15000)
+        .with_default_jwks()
+        .build()
+        .await;
+    test_cluster.wait_for_authenticator_state_update().await;
+    let context = &test_cluster.wallet;
+    // current epoch is 1, upper bound is 1 + 1, so max_epoch as 3 in zklogin signature should fail.
+    let signed_txn = build_zklogin_tx(&test_cluster, 2).await;
+    let res = context.execute_transaction_may_fail(signed_txn).await;
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("ZKLogin max epoch too large"));
 }
 
 #[sim_test]
@@ -144,11 +168,11 @@ async fn test_expired_zklogin_sig() {
 
     // trigger reconfiguration that advanced epoch to 1.
     test_cluster.trigger_reconfiguration().await;
-
     // trigger reconfiguration that advanced epoch to 2.
     test_cluster.trigger_reconfiguration().await;
     // trigger reconfiguration that advanced epoch to 3.
     test_cluster.trigger_reconfiguration().await;
+
     // load one test vector, the zklogin inputs corresponds to max_epoch = 1
     let (kp, pk_zklogin, inputs) =
         &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
@@ -158,6 +182,8 @@ async fn test_expired_zklogin_sig() {
     let gas = test_cluster
         .fund_address_and_return_gas(rgp, Some(20000000000), zklogin_addr)
         .await;
+    let context = &test_cluster.wallet;
+
     let tx_data = TestTransactionBuilder::new(zklogin_addr, gas, rgp)
         .transfer_sui(None, SuiAddress::ZERO)
         .build();
@@ -172,7 +198,6 @@ async fn test_expired_zklogin_sig() {
         eph_sig.clone(),
     ));
     let signed_txn_expired = Transaction::from_generic_sig_data(tx_data.clone(), vec![generic_sig]);
-    let context = &test_cluster.wallet;
 
     let res = context
         .execute_transaction_may_fail(signed_txn_expired)

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -118,16 +118,14 @@ async fn zklogin_end_to_end_test() {
         .build()
         .await;
 
-    // trigger reconfiguration that advanced epoch to 1.
-
-    test_cluster.trigger_reconfiguration().await;
+    test_cluster.wait_for_authenticator_state_update().await;
     let signed_txn = build_zklogin_tx(&test_cluster, 2).await;
     let context = &test_cluster.wallet;
     let res = context.execute_transaction_may_fail(signed_txn).await;
     assert!(res.is_ok());
 
     // a txn with max_epoch mismatch with proof, fails to execute.
-    let signed_txn_with_wrong_max_epoch = build_zklogin_tx(&test_cluster, 2).await;
+    let signed_txn_with_wrong_max_epoch = build_zklogin_tx(&test_cluster, 1).await;
     assert!(context
         .execute_transaction_may_fail(signed_txn_with_wrong_max_epoch)
         .await
@@ -161,7 +159,7 @@ async fn test_max_epoch_too_large_fail_tx() {
 #[sim_test]
 async fn test_expired_zklogin_sig() {
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(15000)
         .with_default_jwks()
         .build()
         .await;
@@ -228,7 +226,7 @@ async fn test_auth_state_creation() {
 async fn test_create_authenticator_state_object() {
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(15000)
         .build()
         .await;
 

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -86,7 +86,7 @@ async fn test_zklogin_feature_legacy_address_deny() {
 
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_verify_legacy_zklogin_address(false);
-        config.set_zklogin_max_epoch_upper_bound(None);
+        config.set_zklogin_max_epoch_upper_bound_delta(None);
         config
     });
 
@@ -136,7 +136,7 @@ async fn zklogin_end_to_end_test() {
 async fn test_max_epoch_too_large_fail_tx() {
     use sui_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_zklogin_max_epoch_upper_bound(Some(1));
+        config.set_zklogin_max_epoch_upper_bound_delta(Some(1));
         config
     });
 

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -85,6 +85,7 @@ insta.workspace = true
 serde_json.workspace = true
 sui-framework.workspace = true
 tower.workspace = true
+sui-test-transaction-builder.workspace = true
 
 [features]
 default = ["pg_backend"]

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -107,8 +107,14 @@ pub(crate) async fn verify_zklogin_signature(
             }
         }
     }
-    let verify_params =
-        VerifyParams::new(oidc_provider_jwks, vec![], zklogin_env_native, true, true);
+    let verify_params = VerifyParams::new(
+        oidc_provider_jwks,
+        vec![],
+        zklogin_env_native,
+        true,
+        true,
+        Some(2),
+    );
 
     let bytes = bytes.0;
     match intent_scope {

--- a/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
+++ b/crates/sui-graphql-rpc/src/types/zklogin_verify_signature.rs
@@ -113,7 +113,7 @@ pub(crate) async fn verify_zklogin_signature(
         zklogin_env_native,
         true,
         true,
-        Some(2),
+        Some(30),
     );
 
     let bytes = bytes.0;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -419,6 +419,15 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_zklogin_sig_verify() {
+        use shared_crypto::intent::Intent;
+        use shared_crypto::intent::IntentMessage;
+        use sui_test_transaction_builder::TestTransactionBuilder;
+        use sui_types::base_types::SuiAddress;
+        use sui_types::crypto::Signature;
+        use sui_types::signature::GenericSignature;
+        use sui_types::utils::load_test_vectors;
+        use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
+
         let _guard = telemetry_subscribers::TelemetryConfig::new()
             .with_env()
             .init();
@@ -427,16 +436,37 @@ mod tests {
         let cluster =
             sui_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
 
-        // wait for epoch to be indexed, so that current epoch and JWK are populated in db.
         let test_cluster = cluster.validator_fullnode_handle;
-        test_cluster.wait_for_epoch(Some(1)).await;
+        test_cluster.wait_for_epoch_all_nodes(1).await;
         test_cluster.wait_for_authenticator_state_update().await;
 
-        // now query the endpoint with a valid tx data bytes and a valid signature with the correct proof for dev env.
-        let bytes = "AAABACACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgEBAQABAAAcpgUkGBwS5nPO79YXkjMyvaRjGS57hqxzfyd2yGtejwGbB4FfBEl+LgXSLKw6oGFBCyCGjMYZFUxCocYb6ZAnFwEAAAAAAAAAIJZw7UpW1XHubORIOaY8d2+WyBNwoJ+FEAxlsa7h7JHrHKYFJBgcEuZzzu/WF5IzMr2kYxkue4asc38ndshrXo8BAAAAAAAAABAnAAAAAAAAAA==";
-        let signature = "BQNNMTczMTgwODkxMjU5NTI0MjE3MzYzNDIyNjM3MTc5MzI3MTk0Mzc3MTc4NDQyODI0MTAxODc5NTc5ODQ3NTE5Mzk5NDI4OTgyNTEyNTBNMTEzNzM5NjY2NDU0NjkxMjI1ODIwNzQwODIyOTU5ODUzODgyNTg4NDA2ODE2MTgyNjg1OTM5NzY2OTczMjU4OTIyODA5MTU2ODEyMDcBMQMCTDU5Mzk4NzExNDczNDg4MzQ5OTczNjE3MjAxMjIyMzg5ODAxNzcxNTIzMDMyNzQzMTEwNDcyNDk5MDU5NDIzODQ5MTU3Njg2OTA4OTVMNDUzMzU2ODI3MTEzNDc4NTI3ODczMTIzNDU3MDM2MTQ4MjY1MTk5Njc0MDc5MTg4ODI4NTg2NDk2Njg4NDAzMjcxNzA0OTgxMTcwOAJNMTA1NjQzODcyODUwNzE1NTU0Njk3NTM5OTA2NjE0MTA4NDAxMTg2MzU5MjU0NjY1OTcwMzcwMTgwNTg3NzAwNDEzNDc1MTg0NjEzNjhNMTI1OTczMjM1NDcyNzc1NzkxNDQ2OTg0OTYzNzIyNDI2MTUzNjgwODU4MDEzMTMzNDMxNTU3MzU1MTEzMzAwMDM4ODQ3Njc5NTc4NTQCATEBMANNMTU3OTE1ODk0NzI1NTY4MjYyNjMyMzE2NDQ3Mjg4NzMzMzc2MjkwMTUyNjk5ODQ2OTk0MDQwNzM2MjM2MDMzNTI1Mzc2Nzg4MTMxNzFMNDU0Nzg2NjQ5OTI0ODg4MTQ0OTY3NjE2MTE1ODAyNDc0ODA2MDQ4NTM3MzI1MDAyOTQyMzkwNDExMzAxNzQyMjUzOTAzNzE2MjUyNwExMXdpYVhOeklqb2lhSFIwY0hNNkx5OXBaQzUwZDJsMFkyZ3VkSFl2YjJGMWRHZ3lJaXcCMmV5SmhiR2NpT2lKU1V6STFOaUlzSW5SNWNDSTZJa3BYVkNJc0ltdHBaQ0k2SWpFaWZRTTIwNzk0Nzg4NTU5NjIwNjY5NTk2MjA2NDU3MDIyOTY2MTc2OTg2Njg4NzI3ODc2MTI4MjIzNjI4MTEzOTE2MzgwOTI3NTAyNzM3OTExCgAAAAAAAABhAG6Bf8BLuaIEgvF8Lx2jVoRWKKRIlaLlEJxgvqwq5nDX+rvzJxYAUFd7KeQBd9upNx+CHpmINkfgj26jcHbbqAy5xu4WMO8+cRFEpkjbBruyKE9ydM++5T/87lA8waSSAA==";
+        // Construct a valid zkLogin transaction data, signature.
+        let (kp, pk_zklogin, inputs) =
+            &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1];
+
+        let zklogin_addr = (pk_zklogin).into();
+        let rgp = test_cluster.get_reference_gas_price().await;
+        let gas = test_cluster
+            .fund_address_and_return_gas(rgp, Some(20000000000), zklogin_addr)
+            .await;
+        let tx_data = TestTransactionBuilder::new(zklogin_addr, gas, rgp)
+            .transfer_sui(None, SuiAddress::ZERO)
+            .build();
+        let msg = IntentMessage::new(Intent::sui_transaction(), tx_data.clone());
+        let eph_sig = Signature::new_secure(&msg, kp);
+        let generic_sig = GenericSignature::ZkLoginAuthenticator(ZkLoginAuthenticator::new(
+            inputs.clone(),
+            2,
+            eph_sig.clone(),
+        ));
+
+        // construct all parameters for the query
+        let bytes = Base64::encode(bcs::to_bytes(&tx_data).unwrap());
+        let signature = Base64::encode(generic_sig.as_ref());
         let intent_scope = "TRANSACTION_DATA";
-        let author = "0x1ca60524181c12e673ceefd617923332bda463192e7b86ac737f2776c86b5e8f";
+        let author = zklogin_addr.to_string();
+
+        // now query the endpoint with a valid tx data bytes and a valid signature with the correct proof for dev env.
         let query = r#"{ verifyZkloginSignature(bytes: $bytes, signature: $signature, intentScope: $intent_scope, author: $author ) { success, errors}}"#;
         let variables = vec![
             GraphqlQueryVariable {
@@ -468,6 +498,7 @@ mod tests {
 
         // a valid signature with tx bytes returns success as true.
         let binding = res.response_body().data.clone().into_json().unwrap();
+        tracing::info!("tktkbinding: {:?}", binding);
         let res = binding.get("verifyZkloginSignature").unwrap();
         assert_eq!(res.get("success").unwrap(), true);
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -397,6 +397,9 @@ struct FeatureFlags {
     // Controls the behavior of per object congestion control in consensus handler.
     #[serde(skip_serializing_if = "PerObjectCongestionControlMode::is_none")]
     per_object_congestion_control_mode: PerObjectCongestionControlMode,
+    // Set the upper bound allowed for max_epoch in zklogin signature.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    zklogin_max_epoch_upper_bound: Option<u64>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1175,6 +1178,10 @@ impl ProtocolConfig {
 
     pub fn accept_zklogin_in_multisig(&self) -> bool {
         self.feature_flags.accept_zklogin_in_multisig
+    }
+
+    pub fn zklogin_max_epoch_upper_bound(&self) -> Option<u64> {
+        self.feature_flags.zklogin_max_epoch_upper_bound
     }
 
     pub fn throughput_aware_consensus_submission(&self) -> bool {
@@ -2052,7 +2059,9 @@ impl ProtocolConfig {
                     cfg.group_ops_bls12381_msm_max_len = Some(32);
                     cfg.group_ops_bls12381_pairing_cost = Some(52);
                 }
-                42 => {}
+                42 => {
+                    cfg.feature_flags.zklogin_max_epoch_upper_bound = Some(2);
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.
@@ -2155,6 +2164,9 @@ impl ProtocolConfig {
 
     pub fn set_max_accumulated_txn_cost_per_object_in_checkpoint(&mut self, val: u64) {
         self.max_accumulated_txn_cost_per_object_in_checkpoint = Some(val);
+    }
+    pub fn set_zklogin_max_epoch_upper_bound(&mut self, val: Option<u64>) {
+        self.feature_flags.zklogin_max_epoch_upper_bound = val
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -399,7 +399,7 @@ struct FeatureFlags {
     per_object_congestion_control_mode: PerObjectCongestionControlMode,
     // Set the upper bound allowed for max_epoch in zklogin signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    zklogin_max_epoch_upper_bound: Option<u64>,
+    zklogin_max_epoch_upper_bound_delta: Option<u64>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1180,8 +1180,8 @@ impl ProtocolConfig {
         self.feature_flags.accept_zklogin_in_multisig
     }
 
-    pub fn zklogin_max_epoch_upper_bound(&self) -> Option<u64> {
-        self.feature_flags.zklogin_max_epoch_upper_bound
+    pub fn zklogin_max_epoch_upper_bound_delta(&self) -> Option<u64> {
+        self.feature_flags.zklogin_max_epoch_upper_bound_delta
     }
 
     pub fn throughput_aware_consensus_submission(&self) -> bool {
@@ -2060,7 +2060,7 @@ impl ProtocolConfig {
                     cfg.group_ops_bls12381_pairing_cost = Some(52);
                 }
                 42 => {
-                    cfg.feature_flags.zklogin_max_epoch_upper_bound = Some(30);
+                    cfg.feature_flags.zklogin_max_epoch_upper_bound_delta = Some(30);
                 }
                 // Use this template when making changes:
                 //
@@ -2165,8 +2165,9 @@ impl ProtocolConfig {
     pub fn set_max_accumulated_txn_cost_per_object_in_checkpoint(&mut self, val: u64) {
         self.max_accumulated_txn_cost_per_object_in_checkpoint = Some(val);
     }
-    pub fn set_zklogin_max_epoch_upper_bound(&mut self, val: Option<u64>) {
-        self.feature_flags.zklogin_max_epoch_upper_bound = val
+
+    pub fn set_zklogin_max_epoch_upper_bound_delta(&mut self, val: Option<u64>) {
+        self.feature_flags.zklogin_max_epoch_upper_bound_delta = val
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2060,7 +2060,7 @@ impl ProtocolConfig {
                     cfg.group_ops_bls12381_pairing_cost = Some(52);
                 }
                 42 => {
-                    cfg.feature_flags.zklogin_max_epoch_upper_bound = Some(2);
+                    cfg.feature_flags.zklogin_max_epoch_upper_bound = Some(30);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
@@ -41,6 +41,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound: 2
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
@@ -41,7 +41,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 30
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
@@ -41,7 +41,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 2
+  zklogin_max_epoch_upper_bound: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
@@ -43,7 +43,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 30
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
@@ -43,6 +43,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound: 2
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_42.snap
@@ -43,7 +43,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 2
+  zklogin_max_epoch_upper_bound: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -46,7 +46,7 @@ feature_flags:
   enable_group_ops_native_functions: true
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 2
+  zklogin_max_epoch_upper_bound: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -46,7 +46,7 @@ feature_flags:
   enable_group_ops_native_functions: true
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound: 30
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -46,6 +46,7 @@ feature_flags:
   enable_group_ops_native_functions: true
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound: 2
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -76,11 +76,15 @@ impl Hash for MultiSig {
 }
 
 impl AuthenticatorTrait for MultiSig {
-    fn verify_user_authenticator_epoch(&self, epoch_id: EpochId) -> Result<(), SuiError> {
+    fn verify_user_authenticator_epoch(
+        &self,
+        epoch_id: EpochId,
+        upper_bound_max_epoch: Option<EpochId>,
+    ) -> Result<(), SuiError> {
         // If there is any zkLogin signatures, filter and check epoch for each.
         self.get_zklogin_sigs()?
             .iter()
-            .try_for_each(|s| s.verify_user_authenticator_epoch(epoch_id))
+            .try_for_each(|s| s.verify_user_authenticator_epoch(epoch_id, upper_bound_max_epoch))
     }
 
     fn verify_uncached_checks<T>(

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -79,12 +79,12 @@ impl AuthenticatorTrait for MultiSig {
     fn verify_user_authenticator_epoch(
         &self,
         epoch_id: EpochId,
-        upper_bound_max_epoch: Option<EpochId>,
+        max_epoch_upper_bound_delta: Option<u64>,
     ) -> Result<(), SuiError> {
         // If there is any zkLogin signatures, filter and check epoch for each.
-        self.get_zklogin_sigs()?
-            .iter()
-            .try_for_each(|s| s.verify_user_authenticator_epoch(epoch_id, upper_bound_max_epoch))
+        self.get_zklogin_sigs()?.iter().try_for_each(|s| {
+            s.verify_user_authenticator_epoch(epoch_id, max_epoch_upper_bound_delta)
+        })
     }
 
     fn verify_uncached_checks<T>(

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -86,8 +86,21 @@ impl Hash for MultiSigLegacy {
 }
 
 impl AuthenticatorTrait for MultiSigLegacy {
-    fn verify_user_authenticator_epoch(&self, _: EpochId) -> Result<(), SuiError> {
-        Ok(())
+    fn verify_user_authenticator_epoch(
+        &self,
+        epoch_id: EpochId,
+        upper_bound_max_epoch: Option<EpochId>,
+    ) -> Result<(), SuiError> {
+        let multisig: MultiSig =
+            self.clone()
+                .try_into()
+                .map_err(|_| SuiError::InvalidSignature {
+                    error: "Invalid legacy multisig".to_string(),
+                })?;
+        multisig
+            .get_zklogin_sigs()?
+            .iter()
+            .try_for_each(|s| s.verify_user_authenticator_epoch(epoch_id, upper_bound_max_epoch))
     }
 
     fn verify_uncached_checks<T>(

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -89,7 +89,7 @@ impl AuthenticatorTrait for MultiSigLegacy {
     fn verify_user_authenticator_epoch(
         &self,
         epoch_id: EpochId,
-        upper_bound_max_epoch: Option<EpochId>,
+        max_epoch_upper_bound_delta: Option<u64>,
     ) -> Result<(), SuiError> {
         let multisig: MultiSig =
             self.clone()
@@ -97,10 +97,9 @@ impl AuthenticatorTrait for MultiSigLegacy {
                 .map_err(|_| SuiError::InvalidSignature {
                     error: "Invalid legacy multisig".to_string(),
                 })?;
-        multisig
-            .get_zklogin_sigs()?
-            .iter()
-            .try_for_each(|s| s.verify_user_authenticator_epoch(epoch_id, upper_bound_max_epoch))
+        multisig.get_zklogin_sigs()?.iter().try_for_each(|s| {
+            s.verify_user_authenticator_epoch(epoch_id, max_epoch_upper_bound_delta)
+        })
     }
 
     fn verify_uncached_checks<T>(

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -32,6 +32,7 @@ pub struct VerifyParams {
     pub zk_login_env: ZkLoginEnv,
     pub verify_legacy_zklogin_address: bool,
     pub accept_zklogin_in_multisig: bool,
+    pub zklogin_max_epoch_upper_bound: Option<EpochId>,
 }
 
 impl VerifyParams {
@@ -41,6 +42,7 @@ impl VerifyParams {
         zk_login_env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
+        zklogin_max_epoch_upper_bound: Option<EpochId>,
     ) -> Self {
         Self {
             oidc_provider_jwks,
@@ -48,6 +50,7 @@ impl VerifyParams {
             zk_login_env,
             verify_legacy_zklogin_address,
             accept_zklogin_in_multisig,
+            zklogin_max_epoch_upper_bound,
         }
     }
 }
@@ -55,7 +58,11 @@ impl VerifyParams {
 /// A lightweight trait that all members of [enum GenericSignature] implement.
 #[enum_dispatch]
 pub trait AuthenticatorTrait {
-    fn verify_user_authenticator_epoch(&self, epoch: EpochId) -> SuiResult;
+    fn verify_user_authenticator_epoch(
+        &self,
+        epoch: EpochId,
+        upper_bound_max_epoch: Option<EpochId>,
+    ) -> SuiResult;
 
     fn verify_claims<T>(
         &self,
@@ -71,15 +78,18 @@ pub trait AuthenticatorTrait {
         value: &IntentMessage<T>,
         author: SuiAddress,
         epoch: Option<EpochId>,
-        aux_verify_data: &VerifyParams,
+        verify_params: &VerifyParams,
     ) -> SuiResult
     where
         T: Serialize,
     {
         if let Some(epoch) = epoch {
-            self.verify_user_authenticator_epoch(epoch)?;
+            self.verify_user_authenticator_epoch(
+                epoch,
+                verify_params.zklogin_max_epoch_upper_bound,
+            )?;
         }
-        self.verify_claims(value, author, aux_verify_data)
+        self.verify_claims(value, author, verify_params)
     }
 
     fn verify_uncached_checks<T>(
@@ -278,7 +288,7 @@ impl<'de> ::serde::Deserialize<'de> for GenericSignature {
 
 /// This ports the wrapper trait to the verify_secure defined on [enum Signature].
 impl AuthenticatorTrait for Signature {
-    fn verify_user_authenticator_epoch(&self, _: EpochId) -> SuiResult {
+    fn verify_user_authenticator_epoch(&self, _: EpochId, _: Option<EpochId>) -> SuiResult {
         Ok(())
     }
     fn verify_uncached_checks<T>(

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -32,7 +32,7 @@ pub struct VerifyParams {
     pub zk_login_env: ZkLoginEnv,
     pub verify_legacy_zklogin_address: bool,
     pub accept_zklogin_in_multisig: bool,
-    pub zklogin_max_epoch_upper_bound: Option<EpochId>,
+    pub zklogin_max_epoch_upper_bound_delta: Option<u64>,
 }
 
 impl VerifyParams {
@@ -42,7 +42,7 @@ impl VerifyParams {
         zk_login_env: ZkLoginEnv,
         verify_legacy_zklogin_address: bool,
         accept_zklogin_in_multisig: bool,
-        zklogin_max_epoch_upper_bound: Option<EpochId>,
+        zklogin_max_epoch_upper_bound_delta: Option<u64>,
     ) -> Self {
         Self {
             oidc_provider_jwks,
@@ -50,7 +50,7 @@ impl VerifyParams {
             zk_login_env,
             verify_legacy_zklogin_address,
             accept_zklogin_in_multisig,
-            zklogin_max_epoch_upper_bound,
+            zklogin_max_epoch_upper_bound_delta,
         }
     }
 }
@@ -61,7 +61,7 @@ pub trait AuthenticatorTrait {
     fn verify_user_authenticator_epoch(
         &self,
         epoch: EpochId,
-        upper_bound_max_epoch: Option<EpochId>,
+        max_epoch_upper_bound_delta: Option<u64>,
     ) -> SuiResult;
 
     fn verify_claims<T>(
@@ -86,7 +86,7 @@ pub trait AuthenticatorTrait {
         if let Some(epoch) = epoch {
             self.verify_user_authenticator_epoch(
                 epoch,
-                verify_params.zklogin_max_epoch_upper_bound,
+                verify_params.zklogin_max_epoch_upper_bound_delta,
             )?;
         }
         self.verify_claims(value, author, verify_params)

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2250,10 +2250,6 @@ impl SenderSignedData {
         upper_bound_for_max_epoch: Option<u64>,
     ) -> SuiResult {
         for sig in &self.inner().tx_signatures {
-            tracing::info!(
-                "verify_max_epoch_for_all_sigs tk={:?}",
-                upper_bound_for_max_epoch
-            );
             sig.verify_user_authenticator_epoch(epoch, upper_bound_for_max_epoch)?;
         }
         Ok(())

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2243,6 +2243,21 @@ impl SenderSignedData {
 
         Ok(())
     }
+
+    pub fn verify_max_epoch_for_all_sigs(
+        &self,
+        epoch: EpochId,
+        upper_bound_for_max_epoch: Option<u64>,
+    ) -> SuiResult {
+        for sig in &self.inner().tx_signatures {
+            tracing::info!(
+                "verify_max_epoch_for_all_sigs tk={:?}",
+                upper_bound_for_max_epoch
+            );
+            sig.verify_user_authenticator_epoch(epoch, upper_bound_for_max_epoch)?;
+        }
+        Ok(())
+    }
 }
 
 impl VersionedProtocolMessage for SenderSignedData {
@@ -2333,9 +2348,9 @@ impl Message for SenderSignedData {
 
     fn verify_epoch(&self, epoch: EpochId) -> SuiResult {
         for sig in &self.inner().tx_signatures {
-            sig.verify_user_authenticator_epoch(epoch)?;
+            // the upper bound is checked for SenderSignedData only via verify_max_epoch_for_all_sigs
+            sig.verify_user_authenticator_epoch(epoch, None)?;
         }
-
         Ok(())
     }
 }

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -417,7 +417,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         .into_iter()
         .collect();
 
-    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(2));
+    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
     let res = multisig.verify_claims(intent_msg, multisig_address, &aux_verify_data);
     // since the zklogin inputs is crafted, it is expected that the proof verify failed, but all checks before passes.
     assert!(

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -417,7 +417,7 @@ fn zklogin_in_multisig_works_with_both_addresses() {
         .into_iter()
         .collect();
 
-    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true);
+    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(2));
     let res = multisig.verify_claims(intent_msg, multisig_address, &aux_verify_data);
     // since the zklogin inputs is crafted, it is expected that the proof verify failed, but all checks before passes.
     assert!(

--- a/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -98,7 +98,7 @@ fn zklogin_sign_personal_message() {
         .collect();
 
     // Construct the required info to verify a zk login authenticator, jwks, supported providers list and env (prod/test).
-    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, None);
+    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, Some(30));
     let res =
         authenticator.verify_authenticator(&intent_msg, user_address, Some(0), &aux_verify_data);
     // Verify passes.

--- a/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -98,7 +98,7 @@ fn zklogin_sign_personal_message() {
         .collect();
 
     // Construct the required info to verify a zk login authenticator, jwks, supported providers list and env (prod/test).
-    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true);
+    let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true, None);
     let res =
         authenticator.verify_authenticator(&intent_msg, user_address, Some(0), &aux_verify_data);
     // Verify passes.

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -19,7 +19,6 @@ use shared_crypto::intent::IntentMessage;
 use std::hash::Hash;
 use std::hash::Hasher;
 
-//#[cfg(any(test, feature = "test-utils"))]
 #[cfg(test)]
 #[path = "unit_tests/zk_login_authenticator_test.rs"]
 mod zk_login_authenticator_test;

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -91,17 +91,19 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
     fn verify_user_authenticator_epoch(
         &self,
         epoch: EpochId,
-        upper_bound_max_epoch: Option<EpochId>,
+        max_epoch_upper_bound_delta: Option<u64>,
     ) -> SuiResult {
-        // the checks here ensure that `current_epoch + upper_bound_max_epoch >= self.max_epoch >= current_epoch`.
+        // the checks here ensure that `current_epoch + max_epoch_upper_bound_delta >= self.max_epoch >= current_epoch`.
         // 1. if the config for upper bound is set, ensure that the max epoch in signature is not larger than epoch + upper_bound.
-        if let Some(upper_bound) = upper_bound_max_epoch {
-            if self.get_max_epoch() > epoch + upper_bound {
+        if let Some(delta) = max_epoch_upper_bound_delta {
+            let max_epoch_upper_bound = epoch + delta;
+            if self.get_max_epoch() > max_epoch_upper_bound {
                 return Err(SuiError::InvalidSignature {
                     error: format!(
-                        "ZKLogin max epoch too large {}, current epoch {}",
+                        "ZKLogin max epoch too large {}, current epoch {}, max accepted: {}",
                         self.get_max_epoch(),
-                        epoch
+                        epoch,
+                        max_epoch_upper_bound
                     ),
                 });
             }

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -94,9 +94,6 @@ impl AuthenticatorTrait for ZkLoginAuthenticator {
         epoch: EpochId,
         upper_bound_max_epoch: Option<EpochId>,
     ) -> SuiResult {
-        tracing::info!("upper_bound_max_epoch: {:?}", upper_bound_max_epoch);
-        tracing::info!("epoch: {:?}", epoch);
-        tracing::info!("get_max_epoch: {:?}", self.get_max_epoch());
         // the checks here ensure that `current_epoch + upper_bound_max_epoch >= self.max_epoch >= current_epoch`.
         // 1. if the config for upper bound is set, ensure that the max epoch in signature is not larger than epoch + upper_bound.
         if let Some(upper_bound) = upper_bound_max_epoch {

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1078,7 +1078,8 @@ impl KeyToolCommand {
                             "mainnet" | "testnet" => ZkLoginEnv::Prod,
                             _ => return Err(anyhow!("Invalid network")),
                         };
-                        let aux_verify_data = VerifyParams::new(parsed, vec![], env, true, true);
+                        let verify_params =
+                            VerifyParams::new(parsed, vec![], env, true, true, Some(2));
 
                         let (serialized, res) = match IntentScope::try_from(intent_scope)
                             .map_err(|_| anyhow!("Invalid scope"))?
@@ -1093,7 +1094,7 @@ impl KeyToolCommand {
                                     &IntentMessage::new(Intent::sui_transaction(), tx_data.clone()),
                                     tx_data.execution_parts().1,
                                     Some(curr_epoch.unwrap()),
-                                    &aux_verify_data,
+                                    &verify_params,
                                 );
                                 (serde_json::to_string(&tx_data)?, res)
                             }
@@ -1108,7 +1109,7 @@ impl KeyToolCommand {
                                     &IntentMessage::new(Intent::personal_message(), data.clone()),
                                     (&zk).try_into()?,
                                     Some(curr_epoch.unwrap()),
-                                    &aux_verify_data,
+                                    &verify_params,
                                 );
                                 (serde_json::to_string(&data)?, res)
                             }

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -98,7 +98,7 @@
 		"test:unit": "vitest run unit __tests__",
 		"test:e2e": "wait-on http://127.0.0.1:9123 -l --timeout 180000 && vitest run e2e",
 		"test:e2e:nowait": "vitest run e2e",
-		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui-test-validator --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui-test-validator -- --with-indexer --use-indexer-v2 --pg-port 5435 --pg-db-name sui_indexer_v2 --graphql-host 127.0.0.1 --graphql-port 9125",
+		"prepare:e2e": "docker-compose down && docker-compose up -d && cargo build --bin sui-test-validator --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui-test-validator -- --with-indexer --pg-port 5435 --pg-db-name sui_indexer_v2 --graphql-host 127.0.0.1 --graphql-port 9125",
 		"prepublishOnly": "pnpm build",
 		"size": "size-limit",
 		"analyze": "size-limit --why",

--- a/sdk/typescript/test/e2e/multisig.test.ts
+++ b/sdk/typescript/test/e2e/multisig.test.ts
@@ -4,6 +4,7 @@
 import { fromB64 } from '@mysten/bcs';
 import { describe, expect, it } from 'vitest';
 
+import { decodeSuiPrivateKey } from '../../src/cryptography';
 import { Ed25519Keypair } from '../../src/keypairs/ed25519';
 import { MultiSigPublicKey } from '../../src/multisig/publickey';
 import { TransactionBlock } from '../../src/transactions';
@@ -13,18 +14,17 @@ import { DEFAULT_RECIPIENT, setupWithFundedAddress } from './utils/setup';
 
 describe('MultiSig with zklogin signature', () => {
 	it('Execute tx with multisig with 1 sig and 1 zkLogin sig combined', async () => {
-		// set up default zklogin public identifier consistent with default zklogin proof.
+		// default ephemeral keypair, address_seed and zklogin inputs defined: https://github.com/MystenLabs/sui/blob/071a2955f7dbb83ee01c35d3a4257926a50a35f5/crates/sui-types/src/unit_tests/zklogin_test_vectors.json
+		// set up default zklogin public identifier with address seed consistent with default zklogin proof.
 		let pkZklogin = toZkLoginPublicIdentifier(
-			BigInt('20794788559620669596206457022966176986688727876128223628113916380927502737911'),
+			BigInt('2455937816256448139232531453880118833510874847675649348355284726183344259587'),
 			'https://id.twitch.tv/oauth2',
 		);
 		// set up ephemeral keypair, consistent with default zklogin proof.
-		let ephemeralKeypair = Ed25519Keypair.fromSecretKey(
-			new Uint8Array([
-				155, 244, 154, 106, 7, 85, 249, 83, 129, 31, 206, 18, 95, 38, 131, 213, 4, 41, 195, 187, 73,
-				224, 116, 20, 126, 0, 137, 165, 46, 174, 21, 95,
-			]),
+		let parsed = decodeSuiPrivateKey(
+			'suiprivkey1qzdlfxn2qa2lj5uprl8pyhexs02sg2wrhdy7qaq50cqgnffw4c2477kg9h3',
 		);
+		let ephemeralKeypair = Ed25519Keypair.fromSecretKey(parsed.secretKey);
 
 		// set up default single keypair.
 		let kp = Ed25519Keypair.fromSecretKey(
@@ -56,9 +56,8 @@ describe('MultiSig with zklogin signature', () => {
 		// sign with the single keypair.
 		const singleSig = (await kp.signTransactionBlock(bytes)).signature;
 
-		// construct default zklogin inputs defined in rust: https://github.com/MystenLabs/sui/blob/577537c76281b95ab8036b21e8ca5a25fde5d4b5/crates/sui-types/src/zk_login_util.rs
 		const zkLoginInputs = {
-			addressSeed: '20794788559620669596206457022966176986688727876128223628113916380927502737911',
+			addressSeed: '2455937816256448139232531453880118833510874847675649348355284726183344259587',
 			headerBase64: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEifQ',
 			issBase64Details: {
 				indexMod4: 2,
@@ -66,24 +65,24 @@ describe('MultiSig with zklogin signature', () => {
 			},
 			proofPoints: {
 				a: [
-					'17318089125952421736342263717932719437717844282410187957984751939942898251250',
-					'11373966645469122582074082295985388258840681618268593976697325892280915681207',
+					'2557188010312611627171871816260238532309920510408732193456156090279866747728',
+					'19071990941441318350711693802255556881405833839657840819058116822481115301678',
 					'1',
 				],
 				b: [
 					[
-						'5939871147348834997361720122238980177152303274311047249905942384915768690895',
-						'4533568271134785278731234570361482651996740791888285864966884032717049811708',
+						'135230770152349711361478655152288995176559604356405117885164129359471890574',
+						'7216898009175721143474942227108999120632545700438440510233575843810308715248',
 					],
 					[
-						'10564387285071555469753990661410840118635925466597037018058770041347518461368',
-						'12597323547277579144698496372242615368085801313343155735511330003884767957854',
+						'13253503214497870514695718691991905909426624538921072690977377011920360793667',
+						'9020530007799152621750172565457249844990381864119377955672172301732296026267',
 					],
 					['1', '0'],
 				],
 				c: [
-					'15791589472556826263231644728873337629015269984699404073623603352537678813171',
-					'4547866499248881449676161158024748060485373250029423904113017422539037162527',
+					'873909373264079078688783673576894039693316815418733093168579354008866728804',
+					'17533051555163888509441575111667473521314561492884091535743445342304799397998',
 					'1',
 				],
 			},
@@ -92,7 +91,7 @@ describe('MultiSig with zklogin signature', () => {
 		// create zklogin signature based on default zk proof.
 		const zkLoginSig = getZkLoginSignature({
 			inputs: zkLoginInputs,
-			maxEpoch: '10',
+			maxEpoch: '2',
 			userSignature: fromB64(ephemeralSig),
 		});
 


### PR DESCRIPTION
## Description 

currently a zklogin sig is valid as long as max_epoch is larger than current epoch. this adds a protocol config that the max_epoch cannot be too large, the config sets the upper bound to 30 + current epoch. 

based on new testing framework in simtest only. 

## Test Plan 

simtest
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [x] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Protocol version upgrades to 42. This adds a feature flag to set the upper bound of the max epoch for a zklogin signature.