### PR TITLE
[suiop] make project name configurable without user input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14007,7 +14007,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.1.7"
+version = "0.1.8"
 
 [lib]
 name = "suioplib"
@@ -28,17 +28,17 @@ include_dir.workspace = true
 inquire.workspace = true
 prettytable-rs.workspace = true
 regex.workspace = true
-reqwest = {workspace = true, features = [
+reqwest = { workspace = true, features = [
   "rustls-tls",
   "json",
-], default-features = false}
+], default-features = false }
 semver.workspace = true
-serde = {workspace = true, features = ["derive"]}
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 spinners.workspace = true
 strum.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 toml_edit.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/crates/suiop-cli/src/cli/pulumi/init.rs
+++ b/crates/suiop-cli/src/cli/pulumi/init.rs
@@ -19,11 +19,15 @@ pub enum ProjectType {
 const KEYRING: &str = "pulumi-kms-automation-f22939d";
 
 impl ProjectType {
-    pub fn create_project(&self, use_kms: &bool) -> Result<()> {
+    pub fn create_project(&self, use_kms: &bool, project_name: Option<String>) -> Result<()> {
         // make sure we're in suiops
         ensure_in_suiops_repo()?;
         // inquire params from user
-        let project_name = Text::new("project name:").prompt()?;
+        let project_name = project_name.unwrap_or_else(|| {
+            Text::new("project name:")
+                .prompt()
+                .expect("couldn't get project name")
+        });
         // create dir
         let project_subdir = match self {
             Self::App | Self::CronJob => "apps",

--- a/crates/suiop-cli/src/cli/pulumi/mod.rs
+++ b/crates/suiop-cli/src/cli/pulumi/mod.rs
@@ -36,6 +36,10 @@ pub enum PulumiAction {
         /// use GCP KMS as encryption provider
         #[arg(short, long, group = "feature")]
         kms: bool,
+
+        /// the name of the project to be created
+        #[arg(long, aliases = ["name"])]
+        project_name: Option<String>,
     },
 }
 
@@ -47,6 +51,7 @@ pub async fn pulumi_cmd(args: &PulumiArgs) -> Result<()> {
             basic,
             cronjob,
             kms,
+            project_name,
         } => {
             if *kms {
                 ensure_gcloud()?;
@@ -56,7 +61,7 @@ pub async fn pulumi_cmd(args: &PulumiArgs) -> Result<()> {
                 (false, false, true) => ProjectType::CronJob,
                 (_, _, _) => ProjectType::Basic,
             };
-            project_type.create_project(kms)
+            project_type.create_project(kms, project_name.clone())
         }
     }
 }


### PR DESCRIPTION
## Description 

tsia

## Test Plan 

```
» suiop p i --help                   
initialize a new pulumi project

Usage: suiop pulumi init [OPTIONS]

Options:
  -a, --app                          initialize app project
  -b, --basic                        initialize barebones project (default)
  -c, --cronjob                      initialize cronjob project
  -k, --kms                          use GCP KMS as encryption provider
      --project-name <PROJECT_NAME>  the name of the project to be created
  -h, --help                         Print help
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
