### PR TITLE
[GraphQL/Docs] Increased Concepts/References cross-linking

### DIFF
--- a/docs/content/concepts/graphql-rpc.mdx
+++ b/docs/content/concepts/graphql-rpc.mdx
@@ -9,4 +9,4 @@ This section explains some of the common concepts when working with GraphQL, suc
 
 For more details on GraphQL fundamentals, see the introductory documentation from [GraphQL](https://graphql.org/learn/) and [GitHub](https://docs.github.com/en/graphql/guides/introduction-to-graphql).
 
-If you are interested in how to interact with the Sui network via the GraphQL RPC, see the [getting started](guides/developer/getting-started/graphql-rpc.mdx) guide. If you are looking for information on migrating from JSON-RPC to GraphQL, see the [migration](../guides/developer/advanced/graphql-migration.mdx) guide.
+If you are interested in how to interact with the Sui network via the GraphQL RPC, see the [getting started](guides/developer/getting-started/graphql-rpc.mdx) guide, and the [full API reference](/references/sui-graphql). If you are looking for information on migrating from JSON-RPC to GraphQL, see the [migration](../guides/developer/advanced/graphql-migration.mdx) guide.

--- a/docs/content/references/sui-graphql.mdx
+++ b/docs/content/references/sui-graphql.mdx
@@ -9,9 +9,10 @@ To get started with the GraphQL RPC, check out the [Getting Started](/guides/dev
 
 ## Key Types
 
-All GraphQL API elements are accessible via the left sidebar, the following are good starting pointsto explore from.
+All GraphQL API elements are accessible via the left sidebar, the following are good starting points to explore from.
 
-- "Queries" lists all top-level queries for reading the chain state from reading details about addresses and objects to [dryRunTransactionBlock](/references/sui-graphql/reference/queries/dry-run-transaction-block), which has an execution-like interface but does not modify the chain.
+- "Queries" lists all top-level queries for reading the chain state, from reading details about addresses and objects to [dryRunTransactionBlock](/references/sui-graphql/reference/queries/dry-run-transaction-block), which has an execution-like interface but does not modify the chain.
 - "Mutations" lists operations that can modify chain state, like [executeTransactionBlock](/references/sui-graphql/reference/mutations/execute-transaction-block).
 - [Object](/references/sui-graphql/reference/objects/object) is the type representing all on-chain objects (Move values and packages)
 - [Address](/references/sui-graphql/reference/objects/address) corresponds to account addresses (derived from the public keys of signatures that sign transactions) and can be used to query the objects owned by these accounts and the transactions they have signed or been affected by.
+- [Owner](/references/sui-graphql/reference/objects/owner) represents any entity that can own a [MoveObject](/references/sui-graphql/reference/objects/move-object) to handle cases where it is not known whether the owner is an [Object](/references/sui-graphql/reference/objects/object) or an [Address](/references/sui-graphql/reference/objects/address) (for example, from the perspective of a Move object looking at its owner).

--- a/docs/content/references/sui-graphql.mdx
+++ b/docs/content/references/sui-graphql.mdx
@@ -5,8 +5,13 @@ description: The Sui GraphQL RPC is a public service that enables interacting wi
 
 The Sui GraphQL RPC is a public service that enables interacting with the Sui [network](https://sui.io/networkinfo).
 
-To get started with the GraphQL RPC, check out the [Getting Started](/guides/developer/getting-started/graphql-rpc.mdx) guide. If you'd like to learn more about the concepts used in the GraphQL RPC service, check out the [GraphQL RPC](/concepts/graphql-rpc.mdx) concepts page.
+To get started with the GraphQL RPC, check out the [Getting Started](/guides/developer/getting-started/graphql-rpc.mdx) guide. If you'd like to learn more about the concepts used in the GraphQL RPC service, check out the [GraphQL RPC concepts](/concepts/graphql-rpc.mdx) page.
 
-Check out the `Queries` reference page on the left sidebar for the root types related to querying the service (e.g., doing a `dryRun`). If you'd like to execute a transaction on the network, check out the `Mutations` page in the left sidebar.
+## Key Types
 
-As Sui uses an object-centric model, it might be of interest to explore the [Object](/references/sui-graphql/reference/objects/object.mdx) and [Address](/references/sui-graphql/reference/objects/address.mdx) types too. For other types and reference API, consult the pages under GraphQL RPC API shown in the left sidebar.
+All GraphQL API elements are accessible via the left sidebar, the following are good starting pointsto explore from.
+
+- "Queries" lists all top-level queries for reading the chain state from reading details about addresses and objects to [dryRunTransactionBlock](/references/sui-graphql/reference/queries/dry-run-transaction-block), which has an execution-like interface but does not modify the chain.
+- "Mutations" lists operations that can modify chain state, like [executeTransactionBlock](/references/sui-graphql/reference/mutations/execute-transaction-block).
+- [Object](/references/sui-graphql/reference/objects/object) is the type representing all on-chain objects (Move values and packages)
+- [Address](/references/sui-graphql/reference/objects/address) corresponds to account addresses (derived from the public keys of signatures that sign transactions) and can be used to query the objects owned by these accounts and the transactions they have signed or been affected by.

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus graphql-to-doc; node src/utils/getopenrpcspecs.js; docusaurus start",
-    "build": "docusaurus graphql-to-doc; node src/utils/getopenrpcspecs.js; docusaurus build",
+    "start": "docusaurus graphql-to-doc; rm '../content/references/sui-graphql/reference/generated.md'; node src/utils/getopenrpcspecs.js; docusaurus start",
+    "build": "docusaurus graphql-to-doc; rm '../content/references/sui-graphql/reference/generated.md'; node src/utils/getopenrpcspecs.js; docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Description

Addressing some specific feedback about lack of cross-linking between different parts of the GraphQL docs (we will need to do a broader audit for other examples of the same).

This change:

- Adds links from GraphQL concepts to references and vice versa.
- Removes a generated but otherwise redundant page from the docs generation process.
- Adds more structure and more inner links to the references landing page, where possible.

## Test Plan

:eyes: