### PR TITLE
[gql] modify consistent objects query to be more performant

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
@@ -582,14 +582,14 @@ Response: {
       "objects": {
         "nodes": [
           {
-            "version": 4,
+            "version": 3,
             "contents": {
               "type": {
-                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+                "repr": "0x7fa8cc064aa9d56a46411e3e0e5878a6cd740a4edabe2cb3c28ec32d6e314db4::M1::Object"
               },
               "json": {
-                "id": "0x40aeb76cad6e19a1bafcb35a1757802096bfe02d15e744c6d263c59810ecb6a6",
-                "value": "1"
+                "id": "0x5cbc81679b7c3fe2763d6129f752abacd0787935b4a081c341e1cebc571446d5",
+                "value": "0"
               }
             }
           },
@@ -597,23 +597,11 @@ Response: {
             "version": 6,
             "contents": {
               "type": {
-                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+                "repr": "0x7fa8cc064aa9d56a46411e3e0e5878a6cd740a4edabe2cb3c28ec32d6e314db4::M1::Object"
               },
               "json": {
-                "id": "0x7f29de25a5de253fef601eb3e89c739f37e4203a59a75b01afbfd72f61f32604",
+                "id": "0x81b0f4f8040edbdd1778dac36f4a6c7ebd4d2689c5f9e28ea916ab3542ea6c5e",
                 "value": "3"
-              }
-            }
-          },
-          {
-            "version": 3,
-            "contents": {
-              "type": {
-                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
-              },
-              "json": {
-                "id": "0xbab0be1a0a78ac1813f3d93773d14ce43e5baeb74bd11787f652b0f03c73d79b",
-                "value": "0"
               }
             }
           },
@@ -621,11 +609,23 @@ Response: {
             "version": 5,
             "contents": {
               "type": {
-                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+                "repr": "0x7fa8cc064aa9d56a46411e3e0e5878a6cd740a4edabe2cb3c28ec32d6e314db4::M1::Object"
               },
               "json": {
-                "id": "0xdf8f9e8b469e8ad9311dab76f691c1a5e99a42c63377a6429a5c00c477f7a21e",
+                "id": "0xb94dc19e08bf7ea2999f22ae8db6ef903d2ace4a08e99d40867064ca10abdf07",
                 "value": "2"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x7fa8cc064aa9d56a46411e3e0e5878a6cd740a4edabe2cb3c28ec32d6e314db4::M1::Object"
+              },
+              "json": {
+                "id": "0xcf941059092fa42fb8bc3c184adaf83083856daa002de4f4aaadfc1e79cfa26a",
+                "value": "1"
               }
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.exp
@@ -580,7 +580,56 @@ Response: {
   "data": {
     "objects_at_version": {
       "objects": {
-        "nodes": []
+        "nodes": [
+          {
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+              },
+              "json": {
+                "id": "0x40aeb76cad6e19a1bafcb35a1757802096bfe02d15e744c6d263c59810ecb6a6",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+              },
+              "json": {
+                "id": "0x7f29de25a5de253fef601eb3e89c739f37e4203a59a75b01afbfd72f61f32604",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+              },
+              "json": {
+                "id": "0xbab0be1a0a78ac1813f3d93773d14ce43e5baeb74bd11787f652b0f03c73d79b",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0xeb58c84a4405f4cbb18ff87ff073438195c1a4797a04c5ed3c3d8f9b302217f0::M1::Object"
+              },
+              "json": {
+                "id": "0xdf8f9e8b469e8ad9311dab76f691c1a5e99a42c63377a6429a5c00c477f7a21e",
+                "value": "2"
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
@@ -264,7 +264,7 @@ module Test::M1 {
 }
 
 //# run-graphql
-# No longer accessible, as there are more recent versions owned by address B.
+# Historical lookups will still return results at version.
 {
   objects_at_version: address(address: "@{A}") {
     objects(

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
@@ -1,4 +1,4 @@
-processed 11 tasks
+processed 13 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -9,9 +9,9 @@ mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 6118000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 41-41:
-created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16), object(2,17), object(2,18), object(2,19), object(2,20), object(2,21), object(2,22), object(2,23), object(2,24), object(2,25), object(2,26), object(2,27), object(2,28), object(2,29), object(2,30), object(2,31), object(2,32), object(2,33), object(2,34), object(2,35), object(2,36), object(2,37), object(2,38), object(2,39), object(2,40), object(2,41), object(2,42), object(2,43), object(2,44), object(2,45), object(2,46), object(2,47), object(2,48), object(2,49), object(2,50), object(2,51), object(2,52), object(2,53), object(2,54), object(2,55), object(2,56), object(2,57), object(2,58), object(2,59), object(2,60), object(2,61), object(2,62), object(2,63), object(2,64), object(2,65), object(2,66), object(2,67), object(2,68), object(2,69), object(2,70), object(2,71), object(2,72), object(2,73), object(2,74), object(2,75), object(2,76), object(2,77), object(2,78), object(2,79), object(2,80), object(2,81), object(2,82), object(2,83), object(2,84), object(2,85), object(2,86), object(2,87), object(2,88), object(2,89), object(2,90), object(2,91), object(2,92), object(2,93), object(2,94), object(2,95), object(2,96), object(2,97), object(2,98), object(2,99), object(2,100), object(2,101), object(2,102), object(2,103), object(2,104), object(2,105), object(2,106), object(2,107), object(2,108), object(2,109), object(2,110), object(2,111), object(2,112), object(2,113), object(2,114), object(2,115), object(2,116), object(2,117), object(2,118), object(2,119), object(2,120), object(2,121), object(2,122), object(2,123), object(2,124), object(2,125), object(2,126), object(2,127), object(2,128), object(2,129), object(2,130), object(2,131), object(2,132), object(2,133), object(2,134), object(2,135), object(2,136), object(2,137), object(2,138), object(2,139), object(2,140), object(2,141), object(2,142), object(2,143), object(2,144), object(2,145), object(2,146), object(2,147), object(2,148), object(2,149), object(2,150), object(2,151), object(2,152), object(2,153), object(2,154), object(2,155), object(2,156), object(2,157), object(2,158), object(2,159), object(2,160), object(2,161), object(2,162), object(2,163), object(2,164), object(2,165), object(2,166), object(2,167), object(2,168), object(2,169), object(2,170), object(2,171), object(2,172), object(2,173), object(2,174), object(2,175), object(2,176), object(2,177), object(2,178), object(2,179), object(2,180), object(2,181), object(2,182), object(2,183), object(2,184), object(2,185), object(2,186), object(2,187), object(2,188), object(2,189), object(2,190), object(2,191), object(2,192), object(2,193), object(2,194), object(2,195), object(2,196), object(2,197), object(2,198), object(2,199), object(2,200), object(2,201), object(2,202), object(2,203), object(2,204), object(2,205), object(2,206), object(2,207), object(2,208), object(2,209), object(2,210), object(2,211), object(2,212), object(2,213), object(2,214), object(2,215), object(2,216), object(2,217), object(2,218), object(2,219), object(2,220), object(2,221), object(2,222), object(2,223), object(2,224), object(2,225), object(2,226), object(2,227), object(2,228), object(2,229), object(2,230), object(2,231), object(2,232), object(2,233), object(2,234), object(2,235), object(2,236), object(2,237), object(2,238), object(2,239), object(2,240), object(2,241), object(2,242), object(2,243), object(2,244), object(2,245), object(2,246), object(2,247), object(2,248), object(2,249), object(2,250), object(2,251), object(2,252), object(2,253), object(2,254), object(2,255), object(2,256), object(2,257), object(2,258), object(2,259), object(2,260), object(2,261), object(2,262), object(2,263), object(2,264), object(2,265), object(2,266), object(2,267), object(2,268), object(2,269), object(2,270), object(2,271), object(2,272), object(2,273), object(2,274), object(2,275), object(2,276), object(2,277), object(2,278), object(2,279), object(2,280), object(2,281), object(2,282), object(2,283), object(2,284), object(2,285), object(2,286), object(2,287), object(2,288), object(2,289), object(2,290), object(2,291), object(2,292), object(2,293), object(2,294), object(2,295), object(2,296), object(2,297), object(2,298), object(2,299), object(2,300), object(2,301), object(2,302), object(2,303), object(2,304), object(2,305), object(2,306), object(2,307), object(2,308), object(2,309), object(2,310), object(2,311), object(2,312), object(2,313), object(2,314), object(2,315), object(2,316), object(2,317), object(2,318), object(2,319), object(2,320), object(2,321), object(2,322), object(2,323), object(2,324), object(2,325), object(2,326), object(2,327), object(2,328), object(2,329), object(2,330), object(2,331), object(2,332), object(2,333), object(2,334), object(2,335), object(2,336), object(2,337), object(2,338), object(2,339), object(2,340), object(2,341), object(2,342), object(2,343), object(2,344), object(2,345), object(2,346), object(2,347), object(2,348), object(2,349), object(2,350), object(2,351), object(2,352), object(2,353), object(2,354), object(2,355), object(2,356), object(2,357), object(2,358), object(2,359), object(2,360), object(2,361), object(2,362), object(2,363), object(2,364), object(2,365), object(2,366), object(2,367), object(2,368), object(2,369), object(2,370), object(2,371), object(2,372), object(2,373), object(2,374), object(2,375), object(2,376), object(2,377), object(2,378), object(2,379), object(2,380), object(2,381), object(2,382), object(2,383), object(2,384), object(2,385), object(2,386), object(2,387), object(2,388), object(2,389), object(2,390), object(2,391), object(2,392), object(2,393), object(2,394), object(2,395), object(2,396), object(2,397), object(2,398), object(2,399), object(2,400), object(2,401), object(2,402), object(2,403), object(2,404), object(2,405), object(2,406), object(2,407), object(2,408), object(2,409), object(2,410), object(2,411), object(2,412), object(2,413), object(2,414), object(2,415), object(2,416), object(2,417), object(2,418), object(2,419), object(2,420), object(2,421), object(2,422), object(2,423), object(2,424), object(2,425), object(2,426), object(2,427), object(2,428), object(2,429), object(2,430), object(2,431), object(2,432), object(2,433), object(2,434), object(2,435), object(2,436), object(2,437), object(2,438), object(2,439), object(2,440), object(2,441), object(2,442), object(2,443), object(2,444), object(2,445), object(2,446), object(2,447), object(2,448), object(2,449), object(2,450), object(2,451), object(2,452), object(2,453), object(2,454), object(2,455), object(2,456), object(2,457), object(2,458), object(2,459), object(2,460), object(2,461), object(2,462), object(2,463), object(2,464), object(2,465), object(2,466), object(2,467), object(2,468), object(2,469), object(2,470), object(2,471), object(2,472), object(2,473), object(2,474), object(2,475), object(2,476), object(2,477), object(2,478), object(2,479), object(2,480), object(2,481), object(2,482), object(2,483), object(2,484), object(2,485), object(2,486), object(2,487), object(2,488), object(2,489), object(2,490), object(2,491), object(2,492), object(2,493), object(2,494), object(2,495), object(2,496), object(2,497), object(2,498), object(2,499), object(2,500), object(2,501), object(2,502), object(2,503), object(2,504), object(2,505), object(2,506), object(2,507), object(2,508), object(2,509), object(2,510), object(2,511), object(2,512), object(2,513), object(2,514), object(2,515), object(2,516), object(2,517), object(2,518), object(2,519), object(2,520), object(2,521), object(2,522), object(2,523), object(2,524), object(2,525), object(2,526), object(2,527), object(2,528), object(2,529), object(2,530), object(2,531), object(2,532), object(2,533), object(2,534), object(2,535), object(2,536), object(2,537), object(2,538), object(2,539), object(2,540), object(2,541), object(2,542), object(2,543), object(2,544), object(2,545), object(2,546), object(2,547), object(2,548), object(2,549), object(2,550), object(2,551), object(2,552), object(2,553), object(2,554), object(2,555), object(2,556), object(2,557), object(2,558), object(2,559), object(2,560), object(2,561), object(2,562), object(2,563), object(2,564), object(2,565), object(2,566), object(2,567), object(2,568), object(2,569), object(2,570), object(2,571), object(2,572), object(2,573), object(2,574), object(2,575), object(2,576), object(2,577), object(2,578), object(2,579), object(2,580), object(2,581), object(2,582), object(2,583), object(2,584), object(2,585), object(2,586), object(2,587), object(2,588), object(2,589), object(2,590), object(2,591), object(2,592), object(2,593), object(2,594), object(2,595), object(2,596), object(2,597), object(2,598), object(2,599), object(2,600), object(2,601), object(2,602), object(2,603), object(2,604), object(2,605), object(2,606), object(2,607), object(2,608), object(2,609), object(2,610), object(2,611), object(2,612), object(2,613), object(2,614), object(2,615), object(2,616), object(2,617), object(2,618), object(2,619), object(2,620), object(2,621), object(2,622), object(2,623), object(2,624), object(2,625), object(2,626), object(2,627), object(2,628), object(2,629), object(2,630), object(2,631), object(2,632), object(2,633), object(2,634), object(2,635), object(2,636), object(2,637), object(2,638), object(2,639), object(2,640), object(2,641), object(2,642), object(2,643), object(2,644), object(2,645), object(2,646), object(2,647), object(2,648), object(2,649), object(2,650), object(2,651), object(2,652), object(2,653), object(2,654), object(2,655), object(2,656), object(2,657), object(2,658), object(2,659), object(2,660), object(2,661), object(2,662), object(2,663), object(2,664), object(2,665), object(2,666), object(2,667), object(2,668), object(2,669), object(2,670), object(2,671), object(2,672), object(2,673), object(2,674), object(2,675), object(2,676), object(2,677), object(2,678), object(2,679), object(2,680), object(2,681), object(2,682), object(2,683), object(2,684), object(2,685), object(2,686), object(2,687), object(2,688), object(2,689), object(2,690), object(2,691), object(2,692), object(2,693), object(2,694), object(2,695), object(2,696), object(2,697), object(2,698), object(2,699), object(2,700), object(2,701), object(2,702), object(2,703), object(2,704), object(2,705), object(2,706), object(2,707), object(2,708), object(2,709), object(2,710), object(2,711), object(2,712), object(2,713), object(2,714), object(2,715), object(2,716), object(2,717), object(2,718), object(2,719), object(2,720), object(2,721), object(2,722), object(2,723), object(2,724), object(2,725), object(2,726), object(2,727), object(2,728), object(2,729), object(2,730), object(2,731), object(2,732), object(2,733), object(2,734), object(2,735), object(2,736), object(2,737), object(2,738), object(2,739), object(2,740), object(2,741), object(2,742), object(2,743), object(2,744), object(2,745), object(2,746), object(2,747), object(2,748), object(2,749), object(2,750), object(2,751), object(2,752), object(2,753), object(2,754), object(2,755), object(2,756), object(2,757), object(2,758), object(2,759), object(2,760), object(2,761), object(2,762), object(2,763), object(2,764), object(2,765), object(2,766), object(2,767), object(2,768), object(2,769), object(2,770), object(2,771), object(2,772), object(2,773), object(2,774), object(2,775), object(2,776), object(2,777), object(2,778), object(2,779), object(2,780), object(2,781), object(2,782), object(2,783), object(2,784), object(2,785), object(2,786), object(2,787), object(2,788), object(2,789), object(2,790), object(2,791), object(2,792), object(2,793), object(2,794), object(2,795), object(2,796), object(2,797), object(2,798), object(2,799), object(2,800), object(2,801), object(2,802), object(2,803), object(2,804), object(2,805), object(2,806), object(2,807), object(2,808), object(2,809), object(2,810), object(2,811), object(2,812), object(2,813), object(2,814), object(2,815), object(2,816), object(2,817), object(2,818), object(2,819), object(2,820), object(2,821), object(2,822), object(2,823), object(2,824), object(2,825), object(2,826), object(2,827), object(2,828), object(2,829), object(2,830), object(2,831), object(2,832), object(2,833), object(2,834), object(2,835), object(2,836), object(2,837), object(2,838), object(2,839), object(2,840), object(2,841), object(2,842), object(2,843), object(2,844), object(2,845), object(2,846), object(2,847), object(2,848), object(2,849), object(2,850), object(2,851), object(2,852), object(2,853), object(2,854), object(2,855), object(2,856), object(2,857), object(2,858), object(2,859), object(2,860), object(2,861), object(2,862), object(2,863), object(2,864), object(2,865), object(2,866), object(2,867), object(2,868), object(2,869), object(2,870), object(2,871), object(2,872), object(2,873), object(2,874), object(2,875), object(2,876), object(2,877), object(2,878), object(2,879), object(2,880), object(2,881), object(2,882), object(2,883), object(2,884), object(2,885), object(2,886), object(2,887), object(2,888), object(2,889), object(2,890), object(2,891), object(2,892), object(2,893), object(2,894), object(2,895), object(2,896), object(2,897), object(2,898), object(2,899), object(2,900), object(2,901), object(2,902), object(2,903), object(2,904), object(2,905), object(2,906), object(2,907), object(2,908), object(2,909), object(2,910), object(2,911), object(2,912), object(2,913), object(2,914), object(2,915), object(2,916), object(2,917), object(2,918), object(2,919), object(2,920), object(2,921), object(2,922), object(2,923), object(2,924), object(2,925), object(2,926), object(2,927), object(2,928), object(2,929), object(2,930), object(2,931), object(2,932), object(2,933), object(2,934), object(2,935), object(2,936), object(2,937), object(2,938), object(2,939), object(2,940), object(2,941), object(2,942), object(2,943), object(2,944), object(2,945), object(2,946), object(2,947), object(2,948), object(2,949), object(2,950), object(2,951), object(2,952), object(2,953), object(2,954), object(2,955), object(2,956), object(2,957), object(2,958), object(2,959), object(2,960), object(2,961), object(2,962), object(2,963), object(2,964), object(2,965), object(2,966), object(2,967), object(2,968), object(2,969), object(2,970), object(2,971), object(2,972), object(2,973), object(2,974), object(2,975), object(2,976), object(2,977), object(2,978), object(2,979), object(2,980), object(2,981), object(2,982), object(2,983), object(2,984), object(2,985), object(2,986), object(2,987), object(2,988), object(2,989), object(2,990), object(2,991), object(2,992), object(2,993), object(2,994), object(2,995), object(2,996), object(2,997), object(2,998), object(2,999)
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16), object(2,17), object(2,18), object(2,19), object(2,20), object(2,21), object(2,22), object(2,23), object(2,24), object(2,25), object(2,26), object(2,27), object(2,28), object(2,29), object(2,30), object(2,31), object(2,32), object(2,33), object(2,34), object(2,35), object(2,36), object(2,37), object(2,38), object(2,39), object(2,40), object(2,41), object(2,42), object(2,43), object(2,44), object(2,45), object(2,46), object(2,47), object(2,48), object(2,49), object(2,50), object(2,51), object(2,52), object(2,53), object(2,54), object(2,55), object(2,56), object(2,57), object(2,58), object(2,59), object(2,60), object(2,61), object(2,62), object(2,63), object(2,64), object(2,65), object(2,66), object(2,67), object(2,68), object(2,69), object(2,70), object(2,71), object(2,72), object(2,73), object(2,74), object(2,75), object(2,76), object(2,77), object(2,78), object(2,79), object(2,80), object(2,81), object(2,82), object(2,83), object(2,84), object(2,85), object(2,86), object(2,87), object(2,88), object(2,89), object(2,90), object(2,91), object(2,92), object(2,93), object(2,94), object(2,95), object(2,96), object(2,97), object(2,98), object(2,99), object(2,100), object(2,101), object(2,102), object(2,103), object(2,104), object(2,105), object(2,106), object(2,107), object(2,108), object(2,109), object(2,110), object(2,111), object(2,112), object(2,113), object(2,114), object(2,115), object(2,116), object(2,117), object(2,118), object(2,119), object(2,120), object(2,121), object(2,122), object(2,123), object(2,124), object(2,125), object(2,126), object(2,127), object(2,128), object(2,129), object(2,130), object(2,131), object(2,132), object(2,133), object(2,134), object(2,135), object(2,136), object(2,137), object(2,138), object(2,139), object(2,140), object(2,141), object(2,142), object(2,143), object(2,144), object(2,145), object(2,146), object(2,147), object(2,148), object(2,149), object(2,150), object(2,151), object(2,152), object(2,153), object(2,154), object(2,155), object(2,156), object(2,157), object(2,158), object(2,159), object(2,160), object(2,161), object(2,162), object(2,163), object(2,164), object(2,165), object(2,166), object(2,167), object(2,168), object(2,169), object(2,170), object(2,171), object(2,172), object(2,173), object(2,174), object(2,175), object(2,176), object(2,177), object(2,178), object(2,179), object(2,180), object(2,181), object(2,182), object(2,183), object(2,184), object(2,185), object(2,186), object(2,187), object(2,188), object(2,189), object(2,190), object(2,191), object(2,192), object(2,193), object(2,194), object(2,195), object(2,196), object(2,197), object(2,198), object(2,199), object(2,200), object(2,201), object(2,202), object(2,203), object(2,204), object(2,205), object(2,206), object(2,207), object(2,208), object(2,209), object(2,210), object(2,211), object(2,212), object(2,213), object(2,214), object(2,215), object(2,216), object(2,217), object(2,218), object(2,219), object(2,220), object(2,221), object(2,222), object(2,223), object(2,224), object(2,225), object(2,226), object(2,227), object(2,228), object(2,229), object(2,230), object(2,231), object(2,232), object(2,233), object(2,234), object(2,235), object(2,236), object(2,237), object(2,238), object(2,239), object(2,240), object(2,241), object(2,242), object(2,243), object(2,244), object(2,245), object(2,246), object(2,247), object(2,248), object(2,249), object(2,250), object(2,251), object(2,252), object(2,253), object(2,254), object(2,255), object(2,256), object(2,257), object(2,258), object(2,259), object(2,260), object(2,261), object(2,262), object(2,263), object(2,264), object(2,265), object(2,266), object(2,267), object(2,268), object(2,269), object(2,270), object(2,271), object(2,272), object(2,273), object(2,274), object(2,275), object(2,276), object(2,277), object(2,278), object(2,279), object(2,280), object(2,281), object(2,282), object(2,283), object(2,284), object(2,285), object(2,286), object(2,287), object(2,288), object(2,289), object(2,290), object(2,291), object(2,292), object(2,293), object(2,294), object(2,295), object(2,296), object(2,297), object(2,298), object(2,299), object(2,300), object(2,301), object(2,302), object(2,303), object(2,304), object(2,305), object(2,306), object(2,307), object(2,308), object(2,309), object(2,310), object(2,311), object(2,312), object(2,313), object(2,314), object(2,315), object(2,316), object(2,317), object(2,318), object(2,319), object(2,320), object(2,321), object(2,322), object(2,323), object(2,324), object(2,325), object(2,326), object(2,327), object(2,328), object(2,329), object(2,330), object(2,331), object(2,332), object(2,333), object(2,334), object(2,335), object(2,336), object(2,337), object(2,338), object(2,339), object(2,340), object(2,341), object(2,342), object(2,343), object(2,344), object(2,345), object(2,346), object(2,347), object(2,348), object(2,349), object(2,350), object(2,351), object(2,352), object(2,353), object(2,354), object(2,355), object(2,356), object(2,357), object(2,358), object(2,359), object(2,360), object(2,361), object(2,362), object(2,363), object(2,364), object(2,365), object(2,366), object(2,367), object(2,368), object(2,369), object(2,370), object(2,371), object(2,372), object(2,373), object(2,374), object(2,375), object(2,376), object(2,377), object(2,378), object(2,379), object(2,380), object(2,381), object(2,382), object(2,383), object(2,384), object(2,385), object(2,386), object(2,387), object(2,388), object(2,389), object(2,390), object(2,391), object(2,392), object(2,393), object(2,394), object(2,395), object(2,396), object(2,397), object(2,398), object(2,399), object(2,400), object(2,401), object(2,402), object(2,403), object(2,404), object(2,405), object(2,406), object(2,407), object(2,408), object(2,409), object(2,410), object(2,411), object(2,412), object(2,413), object(2,414), object(2,415), object(2,416), object(2,417), object(2,418), object(2,419), object(2,420), object(2,421), object(2,422), object(2,423), object(2,424), object(2,425), object(2,426), object(2,427), object(2,428), object(2,429), object(2,430), object(2,431), object(2,432), object(2,433), object(2,434), object(2,435), object(2,436), object(2,437), object(2,438), object(2,439), object(2,440), object(2,441), object(2,442), object(2,443), object(2,444), object(2,445), object(2,446), object(2,447), object(2,448), object(2,449), object(2,450), object(2,451), object(2,452), object(2,453), object(2,454), object(2,455), object(2,456), object(2,457), object(2,458), object(2,459), object(2,460), object(2,461), object(2,462), object(2,463), object(2,464), object(2,465), object(2,466), object(2,467), object(2,468), object(2,469), object(2,470), object(2,471), object(2,472), object(2,473), object(2,474), object(2,475), object(2,476), object(2,477), object(2,478), object(2,479), object(2,480), object(2,481), object(2,482), object(2,483), object(2,484), object(2,485), object(2,486), object(2,487), object(2,488), object(2,489), object(2,490), object(2,491), object(2,492), object(2,493), object(2,494), object(2,495), object(2,496), object(2,497), object(2,498), object(2,499)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 1315788000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 658388000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'create-checkpoint'. lines 43-43:
 Checkpoint created: 2
@@ -31,11 +31,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
-                "value": "505"
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -50,11 +50,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-                "value": "539"
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -72,11 +72,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xfd6cfc20d0c25df4ce2fc5f7c7c40a5b926a3a5ffac5e6bb071c7cd5f740d5b0",
-                "value": "211"
+                "id": "0xfe634b417989c12e4e72daf427d78a361863e9940a3d9c5e138f4fcefb9d7ce5",
+                "value": "231"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           },
@@ -88,11 +88,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff040fb82d647fef4c3075f05bbb14cab1e9771b88eb0b3afff94734ff00d1d9",
-                "value": "926"
+                "id": "0xfe965a0c18f5cb4b1dbe5a982a12ac7ce17fbae1a9b3b7ee474232fd464d2a04",
+                "value": "438"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           },
@@ -104,11 +104,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
-                "value": "505"
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           },
@@ -120,11 +120,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-                "value": "539"
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -135,21 +135,31 @@ Response: {
 }
 
 task 5 'transfer-object'. lines 88-88:
-mutated: object(0,0), object(2,999)
+mutated: object(0,0), object(2,499)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
 
 task 6 'transfer-object'. lines 90-90:
-mutated: object(0,0), object(2,998)
+mutated: object(0,0), object(2,498)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
 
 task 7 'transfer-object'. lines 92-92:
-mutated: object(0,0), object(2,997)
+mutated: object(0,0), object(2,497)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
 
-task 8 'create-checkpoint'. lines 94-94:
+task 8 'view-object'. lines 94-94:
+Owner: Account Address ( B )
+Version: 4
+Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,498)}}, value: 245u64}
+
+task 9 'view-object'. lines 96-96:
+Owner: Account Address ( B )
+Version: 5
+Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,497)}}, value: 438u64}
+
+task 10 'create-checkpoint'. lines 98-98:
 Checkpoint created: 3
 
-task 9 'run-graphql'. lines 96-138:
+task 11 'run-graphql'. lines 100-142:
 Response: {
   "data": {
     "last_3": {
@@ -164,11 +174,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff040fb82d647fef4c3075f05bbb14cab1e9771b88eb0b3afff94734ff00d1d9",
-                "value": "926"
+                "id": "0xfe965a0c18f5cb4b1dbe5a982a12ac7ce17fbae1a9b3b7ee474232fd464d2a04",
+                "value": "438"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -183,11 +193,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
-                "value": "505"
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -202,11 +212,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-                "value": "539"
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -225,11 +235,11 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xfd6cfc20d0c25df4ce2fc5f7c7c40a5b926a3a5ffac5e6bb071c7cd5f740d5b0",
-                "value": "211"
+                "id": "0xfe634b417989c12e4e72daf427d78a361863e9940a3d9c5e138f4fcefb9d7ce5",
+                "value": "231"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -239,7 +249,7 @@ Response: {
   }
 }
 
-task 10 'run-graphql'. lines 140-216:
+task 12 'run-graphql'. lines 144-248:
 Response: {
   "data": {
     "a": {
@@ -251,11 +261,11 @@ Response: {
         },
         "contents": {
           "json": {
-            "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-            "value": "539"
+            "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+            "value": "83"
           },
           "type": {
-            "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+            "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
           }
         }
       }
@@ -269,11 +279,11 @@ Response: {
         },
         "contents": {
           "json": {
-            "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-            "value": "539"
+            "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+            "value": "83"
           },
           "type": {
-            "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+            "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
           }
         }
       }
@@ -289,11 +299,47 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-                "value": "539"
+                "id": "0xfe965a0c18f5cb4b1dbe5a982a12ac7ce17fbae1a9b3b7ee474232fd464d2a04",
+                "value": "438"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
@@ -311,16 +357,128 @@ Response: {
             },
             "contents": {
               "json": {
-                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
-                "value": "539"
+                "id": "0xfe965a0c18f5cb4b1dbe5a982a12ac7ce17fbae1a9b3b7ee474232fd464d2a04",
+                "value": "438"
               },
               "type": {
-                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
               }
             }
           }
         }
       ]
+    },
+    "owned_by_b": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 1,
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xd41dc489aa9cb88f0fd03b478e2185585acdc62e452b533cbb9733dc6e9c9389",
+                "balance": {
+                  "value": "300000000000000"
+                }
+              },
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              }
+            }
+          },
+          {
+            "version": 5,
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xfe965a0c18f5cb4b1dbe5a982a12ac7ce17fbae1a9b3b7ee474232fd464d2a04",
+                "value": "438"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          },
+          {
+            "version": 4,
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffb8fcef6b804e51b3ac9d1d3f789472ed397e764e74c1132ca271e4ac14b4b6",
+                "value": "245"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          },
+          {
+            "version": 3,
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xffe237fc32ab9a718a6c50c761074cbbde5fb691394e147c466de8b0592849df",
+                "value": "83"
+              },
+              "type": {
+                "repr": "0xbb23730728f32620f18fca1a0b54b8c3dcbad08bee7008e9715a4a321500204f::M1::Object"
+              }
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
@@ -14,7 +14,7 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1315788000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'create-checkpoint'. lines 43-43:
-Checkpoint created: 1
+Checkpoint created: 2
 
 task 4 'run-graphql'. lines 45-86:
 Response: {
@@ -147,7 +147,7 @@ mutated: object(0,0), object(2,997)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
 
 task 8 'create-checkpoint'. lines 94-94:
-Checkpoint created: 2
+Checkpoint created: 3
 
 task 9 'run-graphql'. lines 96-138:
 Response: {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.exp
@@ -1,0 +1,326 @@
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1 'publish'. lines 12-39:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6118000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 41-41:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16), object(2,17), object(2,18), object(2,19), object(2,20), object(2,21), object(2,22), object(2,23), object(2,24), object(2,25), object(2,26), object(2,27), object(2,28), object(2,29), object(2,30), object(2,31), object(2,32), object(2,33), object(2,34), object(2,35), object(2,36), object(2,37), object(2,38), object(2,39), object(2,40), object(2,41), object(2,42), object(2,43), object(2,44), object(2,45), object(2,46), object(2,47), object(2,48), object(2,49), object(2,50), object(2,51), object(2,52), object(2,53), object(2,54), object(2,55), object(2,56), object(2,57), object(2,58), object(2,59), object(2,60), object(2,61), object(2,62), object(2,63), object(2,64), object(2,65), object(2,66), object(2,67), object(2,68), object(2,69), object(2,70), object(2,71), object(2,72), object(2,73), object(2,74), object(2,75), object(2,76), object(2,77), object(2,78), object(2,79), object(2,80), object(2,81), object(2,82), object(2,83), object(2,84), object(2,85), object(2,86), object(2,87), object(2,88), object(2,89), object(2,90), object(2,91), object(2,92), object(2,93), object(2,94), object(2,95), object(2,96), object(2,97), object(2,98), object(2,99), object(2,100), object(2,101), object(2,102), object(2,103), object(2,104), object(2,105), object(2,106), object(2,107), object(2,108), object(2,109), object(2,110), object(2,111), object(2,112), object(2,113), object(2,114), object(2,115), object(2,116), object(2,117), object(2,118), object(2,119), object(2,120), object(2,121), object(2,122), object(2,123), object(2,124), object(2,125), object(2,126), object(2,127), object(2,128), object(2,129), object(2,130), object(2,131), object(2,132), object(2,133), object(2,134), object(2,135), object(2,136), object(2,137), object(2,138), object(2,139), object(2,140), object(2,141), object(2,142), object(2,143), object(2,144), object(2,145), object(2,146), object(2,147), object(2,148), object(2,149), object(2,150), object(2,151), object(2,152), object(2,153), object(2,154), object(2,155), object(2,156), object(2,157), object(2,158), object(2,159), object(2,160), object(2,161), object(2,162), object(2,163), object(2,164), object(2,165), object(2,166), object(2,167), object(2,168), object(2,169), object(2,170), object(2,171), object(2,172), object(2,173), object(2,174), object(2,175), object(2,176), object(2,177), object(2,178), object(2,179), object(2,180), object(2,181), object(2,182), object(2,183), object(2,184), object(2,185), object(2,186), object(2,187), object(2,188), object(2,189), object(2,190), object(2,191), object(2,192), object(2,193), object(2,194), object(2,195), object(2,196), object(2,197), object(2,198), object(2,199), object(2,200), object(2,201), object(2,202), object(2,203), object(2,204), object(2,205), object(2,206), object(2,207), object(2,208), object(2,209), object(2,210), object(2,211), object(2,212), object(2,213), object(2,214), object(2,215), object(2,216), object(2,217), object(2,218), object(2,219), object(2,220), object(2,221), object(2,222), object(2,223), object(2,224), object(2,225), object(2,226), object(2,227), object(2,228), object(2,229), object(2,230), object(2,231), object(2,232), object(2,233), object(2,234), object(2,235), object(2,236), object(2,237), object(2,238), object(2,239), object(2,240), object(2,241), object(2,242), object(2,243), object(2,244), object(2,245), object(2,246), object(2,247), object(2,248), object(2,249), object(2,250), object(2,251), object(2,252), object(2,253), object(2,254), object(2,255), object(2,256), object(2,257), object(2,258), object(2,259), object(2,260), object(2,261), object(2,262), object(2,263), object(2,264), object(2,265), object(2,266), object(2,267), object(2,268), object(2,269), object(2,270), object(2,271), object(2,272), object(2,273), object(2,274), object(2,275), object(2,276), object(2,277), object(2,278), object(2,279), object(2,280), object(2,281), object(2,282), object(2,283), object(2,284), object(2,285), object(2,286), object(2,287), object(2,288), object(2,289), object(2,290), object(2,291), object(2,292), object(2,293), object(2,294), object(2,295), object(2,296), object(2,297), object(2,298), object(2,299), object(2,300), object(2,301), object(2,302), object(2,303), object(2,304), object(2,305), object(2,306), object(2,307), object(2,308), object(2,309), object(2,310), object(2,311), object(2,312), object(2,313), object(2,314), object(2,315), object(2,316), object(2,317), object(2,318), object(2,319), object(2,320), object(2,321), object(2,322), object(2,323), object(2,324), object(2,325), object(2,326), object(2,327), object(2,328), object(2,329), object(2,330), object(2,331), object(2,332), object(2,333), object(2,334), object(2,335), object(2,336), object(2,337), object(2,338), object(2,339), object(2,340), object(2,341), object(2,342), object(2,343), object(2,344), object(2,345), object(2,346), object(2,347), object(2,348), object(2,349), object(2,350), object(2,351), object(2,352), object(2,353), object(2,354), object(2,355), object(2,356), object(2,357), object(2,358), object(2,359), object(2,360), object(2,361), object(2,362), object(2,363), object(2,364), object(2,365), object(2,366), object(2,367), object(2,368), object(2,369), object(2,370), object(2,371), object(2,372), object(2,373), object(2,374), object(2,375), object(2,376), object(2,377), object(2,378), object(2,379), object(2,380), object(2,381), object(2,382), object(2,383), object(2,384), object(2,385), object(2,386), object(2,387), object(2,388), object(2,389), object(2,390), object(2,391), object(2,392), object(2,393), object(2,394), object(2,395), object(2,396), object(2,397), object(2,398), object(2,399), object(2,400), object(2,401), object(2,402), object(2,403), object(2,404), object(2,405), object(2,406), object(2,407), object(2,408), object(2,409), object(2,410), object(2,411), object(2,412), object(2,413), object(2,414), object(2,415), object(2,416), object(2,417), object(2,418), object(2,419), object(2,420), object(2,421), object(2,422), object(2,423), object(2,424), object(2,425), object(2,426), object(2,427), object(2,428), object(2,429), object(2,430), object(2,431), object(2,432), object(2,433), object(2,434), object(2,435), object(2,436), object(2,437), object(2,438), object(2,439), object(2,440), object(2,441), object(2,442), object(2,443), object(2,444), object(2,445), object(2,446), object(2,447), object(2,448), object(2,449), object(2,450), object(2,451), object(2,452), object(2,453), object(2,454), object(2,455), object(2,456), object(2,457), object(2,458), object(2,459), object(2,460), object(2,461), object(2,462), object(2,463), object(2,464), object(2,465), object(2,466), object(2,467), object(2,468), object(2,469), object(2,470), object(2,471), object(2,472), object(2,473), object(2,474), object(2,475), object(2,476), object(2,477), object(2,478), object(2,479), object(2,480), object(2,481), object(2,482), object(2,483), object(2,484), object(2,485), object(2,486), object(2,487), object(2,488), object(2,489), object(2,490), object(2,491), object(2,492), object(2,493), object(2,494), object(2,495), object(2,496), object(2,497), object(2,498), object(2,499), object(2,500), object(2,501), object(2,502), object(2,503), object(2,504), object(2,505), object(2,506), object(2,507), object(2,508), object(2,509), object(2,510), object(2,511), object(2,512), object(2,513), object(2,514), object(2,515), object(2,516), object(2,517), object(2,518), object(2,519), object(2,520), object(2,521), object(2,522), object(2,523), object(2,524), object(2,525), object(2,526), object(2,527), object(2,528), object(2,529), object(2,530), object(2,531), object(2,532), object(2,533), object(2,534), object(2,535), object(2,536), object(2,537), object(2,538), object(2,539), object(2,540), object(2,541), object(2,542), object(2,543), object(2,544), object(2,545), object(2,546), object(2,547), object(2,548), object(2,549), object(2,550), object(2,551), object(2,552), object(2,553), object(2,554), object(2,555), object(2,556), object(2,557), object(2,558), object(2,559), object(2,560), object(2,561), object(2,562), object(2,563), object(2,564), object(2,565), object(2,566), object(2,567), object(2,568), object(2,569), object(2,570), object(2,571), object(2,572), object(2,573), object(2,574), object(2,575), object(2,576), object(2,577), object(2,578), object(2,579), object(2,580), object(2,581), object(2,582), object(2,583), object(2,584), object(2,585), object(2,586), object(2,587), object(2,588), object(2,589), object(2,590), object(2,591), object(2,592), object(2,593), object(2,594), object(2,595), object(2,596), object(2,597), object(2,598), object(2,599), object(2,600), object(2,601), object(2,602), object(2,603), object(2,604), object(2,605), object(2,606), object(2,607), object(2,608), object(2,609), object(2,610), object(2,611), object(2,612), object(2,613), object(2,614), object(2,615), object(2,616), object(2,617), object(2,618), object(2,619), object(2,620), object(2,621), object(2,622), object(2,623), object(2,624), object(2,625), object(2,626), object(2,627), object(2,628), object(2,629), object(2,630), object(2,631), object(2,632), object(2,633), object(2,634), object(2,635), object(2,636), object(2,637), object(2,638), object(2,639), object(2,640), object(2,641), object(2,642), object(2,643), object(2,644), object(2,645), object(2,646), object(2,647), object(2,648), object(2,649), object(2,650), object(2,651), object(2,652), object(2,653), object(2,654), object(2,655), object(2,656), object(2,657), object(2,658), object(2,659), object(2,660), object(2,661), object(2,662), object(2,663), object(2,664), object(2,665), object(2,666), object(2,667), object(2,668), object(2,669), object(2,670), object(2,671), object(2,672), object(2,673), object(2,674), object(2,675), object(2,676), object(2,677), object(2,678), object(2,679), object(2,680), object(2,681), object(2,682), object(2,683), object(2,684), object(2,685), object(2,686), object(2,687), object(2,688), object(2,689), object(2,690), object(2,691), object(2,692), object(2,693), object(2,694), object(2,695), object(2,696), object(2,697), object(2,698), object(2,699), object(2,700), object(2,701), object(2,702), object(2,703), object(2,704), object(2,705), object(2,706), object(2,707), object(2,708), object(2,709), object(2,710), object(2,711), object(2,712), object(2,713), object(2,714), object(2,715), object(2,716), object(2,717), object(2,718), object(2,719), object(2,720), object(2,721), object(2,722), object(2,723), object(2,724), object(2,725), object(2,726), object(2,727), object(2,728), object(2,729), object(2,730), object(2,731), object(2,732), object(2,733), object(2,734), object(2,735), object(2,736), object(2,737), object(2,738), object(2,739), object(2,740), object(2,741), object(2,742), object(2,743), object(2,744), object(2,745), object(2,746), object(2,747), object(2,748), object(2,749), object(2,750), object(2,751), object(2,752), object(2,753), object(2,754), object(2,755), object(2,756), object(2,757), object(2,758), object(2,759), object(2,760), object(2,761), object(2,762), object(2,763), object(2,764), object(2,765), object(2,766), object(2,767), object(2,768), object(2,769), object(2,770), object(2,771), object(2,772), object(2,773), object(2,774), object(2,775), object(2,776), object(2,777), object(2,778), object(2,779), object(2,780), object(2,781), object(2,782), object(2,783), object(2,784), object(2,785), object(2,786), object(2,787), object(2,788), object(2,789), object(2,790), object(2,791), object(2,792), object(2,793), object(2,794), object(2,795), object(2,796), object(2,797), object(2,798), object(2,799), object(2,800), object(2,801), object(2,802), object(2,803), object(2,804), object(2,805), object(2,806), object(2,807), object(2,808), object(2,809), object(2,810), object(2,811), object(2,812), object(2,813), object(2,814), object(2,815), object(2,816), object(2,817), object(2,818), object(2,819), object(2,820), object(2,821), object(2,822), object(2,823), object(2,824), object(2,825), object(2,826), object(2,827), object(2,828), object(2,829), object(2,830), object(2,831), object(2,832), object(2,833), object(2,834), object(2,835), object(2,836), object(2,837), object(2,838), object(2,839), object(2,840), object(2,841), object(2,842), object(2,843), object(2,844), object(2,845), object(2,846), object(2,847), object(2,848), object(2,849), object(2,850), object(2,851), object(2,852), object(2,853), object(2,854), object(2,855), object(2,856), object(2,857), object(2,858), object(2,859), object(2,860), object(2,861), object(2,862), object(2,863), object(2,864), object(2,865), object(2,866), object(2,867), object(2,868), object(2,869), object(2,870), object(2,871), object(2,872), object(2,873), object(2,874), object(2,875), object(2,876), object(2,877), object(2,878), object(2,879), object(2,880), object(2,881), object(2,882), object(2,883), object(2,884), object(2,885), object(2,886), object(2,887), object(2,888), object(2,889), object(2,890), object(2,891), object(2,892), object(2,893), object(2,894), object(2,895), object(2,896), object(2,897), object(2,898), object(2,899), object(2,900), object(2,901), object(2,902), object(2,903), object(2,904), object(2,905), object(2,906), object(2,907), object(2,908), object(2,909), object(2,910), object(2,911), object(2,912), object(2,913), object(2,914), object(2,915), object(2,916), object(2,917), object(2,918), object(2,919), object(2,920), object(2,921), object(2,922), object(2,923), object(2,924), object(2,925), object(2,926), object(2,927), object(2,928), object(2,929), object(2,930), object(2,931), object(2,932), object(2,933), object(2,934), object(2,935), object(2,936), object(2,937), object(2,938), object(2,939), object(2,940), object(2,941), object(2,942), object(2,943), object(2,944), object(2,945), object(2,946), object(2,947), object(2,948), object(2,949), object(2,950), object(2,951), object(2,952), object(2,953), object(2,954), object(2,955), object(2,956), object(2,957), object(2,958), object(2,959), object(2,960), object(2,961), object(2,962), object(2,963), object(2,964), object(2,965), object(2,966), object(2,967), object(2,968), object(2,969), object(2,970), object(2,971), object(2,972), object(2,973), object(2,974), object(2,975), object(2,976), object(2,977), object(2,978), object(2,979), object(2,980), object(2,981), object(2,982), object(2,983), object(2,984), object(2,985), object(2,986), object(2,987), object(2,988), object(2,989), object(2,990), object(2,991), object(2,992), object(2,993), object(2,994), object(2,995), object(2,996), object(2,997), object(2,998), object(2,999)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1315788000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'create-checkpoint'. lines 43-43:
+Checkpoint created: 1
+
+task 4 'run-graphql'. lines 45-86:
+Response: {
+  "data": {
+    "last_2": {
+      "nodes": [
+        {
+          "version": 2,
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
+                "value": "505"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "version": 2,
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+                "value": "539"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "last_4_objs_owned_by_A": {
+      "objects": {
+        "nodes": [
+          {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xfd6cfc20d0c25df4ce2fc5f7c7c40a5b926a3a5ffac5e6bb071c7cd5f740d5b0",
+                "value": "211"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          },
+          {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff040fb82d647fef4c3075f05bbb14cab1e9771b88eb0b3afff94734ff00d1d9",
+                "value": "926"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          },
+          {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
+                "value": "505"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          },
+          {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+                "value": "539"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 5 'transfer-object'. lines 88-88:
+mutated: object(0,0), object(2,999)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 6 'transfer-object'. lines 90-90:
+mutated: object(0,0), object(2,998)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7 'transfer-object'. lines 92-92:
+mutated: object(0,0), object(2,997)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 8 'create-checkpoint'. lines 94-94:
+Checkpoint created: 2
+
+task 9 'run-graphql'. lines 96-138:
+Response: {
+  "data": {
+    "last_3": {
+      "nodes": [
+        {
+          "version": 5,
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff040fb82d647fef4c3075f05bbb14cab1e9771b88eb0b3afff94734ff00d1d9",
+                "value": "926"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "version": 4,
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff28e9e797521614a2501970adec06b34c01981efe48249385f049afa102fbb9",
+                "value": "505"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        },
+        {
+          "version": 3,
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+                "value": "539"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "last_obj_owned_by_A": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 2,
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xfd6cfc20d0c25df4ce2fc5f7c7c40a5b926a3a5ffac5e6bb071c7cd5f740d5b0",
+                "value": "211"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10 'run-graphql'. lines 140-216:
+Response: {
+  "data": {
+    "a": {
+      "asMoveObject": {
+        "owner": {
+          "owner": {
+            "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          }
+        },
+        "contents": {
+          "json": {
+            "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+            "value": "539"
+          },
+          "type": {
+            "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+          }
+        }
+      }
+    },
+    "b": {
+      "asMoveObject": {
+        "owner": {
+          "owner": {
+            "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+          }
+        },
+        "contents": {
+          "json": {
+            "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+            "value": "539"
+          },
+          "type": {
+            "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+          }
+        }
+      }
+    },
+    "objects_a": {
+      "nodes": [
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+                "value": "539"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "objects_b": {
+      "nodes": [
+        {
+          "asMoveObject": {
+            "owner": {
+              "owner": {
+                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+              }
+            },
+            "contents": {
+              "json": {
+                "id": "0xff92c4be9b1943d5a4d957ea956b2073437e82959747da5ff802881b887910ca",
+                "value": "539"
+              },
+              "type": {
+                "repr": "0x50ef24c509a74f2c42fa3de58b2d3b1d41518fefe286e0f734c9841b827ac0a7::M1::Object"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
@@ -1,0 +1,216 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Transfer 1000 objects to A. The first graphql query fetches the last 4 objects owned by A. Then
+// transfer the last 3 objects from A to B. Make a graphql query for the `last: 1` - this is to test
+// that we return the next valid result even if the first `limit` rows that match the filtering
+// criteria are then invalidated by a newer version of the matched object. We set `last: 1` but
+// transfer the last 3 objects because we increase the limit by 2 behind the scenes.
+
+//# init --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    struct Ledger has key, store {
+        id: UID,
+        object_ids: vector<UID>,
+    }
+
+    public entry fun create_many(recipient: address, ctx: &mut TxContext) {
+        let i = 0;
+        while (i < 1000) {
+            transfer::public_transfer(
+
+                Object { id: object::new(ctx), value: i },
+                recipient
+            );
+            i = i + 1;
+        }
+    }
+}
+
+//# run Test::M1::create_many --sender A --args @A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  last_2: objects(last: 2, filter: {type: "@{Test}"}) {
+    nodes {
+      version
+      asMoveObject {
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+  last_4_objs_owned_by_A: address(address: "@{A}") {
+    objects(last: 4) {
+      nodes {
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+}
+
+//# transfer-object 2,999 --sender A --recipient B
+
+//# transfer-object 2,998 --sender A --recipient B
+
+//# transfer-object 2,997 --sender A --recipient B
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  last_3: objects(last: 3, filter: {type: "@{Test}"}) {
+    nodes {
+      version
+      asMoveObject {
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+  last_obj_owned_by_A: address(address: "@{A}") {
+    objects(last: 1) {
+      nodes {
+        version
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Test that we correctly return the object at version, both for the `object` and `objects`
+# resolvers.
+{
+  a: object(address: "@{obj_2_999}", version: 2) {
+    asMoveObject {
+      owner {
+        ... on AddressOwner {
+          owner {
+            address
+          }
+        }
+      }
+      contents {
+        json
+        type {
+          repr
+        }
+      }
+    }
+  }
+  b: object(address: "@{obj_2_999}", version: 3) {
+    asMoveObject {
+      owner {
+        ... on AddressOwner {
+          owner {
+            address
+          }
+        }
+      }
+      contents {
+        json
+        type {
+          repr
+        }
+      }
+    }
+  }
+  objects_a: objects(filter: {objectKeys: {objectId: "@{obj_2_999}", version: 2}}) {
+    nodes {
+      asMoveObject {
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+  objects_b: objects(filter: {objectKeys: {objectId: "@{obj_2_999}", version: 3}}) {
+    nodes {
+      asMoveObject {
+        owner {
+          ... on AddressOwner {
+            owner {
+              address
+            }
+          }
+        }
+        contents {
+          json
+          type {
+            repr
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
@@ -40,7 +40,7 @@ module Test::M1 {
 
 //# run Test::M1::create_many --sender A --args @A
 
-//# create-checkpoint
+//# create-checkpoint 2
 
 //# run-graphql
 {

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -87,7 +87,7 @@ impl Checkpointed for JsonCursor<ConsistentNamedCursor> {
 /// is applied, otherwise if the `view` parameter is set to `Historical`, this filter is not
 /// applied.
 ///
-/// Finallly, the two queries are merged together with `UNION ALL`. We use `UNION ALL` instead of
+/// Finally, the two queries are merged together with `UNION ALL`. We use `UNION ALL` instead of
 /// `UNION`; the latter incurs significant overhead as it additionally de-duplicates records from
 /// both sources. This dedupe is unnecessary, since we have the fragment `SELECT DISTINCT ON
 /// (object_id) ... ORDER BY object_id, object_version DESC`. This is also redundant for the most

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -65,7 +65,8 @@ impl Checkpointed for JsonCursor<ConsistentNamedCursor> {
 /// `lhs` and `rhs`. If the `view` parameter is set to `Consistent`, the query additionally filters
 /// out objects that satisfy the provided filters, but are not the most recent version of the object
 /// within the checkpoint range. If the view parameter is set to `Historical`, this final filter is
-/// not applied.
+/// not applied. The query is a union of the results from `objects_snapshot` and `objects_history`
+/// to ensure that there are no gaps in the result set ordered by `object_id`.
 pub(crate) fn build_objects_query<F>(
     view: View,
     lhs: i64,

--- a/crates/sui-graphql-rpc/src/types/balance.rs
+++ b/crates/sui-graphql-rpc/src/types/balance.rs
@@ -211,7 +211,7 @@ fn balance_query(address: SuiAddress, coin_type: Option<TypeTag>, lhs: i64, rhs:
 
     // Combine the two queries, and select the most recent version of each object.
     let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) o"#,
         snapshot_objs,
         history_objs
     )

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -372,7 +372,15 @@ impl TryFrom<&MoveObject> for Coin {
 }
 
 fn coins_query(coin_type: TypeTag, owner: Option<SuiAddress>, lhs: i64, rhs: i64) -> RawQuery {
-    build_objects_query(View::Consistent, lhs, rhs, move |query| {
+    // Require a consistent view of objects if the owner is specified, to filter out object versions
+    // that satisfy the criteria, but have a later version in the same checkpoint.
+    let view = if owner.is_some() {
+        View::Consistent
+    } else {
+        View::Historical
+    };
+
+    build_objects_query(view, lhs, rhs, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -315,7 +315,7 @@ impl Coin {
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
                     rhs,
-                    coins_query(coin_type, owner, lhs as i64, rhs as i64),
+                    coins_query(coin_type, owner, lhs as i64, rhs as i64, &page),
                 )?;
 
                 Ok(Some((result, rhs)))
@@ -371,7 +371,13 @@ impl TryFrom<&MoveObject> for Coin {
     }
 }
 
-fn coins_query(coin_type: TypeTag, owner: Option<SuiAddress>, lhs: i64, rhs: i64) -> RawQuery {
+fn coins_query(
+    coin_type: TypeTag,
+    owner: Option<SuiAddress>,
+    lhs: i64,
+    rhs: i64,
+    page: &Page<object::Cursor>,
+) -> RawQuery {
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
     let view = if owner.is_some() {
@@ -380,7 +386,7 @@ fn coins_query(coin_type: TypeTag, owner: Option<SuiAddress>, lhs: i64, rhs: i64
         View::Historical
     };
 
-    build_objects_query(view, lhs, rhs, move |query| {
+    build_objects_query(view, lhs, rhs, &page, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -371,9 +371,9 @@ impl TryFrom<&MoveObject> for Coin {
     }
 }
 
-/// Constructs a raw query to fetch objects from the database. The `page`'s limit and cursor are
-/// applied to reduce the number of rows to be fetched. Objects are filtered out if they satisfy the
-/// criteria but have a later version in the same checkpoint.
+/// Constructs a raw query to fetch objects from the database. Since there are no point lookups for
+/// the coin query, objects are filtered out if they satisfy the criteria but have a later version
+/// in the same checkpoint.
 fn coins_query(
     coin_type: TypeTag,
     owner: Option<SuiAddress>,

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::consistency::{build_objects_query, build_objects_query_v2, consistent_range, View};
+use crate::consistency::{build_objects_query, consistent_range, View};
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
 use crate::filter;
@@ -381,7 +381,7 @@ fn coins_query(
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
 
-    build_objects_query_v2(View::Consistent, lhs, rhs, &page, move |query| {
+    build_objects_query(View::Consistent, lhs, rhs, &page, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -381,7 +381,7 @@ fn coins_query(
     rhs: i64,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
-    build_objects_query(View::Consistent, lhs, rhs, &page, move |query| {
+    build_objects_query(View::Consistent, lhs, rhs, page, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -380,13 +380,8 @@ fn coins_query(
 ) -> RawQuery {
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
-    let view = if owner.is_some() {
-        View::Consistent
-    } else {
-        View::Historical
-    };
 
-    build_objects_query_v2(lhs, rhs, &page, move |query| {
+    build_objects_query_v2(View::Consistent, lhs, rhs, &page, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -371,6 +371,9 @@ impl TryFrom<&MoveObject> for Coin {
     }
 }
 
+/// Constructs a raw query to fetch objects from the database. The `page`'s limit and cursor are
+/// applied to reduce the number of rows to be fetched. Objects are filtered out if they satisfy the
+/// criteria but have a later version in the same checkpoint.
 fn coins_query(
     coin_type: TypeTag,
     owner: Option<SuiAddress>,
@@ -378,9 +381,6 @@ fn coins_query(
     rhs: i64,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
-    // Require a consistent view of objects if the owner is specified, to filter out object versions
-    // that satisfy the criteria, but have a later version in the same checkpoint.
-
     build_objects_query(View::Consistent, lhs, rhs, &page, move |query| {
         apply_filter(query, &coin_type, owner)
     })

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::consistency::{build_objects_query, consistent_range, View};
+use crate::consistency::{build_objects_query, build_objects_query_v2, consistent_range, View};
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
 use crate::filter;
@@ -386,7 +386,7 @@ fn coins_query(
         View::Historical
     };
 
-    build_objects_query(view, lhs, rhs, &page, move |query| {
+    build_objects_query_v2(lhs, rhs, &page, move |query| {
         apply_filter(query, &coin_type, owner)
     })
 }

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -328,18 +328,7 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         T: Send + RawPaginated<C> + FromSqlRow<Untyped, DieselBackend> + 'static,
     {
         let new_query = move || {
-            let mut query = query.clone();
-            if let Some(after) = self.after() {
-                query = T::filter_ge(after, query);
-            }
-
-            if let Some(before) = self.before() {
-                query = T::filter_le(before, query);
-            }
-
-            query = T::order(self.is_from_front(), query);
-
-            query = query.limit(self.limit() as i64 + 2);
+            let query = self.yeet::<T>(query.clone());
             query.into_boxed()
         };
 
@@ -444,6 +433,23 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         }
 
         (prev, next, results)
+    }
+
+    pub(crate) fn yeet<T>(&self, mut query: RawQuery) -> RawQuery
+    where
+        T: RawPaginated<C>,
+    {
+        if let Some(after) = self.after() {
+            query = T::filter_ge(after, query);
+        }
+
+        if let Some(before) = self.before() {
+            query = T::filter_le(before, query);
+        }
+
+        query = T::order(self.is_from_front(), query);
+
+        query.limit(self.limit() as i64 + 2)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/cursor.rs
+++ b/crates/sui-graphql-rpc/src/types/cursor.rs
@@ -328,7 +328,7 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         T: Send + RawPaginated<C> + FromSqlRow<Untyped, DieselBackend> + 'static,
     {
         let new_query = move || {
-            let query = self.yeet::<T>(query.clone());
+            let query = self.apply::<T>(query.clone());
             query.into_boxed()
         };
 
@@ -435,7 +435,7 @@ impl<C: CursorType + Eq + Clone + Send + Sync + 'static> Page<C> {
         (prev, next, results)
     }
 
-    pub(crate) fn yeet<T>(&self, mut query: RawQuery) -> RawQuery
+    pub(crate) fn apply<T>(&self, mut query: RawQuery) -> RawQuery
     where
         T: RawPaginated<C>,
     {

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -345,7 +345,7 @@ fn dynamic_fields_query(
 
     // Combine the two queries, and select the most recent version of each object.
     let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ({})) o"#,
+        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) o"#,
         snapshot_objs,
         history_objs
     )

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -22,8 +22,7 @@ use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
-use crate::consistency::{build_objects_query, consistent_range, View};
-use crate::consistency::{build_objects_query_v2, Checkpointed};
+use crate::consistency::{build_objects_query, consistent_range, Checkpointed, View};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
@@ -1371,7 +1370,7 @@ where
     };
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
-    build_objects_query_v2(view, lhs, rhs, &page, move |query| filter.apply(query))
+    build_objects_query(view, lhs, rhs, &page, move |query| filter.apply(query))
 }
 
 #[cfg(test)]

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -755,7 +755,7 @@ impl Object {
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
                     rhs,
-                    objects_query::<StoredHistoryObject>(&filter, lhs as i64, rhs as i64, &page),
+                    objects_query(&filter, lhs as i64, rhs as i64, &page),
                 )?;
 
                 Ok(Some((result, rhs)))
@@ -1213,13 +1213,6 @@ impl ObjectFilter {
 
         query
     }
-
-    pub(crate) fn has_filter(&self) -> bool {
-        self.object_ids.is_some()
-            || self.object_keys.is_some()
-            || self.owner.is_some()
-            || self.type_.is_some()
-    }
 }
 
 impl HistoricalObjectCursor {
@@ -1368,9 +1361,8 @@ pub(crate) async fn deserialize_move_struct(
 /// Constructs a raw query to fetch objects from the database. If an `owner` is provided as a filter,  filters are provided, the page
 /// limit and cursor are used to "filter" the inner queries against `objects_snapshot` and
 /// `objects_history` to reduce the number of rows to be fetched.
-fn objects_query<T>(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
+fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
-    T: RawPaginated<Cursor>,
 {
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
@@ -1380,25 +1372,7 @@ where
         View::Historical
     };
 
-    build_objects_query(view, lhs, rhs, move |mut query| {
-        let has_filter = filter.has_filter();
-        query = filter.apply(query);
-
-        if let View::Historical = view {
-            if let Some(after) = page.after() {
-                query = T::filter_ge(after, query);
-            }
-
-            if let Some(before) = page.before() {
-                query = T::filter_le(before, query);
-            }
-
-            query = T::order(page.is_from_front(), query);
-
-            query = query.limit(page.limit() as i64 + 2);
-        }
-        query
-    })
+    build_objects_query(view, lhs, rhs, &page, move |query| filter.apply(query))
 }
 
 #[cfg(test)]

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1357,9 +1357,10 @@ pub(crate) async fn deserialize_move_struct(
     Ok((struct_tag, move_struct))
 }
 
-/// Constructs a raw query to fetch objects from the database. If an `owner` is provided as a
-/// filter,  filters are provided, the page limit and cursor are used to "filter" the inner queries
-/// against `objects_snapshot` and `objects_history` to reduce the number of rows to be fetched.
+/// Constructs a raw query to fetch objects from the database. The `page`'s limit and cursor are
+/// applied to reduce the number of rows to be fetched. Objects are filtered out if they satisfy the
+/// criteria but have a later version in the same checkpoint. If object keys are provided, then this
+/// filter is not applied.
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
 {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1214,10 +1214,7 @@ impl ObjectFilter {
     }
 
     pub(crate) fn has_filters(&self) -> bool {
-        self.type_.is_some()
-            || self.owner.is_some()
-            || self.object_ids.is_some()
-            || self.object_keys.is_some()
+        self != &Default::default()
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1364,9 +1364,14 @@ pub(crate) async fn deserialize_move_struct(
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
 {
+    let view = if filter.object_keys.is_some() {
+        View::Historical
+    } else {
+        View::Consistent
+    };
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
-    build_objects_query_v2(lhs, rhs, &page, move |query| filter.apply(query))
+    build_objects_query_v2(view, lhs, rhs, &page, move |query| filter.apply(query))
 }
 
 #[cfg(test)]

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -22,8 +22,8 @@ use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
 use super::{owner::Owner, sui_address::SuiAddress, transaction_block::TransactionBlock};
-use crate::consistency::Checkpointed;
 use crate::consistency::{build_objects_query, consistent_range, View};
+use crate::consistency::{build_objects_query_v2, Checkpointed};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{self, Db, DbConnection, QueryExecutor};
 use crate::error::Error;
@@ -1366,13 +1366,7 @@ where
 {
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
-    let view = if filter.owner.is_some() {
-        View::Consistent
-    } else {
-        View::Historical
-    };
-
-    build_objects_query(view, lhs, rhs, &page, move |query| filter.apply(query))
+    build_objects_query_v2(lhs, rhs, &page, move |query| filter.apply(query))
 }
 
 #[cfg(test)]

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1357,9 +1357,9 @@ pub(crate) async fn deserialize_move_struct(
     Ok((struct_tag, move_struct))
 }
 
-/// Constructs a raw query to fetch objects from the database. If an `owner` is provided as a filter,  filters are provided, the page
-/// limit and cursor are used to "filter" the inner queries against `objects_snapshot` and
-/// `objects_history` to reduce the number of rows to be fetched.
+/// Constructs a raw query to fetch objects from the database. If an `owner` is provided as a
+/// filter,  filters are provided, the page limit and cursor are used to "filter" the inner queries
+/// against `objects_snapshot` and `objects_history` to reduce the number of rows to be fetched.
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
 {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1371,7 +1371,7 @@ where
     };
     // Require a consistent view of objects if the owner is specified, to filter out object versions
     // that satisfy the criteria, but have a later version in the same checkpoint.
-    build_objects_query(view, lhs, rhs, &page, move |query| filter.apply(query))
+    build_objects_query(view, lhs, rhs, page, move |query| filter.apply(query))
 }
 
 #[cfg(test)]

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1212,6 +1212,13 @@ impl ObjectFilter {
 
         query
     }
+
+    pub(crate) fn has_filters(&self) -> bool {
+        self.type_.is_some()
+            || self.owner.is_some()
+            || self.object_ids.is_some()
+            || self.object_keys.is_some()
+    }
 }
 
 impl HistoricalObjectCursor {
@@ -1364,7 +1371,7 @@ pub(crate) async fn deserialize_move_struct(
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
 {
-    let view = if filter.object_keys.is_some() {
+    let view = if filter.object_keys.is_some() || !filter.has_filters() {
         View::Historical
     } else {
         View::Consistent

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1364,10 +1364,9 @@ pub(crate) async fn deserialize_move_struct(
     Ok((struct_tag, move_struct))
 }
 
-/// Constructs a raw query to fetch objects from the database. The `page`'s limit and cursor are
-/// applied to reduce the number of rows to be fetched. Objects are filtered out if they satisfy the
-/// criteria but have a later version in the same checkpoint. If object keys are provided, then this
-/// filter is not applied.
+/// Constructs a raw query to fetch objects from the database. Objects are filtered out if they
+/// satisfy the criteria but have a later version in the same checkpoint. If object keys are
+/// provided, or no filters are specified at all, then this final condition is not applied.
 fn objects_query(filter: &ObjectFilter, lhs: i64, rhs: i64, page: &Page<Cursor>) -> RawQuery
 where
 {
@@ -1376,8 +1375,7 @@ where
     } else {
         View::Consistent
     };
-    // Require a consistent view of objects if the owner is specified, to filter out object versions
-    // that satisfy the criteria, but have a later version in the same checkpoint.
+
     build_objects_query(view, lhs, rhs, page, move |query| filter.apply(query))
 }
 

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -130,7 +130,7 @@ impl TypeFilter {
                 let generic_pattern =
                     format!("{}<%", tag.to_canonical_display(/* with_prefix */ true));
 
-                let statement = field.to_string() + " = {} OR " + field + " LIKE {}";
+                let statement = format!("({}", field) + " = {} OR " + field + " LIKE {})";
 
                 query = filter!(query, statement, exact_pattern, generic_pattern);
             }

--- a/crates/sui-graphql-rpc/src/types/type_filter.rs
+++ b/crates/sui-graphql-rpc/src/types/type_filter.rs
@@ -130,7 +130,7 @@ impl TypeFilter {
                 let generic_pattern =
                     format!("{}<%", tag.to_canonical_display(/* with_prefix */ true));
 
-                let statement = format!("({}", field) + " = {} OR " + field + " LIKE {})";
+                let statement = format!("({field} = {{}} OR {field} LIKE {{}})");
 
                 query = filter!(query, statement, exact_pattern, generic_pattern);
             }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -582,7 +582,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 let cluster = self.cluster.as_ref().unwrap();
                 let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
                 cluster
-                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(30))
+                    .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
                     .await;
 
                 cluster


### PR DESCRIPTION
## Description 

Today the consistent objects query is the union of filters applied to the `objects_snapshot` and `objects_history` table. This set of candidates is then `LEFT JOIN`ed against the `objects_history` table again to filter out yet more recent versions of objects that match the criteria. The left hand side grows ever-larger as `objects_snapshot` gets updated, so to limit the number of rows read, we push the `LEFT JOIN` down into the inner queries, essentially treating it as a filter. 

## Test Plan 

performance/many_objects.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
