### PR TITLE
move: scaffold manage-package command

### DIFF
--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -14,6 +14,7 @@ pub mod build;
 pub mod coverage;
 #[cfg(feature = "disassemble")]
 pub mod disassemble;
+pub mod manage_package;
 pub mod new;
 #[cfg(feature = "unit_test")]
 pub mod unit_test;
@@ -26,6 +27,7 @@ pub enum Command {
     Coverage(coverage::Coverage),
     #[cfg(feature = "disassemble")]
     Disassemble(disassemble::Disassemble),
+    ManagePackage(manage_package::ManagePackage),
     New(new::New),
     #[cfg(feature = "unit_test")]
     Test(unit_test::Test),
@@ -53,6 +55,7 @@ pub fn execute_move_command(
         Command::Coverage(c) => c.execute(package_path, build_config),
         #[cfg(feature = "disassemble")]
         Command::Disassemble(c) => c.execute(package_path, build_config),
+        Command::ManagePackage(c) => c.execute(package_path, build_config),
         Command::New(c) => c.execute(package_path),
 
         #[cfg(feature = "unit_test")]

--- a/crates/sui-move/src/manage_package.rs
+++ b/crates/sui-move/src/manage_package.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+use sui_types::base_types::ObjectID;
+
+/// Record addresses (Object IDs) for where this package is published on chain (this command sets variables in Move.lock).
+#[derive(Parser)]
+#[group(id = "sui-move-manage-package")]
+pub struct ManagePackage {
+    #[clap(long)]
+    /// The network chain identifer. Use '35834a8a' for mainnet.
+    pub network: String,
+    #[clap(long = "original-id", value_parser = ObjectID::from_hex_literal)]
+    /// The original address (Object ID) where this package is published.
+    pub original_id: ObjectID,
+    #[clap(long = "latest-id", value_parser = ObjectID::from_hex_literal)]
+    /// The most recent address (Object ID) where this package is published. It is the same as 'original-id' if the package is immutable and published once. It is different from 'original-id' if the package has been upgraded to a different address.
+    pub latest_id: ObjectID,
+    #[clap(long = "version-number")]
+    /// The version number of the published package. It is '1' if the package is immutable and published once. It is some number greater than '1' if the package has been upgraded once or more.
+    pub version_number: u64,
+}
+
+impl ManagePackage {
+    pub fn execute(self, _path: Option<PathBuf>, _build_config: BuildConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/external-crates/move/crates/move-cli/src/base/disassemble.rs
+++ b/external-crates/move/crates/move-cli/src/base/disassemble.rs
@@ -12,17 +12,17 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[clap(name = "disassemble")]
 pub struct Disassemble {
-    /// Start a disassembled bytecode-to-source explorer
     #[clap(long = "interactive")]
+    /// Start a disassembled bytecode-to-source explorer
     pub interactive: bool,
-    /// The package name. If not provided defaults to current package modules only
     #[clap(long = "package")]
+    /// The package name. If not provided defaults to current package modules only
     pub package_name: Option<String>,
-    /// The name of the module or script in the package to disassemble
     #[clap(long = "name")]
+    /// The name of the module or script in the package to disassemble
     pub module_or_script_name: String,
-    /// Also print the raw disassembly using Rust's Debug output, at the end.
     #[clap(long = "Xdebug")]
+    /// Also print the raw disassembly using Rust's Debug output, at the end.
     pub debug: bool,
 }
 


### PR DESCRIPTION
## Description 

Adds `sui move manage-package` to scaffold a command that will record `Move.lock` variables for automated address management. Relevant portion of CLI output when running `sui move manage-package --help`:

```
Record addresses (Object IDs) for where this package is published on chain (this command sets variables in Move.lock)

Usage: sui move manage-package [OPTIONS] --network <NETWORK> --original-id <ORIGINAL_ID> --latest-id <LATEST_ID> --version-number <VERSION_NUMBER>

Options:
      --network <NETWORK>                       The network chain identifer. Use '35834a8a' for mainnet
      --original-id <ORIGINAL_ID>               The original address (Object ID) where this package is published
      --latest-id <LATEST_ID>                   The most recent address (Object ID) where this package is published. It is the same as
                                                'original-id' if the package is immutable and published once. It is different from
                                                'original-id' if the package has been upgraded to a different address
      --version-number <VERSION_NUMBER>         The version number of the published package. It is '1' if the package is immutable and
                                                published once. It is some number greater than '1' if the package has been upgraded once
                                                or more
```

See [this doc](https://www.notion.so/mystenlabs/Automated-Address-Management-Domain-Separation-afe2bf0b796d47cb80350a0581da1f61?pvs=4#405f500c40904e078944c718acbc6ea4) for more context.

## Test Plan 

N/A, scaffolding for comments / review.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
