### PR TITLE
[CLI] Adds initial package layout on `sui move new`

### DIFF
--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -46,7 +46,8 @@ module {name}::{name} {{
         writeln!(w, r#"/*
 #[test_only]
 module {name}::{name}_tests {{
-    use {name}::{name};
+    // uncomment this line to import the module
+    // use {name}::{name};
 
     const ENotImplemented: u64 = 0;
 

--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -3,7 +3,12 @@
 
 use clap::Parser;
 use move_cli::base::new;
-use std::path::PathBuf;
+use move_package::source_package::layout::SourcePackageLayout;
+use std::{
+    io::Write,
+    fs::create_dir_all,
+    path::{Path, PathBuf}
+};
 
 const SUI_PKG_NAME: &str = "Sui";
 
@@ -20,8 +25,43 @@ pub struct New {
 impl New {
     pub fn execute(self, path: Option<PathBuf>) -> anyhow::Result<()> {
         let name = &self.new.name.to_lowercase();
+        let p = match &path {
+            Some(path) => path,
+            None => Path::new(&name),
+        };
+
         self.new
-            .execute(path, [(SUI_PKG_NAME, SUI_PKG_PATH)], [(name, "0x0")], "")?;
+            .execute(path.clone(), [(SUI_PKG_NAME, SUI_PKG_PATH)], [(name, "0x0")], "")?;
+
+        let mut w = std::fs::File::create(p.join(SourcePackageLayout::Sources.path()).join(format!("{name}.move")))?;
+        writeln!(w, r#"/*
+/// Module: {name}
+module {name}::{name} {{
+
+}}
+*/"#, name = name)?;
+
+        create_dir_all(p.join(SourcePackageLayout::Tests.path()))?;
+        let mut w = std::fs::File::create(p.join(SourcePackageLayout::Tests.path()).join(format!("{name}_tests.move")))?;
+        writeln!(w, r#"/*
+#[test_only]
+module {name}::{name}_tests {{
+    use {name}::{name};
+
+    const ENotImplemented: u64 = 0;
+
+    #[test]
+    fun test_{name}() {{
+        // pass
+    }}
+
+    #[test, expected_failure(abort_code = {name}::{name}_tests::ENotImplemented)]
+    fun test_{name}_fail() {{
+        abort ENotImplemented
+    }}
+}}
+*/"#, name = name)?;
+
         Ok(())
     }
 }

--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -5,9 +5,9 @@ use clap::Parser;
 use move_cli::base::new;
 use move_package::source_package::layout::SourcePackageLayout;
 use std::{
-    io::Write,
     fs::create_dir_all,
-    path::{Path, PathBuf}
+    io::Write,
+    path::{Path, PathBuf},
 };
 
 const SUI_PKG_NAME: &str = "Sui";
@@ -30,20 +30,36 @@ impl New {
             None => Path::new(&name),
         };
 
-        self.new
-            .execute(path.clone(), [(SUI_PKG_NAME, SUI_PKG_PATH)], [(name, "0x0")], "")?;
+        self.new.execute(
+            path.clone(),
+            [(SUI_PKG_NAME, SUI_PKG_PATH)],
+            [(name, "0x0")],
+            "",
+        )?;
 
-        let mut w = std::fs::File::create(p.join(SourcePackageLayout::Sources.path()).join(format!("{name}.move")))?;
-        writeln!(w, r#"/*
+        let mut w = std::fs::File::create(
+            p.join(SourcePackageLayout::Sources.path())
+                .join(format!("{name}.move")),
+        )?;
+        writeln!(
+            w,
+            r#"/*
 /// Module: {name}
 module {name}::{name} {{
 
 }}
-*/"#, name = name)?;
+*/"#,
+            name = name
+        )?;
 
         create_dir_all(p.join(SourcePackageLayout::Tests.path()))?;
-        let mut w = std::fs::File::create(p.join(SourcePackageLayout::Tests.path()).join(format!("{name}_tests.move")))?;
-        writeln!(w, r#"/*
+        let mut w = std::fs::File::create(
+            p.join(SourcePackageLayout::Tests.path())
+                .join(format!("{name}_tests.move")),
+        )?;
+        writeln!(
+            w,
+            r#"/*
 #[test_only]
 module {name}::{name}_tests {{
     // uncomment this line to import the module
@@ -61,7 +77,9 @@ module {name}::{name}_tests {{
         abort ENotImplemented
     }}
 }}
-*/"#, name = name)?;
+*/"#,
+            name = name
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description 

Following the discussion on scaffolding the app:

- adds `sources/{name}.move`
- adds `tests/{name}_tests.move`

```sh
sources/
    donuts.move
tests/
    donuts_tests.move
Move.toml
```

File: sources/name.move; Commented out contents:
```move
/// Module: donuts
module donuts::donuts {

}
```

File: tests/name_tests.move; Commented out contents:
```move
#[test_only]
module donuts::donuts_tests {
    // uncomment this line to import the module
    // use donuts::donuts;

    const ENotImplemented: u64 = 0;

    #[test]
    fun test_donuts() {
        // pass
    }

    #[test, expected_failure(abort_code = donuts::donuts_tests::ENotImplemented)]
    fun test_donuts_fail() {
        abort ENotImplemented
    }
}
```

## Test Plan 

Tests pass!

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
