### PR TITLE
[bridge 43/n ] add bridge types in sui-types and helper functions

### DIFF
--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -23,6 +23,10 @@ use sui_json_rpc_types::{
 };
 use sui_sdk::{SuiClient as SuiSdkClient, SuiClientBuilder};
 use sui_types::base_types::ObjectRef;
+use sui_types::bridge::BridgeInnerDynamicField;
+use sui_types::bridge::BridgeRecordDyanmicField;
+use sui_types::bridge::MoveTypeBridgeCommittee;
+use sui_types::bridge::MoveTypeCommitteeMember;
 use sui_types::collection_types::LinkedTableNode;
 use sui_types::crypto::get_key_pair;
 use sui_types::dynamic_field::DynamicFieldName;
@@ -49,14 +53,7 @@ use crate::events::SuiBridgeEvent;
 use crate::retry_with_max_elapsed_time;
 use crate::sui_transaction_builder::get_bridge_package_id;
 use crate::types::BridgeActionStatus;
-use crate::types::BridgeInnerDynamicField;
-use crate::types::BridgeRecordDyanmicField;
-use crate::types::MoveTypeBridgeMessageKey;
-use crate::types::MoveTypeBridgeRecord;
-use crate::types::{
-    BridgeAction, BridgeAuthority, BridgeCommittee, MoveTypeBridgeCommittee, MoveTypeBridgeInner,
-    MoveTypeCommitteeMember,
-};
+use crate::types::{BridgeAction, BridgeAuthority, BridgeCommittee};
 
 // TODO: once we have bridge package on sui framework, we can hardcode the actual
 // bridge dynamic field object id (not 0x9 or dynamic field wrapper) and update

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -11,6 +11,7 @@ use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::{EventFilter, EventPage, SuiEvent};
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
+use sui_types::bridge::MoveTypeBridgeCommittee;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -19,7 +20,7 @@ use sui_types::transaction::Transaction;
 use sui_types::Identifier;
 
 use crate::sui_client::SuiClientInner;
-use crate::types::{BridgeAction, BridgeActionDigest, BridgeActionStatus, MoveTypeBridgeCommittee};
+use crate::types::{BridgeAction, BridgeActionDigest, BridgeActionStatus};
 
 /// Mock client used in test environments.
 #[allow(clippy::type_complexity)]

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -8,7 +8,6 @@ use crate::server::mock_handler::run_mock_server;
 use crate::sui_transaction_builder::{
     get_bridge_package_id, get_root_bridge_object_arg, get_sui_token_type_tag,
 };
-use crate::types::BridgeInnerDynamicField;
 use crate::{
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKey, BridgeAuthoritySignInfo},
     events::EmittedSuiToEthTokenBridgeV1,
@@ -37,6 +36,7 @@ use sui_json_rpc_types::ObjectChange;
 use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
+use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -19,12 +19,9 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 use std::collections::{BTreeMap, BTreeSet};
-use sui_types::base_types::SuiAddress;
-use sui_types::collection_types::{Bag, LinkedTable, LinkedTableNode, VecMap};
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::StakeUnit;
 use sui_types::digests::{Digest, TransactionDigest};
-use sui_types::dynamic_field::Field;
 use sui_types::error::SuiResult;
 use sui_types::message_envelope::{Envelope, Message, VerifiedEnvelope};
 use sui_types::{base_types::SUI_ADDRESS_LENGTH, committee::EpochId};
@@ -32,12 +29,6 @@ use sui_types::{base_types::SUI_ADDRESS_LENGTH, committee::EpochId};
 pub const BRIDGE_AUTHORITY_TOTAL_VOTING_POWER: u64 = 10000;
 
 pub const USD_MULTIPLIER: u64 = 10000; // decimal places = 4
-
-pub type BridgeInnerDynamicField = Field<u64, MoveTypeBridgeInner>;
-pub type BridgeRecordDyanmicField = Field<
-    MoveTypeBridgeMessageKey,
-    LinkedTableNode<MoveTypeBridgeMessageKey, MoveTypeBridgeRecord>,
->;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct BridgeAuthority {
@@ -636,71 +627,6 @@ pub struct EthLog {
     // TODO: pull necessary fields from `Log`.
     pub log: Log,
 }
-
-/////////////////////////// Move Types Start //////////////////////////
-
-/// Rust version of the Move bridge::BridgeInner type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeInner {
-    pub bridge_version: u64,
-    pub chain_id: u8,
-    pub sequence_nums: VecMap<u8, u64>,
-    pub committee: MoveTypeBridgeCommittee,
-    pub treasury: MoveTypeBridgeTreasury,
-    pub bridge_records: LinkedTable<MoveTypeBridgeMessageKey>,
-    pub frozen: bool,
-}
-
-/// Rust version of the Move treasury::BridgeTreasury type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeTreasury {
-    pub treasuries: Bag,
-}
-
-/// Rust version of the Move committee::BridgeCommittee type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeCommittee {
-    pub members: VecMap<Vec<u8>, MoveTypeCommitteeMember>,
-    pub thresholds: VecMap<u8, u64>,
-}
-
-/// Rust version of the Move committee::CommitteeMember type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeCommitteeMember {
-    pub sui_address: SuiAddress,
-    pub bridge_pubkey_bytes: Vec<u8>,
-    pub voting_power: u64,
-    pub http_rest_url: Vec<u8>,
-    pub blocklisted: bool,
-}
-
-/// Rust version of the Move message::BridgeMessageKey type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeMessageKey {
-    pub source_chain: u8,
-    pub message_type: u8,
-    pub bridge_seq_num: u64,
-}
-
-/// Rust version of the Move message::BridgeMessage type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeMessage {
-    pub message_type: u8,
-    pub message_version: u8,
-    pub seq_num: u64,
-    pub source_chain: u8,
-    pub payload: Vec<u8>,
-}
-
-/// Rust version of the Move message::BridgeMessage type.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MoveTypeBridgeRecord {
-    pub message: MoveTypeBridgeMessage,
-    pub verified_signatures: Option<Vec<Vec<u8>>>,
-    pub claimed: bool,
-}
-
-/////////////////////////// Move Types End //////////////////////////
 
 #[cfg(test)]
 mod tests {

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -1,13 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base_types::ObjectID;
 use crate::base_types::SequenceNumber;
 use crate::error::SuiResult;
 use crate::object::Owner;
 use crate::storage::ObjectStore;
+use crate::sui_serde::BigInt;
+use crate::sui_serde::Readable;
 use crate::SUI_BRIDGE_OBJECT_ID;
+use enum_dispatch::enum_dispatch;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::collection_types::LinkedTableNode;
+use crate::dynamic_field::{get_dynamic_field_from_store, Field};
+use crate::{
+    base_types::SuiAddress,
+    collection_types::{Bag, LinkedTable, VecMap},
+    error::SuiError,
+    id::UID,
+};
+
+pub type BridgeInnerDynamicField = Field<u64, BridgeInnerV1>;
+pub type BridgeRecordDyanmicField = Field<
+    MoveTypeBridgeMessageKey,
+    LinkedTableNode<MoveTypeBridgeMessageKey, MoveTypeBridgeRecord>,
+>;
 
 pub const BRIDGE_MODULE_NAME: &IdentStr = ident_str!("bridge");
 pub const BRIDGE_CREATE_FUNCTION_NAME: &IdentStr = ident_str!("create");
@@ -25,4 +47,229 @@ pub fn get_bridge_obj_initial_shared_version(
             } => initial_shared_version,
             _ => unreachable!("Bridge object must be shared"),
         }))
+}
+
+/// Bridge provides an abstraction over multiple versions of the inner BridgeInner object.
+/// This should be the primary interface to the bridge object in Rust.
+/// We use enum dispatch to dispatch all methods defined in BridgeTrait to the actual
+/// implementation in the inner types.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[enum_dispatch(BridgeTrait)]
+pub enum Bridge {
+    V1(BridgeInnerV1),
+}
+
+/// Rust version of the Move sui::bridge::Bridge type
+/// This repreents the object with 0x9 ID.
+/// In Rust, this type should be rarely used since it's just a thin
+/// wrapper used to access the inner object.
+/// Within this module, we use it to determine the current version of the bridge inner object type,
+/// so that we could deserialize the inner object correctly.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BridgeWrapper {
+    pub id: UID,
+    pub version: u64,
+}
+
+/// This is the standard API that all bridge inner object type should implement.
+#[enum_dispatch]
+pub trait BridgeTrait {
+    fn message_version(&self) -> u64;
+    fn chain_id(&self) -> u8;
+    fn sequence_nums(&self) -> &VecMap<u8, u64>;
+    fn committee(&self) -> &MoveTypeBridgeCommittee;
+    fn treasury(&self) -> &MoveTypeBridgeTreasury;
+    fn bridge_records(&self) -> &LinkedTable<MoveTypeBridgeMessageKey>;
+    fn frozen(&self) -> bool;
+    fn into_bridge_summary(self) -> BridgeSummary;
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeSummary {
+    // Message version
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    pub message_version: u64,
+    /// Self Chain ID
+    pub chain_id: u8,
+    /// Sequence numbers of all message types
+    #[schemars(with = "Vec<(u8, BigInt<u64>)>")]
+    #[serde_as(as = "Vec<(_, Readable<BigInt<u64>, _>)>")]
+    pub sequence_nums: Vec<(u8, u64)>,
+    pub committee: BridgeCommitteeSummary,
+    /// Object ID of bridge Records (dynamic field)
+    pub bridge_records_id: ObjectID,
+    /// Whether the bridge is currently frozen or not
+    pub is_frozen: bool,
+    // TODO: add treasury
+}
+
+pub fn get_bridge_wrapper(object_store: &dyn ObjectStore) -> Result<BridgeWrapper, SuiError> {
+    let wrapper = object_store
+        .get_object(&SUI_BRIDGE_OBJECT_ID)?
+        // Don't panic here on None because object_store is a generic store.
+        .ok_or_else(|| SuiError::SuiBridgeReadError("BridgeWrapper object not found".to_owned()))?;
+    let move_object = wrapper.data.try_as_move().ok_or_else(|| {
+        SuiError::SuiBridgeReadError("BridgeWrapper object must be a Move object".to_owned())
+    })?;
+    let result = bcs::from_bytes::<BridgeWrapper>(move_object.contents())
+        .map_err(|err| SuiError::SuiBridgeReadError(err.to_string()))?;
+    Ok(result)
+}
+
+pub fn get_bridge(object_store: &dyn ObjectStore) -> Result<Bridge, SuiError> {
+    let wrapper = get_bridge_wrapper(object_store)?;
+    let id = wrapper.id.id.bytes;
+    match wrapper.version {
+        1 => {
+            let result: BridgeInnerV1 =
+                get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
+                    |err| {
+                        SuiError::DynamicFieldReadError(format!(
+                    "Failed to load bridge inner object with ID {:?} and version {:?}: {:?}",
+                    id, wrapper.version, err
+                ))
+                    },
+                )?;
+            Ok(Bridge::V1(result))
+        }
+        _ => Err(SuiError::SuiBridgeReadError(format!(
+            "Unsupported SuiBridge version: {}",
+            wrapper.version
+        ))),
+    }
+}
+
+/// Rust version of the Move bridge::BridgeInner type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BridgeInnerV1 {
+    pub message_version: u64,
+    pub chain_id: u8,
+    pub sequence_nums: VecMap<u8, u64>,
+    pub committee: MoveTypeBridgeCommittee,
+    pub treasury: MoveTypeBridgeTreasury,
+    pub bridge_records: LinkedTable<MoveTypeBridgeMessageKey>,
+    pub frozen: bool,
+}
+
+impl BridgeTrait for BridgeInnerV1 {
+    fn message_version(&self) -> u64 {
+        self.message_version
+    }
+
+    fn chain_id(&self) -> u8 {
+        self.chain_id
+    }
+
+    fn sequence_nums(&self) -> &VecMap<u8, u64> {
+        &self.sequence_nums
+    }
+
+    fn committee(&self) -> &MoveTypeBridgeCommittee {
+        &self.committee
+    }
+
+    fn treasury(&self) -> &MoveTypeBridgeTreasury {
+        &self.treasury
+    }
+
+    fn bridge_records(&self) -> &LinkedTable<MoveTypeBridgeMessageKey> {
+        &self.bridge_records
+    }
+
+    fn frozen(&self) -> bool {
+        self.frozen
+    }
+
+    fn into_bridge_summary(self) -> BridgeSummary {
+        BridgeSummary {
+            message_version: self.message_version,
+            chain_id: self.chain_id,
+            sequence_nums: self
+                .sequence_nums
+                .contents
+                .into_iter()
+                .map(|e| (e.key, e.value))
+                .collect(),
+            committee: BridgeCommitteeSummary {
+                members: self
+                    .committee
+                    .members
+                    .contents
+                    .into_iter()
+                    .map(|e| (e.key, e.value))
+                    .collect(),
+                thresholds: self
+                    .committee
+                    .thresholds
+                    .contents
+                    .into_iter()
+                    .map(|e| (e.key, e.value))
+                    .collect(),
+            },
+            bridge_records_id: self.bridge_records.id,
+            is_frozen: self.frozen,
+        }
+    }
+}
+
+/// Rust version of the Move treasury::BridgeTreasury type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MoveTypeBridgeTreasury {
+    pub treasuries: Bag,
+}
+
+/// Rust version of the Move committee::BridgeCommittee type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MoveTypeBridgeCommittee {
+    pub members: VecMap<Vec<u8>, MoveTypeCommitteeMember>,
+    pub thresholds: VecMap<u8, u64>,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeCommitteeSummary {
+    pub members: Vec<(Vec<u8>, MoveTypeCommitteeMember)>,
+    pub thresholds: Vec<(u8, u64)>,
+}
+
+/// Rust version of the Move committee::CommitteeMember type.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MoveTypeCommitteeMember {
+    pub sui_address: SuiAddress,
+    pub bridge_pubkey_bytes: Vec<u8>,
+    pub voting_power: u64,
+    pub http_rest_url: Vec<u8>,
+    pub blocklisted: bool,
+}
+
+/// Rust version of the Move message::BridgeMessageKey type.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MoveTypeBridgeMessageKey {
+    pub source_chain: u8,
+    pub message_type: u8,
+    pub bridge_seq_num: u64,
+}
+
+/// Rust version of the Move message::BridgeMessage type.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MoveTypeBridgeMessage {
+    pub message_type: u8,
+    pub message_version: u8,
+    pub seq_num: u64,
+    pub source_chain: u8,
+    pub payload: Vec<u8>,
+}
+
+/// Rust version of the Move message::BridgeMessage type.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MoveTypeBridgeRecord {
+    pub message: MoveTypeBridgeMessage,
+    pub verified_signatures: Option<Vec<Vec<u8>>>,
+    pub claimed: bool,
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -591,6 +591,9 @@ pub enum SuiError {
     #[error("Failed to read or deserialize system state related data structures on-chain: {0}")]
     SuiSystemStateReadError(String),
 
+    #[error("Failed to read or deserialize bridge related data structures on-chain: {0}")]
+    SuiBridgeReadError(String),
+
     #[error("Unexpected version error: {0}")]
     UnexpectedVersion(String),
 


### PR DESCRIPTION
## Description 

This PR facilitates the creation of bridge-api skeleton: https://github.com/MystenLabs/sui/pull/16293

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
