### PR TITLE
Rename OverloadThresholdConfig to AuthorityOverloadConfig

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -162,8 +162,8 @@ pub struct NodeConfig {
     #[serde(default = "default_zklogin_oauth_providers")]
     pub zklogin_oauth_providers: BTreeMap<Chain, BTreeSet<String>>,
 
-    #[serde(default = "default_overload_threshold_config")]
-    pub overload_threshold_config: OverloadThresholdConfig,
+    #[serde(default = "default_authority_overload_config")]
+    pub authority_overload_config: AuthorityOverloadConfig,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_with_range: Option<RunWithRange>,
@@ -686,7 +686,7 @@ pub struct TransactionKeyValueStoreWriteConfig {
 /// resolves.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct OverloadThresholdConfig {
+pub struct AuthorityOverloadConfig {
     #[serde(default = "default_max_txn_age_in_queue")]
     pub max_txn_age_in_queue: Duration,
 
@@ -757,7 +757,7 @@ fn default_safe_transaction_ready_rate() -> u32 {
     100
 }
 
-impl Default for OverloadThresholdConfig {
+impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
             max_txn_age_in_queue: default_max_txn_age_in_queue(),
@@ -774,8 +774,8 @@ impl Default for OverloadThresholdConfig {
     }
 }
 
-fn default_overload_threshold_config() -> OverloadThresholdConfig {
-    OverloadThresholdConfig::default()
+fn default_authority_overload_config() -> AuthorityOverloadConfig {
+    AuthorityOverloadConfig::default()
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -39,7 +39,7 @@ use std::{
     sync::Arc,
     vec,
 };
-use sui_config::node::{OverloadThresholdConfig, StateDebugDumpConfig};
+use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
 use sui_config::NodeConfig;
 use sui_types::type_resolver::LayoutResolver;
 use tap::{TapFallible, TapOptional};
@@ -748,7 +748,7 @@ pub struct AuthorityState {
     debug_dump_config: StateDebugDumpConfig,
 
     /// Config for when we consider the node overloaded.
-    overload_threshold_config: OverloadThresholdConfig,
+    authority_overload_config: AuthorityOverloadConfig,
 
     /// Current overload status in this authority. Updated periodically.
     pub overload_info: AuthorityOverloadInfo,
@@ -778,7 +778,7 @@ impl AuthorityState {
     }
 
     pub fn max_txn_age_in_queue(&self) -> Duration {
-        self.overload_threshold_config.max_txn_age_in_queue
+        self.authority_overload_config.max_txn_age_in_queue
     }
 
     pub fn get_epoch_state_commitments(
@@ -935,12 +935,12 @@ impl AuthorityState {
     }
 
     pub fn check_system_overload_at_signing(&self) -> bool {
-        self.overload_threshold_config
+        self.authority_overload_config
             .check_system_overload_at_signing
     }
 
     pub fn check_system_overload_at_execution(&self) -> bool {
-        self.overload_threshold_config
+        self.authority_overload_config
             .check_system_overload_at_execution
     }
 
@@ -2501,7 +2501,7 @@ impl AuthorityState {
         certificate_deny_config: CertificateDenyConfig,
         indirect_objects_threshold: usize,
         debug_dump_config: StateDebugDumpConfig,
-        overload_threshold_config: OverloadThresholdConfig,
+        authority_overload_config: AuthorityOverloadConfig,
         archive_readers: ArchiveReaderBalancer,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
@@ -2554,7 +2554,7 @@ impl AuthorityState {
             transaction_deny_config,
             certificate_deny_config,
             debug_dump_config,
-            overload_threshold_config: overload_threshold_config.clone(),
+            authority_overload_config: authority_overload_config.clone(),
             overload_info: AuthorityOverloadInfo::default(),
         });
 
@@ -2567,9 +2567,9 @@ impl AuthorityState {
         ));
 
         // Don't start the overload monitor when max_load_shedding_percentage is 0.
-        if overload_threshold_config.max_load_shedding_percentage > 0 {
+        if authority_overload_config.max_load_shedding_percentage > 0 {
             let authority_state = Arc::downgrade(&state);
-            spawn_monitored_task!(overload_monitor(authority_state, overload_threshold_config));
+            spawn_monitored_task!(overload_monitor(authority_state, authority_overload_config));
         }
 
         // TODO: This doesn't belong to the constructor of AuthorityState.

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::certificate_deny_config::CertificateDenyConfig;
 use sui_config::genesis::Genesis;
+use sui_config::node::{AuthorityOverloadConfig, StateDebugDumpConfig};
 use sui_config::node::{
     AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
 };
-use sui_config::node::{OverloadThresholdConfig, StateDebugDumpConfig};
 use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_macros::nondeterministic;
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
@@ -53,7 +53,7 @@ pub struct TestAuthorityBuilder<'a> {
     accounts: Vec<AccountConfig>,
     /// By default, we don't insert the genesis checkpoint, which isn't needed by most tests.
     insert_genesis_checkpoint: bool,
-    overload_threshold_config: Option<OverloadThresholdConfig>,
+    authority_overload_config: Option<AuthorityOverloadConfig>,
 }
 
 impl<'a> TestAuthorityBuilder<'a> {
@@ -145,8 +145,8 @@ impl<'a> TestAuthorityBuilder<'a> {
         self
     }
 
-    pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
-        assert!(self.overload_threshold_config.replace(config).is_none());
+    pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
+        assert!(self.authority_overload_config.replace(config).is_none());
         self
     }
 
@@ -249,7 +249,7 @@ impl<'a> TestAuthorityBuilder<'a> {
         };
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
         let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
-        let overload_threshold_config = self.overload_threshold_config.unwrap_or_default();
+        let authority_overload_config = self.authority_overload_config.unwrap_or_default();
         let mut pruning_config = AuthorityStorePruningConfig::default();
         if !epoch_store
             .protocol_config()
@@ -279,7 +279,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             StateDebugDumpConfig {
                 dump_file_directory: Some(tempdir().unwrap().into_path()),
             },
-            overload_threshold_config,
+            authority_overload_config,
             ArchiveReaderBalancer::default(),
         )
         .await;

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Weak;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
-use sui_config::node::OverloadThresholdConfig;
+use sui_config::node::AuthorityOverloadConfig;
 use sui_types::digests::TransactionDigest;
 use sui_types::error::SuiError;
 use sui_types::error::SuiResult;
@@ -47,7 +47,7 @@ const ADDITIONAL_LOAD_SHEDDING: f64 = 0.1;
 // when the signals indicates overload.
 pub async fn overload_monitor(
     authority_state: Weak<AuthorityState>,
-    config: OverloadThresholdConfig,
+    config: AuthorityOverloadConfig,
 ) {
     info!("Starting system overload monitor.");
 
@@ -67,7 +67,7 @@ pub async fn overload_monitor(
 // Returns whether the authority state exists.
 fn check_authority_overload(
     authority_state: &Weak<AuthorityState>,
-    config: &OverloadThresholdConfig,
+    config: &AuthorityOverloadConfig,
 ) -> bool {
     let authority_arc = authority_state.upgrade();
     if authority_arc.is_none() {
@@ -153,7 +153,7 @@ fn calculate_load_shedding_percentage(txn_ready_rate: f64, execution_rate: f64) 
 // When txn_ready_rate is less than execution_rate, we gradually reduce load shedding percentage until
 // the queueing latency is back to normal.
 fn check_overload_signals(
-    config: &OverloadThresholdConfig,
+    config: &AuthorityOverloadConfig,
     current_load_shedding_percentage: u32,
     queueing_latency: Duration,
     txn_ready_rate: f64,
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     pub fn test_check_overload_signals() {
-        let config = OverloadThresholdConfig {
+        let config = AuthorityOverloadConfig {
             execution_queue_latency_hard_limit: Duration::from_secs(10),
             execution_queue_latency_soft_limit: Duration::from_secs(1),
             max_load_shedding_percentage: 90,
@@ -400,12 +400,12 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     pub async fn test_check_authority_overload() {
-        let config = OverloadThresholdConfig {
+        let config = AuthorityOverloadConfig {
             safe_transaction_ready_rate: 0,
             ..Default::default()
         };
         let state = TestAuthorityBuilder::new()
-            .with_overload_threshold_config(config.clone())
+            .with_authority_overload_config(config.clone())
             .build()
             .await;
 

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::genesis::Genesis;
 use sui_config::local_ip_utils;
-use sui_config::node::OverloadThresholdConfig;
+use sui_config::node::AuthorityOverloadConfig;
 use sui_framework::BuiltInFramework;
 use sui_genesis_builder::validator_info::ValidatorInfo;
 use sui_macros::nondeterministic;
@@ -287,7 +287,7 @@ pub async fn init_local_authorities(
 pub async fn init_local_authorities_with_overload_thresholds(
     committee_size: usize,
     genesis_objects: Vec<Object>,
-    overload_thresholds: OverloadThresholdConfig,
+    overload_thresholds: AuthorityOverloadConfig,
 ) -> (
     AuthorityAggregator<LocalAuthorityClient>,
     Vec<Arc<AuthorityState>>,
@@ -298,7 +298,7 @@ pub async fn init_local_authorities_with_overload_thresholds(
     let authorities = join_all(key_pairs.iter().map(|(_, key_pair)| {
         TestAuthorityBuilder::new()
             .with_genesis_and_keypair(&genesis, key_pair)
-            .with_overload_threshold_config(overload_thresholds.clone())
+            .with_authority_overload_config(overload_thresholds.clone())
             .build()
     }))
     .await;

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
-use sui_config::node::OverloadThresholdConfig;
+use sui_config::node::AuthorityOverloadConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
@@ -597,7 +597,7 @@ async fn test_txn_age_overload() {
         init_local_authorities_with_overload_thresholds(
             4,
             gas_objects.clone(),
-            OverloadThresholdConfig {
+            AuthorityOverloadConfig {
                 max_txn_age_in_queue: Duration::from_secs(5),
                 ..Default::default()
             },
@@ -726,13 +726,13 @@ async fn test_authority_txn_signing_pushback() {
 
     // Initialize an AuthorityState. Disable overload monitor by setting max_load_shedding_percentage to 0;
     // Set check_system_overload_at_signing to true.
-    let overload_config = OverloadThresholdConfig {
+    let overload_config = AuthorityOverloadConfig {
         check_system_overload_at_signing: true,
         max_load_shedding_percentage: 0,
         ..Default::default()
     };
     let authority_state = TestAuthorityBuilder::new()
-        .with_overload_threshold_config(overload_config)
+        .with_authority_overload_config(overload_config)
         .build()
         .await;
     authority_state
@@ -853,13 +853,13 @@ async fn test_authority_txn_execution_pushback() {
 
     // Initialize an AuthorityState. Disable overload monitor by setting max_load_shedding_percentage to 0;
     // Set check_system_overload_at_execution to true.
-    let overload_config = OverloadThresholdConfig {
+    let overload_config = AuthorityOverloadConfig {
         check_system_overload_at_execution: true,
         max_load_shedding_percentage: 0,
         ..Default::default()
     };
     let authority_state = TestAuthorityBuilder::new()
-        .with_overload_threshold_config(overload_config)
+        .with_authority_overload_config(overload_config)
         .build()
         .await;
     authority_state

--- a/crates/sui-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_tests.rs
@@ -6,7 +6,7 @@ use futures::join;
 use rand::distributions::Distribution;
 use std::ops::Deref;
 use std::time::{Duration, SystemTime};
-use sui_config::node::OverloadThresholdConfig;
+use sui_config::node::AuthorityOverloadConfig;
 use sui_core::authority::EffectsNotifyRead;
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
@@ -534,7 +534,7 @@ async fn access_clock_object_test() {
 async fn shared_object_sync() {
     let test_cluster = TestClusterBuilder::new()
         // Set the threshold high enough so it won't be triggered.
-        .with_overload_threshold_config(OverloadThresholdConfig {
+        .with_authority_overload_config(AuthorityOverloadConfig {
             max_txn_age_in_queue: Duration::from_secs(60),
             ..Default::default()
         })

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -595,7 +595,7 @@ impl SuiNode {
             config.certificate_deny_config.clone(),
             config.indirect_objects_threshold,
             config.state_debug_dump_config.clone(),
-            config.overload_threshold_config.clone(),
+            config.authority_overload_config.clone(),
             archive_readers,
         )
         .await;

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -7,7 +7,7 @@ use std::{num::NonZeroUsize, path::Path, sync::Arc};
 
 use rand::rngs::OsRng;
 use sui_config::genesis::{TokenAllocation, TokenDistributionScheduleBuilder};
-use sui_config::node::OverloadThresholdConfig;
+use sui_config::node::AuthorityOverloadConfig;
 use sui_macros::nondeterministic;
 use sui_protocol_config::SupportedProtocolVersions;
 use sui_types::base_types::{AuthorityName, SuiAddress};
@@ -60,7 +60,7 @@ pub struct ConfigBuilder<R = OsRng> {
     additional_objects: Vec<Object>,
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
-    overload_threshold_config: Option<OverloadThresholdConfig>,
+    authority_overload_config: Option<AuthorityOverloadConfig>,
     data_ingestion_dir: Option<PathBuf>,
 }
 
@@ -76,7 +76,7 @@ impl ConfigBuilder {
             additional_objects: vec![],
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
-            overload_threshold_config: None,
+            authority_overload_config: None,
             data_ingestion_dir: None,
         }
     }
@@ -195,8 +195,8 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_overload_threshold_config(mut self, c: OverloadThresholdConfig) -> Self {
-        self.overload_threshold_config = Some(c);
+    pub fn with_authority_overload_config(mut self, c: AuthorityOverloadConfig) -> Self {
+        self.authority_overload_config = Some(c);
         self
     }
 
@@ -211,7 +211,7 @@ impl<R> ConfigBuilder<R> {
             additional_objects: self.additional_objects,
             num_unpruned_validators: self.num_unpruned_validators,
             jwk_fetch_interval: self.jwk_fetch_interval,
-            overload_threshold_config: self.overload_threshold_config,
+            authority_overload_config: self.authority_overload_config,
             data_ingestion_dir: self.data_ingestion_dir,
         }
     }
@@ -359,9 +359,9 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     builder = builder.with_jwk_fetch_interval(jwk_fetch_interval);
                 }
 
-                if let Some(overload_threshold_config) = &self.overload_threshold_config {
+                if let Some(authority_overload_config) = &self.authority_overload_config {
                     builder =
-                        builder.with_overload_threshold_config(overload_threshold_config.clone());
+                        builder.with_authority_overload_config(authority_overload_config.clone());
                 }
 
                 if let Some(path) = &self.data_ingestion_dir {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -11,10 +11,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 use sui_config::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
-    AuthorityKeyPairWithPath, AuthorityStorePruningConfig, CheckpointExecutorConfig,
-    DBCheckpointConfig, ExpensiveSafetyCheckConfig, Genesis, KeyPairWithPath,
-    OverloadThresholdConfig, StateArchiveConfig, StateSnapshotConfig,
-    DEFAULT_GRPC_CONCURRENCY_LIMIT,
+    AuthorityKeyPairWithPath, AuthorityOverloadConfig, AuthorityStorePruningConfig,
+    CheckpointExecutorConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig, Genesis,
+    KeyPairWithPath, StateArchiveConfig, StateSnapshotConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT,
 };
 use sui_config::node::{default_zklogin_oauth_providers, ConsensusProtocol, RunWithRange};
 use sui_config::p2p::{P2pConfig, SeedPeer, StateSyncConfig};
@@ -34,7 +33,7 @@ pub struct ValidatorConfigBuilder {
     supported_protocol_versions: Option<SupportedProtocolVersions>,
     force_unpruned_checkpoints: bool,
     jwk_fetch_interval: Option<Duration>,
-    overload_threshold_config: Option<OverloadThresholdConfig>,
+    authority_overload_config: Option<AuthorityOverloadConfig>,
     data_ingestion_dir: Option<PathBuf>,
 }
 
@@ -68,8 +67,8 @@ impl ValidatorConfigBuilder {
         self
     }
 
-    pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
-        self.overload_threshold_config = Some(config);
+    pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
+        self.authority_overload_config = Some(config);
         self
     }
 
@@ -194,7 +193,7 @@ impl ValidatorConfigBuilder {
                 .map(|i| i.as_secs())
                 .unwrap_or(3600),
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
-            overload_threshold_config: self.overload_threshold_config.unwrap_or_default(),
+            authority_overload_config: self.authority_overload_config.unwrap_or_default(),
             run_with_range: None,
         }
     }
@@ -446,7 +445,7 @@ impl FullnodeConfigBuilder {
             // note: not used by fullnodes.
             jwk_fetch_interval_seconds: 3600,
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
-            overload_threshold_config: Default::default(),
+            authority_overload_config: Default::default(),
             run_with_range: self.run_with_range,
         }
     }

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -110,7 +110,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -233,7 +233,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -356,7 +356,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -479,7 +479,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -602,7 +602,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -725,7 +725,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0
@@ -848,7 +848,7 @@ validator_configs:
         - Kakao
         - Slack
         - Twitch
-    overload-threshold-config:
+    authority-overload-config:
       max-txn-age-in-queue:
         secs: 1
         nanos: 0

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -13,7 +13,7 @@ use std::{
     ops,
     path::{Path, PathBuf},
 };
-use sui_config::node::{DBCheckpointConfig, OverloadThresholdConfig, RunWithRange};
+use sui_config::node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange};
 use sui_config::NodeConfig;
 use sui_macros::nondeterministic;
 use sui_node::SuiNodeHandle;
@@ -46,7 +46,7 @@ pub struct SwarmBuilder<R = OsRng> {
     db_checkpoint_config: DBCheckpointConfig,
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
-    overload_threshold_config: Option<OverloadThresholdConfig>,
+    authority_overload_config: Option<AuthorityOverloadConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
 }
@@ -69,7 +69,7 @@ impl SwarmBuilder {
             db_checkpoint_config: DBCheckpointConfig::default(),
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
-            overload_threshold_config: None,
+            authority_overload_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
         }
@@ -94,7 +94,7 @@ impl<R> SwarmBuilder<R> {
             db_checkpoint_config: self.db_checkpoint_config,
             jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
-            overload_threshold_config: self.overload_threshold_config,
+            authority_overload_config: self.authority_overload_config,
             data_ingestion_dir: self.data_ingestion_dir,
             fullnode_run_with_range: self.fullnode_run_with_range,
         }
@@ -218,12 +218,12 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    pub fn with_overload_threshold_config(
+    pub fn with_authority_overload_config(
         mut self,
-        overload_threshold_config: OverloadThresholdConfig,
+        authority_overload_config: AuthorityOverloadConfig,
     ) -> Self {
         assert!(self.network_config.is_none());
-        self.overload_threshold_config = Some(overload_threshold_config);
+        self.authority_overload_config = Some(authority_overload_config);
         self
     }
 
@@ -273,9 +273,9 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 config_builder = config_builder.with_jwk_fetch_interval(jwk_fetch_interval);
             }
 
-            if let Some(overload_threshold_config) = self.overload_threshold_config {
+            if let Some(authority_overload_config) = self.authority_overload_config {
                 config_builder =
-                    config_builder.with_overload_threshold_config(overload_threshold_config);
+                    config_builder.with_authority_overload_config(authority_overload_config);
             }
 
             if let Some(path) = self.data_ingestion_dir {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use sui_config::node::{DBCheckpointConfig, OverloadThresholdConfig, RunWithRange};
+use sui_config::node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange};
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{NodeConfig, PersistedConfig, SUI_KEYSTORE_FILENAME};
 use sui_core::authority_aggregator::AuthorityAggregator;
@@ -720,7 +720,7 @@ pub struct TestClusterBuilder {
     jwk_fetch_interval: Option<Duration>,
     config_dir: Option<PathBuf>,
     default_jwks: bool,
-    overload_threshold_config: Option<OverloadThresholdConfig>,
+    authority_overload_config: Option<AuthorityOverloadConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
 }
@@ -742,7 +742,7 @@ impl TestClusterBuilder {
             jwk_fetch_interval: None,
             config_dir: None,
             default_jwks: false,
-            overload_threshold_config: None,
+            authority_overload_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
         }
@@ -890,9 +890,9 @@ impl TestClusterBuilder {
         self
     }
 
-    pub fn with_overload_threshold_config(mut self, config: OverloadThresholdConfig) -> Self {
+    pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
         assert!(self.network_config.is_none());
-        self.overload_threshold_config = Some(config);
+        self.authority_overload_config = Some(config);
         self
     }
 
@@ -992,8 +992,8 @@ impl TestClusterBuilder {
             builder = builder.with_network_config(network_config);
         }
 
-        if let Some(overload_threshold_config) = self.overload_threshold_config.take() {
-            builder = builder.with_overload_threshold_config(overload_threshold_config);
+        if let Some(authority_overload_config) = self.authority_overload_config.take() {
+            builder = builder.with_authority_overload_config(authority_overload_config);
         }
 
         if let Some(fullnode_rpc_port) = self.fullnode_rpc_port {


### PR DESCRIPTION
## Description 

The config is no longer just threshold. Should be a safe change since it is not being explicitly set in prod.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
