### PR TITLE
Add a simple suggestion in ValidatorOverloadedRetryAfter

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -613,8 +613,8 @@ pub enum SuiError {
     #[error("Storage error: {0}")]
     Storage(String),
 
-    #[error("Validator cannot handle the request at the moment. Please retry after at least {retry_after_sec}.")]
-    ValidatorOverloadedRetryAfter { retry_after_sec: u64 },
+    #[error("Validator cannot handle the request at the moment. Please retry after at least {retry_after_secs} seconds.")]
+    ValidatorOverloadedRetryAfter { retry_after_secs: u64 },
 }
 
 #[repr(u64)]


### PR DESCRIPTION
## Description 

With some other nit changes:
- add `s` in `retry_after_secs`
- create a const for calculate the seed used in should_reject_tx, and change interval to 30s (60s may be too long).

## Test Plan 

Existing tests. No logic change in this PR.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
