### PR TITLE
[cli] Improve display for gas cost summary

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -927,10 +927,10 @@ impl Display for SuiTransactionBlockEffects {
         let gas_cost_summary = self.gas_cost_summary();
         builder.push_record(vec![format!(
             "Gas Cost Summary:\n   \
-             Storage Cost: {}\n   \
-             Computation Cost: {}\n   \
-             Storage Rebate: {}\n   \
-             Non-refundable Storage Fee: {}",
+             Storage Cost: {} MIST\n   \
+             Computation Cost: {} MIST\n   \
+             Storage Rebate: {} MIST\n   \
+             Non-refundable Storage Fee: {} MIST",
             gas_cost_summary.storage_cost,
             gas_cost_summary.computation_cost,
             gas_cost_summary.storage_rebate,


### PR DESCRIPTION
## Description 

This PR adds the postfix `MIST` to gas cost summary display implementation to make it consistent with how gas cost is showed in transaction data.

## Test Plan 

Existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
