### PR TITLE
[Consensus 2.0] one ancestor per authority in block proposal

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -199,9 +199,6 @@ impl Core {
 
             //3. create the block and insert to storage.
             // TODO: take a decision on whether we want to flush to disk at this point the DagState.
-
-            // TODO: this will be refactored once the signing path/approach has been introduced. Adding as is for now
-            // to keep things rolling in the implementation.
             let block = Block::V1(BlockV1::new(
                 self.context.committee.epoch(),
                 clock_round,
@@ -278,15 +275,17 @@ impl Core {
             .flat_map(|block| block.ancestors())
             .collect();
 
-        let mut to_propose = HashSet::new();
+        // Keep block refs to propose to a map, so even if somehow a byzantine node managed to provide blocks that don't
+        // form a valid chains we can still pick one block per author.
+        let mut to_propose = BTreeMap::new();
         for block in ancestors.into_iter() {
             if !all_ancestors_parents.contains(&block.reference()) {
-                to_propose.insert(block.reference());
+                to_propose.insert(block.author(), block.reference());
             }
         }
 
         // always include our last block to ensure that is not somehow excluded by the DAG compression
-        to_propose.insert(self.last_proposed_block.reference());
+        to_propose.insert(self.context.own_index, self.last_proposed_block.reference());
 
         assert!(!to_propose.is_empty());
 
@@ -294,7 +293,7 @@ impl Core {
         self.pending_ancestors
             .retain(|round, _blocks| *round >= clock_round);
 
-        to_propose.into_iter().collect()
+        to_propose.values().cloned().collect()
     }
 
     /// Checks whether all the leaders of the previous quorum exist.


### PR DESCRIPTION
## Description 

A small refactoring to ensure that only ancestor per authority is included per block proposal - that should happen mostly under some out of order block processing or byzantine cases

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
