### PR TITLE
[data ingestion] add timeouts to all dynamodb operations

### DIFF
--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -216,13 +216,13 @@ impl CheckpointReader {
 
         loop {
             tokio::select! {
-                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(timeout_ms), inotify_recv.recv())  => {
-                    self.sync().await.expect("Failed to read checkpoint files");
-                }
+                _ = &mut self.exit_receiver => break,
                 Some(gc_checkpoint_number) = self.processed_receiver.recv() => {
                     self.gc_processed_files(gc_checkpoint_number).expect("Failed to clean the directory");
                 }
-                _ = &mut self.exit_receiver => break,
+                Ok(Some(_)) | Err(_) = timeout(Duration::from_millis(timeout_ms), inotify_recv.recv())  => {
+                    self.sync().await.expect("Failed to read checkpoint files");
+                }
             }
         }
         Ok(())

--- a/crates/sui-data-ingestion/src/workers/kv_store.rs
+++ b/crates/sui-data-ingestion/src/workers/kv_store.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use aws_config::timeout::TimeoutConfig;
 use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::{AttributeValue, PutRequest, WriteRequest};
 use aws_sdk_dynamodb::Client;
@@ -58,9 +59,15 @@ impl KVStoreWorker {
             None,
             "dynamodb",
         );
+        let timeout_config = TimeoutConfig::builder()
+            .operation_timeout(Duration::from_secs(3))
+            .operation_attempt_timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(3))
+            .build();
         let aws_config = aws_config::from_env()
             .credentials_provider(credentials)
             .region(Region::new(config.aws_region))
+            .timeout_config(timeout_config)
             .load()
             .await;
         let dynamo_client = Client::new(&aws_config);


### PR DESCRIPTION
dynamodb connection timeout is the reason why single task can stop whole daemon from making any progress