### PR TITLE
Fix brew install all deps by including libpq

### DIFF
--- a/docs/content/guides/developer/getting-started/sui-install.mdx
+++ b/docs/content/guides/developer/getting-started/sui-install.mdx
@@ -246,7 +246,7 @@ If you used the commands in the [Install using Homebrew](#install-homebrew) sect
 With Homebrew installed, you can install individual prerequisites from the following sections or install them all at once with this command:
 
 ```bash
-brew install curl cmake git
+brew install curl cmake libpq git
 ```
 
 


### PR DESCRIPTION
## Description 

Suggested brew install "all deps" command did not include all deps.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
