### PR TITLE
Fix how we track object status in analytics

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/mod.rs
+++ b/crates/sui-analytics-indexer/src/handlers/mod.rs
@@ -147,11 +147,11 @@ impl ObjectStatusTracker {
 
     fn get_object_status(&self, object_id: &ObjectID) -> Option<ObjectStatus> {
         if self.mutated.contains(object_id) {
-            Some(ObjectStatus::Created)
-        } else if self.deleted.contains(object_id) {
             Some(ObjectStatus::Mutated)
-        } else if self.created.contains(object_id) {
+        } else if self.deleted.contains(object_id) {
             Some(ObjectStatus::Deleted)
+        } else if self.created.contains(object_id) {
+            Some(ObjectStatus::Created)
         } else {
             None
         }


### PR DESCRIPTION
## Description 

This PR fixes how we are tagging object status in object and transaction object table. Currently, all output object statuses are incorrect i.e. created objects are marked as deleted, deleted as mutated and mutated as created. This would require some careful fixing. These are the proposed steps to fix:

1. Stop the ingestion pipelines for object and transaction_object tables (ensure currently running pipelines are done processing) and run the following commands:
2. `UPDATE dataset.OBJECT SET object_status = 'Mutated_tmp' WHERE object_status = 'Created';`
3. `UPDATE dataset.OBJECT SET object_status = 'Created' WHERE object_status = 'Deleted';`
4. `UPDATE dataset.OBJECT SET object_status = 'Deleted' WHERE object_status = 'Mutated';`
5. `UPDATE dataset.OBJECT SET object_status = 'Mutated' WHERE object_status = 'Mutated_tmp';`
6. `UPDATE dataset.TRANSACTION_OBJECT SET object_status = 'Mutated_tmp' WHERE object_status = 'Created';`
7. `UPDATE dataset.TRANSACTION_OBJECT SET object_status = 'Created' WHERE object_status = 'Deleted';`
8. `UPDATE dataset.TRANSACTION_OBJECT SET object_status = 'Deleted' WHERE object_status = 'Mutated';`
9. `UPDATE dataset.TRANSACTION_OBJECT SET object_status = 'Mutated' WHERE object_status = 'Mutated_tmp';`
10. Deploy pipelines with the new binary (which includes this fix)
