### PR TITLE
[execution-layer] update hakari exclude

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -39,6 +39,7 @@ third-party = [
     { name = "move-vm-profiler", path = "external-crates/move/crates/move-vm-profiler" },
     { name = "move-vm-runtime-v0", path = "external-crates/move/move-execution/v0/move-vm/runtime" },
     { name = "move-vm-runtime-v1", path = "external-crates/move/move-execution/v1/crates/move-vm-runtime" },
+#     { name = "move-vm-runtime-$CUT", path = "external-crates/move/move-execution/$CUT/crates/move-vm-runtime" },
     { name = "move-vm-test-utils", path = "external-crates/move/crates/move-vm-test-utils" },
     { name = "move-vm-types", path = "external-crates/move/crates/move-vm-types" },
 ]

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -152,7 +152,8 @@ def do_cut(args):
         exit(result.returncode)
 
     clean_up_cut(args.feature)
-    update_toml(args.feature)
+    update_toml(args.feature, Path() / "sui-execution" / "Cargo.toml")
+    update_toml(args.feature, Path() / ".config" / "hakari.toml")
     generate_impls(args.feature, impl_module)
 
     with open(Path() / "sui-execution" / "src" / "lib.rs", mode="w") as lib:
@@ -419,9 +420,8 @@ def delete_cut_crates(feature):
         rmtree(module)
 
 
-def update_toml(feature):
+def update_toml(feature, toml_path):
     """Add dependencies for 'feature' to sui-execution's manifest."""
-    toml_path = Path() / "sui-execution" / "Cargo.toml"
 
     # Read all the lines
     with open(toml_path) as toml:


### PR DESCRIPTION
## Description

Execution layer cuts need to be added to hakari excludes to avoid feature merging.

## Test Plan

Mostly CI, but can be tested locally by:

```
sui$ ./scripts/execution_layer.py cut for_ci_test
sui$ cargo build -p sui-execution
```

(Which should succeed, and then you'll need to reset the working directory).