### PR TITLE
[Consensus 2.0] block_manager to return missing blocks & introduce synchronizer

### DIFF
--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -84,6 +84,8 @@ impl BlockManager {
         accepted_blocks.sort_by_key(|b| b.reference());
 
         // Newly missed blocks
+        // TODO: make sure that the computation here is bounded either in the byzantine or node fall
+        // back scenario.
         let missing_blocks_after = self
             .missing_blocks
             .difference(&missing_blocks_before)
@@ -133,7 +135,7 @@ impl BlockManager {
         }
 
         // Remove the block ref from the `missing_blocks` - if exists - since we now have received the block. The block
-        // might still get suspended, but we won't report it as missing in order to re-fetch.
+        // might still get suspended, but we won't report it as missing in order to not re-fetch.
         self.missing_blocks.remove(&block.reference());
 
         if !missing_ancestors.is_empty() {

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -37,6 +37,9 @@ pub(crate) struct BlockManager {
     /// as ancestors and need them to get unsuspended. It is possible for a missing dependency (key) to be a suspended block, so
     /// the block has been already fetched but it self is still missing some of its ancestors to be processed.
     missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
+    /// Keeps all the blocks that we actually miss and haven't fetched them yet. That set will basically contain all the
+    /// keys from the `missing_ancestors` minus any keys that exist in `suspended_blocks`.
+    missing_blocks: BTreeSet<BlockRef>,
     dag_state: Arc<RwLock<DagState>>,
     context: Arc<Context>,
 }
@@ -46,6 +49,7 @@ impl BlockManager {
         Self {
             suspended_blocks: BTreeMap::new(),
             missing_ancestors: BTreeMap::new(),
+            missing_blocks: BTreeSet::new(),
             context,
             dag_state,
         }
@@ -53,12 +57,13 @@ impl BlockManager {
 
     /// Tries to accept the provided blocks assuming that all their causal history exists. The method
     /// returns all the blocks that have been successfully processed in round ascending order, that includes also previously
-    /// suspended blocks that have now been able to get accepted.
+    /// suspended blocks that have now been able to get accepted. Method also returns a set with the new missing ancestor blocks.
     pub(crate) fn try_accept_blocks(
         &mut self,
         mut blocks: Vec<VerifiedBlock>,
-    ) -> ConsensusResult<Vec<VerifiedBlock>> {
+    ) -> ConsensusResult<(Vec<VerifiedBlock>, BTreeSet<BlockRef>)> {
         let mut accepted_blocks = vec![];
+        let missing_blocks_before = self.missing_blocks.clone();
 
         blocks.sort_by_key(|b| b.round());
         for block in blocks {
@@ -77,7 +82,16 @@ impl BlockManager {
         }
 
         accepted_blocks.sort_by_key(|b| b.reference());
-        Ok(accepted_blocks)
+
+        // Newly missed blocks
+        let missing_blocks_after = self
+            .missing_blocks
+            .difference(&missing_blocks_before)
+            .cloned()
+            .collect();
+
+        // Figure out the new missing blocks
+        Ok((accepted_blocks, missing_blocks_after))
     }
 
     /// Tries to accept the provided block. To accept a block its ancestors must have been already successfully accepted. If
@@ -109,8 +123,18 @@ impl BlockManager {
                     .entry(*ancestor)
                     .or_default()
                     .insert(block_ref);
+
+                // Add the ancestor to the missing blocks set only if it doesn't already exist in the suspended blocks - meaning
+                // that we already have its payload.
+                if !self.suspended_blocks.contains_key(ancestor) {
+                    self.missing_blocks.insert(*ancestor);
+                }
             }
         }
+
+        // Remove the block ref from the `missing_blocks` - if exists - since we now have received the block. The block
+        // might still get suspended, but we won't report it as missing in order to re-fetch.
+        self.missing_blocks.remove(&block.reference());
 
         if !missing_ancestors.is_empty() {
             let hostname = self
@@ -206,13 +230,8 @@ impl BlockManager {
     #[allow(dead_code)]
     /// Returns all the blocks that are currently missing and needed in order to accept suspended
     /// blocks.
-    pub(crate) fn missing_blocks(&self) -> Vec<BlockRef> {
-        self.missing_ancestors
-            .iter()
-            .flat_map(|(block_ref, _)| {
-                (!self.suspended_blocks.contains_key(block_ref)).then_some(*block_ref)
-            })
-            .collect()
+    pub(crate) fn missing_blocks(&self) -> BTreeSet<BlockRef> {
+        self.missing_blocks.clone()
     }
 
     #[allow(dead_code)]
@@ -233,6 +252,7 @@ mod tests {
     use rand::prelude::StdRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     #[test]
@@ -255,17 +275,21 @@ mod tests {
             .collect::<Vec<VerifiedBlock>>();
 
         // WHEN
-        let accepted_blocks = block_manager
+        let (accepted_blocks, missing) = block_manager
             .try_accept_blocks(round_2_blocks.clone())
             .expect("No error was expected");
 
         // THEN
         assert!(accepted_blocks.is_empty());
 
+        // AND the returned missing ancestors should be the same as the provided block ancestors
+        let missing_block_refs = round_2_blocks.first().unwrap().ancestors();
+        let missing_block_refs = missing_block_refs.iter().cloned().collect::<BTreeSet<_>>();
+        assert_eq!(missing, missing_block_refs);
+
         // AND the missing blocks are the parents of the round 2 blocks. Since this is a fully connected DAG taking the
         // ancestors of the first element suffices.
-        let missing_blocks = round_2_blocks.first().unwrap().ancestors();
-        assert_eq!(block_manager.missing_blocks(), missing_blocks);
+        assert_eq!(block_manager.missing_blocks(), missing_block_refs);
 
         // AND suspended blocks should return the round_2_blocks
         assert_eq!(
@@ -275,6 +299,44 @@ mod tests {
                 .map(|block| block.reference())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn try_accept_block_returns_missing_blocks_once() {
+        let (context, _key_pairs) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        let mut block_manager = BlockManager::new(context.clone(), dag_state);
+
+        // create a DAG of 2 rounds
+        let all_blocks = dag(context, 4);
+
+        // Take the blocks from round 4 up to 2 (included). Only the first block of each round should return missing
+        // ancestors when try to accept
+        for (i, block) in all_blocks
+            .into_iter()
+            .rev()
+            .take_while(|block| block.round() >= 2)
+            .enumerate()
+        {
+            // WHEN
+            let (accepted_blocks, missing) = block_manager
+                .try_accept_blocks(vec![block.clone()])
+                .expect("No error was expected");
+
+            // THEN
+            assert!(accepted_blocks.is_empty());
+
+            // Only the first block for each round should return missing blocks. Every other shouldn't
+            if i % 4 == 0 {
+                let block_ancestors = block.ancestors().iter().cloned().collect::<BTreeSet<_>>();
+                assert_eq!(missing, block_ancestors);
+            } else {
+                assert!(missing.is_empty());
+            }
+        }
     }
 
     #[test]
@@ -291,7 +353,7 @@ mod tests {
         let all_blocks = dag(context, 2);
 
         // WHEN
-        let accepted_blocks = block_manager
+        let (accepted_blocks, missing) = block_manager
             .try_accept_blocks(all_blocks.clone())
             .expect("No error was expected");
 
@@ -305,9 +367,10 @@ mod tests {
                 .cloned()
                 .collect::<Vec<VerifiedBlock>>()
         );
+        assert!(missing.is_empty());
 
         // WHEN trying to accept same blocks again, then none will be returned as those have been already accepted
-        let accepted_blocks = block_manager
+        let (accepted_blocks, _) = block_manager
             .try_accept_blocks(all_blocks)
             .expect("No error was expected");
         assert!(accepted_blocks.is_empty());
@@ -340,7 +403,7 @@ mod tests {
             // WHEN
             let mut all_accepted_blocks = vec![];
             for block in &all_blocks {
-                let accepted_blocks = block_manager
+                let (accepted_blocks, _) = block_manager
                     .try_accept_blocks(vec![block.clone()])
                     .expect("No error was expected");
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -310,7 +310,7 @@ mod tests {
 
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
 
-        // create a DAG of 2 rounds
+        // create a DAG of 4 rounds
         let all_blocks = dag(context, 4);
 
         // Take the blocks from round 4 up to 2 (included). Only the first block of each round should return missing

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -131,11 +131,11 @@ impl Core {
 
     /// Processes the provided blocks and accepts them if possible when their causal history exists.
     /// The method returns the references of parents that are unknown and need to be fetched.
-    pub(crate) fn add_blocks(&mut self, blocks: Vec<VerifiedBlock>) -> Vec<BlockRef> {
+    pub(crate) fn add_blocks(&mut self, blocks: Vec<VerifiedBlock>) -> BTreeSet<BlockRef> {
         let _scope = monitored_scope("Core::add_blocks");
 
         // Try to accept them via the block manager
-        let accepted_blocks = self
+        let (accepted_blocks, missing_blocks) = self
             .block_manager
             .try_accept_blocks(blocks)
             .unwrap_or_else(|err| panic!("Fatal error while accepting blocks: {err}"));
@@ -154,8 +154,7 @@ impl Core {
             }
         }
 
-        // TODO: we don't deal for now with missed references, will address later.
-        vec![]
+        missing_blocks
     }
 
     /// Adds/processed all the newly `accepted_blocks`. We basically try to move the threshold clock and add them to the
@@ -275,10 +274,12 @@ impl Core {
                 .or_default()
                 .push(verified_block.clone());
 
-            let _ = self
+            let (accepted_blocks, missing) = self
                 .block_manager
                 .try_accept_blocks(vec![verified_block.clone()])
                 .unwrap_or_else(|err| panic!("Fatal error while accepting our own block: {err}"));
+            assert_eq!(accepted_blocks.len(), 1);
+            assert!(missing.is_empty());
 
             self.last_proposed_block = verified_block.clone();
 

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -20,7 +20,7 @@ const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 32;
 
 enum CoreThreadCommand {
     /// Add blocks to be processed and accepted
-    AddBlocks(Vec<VerifiedBlock>, oneshot::Sender<Vec<BlockRef>>),
+    AddBlocks(Vec<VerifiedBlock>, oneshot::Sender<BTreeSet<BlockRef>>),
     /// Called when a leader timeout occurs and a block should be produced
     ForceNewBlock(Round, oneshot::Sender<()>),
     /// Request missing blocks that need to be synced.
@@ -37,7 +37,8 @@ pub enum CoreError {
 /// Also this allows the easier mocking during unit tests.
 #[async_trait]
 pub trait CoreThreadDispatcher: Sync + Send + 'static {
-    async fn add_blocks(&self, blocks: Vec<VerifiedBlock>) -> Result<Vec<BlockRef>, CoreError>;
+    async fn add_blocks(&self, blocks: Vec<VerifiedBlock>)
+        -> Result<BTreeSet<BlockRef>, CoreError>;
 
     async fn force_new_block(&self, round: Round) -> Result<(), CoreError>;
 
@@ -141,7 +142,10 @@ impl ChannelCoreThreadDispatcher {
 
 #[async_trait]
 impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
-    async fn add_blocks(&self, blocks: Vec<VerifiedBlock>) -> Result<Vec<BlockRef>, CoreError> {
+    async fn add_blocks(
+        &self,
+        blocks: Vec<VerifiedBlock>,
+    ) -> Result<BTreeSet<BlockRef>, CoreError> {
         let (sender, receiver) = oneshot::channel();
         self.send(CoreThreadCommand::AddBlocks(blocks, sender))
             .await;

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -8,7 +8,7 @@ use fastcrypto::error::FastCryptoError;
 use thiserror::Error;
 use typed_store::TypedStoreError;
 
-use crate::block::{BlockTimestampMs, Round};
+use crate::block::{BlockRef, BlockTimestampMs, Round};
 
 /// Errors that can occur when processing blocks, reading from storage, or encountering shutdown.
 #[allow(unused)]
@@ -29,6 +29,12 @@ pub enum ConsensusError {
     #[error("Genesis blocks should only be generated from Committee!")]
     UnexpectedGenesisBlock,
 
+    #[error("Unexpected block returned while fetching missing blocks")]
+    UnexpectedFetchedBlock {
+        index: AuthorityIndex,
+        block_ref: BlockRef,
+    },
+
     #[error("Invalid authority index: {index} > {max}")]
     InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
 
@@ -37,6 +43,9 @@ pub enum ConsensusError {
 
     #[error("Failed to verify the block's signature: {0}")]
     SignatureVerificationFailure(FastCryptoError),
+
+    #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
+    SynchronizerSaturated(AuthorityIndex),
 
     #[error("Ancestor's round ({ancestor}) should be lower than the block's round ({block})")]
     InvalidAncestorRound { ancestor: Round, block: Round },

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -25,7 +25,7 @@ impl LeaderTimeoutTaskHandle {
 }
 
 pub(crate) struct LeaderTimeoutTask<D: CoreThreadDispatcher> {
-    dispatcher: D,
+    dispatcher: Arc<D>,
     new_round_receiver: watch::Receiver<Round>,
     leader_timeout: Duration,
     stop: Receiver<()>,
@@ -33,7 +33,7 @@ pub(crate) struct LeaderTimeoutTask<D: CoreThreadDispatcher> {
 
 impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
     pub fn start(
-        dispatcher: D,
+        dispatcher: Arc<D>,
         signals_receivers: &CoreSignalsReceivers,
         context: Arc<Context>,
     ) -> LeaderTimeoutTaskHandle {
@@ -148,7 +148,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_leader_timeout() {
         let (context, _signers) = Context::new_for_test(4);
-        let dispatcher = MockCoreThreadDispatcher::default();
+        let dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let leader_timeout = Duration::from_millis(500);
         let parameters = Parameters {
             leader_timeout,
@@ -190,7 +190,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn multiple_leader_timeouts() {
         let (context, _signers) = Context::new_for_test(4);
-        let dispatcher = MockCoreThreadDispatcher::default();
+        let dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let leader_timeout = Duration::from_millis(500);
         let parameters = Parameters {
             leader_timeout,

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -140,7 +140,7 @@ mod tests {
             Ok(())
         }
 
-        async fn get_missing_blocks(&self) -> Result<Vec<BTreeSet<BlockRef>>, CoreError> {
+        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }
     }

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -129,7 +129,7 @@ mod tests {
         async fn add_blocks(
             &self,
             _blocks: Vec<VerifiedBlock>,
-        ) -> Result<Vec<BlockRef>, CoreError> {
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -24,7 +24,7 @@ mod storage;
 mod threshold_clock;
 mod transaction;
 mod universal_committer;
-
+mod synchronizer;
 #[cfg(test)]
 mod test_dag;
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -21,12 +21,12 @@ mod metrics;
 mod network;
 mod stake_aggregator;
 mod storage;
-mod threshold_clock;
-mod transaction;
-mod universal_committer;
 mod synchronizer;
 #[cfg(test)]
 mod test_dag;
+mod threshold_clock;
+mod transaction;
+mod universal_committer;
 
 pub use authority_node::ConsensusAuthority;
 pub use block::BlockAPI;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -113,7 +113,7 @@ impl NodeMetrics {
             invalid_blocks: register_int_counter_vec_with_registry!(
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
-                &["authority"],
+                &["authority", "source"],
                 registry,
             )
             .unwrap(),

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1,32 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::BlockRef;
+use crate::block::{BlockRef, SignedBlock, VerifiedBlock};
+use crate::block_verifier::BlockVerifier;
 use crate::context::Context;
-use crate::core_thread::ChannelCoreThreadDispatcher;
+use crate::core_thread::CoreThreadDispatcher;
+use crate::error::{ConsensusError, ConsensusResult};
+use crate::network::NetworkClient;
+use bytes::Bytes;
 use consensus_config::AuthorityIndex;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use parking_lot::Mutex;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
-use thiserror::Error;
+use std::time::Duration;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
+use tokio::time::{error::Elapsed, sleep_until, timeout, Instant};
+use tracing::{error, info, warn};
 
-#[derive(Error, Debug)]
-pub(crate) enum SynchronizerError {
-    #[error("Synchronizer shutdown")]
-    Shutdown,
-    #[error("Synchronizer is full for peer with index: {0}")]
-    SynchronizerFull(AuthorityIndex),
-}
+/// The number of concurrent fetch blocks requests per authority
+const FETCH_BLOCKS_CONCURRENCY: usize = 5;
 
 enum Command {
     FetchBlocks {
         missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
-        send_result: oneshot::Sender<Result<(), SynchronizerError>>,
+        result: oneshot::Sender<Result<(), ConsensusError>>,
     },
 }
 
@@ -43,17 +46,17 @@ impl SynchronizerHandle {
         &self,
         block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
-    ) -> Result<(), SynchronizerError> {
+    ) -> Result<(), ConsensusError> {
         let (sender, receiver) = oneshot::channel();
         self.commands_sender
             .send(Command::FetchBlocks {
                 missing_block_refs: block_refs,
                 peer_index,
-                send_result: sender,
+                result: sender,
             })
             .await
-            .map_err(|_err| SynchronizerError::Shutdown)?;
-        receiver.await.map_err(|_err| SynchronizerError::Shutdown)?
+            .map_err(|_err| ConsensusError::Shutdown)?;
+        receiver.await.map_err(|_err| ConsensusError::Shutdown)?
     }
 
     pub async fn stop(&self) {
@@ -65,35 +68,42 @@ impl SynchronizerHandle {
 #[allow(dead_code)]
 pub(crate) struct Synchronizer {
     context: Arc<Context>,
-    core_thread_dispatcher: ChannelCoreThreadDispatcher,
     commands_receiver: Receiver<Command>,
-    fetch_block_senders: Vec<Sender<BTreeSet<BlockRef>>>,
+    fetch_block_senders: BTreeMap<AuthorityIndex, Sender<BTreeSet<BlockRef>>>,
 }
 
 impl Synchronizer {
-    pub fn start(
+    pub fn start<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>(
+        network_client: Arc<C>,
         context: Arc<Context>,
-        core_thread_dispatcher: ChannelCoreThreadDispatcher,
+        core_dispatcher: Arc<D>,
+        block_verifier: Arc<V>,
     ) -> Arc<SynchronizerHandle> {
         let (commands_sender, commands_receiver) = channel(1_000);
 
         // Spawn the tasks to fetch the blocks from the others
-        let mut fetch_block_senders = Vec::with_capacity(context.committee.size());
+        let mut fetch_block_senders = BTreeMap::new();
         let mut tasks = JoinSet::new();
         for (index, _) in context.committee.authorities() {
             if index == context.own_index {
                 continue;
             }
-            let (sender, receiver) = channel(5);
-            tasks.spawn(Self::fetch_blocks_from_authority(receiver, index));
-            fetch_block_senders[index.value()] = sender;
+            let (sender, receiver) = channel(FETCH_BLOCKS_CONCURRENCY);
+            tasks.spawn(Self::fetch_blocks_from_authority(
+                index,
+                network_client.clone(),
+                block_verifier.clone(),
+                context.clone(),
+                core_dispatcher.clone(),
+                receiver,
+            ));
+            fetch_block_senders.insert(index, sender);
         }
 
         // Spawn the task to listen to the requests & periodic runs
         tasks.spawn(async {
             let mut s = Self {
                 context,
-                core_thread_dispatcher,
                 commands_receiver,
                 fetch_block_senders,
             };
@@ -106,31 +116,363 @@ impl Synchronizer {
         })
     }
 
-    async fn fetch_blocks_from_authority(
-        _receiver: Receiver<BTreeSet<BlockRef>>,
-        _authority: AuthorityIndex,
+    async fn fetch_blocks_from_authority<
+        C: NetworkClient,
+        V: BlockVerifier,
+        D: CoreThreadDispatcher,
+    >(
+        peer_index: AuthorityIndex,
+        network_client: Arc<C>,
+        block_verifier: Arc<V>,
+        context: Arc<Context>,
+        core_dispatcher: Arc<D>,
+        mut receiver: Receiver<BTreeSet<BlockRef>>,
     ) {
+        const REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
+        const MAX_RETRIES: u32 = 5;
+
+        let mut requests = FuturesUnordered::new();
+
+        loop {
+            tokio::select! {
+                Some(block_refs) = receiver.recv(), if requests.len() < FETCH_BLOCKS_CONCURRENCY => {
+                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, block_refs, REQUEST_TIMEOUT, 1))
+                },
+                Some((response, block_refs, retries)) = requests.next() => {
+                    match response {
+                        Ok(Ok(blocks)) => {
+                            if let Err(err) = Self::process_fetched_blocks(blocks,
+                                peer_index,
+                                block_refs,
+                                core_dispatcher.clone(),
+                                block_verifier.clone(),
+                                context.clone()).await {
+                                error!("Error while processing fetched blocks from peer {peer_index}: {err}");
+                            }
+                        },
+                        Ok(Err(_)) | Err(Elapsed {..}) => {
+                            if retries <= MAX_RETRIES {
+                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, block_refs, REQUEST_TIMEOUT, retries))
+                            } else {
+                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_index}.");
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
+    /// Processes the requested raw fetched blocks from peer `peer_index`. If no error is returned then
+    /// the verified blocks are immediately sent to Core for processing.
+    async fn process_fetched_blocks<V: BlockVerifier, D: CoreThreadDispatcher>(
+        serialized_blocks: Vec<Bytes>,
+        peer_index: AuthorityIndex,
+        requested_block_refs: BTreeSet<BlockRef>,
+        core_dispatcher: Arc<D>,
+        block_verifier: Arc<V>,
+        context: Arc<Context>,
+    ) -> ConsensusResult<()> {
+        let mut verified_blocks = Vec::new();
+        for serialized_block in serialized_blocks {
+            let signed_block: SignedBlock =
+                bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
+
+            // TODO: dedup block verifications, here and with fetched blocks.
+            if let Err(e) = block_verifier.verify(&signed_block) {
+                // TODO: we might want to use a different metric to track the invalid "served" blocks
+                // from the invalid "proposed" ones.
+                context
+                    .metrics
+                    .node_metrics
+                    .invalid_blocks
+                    .with_label_values(&[&peer_index.to_string()])
+                    .inc();
+                info!("Invalid block from {}: {}", peer_index, e);
+                return Err(e);
+            }
+            let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
+
+            // we want the peer to only respond with blocks that we have asked for.
+            if !requested_block_refs.contains(&verified_block.reference()) {
+                return Err(ConsensusError::UnexpectedFetchedBlock {
+                    index: peer_index,
+                    block_ref: verified_block.reference(),
+                });
+            }
+
+            verified_blocks.push(verified_block);
+        }
+
+        // Now send them to core for processing. Ignore the returned missing blocks as we don't want
+        // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
+        // will take care of that.
+        let _ = core_dispatcher
+            .add_blocks(verified_blocks)
+            .await
+            .map_err(|_| ConsensusError::Shutdown)?;
+
+        Ok(())
+    }
+
+    async fn fetch_blocks_request<C: NetworkClient>(
+        network_client: Arc<C>,
+        peer: AuthorityIndex,
+        block_refs: BTreeSet<BlockRef>,
+        request_timeout: Duration,
+        mut retries: u32,
+    ) -> (
+        Result<ConsensusResult<Vec<Bytes>>, Elapsed>,
+        BTreeSet<BlockRef>,
+        u32,
+    ) {
+        let start = Instant::now();
+        let resp = timeout(
+            request_timeout,
+            network_client.fetch_blocks(peer, block_refs.clone().into_iter().collect::<Vec<_>>()),
+        )
+        .await;
+
+        if matches!(resp, Ok(Err(_))) {
+            // Add a delay before retrying - if that is needed. If request has timed out then eventually
+            // this will be a no-op.
+            sleep_until(start + request_timeout).await;
+            retries += 1;
+        }
+        (resp, block_refs, retries)
+    }
+
+    // The main loop to listen for the submitted commands.
     async fn run(&mut self) {
         loop {
             tokio::select! {
                 Some(command) = self.commands_receiver.recv() => {
                     match command {
-                        Command::FetchBlocks{ missing_block_refs, peer_index, send_result } => {
+                        Command::FetchBlocks{ missing_block_refs, peer_index, result } => {
                             assert_ne!(peer_index, self.context.own_index, "We should never attempt to fetch blocks from our own node");
 
-                            if let Err(err) = self.fetch_block_senders[peer_index].try_send(missing_block_refs) {
-                                match err {
-                                    TrySendError::Full(_) => send_result.send(Err(SynchronizerError::SynchronizerFull(peer_index))).ok(),
-                                    TrySendError::Closed(_) => send_result.send(Err(SynchronizerError::Shutdown)).ok()
-                                };
-                            } else {
-                                send_result.send(Ok(())).ok();
+                            if missing_block_refs.is_empty() {
+                                result.send(Ok(())).ok();
+                                continue;
                             }
+
+                            // We don't block if the corresponding peer task is saturated - but we rather drop the request. That's ok as the periodic
+                            // synchronization task will handle any still missing blocks in next run.
+                            let r = self.fetch_block_senders.get(&peer_index).expect("Fatal error, sender should be present").try_send(missing_block_refs).map_err(|err| {
+                                match err {
+                                    TrySendError::Full(_) => ConsensusError::SynchronizerSaturated(peer_index),
+                                    TrySendError::Closed(_) => ConsensusError::Shutdown
+                                }
+                            });
+                            result.send(r).ok();
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::block::{BlockRef, Round, TestBlock, VerifiedBlock};
+    use crate::block_verifier::NoopBlockVerifier;
+    use crate::context::Context;
+    use crate::core_thread::{CoreError, CoreThreadDispatcher};
+    use crate::error::{ConsensusError, ConsensusResult};
+    use crate::network::NetworkClient;
+    use crate::synchronizer::{Synchronizer, FETCH_BLOCKS_CONCURRENCY};
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use consensus_config::AuthorityIndex;
+    use std::collections::{BTreeMap, BTreeSet, HashSet};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    // TODO: create a complete Mock for thread dispatcher to be used from several tests
+    #[derive(Default)]
+    struct MockCoreThreadDispatcher {
+        add_blocks: tokio::sync::Mutex<Vec<VerifiedBlock>>,
+    }
+
+    impl MockCoreThreadDispatcher {
+        async fn get_add_blocks(&self) -> Vec<VerifiedBlock> {
+            let lock = self.add_blocks.lock().await;
+            lock.to_vec()
+        }
+    }
+
+    #[async_trait]
+    impl CoreThreadDispatcher for MockCoreThreadDispatcher {
+        async fn add_blocks(
+            &self,
+            blocks: Vec<VerifiedBlock>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            let mut lock = self.add_blocks.lock().await;
+            lock.extend(blocks);
+            Ok(BTreeSet::new())
+        }
+
+        async fn force_new_block(&self, _round: Round) -> Result<(), CoreError> {
+            todo!()
+        }
+
+        async fn get_missing_blocks(&self) -> Result<Vec<HashSet<BlockRef>>, CoreError> {
+            todo!()
+        }
+    }
+
+    type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
+    type FetchRequestResponse = (Vec<VerifiedBlock>, Option<Duration>);
+
+    #[derive(Default)]
+    struct MockNetworkClient {
+        fetch_blocks_requests: tokio::sync::Mutex<BTreeMap<FetchRequestKey, FetchRequestResponse>>,
+    }
+
+    impl MockNetworkClient {
+        async fn stub_fetch_blocks(
+            &self,
+            blocks: Vec<VerifiedBlock>,
+            peer: AuthorityIndex,
+            latency: Option<Duration>,
+        ) {
+            let mut lock = self.fetch_blocks_requests.lock().await;
+            let block_refs = blocks
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>();
+            lock.insert((block_refs, peer), (blocks, latency));
+        }
+    }
+
+    #[async_trait]
+    impl NetworkClient for MockNetworkClient {
+        async fn send_block(
+            &self,
+            _peer: AuthorityIndex,
+            _serialized_block: &Bytes,
+        ) -> ConsensusResult<()> {
+            todo!()
+        }
+
+        async fn fetch_blocks(
+            &self,
+            peer: AuthorityIndex,
+            block_refs: Vec<BlockRef>,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            let mut lock = self.fetch_blocks_requests.lock().await;
+            let response = lock
+                .remove(&(block_refs, peer))
+                .expect("Unexpected fetch blocks request made");
+
+            let serialised = response
+                .0
+                .into_iter()
+                .map(|block| block.serialized().clone())
+                .collect::<Vec<_>>();
+
+            drop(lock);
+
+            if let Some(latency) = response.1 {
+                sleep(latency).await;
+            }
+
+            Ok(serialised)
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_fetch_blocks_from_peer() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let network_client = Arc::new(MockNetworkClient::default());
+
+        let handle = Synchronizer::start(
+            network_client.clone(),
+            context,
+            core_dispatcher.clone(),
+            block_verifier,
+        );
+
+        // Create some test blocks
+        let expected_blocks = (0..10)
+            .map(|round| VerifiedBlock::new_for_test(TestBlock::new(round, 0).build()))
+            .collect::<Vec<_>>();
+        let missing_blocks = expected_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<BTreeSet<_>>();
+
+        // AND stub the fetch_blocks request from peer 1
+        let peer = AuthorityIndex::new_for_test(1);
+        network_client
+            .stub_fetch_blocks(expected_blocks.clone(), peer, None)
+            .await;
+
+        // WHEN request missing blocks from peer 1
+        assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
+
+        // Wait a little bit until those have been added in core
+        sleep(Duration::from_millis(1_000)).await;
+
+        // THEN ensure those ended up in Core
+        let added_blocks = core_dispatcher.get_add_blocks().await;
+        assert_eq!(added_blocks, expected_blocks);
+    }
+
+    #[tokio::test]
+    async fn saturate_fetch_blocks_from_peer() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let network_client = Arc::new(MockNetworkClient::default());
+
+        let handle = Synchronizer::start(
+            network_client.clone(),
+            context,
+            core_dispatcher.clone(),
+            block_verifier,
+        );
+
+        // Create some test blocks
+        let expected_blocks = (0..=2 * FETCH_BLOCKS_CONCURRENCY)
+            .map(|round| VerifiedBlock::new_for_test(TestBlock::new(round as Round, 0).build()))
+            .collect::<Vec<_>>();
+
+        // Now start sending requests to fetch blocks by trying to saturate peer 1 task
+        let peer = AuthorityIndex::new_for_test(1);
+        let mut iter = expected_blocks.iter().peekable();
+        while let Some(block) = iter.next() {
+            // stub the fetch_blocks request from peer 1
+            network_client
+                .stub_fetch_blocks(
+                    vec![block.clone()],
+                    peer,
+                    Some(Duration::from_millis(5_000)),
+                )
+                .await;
+
+            let mut missing_blocks = BTreeSet::new();
+            missing_blocks.insert(block.reference());
+
+            // WHEN requesting to fetch the blocks, it should not succeed for the last request and get
+            // an error with "saturated" synchronizer
+            if iter.peek().is_none() {
+                match handle.fetch_blocks(missing_blocks, peer).await {
+                    Err(ConsensusError::SynchronizerSaturated(index)) => {
+                        assert_eq!(index, peer);
+                    }
+                    _ => panic!("A saturated synchronizer error was expected"),
+                }
+            } else {
+                assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
             }
         }
     }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::block::BlockRef;
+use crate::context::Context;
+use crate::core_thread::ChannelCoreThreadDispatcher;
+use consensus_config::AuthorityIndex;
+use parking_lot::Mutex;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::oneshot;
+use tokio::task::JoinSet;
+
+#[derive(Error, Debug)]
+pub(crate) enum SynchronizerError {
+    #[error("Synchronizer shutdown")]
+    Shutdown,
+    #[error("Synchronizer is full for peer with index: {0}")]
+    SynchronizerFull(AuthorityIndex),
+}
+
+enum Command {
+    FetchBlocks {
+        missing_block_refs: BTreeSet<BlockRef>,
+        peer_index: AuthorityIndex,
+        send_result: oneshot::Sender<Result<(), SynchronizerError>>,
+    },
+}
+
+#[allow(dead_code)]
+pub(crate) struct SynchronizerHandle {
+    commands_sender: Sender<Command>,
+    tasks: Mutex<JoinSet<()>>,
+}
+
+impl SynchronizerHandle {
+    /// Explicitly asks from the synchronizer to fetch the blocks - provided the block_refs set - from
+    /// the peer authority.
+    pub async fn fetch_blocks(
+        &self,
+        block_refs: BTreeSet<BlockRef>,
+        peer_index: AuthorityIndex,
+    ) -> Result<(), SynchronizerError> {
+        let (sender, receiver) = oneshot::channel();
+        self.commands_sender
+            .send(Command::FetchBlocks {
+                missing_block_refs: block_refs,
+                peer_index,
+                send_result: sender,
+            })
+            .await
+            .map_err(|_err| SynchronizerError::Shutdown)?;
+        receiver.await.map_err(|_err| SynchronizerError::Shutdown)?
+    }
+
+    pub async fn stop(&self) {
+        let mut tasks = self.tasks.lock();
+        tasks.abort_all();
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct Synchronizer {
+    context: Arc<Context>,
+    core_thread_dispatcher: ChannelCoreThreadDispatcher,
+    commands_receiver: Receiver<Command>,
+    fetch_block_senders: Vec<Sender<BTreeSet<BlockRef>>>,
+}
+
+impl Synchronizer {
+    pub fn start(
+        context: Arc<Context>,
+        core_thread_dispatcher: ChannelCoreThreadDispatcher,
+    ) -> Arc<SynchronizerHandle> {
+        let (commands_sender, commands_receiver) = channel(1_000);
+
+        // Spawn the tasks to fetch the blocks from the others
+        let mut fetch_block_senders = Vec::with_capacity(context.committee.size());
+        let mut tasks = JoinSet::new();
+        for (index, _) in context.committee.authorities() {
+            if index == context.own_index {
+                continue;
+            }
+            let (sender, receiver) = channel(5);
+            tasks.spawn(Self::fetch_blocks_from_authority(receiver, index));
+            fetch_block_senders[index.value()] = sender;
+        }
+
+        // Spawn the task to listen to the requests & periodic runs
+        tasks.spawn(async {
+            let mut s = Self {
+                context,
+                core_thread_dispatcher,
+                commands_receiver,
+                fetch_block_senders,
+            };
+            s.run().await;
+        });
+
+        Arc::new(SynchronizerHandle {
+            commands_sender,
+            tasks: Mutex::new(tasks),
+        })
+    }
+
+    async fn fetch_blocks_from_authority(
+        _receiver: Receiver<BTreeSet<BlockRef>>,
+        _authority: AuthorityIndex,
+    ) {
+    }
+
+    async fn run(&mut self) {
+        loop {
+            tokio::select! {
+                Some(command) = self.commands_receiver.recv() => {
+                    match command {
+                        Command::FetchBlocks{ missing_block_refs, peer_index, send_result } => {
+                            assert_ne!(peer_index, self.context.own_index, "We should never attempt to fetch blocks from our own node");
+
+                            if let Err(err) = self.fetch_block_senders[peer_index].try_send(missing_block_refs) {
+                                match err {
+                                    TrySendError::Full(_) => send_result.send(Err(SynchronizerError::SynchronizerFull(peer_index))).ok(),
+                                    TrySendError::Closed(_) => send_result.send(Err(SynchronizerError::Shutdown)).ok()
+                                };
+                            } else {
+                                send_result.send(Ok(())).ok();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -450,7 +450,8 @@ mod tests {
         let peer = AuthorityIndex::new_for_test(1);
         let mut iter = expected_blocks.iter().peekable();
         while let Some(block) = iter.next() {
-            // stub the fetch_blocks request from peer 1
+            // stub the fetch_blocks request from peer 1 and give some high response latency so requests
+            // can start blocking the peer task.
             network_client
                 .stub_fetch_blocks(
                     vec![block.clone()],


### PR DESCRIPTION
## Description 

This PR is doing the following:
* Refactoring the `block_manager` to return the missing ancestors that encountered for first time
* Introduce the `Synchronizer` component to fetch the missing blocks from the designated peer (the "live synchronization" mechanism)
* Refactor the `handle_send_block` rpc handler in order to submit the missing ancestors during block proposal to the synchronizer.

Please keep in mind that this implementation can/will be improved but for now keeping it to a functional level for the immediate milestone purposes.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
