### PR TITLE
[move-2024] Switch Move transactional tests in Sui to use move2024

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/call/simple.move
+++ b/crates/sui-adapter-transactional-tests/tests/call/simple.move
@@ -10,7 +10,7 @@ module Test::M1 {
     use sui::transfer;
     use sui::coin::Coin;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.move
@@ -12,17 +12,17 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key {
+    public struct R has key {
         id: sui::object::UID,
         s: S,
     }
 
     public entry fun test_wrap(ctx: &mut TxContext) {
-        let id = sui::object::new(ctx);
+        let mut id = sui::object::new(ctx);
         let child = S { id: sui::object::new(ctx) };
         ofield::add(&mut id, 0, child);
         let parent = S { id };

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.move
@@ -12,7 +12,7 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.move
@@ -13,11 +13,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }
@@ -57,7 +57,7 @@ module test::m {
         sui::transfer::public_transfer(r, tx_context::sender(ctx))
     }
 
-    public entry fun remove_and_delete(s: S, idx: u64) {
+    public entry fun remove_and_delete(mut s: S, idx: u64) {
         let S { id } = ofield::remove(&mut s.id, idx);
         sui::object::delete(id);
         let S { id } = s;

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.move
@@ -13,11 +13,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }
@@ -57,7 +57,7 @@ module test::m {
         sui::transfer::public_transfer(r, tx_context::sender(ctx))
     }
 
-    public entry fun remove_and_freeze(s: S, idx: u64) {
+    public entry fun remove_and_freeze(mut s: S, idx: u64) {
         let S { id } = ofield::remove(&mut s.id, idx);
         sui::object::delete(id);
         sui::transfer::public_freeze_object(s)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.move
@@ -12,24 +12,24 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }
 
     public entry fun mint(ctx: &mut TxContext) {
-        let id = sui::object::new(ctx);
+        let mut id = sui::object::new(ctx);
         let child = S { id: sui::object::new(ctx) };
         ofield::add(&mut id, 0, child);
         sui::transfer::public_transfer(S { id }, tx_context::sender(ctx))
     }
 
     public entry fun mint_and_share(ctx: &mut TxContext) {
-        let id = sui::object::new(ctx);
+        let mut id = sui::object::new(ctx);
         let child = S { id: sui::object::new(ctx) };
         ofield::add(&mut id, 0, child);
         sui::transfer::public_share_object(S { id })

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.move
@@ -13,17 +13,17 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key, store {
+    public struct R has key, store {
         id: sui::object::UID,
         s: S,
     }
 
     public entry fun share(ctx: &mut TxContext) {
-        let id = sui::object::new(ctx);
+        let mut id = sui::object::new(ctx);
         let child = S { id: sui::object::new(ctx) };
         ofield::add(&mut id, 0, child);
         sui::transfer::public_share_object(S { id })

--- a/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.move
@@ -11,12 +11,12 @@
 module test::m {
     use sui::tx_context::TxContext;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
     public entry fun t(ctx: &mut TxContext) {
-        let parent = sui::object::new(ctx);
+        let mut parent = sui::object::new(ctx);
         let child = S { id: sui::object::new(ctx) };
         sui::dynamic_object_field::add(&mut parent, 0, child);
         sui::object::delete(parent);

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.move
@@ -11,11 +11,11 @@
 module test::m {
     use sui::tx_context::{Self, TxContext};
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key {
+    public struct R has key {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.move
@@ -11,11 +11,11 @@
 module test::m {
     use sui::tx_context::{Self, TxContext};
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key {
+    public struct R has key {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: sui::object::UID,
     }
 
-    struct R has key {
+    public struct R has key {
         id: sui::object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
@@ -10,7 +10,7 @@ module t3::o3 {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Obj3 has key, store {
+    public struct Obj3 has key, store {
         id: UID,
     }
 
@@ -28,7 +28,7 @@ module t2::o2 {
     use sui::tx_context::{Self, TxContext};
     use t3::o3::Obj3;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 
@@ -45,7 +45,7 @@ module t2::o2 {
     }
 
     fun new(child: Obj3, ctx: &mut TxContext): Obj2 {
-        let id = object::new(ctx);
+        let mut id = object::new(ctx);
         sui::dynamic_object_field::add(&mut id, 0, child);
         Obj2 { id }
     }
@@ -61,7 +61,7 @@ module t1::o1 {
     use t2::o2::Obj2;
     use t3::o3::Obj3;
 
-    struct Obj1 has key {
+    public struct Obj1 has key {
         id: UID,
     }
 
@@ -75,7 +75,7 @@ module t1::o1 {
     }
 
     fun new(child: Obj2, ctx: &mut TxContext): Obj1 {
-        let id = object::new(ctx);
+        let mut id = object::new(ctx);
         sui::dynamic_object_field::add(&mut id, 0, child);
         Obj1 { id }
     }

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_and_undeny.move
@@ -17,10 +17,10 @@ module test::regulated_coin {
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
-    struct REGULATED_COIN has drop {}
+    public struct REGULATED_COIN has drop {}
 
     fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
-        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
             otw,
             9,
             b"RC",

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_multiple_per_module.move
@@ -14,10 +14,10 @@ module test::first_coin {
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
-    struct FIRST_COIN has drop {}
+    public struct FIRST_COIN has drop {}
 
     fun init(otw: FIRST_COIN, ctx: &mut TxContext) {
-        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
             otw,
             9,
             b"RC",
@@ -41,10 +41,10 @@ module test::second_coin {
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
-    struct SECOND_COIN has drop {}
+    public struct SECOND_COIN has drop {}
 
     fun init(otw: SECOND_COIN, ctx: &mut TxContext) {
-        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
             otw,
             9,
             b"RC",

--- a/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list/coin_deny_tto.move
@@ -17,14 +17,14 @@ module test::regulated_coin {
     use sui::tx_context;
     use sui::tx_context::TxContext;
 
-    struct REGULATED_COIN has drop {}
+    public struct REGULATED_COIN has drop {}
 
-    struct Wallet has key {
+    public struct Wallet has key {
         id: UID,
     }
 
     fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
-        let (treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency(
             otw,
             9,
             b"RC",

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/load_old_object.move
@@ -11,7 +11,7 @@ module test::m {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         value: u64
     }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.move
@@ -13,12 +13,12 @@ use sui::dynamic_field::add;
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key {
+public struct Obj has key {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add<u64, u64>(&mut id, 0, 0);
     sui::transfer::transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.move
@@ -14,12 +14,12 @@ use sui::dynamic_object_field::add;
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add(&mut id, 0, Obj { id: object::new(ctx) });
     sui::transfer::public_transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.move
@@ -13,12 +13,12 @@ use sui::dynamic_field::{add, borrow, borrow_mut};
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key {
+public struct Obj has key {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add<u64, u64>(&mut id, 0, 0);
     sui::transfer::transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.move
@@ -14,16 +14,16 @@ use sui::dynamic_object_field::{add, borrow, borrow_mut};
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: object::UID,
 }
 
-struct Fake has key, store {
+public struct Fake has key, store {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add(&mut id, 0, Obj { id: object::new(ctx) });
     sui::transfer::public_transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.move
@@ -11,16 +11,16 @@ module test::m {
     use sui::transfer;
     use sui::dynamic_object_field as ofield;
 
-    struct Outer has key {
+    public struct Outer has key {
         id: UID,
         inner: Inner,
     }
 
-    struct Inner has key, store {
+    public struct Inner has key, store {
         id: UID,
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
         value: u64,
     }
@@ -44,7 +44,7 @@ module test::m {
     }
 
     public fun buy(parent: &mut Outer, ctx: &mut TxContext) {
-        let new_parent = new_parent(ctx);
+        let mut new_parent = new_parent(ctx);
         swap(parent, &mut new_parent);
         give(&mut new_parent, tx_context::sender(ctx));
         transfer::share_object(new_parent)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-79:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12395600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 81-81:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.move
@@ -13,7 +13,7 @@ use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key {
+public struct Obj has key {
     id: object::UID,
 }
 

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.move
@@ -14,11 +14,11 @@ use sui::dynamic_object_field::{add, exists_, borrow, borrow_mut, remove};
 use sui::object::{Self, UID};
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: UID,
 }
 
-struct Counter has key, store {
+public struct Counter has key, store {
     id: UID,
     count: u64,
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.move
@@ -13,12 +13,12 @@ use sui::dynamic_field::{add, borrow};
 use sui::object;
 use sui::tx_context::TxContext;
 
-struct Obj has key {
+public struct Obj has key {
     id: object::UID,
 }
 
 entry fun add_then_freeze(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add<u64, u64>(&mut id, 0, 0);
     sui::transfer::freeze_object(Obj { id })
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/receive_remove_add_back_and_remove_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/receive_remove_add_back_and_remove_type.move
@@ -14,19 +14,19 @@ module test::m1 {
     use sui::transfer::{Self, Receiving};
     use sui::tx_context::{Self, TxContext};
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
     }
 
-    struct C1 has key, store {
+    public struct C1 has key, store {
         id: UID,
     }
 
-    struct C2 has key, store {
+    public struct C2 has key, store {
         id: UID,
     }
 
-    struct Wrapper<T: store> has key, store {
+    public struct Wrapper<T: store> has key, store {
         id: UID, 
         value: T,
     }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove.move
@@ -15,12 +15,12 @@ module test::m1 {
     use sui::tx_context::{Self, TxContext};
     use std::option::{Self, Option};
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         wrapped: Option<Child>,
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_add_back_and_remove_type.move
@@ -14,15 +14,15 @@ module test::m1 {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
     }
 
-    struct C1 has key, store {
+    public struct C1 has key, store {
         id: UID,
     }
 
-    struct C2 has key, store {
+    public struct C2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.move
@@ -13,12 +13,12 @@ use sui::dynamic_field::{add, remove};
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key {
+public struct Obj has key {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add<u64, u64>(&mut id, 0, 0);
     sui::transfer::transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.move
@@ -14,16 +14,16 @@ use sui::dynamic_object_field::{add, remove};
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: object::UID,
 }
 
-struct Fake has key, store {
+public struct Fake has key, store {
     id: object::UID,
 }
 
 entry fun t1(ctx: &mut TxContext) {
-    let id = object::new(ctx);
+    let mut id = object::new(ctx);
     add(&mut id, 0, Obj { id: object::new(ctx) });
     sui::transfer::public_transfer(Obj { id }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.move
@@ -13,16 +13,16 @@ module test::m {
     use sui::transfer;
     use sui::dynamic_object_field as ofield;
 
-    struct Outer has key {
+    public struct Outer has key {
         id: UID,
         inner: Inner,
     }
 
-    struct Inner has key, store {
+    public struct Inner has key, store {
         id: UID,
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
         value: u64,
     }
@@ -46,7 +46,7 @@ module test::m {
     }
 
     public fun buy(parent: &mut Outer, ctx: &mut TxContext) {
-        let new_parent = new_parent(ctx);
+        let mut new_parent = new_parent(ctx);
         swap(parent, &mut new_parent);
         give(&mut new_parent, tx_context::sender(ctx));
         transfer::share_object(new_parent)
@@ -65,7 +65,7 @@ module test::m {
     public fun make_dynamic_remove_and_then_share(ctx: &mut TxContext): Outer {
         let child = Child { id: object::new(ctx), value: 0 };
 
-        let parent = new_parent(ctx);
+        let mut parent = new_parent(ctx);
 
         add_field(&mut parent, child);
         let c: Child = ofield::remove(&mut parent.id, 0u64);

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.move
@@ -14,11 +14,11 @@ use sui::dynamic_object_field::{add, borrow, borrow_mut, remove};
 use sui::object::{Self, UID};
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: UID,
 }
 
-struct Counter has key, store {
+public struct Counter has key, store {
     id: UID,
     count: u64,
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.move
@@ -13,12 +13,12 @@ use sui::dynamic_object_field;
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: object::UID,
 }
 
 entry fun mint(ctx: &mut TxContext) {
-    let parent = object::new(ctx);
+    let mut parent = object::new(ctx);
     dynamic_field::add(&mut parent, 0, Obj { id: object::new(ctx) });
     sui::transfer::public_transfer(Obj { id: parent }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.move
@@ -13,12 +13,12 @@ use sui::dynamic_object_field;
 use sui::object;
 use sui::tx_context::{sender, TxContext};
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: object::UID,
 }
 
 entry fun mint(ctx: &mut TxContext) {
-    let parent = object::new(ctx);
+    let mut parent = object::new(ctx);
     dynamic_object_field::add(&mut parent, 0, Obj { id: object::new(ctx) });
     sui::transfer::public_transfer(Obj { id: parent }, sender(ctx))
 }

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.move
@@ -14,16 +14,16 @@ use sui::dynamic_field::{add, exists_, borrow, borrow_mut};
 use sui::object::{Self, UID};
 use sui::tx_context::{sender, TxContext};
 
-struct Wrapper has key {
+public struct Wrapper has key {
     id: UID,
     old: UID,
 }
 
-struct Obj has key, store {
+public struct Obj has key, store {
     id: UID,
 }
 
-struct Counter has key, store {
+public struct Counter has key, store {
     id: UID,
     count: u64,
 }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.move
@@ -14,8 +14,8 @@ module Test::M {
         assert!(ascii::length(&s) == 10, 0);
     }
 
-    public entry fun ascii_vec_arg(v: vector<ascii::String>, _: &mut TxContext) {
-        let l = 0;
+    public entry fun ascii_vec_arg(mut v: vector<ascii::String>, _: &mut TxContext) {
+        let mut l = 0;
         while (!vector::is_empty(&v)) {
             let s = vector::pop_back(&mut v);
             l = l + ascii::length(&s)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.move
@@ -6,7 +6,7 @@
 //# publish
 module Test::M {
     use sui::tx_context::{Self, TxContext};
-    struct Obj has key {
+    public struct Obj has key {
         id: sui::object::UID,
         value: u64
     }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.move
@@ -8,7 +8,7 @@
 //# publish
 module test::m {
 
-struct S<phantom T: copy> {}
+public struct S<phantom T: copy> {}
 
 entry fun foo<T>() {}
 

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.move
@@ -6,7 +6,7 @@
 //# publish
 module Test::M {
     use sui::tx_context::{Self, TxContext};
-    struct Obj has key {
+    public struct Obj has key {
         id: sui::object::UID,
         value: u64
     }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
@@ -12,12 +12,12 @@ module Test::M {
     use sui::tx_context::{Self, TxContext};
     use std::vector;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64
     }
 
-    struct AnotherObj has key {
+    public struct AnotherObj has key {
         id: UID,
         value: u64
     }
@@ -65,7 +65,7 @@ module Test::M {
         assert!(vector::length(&v) == 2, 0);
     }
 
-    public entry fun obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+    public entry fun obj_vec_destroy(mut v: vector<Obj>, _: &mut TxContext) {
         assert!(vector::length(&v) == 1, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -73,7 +73,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun two_obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+    public entry fun two_obj_vec_destroy(mut v: vector<Obj>, _: &mut TxContext) {
         assert!(vector::length(&v) == 2, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -84,7 +84,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects(o: Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun same_objects(o: Obj, mut v: vector<Obj>, _: &mut TxContext) {
         let Obj {id, value} = o;
         assert!(value == 42, 0);
         object::delete(id);
@@ -94,14 +94,14 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_ref(o: &Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun same_objects_ref(o: &Obj, mut v: vector<Obj>, _: &mut TxContext) {
         assert!(o.value == 42, 0);
         let Obj {id, value: _} = vector::pop_back(&mut v);
         object::delete(id);
         vector::destroy_empty(v);
     }
 
-    public entry fun child_access(child: Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun child_access(child: Obj, mut v: vector<Obj>, _: &mut TxContext) {
         let Obj {id, value} = child;
         assert!(value == 42, 0);
         object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
@@ -12,17 +12,17 @@ module Test::M {
     use sui::tx_context::{Self, TxContext};
     use std::vector;
 
-    struct ObjAny<phantom Any> has key, store {
+    public struct ObjAny<phantom Any> has key, store {
         id: UID,
         value: u64
     }
 
-    struct AnotherObjAny<phantom Any> has key {
+    public struct AnotherObjAny<phantom Any> has key {
         id: UID,
         value: u64
     }
 
-    struct Any {}
+    public struct Any {}
 
     public entry fun mint_any<Any>(v: u64, ctx: &mut TxContext) {
         transfer::public_transfer(
@@ -64,7 +64,7 @@ module Test::M {
         )
     }
 
-    public entry fun obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun obj_vec_destroy_any<Any>(mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(vector::length(&v) == 1, 0);
         let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -72,7 +72,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun two_obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun two_obj_vec_destroy_any<Any>(mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(vector::length(&v) == 2, 0);
         let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -83,7 +83,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_any<Any>(o: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun same_objects_any<Any>(o: ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         let ObjAny<Any> {id, value} = o;
         assert!(value == 42, 0);
         object::delete(id);
@@ -93,14 +93,14 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(o.value == 42, 0);
         let ObjAny<Any> {id, value: _} = vector::pop_back(&mut v);
         object::delete(id);
         vector::destroy_empty(v);
     }
 
-    public entry fun child_access_any<Any>(child: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun child_access_any<Any>(child: ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         let ObjAny<Any> {id, value} = child;
         assert!(value == 42, 0);
         object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic_v20.move
@@ -12,17 +12,17 @@ module Test::M {
     use sui::tx_context::{Self, TxContext};
     use std::vector;
 
-    struct ObjAny<phantom Any> has key, store {
+    public struct ObjAny<phantom Any> has key, store {
         id: UID,
         value: u64
     }
 
-    struct AnotherObjAny<phantom Any> has key {
+    public struct AnotherObjAny<phantom Any> has key {
         id: UID,
         value: u64
     }
 
-    struct Any {}
+    public struct Any {}
 
     public entry fun mint_any<Any>(v: u64, ctx: &mut TxContext) {
         transfer::public_transfer(
@@ -64,7 +64,7 @@ module Test::M {
         )
     }
 
-    public entry fun obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun obj_vec_destroy_any<Any>(mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(vector::length(&v) == 1, 0);
         let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -72,7 +72,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun two_obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun two_obj_vec_destroy_any<Any>(mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(vector::length(&v) == 2, 0);
         let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -83,7 +83,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_any<Any>(o: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun same_objects_any<Any>(o: ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         let ObjAny<Any> {id, value} = o;
         assert!(value == 42, 0);
         object::delete(id);
@@ -93,14 +93,14 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         assert!(o.value == 42, 0);
         let ObjAny<Any> {id, value: _} = vector::pop_back(&mut v);
         object::delete(id);
         vector::destroy_empty(v);
     }
 
-    public entry fun child_access_any<Any>(child: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+    public entry fun child_access_any<Any>(child: ObjAny<Any>, mut v: vector<ObjAny<Any>>, _: &mut TxContext) {
         let ObjAny<Any> {id, value} = child;
         assert!(value == 42, 0);
         object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_v20.move
@@ -12,12 +12,12 @@ module Test::M {
     use sui::tx_context::{Self, TxContext};
     use std::vector;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64
     }
 
-    struct AnotherObj has key {
+    public struct AnotherObj has key {
         id: UID,
         value: u64
     }
@@ -65,7 +65,7 @@ module Test::M {
         assert!(vector::length(&v) == 2, 0);
     }
 
-    public entry fun obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+    public entry fun obj_vec_destroy(mut v: vector<Obj>, _: &mut TxContext) {
         assert!(vector::length(&v) == 1, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -73,7 +73,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun two_obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+    public entry fun two_obj_vec_destroy(mut v: vector<Obj>, _: &mut TxContext) {
         assert!(vector::length(&v) == 2, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
@@ -84,7 +84,7 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects(o: Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun same_objects(o: Obj, mut v: vector<Obj>, _: &mut TxContext) {
         let Obj {id, value} = o;
         assert!(value == 42, 0);
         object::delete(id);
@@ -94,14 +94,14 @@ module Test::M {
         vector::destroy_empty(v);
     }
 
-    public entry fun same_objects_ref(o: &Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun same_objects_ref(o: &Obj, mut v: vector<Obj>, _: &mut TxContext) {
         assert!(o.value == 42, 0);
         let Obj {id, value: _} = vector::pop_back(&mut v);
         object::delete(id);
         vector::destroy_empty(v);
     }
 
-    public entry fun child_access(child: Obj, v: vector<Obj>, _: &mut TxContext) {
+    public entry fun child_access(child: Obj, mut v: vector<Obj>, _: &mut TxContext) {
         let Obj {id, value} = child;
         assert!(value == 42, 0);
         object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.move
@@ -14,8 +14,8 @@ module Test::M {
         assert!(string::length(&s) == 24, 0);
     }
 
-    public entry fun utf8_vec_arg(v: vector<string::String>, _: &mut TxContext) {
-        let concat = string::utf8(vector::empty());
+    public entry fun utf8_vec_arg(mut v: vector<string::String>, _: &mut TxContext) {
+        let mut concat = string::utf8(vector::empty());
         while (!vector::is_empty(&v)) {
             let s = vector::pop_back(&mut v);
             string::append(&mut concat, s);

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-69:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9218800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 71-73:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 
 task 3 'view-object'. lines 75-75:
 Owner: Account Address ( A )
 Version: 2
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 0u64}
 
 task 4 'programmable'. lines 77-78:
 mutated: object(0,0), object(2,2), object(2,3), object(2,4)
@@ -25,28 +25,28 @@ gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 
 task 5 'view-object'. lines 80-80:
 Owner: Account Address ( A )
 Version: 3
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
 
 task 6 'programmable'. lines 82-83:
-mutated: object(0,0), object(2,2)
-deleted: object(2,0), object(2,3)
+mutated: object(0,0), object(2,4)
+deleted: object(2,0), object(2,2)
 gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
 
 task 7 'view-object'. lines 85-88:
 Owner: Account Address ( A )
 Version: 4
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
 
 task 8 'programmable'. lines 90-91:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 9 'programmable'. lines 93-94:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 10 'programmable'. lines 96-100:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 11 'programmable'. lines 102-103:

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
@@ -13,7 +13,7 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_object_field as ofield;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64,
     }
@@ -24,8 +24,8 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Obj {
-        let grand = Obj { id: object::new(ctx), value: 0 };
-        let parent = Obj { id: object::new(ctx), value: 0 };
+        let mut grand = Obj { id: object::new(ctx), value: 0 };
+        let mut parent = Obj { id: object::new(ctx), value: 0 };
         let child = Obj { id: object::new(ctx), value: 0 };
         ofield::add(&mut parent.id, KEY, child);
         ofield::add(&mut grand.id, KEY, parent);
@@ -72,38 +72,38 @@ module test::m {
 //> 0: test::m::new();
 //> TransferObjects([Result(0)], Input(0))
 
-//# view-object 2,2
+//# view-object 2,4
 
-//# programmable --sender A --inputs object(2,2) 1 2 3
+//# programmable --sender A --inputs object(2,4) 1 2 3
 //> test::m::set(Input(0), Input(1), Input(2), Input(3))
 
-//# view-object 2,2
+//# view-object 2,4
 
-//# programmable --sender A --inputs object(2,2)
+//# programmable --sender A --inputs object(2,4)
 //> test::m::remove(Input(0))
 
-//# view-object 2,2
+//# view-object 2,4
 
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@2 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@3 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@4 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@3 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@4 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@2 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
@@ -3,60 +3,60 @@ processed 14 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 8-121:
+task 1 'publish'. lines 8-119:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'programmable'. lines 123-125:
+task 2 'programmable'. lines 121-123:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3 'view-object'. lines 127-127:
+task 3 'view-object'. lines 125-125:
 Owner: Account Address ( A )
 Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 4 'programmable'. lines 129-130:
+task 4 'programmable'. lines 127-128:
 mutated: object(0,0), object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
 gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
 
-task 5 'view-object'. lines 132-132:
+task 5 'view-object'. lines 130-130:
 Owner: Account Address ( A )
 Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 6 'programmable'. lines 134-135:
+task 6 'programmable'. lines 132-133:
 mutated: object(0,0), object(2,8)
 deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7)
 gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
 
-task 7 'view-object'. lines 137-140:
+task 7 'view-object'. lines 135-138:
 Owner: Account Address ( A )
 Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 8 'programmable'. lines 142-143:
+task 8 'programmable'. lines 140-141:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 9 'programmable'. lines 145-146:
+task 9 'programmable'. lines 143-144:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 10 'programmable'. lines 148-152:
+task 10 'programmable'. lines 146-150:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 11 'programmable'. lines 154-155:
+task 11 'programmable'. lines 152-153:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
 
-task 12 'programmable'. lines 157-158:
+task 12 'programmable'. lines 155-156:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
-task 13 'programmable'. lines 160-161:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+task 13 'programmable'. lines 158-159:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.move
@@ -8,20 +8,18 @@
 //# publish
 
 module test::m {
-    use std::option::{Self, Option};
-    use std::vector;
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
@@ -32,7 +30,7 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -44,7 +42,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-134:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13353200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 136-138:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 173-174:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.move
@@ -14,19 +14,19 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
 
-    struct Value has key, store {
+    public struct Value has key, store {
         id: UID,
         value: u64,
     }
@@ -37,7 +37,7 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -49,7 +49,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-144:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13862400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 146-148:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 183-184:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.move
@@ -14,18 +14,18 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
     }
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
@@ -36,13 +36,13 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Parent {
-        let parent = Parent { id: object::new(ctx) };
+        let mut parent = Parent { id: object::new(ctx) };
         field::add(&mut parent.id, KEY, s(ctx));
         parent
     }
 
     fun s(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -54,7 +54,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.move
@@ -12,7 +12,7 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64,
     }
@@ -23,8 +23,8 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Obj {
-        let grand = Obj { id: object::new(ctx), value: 0 };
-        let parent = Obj { id: object::new(ctx), value: 0 };
+        let mut grand = Obj { id: object::new(ctx), value: 0 };
+        let mut parent = Obj { id: object::new(ctx), value: 0 };
         let child = Obj { id: object::new(ctx), value: 0 };
         field::add(&mut parent.id, KEY, child);
         field::add(&mut grand.id, KEY, parent);

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -27,7 +27,7 @@ module test::m {
     }
 
     public fun b(ctx: &mut TxContext): B {
-        let b = B { id: object::new(ctx) };
+        let mut b = B { id: object::new(ctx) };
         field::add(&mut b.id, KEY, 0);
         b
 

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -27,7 +27,7 @@ module test::m {
     }
 
     public fun b(ctx: &mut TxContext): B {
-        let b = B { id: object::new(ctx) };
+        let mut b = B { id: object::new(ctx) };
         field::add(&mut b.id, KEY, 0);
         b
 

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_df.move
@@ -14,12 +14,12 @@ module tto::M1 {
     const KEY: u64 = 0;
     const BKEY: u64 = 1;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: vector<u8>,
     }
 
-    struct Wrapper<T: key + store> has key, store {
+    public struct Wrapper<T: key + store> has key, store {
         id: UID, 
         value: T,
     }
@@ -27,13 +27,13 @@ module tto::M1 {
     public fun start(ctx: &mut TxContext) {
         let a_parent = A { id: object::new(ctx), value: b"a_parent" };
 
-        let b_parent = A { id: object::new(ctx), value: b"b_parent" };
-        let b_child = A { id: object::new(ctx), value: b"b_child" };
+        let mut b_parent = A { id: object::new(ctx), value: b"b_parent" };
+        let mut b_child = A { id: object::new(ctx), value: b"b_child" };
         let b_child_child = A { id: object::new(ctx), value: b"b_child_child" };
         let b_child_child_dof = A { id: object::new(ctx), value: b"b_child_child_dof" };
 
         let wrapped_df = A { id: object::new(ctx), value: b"wrapped_dof" };
-        let to_wrap = A { id: object::new(ctx), value: b"wrapped" };
+        let mut to_wrap = A { id: object::new(ctx), value: b"wrapped" };
         df::add(&mut to_wrap.id, KEY, wrapped_df);
         let wrapped = Wrapper { id: object::new(ctx), value: to_wrap };
 

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_access_through_parent_dof.move
@@ -14,12 +14,12 @@ module tto::M1 {
     const KEY: u64 = 0;
     const BKEY: u64 = 1;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: vector<u8>,
     }
 
-    struct Wrapper<T: key + store> has key, store {
+    public struct Wrapper<T: key + store> has key, store {
         id: UID, 
         value: T,
     }
@@ -27,13 +27,13 @@ module tto::M1 {
     public fun start(ctx: &mut TxContext) {
         let a_parent = A { id: object::new(ctx), value: b"a_parent" };
 
-        let b_parent = A { id: object::new(ctx), value: b"b_parent" };
-        let b_child = A { id: object::new(ctx), value: b"b_child" };
+        let mut b_parent = A { id: object::new(ctx), value: b"b_parent" };
+        let mut b_child = A { id: object::new(ctx), value: b"b_child" };
         let b_child_child = A { id: object::new(ctx), value: b"b_child_child" };
         let b_child_child_df = A { id: object::new(ctx), value: b"b_child_child_df" };
 
         let wrapped_dof = A { id: object::new(ctx), value: b"wrapped_df" };
-        let to_wrap = A { id: object::new(ctx), value: b"wrapped" };
+        let mut to_wrap = A { id: object::new(ctx), value: b"wrapped" };
         dof::add(&mut to_wrap.id, KEY, wrapped_dof);
         let wrapped = Wrapper { id: object::new(ctx), value: to_wrap };
 

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-61:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 10548800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10533600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 63-63:
 created: object(2,0), object(2,1), object(2,2), object(2,3)
@@ -14,89 +14,89 @@ mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'view-object'. lines 65-65:
-Owner: Object ID: ( fake(2,2) )
+Owner: Object ID: ( fake(2,1) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
 
 task 4 'view-object'. lines 67-67:
 Owner: Object ID: ( fake(2,0) )
 Version: 2
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
 
 task 5 'view-object'. lines 69-69:
-Owner: Account Address ( fake(2,3) )
+Owner: Account Address ( fake(2,2) )
 Version: 2
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
 
 task 6 'view-object'. lines 71-71:
 Owner: Account Address ( A )
 Version: 2
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 7 'run'. lines 73-73:
 created: object(7,0)
-mutated: object(0,0), object(2,2), object(2,3)
+mutated: object(0,0), object(2,1), object(2,2)
 gas summary: computation_cost: 1000000, storage_cost: 5996400,  storage_rebate: 3506184, non_refundable_storage_fee: 35416
 
 task 8 'view-object'. lines 75-77:
-Owner: Object ID: ( fake(2,2) )
+Owner: Object ID: ( fake(2,1) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
 
 task 9 'view-object'. lines 78-78:
 Owner: Object ID: ( fake(2,0) )
 Version: 2
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
 
 task 10 'view-object'. lines 80-80:
 Owner: Object ID: ( fake(7,0) )
 Version: 3
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 0u64}
 
 task 11 'view-object'. lines 82-82:
 Owner: Account Address ( A )
 Version: 3
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 0u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
 
 task 12 'programmable'. lines 84-85:
 mutated: object(0,0), object(2,1), object(2,2), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 4818400,  storage_rebate: 4770216, non_refundable_storage_fee: 48184
 
 task 13 'view-object'. lines 87-89:
-Owner: Object ID: ( fake(2,2) )
+Owner: Object ID: ( fake(2,1) )
 Version: 2
-Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,1)}}
+Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(2,3)}}
 
 task 14 'view-object'. lines 90-90:
 Owner: Object ID: ( fake(2,0) )
 Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 3u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 3u64}
 
 task 15 'view-object'. lines 92-92:
 Owner: Object ID: ( fake(7,0) )
 Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 2u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, value: 2u64}
 
 task 16 'view-object'. lines 94-94:
 Owner: Account Address ( A )
 Version: 4
-Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,3)}}, value: 1u64}
+Contents: tto::M1::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
 
 task 17 'programmable'. lines 96-99:
-mutated: object(0,0), object(2,3)
-deleted: object(2,0), object(2,1)
+mutated: object(0,0), object(2,2)
+deleted: object(2,0), object(2,3)
 gas summary: computation_cost: 1000000, storage_cost: 2264800,  storage_rebate: 5936436, non_refundable_storage_fee: 59964
 
 task 18 'programmable'. lines 101-102:
-mutated: object(_), object(2,3)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
 task 19 'programmable'. lines 104-105:
-mutated: object(_), object(2,3)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
 task 20 'programmable'. lines 107-110:
-mutated: object(_), object(2,3)
+mutated: object(_), object(2,2)
 gas summary: computation_cost: 500000, storage_cost: 2264800,  storage_rebate: 1264032, non_refundable_storage_fee: 12768
 
 task 21 'programmable'. lines 112-113:

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/receive_object_dof.move
@@ -13,7 +13,7 @@ module tto::M1 {
 
     const KEY: u64 = 0;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: u64,
     }
@@ -22,7 +22,7 @@ module tto::M1 {
     public fun start(ctx: &mut TxContext) {
         let a = A { id: object::new(ctx), value: 0 };
         let a_address = object::id_address(&a);
-        let b = A { id: object::new(ctx), value: 0 };
+        let mut b = A { id: object::new(ctx), value: 0 };
         dof::add(&mut b.id, KEY, A { id: object::new(ctx), value: 0 });
         transfer::public_transfer(a, tx_context::sender(ctx));
         transfer::public_transfer(b, a_address);
@@ -64,56 +64,56 @@ module tto::M1 {
 
 //# view-object 2,0
 
+//# view-object 2,3
+
 //# view-object 2,1
 
 //# view-object 2,2
 
-//# view-object 2,3
-
-//# run tto::M1::receive --args object(2,3) receiving(2,2) --sender A
+//# run tto::M1::receive --args object(2,2) receiving(2,1) --sender A
 
 //# view-object 2,0
 
 // The grand parent
+//# view-object 2,3
+
 //# view-object 2,1
 
 //# view-object 2,2
 
-//# view-object 2,3
-
-//# programmable --sender A --inputs object(2,3) 1 2 3
+//# programmable --sender A --inputs object(2,2) 1 2 3
 //> tto::M1::set(Input(0), Input(1), Input(2), Input(3))
 
 //# view-object 2,0
 
 // The grand parent
+//# view-object 2,3
+
 //# view-object 2,1
 
 //# view-object 2,2
 
-//# view-object 2,3
-
-//# programmable --sender A --inputs object(2,3)
+//# programmable --sender A --inputs object(2,2)
 //> tto::M1::remove(Input(0))
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,3)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,3)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,3)@5 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@5 1 2 vector[] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,3)@4 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@4 0 0 vector[0] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,3)@5 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@5 1 2 vector[3] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,3)@3 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,2)@3 1 2 vector[] --dev-inspect
 //> tto::M1::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-69:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9218800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 71-73:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 
 task 3 'view-object'. lines 75-75:
 Owner: Account Address ( A )
 Version: 2
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 0u64}
 
 task 4 'programmable'. lines 77-78:
 mutated: object(0,0), object(2,2), object(2,3), object(2,4)
@@ -25,28 +25,28 @@ gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 
 task 5 'view-object'. lines 80-80:
 Owner: Account Address ( A )
 Version: 3
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
 
 task 6 'programmable'. lines 82-83:
-mutated: object(0,0), object(2,2)
-deleted: object(2,0), object(2,3)
+mutated: object(0,0), object(2,4)
+deleted: object(2,0), object(2,2)
 gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
 
 task 7 'view-object'. lines 85-88:
 Owner: Account Address ( A )
 Version: 4
-Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,4)}}, value: 1u64}
 
 task 8 'programmable'. lines 90-91:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 9 'programmable'. lines 93-94:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 10 'programmable'. lines 96-100:
-mutated: object(_), object(2,2)
+mutated: object(_), object(2,4)
 gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
 
 task 11 'programmable'. lines 102-103:

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
@@ -13,7 +13,7 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_object_field as ofield;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64,
     }
@@ -24,8 +24,8 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Obj {
-        let grand = Obj { id: object::new(ctx), value: 0 };
-        let parent = Obj { id: object::new(ctx), value: 0 };
+        let mut grand = Obj { id: object::new(ctx), value: 0 };
+        let mut parent = Obj { id: object::new(ctx), value: 0 };
         let child = Obj { id: object::new(ctx), value: 0 };
         ofield::add(&mut parent.id, KEY, child);
         ofield::add(&mut grand.id, KEY, parent);
@@ -72,38 +72,38 @@ module test::m {
 //> 0: test::m::new();
 //> TransferObjects([Result(0)], Input(0))
 
-//# view-object 2,2
+//# view-object 2,4
 
-//# programmable --sender A --inputs object(2,2) 1 2 3
+//# programmable --sender A --inputs object(2,4) 1 2 3
 //> test::m::set(Input(0), Input(1), Input(2), Input(3))
 
-//# view-object 2,2
+//# view-object 2,4
 
-//# programmable --sender A --inputs object(2,2)
+//# programmable --sender A --inputs object(2,4)
 //> test::m::remove(Input(0))
 
-//# view-object 2,2
+//# view-object 2,4
 
 
 // dev-inspect with 'check' and correct values
 
-//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@2 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@3 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@4 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
 
 // dev-inspect with 'check' and _incorrect_ values
 
-//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@3 0 0 vector[0] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@4 1 2 vector[3] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))
 
-//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
+//# programmable --sender A --inputs object(2,4)@2 1 2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
@@ -3,60 +3,60 @@ processed 14 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 8-121:
+task 1 'publish'. lines 8-119:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12205600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'programmable'. lines 123-125:
+task 2 'programmable'. lines 121-123:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3 'view-object'. lines 127-127:
+task 3 'view-object'. lines 125-125:
 Owner: Account Address ( A )
 Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 4 'programmable'. lines 129-130:
+task 4 'programmable'. lines 127-128:
 mutated: object(0,0), object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
 gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
 
-task 5 'view-object'. lines 132-132:
+task 5 'view-object'. lines 130-130:
 Owner: Account Address ( A )
 Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 6 'programmable'. lines 134-135:
+task 6 'programmable'. lines 132-133:
 mutated: object(0,0), object(2,8)
 deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7)
 gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
 
-task 7 'view-object'. lines 137-140:
+task 7 'view-object'. lines 135-138:
 Owner: Account Address ( A )
 Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
 
-task 8 'programmable'. lines 142-143:
+task 8 'programmable'. lines 140-141:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 9 'programmable'. lines 145-146:
+task 9 'programmable'. lines 143-144:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 10 'programmable'. lines 148-152:
+task 10 'programmable'. lines 146-150:
 mutated: object(_), object(2,8)
 gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
 
-task 11 'programmable'. lines 154-155:
+task 11 'programmable'. lines 152-153:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
 
-task 12 'programmable'. lines 157-158:
+task 12 'programmable'. lines 155-156:
 Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
-task 13 'programmable'. lines 160-161:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+task 13 'programmable'. lines 158-159:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 20, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.move
@@ -8,20 +8,18 @@
 //# publish
 
 module test::m {
-    use std::option::{Self, Option};
-    use std::vector;
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
@@ -32,7 +30,7 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -44,7 +42,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-134:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13353200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 136-138:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 173-174:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 26, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.move
@@ -14,19 +14,19 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_object_field as ofield;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
 
-    struct Value has key, store {
+    public struct Value has key, store {
         id: UID,
         value: u64,
     }
@@ -37,7 +37,7 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -49,7 +49,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-144:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13862400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 146-148:
 created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
@@ -58,5 +58,5 @@ Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { a
 Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
 
 task 13 'programmable'. lines 183-184:
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 20, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.move
@@ -14,18 +14,18 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
     }
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         other: UID,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
 
-    struct Wrapped has key, store {
+    public struct Wrapped has key, store {
         id: UID,
         other: UID,
     }
@@ -36,13 +36,13 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Parent {
-        let parent = Parent { id: object::new(ctx) };
+        let mut parent = Parent { id: object::new(ctx) };
         field::add(&mut parent.id, KEY, s(ctx));
         parent
     }
 
     fun s(ctx: &mut TxContext): S {
-        let s = S {
+        let mut s = S {
             id: object::new(ctx),
             other: object::new(ctx),
             wrapped: wrapped(ctx),
@@ -54,7 +54,7 @@ module test::m {
     }
 
     fun wrapped(ctx: &mut TxContext): Wrapped {
-        let w = Wrapped {
+        let mut w = Wrapped {
             id: object::new(ctx),
             other: object::new(ctx),
         };

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.move
@@ -12,7 +12,7 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
         value: u64,
     }
@@ -23,8 +23,8 @@ module test::m {
     // new
 
     public fun new(ctx: &mut TxContext): Obj {
-        let grand = Obj { id: object::new(ctx), value: 0 };
-        let parent = Obj { id: object::new(ctx), value: 0 };
+        let mut grand = Obj { id: object::new(ctx), value: 0 };
+        let mut parent = Obj { id: object::new(ctx), value: 0 };
         let child = Obj { id: object::new(ctx), value: 0 };
         field::add(&mut parent.id, KEY, child);
         field::add(&mut grand.id, KEY, parent);

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -27,7 +27,7 @@ module test::m {
     }
 
     public fun b(ctx: &mut TxContext): B {
-        let b = B { id: object::new(ctx) };
+        let mut b = B { id: object::new(ctx) };
         field::add(&mut b.id, KEY, 0);
         b
 

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.move
@@ -12,11 +12,11 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::dynamic_field as field;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -27,7 +27,7 @@ module test::m {
     }
 
     public fun b(ctx: &mut TxContext): B {
-        let b = B { id: object::new(ctx) };
+        let mut b = B { id: object::new(ctx) };
         field::add(&mut b.id, KEY, 0);
         b
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_non_copyable_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_non_copyable_invalid.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun r(): R { R{} }
 
     public fun take_and_imm(_: R, _: &R) { abort 0 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_valid.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun r(): R { R {} }
 
     public fun imm_copy(_: &u64, _: u64,) {}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct A has copy, drop, store {}
+    public struct A has copy, drop, store {}
     public fun a(): A { A {} }
 }
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.move
@@ -12,7 +12,7 @@ module test::fake {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext) {
         let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.move
@@ -12,7 +12,7 @@ module test::fake {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext) {
         let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.move
@@ -11,7 +11,7 @@ module test::m1 {
     use sui::tx_context::TxContext;
 
     // not a native coin, but same type structure and BCS layout
-    struct Coin<phantom T> has key, store {
+    public struct Coin<phantom T> has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.move
@@ -12,7 +12,7 @@ module test::fake {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext) {
         let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-13:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 3982400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3990000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 15-17:
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.move
@@ -9,7 +9,7 @@
 module test::m1 {
     public fun take<T: key>(_: T) { abort 0 }
     public fun imm<T: key>(_: &T, _: T) { abort 0 }
-    public fun mut<T: key>(_: &mut T, _: T) { abort 0 }
+    public fun mut_<T: key>(_: &mut T, _: T) { abort 0 }
 }
 
 //# programmable --sender A --inputs @A
@@ -20,4 +20,4 @@ module test::m1 {
 //> test::m1::imm<sui::coin::Coin<sui::sui::SUI>>(Gas, Gas)
 
 //# programmable
-//> test::m1::mut<sui::coin::Coin<sui::sui::SUI>>(Gas, Gas)
+//> test::m1::mut_<sui::coin::Coin<sui::sui::SUI>>(Gas, Gas)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-32:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5753200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5760800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 34-35:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.move
@@ -11,7 +11,7 @@ module test::m1 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct R has key {
+    public struct R has key {
         id: UID,
     }
 
@@ -28,7 +28,7 @@ module test::m1 {
     }
 
     public fun imm(_: &R, _: R) { abort 0 }
-    public fun mut(_: &mut R, _: R) { abort 0 }
+    public fun mut_(_: &mut R, _: R) { abort 0 }
 }
 
 //# programmable
@@ -38,7 +38,7 @@ module test::m1 {
 //> test::m1::imm(Input(0), Input(0));
 
 //# programmable --inputs object(2,0)
-//> test::m1::mut(Input(0), Input(0));
+//> test::m1::mut_(Input(0), Input(0));
 
 //# programmable
 //> test::m1::freeze_r();
@@ -47,4 +47,4 @@ module test::m1 {
 //> test::m1::imm(Input(0), Input(0));
 
 //# programmable --inputs object(5,0)
-//> test::m1::mut(Input(0), Input(0));
+//> test::m1::mut_(Input(0), Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.move
@@ -7,8 +7,8 @@
 
 //# publish
 module test::m1 {
-    struct A has copy, drop { value: u64 }
-    struct B has copy, drop { value: u256 }
+    public struct A has copy, drop { value: u64 }
+    public struct B has copy, drop { value: u256 }
 
     public fun a(): A { A { value: 0 } }
     public fun b(): B { B { value: 0 } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.move
@@ -7,8 +7,8 @@
 
 //# publish
 module test::m1 {
-    struct A has copy, drop { value: u64 }
-    struct B has copy, drop { value: u256 }
+    public struct A has copy, drop { value: u64 }
+    public struct B has copy, drop { value: u256 }
 
     public fun t1(_: &mut u64): &mut u64 { abort 0}
     public fun t2(_: &mut u64): &u64 { abort 0}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_result_arity.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_result_arity.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun nop() {}
     public fun r(): (R, R) { (R{}, R{}) }
     public fun take(_: R) { abort 0 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.move
@@ -11,14 +11,14 @@ module test::m1 {
     use sui::tx_context::TxContext;
     use std::vector;
 
-    struct Pub has key, store {
+    public struct Pub has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Cap {}
+    public struct Cap {}
 
-    struct Cup<T> has key, store {
+    public struct Cup<T> has key, store {
         id: UID,
         value: T,
     }
@@ -35,7 +35,7 @@ module test::m1 {
         Cap {}
     }
 
-    public fun pubs(v: vector<Pub>) {
+    public fun pubs(mut v: vector<Pub>) {
         while (!vector::is_empty(&v)) {
             let Pub { id, value: _ } = vector::pop_back(&mut v);
             object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.move
@@ -11,7 +11,7 @@ module test::m1 {
     use std::string::{Self, String};
     use std::option::{Self, Option};
 
-    public entry fun vec_option_u64(v: vector<Option<u64>>) {
+    public entry fun vec_option_u64(mut v: vector<Option<u64>>) {
         while (!vector::is_empty(&v)) {
             let opt = vector::pop_back(&mut v);
             if (option::is_some(&opt)) {
@@ -20,7 +20,7 @@ module test::m1 {
         }
     }
 
-    public entry fun vec_option_string(v: vector<Option<String>>) {
+    public entry fun vec_option_string(mut v: vector<Option<String>>) {
         while (!vector::is_empty(&v)) {
             let opt = vector::pop_back(&mut v);
             if (option::is_some(&opt)) {

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.move
@@ -12,7 +12,7 @@ module test::fake {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext) {
         let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/nested_result_zero_zero.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/nested_result_zero_zero.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has copy, drop {}
+    public struct R has copy, drop {}
     public fun r(): R { R{} }
     public fun copy_(_: R) {}
 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-19:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4658800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4666400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 21-26:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.move
@@ -7,14 +7,14 @@
 
 //# publish
 module test::m1 {
-    struct Potato {}
+    public struct Potato {}
 
     public fun potato(): Potato { Potato {} }
     public fun otatop(tater: Potato) { let Potato {} = tater; }
 
     public fun pass(tater: Potato): Potato { tater }
     public fun imm(_: &Potato) {}
-    public fun mut(_: &mut Potato) {}
+    public fun mut_(_: &mut Potato) {}
 
 }
 
@@ -22,5 +22,5 @@ module test::m1 {
 //> 0: test::m1::potato();
 //> 1: test::m1::pass(Result(0));
 //> test::m1::imm(Result(1));
-//> test::m1::mut(Result(1));
+//> test::m1::mut_(Result(1));
 //> test::m1::otatop(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_input.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_input.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun copy_(_: u64) { abort 0 }
     public fun take(_: R) { abort 0 }
     public fun by_imm(_: &u64) { abort 0 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_nested.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_nested.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun r(): (R, R) { (R{}, R{}) }
     public fun copy_(_: u64) { abort 0 }
     public fun take(_: R) { abort 0 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_result.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_result.move
@@ -7,7 +7,7 @@
 
 //# publish
 module test::m1 {
-    struct R has drop {}
+    public struct R has drop {}
     public fun r(): R { R{} }
     public fun copy_(_: u64) { abort 0 }
     public fun take(_: R) { abort 0 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.move
@@ -11,7 +11,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public fun id(r: R): R { r }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.move
@@ -13,7 +13,7 @@ module test::m1 {
     use sui::coin::Coin;
     use sui::sui::SUI;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public fun v(): u64 { 100 }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.move
@@ -11,7 +11,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public fun dirty(_: &mut R) {}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.move
@@ -12,13 +12,13 @@ module test::m1 {
     use sui::tx_context::TxContext;
     use std::vector;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public entry fun clean(_: &mut R) {}
     public entry fun clean_u64(_: u64) {}
     entry fun priv1(_: &mut R) {}
-    entry fun priv2(v: vector<R>) {
+    entry fun priv2(mut v: vector<R>) {
         while (!vector::is_empty(&v)) {
             let R { id } = vector::pop_back(&mut v);
             object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.move
@@ -10,7 +10,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public fun dirty(_: &mut R) {}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.move
@@ -10,7 +10,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
+    public struct R has key, store { id: UID }
     public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
 
     public fun dirty(_: &mut R) {}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.move
@@ -10,10 +10,10 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Pub has key, store { id: UID }
+    public struct Pub has key, store { id: UID }
     public fun pub(ctx: &mut TxContext): Pub { Pub { id: object::new(ctx) } }
 
-    struct Priv has key { id: UID }
+    public struct Priv has key { id: UID }
     public fun priv(ctx: &mut TxContext): Priv { Priv { id: object::new(ctx) } }
 }
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.move
@@ -10,7 +10,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Pub has key, store { id: UID }
+    public struct Pub has key, store { id: UID }
     public fun pub(ctx: &mut TxContext): Pub { Pub { id: object::new(ctx) } }
 }
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-27:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5327600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5380800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-35:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
@@ -17,7 +17,7 @@ module test::m1 {
     public fun addr(_: address) {}
     public fun id(_: ID) {}
 
-    public fun ascii(_: ascii::String) {}
+    public fun ascii_(_: ascii::String) {}
     public fun string(_: String) {}
 
     public fun vec<T: drop>(_: vector<T>) {}
@@ -28,7 +28,7 @@ module test::m1 {
 
 //# programmable --inputs "hello"
 
-//> 0: test::m1::ascii(Input(0));
+//> 0: test::m1::ascii_(Input(0));
 //> 1: test::m1::string(Input(0));
 //> 2: test::m1::fix<std::ascii::String>(Input(0));
 // now will fail as Input(0) if always a String

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-26:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5327600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5403600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 28-32:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.move
@@ -16,7 +16,7 @@ module test::m1 {
         100
     }
 
-    public fun transfer(v: vector<coin::Coin<sui::sui::SUI>>, r: address) {
+    public fun transfer_(mut v: vector<coin::Coin<sui::sui::SUI>>, r: address) {
         while (!vector::is_empty(&v)) {
             let c = vector::pop_back(&mut v);
             transfer::public_transfer(c, r);
@@ -73,7 +73,7 @@ module test::m1 {
 //> 0: test::m1::ret_one_amount();
 //> 1: SplitCoins(Input(0), [Result(0), Input(1)]);
 //> 2: MakeMoveVec<sui::coin::Coin<sui::sui::SUI>>([NestedResult(1,0), NestedResult(1,1)]);
-//> test::m1::transfer(Result(2), Input(2));
+//> test::m1::transfer_(Result(2), Input(2));
 
 //# view-object 3,0
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1), C: object(0,2)
 task 1 'publish'. lines 9-26:
 created: object(1,0)
 mutated: object(0,3)
-gas summary: computation_cost: 1000000, storage_cost: 5563200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5639200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 28-32:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.move
@@ -16,7 +16,7 @@ module test::m1 {
         @42
     }
 
-    public fun transfer(v: vector<coin::Coin<sui::sui::SUI>>, r: address) {
+    public fun transfer_(mut v: vector<coin::Coin<sui::sui::SUI>>, r: address) {
         while (!vector::is_empty(&v)) {
             let c = vector::pop_back(&mut v);
             transfer::public_transfer(c, r);
@@ -64,4 +64,4 @@ module test::m1 {
 // vector first
 //# programmable --sender A --inputs object(3,0) 100 100 @B
 //> 0: SplitCoins(Input(0), [Input(1), Input(2)]);
-//> test::m1::transfer(Result(0), Input(3));
+//> test::m1::transfer_(Result(0), Input(3));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.move
@@ -10,12 +10,12 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Pub has key, store {
+    public struct Pub has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Cup<phantom T> has key, store {
+    public struct Cup<phantom T> has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.move
@@ -10,7 +10,7 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Pub has key, store {
+    public struct Pub has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.move
@@ -10,14 +10,14 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Pub has key, store {
+    public struct Pub has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Cap {}
+    public struct Cap {}
 
-    struct Cup<T> has key, store {
+    public struct Cup<T> has key, store {
         id: UID,
         value: T,
     }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_invalid.move
@@ -10,9 +10,9 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
-    struct Cup<T> has copy, drop { t: T }
-    struct Copyable has copy {}
+    public struct R has key, store { id: UID }
+    public struct Cup<T> has copy, drop { t: T }
+    public struct Copyable has copy {}
 
     public fun r(ctx: &mut TxContext): R {
         R { id: object::new(ctx) }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.move
@@ -10,10 +10,10 @@ module test::m1 {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct R has key, store { id: UID }
-    struct Droppable has drop {}
-    struct Cup<T> has copy, drop { t: T }
-    struct Copyable has copy {}
+    public struct R has key, store { id: UID }
+    public struct Droppable has drop {}
+    public struct Cup<T> has copy, drop { t: T }
+    public struct Copyable has copy {}
 
     public fun r(ctx: &mut TxContext): R {
         R { id: object::new(ctx) }

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.move
@@ -11,7 +11,7 @@ module test::m1 {
     use sui::coin::{Self, Coin};
     use sui::sui::SUI;
 
-    struct CoolMarker has key, store { id: UID }
+    public struct CoolMarker has key, store { id: UID }
 
     public entry fun purchase(coin: Coin<SUI>, ctx: &mut TxContext) {
         transfer::public_transfer(purchase_(coin, ctx), tx_context::sender(ctx))

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.move
@@ -11,7 +11,7 @@ module test::m1 {
     use std::string::{Self, String};
     use std::option::{Self, Option};
 
-    struct CoolMarker has key, store { id: UID }
+    public struct CoolMarker has key, store { id: UID }
 
     public entry fun vec_u64(_: vector<u64>) {
     }
@@ -19,17 +19,17 @@ module test::m1 {
     public entry fun vec_vec_u64(_: vector<vector<u64>>) {
     }
 
-    public entry fun vec_string(v: vector<String>) {
+    public entry fun vec_string(mut v: vector<String>) {
         while (!vector::is_empty(&v)) {
             string::utf8(*string::bytes(&vector::pop_back(&mut v)));
         }
     }
 
-    public entry fun vec_vec_string(v: vector<vector<String>>) {
+    public entry fun vec_vec_string(mut v: vector<vector<String>>) {
         while (!vector::is_empty(&v)) vec_string(vector::pop_back(&mut v))
     }
 
-    public entry fun vec_option_string(v: vector<Option<String>>) {
+    public entry fun vec_option_string(mut v: vector<Option<String>>) {
         while (!vector::is_empty(&v)) {
             let opt = vector::pop_back(&mut v);
             if (option::is_some(&opt)) {
@@ -42,7 +42,7 @@ module test::m1 {
         CoolMarker { id: object::new(ctx) }
     }
 
-    public fun burn_markers(markers: vector<CoolMarker>) {
+    public fun burn_markers(mut markers: vector<CoolMarker>) {
         while (!vector::is_empty(&markers)) {
             let CoolMarker { id } = vector::pop_back(&mut markers);
             object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec_shared.move
@@ -13,7 +13,7 @@ module t2::o2 {
     use sui::tx_context::TxContext;
     use std::vector;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 
@@ -22,7 +22,7 @@ module t2::o2 {
         transfer::public_share_object(o)
     }
 
-    public entry fun consume(v: vector<Obj2>) {
+    public entry fun consume(mut v: vector<Obj2>) {
         while (!vector::is_empty(&v)) {
             let Obj2 { id } = vector::pop_back(&mut v);
             object::delete(id);

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/merge_coin_shared.move
@@ -13,7 +13,7 @@ module test::m1 {
     use sui::transfer;
 
     // not a native coin, but same type structure and BCS layout
-    struct Coin has key, store {
+    public struct Coin has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.move
@@ -9,8 +9,8 @@ module test::m1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct PrologueReceipt {}
-    struct Witness has key { id: UID }
+    public struct PrologueReceipt {}
+    public struct Witness has key { id: UID }
 
     public fun prologue(): PrologueReceipt {
         PrologueReceipt {}

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.move
@@ -12,7 +12,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/publish/init.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init.move
@@ -9,7 +9,7 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_param.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_param.move
@@ -11,7 +11,7 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_public.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_public.move
@@ -11,7 +11,7 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_ret.move
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_ret.move
@@ -11,7 +11,7 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/basic_receive.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/basic_receive.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/drop_receiving.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/drop_receiving.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/duplicate_receive_argument.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/move_vec_receiving_types.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/move_vec_receiving_types.move
@@ -10,19 +10,19 @@ module tto::M1 {
     use sui::transfer::{Self, Receiving};
     use std::vector;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
-    struct C has key, store {
+    public struct C has key, store {
         id: UID,
     }
 
-    struct RecvSpoof<phantom T: key> has drop {
+    public struct RecvSpoof<phantom T: key> has drop {
         id: ID,
         version: u64,
     }
@@ -56,7 +56,7 @@ module tto::M1 {
 
     public fun receive_none_a(_v: vector<Receiving<A>>){ }
 
-    public fun receive_all(parent: &mut A, x: vector<Receiving<B>>) {
+    public fun receive_all(parent: &mut A, mut x: vector<Receiving<B>>) {
         while (!vector::is_empty(&x)) {
             let r = vector::pop_back(&mut x);
             let b = transfer::receive(&mut parent.id, r);

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pass_receiver_immut_then_reuse.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pass_receiver_immut_then_reuse.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pass_receiver_mut_then_reuse.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pass_receiver_mut_then_reuse.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.move
@@ -10,11 +10,11 @@ module tto::M1 {
     use sui::transfer::{Self, Receiving};
     use std::vector;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -34,15 +34,15 @@ module tto::M1 {
 
     public entry fun pass_through_mut_ref_a(_x: &mut Receiving<A>) { }
 
-    public fun unpacker_a(x: vector<Receiving<A>>): Receiving<A> {
+    public fun unpacker_a(mut x: vector<Receiving<A>>): Receiving<A> {
         vector::pop_back(&mut x)
     }
 
-    public fun unpacker_b(x: vector<Receiving<B>>): Receiving<B> {
+    public fun unpacker_b(mut x: vector<Receiving<B>>): Receiving<B> {
         vector::pop_back(&mut x)
     }
 
-    public fun unpacker_generic<T: key + store>(x: vector<Receiving<T>>): Receiving<T> {
+    public fun unpacker_generic<T: key + store>(mut x: vector<Receiving<T>>): Receiving<T> {
         vector::pop_back(&mut x)
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_add_dof_and_mutate.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_add_dof_and_mutate.move
@@ -12,7 +12,7 @@ module tto::M1 {
 
     const KEY: u64 = 0;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: u64,
     }
@@ -26,7 +26,7 @@ module tto::M1 {
     }
 
     public entry fun receive(parent: &mut A, x: Receiving<A>, ctx: &mut TxContext) {
-        let b = transfer::receive(&mut parent.id, x);
+        let mut b = transfer::receive(&mut parent.id, x);
         let x = A { id: object::new(ctx), value: 0 };
         dof::add(&mut b.id, KEY, x);
         dof::add(&mut parent.id, KEY, b);

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_abort.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_abort.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_deleted.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_deleted.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_send_back.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_send_back.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_wrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_and_wrap.move
@@ -9,16 +9,16 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct Wrapper has key, store {
+    public struct Wrapper has key, store {
         id: UID,
         elem: B
     }
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_by_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_by_ref.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_by_value_flow_through.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_by_value_flow_through.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_dof_and_mutate.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_dof_and_mutate.move
@@ -12,7 +12,7 @@ module tto::M1 {
 
     const KEY: u64 = 0;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: u64,
     }
@@ -20,7 +20,7 @@ module tto::M1 {
     public fun start(ctx: &mut TxContext) {
         let a = A { id: object::new(ctx), value: 0 };
         let a_address = object::id_address(&a);
-        let b = A { id: object::new(ctx), value: 0 };
+        let mut b = A { id: object::new(ctx), value: 0 };
         dof::add(&mut b.id, KEY, A { id: object::new(ctx), value: 0 });
         transfer::public_transfer(a, tx_context::sender(ctx));
         transfer::public_transfer(b, a_address);

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_duo_struct.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_duo_struct.move
@@ -9,15 +9,15 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
-    struct Duo<phantom T: key> has drop {
+    public struct Duo<phantom T: key> has drop {
         r1: Receiving<T>,
         r2: Receiving<T>,
     }
@@ -39,7 +39,7 @@ module tto::M1 {
 
     public fun receive_duo(parent: &mut A, d: Duo<B>): (B, B) {
         let Duo { r1, r2 } = d;
-        let r1 = transfer::receive(&mut parent.id, r1);
+        let mut r1 = transfer::receive(&mut parent.id, r1);
         let r2 = transfer::receive(&mut r1.id, r2);
         (r1, r2)
     }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_param_ty.move
@@ -9,17 +9,17 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
-    struct Fake<phantom T> has drop { }
+    public struct Fake<phantom T> has drop { }
 
-    struct FakeSameLayout<phantom T> has drop {
+    public struct FakeSameLayout<phantom T> has drop {
         id: ID, 
         version: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_invalid_type.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_many_move_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_many_move_vec.move
@@ -10,11 +10,11 @@ module tto::M1 {
     use sui::transfer::{Self, Receiving};
     use std::vector;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 
@@ -54,7 +54,7 @@ module tto::M1 {
         };
     }
 
-    public fun receive_all_but_last(parent: &mut A, x: vector<Receiving<B>>) {
+    public fun receive_all_but_last(parent: &mut A, mut x: vector<Receiving<B>>) {
         while (vector::length(&x) > 1) {
             let r = vector::pop_back(&mut x);
             let b = transfer::receive(&mut parent.id, r);
@@ -62,7 +62,7 @@ module tto::M1 {
         };
     }
 
-    public fun receive_all_send_back(parent: &mut A, x: vector<Receiving<B>>) {
+    public fun receive_all_send_back(parent: &mut A, mut x: vector<Receiving<B>>) {
         while (!vector::is_empty(&x)) {
             let r = vector::pop_back(&mut x);
             let b = transfer::receive(&mut parent.id, r);
@@ -70,7 +70,7 @@ module tto::M1 {
         };
     }
 
-    public fun receive_all(parent: &mut A, x: vector<Receiving<B>>) {
+    public fun receive_all(parent: &mut A, mut x: vector<Receiving<B>>) {
         while (!vector::is_empty(&x)) {
             let r = vector::pop_back(&mut x);
             let b = transfer::receive(&mut parent.id, r);

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_multiple_times_in_row.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_multiple_times_in_row.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_id.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_id.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_object_owner.move
@@ -12,13 +12,13 @@ module tto::M1 {
 
     const KEY: u64 = 0;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: u64,
     }
 
     public fun start(ctx: &mut TxContext) {
-        let a = A { id: object::new(ctx), value: 0 };
+        let mut a = A { id: object::new(ctx), value: 0 };
         dof::add(&mut a.id, KEY, A { id: object::new(ctx), value: 0 });
         transfer::public_transfer(a, tx_context::sender(ctx));
     }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_return_object_dont_touch.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_return_object_dont_touch.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_return_object_then_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_return_object_then_transfer.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/receive_ticket_coin_operations.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/receive_ticket_coin_operations.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::Self;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/basic_receive.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/drop_receiving.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/drop_receiving.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
     public fun start(ctx: &mut TxContext) {

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_dof_and_mutate.move
@@ -12,7 +12,7 @@ module tto::M1 {
 
     const KEY: u64 = 0;
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
         value: u64,
     }
@@ -20,7 +20,7 @@ module tto::M1 {
     public fun start(ctx: &mut TxContext) {
         let a = A { id: object::new(ctx), value: 0 };
         let a_address = object::id_address(&a);
-        let b = A { id: object::new(ctx), value: 0 };
+        let mut b = A { id: object::new(ctx), value: 0 };
         dof::add(&mut b.id, KEY, A { id: object::new(ctx), value: 0 });
         transfer::public_share_object(a);
         transfer::public_transfer(b, a_address);

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/receive_multiple_times_in_row.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/shared_parent/transfer_then_share.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/take_receiver_then_try_to_reuse.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/take_receiver_then_try_to_reuse.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer::{Self, Receiving};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/transfer_object_cyclic.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/transfer_object_cyclic.move
@@ -9,11 +9,11 @@ module tto::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer::{Self};
 
-    struct A has key, store {
+    public struct A has key, store {
         id: UID,
     }
 
-    struct B has key, store {
+    public struct B has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/versioned_check_swap_loc_new.move
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/versioned_check_swap_loc_new.move
@@ -8,8 +8,8 @@
 //# publish
 module test::m {
     public fun t1(cond: bool) {
-        let x: vector<u64>;
-        let r: &vector<u64>;
+        let mut x: vector<u64>;
+        let mut r: &vector<u64>;
         if (cond) {
             x = vector[];
             r = &x;
@@ -26,7 +26,7 @@ module test::m {
 
     public fun t2(cond: bool) {
         let x: vector<u64> = vector[];
-        let r: &vector<u64>;
+        let mut r: &vector<u64>;
         if (cond) {
             r = &x;
             // use r in ways to disable optimizations or moving

--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/versioned_check_swap_loc_old.move
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/versioned_check_swap_loc_old.move
@@ -8,8 +8,8 @@
 //# publish
 module test::m {
     public fun t1(cond: bool) {
-        let x: vector<u64>;
-        let r: &vector<u64>;
+        let mut x: vector<u64>;
+        let mut r: &vector<u64>;
         if (cond) {
             x = vector[];
             r = &x;
@@ -26,7 +26,7 @@ module test::m {
 
     public fun t2(cond: bool) {
         let x: vector<u64> = vector[];
-        let r: &vector<u64>;
+        let mut r: &vector<u64>;
         if (cond) {
             r = &x;
             // use r in ways to disable optimizations or moving

--- a/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/add_dynamic_field.move
@@ -13,7 +13,7 @@ module a::m {
     use sui::object;
     use sui::tx_context:: TxContext;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: object::UID,
     }
 
@@ -21,12 +21,12 @@ module a::m {
         transfer::public_share_object(Obj { id: object::new(ctx) })
     }
 
-    public entry fun add_dynamic_field(obj: Obj) {
+    public entry fun add_dynamic_field(mut obj: Obj) {
         add<u64, u64>(&mut obj.id, 0, 0);
         transfer::public_share_object(obj);
     }
 
-    public entry fun add_and_remove_dynamic_field(obj: Obj) {
+    public entry fun add_and_remove_dynamic_field(mut obj: Obj) {
         add<u64, u64>(&mut obj.id, 0, 0);
         remove<u64, u64>(&mut obj.id, 0 );
         transfer::public_share_object(obj);

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.move
@@ -13,11 +13,11 @@ module a::m {
     use sui::object;
     use sui::tx_context::{sender, TxContext};
 
-    struct Outer has key, store {
+    public struct Outer has key, store {
         id: object::UID,
     }
 
-    struct Inner has key, store {
+    public struct Inner has key, store {
         id: object::UID,
     }
 
@@ -26,13 +26,13 @@ module a::m {
     }
 
     public entry fun add_dynamic_field(inner: Inner, ctx: &mut TxContext) {
-        let outer = Outer {id: object::new(ctx)};
+        let mut outer = Outer {id: object::new(ctx)};
         add<u64, Inner>(&mut outer.id, 0, inner);
         transfer::transfer(outer, sender(ctx));
     }
 
     public entry fun add_and_remove_dynamic_field(inner: Inner, ctx: &mut TxContext) {
-        let outer = Outer {id: object::new(ctx)};
+        let mut outer = Outer {id: object::new(ctx)};
         add<u64, Inner>(&mut outer.id, 0, inner);
         let removed = remove<u64, Inner>(&mut outer.id, 0);
         transfer::public_share_object(removed);

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.move
@@ -13,11 +13,11 @@ module a::m {
     use sui::object;
     use sui::tx_context::{sender, TxContext};
 
-    struct Outer has key, store {
+    public struct Outer has key, store {
         id: object::UID,
     }
 
-    struct Inner has key, store {
+    public struct Inner has key, store {
         id: object::UID,
     }
 
@@ -26,13 +26,13 @@ module a::m {
     }
 
     public entry fun add_dynamic_object_field(inner: Inner, ctx: &mut TxContext) {
-        let outer = Outer {id: object::new(ctx)};
+        let mut outer = Outer {id: object::new(ctx)};
         add(&mut outer.id, 0, inner);
         transfer::transfer(outer, sender(ctx));
     }
 
     public entry fun add_and_remove_dynamic_object_field(inner: Inner, ctx: &mut TxContext) {
-        let outer = Outer {id: object::new(ctx)};
+        let mut outer = Outer {id: object::new(ctx)};
         add(&mut outer.id, 0, inner);
         let removed: Inner = remove(&mut outer.id, 0);
         transfer::public_share_object(removed);

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion.move
@@ -13,7 +13,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.move
@@ -13,7 +13,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 
@@ -26,7 +26,7 @@ module t2::o2 {
         transfer::public_share_object(o)
     }
 
-    public fun delete(o2: vector<Obj2>) {
+    public fun delete(mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         deleter(o);
         vector::destroy_empty(o2);
@@ -37,7 +37,7 @@ module t2::o2 {
         object::delete(id);
     }
 
-    public fun pop_coin(o2: vector<Coin<SUI>>): Coin<SUI> {
+    public fun pop_coin(mut o2: vector<Coin<SUI>>): Coin<SUI> {
         let o = vector::pop_back(&mut o2);
         vector::destroy_empty(o2);
         o

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.exp
@@ -3,7 +3,7 @@ processed 22 tasks
 task 1 'publish'. lines 6-101:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 10852800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10944000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 103-103:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.move
@@ -15,7 +15,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 
@@ -23,7 +23,7 @@ module t2::o2 {
         transfer::public_share_object(coin::zero<SUI>(ctx))
     }
 
-    public fun pop_coin(o2: vector<Coin<SUI>>): Coin<SUI> {
+    public fun pop_coin(mut o2: vector<Coin<SUI>>): Coin<SUI> {
         let o = vector::pop_back(&mut o2);
         vector::destroy_empty(o2);
         o
@@ -34,37 +34,37 @@ module t2::o2 {
         transfer::public_share_object(o)
     }
 
-    public fun delete(o2: vector<Obj2>) {
+    public fun delete(mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         deleter(o);
         vector::destroy_empty(o2);
     }
 
-    public fun freezee(o2: vector<Obj2>) {
+    public fun freezee(mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         freezer(o);
         vector::destroy_empty(o2);
     }
 
-    public fun dof(parent: &mut Obj2, o2: vector<Obj2>) {
+    public fun dof_(parent: &mut Obj2, mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         dofer(parent, o);
         vector::destroy_empty(o2);
     }
 
-    public fun df(parent: &mut Obj2, o2: vector<Obj2>) {
+    public fun df_(parent: &mut Obj2, mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         dfer(parent, o);
         vector::destroy_empty(o2);
     }
 
-    public fun transfer(o2: vector<Obj2>) {
+    public fun transfer_(mut o2: vector<Obj2>) {
         let o = vector::pop_back(&mut o2);
         transferer(o);
         vector::destroy_empty(o2);
     }
 
-    public fun pop_it(o2: vector<Obj2>): Obj2 {
+    public fun pop_it(mut o2: vector<Obj2>): Obj2 {
         let o = vector::pop_back(&mut o2);
         vector::destroy_empty(o2);
         o
@@ -116,17 +116,17 @@ module t2::o2 {
 // Make MoveVec and then try to add as dof
 //# programmable --inputs object(2,0) object(3,0)
 //> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
-//> 1: t2::o2::dof(Input(0), Result(0));
+//> 1: t2::o2::dof_(Input(0), Result(0));
 
 // Make MoveVec and then try to add as df
 //# programmable --inputs object(2,0) object(3,0)
 //> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
-//> 1: t2::o2::df(Input(0), Result(0));
+//> 1: t2::o2::df_(Input(0), Result(0));
 
 // Make MoveVec and then try to transfer it
 //# programmable --inputs object(2,0) object(3,0)
 //> 0: MakeMoveVec<t2::o2::Obj2>([Input(1)]);
-//> 1: t2::o2::transfer(Result(0));
+//> 1: t2::o2::transfer_(Result(0));
 
 // Make MoveVec pop and return it, then try to freeze
 //# programmable --inputs object(2,0) object(3,0)

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge.move
@@ -21,7 +21,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.move
@@ -21,7 +21,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.move
@@ -12,7 +12,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.move
@@ -14,7 +14,7 @@ module t2::o2 {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_v20.move
@@ -12,7 +12,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/freeze.move
@@ -13,7 +13,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/re_share.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/re_share.move
@@ -12,7 +12,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/transfer.move
@@ -13,7 +13,7 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.move
@@ -12,12 +12,12 @@ module t::m {
     use sui::transfer;
     use sui::tx_context::{sender, TxContext};
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID,
     }
 
     public entry fun create(ctx: &mut TxContext) {
-        let o = Obj { id: object::new(ctx) };
+        let mut o = Obj { id: object::new(ctx) };
         sui::dynamic_field::add(&mut o.id, 0, Obj { id: object::new(ctx) });
         sui::dynamic_object_field::add(&mut o.id, 0, Obj { id: object::new(ctx) });
         transfer::public_transfer(o, sender(ctx))

--- a/crates/sui-adapter-transactional-tests/tests/shared/wrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/wrap.move
@@ -12,11 +12,11 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Obj2 has key, store {
+    public struct Obj2 has key, store {
         id: UID,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o2: Obj2
     }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.move
@@ -15,8 +15,8 @@ module Test::M1 {
     use std::vector;
 
     public entry fun delete_n_ids(n: u64, ctx: &mut TxContext) {
-        let v: vector<UID> = vector::empty();
-        let i = 0;
+        let mut v: vector<UID> = vector::empty();
+        let mut i = 0;
         while (i < n) {
             let id = object::new(ctx);
             vector::push_back(&mut v, id);

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
@@ -3,7 +3,7 @@ processed 10 tasks
 task 1 'publish'. lines 8-57:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7326400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7311200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 58-60:
 events: 1
@@ -26,12 +26,12 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 6 'run'. lines 70-72:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1413000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1393000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 7 'run'. lines 73-75:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1840000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1814000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8 'run'. lines 76-78:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
@@ -14,26 +14,26 @@ module Test::M1 {
     use std::vector;
     use sui::bcs;
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         contents: vector<u8>
     }
 
     // emit an event of size n
-    public fun emit_event_with_size(n: u64) {
+    public fun emit_event_with_size(mut n: u64) {
         // 46 seems to be the added size from event size derivation for `NewValueEvent`
         assert!(n > 46, 0);
         n = n - 46;
         // minimum object size for NewValueEvent is 1 byte for vector length
         assert!(n > 1, 0);
-        let contents = vector[];
-        let i = 0;
+        let mut contents = vector[];
+        let mut i = 0;
         let bytes_to_add = n - 1;
         while (i < bytes_to_add) {
             vector::push_back(&mut contents, 9);
             i = i + 1;
         };
-        let s = NewValueEvent { contents };
-        let size = vector::length(&bcs::to_bytes(&s));
+        let mut s = NewValueEvent { contents };
+        let mut size = vector::length(&bcs::to_bytes(&s));
         // shrink by 1 byte until we match size. mismatch happens because of len(UID) + vector length byte
         while (size > n) {
             let _ = vector::pop_back(&mut s.contents);
@@ -46,7 +46,7 @@ module Test::M1 {
 
     // Emit small (less than max size) events to test that the number of events is limited to the max count
     public entry fun emit_n_small_events(n: u64, _ctx: &mut TxContext) {
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
             emit_event_with_size(50);
             i = i + 1;

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.exp
@@ -3,7 +3,7 @@ processed 6 tasks
 task 1 'publish'. lines 8-68:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7934400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7919200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 69-71:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
@@ -19,4 +19,4 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5 'run'. lines 78-78:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 33)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests_out_of_gas.move
@@ -14,26 +14,26 @@ module Test::M1 {
     use std::vector;
     use sui::bcs;
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         contents: vector<u8>
     }
 
     // emit an event of size n
-    public fun emit_event_with_size(n: u64) {
+    public fun emit_event_with_size(mut n: u64) {
         // 46 seems to be the added size from event size derivation for `NewValueEvent`
         assert!(n > 46, 0);
         n = n - 46;
         // minimum object size for NewValueEvent is 1 byte for vector length
         assert!(n > 1, 0);
-        let contents = vector[];
-        let i = 0;
+        let mut contents = vector[];
+        let mut i = 0;
         let bytes_to_add = n - 1;
         while (i < bytes_to_add) {
             vector::push_back(&mut contents, 9);
             i = i + 1;
         };
-        let s = NewValueEvent { contents };
-        let size = vector::length(&bcs::to_bytes(&s));
+        let mut s = NewValueEvent { contents };
+        let mut size = vector::length(&bcs::to_bytes(&s));
         // shrink by 1 byte until we match size. mismatch happens because of len(UID) + vector length byte
         while (size > n) {
             let _ = vector::pop_back(&mut s.contents);
@@ -46,7 +46,7 @@ module Test::M1 {
 
     // Emit small (less than max size) events to test that the number of events is limited to the max count
     public entry fun emit_n_small_events(n: u64, _ctx: &mut TxContext) {
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
             emit_event_with_size(50);
             i = i + 1;
@@ -55,7 +55,7 @@ module Test::M1 {
 
     // emit n events each of size s
     public fun emit_n_events_with_size(n: u64, s: u64) {
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
             emit_event_with_size(s);
             i = i + 1;

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/identitifer_len_limits.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/identitifer_len_limits.move
@@ -39,8 +39,8 @@ module Test::M1_1234567891234567890123456789012345678912345678901234567 {
     use std::vector;
 
     public entry fun create_n_(n: u64, ctx: &mut TxContext) {
-        let v: vector<UID> = vector::empty();
-        let i = 0;
+        let mut v: vector<UID> = vector::empty();
+        let mut i = 0;
         while (i < n) {
             let id = object::new(ctx);
             vector::push_back(&mut v, id);

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-82:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9963600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9933200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 83-85:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
@@ -15,9 +15,9 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 3 'run'. lines 86-88:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1888000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1863000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 89-89:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1888000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1863000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
@@ -14,12 +14,12 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct S has key, store {
+    public struct S has key, store {
         id: UID,
         contents: vector<u8>
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         s: S,
     }
@@ -28,15 +28,15 @@ module Test::M1 {
     public fun create_object_with_size(n: u64, ctx: &mut TxContext): S {
         // minimum object size for S is 32 bytes for UID + 1 byte for vector length
         assert!(n > std::address::length() + 1, 0);
-        let contents = vector[];
-        let i = 0;
+        let mut contents = vector[];
+        let mut i = 0;
         let bytes_to_add = n - (std::address::length() + 1);
         while (i < bytes_to_add) {
             vector::push_back(&mut contents, 9);
             i = i + 1;
         };
-        let s = S { id: object::new(ctx), contents };
-        let size = vector::length(&bcs::to_bytes(&s));
+        let mut s = S { id: object::new(ctx), contents };
+        let mut size = vector::length(&bcs::to_bytes(&s));
         // shrink by 1 byte until we match size. mismatch happens because of len(UID) + vector length byte
         while (size > n) {
             let _ = vector::pop_back(&mut s.contents);
@@ -64,8 +64,8 @@ module Test::M1 {
 
     /// Add `n` bytes to the `s` inside `wrapper`, then unwrap it. This should fail
     /// if `s` is larger than the max object size
-    public entry fun add_bytes_then_unwrap(wrapper: Wrapper, n: u64, ctx: &mut TxContext) {
-        let i = 0;
+    public entry fun add_bytes_then_unwrap(mut wrapper: Wrapper, n: u64, ctx: &mut TxContext) {
+        let mut i = 0;
         while (i < n) {
             vector::push_back(&mut wrapper.s.contents, 7);
             i = i + 1

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
@@ -14,8 +14,8 @@ module Test::M1 {
     use std::vector;
 
     public entry fun create_n_ids(n: u64, ctx: &mut TxContext) {
-        let v: vector<UID> = vector::empty();
-        let i = 0;
+        let mut v: vector<UID> = vector::empty();
+        let mut i = 0;
         while (i < n) {
             let id = object::new(ctx);
             vector::push_back(&mut v, id);

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.move
@@ -11,14 +11,14 @@ module a::m {
     use sui::object;
     use sui::tx_context::{sender, TxContext};
 
-    struct Obj has key {
+    public struct Obj has key {
         id: object::UID,
     }
 
     public entry fun add_n_items(n: u64, ctx: &mut TxContext) {
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
-            let id = object::new(ctx);
+            let mut id = object::new(ctx);
             add<u64, u64>(&mut id, i, i);
             sui::transfer::transfer(Obj { id }, sender(ctx));
 

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.move
@@ -14,12 +14,12 @@ module Test::M1 {
     use sui::object::{Self, UID};
     use sui::transfer;
 
-    struct Obj has key, store {
+    public struct Obj has key, store {
         id: UID
     }
 
     public entry fun transfer_n_ids(n: u64, ctx: &mut TxContext) {
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
             transfer::public_transfer(
                 Obj {

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
@@ -12,8 +12,8 @@ module Test::M1 {
     use std::vector;
 
     public entry fun push_n_items(n: u64) {
-        let v: vector<u64> = vector::empty();
-        let i = 0;
+        let mut v: vector<u64> = vector::empty();
+        let mut i = 0;
         while (i < n) {
             vector::push_back(&mut v, i);
             i = i + 1;

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.move
@@ -13,7 +13,7 @@ module test::coin_in_vec {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         coins: vector<Coin<SUI>>,
     }

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-70:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9241600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9317600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.move
@@ -13,17 +13,17 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         new_value: u64
     }
 
@@ -34,7 +34,7 @@ module test::object_basics {
         )
     }
 
-    public entry fun transfer(o: Object, recipient: address) {
+    public entry fun transfer_(o: Object, recipient: address) {
         transfer::public_transfer(o, recipient)
     }
 
@@ -73,6 +73,6 @@ module test::object_basics {
 
 //# run test::object_basics::freeze_object --args object(2,0) --sender A
 
-//# run test::object_basics::transfer --args object(2,0) @A --sender A
+//# run test::object_basics::transfer_ --args object(2,0) @A --sender A
 
 //# run test::object_basics::set_value --args object(2,0) 1 --sender A

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-70:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9241600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9317600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze_v20.move
@@ -13,17 +13,17 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         new_value: u64
     }
 
@@ -34,7 +34,7 @@ module test::object_basics {
         )
     }
 
-    public entry fun transfer(o: Object, recipient: address) {
+    public entry fun transfer_(o: Object, recipient: address) {
         transfer::public_transfer(o, recipient)
     }
 
@@ -73,6 +73,6 @@ module test::object_basics {
 
 //# run test::object_basics::freeze_object --args object(2,0) --sender A
 
-//# run test::object_basics::transfer --args object(2,0) @A --sender A
+//# run test::object_basics::transfer_ --args object(2,0) @A --sender A
 
 //# run test::object_basics::set_value --args object(2,0) 1 --sender A

--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-70:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 9241600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9317600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.move
@@ -13,17 +13,17 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         new_value: u64
     }
 
@@ -34,7 +34,7 @@ module test::object_basics {
         )
     }
 
-    public entry fun transfer(o: Object, recipient: address) {
+    public entry fun transfer_(o: Object, recipient: address) {
         transfer::public_transfer(o, recipient)
     }
 
@@ -73,7 +73,7 @@ module test::object_basics {
 
 //# view-object 2,0
 
-//# run test::object_basics::transfer --sender A --args object(2,0) @B
+//# run test::object_basics::transfer_ --sender A --args object(2,0) @B
 
 //# view-object 2,0
 

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-71:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9074400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9150400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 73-73:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap.move
@@ -14,17 +14,17 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }
 
-    struct NewValueEvent has copy, drop {
+    public struct NewValueEvent has copy, drop {
         new_value: u64
     }
 
@@ -35,7 +35,7 @@ module test::object_basics {
         )
     }
 
-    public entry fun transfer(o: Object, recipient: address) {
+    public entry fun transfer_(o: Object, recipient: address) {
         transfer::transfer(o, recipient)
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.move
@@ -18,12 +18,12 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.move
@@ -13,12 +13,12 @@ module test::object_basics {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.move
@@ -12,8 +12,8 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::object::{Self, UID};
 
-    struct S has key { id: UID }
-    struct Cup<phantom T> has key { id: UID }
+    public struct S has key { id: UID }
+    public struct Cup<phantom T> has key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive.move
@@ -12,10 +12,10 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::object::{Self, UID};
 
-    struct Parent has key { id: UID }
-    struct S has key { id: UID }
-    struct Cup<phantom T> has key { id: UID }
-    struct Store has key, store { id: UID }
+    public struct Parent has key { id: UID }
+    public struct S has key { id: UID }
+    public struct Cup<phantom T> has key { id: UID }
+    public struct Store has key, store { id: UID }
 
     public fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive_version30.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store_receive_version30.move
@@ -12,10 +12,10 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::object::{Self, UID};
 
-    struct Parent has key { id: UID }
-    struct S has key { id: UID }
-    struct Cup<phantom T> has key { id: UID }
-    struct Store has key, store { id: UID }
+    public struct Parent has key { id: UID }
+    public struct S has key { id: UID }
+    public struct Cup<phantom T> has key { id: UID }
+    public struct Store has key, store { id: UID }
 
     public fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.move
@@ -12,8 +12,8 @@ module test::m {
     use sui::tx_context::{Self, TxContext};
     use sui::object::{Self, UID};
 
-    struct S has store, key { id: UID }
-    struct Cup<phantom T: store> has store, key { id: UID }
+    public struct S has store, key { id: UID }
+    public struct Cup<phantom T: store> has store, key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.move
@@ -12,8 +12,8 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
 
-    struct S has store, key { id: UID }
-    struct Cup<phantom T: store> has store, key { id: UID }
+    public struct S has store, key { id: UID }
+    public struct Cup<phantom T: store> has store, key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable_v20.move
@@ -12,8 +12,8 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
 
-    struct S has store, key { id: UID }
-    struct Cup<phantom T: store> has store, key { id: UID }
+    public struct S has store, key { id: UID }
+    public struct Cup<phantom T: store> has store, key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.move
@@ -12,8 +12,8 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
 
-    struct S has key { id: UID }
-    struct Child has key, store { id: UID }
+    public struct S has key { id: UID }
+    public struct Child has key, store { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.move
@@ -12,9 +12,9 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
 
-    struct S has key { id: UID }
+    public struct S has key { id: UID }
 
-    struct S2 has key, store { id: UID }
+    public struct S2 has key, store { id: UID }
 
     public fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared_v20.move
@@ -12,7 +12,7 @@ module test::m {
     use sui::tx_context::TxContext;
     use sui::object::{Self, UID};
 
-    struct S has key { id: UID }
+    public struct S has key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.move
@@ -10,11 +10,11 @@ module a::m {
     use sui::object;
     use sui::tx_context::{Self, TxContext};
 
-    struct S has key, store {
+    public struct S has key, store {
         id: object::UID,
     }
 
-    struct T has key, store {
+    public struct T has key, store {
         id: object::UID,
         s: S,
     }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade.move
@@ -5,62 +5,62 @@
 
 //# publish --upgradeable --sender A
 module Test_V0::base {
-    struct Foo {
+    public struct Foo {
     }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
     use sui::object::UID;
-    struct Foo has key {
+    public struct Foo has key {
         id: UID
     }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has drop { }
+    public struct Foo has drop { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has copy { }
+    public struct Foo has copy { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has store { }
+    public struct Foo has store { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has drop, store { }
+    public struct Foo has drop, store { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has drop, copy { }
+    public struct Foo has drop, copy { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has drop, key { }
+    public struct Foo has drop, key { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
     use sui::object::UID;
-    struct Foo has store, key {
+    public struct Foo has store, key {
         id: UID
     }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has store, copy { }
+    public struct Foo has store, copy { }
 }
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
-    struct Foo has drop, copy, store { }
+    public struct Foo has drop, copy, store { }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade_generics.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/add_ability_during_upgrade_generics.move
@@ -5,25 +5,25 @@
 
 //# publish --upgradeable --sender A
 module A0::base {
-    struct Foo<phantom T> { }
+    public struct Foo<phantom T> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: store> { }
+    public struct Foo<T: store> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: copy> { }
+    public struct Foo<T: copy> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: drop> { }
+    public struct Foo<T: drop> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: copy + drop + key> { }
+    public struct Foo<T: copy + drop + key> { }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/add_key_during_upgrade.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/add_key_during_upgrade.move
@@ -6,10 +6,10 @@
 //# publish --upgradeable --sender A
 module Test_V0::base {
     use sui::object::UID;
-    struct Foo {
+    public struct Foo {
         id: UID,
     }
-    struct Bar {
+    public struct Bar {
         id: UID,
     }
 }
@@ -17,10 +17,10 @@ module Test_V0::base {
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
     use sui::object::UID;
-    struct Foo has key {
+    public struct Foo has key {
         id: UID,
     }
-    struct Bar has key {
+    public struct Bar has key {
         id: UID,
     }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/add_new_type_with_key.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/add_new_type_with_key.move
@@ -6,7 +6,7 @@
 //# publish --upgradeable --sender A
 module Test_V0::base {
     use sui::object::UID;
-    struct Foo {
+    public struct Foo {
         id: UID,
     }
 }
@@ -14,10 +14,10 @@ module Test_V0::base {
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base {
     use sui::object::UID;
-    struct Foo {
+    public struct Foo {
         id: UID,
     }
-    struct Bar has key {
+    public struct Bar has key {
         id: UID,
     }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/constants.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/constants.move
@@ -8,7 +8,7 @@ module V0::base_module {
 
     const A: u64 = 0;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -20,7 +20,7 @@ module V1::base_module {
 
     const A: u64 = 1;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -32,7 +32,7 @@ module V2::base_module {
 
     const Y: u64 = 1;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -46,7 +46,7 @@ module V3::base_module {
 
     const Y: u64 = 0;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -58,7 +58,7 @@ module V3::base_module {
 
     const Y: u64 = 0;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -75,7 +75,7 @@ module V3::base_module {
     const Z: u64 = 0;
     const A: u64 = 42;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -92,7 +92,7 @@ module V4::base_module {
     const T: u64 = 2;
     const A: u64 = 42;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -107,7 +107,7 @@ module V5::base_module {
     const Y: u64 = 1;
     const T: u64 = 2;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -123,7 +123,7 @@ module V6::base_module {
     const T: u64 = 2;
     const Y: u64 = 1;
 
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.move
@@ -10,7 +10,7 @@
 //# publish --upgradeable --sender A
 module Test_DepDepV1::DepDepM1 {
 
-    struct Obj has key, store { id: sui::object::UID, v: u64 }
+    public struct Obj has key, store { id: sui::object::UID, v: u64 }
 
     public fun foo(ctx: &mut sui::tx_context::TxContext) {
         sui::transfer::share_object(Obj { id: sui::object::new(ctx), v: 42 })
@@ -20,7 +20,7 @@ module Test_DepDepV1::DepDepM1 {
 //# upgrade --package Test_DepDepV1 --upgrade-capability 1,1 --sender A
 module Test_DepDepV2::DepDepM1 {
 
-    struct Obj has key, store { id: sui::object::UID, v: u64 }
+    public struct Obj has key, store { id: sui::object::UID, v: u64 }
 
     public fun foo(ctx: &mut sui::tx_context::TxContext) {
         sui::transfer::share_object(Obj { id: sui::object::new(ctx), v: 7 })
@@ -30,7 +30,7 @@ module Test_DepDepV2::DepDepM1 {
 //# upgrade --package Test_DepDepV2 --upgrade-capability 1,1 --sender A
 module Test_DepDepV3::DepDepM1 {
 
-    struct Obj has key, store { id: sui::object::UID, v: u64 }
+    public struct Obj has key, store { id: sui::object::UID, v: u64 }
 
     public fun foo(ctx: &mut sui::tx_context::TxContext) {
         sui::transfer::share_object(Obj { id: sui::object::new(ctx), v: 0 })

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.move
@@ -6,7 +6,7 @@
 //# publish --upgradeable --sender A
 module V0::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -24,7 +24,7 @@ module V0::friend_module {
 //# upgrade --package V0 --upgrade-capability 1,1 --sender A
 module V1::base_module {
     use sui::object::UID;
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         field0: u64,
         field1: u64,
@@ -44,7 +44,7 @@ module V2::base_module {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::transfer;
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         field0: u64,
         field1: u64,
@@ -74,7 +74,7 @@ module V3::base_module {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
     use sui::transfer;
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         field0: u64,
         field1: u64,

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.move
@@ -8,8 +8,8 @@ module V0::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct String has copy, drop, store { bytes: vector<u8>, }
-   struct Char has copy, drop, store { byte: u8, }
+   public struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
     public fun char(byte: u8): Char {
         assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
         Char { byte }
@@ -24,7 +24,7 @@ module V0::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -34,7 +34,7 @@ module V0::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -61,8 +61,8 @@ module V1::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct String has copy, drop, store { bytes: vector<u8>, }
-   struct Char has copy, drop, store { byte: u8, }
+   public struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
     public fun char(byte: u8): Char {
         assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
         Char { byte }
@@ -77,7 +77,7 @@ module V1::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -87,7 +87,7 @@ module V1::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -115,8 +115,8 @@ module V1::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct String has copy, drop, store { bytes: vector<u8>, }
-   struct Char has copy, drop, store { byte: u8, }
+   public struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
     public fun char(byte: u8): Char {
         assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
         Char { byte }
@@ -131,7 +131,7 @@ module V1::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        // CHANGED: Swapped the order of these two let declarations.
-       let i = 0;
+       let mut i = 0;
        let len = vector::length(&bytes);
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
@@ -142,7 +142,7 @@ module V1::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -169,8 +169,8 @@ module V1::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct Char has copy, drop, store { byte: u8, }
-   struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
+   public struct String has copy, drop, store { bytes: vector<u8>, }
     public fun string(bytes: vector<u8>): String {
        let x = try_string(bytes);
        assert!(
@@ -185,7 +185,7 @@ module V1::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -195,7 +195,7 @@ module V1::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -222,9 +222,9 @@ module V2::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct Char has copy, drop, store { byte: u8, }
-   struct NewStruct { }
-   struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
+   public struct NewStruct { }
+   public struct String has copy, drop, store { bytes: vector<u8>, }
     public fun string(bytes: vector<u8>): String {
        let x = try_string(bytes);
        assert!(
@@ -239,7 +239,7 @@ module V2::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -249,7 +249,7 @@ module V2::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -277,9 +277,9 @@ module V2::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct Char has copy, drop, store { byte: u8, }
-   struct NewStruct { } // <<<<<<<<< NEW STRUCT
-   struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
+   public struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   public struct String has copy, drop, store { bytes: vector<u8>, }
     public fun string(bytes: vector<u8>): String {
        let x = try_string(bytes);
        assert!(
@@ -294,7 +294,7 @@ module V2::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -304,7 +304,7 @@ module V2::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -332,9 +332,9 @@ module V3::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct Char has copy, drop, store { byte: u8, }
-   struct NewStruct { } // <<<<<<<<< NEW STRUCT
-   struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
+   public struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   public struct String has copy, drop, store { bytes: vector<u8>, }
     public fun string(bytes: vector<u8>): String {
        let x = try_string(bytes);
        assert!(
@@ -349,7 +349,7 @@ module V3::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -359,7 +359,7 @@ module V3::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;
@@ -387,9 +387,9 @@ module V4::ascii {
     use std::vector;
     use std::option::{Self, Option};
     const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
-   struct Char has copy, drop, store { byte: u8, }
-   struct NewStruct { } // <<<<<<<<< NEW STRUCT
-   struct String has copy, drop, store { bytes: vector<u8>, }
+   public struct Char has copy, drop, store { byte: u8, }
+   public struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   public struct String has copy, drop, store { bytes: vector<u8>, }
     public fun string(bytes: vector<u8>): String {
        let x = try_string(bytes);
        assert!(
@@ -404,7 +404,7 @@ module V4::ascii {
     }
     public fun try_string(bytes: vector<u8>): Option<String> {
        let len = vector::length(&bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let possible_byte = *vector::borrow(&bytes, i);
            if (!is_valid_char(possible_byte)) return option::none();
@@ -414,7 +414,7 @@ module V4::ascii {
     }
     public fun all_characters_printable(string: &String): bool {
        let len = vector::length(&string.bytes);
-       let i = 0;
+       let mut i = 0;
        while (i < len) {
            let byte = *vector::borrow(&string.bytes, i);
            if (!is_printable_char(byte)) return false;

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.move
@@ -5,7 +5,7 @@
 
 //# publish --upgradeable --sender A
 module Test_DepV1::DepM1 {
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
     public fun mod_obj(o: &mut DepObj) {
         o.v = 0;
     }
@@ -13,7 +13,7 @@ module Test_DepV1::DepM1 {
 
 //# upgrade --package Test_DepV1 --upgrade-capability 1,1 --sender A
 module Test_DepV2::DepM1 {
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
     public fun mod_obj(o: &mut DepObj) {
         o.v = 0;
     }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/modules.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/modules.move
@@ -6,7 +6,7 @@
 //# publish --upgradeable --sender A
 module V0::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -21,7 +21,7 @@ module V0::b {
     public fun public_fun(): u64 { 0 }
 }
 module V0::other_module {
-    struct Y { }
+    public struct Y { }
     fun public_fun(): u64 { 0 }
 }
 
@@ -29,7 +29,7 @@ module V0::other_module {
 //# upgrade --package V0 --upgrade-capability 1,1 --sender A
 module V1::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -51,7 +51,7 @@ module V1::other_module {
 //# upgrade --package V0 --upgrade-capability 1,1 --sender A
 module V1::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -70,7 +70,7 @@ module V1::b {
 //# upgrade --package V0 --upgrade-capability 1,1 --sender A
 module V1::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -82,7 +82,7 @@ module V1::a {
     fun call_friend(): u64 { V0::base_module::public_fun() }
 }
 module V1::other_module {
-    struct Y { }
+    public struct Y { }
     fun public_fun(): u64 { 0 }
 }
 
@@ -90,7 +90,7 @@ module V1::other_module {
 //# upgrade --package V0 --upgrade-capability 1,1 --sender A
 module V0::base_module {
     use sui::object::UID;
-    struct Object has key, store { 
+    public struct Object has key, store { 
         id: UID,
         field0: u64,
         field1: u64,
@@ -102,6 +102,6 @@ module V0::b {
     public fun public_fun(): u64 { 0 }
 }
 module V0::other_module {
-    struct Y { }
+    public struct Y { }
     fun public_fun(): u64 { 0 }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.move
@@ -6,7 +6,7 @@
 //# publish --upgradeable --sender A
 module Test_DepV1::DepM1 {
 
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
 
     public fun foo(ctx: &mut sui::tx_context::TxContext) {
         sui::transfer::share_object(DepObj { id: sui::object::new(ctx), v: 42 });
@@ -21,7 +21,7 @@ module Test_DepV1::DepM1 {
 //# upgrade --package Test_DepV1 --upgrade-capability 1,1 --sender A
 module Test_DepV2::DepM1 {
 
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
 
     public fun foo(ctx: &mut sui::tx_context::TxContext) {
         sui::transfer::share_object(DepObj { id: sui::object::new(ctx), v: 7 });

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.move
@@ -8,8 +8,8 @@ module A0::m {
     use sui::package;
     use sui::tx_context::TxContext;
 
-    struct A {}
-    struct M has drop {}
+    public struct A {}
+    public struct M has drop {}
 
     fun init(m: M, ctx: &mut TxContext) {
         package::claim_and_keep(m, ctx);
@@ -21,9 +21,9 @@ module A1::m {
     use sui::package::{Self, Publisher};
     use sui::tx_context::TxContext;
 
-    struct A {}
-    struct B {}
-    struct M has drop {}
+    public struct A {}
+    public struct B {}
+    public struct M has drop {}
 
     fun init(m: M, ctx: &mut TxContext) {
         package::claim_and_keep(m, ctx);

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/remove_ability_during_upgrade_generics.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/remove_ability_during_upgrade_generics.move
@@ -5,42 +5,42 @@
 
 //# publish --upgradeable --sender A
 module A0::base {
-    struct Foo<T: store + copy + drop + key> {
+    public struct Foo<T: store + copy + drop + key> {
         x: T
     }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: store + copy + drop> {
+    public struct Foo<T: store + copy + drop> {
         x: T
     }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: copy> {
+    public struct Foo<T: copy> {
         x: T
     }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: drop> {
+    public struct Foo<T: drop> {
         x: T
     }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: key> {
+    public struct Foo<T: key> {
         x: T
     }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: store> {
+    public struct Foo<T: store> {
         x: T
     }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/remove_phantom.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/remove_phantom.move
@@ -5,16 +5,16 @@
 
 //# publish --upgradeable --sender A
 module A0::base {
-    struct Foo<phantom T> { }
+    public struct Foo<phantom T> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T> { }
+    public struct Foo<T> { }
 }
 
 //# upgrade --package A0 --upgrade-capability 1,1 --sender A
 module A1::base {
-    struct Foo<T: store> { }
+    public struct Foo<T: store> { }
 }
 

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/structs.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/structs.move
@@ -5,7 +5,7 @@
 
 //# publish --upgradeable --sender A
 module Test_V0::base_module {
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
     }
@@ -15,7 +15,7 @@ module Test_V0::base_module {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base_module {
-    struct Y {
+    public struct Y {
         field0: u64,
         field1: u64,
     }
@@ -30,7 +30,7 @@ module Test_V1::base_module {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base_module {
-    struct X {
+    public struct X {
         field2: u64,
         field1: u64,
     }
@@ -40,7 +40,7 @@ module Test_V1::base_module {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base_module {
-    struct X {
+    public struct X {
         field1: u64,
         field0: u64,
     }
@@ -50,7 +50,7 @@ module Test_V1::base_module {
 
 //# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
 module Test_V1::base_module {
-    struct X {
+    public struct X {
         field0: u64,
         field1: u64,
         field2: u64,

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.move
@@ -5,7 +5,7 @@
 
 //# publish --upgradeable --sender A
 module Test_DepV1::DepM1 {
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
     public fun mod_obj(o: &mut DepObj) {
         o.v = 0;
     }
@@ -14,7 +14,7 @@ module Test_DepV1::DepM1 {
 
 //# upgrade --package Test_DepV1 --upgrade-capability 1,1 --sender A
 module Test_DepV2::DepM1 {
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
     public fun mod_obj(o: &mut DepObj) {
         o.v = 0;
     }
@@ -22,7 +22,7 @@ module Test_DepV2::DepM1 {
 
 //# upgrade --package Test_DepV2 --upgrade-capability 1,1 --sender A
 module Test_DepV3::DepM1 {
-    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public struct DepObj has key, store { id: sui::object::UID, v: u64 }
     public fun mod_obj(o: &mut DepObj) {
         o.v = 0;
     }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
@@ -7,12 +7,12 @@
 module A0::m {
     use sui::object::UID;
 
-    struct Canary has key {
+    public struct Canary has key {
         id: UID,
         addr: vector<u8>,
     }
 
-    struct A {}
+    public struct A {}
 
 }
 
@@ -20,13 +20,13 @@ module A0::m {
 module A1::m {
     use sui::object::UID;
 
-    struct Canary has key {
+    public struct Canary has key {
         id: UID,
         addr: vector<u8>,
     }
 
-    struct A {}
-    struct B {}
+    public struct A {}
+    public struct B {}
 }
 
 //# upgrade --package A1 --upgrade-capability 1,1 --sender A
@@ -37,22 +37,22 @@ module A2::m {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Canary has key {
+    public struct Canary has key {
         id: UID,
         addr: vector<u8>,
     }
 
-    struct A {}
-    struct B {}
+    public struct A {}
+    public struct B {}
 
     entry fun canary<T>(use_original: bool, ctx: &mut TxContext) {
-        let type = if (use_original) {
+        let type_ = if (use_original) {
             type_name::get_with_original_ids<T>()
         } else {
             type_name::get<T>()
         };
 
-        let addr = ascii::into_bytes(type_name::get_address(&type));
+        let addr = ascii::into_bytes(type_name::get_address(&type_));
 
         transfer::transfer(
             Canary { id: object::new(ctx), addr },

--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[defines_primitive(vector)]
 /// A variable-sized container that can hold any type. Indexing is 0-based, and
 /// vectors are growable. This module has many native functions.
 module std::vector {

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.exp
@@ -3,15 +3,15 @@ processed 7 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 6-20:
+task 1 'publish'. lines 6-19:
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'create-checkpoint'. lines 22-22:
+task 2 'create-checkpoint'. lines 21-21:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 24-35:
+task 3 'run-graphql'. lines 23-34:
 Response: {
   "data": {
     "coinMetadata": {
@@ -26,15 +26,15 @@ Response: {
   }
 }
 
-task 4 'programmable'. lines 38-40:
+task 4 'programmable'. lines 37-39:
 created: object(4,0)
 mutated: object(0,0), object(1,2)
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
-task 5 'create-checkpoint'. lines 42-42:
+task 5 'create-checkpoint'. lines 41-41:
 Checkpoint created: 2
 
-task 6 'run-graphql'. lines 44-55:
+task 6 'run-graphql'. lines 43-54:
 Response: {
   "data": {
     "coinMetadata": {

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
@@ -5,12 +5,11 @@
 
 //# publish --sender A
 module test::fake {
-    use std::option;
     use sui::coin;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext){
         let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -17,16 +17,16 @@ module Test::m {
     use sui::object;
     use sui::tx_context::{sender, TxContext};
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: object::UID,
         o: Parent
     }
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: object::UID,
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: object::UID,
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -26,7 +26,7 @@ module Test::M1 {
     use sui::transfer;
     use sui::coin::Coin;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -10,7 +10,7 @@ module Test::M1 {
     use sui::transfer;
     use sui::coin::Coin;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.exp
@@ -3,45 +3,45 @@ processed 34 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1 'publish'. lines 19-49:
+task 1 'publish'. lines 19-48:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'create-checkpoint'. lines 51-51:
+task 2 'create-checkpoint'. lines 50-50:
 Checkpoint created: 1
 
-task 3 'programmable'. lines 53-55:
+task 3 'programmable'. lines 52-54:
 mutated: object(0,0), object(1,1), object(1,5)
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 3972672, non_refundable_storage_fee: 40128
 
-task 4 'create-checkpoint'. lines 57-57:
+task 4 'create-checkpoint'. lines 56-56:
 Checkpoint created: 2
 
-task 5 'transfer-object'. lines 59-59:
+task 5 'transfer-object'. lines 58-58:
 mutated: object(0,0), object(1,2)
 gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
 
-task 6 'create-checkpoint'. lines 61-61:
+task 6 'create-checkpoint'. lines 60-60:
 Checkpoint created: 3
 
-task 7 'transfer-object'. lines 63-63:
+task 7 'transfer-object'. lines 62-62:
 mutated: object(0,0), object(1,3)
 gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
 
-task 9 'create-checkpoint'. lines 67-67:
+task 9 'create-checkpoint'. lines 66-66:
 Checkpoint created: 4
 
-task 11 'create-checkpoint'. lines 71-71:
+task 11 'create-checkpoint'. lines 70-70:
 Checkpoint created: 5
 
-task 13 'create-checkpoint'. lines 75-75:
+task 13 'create-checkpoint'. lines 74-74:
 Checkpoint created: 6
 
-task 15 'create-checkpoint'. lines 79-79:
+task 15 'create-checkpoint'. lines 78-78:
 Checkpoint created: 7
 
-task 16 'run-graphql'. lines 81-102:
+task 16 'run-graphql'. lines 80-101:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -76,7 +76,7 @@ Response: {
   }
 }
 
-task 17 'run-graphql'. lines 104-125:
+task 17 'run-graphql'. lines 103-124:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -111,7 +111,7 @@ Response: {
   }
 }
 
-task 18 'run-graphql'. lines 127-148:
+task 18 'run-graphql'. lines 126-147:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -146,13 +146,13 @@ Response: {
   }
 }
 
-task 19 'force-object-snapshot-catchup'. lines 150-150:
+task 19 'force-object-snapshot-catchup'. lines 149-149:
 Objects snapshot updated to [0 to 3)
 
-task 20 'create-checkpoint'. lines 152-152:
+task 20 'create-checkpoint'. lines 151-151:
 Checkpoint created: 8
 
-task 21 'run-graphql'. lines 154-175:
+task 21 'run-graphql'. lines 153-174:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -187,7 +187,7 @@ Response: {
   }
 }
 
-task 22 'run-graphql'. lines 177-198:
+task 22 'run-graphql'. lines 176-197:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -222,7 +222,7 @@ Response: {
   }
 }
 
-task 23 'run-graphql'. lines 200-221:
+task 23 'run-graphql'. lines 199-220:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -257,13 +257,13 @@ Response: {
   }
 }
 
-task 24 'force-object-snapshot-catchup'. lines 223-223:
+task 24 'force-object-snapshot-catchup'. lines 222-222:
 Objects snapshot updated to [0 to 4)
 
-task 25 'create-checkpoint'. lines 225-225:
+task 25 'create-checkpoint'. lines 224-224:
 Checkpoint created: 9
 
-task 26 'run-graphql'. lines 227-248:
+task 26 'run-graphql'. lines 226-247:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -297,7 +297,7 @@ Response: {
   ]
 }
 
-task 27 'run-graphql'. lines 250-271:
+task 27 'run-graphql'. lines 249-270:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -332,7 +332,7 @@ Response: {
   }
 }
 
-task 28 'run-graphql'. lines 273-294:
+task 28 'run-graphql'. lines 272-293:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -367,13 +367,13 @@ Response: {
   }
 }
 
-task 29 'force-object-snapshot-catchup'. lines 297-297:
+task 29 'force-object-snapshot-catchup'. lines 296-296:
 Objects snapshot updated to [0 to 6)
 
-task 30 'create-checkpoint'. lines 299-299:
+task 30 'create-checkpoint'. lines 298-298:
 Checkpoint created: 10
 
-task 31 'run-graphql'. lines 301-322:
+task 31 'run-graphql'. lines 300-321:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -407,7 +407,7 @@ Response: {
   ]
 }
 
-task 32 'run-graphql'. lines 324-345:
+task 32 'run-graphql'. lines 323-344:
 Response: {
   "data": {
     "transactionBlocks": {
@@ -441,7 +441,7 @@ Response: {
   ]
 }
 
-task 33 'run-graphql'. lines 347-368:
+task 33 'run-graphql'. lines 346-367:
 Response: {
   "data": {
     "transactionBlocks": {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -18,15 +18,14 @@
 
 //# publish --sender A
 module P0::fake {
-    use std::option;
     use sui::coin;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext){
-        let (treasury_cap, metadata) = coin::create_currency(
+        let (mut treasury_cap, metadata) = coin::create_currency(
             witness,
             2,
             b"FAKE",

--- a/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
@@ -16,7 +16,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/coins.exp
@@ -3,22 +3,22 @@ processed 21 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1 'publish'. lines 12-42:
+task 1 'publish'. lines 12-41:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'create-checkpoint'. lines 44-44:
+task 2 'create-checkpoint'. lines 43-43:
 Checkpoint created: 1
 
-task 3 'programmable'. lines 46-48:
+task 3 'programmable'. lines 45-47:
 mutated: object(0,0), object(1,1), object(1,5)
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 3972672, non_refundable_storage_fee: 40128
 
-task 4 'create-checkpoint'. lines 50-50:
+task 4 'create-checkpoint'. lines 49-49:
 Checkpoint created: 2
 
-task 5 'run-graphql'. lines 52-93:
+task 5 'run-graphql'. lines 51-92:
 Response: {
   "data": {
     "queryCoinsAtLatest": {
@@ -256,7 +256,7 @@ Response: {
   }
 }
 
-task 6 'run-graphql'. lines 95-136:
+task 6 'run-graphql'. lines 94-135:
 Response: {
   "data": {
     "queryCoinsAtChkpt1": {
@@ -420,18 +420,18 @@ Response: {
   }
 }
 
-task 7 'transfer-object'. lines 138-138:
+task 7 'transfer-object'. lines 137-137:
 mutated: object(0,0), object(1,2)
 gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
 
-task 8 'transfer-object'. lines 140-140:
+task 8 'transfer-object'. lines 139-139:
 mutated: object(0,0), object(1,3)
 gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
 
-task 9 'create-checkpoint'. lines 142-142:
+task 9 'create-checkpoint'. lines 141-141:
 Checkpoint created: 3
 
-task 10 'run-graphql'. lines 144-197:
+task 10 'run-graphql'. lines 143-196:
 Response: {
   "data": {
     "queryCoins": {
@@ -623,16 +623,16 @@ Response: {
   }
 }
 
-task 12 'create-checkpoint'. lines 201-201:
+task 12 'create-checkpoint'. lines 200-200:
 Checkpoint created: 4
 
-task 14 'create-checkpoint'. lines 205-205:
+task 14 'create-checkpoint'. lines 204-204:
 Checkpoint created: 5
 
-task 16 'create-checkpoint'. lines 209-209:
+task 16 'create-checkpoint'. lines 208-208:
 Checkpoint created: 6
 
-task 17 'run-graphql'. lines 211-252:
+task 17 'run-graphql'. lines 210-251:
 Response: {
   "data": {
     "queryCoinsAtChkpt1BeforeSnapshotCatchup": {
@@ -796,13 +796,13 @@ Response: {
   }
 }
 
-task 18 'force-object-snapshot-catchup'. lines 254-254:
+task 18 'force-object-snapshot-catchup'. lines 253-253:
 Objects snapshot updated to [0 to 4)
 
-task 19 'create-checkpoint'. lines 256-256:
+task 19 'create-checkpoint'. lines 255-255:
 Checkpoint created: 7
 
-task 20 'run-graphql'. lines 258-287:
+task 20 'run-graphql'. lines 257-286:
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/consistency/coins.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/coins.move
@@ -11,15 +11,14 @@
 
 //# publish --sender A
 module P0::fake {
-    use std::option;
     use sui::coin;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext){
-        let (treasury_cap, metadata) = coin::create_currency(
+        let (mut treasury_cap, metadata) = coin::create_currency(
             witness,
             2,
             b"FAKE",

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
@@ -19,7 +19,7 @@ module Test::M1 {
     use sui::transfer;
     use std::string::{String, utf8};
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
         count: u64
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
@@ -18,12 +18,12 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
         count: u64
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
         count: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
@@ -18,11 +18,11 @@ module Test::M1 {
     use sui::transfer;
     use std::string::{String, utf8};
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
         count: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
@@ -19,7 +19,7 @@ module Test::M1 {
     use sui::transfer;
     use std::string::{String, utf8};
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
         count: u64
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
@@ -19,12 +19,12 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Parent has key, store {
+    public struct Parent has key, store {
         id: UID,
         count: u64
     }
 
-    struct Child has key, store {
+    public struct Child has key, store {
         id: UID,
         count: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
@@ -25,7 +25,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.move
@@ -22,12 +22,12 @@ module Test::M1 {
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Wrapper has key {
+    public struct Wrapper has key {
         id: UID,
         o: Object
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
@@ -18,7 +18,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
@@ -13,7 +13,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
@@ -15,18 +15,18 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
 
-    struct Ledger has key, store {
+    public struct Ledger has key, store {
         id: UID,
         object_ids: vector<UID>,
     }
 
     public entry fun create_many(recipient: address, ctx: &mut TxContext) {
-        let i = 0;
+        let mut i = 0;
         while (i < 500) {
             transfer::public_transfer(
 

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
@@ -20,7 +20,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -18,15 +18,15 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct EventA has copy, drop {
+    public struct EventA has copy, drop {
         new_value: u64
     }
 
-    struct EventB<phantom T> has copy, drop {
+    public struct EventB<phantom T> has copy, drop {
         new_value: u64
     }
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }
@@ -55,15 +55,15 @@ module Test::M2 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct EventA has copy, drop {
+    public struct EventA has copy, drop {
         new_value: u64
     }
 
-    struct EventB<phantom T> has copy, drop {
+    public struct EventB<phantom T> has copy, drop {
         new_value: u64
     }
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
@@ -11,7 +11,7 @@
 module Test::M1 {
     use sui::event;
 
-    struct EventA has copy, drop {
+    public struct EventA has copy, drop {
         new_value: u64
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -7,7 +7,7 @@
 module Test::M1 {
     use sui::event;
 
-    struct EventA has copy, drop {
+    public struct EventA has copy, drop {
         new_value: u64
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.exp
@@ -3,15 +3,15 @@ processed 4 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 6-36:
+task 1 'publish'. lines 6-35:
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 15663600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'create-checkpoint'. lines 38-38:
+task 2 'create-checkpoint'. lines 37-37:
 Checkpoint created: 1
 
-task 3 'run-graphql'. lines 40-88:
+task 3 'run-graphql'. lines 39-87:
 Response: {
   "data": {
     "suiCoins": {

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.move
@@ -5,15 +5,14 @@
 
 //# publish --sender A
 module P0::fake {
-    use std::option;
     use sui::coin;
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct FAKE has drop {}
+    public struct FAKE has drop {}
 
     fun init(witness: FAKE, ctx: &mut TxContext){
-        let (treasury_cap, metadata) = coin::create_currency(
+        let (mut treasury_cap, metadata) = coin::create_currency(
             witness,
             2,
             b"FAKE",

--- a/crates/sui-graphql-e2e-tests/tests/objects/data.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/data.exp
@@ -3,20 +3,20 @@ processed 5 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 6-42:
+task 1 'publish'. lines 6-41:
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 7622800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'programmable'. lines 44-46:
+task 2 'programmable'. lines 43-45:
 created: object(2,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 2910800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3 'create-checkpoint'. lines 48-48:
+task 3 'create-checkpoint'. lines 47-47:
 Checkpoint created: 1
 
-task 4 'run-graphql'. lines 50-71:
+task 4 'run-graphql'. lines 49-70:
 Response: {
   "data": {
     "transactionBlocks": {

--- a/crates/sui-graphql-e2e-tests/tests/objects/data.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/data.move
@@ -6,12 +6,11 @@
 //# publish
 module P0::m {
     use std::ascii::{Self, String as ASCII};
-    use std::option::{Self, Option};
     use std::string::{Self, String as UTF8};
     use sui::object::{Self, ID, UID};
     use sui::tx_context::TxContext;
 
-    struct Foo has key, store {
+    public struct Foo has key, store {
         id: UID,
         f0: ID,
         f1: bool,
@@ -23,7 +22,7 @@ module P0::m {
         f7: Option<u32>,
     }
 
-    struct Bar has key {
+    public struct Bar has key {
         id: UID,
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.exp
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.exp
@@ -3,37 +3,37 @@ processed 17 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 6-134:
+task 1 'publish'. lines 6-133:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("DisplayCreated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [137, 236, 247, 104, 190, 160, 51, 217, 81, 210, 34, 217, 48, 200, 208, 81, 117, 153, 174, 197, 223, 239, 0, 20, 221, 16, 213, 187, 226, 38, 213, 74] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 21470000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'create-checkpoint'. lines 136-136:
+task 2 'create-checkpoint'. lines 135-135:
 Checkpoint created: 1
 
-task 3 'view-checkpoint'. lines 138-138:
+task 3 'view-checkpoint'. lines 137-137:
 CheckpointSummary { epoch: 0, seq: 1, content_digest: 9Z4obEXKrYjxKut6D4YysJdsJZKmabj9sc3xvCSMTPKF,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 1000000, storage_cost: 21470000, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
-task 4 'run'. lines 140-140:
+task 4 'run'. lines 139-139:
 created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 3556800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5 'run'. lines 142-142:
+task 5 'run'. lines 141-141:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [137, 236, 247, 104, 190, 160, 51, 217, 81, 210, 34, 217, 48, 200, 208, 81, 117, 153, 174, 197, 223, 239, 0, 20, 221, 16, 213, 187, 226, 38, 213, 74, 1, 0, 3, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 2941200,  storage_rebate: 2625876, non_refundable_storage_fee: 26524
 
-task 6 'create-checkpoint'. lines 144-144:
+task 6 'create-checkpoint'. lines 143-143:
 Checkpoint created: 2
 
-task 7 'view-checkpoint'. lines 146-146:
+task 7 'view-checkpoint'. lines 145-145:
 CheckpointSummary { epoch: 0, seq: 2, content_digest: 6UmUjhg3HuzgWSCAQde8cRbnrsHnUaoFbxbWDcGszB9s,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, storage_cost: 27968000, storage_rebate: 3603996, non_refundable_storage_fee: 36404 }}
 
-task 8 'run-graphql'. lines 148-161:
+task 8 'run-graphql'. lines 147-160:
 Response: {
   "data": {
     "address": {
@@ -64,19 +64,19 @@ Response: {
   }
 }
 
-task 9 'run'. lines 163-163:
+task 9 'run'. lines 162-162:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [137, 236, 247, 104, 190, 160, 51, 217, 81, 210, 34, 217, 48, 200, 208, 81, 117, 153, 174, 197, 223, 239, 0, 20, 221, 16, 213, 187, 226, 38, 213, 74, 2, 0, 4, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 3032400,  storage_rebate: 2911788, non_refundable_storage_fee: 29412
 
-task 10 'create-checkpoint'. lines 165-165:
+task 10 'create-checkpoint'. lines 164-164:
 Checkpoint created: 3
 
-task 11 'view-checkpoint'. lines 167-167:
+task 11 'view-checkpoint'. lines 166-166:
 CheckpointSummary { epoch: 0, seq: 3, content_digest: Dx6ymhRZRHx31vgjQ9PPhetGVHP4hxBgZ7WupSWP9ACZ,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 4000000, storage_cost: 31000400, storage_rebate: 6515784, non_refundable_storage_fee: 65816 }}
 
-task 12 'run-graphql'. lines 169-182:
+task 12 'run-graphql'. lines 168-181:
 Response: {
   "data": {
     "address": {
@@ -112,19 +112,19 @@ Response: {
   }
 }
 
-task 13 'run'. lines 184-184:
+task 13 'run'. lines 183-183:
 events: Event { package_id: Test, transaction_module: Identifier("boars"), sender: A, type_: StructTag { address: sui, module: Identifier("display"), name: Identifier("VersionUpdated"), type_params: [Struct(StructTag { address: Test, module: Identifier("boars"), name: Identifier("Boar"), type_params: [] })] }, contents: [137, 236, 247, 104, 190, 160, 51, 217, 81, 210, 34, 217, 48, 200, 208, 81, 117, 153, 174, 197, 223, 239, 0, 20, 221, 16, 213, 187, 226, 38, 213, 74, 3, 0, 15, 7, 118, 101, 99, 116, 111, 114, 115, 5, 123, 118, 101, 99, 125, 3, 105, 100, 100, 5, 123, 105, 100, 100, 125, 5, 110, 97, 109, 101, 101, 7, 123, 110, 97, 109, 101, 101, 125, 4, 110, 117, 109, 115, 6, 123, 110, 117, 109, 115, 125, 5, 98, 111, 111, 108, 115, 7, 123, 98, 111, 111, 108, 115, 125, 5, 98, 117, 121, 101, 114, 7, 123, 98, 117, 121, 101, 114, 125, 4, 110, 97, 109, 101, 6, 123, 110, 97, 109, 101, 125, 7, 99, 114, 101, 97, 116, 111, 114, 9, 123, 99, 114, 101, 97, 116, 111, 114, 125, 5, 112, 114, 105, 99, 101, 7, 123, 112, 114, 105, 99, 101, 125, 11, 112, 114, 111, 106, 101, 99, 116, 95, 117, 114, 108, 58, 85, 110, 105, 113, 117, 101, 32, 66, 111, 97, 114, 32, 102, 114, 111, 109, 32, 116, 104, 101, 32, 66, 111, 97, 114, 115, 32, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110, 32, 119, 105, 116, 104, 32, 123, 110, 97, 109, 101, 125, 32, 97, 110, 100, 32, 123, 105, 100, 125, 8, 98, 97, 115, 101, 95, 117, 114, 108, 32, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 123, 105, 109, 103, 95, 117, 114, 108, 125, 11, 110, 111, 95, 116, 101, 109, 112, 108, 97, 116, 101, 23, 104, 116, 116, 112, 115, 58, 47, 47, 103, 101, 116, 45, 97, 45, 98, 111, 97, 114, 46, 99, 111, 109, 47, 3, 97, 103, 101, 21, 123, 109, 101, 116, 97, 100, 97, 116, 97, 46, 110, 101, 115, 116, 101, 100, 46, 97, 103, 101, 125, 8, 102, 117, 108, 108, 95, 117, 114, 108, 10, 123, 102, 117, 108, 108, 95, 117, 114, 108, 125, 13, 101, 115, 99, 97, 112, 101, 95, 115, 121, 110, 116, 97, 120, 8, 92, 123, 110, 97, 109, 101, 92, 125] }
 mutated: object(0,0), object(1,1)
 gas summary: computation_cost: 1000000, storage_cost: 5236400,  storage_rebate: 3002076, non_refundable_storage_fee: 30324
 
-task 14 'create-checkpoint'. lines 186-186:
+task 14 'create-checkpoint'. lines 185-185:
 Checkpoint created: 4
 
-task 15 'view-checkpoint'. lines 188-188:
+task 15 'view-checkpoint'. lines 187-187:
 CheckpointSummary { epoch: 0, seq: 4, content_digest: 7cSXLQ77UaYAapxP27LVi9Rx5BRgtpKJUSySemrHBpNC,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 5000000, storage_cost: 36236800, storage_rebate: 9517860, non_refundable_storage_fee: 96140 }}
 
-task 16 'run-graphql'. lines 190-203:
+task 16 'run-graphql'. lines 189-202:
 Response: {
   "data": {
     "address": {

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -6,7 +6,6 @@
 //# publish --sender A
 module Test::boars {
     use sui::object::{Self, UID};
-    use std::option::{Self, Option};
     use sui::tx_context::{TxContext, sender};
     use sui::transfer;
     use sui::package;
@@ -18,9 +17,9 @@ module Test::boars {
     const ENotOneTimeWitness: u64 = 0;
 
     /// An OTW to use when creating a Publisher
-    struct BOARS has drop {}
+    public struct BOARS has drop {}
 
-    struct Boar has key, store {
+    public struct Boar has key, store {
         id: UID,
         img_url: String,
         name: String,
@@ -35,11 +34,11 @@ module Test::boars {
         vec: vector<u64>,
     }
 
-    struct Metadata has store {
+    public struct Metadata has store {
         age: u64,
     }
 
-    struct NestedMetadata has store {
+    public struct NestedMetadata has store {
         nested: Metadata
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -9,7 +9,7 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
@@ -9,11 +9,11 @@ module P0::m {
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct Foo has key, store {
+    public struct Foo has key, store {
         id: UID,
     }
 
-    struct Bar has key {
+    public struct Bar has key {
         id: UID,
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/objects/received.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.move
@@ -20,7 +20,7 @@ module P0::m {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct Obj has key {
+    public struct Obj has key {
         id: UID
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -52,7 +52,7 @@
 //# publish --upgradeable --sender A
 
 module P0::m {
-    struct S has copy, drop { x: u64 }
+    public struct S has copy, drop { x: u64 }
 }
 
 //# create-checkpoint
@@ -104,9 +104,9 @@ fragment Structs on Object {
 //# upgrade --package P0 --upgrade-capability 2,1 --sender A
 
 module P1::m {
-    struct S has copy, drop { x: u64 }
-    struct T<U: drop> { y: u64, s: S, u: U }
-    struct V { t: T<S> }
+    public struct S has copy, drop { x: u64 }
+    public struct T<U: drop> { y: u64, s: S, u: U }
+    public struct V { t: T<S> }
 }
 
 //# create-checkpoint
@@ -172,7 +172,7 @@ fragment Structs on Object {
 
 //# run-graphql
 
-# But we can still confirm that we can roundtrip the `T` struct from
+# But we can still confirm that we can roundtrip the `T` public struct from
 # its own module, but cannot reach `T` from `S`'s defining module.
 
 fragment ReachT on MoveStruct {

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.move
@@ -122,7 +122,7 @@
 
 //# publish
 module P0::m {
-    struct S0<T> {
+    public struct S0<T> {
         xs: vector<vector<vector<vector<
             vector<vector<vector<vector<
                 T
@@ -130,7 +130,7 @@ module P0::m {
             >>>>
     }
 
-    struct S1<T> {
+    public struct S1<T> {
         xss: S0<S0<S0<S0<S0<S0<S0<S0<
              S0<S0<S0<S0<S0<S0<S0<S0<
                  T

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
@@ -10,7 +10,7 @@ module Test::M1 {
     use sui::transfer;
     use sui::coin::Coin;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
@@ -7,7 +7,7 @@
 module Test::M1 {
     use sui::event;
 
-    struct EventA has copy, drop {
+    public struct EventA has copy, drop {
         new_value: u64
     }
 

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
@@ -10,7 +10,7 @@ module Test::M1 {
     use sui::transfer;
     use sui::coin::Coin;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: UID,
         value: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -8,7 +8,7 @@ module P0::m {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Foo has key, store {
+    public struct Foo has key, store {
         id: UID,
         xs: vector<u64>,
     }
@@ -206,7 +206,7 @@ module P0::m {
     use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
-    struct Foo has key, store {
+    public struct Foo has key, store {
         id: UID,
         xs: vector<u64>,
     }

--- a/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
@@ -9,7 +9,7 @@ module P0::m {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: UID,
         x: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.exp
@@ -9,38 +9,38 @@ Epoch advanced: 0
 task 2 'create-checkpoint'. lines 10-10:
 Checkpoint created: 2
 
-task 3 'publish'. lines 12-41:
+task 3 'publish'. lines 12-40:
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 5920400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 4 'run'. lines 43-43:
+task 4 'run'. lines 42-42:
 created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5 'run'. lines 45-45:
+task 5 'run'. lines 44-44:
 created: object(5,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 6 'run'. lines 47-47:
+task 6 'run'. lines 46-46:
 created: object(6,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7 'run'. lines 49-49:
+task 7 'run'. lines 48-48:
 created: object(7,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8 'create-checkpoint'. lines 51-51:
+task 8 'create-checkpoint'. lines 50-50:
 Checkpoint created: 3
 
-task 9 'advance-epoch'. lines 53-53:
+task 9 'advance-epoch'. lines 52-52:
 Epoch advanced: 1
 
-task 10 'run-graphql'. lines 55-67:
+task 10 'run-graphql'. lines 54-66:
 Response: {
   "data": {
     "epoch": {
@@ -58,88 +58,88 @@ Response: {
   }
 }
 
-task 11 'run'. lines 69-69:
+task 11 'run'. lines 68-68:
 created: object(11,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 12 'run'. lines 71-71:
+task 12 'run'. lines 70-70:
 created: object(12,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 13 'run'. lines 73-73:
+task 13 'run'. lines 72-72:
 created: object(13,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 14 'run'. lines 75-75:
+task 14 'run'. lines 74-74:
 created: object(14,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 15 'run'. lines 77-77:
+task 15 'run'. lines 76-76:
 created: object(15,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 16 'run'. lines 79-79:
+task 16 'run'. lines 78-78:
 created: object(16,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 17 'run'. lines 81-81:
+task 17 'run'. lines 80-80:
 created: object(17,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 18 'run'. lines 83-83:
+task 18 'run'. lines 82-82:
 created: object(18,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 19 'run'. lines 85-85:
+task 19 'run'. lines 84-84:
 created: object(19,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 20 'run'. lines 87-87:
+task 20 'run'. lines 86-86:
 created: object(20,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 21 'run'. lines 89-89:
+task 21 'run'. lines 88-88:
 created: object(21,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 22 'run'. lines 91-91:
+task 22 'run'. lines 90-90:
 created: object(22,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 23 'run'. lines 93-93:
+task 23 'run'. lines 92-92:
 created: object(23,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 24 'run'. lines 95-95:
+task 24 'run'. lines 94-94:
 created: object(24,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 25 'run'. lines 97-97:
+task 25 'run'. lines 96-96:
 created: object(25,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1441000000, storage_cost: 1932269600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 26 'create-checkpoint'. lines 99-99:
+task 26 'create-checkpoint'. lines 98-98:
 Checkpoint created: 5
 
-task 27 'advance-epoch'. lines 101-103:
+task 27 'advance-epoch'. lines 100-102:
 Epoch advanced: 2
 
-task 28 'run-graphql'. lines 105-122:
+task 28 'run-graphql'. lines 104-121:
 Response: {
   "data": {
     "epoch": {

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.move
@@ -13,16 +13,15 @@
 module P0::m {
     use sui::object::{Self, UID};
     use sui::tx_context::{sender, TxContext};
-    use std::vector;
 
-    struct Big has key, store {
+    public struct Big has key, store {
         id: UID,
         weight: vector<u8>,
     }
 
     fun weight(): vector<u8> {
-        let i = 0;
-        let v = vector[];
+        let mut i = 0;
+        let mut v = vector[];
         while (i < 248 * 1024) {
             vector::push_back(&mut v, 42);
             i = i + 1;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -17,6 +17,7 @@ use move_bytecode_utils::module_cache::GetModule;
 use move_command_line_common::{
     address::ParsedAddress, files::verify_and_create_named_address_mapping,
 };
+use move_compiler::editions::Edition;
 use move_compiler::{
     shared::{NumberFormat, NumericalAddress, PackagePaths},
     Flags, FullyCompiledProgram,
@@ -325,7 +326,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     AccountAddress::ZERO.into_bytes(),
                     NumberFormat::Hex,
                 )),
-                None,
+                Some(Edition::E2024_ALPHA),
             ),
             package_upgrade_mapping: BTreeMap::new(),
             accounts,


### PR DESCRIPTION
## Description 

Switches the `sui-transactional-test-runner` use Move 2024 edition, and updates the tests accordingly.

## Test Plan 

Test-only change (+ adding an annotation to the move-stdlib vector module).

