### PR TITLE
[move-compiler] Added support for virtual file system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,6 +6822,7 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "once_cell",
+ "pathdiff",
  "petgraph 0.5.1",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6821,11 +6821,13 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "once_cell",
+ "pathdiff",
  "petgraph 0.5.1",
  "regex",
  "serde",
  "stacker",
  "tempfile",
+ "vfs",
 ]
 
 [[package]]
@@ -15481,6 +15483,12 @@ dependencies = [
  "itertools 0.10.5",
  "nom",
 ]
+
+[[package]]
+name = "vfs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,7 +6822,6 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "once_cell",
- "pathdiff",
  "petgraph 0.5.1",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6810,6 +6810,7 @@ dependencies = [
  "bcs",
  "clap",
  "codespan-reporting",
+ "dunce",
  "hex",
  "move-binary-format",
  "move-borrow-graph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6799,6 +6799,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.9.9",
+ "vfs",
  "walkdir",
 ]
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1714,7 +1714,6 @@ dependencies = [
  "move-stdlib",
  "move-symbol-pool",
  "once_cell",
- "pathdiff",
  "petgraph",
  "regex",
  "serde",
@@ -2508,12 +2507,6 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "url",
+ "vfs",
 ]
 
 [[package]]
@@ -1700,6 +1701,7 @@ dependencies = [
  "clap 4.4.1",
  "codespan-reporting",
  "datatest-stable",
+ "dunce",
  "hex",
  "move-binary-format",
  "move-borrow-graph",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1712,11 +1712,13 @@ dependencies = [
  "move-stdlib",
  "move-symbol-pool",
  "once_cell",
+ "pathdiff",
  "petgraph",
  "regex",
  "serde",
  "stacker",
  "tempfile",
+ "vfs",
 ]
 
 [[package]]
@@ -2504,6 +2506,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -3758,6 +3766,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vfs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4fe92cfc1bad19c19925d5eee4b30584dbbdee4ff10183b261acccbef74e2d"
 
 [[package]]
 name = "wait-timeout"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2",
+ "vfs",
  "walkdir",
 ]
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "move-stdlib",
  "move-symbol-pool",
  "once_cell",
+ "pathdiff",
  "petgraph",
  "regex",
  "serde",
@@ -2507,6 +2508,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -61,6 +61,7 @@ once_cell = "1.7.2"
 ouroboros = "0.17.2"
 parking_lot = "0.11.1"
 paste = "1.0.5"
+pathdiff = "0.2.1"
 petgraph = "0.5.1"
 phf = { version = "0.11", features = ["macros"] }
 plotters = { version = "0.3.0", default_features = false, features = ["evcxr", "line_series", "histogram"]}
@@ -104,6 +105,7 @@ tui = "0.17.0"
 uint = "0.9.4"
 url = "2.2.2"
 variant_count = "1.1.0"
+vfs = "0.10.0"
 walkdir = "2.3.1"
 whoami = { version = "1.2.1" }
 x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -61,7 +61,6 @@ once_cell = "1.7.2"
 ouroboros = "0.17.2"
 parking_lot = "0.11.1"
 paste = "1.0.5"
-pathdiff = "0.2.1"
 petgraph = "0.5.1"
 phf = { version = "0.11", features = ["macros"] }
 plotters = { version = "0.3.0", default_features = false, features = ["evcxr", "line_series", "histogram"]}

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -61,6 +61,7 @@ once_cell = "1.7.2"
 ouroboros = "0.17.2"
 parking_lot = "0.11.1"
 paste = "1.0.5"
+pathdiff = "0.2.1"
 petgraph = "0.5.1"
 phf = { version = "0.11", features = ["macros"] }
 plotters = { version = "0.3.0", default_features = false, features = ["evcxr", "line_series", "histogram"]}

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -19,6 +19,7 @@ lsp-types.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 url.workspace = true
+vfs.workspace = true
 clap.workspace = true
 crossbeam.workspace = true
 move-command-line-common.workspace = true

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -18,12 +18,11 @@ use std::{
 };
 
 use move_analyzer::{
-    completion::on_completion_request,
-    context::Context,
-    symbols,
-    vfs::{on_text_document_sync_notification, VirtualFileSystem},
+    completion::on_completion_request, context::Context, symbols,
+    vfs::on_text_document_sync_notification,
 };
 use url::Url;
+use vfs::{impls::memory::MemoryFS, VfsPath};
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -48,9 +47,9 @@ fn main() {
 
     let (connection, io_threads) = Connection::stdio();
     let symbols = Arc::new(Mutex::new(symbols::empty_symbols()));
-    let mut context = Context {
+    let ide_files: VfsPath = MemoryFS::new().into();
+    let context = Context {
         connection,
-        files: VirtualFileSystem::default(),
         symbols: symbols.clone(),
     };
 
@@ -125,7 +124,8 @@ fn main() {
                 .unwrap_or(false);
         }
 
-        symbolicator_runner = symbols::SymbolicatorRunner::new(symbols.clone(), diag_sender, lint);
+        symbolicator_runner =
+            symbols::SymbolicatorRunner::new(ide_files.clone(), symbols.clone(), diag_sender, lint);
 
         // If initialization information from the client contains a path to the directory being
         // opened, try to initialize symbols before sending response to the client. Do not bother
@@ -134,7 +134,9 @@ fn main() {
         // to be available right after the client is initialized.
         if let Some(uri) = initialize_params.root_uri {
             if let Some(p) = symbols::SymbolicatorRunner::root_dir(&uri.to_file_path().unwrap()) {
-                if let Ok((Some(new_symbols), _)) = symbols::get_symbols(p.as_path(), lint) {
+                if let Ok((Some(new_symbols), _)) =
+                    symbols::get_symbols(ide_files.clone(), p.as_path(), lint)
+                {
                     let mut old_symbols = symbols.lock().unwrap();
                     (*old_symbols).merge(new_symbols);
                 }
@@ -189,7 +191,8 @@ fn main() {
                             },
                         }
                     },
-                    Err(error) => eprintln!("symbolicator message error: {:?}", error),
+                    Err(error) =>
+                        eprintln!("symbolicator message error: {:?}", error),
                 }
             },
             recv(context.connection.receiver) -> message => {
@@ -199,7 +202,7 @@ fn main() {
                         // a chance of completing pending requests (but should not accept new requests
                         // either which is handled inside on_requst) - instead it quits after receiving
                         // the exit notification from the client, which is handled below
-                        shutdown_req_received = on_request(&context, &request, shutdown_req_received);
+                        shutdown_req_received = on_request(&context, &request, ide_files.clone(), shutdown_req_received);
                     }
                     Ok(Message::Response(response)) => on_response(&context, &response),
                     Ok(Message::Notification(notification)) => {
@@ -210,7 +213,7 @@ fn main() {
                                 // It ought to, especially once it begins processing requests that may
                                 // take a long time to respond to.
                             }
-                            _ => on_notification(&mut context, &symbolicator_runner, &notification),
+                            _ => on_notification(ide_files.clone(), &symbolicator_runner, &notification),
                         }
                     }
                     Err(error) => eprintln!("IDE message error: {:?}", error),
@@ -228,7 +231,12 @@ fn main() {
 /// The reason why this information is also passed as an argument is that according to the LSP
 /// spec, if any additional requests are received after shutdownd then the LSP implementation
 /// should respond with a particular type of error.
-fn on_request(context: &Context, request: &Request, shutdown_request_received: bool) -> bool {
+fn on_request(
+    context: &Context,
+    request: &Request,
+    ide_files: VfsPath,
+    shutdown_request_received: bool,
+) -> bool {
     if shutdown_request_received {
         let response = lsp_server::Response::new_err(
             request.id.clone(),
@@ -245,9 +253,12 @@ fn on_request(context: &Context, request: &Request, shutdown_request_received: b
         return true;
     }
     match request.method.as_str() {
-        lsp_types::request::Completion::METHOD => {
-            on_completion_request(context, request, &context.symbols.lock().unwrap())
-        }
+        lsp_types::request::Completion::METHOD => on_completion_request(
+            context,
+            request,
+            ide_files.clone(),
+            &context.symbols.lock().unwrap(),
+        ),
         lsp_types::request::GotoDefinition::METHOD => {
             symbols::on_go_to_def_request(context, request, &context.symbols.lock().unwrap());
         }
@@ -286,7 +297,7 @@ fn on_response(_context: &Context, _response: &Response) {
 }
 
 fn on_notification(
-    context: &mut Context,
+    ide_files: VfsPath,
     symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
@@ -295,11 +306,7 @@ fn on_notification(
         | lsp_types::notification::DidChangeTextDocument::METHOD
         | lsp_types::notification::DidSaveTextDocument::METHOD
         | lsp_types::notification::DidCloseTextDocument::METHOD => {
-            on_text_document_sync_notification(
-                &mut context.files,
-                symbolicator_runner,
-                notification,
-            )
+            on_text_document_sync_notification(ide_files, symbolicator_runner, notification)
         }
         _ => eprintln!("handle notification '{}' from client", notification.method),
     }

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -15,6 +15,7 @@ use move_compiler::{
 };
 use move_symbol_pool::Symbol;
 use std::{collections::HashSet, path::PathBuf};
+use vfs::VfsPath;
 
 /// Constructs an `lsp_types::CompletionItem` with the given `label` and `kind`.
 fn completion_item(label: &str, kind: CompletionItemKind) -> CompletionItem {
@@ -149,7 +150,12 @@ fn get_cursor_token(buffer: &str, position: &Position) -> Option<Tok> {
 /// Sends the given connection a response to a completion request.
 ///
 /// The completions returned depend upon where the user's cursor is positioned.
-pub fn on_completion_request(context: &Context, request: &Request, symbols: &Symbols) {
+pub fn on_completion_request(
+    context: &Context,
+    request: &Request,
+    ide_files: VfsPath,
+    symbols: &Symbols,
+) {
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
@@ -160,38 +166,45 @@ pub fn on_completion_request(context: &Context, request: &Request, symbols: &Sym
         .uri
         .to_file_path()
         .unwrap();
-    let buffer = context.files.get(&path);
-    if buffer.is_none() {
-        eprintln!(
-            "Could not read '{:?}' when handling completion request",
-            path
-        );
+    let mut buffer = String::new();
+    if let Some(mut f) = ide_files
+        .join(path.to_string_lossy().to_string())
+        .unwrap()
+        .open_file()
+        .ok()
+    {
+        if f.read_to_string(&mut buffer).is_err() {
+            eprintln!(
+                "Could not read '{:?}' when handling completion request",
+                path
+            );
+        }
     }
-
-    // The completion items we provide depend upon where the user's cursor is positioned.
-    let cursor =
-        buffer.and_then(|buf| get_cursor_token(buf, &parameters.text_document_position.position));
 
     let mut items = vec![];
-    match cursor {
-        Some(Tok::Colon) => {
-            items.extend_from_slice(&primitive_types());
+    if !buffer.is_empty() {
+        let cursor = get_cursor_token(buffer.as_str(), &parameters.text_document_position.position);
+        match cursor {
+            Some(Tok::Colon) => {
+                items.extend_from_slice(&primitive_types());
+            }
+            Some(Tok::Period) | Some(Tok::ColonColon) => {
+                // `.` or `::` must be followed by identifiers, which are added to the completion items
+                // below.
+            }
+            _ => {
+                // If the user's cursor is positioned anywhere other than following a `.`, `:`, or `::`,
+                // offer them Move's keywords, operators, and builtins as completion items.
+                items.extend_from_slice(&keywords());
+                items.extend_from_slice(&builtins());
+            }
         }
-        Some(Tok::Period) | Some(Tok::ColonColon) => {
-            // `.` or `::` must be followed by identifiers, which are added to the completion items
-            // below.
-        }
-        _ => {
-            // If the user's cursor is positioned anywhere other than following a `.`, `:`, or `::`,
-            // offer them Move's keywords, operators, and builtins as completion items.
-            items.extend_from_slice(&keywords());
-            items.extend_from_slice(&builtins());
-        }
-    }
-
-    if let Some(buffer) = &buffer {
-        let identifiers = identifiers(buffer, symbols, &path);
+        let identifiers = identifiers(buffer.as_str(), symbols, &path);
         items.extend_from_slice(&identifiers);
+    } else {
+        // no file content
+        items.extend_from_slice(&keywords());
+        items.extend_from_slice(&builtins());
     }
 
     let result = serde_json::to_value(items).expect("could not serialize completion response");

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -167,12 +167,7 @@ pub fn on_completion_request(
         .to_file_path()
         .unwrap();
     let mut buffer = String::new();
-    if let Some(mut f) = ide_files
-        .join(path.to_string_lossy().to_string())
-        .unwrap()
-        .open_file()
-        .ok()
-    {
+    if let Ok(mut f) = ide_files.join(&path.to_string_lossy()).unwrap().open_file() {
         if f.read_to_string(&mut buffer).is_err() {
             eprintln!(
                 "Could not read '{:?}' when handling completion request",

--- a/external-crates/move/crates/move-analyzer/src/completion.rs
+++ b/external-crates/move/crates/move-analyzer/src/completion.rs
@@ -167,7 +167,7 @@ pub fn on_completion_request(
         .to_file_path()
         .unwrap();
     let mut buffer = String::new();
-    if let Ok(mut f) = ide_files.join(&path.to_string_lossy()).unwrap().open_file() {
+    if let Ok(mut f) = ide_files.join(path.to_string_lossy()).unwrap().open_file() {
         if f.read_to_string(&mut buffer).is_err() {
             eprintln!(
                 "Could not read '{:?}' when handling completion request",

--- a/external-crates/move/crates/move-analyzer/src/context.rs
+++ b/external-crates/move/crates/move-analyzer/src/context.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{symbols::Symbols, vfs::VirtualFileSystem};
+use crate::symbols::Symbols;
 use lsp_server::Connection;
 use std::sync::{Arc, Mutex};
 
@@ -10,8 +10,6 @@ use std::sync::{Arc, Mutex};
 pub struct Context {
     /// The connection with the language server's client.
     pub connection: Connection,
-    /// The files that the language server is providing information about.
-    pub files: VirtualFileSystem,
     /// Symbolication information
     pub symbols: Arc<Mutex<Symbols>>,
 }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -81,6 +81,12 @@ use std::{
 };
 use tempfile::tempdir;
 use url::Url;
+#[cfg(test)]
+use vfs::impls::memory::MemoryFS;
+use vfs::{
+    impls::{overlay::OverlayFS, physical::PhysicalFS},
+    VfsPath,
+};
 
 use move_command_line_common::files::FileHash;
 use move_compiler::{
@@ -96,7 +102,10 @@ use move_compiler::{
     PASS_PARSER, PASS_TYPING,
 };
 use move_ir_types::location::*;
-use move_package::compilation::build_plan::BuildPlan;
+use move_package::{
+    compilation::build_plan::BuildPlan, resolution::resolution_graph::ResolvedGraph,
+    source_package::parsed_manifest::FileName,
+};
 use move_symbol_pool::Symbol;
 
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
@@ -652,6 +661,7 @@ impl SymbolicatorRunner {
 
     /// Create a new runner
     pub fn new(
+        ide_files: VfsPath,
         symbols: Arc<Mutex<Symbols>>,
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: bool,
@@ -711,7 +721,7 @@ impl SymbolicatorRunner {
                             continue;
                         }
                         eprintln!("symbolication started");
-                        match get_symbols(root_dir.unwrap().as_path(), lint) {
+                        match get_symbols(ide_files.clone(), root_dir.unwrap().as_path(), lint) {
                             Ok((symbols_opt, lsp_diagnostics)) => {
                                 eprintln!("symbolication finished");
                                 if let Some(new_symbols) = symbols_opt {
@@ -949,6 +959,7 @@ impl Symbols {
 /// actually (re)computed and the diagnostics are returned, the old symbolic information should
 /// be retained even if it's getting out-of-date.
 pub fn get_symbols(
+    ide_files: VfsPath,
     pkg_path: &Path,
     lint: bool,
 ) -> Result<(Option<Symbols>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
@@ -966,20 +977,20 @@ pub fn get_symbols(
     // vector as the writer
     let resolution_graph = build_config.resolution_graph_for_package(pkg_path, &mut Vec::new())?;
 
+    let physical_root = VfsPath::new(PhysicalFS::new("/"));
+    let overlay_fs = VfsPath::new(OverlayFS::new(&[ide_files.clone(), physical_root.clone()]));
+
     // get source files to be able to correlate positions (in terms of byte offsets) with actual
     // file locations (in terms of line/column numbers)
-    let source_files = &resolution_graph.file_sources();
+    let source_files = file_sources(&resolution_graph, overlay_fs.clone());
     let mut files = SimpleFiles::new();
     let mut file_id_mapping = HashMap::new();
     let mut file_id_to_lines = HashMap::new();
     let mut file_name_mapping = BTreeMap::new();
-    for (fhash, (fname, source)) in source_files {
+    for (fhash, (fname, source)) in &source_files {
         let id = files.add(*fname, source.clone());
         file_id_mapping.insert(*fhash, id);
-        file_name_mapping.insert(
-            *fhash,
-            dunce::canonicalize(fname.as_str()).unwrap_or_else(|_| PathBuf::from(fname.as_str())),
-        );
+        file_name_mapping.insert(*fhash, PathBuf::from(fname.as_str()));
         let lines: Vec<String> = source.lines().map(String::from).collect();
         file_id_to_lines.insert(id, lines);
     }
@@ -988,7 +999,8 @@ pub fn get_symbols(
     let mut parsed_ast = None;
     let mut typed_ast = None;
     let mut diagnostics = None;
-    build_plan.compile_with_driver(&mut std::io::sink(), |compiler| {
+    build_plan.compile_with_driver(&mut std::io::sink(), |mut compiler| {
+        compiler = compiler.set_vfs(overlay_fs.clone());
         // extract expansion AST
         let (files, compilation_result) = compiler.run::<PASS_PARSER>()?;
         let (_, compiler) = match compilation_result {
@@ -1087,7 +1099,7 @@ pub fn get_symbols(
         let cloned_defs = defs.clone();
         let path = file_name_mapping.get(&cloned_defs.fhash.clone()).unwrap();
         file_mods
-            .entry(dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+            .entry(path.to_path_buf())
             .or_insert_with(BTreeSet::new)
             .insert(cloned_defs);
 
@@ -1160,6 +1172,48 @@ pub fn get_symbols(
     eprintln!("get_symbols load complete");
 
     Ok((Some(symbols), ide_diagnostics))
+}
+
+fn file_sources(
+    resolved_graph: &ResolvedGraph,
+    overlay_fs: VfsPath,
+) -> BTreeMap<FileHash, (FileName, String)> {
+    resolved_graph
+        .package_table
+        .iter()
+        .flat_map(|(_, rpkg)| {
+            rpkg.get_sources(&resolved_graph.build_options)
+                .unwrap()
+                .iter()
+                .map(|f| {
+                    // dunce does a better job of canonicalization on Windows
+                    let fname = dunce::canonicalize(f.as_str())
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| f.to_string());
+                    let mut contents = String::new();
+                    // there is a fair number of unwraps here but if we can't read the files
+                    // that by all accounts should be in the file system, then there is not much
+                    // we can do so it's better to fail so that we can investigate
+                    let mut vfs_file = overlay_fs
+                        .join(fname.as_str())
+                        .unwrap()
+                        .open_file()
+                        .unwrap();
+                    let _ = vfs_file.read_to_string(&mut contents);
+                    let fhash = FileHash::new(&contents);
+                    // write to top layer of the overlay file system so that the content
+                    // is immutable for the duration of compliation and symbolication
+                    let mut vfs_file = overlay_fs
+                        .join(fname.as_str())
+                        .unwrap()
+                        .create_file()
+                        .unwrap();
+                    let _ = vfs_file.write_all(contents.as_bytes());
+                    (fhash, (Symbol::from(fname), contents))
+                })
+                .collect::<BTreeMap<_, _>>()
+        })
+        .collect()
 }
 
 /// Produces module ident string of the form pkg_name::module_name to be used as a map key.
@@ -3468,7 +3522,8 @@ fn docstring_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -3738,7 +3793,8 @@ fn symbols_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -4778,7 +4834,8 @@ fn const_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5017,7 +5074,8 @@ fn imports_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5218,7 +5276,8 @@ fn module_access_test() {
 
     path.push("tests/symbols");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5372,7 +5431,8 @@ fn parse_error_test() {
 
     path.push("tests/parse-error");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5456,7 +5516,8 @@ fn parse_error_with_deps_test() {
 
     path.push("tests/parse-error-dep");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5504,7 +5565,8 @@ fn pretype_error_test() {
 
     path.push("tests/pre-type-error");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5538,7 +5600,8 @@ fn pretype_error_with_deps_test() {
 
     path.push("tests/pre-type-error-dep");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5635,7 +5698,8 @@ fn dot_call_test() {
 
     path.push("tests/move-2024");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();
@@ -5964,7 +6028,8 @@ fn mod_ident_uniform_test() {
 
     path.push("tests/mod-ident-uniform");
 
-    let (symbols_opt, _) = get_symbols(path.as_path(), false).unwrap();
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(ide_files_layer, path.as_path(), false).unwrap();
     let symbols = symbols_opt.unwrap();
 
     let mut fpath = path.clone();

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -59,7 +59,7 @@ pub fn on_text_document_sync_notification(
         file_path: PathBuf,
         first_access: bool,
     ) -> Option<Box<dyn Write + Send>> {
-        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy().to_string()).ok() else {
+        let Some(vfs_path) = ide_files.join(&file_path.to_string_lossy()).ok() else {
             eprintln!(
                 "Could not construct file path for file creation at {:?}",
                 file_path
@@ -78,7 +78,7 @@ pub fn on_text_document_sync_notification(
     }
 
     fn vfs_file_remove(ide_files: &VfsPath, file_path: PathBuf) {
-        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy().to_string()).ok() else {
+        let Some(vfs_path) = ide_files.join(&file_path.to_string_lossy()).ok() else {
             eprintln!(
                 "Could not construct file path for file removal at {:?}",
                 file_path

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -16,7 +16,8 @@ use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
-use std::path::PathBuf;
+use std::{io::Write, path::PathBuf};
+use vfs::VfsPath;
 
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
 #[derive(Debug, Default)]
@@ -49,46 +50,135 @@ impl VirtualFileSystem {
 
 /// Updates the given virtual file system based on the text document sync notification that was sent.
 pub fn on_text_document_sync_notification(
-    files: &mut VirtualFileSystem,
+    ide_files: VfsPath,
     symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
+    fn vfs_file_create(
+        ide_files: &VfsPath,
+        file_path: PathBuf,
+        first_access: bool,
+    ) -> Option<Box<dyn Write + Send>> {
+        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy().to_string()).ok() else {
+            eprintln!(
+                "Could not construct file path for file creation at {:?}",
+                file_path
+            );
+            return None;
+        };
+        if first_access {
+            // create all directories on first access, otherwise file creation will fail
+            let _ = vfs_path.parent().create_dir();
+        }
+        let Some(vfs_file) = vfs_path.create_file().ok() else {
+            eprintln!("Could not create file at {:?}", vfs_path);
+            return None;
+        };
+        Some(vfs_file)
+    }
+
+    fn vfs_file_remove(ide_files: &VfsPath, file_path: PathBuf) {
+        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy().to_string()).ok() else {
+            eprintln!(
+                "Could not construct file path for file removal at {:?}",
+                file_path
+            );
+            return;
+        };
+        if vfs_path.remove_file().is_err() {
+            eprintln!("Could not remove file at {:?}", vfs_path);
+        };
+    }
+
     eprintln!("text document notification");
     match notification.method.as_str() {
         lsp_types::notification::DidOpenTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidOpenTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
-                parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.text_document.text,
-            );
-            symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
+            let Some(file_path) = parameters.text_document.uri.to_file_path().ok() else {
+                eprintln!(
+                    "Could not create file path from URI {:?}",
+                    parameters.text_document.uri
+                );
+                return;
+            };
+            let Some(mut vfs_file) =
+                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ true)
+            else {
+                return;
+            };
+            if vfs_file
+                .write_all(parameters.text_document.text.as_bytes())
+                .is_ok()
+            {
+                symbolicator_runner.run(file_path);
+            }
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
-                parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.content_changes.last().unwrap().text,
-            );
+
+            let Some(file_path) = parameters.text_document.uri.to_file_path().ok() else {
+                eprintln!(
+                    "Could not create file path from URI {:?}",
+                    parameters.text_document.uri
+                );
+                return;
+            };
+            let Some(mut vfs_file) =
+                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ false)
+            else {
+                return;
+            };
+            let Some(changes) = parameters.content_changes.last() else {
+                eprintln!("Could not read last opened file change");
+                return;
+            };
+            if vfs_file.write_all(changes.text.as_bytes()).is_ok() {
+                symbolicator_runner.run(file_path);
+            }
         }
         lsp_types::notification::DidSaveTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidSaveTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.update(
-                parameters.text_document.uri.to_file_path().unwrap(),
-                &parameters.text.unwrap(),
-            );
-            symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
+            let Some(file_path) = parameters.text_document.uri.to_file_path().ok() else {
+                eprintln!(
+                    "Could not create file path from URI {:?}",
+                    parameters.text_document.uri
+                );
+                return;
+            };
+            let Some(mut vfs_file) =
+                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ false)
+            else {
+                return;
+            };
+            let Some(content) = parameters.text else {
+                eprintln!("Could not read saved file change");
+                return;
+            };
+            if vfs_file.write_all(content.as_bytes()).is_err() {
+                // try to remove file from the file system and schedule symbolicator to pick up
+                // changes from the file system
+                vfs_file_remove(&ide_files, file_path.clone());
+                symbolicator_runner.run(file_path);
+            }
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidCloseTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.remove(&parameters.text_document.uri.to_file_path().unwrap());
+            let Some(file_path) = parameters.text_document.uri.to_file_path().ok() else {
+                eprintln!(
+                    "Could not create file path from URI {:?}",
+                    parameters.text_document.uri
+                );
+                return;
+            };
+            vfs_file_remove(&ide_files, file_path.clone());
         }
         _ => eprintln!("invalid notification '{}'", notification.method),
     }

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -59,7 +59,7 @@ pub fn on_text_document_sync_notification(
         file_path: PathBuf,
         first_access: bool,
     ) -> Option<Box<dyn Write + Send>> {
-        let Some(vfs_path) = ide_files.join(&file_path.to_string_lossy()).ok() else {
+        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy()).ok() else {
             eprintln!(
                 "Could not construct file path for file creation at {:?}",
                 file_path
@@ -78,7 +78,7 @@ pub fn on_text_document_sync_notification(
     }
 
     fn vfs_file_remove(ide_files: &VfsPath, file_path: PathBuf) {
-        let Some(vfs_path) = ide_files.join(&file_path.to_string_lossy()).ok() else {
+        let Some(vfs_path) = ide_files.join(file_path.to_string_lossy()).ok() else {
             eprintln!(
                 "Could not construct file path for file removal at {:?}",
                 file_path

--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -50,7 +50,7 @@ impl VirtualFileSystem {
 
 /// Updates the given virtual file system based on the text document sync notification that was sent.
 pub fn on_text_document_sync_notification(
-    ide_files: VfsPath,
+    ide_files_root: VfsPath,
     symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
@@ -103,9 +103,11 @@ pub fn on_text_document_sync_notification(
                 );
                 return;
             };
-            let Some(mut vfs_file) =
-                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ true)
-            else {
+            let Some(mut vfs_file) = vfs_file_create(
+                &ide_files_root,
+                file_path.clone(),
+                /* first_access */ true,
+            ) else {
                 return;
             };
             if vfs_file
@@ -127,9 +129,11 @@ pub fn on_text_document_sync_notification(
                 );
                 return;
             };
-            let Some(mut vfs_file) =
-                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ false)
-            else {
+            let Some(mut vfs_file) = vfs_file_create(
+                &ide_files_root,
+                file_path.clone(),
+                /* first_access */ false,
+            ) else {
                 return;
             };
             let Some(changes) = parameters.content_changes.last() else {
@@ -151,9 +155,11 @@ pub fn on_text_document_sync_notification(
                 );
                 return;
             };
-            let Some(mut vfs_file) =
-                vfs_file_create(&ide_files, file_path.clone(), /* first_access */ false)
-            else {
+            let Some(mut vfs_file) = vfs_file_create(
+                &ide_files_root,
+                file_path.clone(),
+                /* first_access */ false,
+            ) else {
                 return;
             };
             let Some(content) = parameters.text else {
@@ -163,7 +169,7 @@ pub fn on_text_document_sync_notification(
             if vfs_file.write_all(content.as_bytes()).is_err() {
                 // try to remove file from the file system and schedule symbolicator to pick up
                 // changes from the file system
-                vfs_file_remove(&ide_files, file_path.clone());
+                vfs_file_remove(&ide_files_root, file_path.clone());
                 symbolicator_runner.run(file_path);
             }
         }
@@ -178,7 +184,7 @@ pub fn on_text_document_sync_notification(
                 );
                 return;
             };
-            vfs_file_remove(&ide_files, file_path.clone());
+            vfs_file_remove(&ide_files_root, file_path.clone());
         }
         _ => eprintln!("invalid notification '{}'", notification.method),
     }

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
@@ -5,10 +5,9 @@ External Command `rm -rf ./C/build/Foo/sources`:
 Command `build -v -p ./B`:
 INCLUDING DEPENDENCY Foo
 BUILDING Bar
-Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/buiExternal Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
+External Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
 External Command `rm -rf ./B/build/Bar/sources`:
 Command `build -v`:
 INCLUDING DEPENDENCY Bar
 INCLUDING DEPENDENCY Foo
 BUILDING A
-Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/bui

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
@@ -5,9 +5,11 @@ External Command `rm -rf ./C/build/Foo/sources`:
 Command `build -v -p ./B`:
 INCLUDING DEPENDENCY Foo
 BUILDING Bar
+Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/build/Foo/bytecode_modules/Foo.mv': PartialVMError with status BAD_MAGIC
 External Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
 External Command `rm -rf ./B/build/Bar/sources`:
 Command `build -v`:
 INCLUDING DEPENDENCY Bar
 INCLUDING DEPENDENCY Foo
 BUILDING A
+Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/build/Foo/bytecode_modules/Foo.mv': PartialVMError with status BAD_MAGIC

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/args.exp
@@ -5,11 +5,10 @@ External Command `rm -rf ./C/build/Foo/sources`:
 Command `build -v -p ./B`:
 INCLUDING DEPENDENCY Foo
 BUILDING Bar
-Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/build/Foo/bytecode_modules/Foo.mv': PartialVMError with status BAD_MAGIC
-External Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
+Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/buiExternal Command `mv ./B/sources/Bar.move ./C/sources/Bar.move_old`:
 External Command `rm -rf ./B/build/Bar/sources`:
 Command `build -v`:
 INCLUDING DEPENDENCY Bar
 INCLUDING DEPENDENCY Foo
 BUILDING A
-Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/build/Foo/bytecode_modules/Foo.mv': PartialVMError with status BAD_MAGIC
+Error: Unable to deserialize module at '/private/var/folders/gw/732jkstx1j3fxgsqnlxg35c80000gn/T/.tmpDkeDrJ/0/1/C/bui

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
@@ -15,7 +15,7 @@ B0:
 Command `build -p dep`:
 BUILDING SomeDep
 warning[W09002]: unused variable
-  ┌─ sources/has_warning.move:2:20
+  ┌─ ./sources/has_warning.move:2:20
   │
 2 │     public fun foo(x: u64): u64 {
   │                    ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/args.exp
@@ -15,7 +15,7 @@ B0:
 Command `build -p dep`:
 BUILDING SomeDep
 warning[W09002]: unused variable
-  ┌─ ./sources/has_warning.move:2:20
+  ┌─ sources/has_warning.move:2:20
   │
 2 │     public fun foo(x: u64): u64 {
   │                    ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/args.exp
@@ -1,7 +1,7 @@
 Command `build`:
 BUILDING Test
 warning[W09002]: unused variable
-  ┌─ sources/m.move:2:16
+  ┌─ ./sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -20,7 +20,7 @@ B0:
 }
 }
 warning[W09002]: unused variable
-  ┌─ sources/m.move:2:16
+  ┌─ ./sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -34,7 +34,7 @@ BUILDING Test
 Command `build --warnings-are-errors`:
 BUILDING Test
 error[E09002]: unused variable
-  ┌─ sources/m.move:2:16
+  ┌─ ./sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/args.exp
@@ -1,7 +1,7 @@
 Command `build`:
 BUILDING Test
 warning[W09002]: unused variable
-  ┌─ ./sources/m.move:2:16
+  ┌─ sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -20,7 +20,7 @@ B0:
 }
 }
 warning[W09002]: unused variable
-  ┌─ ./sources/m.move:2:16
+  ┌─ sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -34,7 +34,7 @@ BUILDING Test
 Command `build --warnings-are-errors`:
 BUILDING Test
 error[E09002]: unused variable
-  ┌─ ./sources/m.move:2:16
+  ┌─ sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -1,13 +1,13 @@
 Command `build -v`:
 BUILDING build_include_exclude_stdlib
 error[E03002]: unbound module
-  ┌─ sources/UseSigner.move:2:7
+  ┌─ ./sources/UseSigner.move:2:7
   │
 2 │   use std::signer;
   │       ^^^^^^^^^^^ Invalid 'use'. Unbound module: 'std::signer'
 
 warning[W09002]: unused variable
-  ┌─ sources/UseSigner.move:4:16
+  ┌─ ./sources/UseSigner.move:4:16
   │
 4 │   public fun f(account: &signer): address {
   │                ^^^^^^^ Unused parameter 'account'. Consider removing or prefixing with an underscore: '_account'
@@ -15,7 +15,7 @@ warning[W09002]: unused variable
   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03002]: unbound module
-  ┌─ sources/UseSigner.move:5:5
+  ┌─ ./sources/UseSigner.move:5:5
   │
 5 │     signer::address_of(account)
   │     ^^^^^^ Unbound module alias 'signer'

--- a/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -1,13 +1,13 @@
 Command `build -v`:
 BUILDING build_include_exclude_stdlib
 error[E03002]: unbound module
-  ┌─ ./sources/UseSigner.move:2:7
+  ┌─ sources/UseSigner.move:2:7
   │
 2 │   use std::signer;
   │       ^^^^^^^^^^^ Invalid 'use'. Unbound module: 'std::signer'
 
 warning[W09002]: unused variable
-  ┌─ ./sources/UseSigner.move:4:16
+  ┌─ sources/UseSigner.move:4:16
   │
 4 │   public fun f(account: &signer): address {
   │                ^^^^^^^ Unused parameter 'account'. Consider removing or prefixing with an underscore: '_account'
@@ -15,7 +15,7 @@ warning[W09002]: unused variable
   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03002]: unbound module
-  ┌─ ./sources/UseSigner.move:5:5
+  ┌─ sources/UseSigner.move:5:5
   │
 5 │     signer::address_of(account)
   │     ^^^^^^ Unbound module alias 'signer'

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -8,7 +8,7 @@ Please select one of the following editions:
 
 Selection (default=1): Recorded edition in 'Move.toml'
 
-Would you like the Move compiler to migrate your code to Move 2024? (Y/n)
+Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
 Generated changes . . .
 BUILDING A
 
@@ -97,8 +97,8 @@ The following changes will be made.
 @@ -15,1 +15,1 @@
 -        let i = 0;
 +        let mut i = 0;
---- ./tests/test0.move
-+++ ./tests/test0.move
+--- tests/test0.move
++++ tests/test0.move
 @@ -5,1 +5,1 @@
 -    struct R has store { }
 +    public struct R has store { }
@@ -129,13 +129,13 @@ The following changes will be made.
 
 
 ============================================================
-Apply changes? (Y/n)
-Updating "./sources/mod0.move" . . .
-Updating "./sources/mod1.move" . . .
-Updating "./sources/mod2.move" . . .
-Updating "./sources/mod3_4.move" . . .
-Updating "./sources/mod5.move" . . .
-Updating "./tests/test0.move" . . .
+Apply changes? (Y/n) 
+Updating "sources/mod0.move" . . .
+Updating "sources/mod1.move" . . .
+Updating "sources/mod2.move" . . .
+Updating "sources/mod3_4.move" . . .
+Updating "sources/mod5.move" . . .
+Updating "tests/test0.move" . . .
 
 Changes complete
 Wrote patchfile out to: ./migration.patch

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -15,8 +15,8 @@ BUILDING A
 The following changes will be made.
 ============================================================
 
---- ./sources/mod0.move
-+++ ./sources/mod0.move
+--- sources/mod0.move
++++ sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -32,8 +32,8 @@ The following changes will be made.
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod1.move
-+++ ./sources/mod1.move
+--- sources/mod1.move
++++ sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -43,8 +43,8 @@ The following changes will be made.
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod2.move
-+++ ./sources/mod2.move
+--- sources/mod2.move
++++ sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -57,8 +57,8 @@ The following changes will be made.
 @@ -15,1 +15,1 @@
 -        let x = 5; let y = 10;
 +        let mut x = 5; let mut y = 10;
---- ./sources/mod3_4.move
-+++ ./sources/mod3_4.move
+--- sources/mod3_4.move
++++ sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -83,8 +83,8 @@ The following changes will be made.
 @@ -24,1 +24,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod5.move
-+++ ./sources/mod5.move
+--- sources/mod5.move
++++ sources/mod5.move
 @@ -3,1 +3,1 @@
 -    struct UID { }
 +    public struct UID { }
@@ -141,6 +141,12 @@ Changes complete
 Wrote patchfile out to: ./migration.patch
 
 External Command `diff -s migration.patch expected_migration.patch`:
+69,70c69,70
+< --- sources/mod5.move
+< +++ sources/mod5.move
+---
+> --- ./sources/mod5.move
+> +++ ./sources/mod5.move
 Files migration.patch and expected_migration.patch are identical
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -8,15 +8,15 @@ Please select one of the following editions:
 
 Selection (default=1): Recorded edition in 'Move.toml'
 
-Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
+Would you like the Move compiler to migrate your code to Move 2024? (Y/n)
 Generated changes . . .
 BUILDING A
 
 The following changes will be made.
 ============================================================
 
---- ./sources/mod0.move
-+++ ./sources/mod0.move
+--- sources/mod0.move
++++ sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -32,8 +32,8 @@ The following changes will be made.
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod1.move
-+++ ./sources/mod1.move
+--- sources/mod1.move
++++ sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -43,8 +43,8 @@ The following changes will be made.
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod2.move
-+++ ./sources/mod2.move
+--- sources/mod2.move
++++ sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -57,8 +57,8 @@ The following changes will be made.
 @@ -15,1 +15,1 @@
 -        let x = 5; let y = 10;
 +        let mut x = 5; let mut y = 10;
---- ./sources/mod3_4.move
-+++ ./sources/mod3_4.move
+--- sources/mod3_4.move
++++ sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -83,8 +83,8 @@ The following changes will be made.
 @@ -24,1 +24,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod5.move
-+++ ./sources/mod5.move
+--- sources/mod5.move
++++ sources/mod5.move
 @@ -3,1 +3,1 @@
 -    struct UID { }
 +    public struct UID { }
@@ -129,7 +129,7 @@ The following changes will be made.
 
 
 ============================================================
-Apply changes? (Y/n) 
+Apply changes? (Y/n)
 Updating "./sources/mod0.move" . . .
 Updating "./sources/mod1.move" . . .
 Updating "./sources/mod2.move" . . .
@@ -141,6 +141,36 @@ Changes complete
 Wrote patchfile out to: ./migration.patch
 
 External Command `diff -s migration.patch expected_migration.patch`:
+1,2c1,2
+< --- sources/mod0.move
+< +++ sources/mod0.move
+---
+> --- ./sources/mod0.move
+> +++ ./sources/mod0.move
+18,19c18,19
+< --- sources/mod1.move
+< +++ sources/mod1.move
+---
+> --- ./sources/mod1.move
+> +++ ./sources/mod1.move
+29,30c29,30
+< --- sources/mod2.move
+< +++ sources/mod2.move
+---
+> --- ./sources/mod2.move
+> +++ ./sources/mod2.move
+43,44c43,44
+< --- sources/mod3_4.move
+< +++ sources/mod3_4.move
+---
+> --- ./sources/mod3_4.move
+> +++ ./sources/mod3_4.move
+69,70c69,70
+< --- sources/mod5.move
+< +++ sources/mod5.move
+---
+> --- ./sources/mod5.move
+> +++ ./sources/mod5.move
 Files migration.patch and expected_migration.patch are identical
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -15,8 +15,8 @@ BUILDING A
 The following changes will be made.
 ============================================================
 
---- sources/mod0.move
-+++ sources/mod0.move
+--- ./sources/mod0.move
++++ ./sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -32,8 +32,8 @@ The following changes will be made.
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod1.move
-+++ sources/mod1.move
+--- ./sources/mod1.move
++++ ./sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -43,8 +43,8 @@ The following changes will be made.
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod2.move
-+++ sources/mod2.move
+--- ./sources/mod2.move
++++ ./sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -57,8 +57,8 @@ The following changes will be made.
 @@ -15,1 +15,1 @@
 -        let x = 5; let y = 10;
 +        let mut x = 5; let mut y = 10;
---- sources/mod3_4.move
-+++ sources/mod3_4.move
+--- ./sources/mod3_4.move
++++ ./sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -83,8 +83,8 @@ The following changes will be made.
 @@ -24,1 +24,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod5.move
-+++ sources/mod5.move
+--- ./sources/mod5.move
++++ ./sources/mod5.move
 @@ -3,1 +3,1 @@
 -    struct UID { }
 +    public struct UID { }
@@ -141,12 +141,6 @@ Changes complete
 Wrote patchfile out to: ./migration.patch
 
 External Command `diff -s migration.patch expected_migration.patch`:
-69,70c69,70
-< --- sources/mod5.move
-< +++ sources/mod5.move
----
-> --- ./sources/mod5.move
-> +++ ./sources/mod5.move
 Files migration.patch and expected_migration.patch are identical
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -141,30 +141,6 @@ Changes complete
 Wrote patchfile out to: ./migration.patch
 
 External Command `diff -s migration.patch expected_migration.patch`:
-1,2c1,2
-< --- sources/mod0.move
-< +++ sources/mod0.move
----
-> --- ./sources/mod0.move
-> +++ ./sources/mod0.move
-18,19c18,19
-< --- sources/mod1.move
-< +++ sources/mod1.move
----
-> --- ./sources/mod1.move
-> +++ ./sources/mod1.move
-29,30c29,30
-< --- sources/mod2.move
-< +++ sources/mod2.move
----
-> --- ./sources/mod2.move
-> +++ ./sources/mod2.move
-43,44c43,44
-< --- sources/mod3_4.move
-< +++ sources/mod3_4.move
----
-> --- ./sources/mod3_4.move
-> +++ ./sources/mod3_4.move
 69,70c69,70
 < --- sources/mod5.move
 < +++ sources/mod5.move

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -141,12 +141,6 @@ Changes complete
 Wrote patchfile out to: ./migration.patch
 
 External Command `diff -s migration.patch expected_migration.patch`:
-69,70c69,70
-< --- sources/mod5.move
-< +++ sources/mod5.move
----
-> --- ./sources/mod5.move
-> +++ ./sources/mod5.move
 Files migration.patch and expected_migration.patch are identical
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
@@ -1,5 +1,5 @@
---- sources/mod0.move
-+++ sources/mod0.move
+--- ./sources/mod0.move
++++ ./sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -15,8 +15,8 @@
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod1.move
-+++ sources/mod1.move
+--- ./sources/mod1.move
++++ ./sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -26,8 +26,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod2.move
-+++ sources/mod2.move
+--- ./sources/mod2.move
++++ ./sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -40,8 +40,8 @@
 @@ -15,1 +15,1 @@
 -        let x = 5; let y = 10;
 +        let mut x = 5; let mut y = 10;
---- sources/mod3_4.move
-+++ sources/mod3_4.move
+--- ./sources/mod3_4.move
++++ ./sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
@@ -1,5 +1,5 @@
---- ./sources/mod0.move
-+++ ./sources/mod0.move
+--- sources/mod0.move
++++ sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -15,8 +15,8 @@
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod1.move
-+++ ./sources/mod1.move
+--- sources/mod1.move
++++ sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -26,8 +26,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod2.move
-+++ ./sources/mod2.move
+--- sources/mod2.move
++++ sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -40,8 +40,8 @@
 @@ -15,1 +15,1 @@
 -        let x = 5; let y = 10;
 +        let mut x = 5; let mut y = 10;
---- ./sources/mod3_4.move
-+++ ./sources/mod3_4.move
+--- sources/mod3_4.move
++++ sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
@@ -66,8 +66,8 @@
 @@ -24,1 +24,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod5.move
-+++ ./sources/mod5.move
+--- sources/mod5.move
++++ sources/mod5.move
 @@ -3,1 +3,1 @@
 -    struct UID { }
 +    public struct UID { }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/expected_migration.patch
@@ -80,8 +80,8 @@
 @@ -15,1 +15,1 @@
 -        let i = 0;
 +        let mut i = 0;
---- ./tests/test0.move
-+++ ./tests/test0.move
+--- tests/test0.move
++++ tests/test0.move
 @@ -5,1 +5,1 @@
 -    struct R has store { }
 +    public struct R has store { }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/migration.patch
@@ -1,5 +1,5 @@
---- ./sources/mod0.move
-+++ ./sources/mod0.move
+--- sources/mod0.move
++++ sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -15,8 +15,8 @@
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod1.move
-+++ ./sources/mod1.move
+--- sources/mod1.move
++++ sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -26,8 +26,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod2.move
-+++ ./sources/mod2.move
+--- sources/mod2.move
++++ sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -37,8 +37,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- ./sources/mod3_4.move
-+++ ./sources/mod3_4.move
+--- sources/mod3_4.move
++++ sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/migration.patch
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/migration.patch
@@ -1,5 +1,5 @@
---- sources/mod0.move
-+++ sources/mod0.move
+--- ./sources/mod0.move
++++ ./sources/mod0.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }
@@ -15,8 +15,8 @@
 @@ -12,1 +12,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod1.move
-+++ sources/mod1.move
+--- ./sources/mod1.move
++++ ./sources/mod1.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -26,8 +26,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod2.move
-+++ sources/mod2.move
+--- ./sources/mod2.move
++++ ./sources/mod2.move
 @@ -3,1 +3,1 @@
 -    public fun t(x: u64, yip: u64, s: S): u64  {
 +    public fun t(mut x: u64, mut yip: u64, s: S): u64  {
@@ -37,8 +37,8 @@
 @@ -5,1 +5,1 @@
 -        let S { f: fin } = s;
 +        let S { f: mut fin } = s;
---- sources/mod3_4.move
-+++ sources/mod3_4.move
+--- ./sources/mod3_4.move
++++ ./sources/mod3_4.move
 @@ -2,1 +2,1 @@
 -    struct S { f: u64 }
 +    public struct S { f: u64 }

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_addresses/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_addresses/args.exp
@@ -1,12 +1,12 @@
 Command `build -v`:
 BUILDING Defn
 error[E04001]: restricted visibility
-  ┌─ sources/B.move:3:31
+  ┌─ ./sources/B.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ sources/A.move:2:5
+  ┌─ ./sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'B' in package 'Defn'

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_addresses/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_addresses/args.exp
@@ -1,12 +1,12 @@
 Command `build -v`:
 BUILDING Defn
 error[E04001]: restricted visibility
-  ┌─ ./sources/B.move:3:31
+  ┌─ sources/B.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ ./sources/A.move:2:5
+  ┌─ sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'B' in package 'Defn'

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_both/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_both/args.exp
@@ -2,12 +2,12 @@ Command `build -v`:
 INCLUDING DEPENDENCY Defn
 BUILDING Usage
 error[E04001]: restricted visibility
-  ┌─ sources/B.move:3:31
+  ┌─ ./sources/B.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ defn/sources/A.move:2:5
+  ┌─ ./defn/sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'B' in package 'Usage'

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_both/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_both/args.exp
@@ -2,12 +2,12 @@ Command `build -v`:
 INCLUDING DEPENDENCY Defn
 BUILDING Usage
 error[E04001]: restricted visibility
-  ┌─ ./sources/B.move:3:31
+  ┌─ sources/B.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ ./defn/sources/A.move:2:5
+  ┌─ defn/sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'B' in package 'Usage'

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_packages/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_packages/args.exp
@@ -2,12 +2,12 @@ Command `build -v`:
 INCLUDING DEPENDENCY Defn
 BUILDING Usage
 error[E04001]: restricted visibility
-  ┌─ sources/A.move:3:31
+  ┌─ ./sources/A.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ defn/sources/A.move:2:5
+  ┌─ ./defn/sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'A' in package 'Usage'

--- a/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_packages/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/public_package_different_packages/args.exp
@@ -2,12 +2,12 @@ Command `build -v`:
 INCLUDING DEPENDENCY Defn
 BUILDING Usage
 error[E04001]: restricted visibility
-  ┌─ ./sources/A.move:3:31
+  ┌─ sources/A.move:3:31
   │
 3 │     public fun usage(): u64 { defn::definition() }
   │                               ^^^^^^^^^^^^^^^^^^ Invalid call to 'public(package)' visible function 'A::defn::definition'
   │
-  ┌─ ./defn/sources/A.move:2:5
+  ┌─ defn/sources/A.move:2:5
   │
 2 │     public(package) fun definition(): u64 { 0 }
   │     --------------- A 'public(package)' function can only be called from the same address and package as module 'A::defn' in package 'Defn'. This call is from address 'A' in package 'Usage'

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/test_with_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/test_with_warnings/args.exp
@@ -6,7 +6,7 @@ Running Move unit tests
 [ PASS    ] 0x42::m::nop
 Test result: OK. Total tests: 2; passed: 2; failed: 0
 warning[W09002]: unused variable
-  ┌─ sources/m.move:2:16
+  ┌─ ./sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -31,7 +31,7 @@ Command `test --warnings-are-errors`:
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING Test
 error[E09002]: unused variable
-  ┌─ sources/m.move:2:16
+  ┌─ ./sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/test_with_warnings/args.exp
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/test_with_warnings/args.exp
@@ -6,7 +6,7 @@ Running Move unit tests
 [ PASS    ] 0x42::m::nop
 Test result: OK. Total tests: 2; passed: 2; failed: 0
 warning[W09002]: unused variable
-  ┌─ ./sources/m.move:2:16
+  ┌─ sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
@@ -31,7 +31,7 @@ Command `test --warnings-are-errors`:
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING Test
 error[E09002]: unused variable
-  ┌─ ./sources/m.move:2:16
+  ┌─ sources/m.move:2:16
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/args.exp
@@ -2,14 +2,14 @@ Command `build`:
 INCLUDING DEPENDENCY Dep
 BUILDING use_named_address
 error[E04007]: incompatible types
-  ┌─ sources/example.move:3:9
+  ┌─ ./sources/example.move:3:9
   │
 2 │     public fun next(): b::m::Y {
   │                        ------- Expected: '(b=0x41)::m::Y'
 3 │         b::m::x()
   │         ^^^^^^^^^ Invalid return expression
   │
-  ┌─ dep/sources/m.move:4:21
+  ┌─ ./dep/sources/m.move:4:21
   │
 4 │     public fun x(): X {
   │                     - Given: '(a=0x41)::m::X'

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/args.exp
@@ -2,14 +2,14 @@ Command `build`:
 INCLUDING DEPENDENCY Dep
 BUILDING use_named_address
 error[E04007]: incompatible types
-  ┌─ ./sources/example.move:3:9
+  ┌─ sources/example.move:3:9
   │
 2 │     public fun next(): b::m::Y {
   │                        ------- Expected: '(b=0x41)::m::Y'
 3 │         b::m::x()
   │         ^^^^^^^^^ Invalid return expression
   │
-  ┌─ ./dep/sources/m.move:4:21
+  ┌─ dep/sources/m.move:4:21
   │
 4 │     public fun x(): X {
   │                     - Given: '(a=0x41)::m::X'

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/args.exp
@@ -1,11 +1,11 @@
 Command `sandbox publish`:
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ sources/M_no_named.move:1:14
+  ┌─ ./sources/M_no_named.move:1:14
   │
 1 │ module 0x42::M {
   │              ^ Duplicate definition for module '0x42::M'
   │
-  ┌─ sources/M.move:1:11
+  ┌─ ./sources/M.move:1:11
   │
 1 │ module A::M {
   │           - Module previously defined here, with 'A::M'

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/args.exp
@@ -1,11 +1,11 @@
 Command `sandbox publish`:
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ ./sources/M_no_named.move:1:14
+  ┌─ sources/M_no_named.move:1:14
   │
 1 │ module 0x42::M {
   │              ^ Duplicate definition for module '0x42::M'
   │
-  ┌─ ./sources/M.move:1:11
+  ┌─ sources/M.move:1:11
   │
 1 │ module A::M {
   │           - Module previously defined here, with 'A::M'

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish --bundle --override-ordering M --override-ordering N`:
 Invalid multi-module publishing: VMError with status MISSING_DEPENDENCY at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("M") } at index 0 for function handle
 error[E02007]: invalid 'fun' declaration
-  ┌─ sources/example.move:3:16
+  ┌─ ./sources/example.move:3:16
   │
 3 │     native fun create_signer(addr: address): signer;
   │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/args.exp
@@ -1,7 +1,7 @@
 Command `sandbox publish --bundle --override-ordering M --override-ordering N`:
 Invalid multi-module publishing: VMError with status MISSING_DEPENDENCY at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("M") } at index 0 for function handle
 error[E02007]: invalid 'fun' declaration
-  ┌─ ./sources/example.move:3:16
+  ┌─ sources/example.move:3:16
   │
 3 │     native fun create_signer(addr: address): signer;
   │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
@@ -1,6 +1,6 @@
 Command `sandbox publish`:
 error[E02007]: invalid 'fun' declaration
-  ┌─ sources/example.move:3:16
+  ┌─ ./sources/example.move:3:16
   │
 3 │     native fun create_signer(addr: address): signer;
   │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/args.exp
@@ -1,6 +1,6 @@
 Command `sandbox publish`:
 error[E02007]: invalid 'fun' declaration
-  ┌─ ./sources/example.move:3:16
+  ┌─ sources/example.move:3:16
   │
 3 │     native fun create_signer(addr: address): signer;
   │                ^^^^^^^^^^^^^ Missing implementation for the native function M::create_signer

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -19,5 +19,6 @@ num-bigint.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 dirs-next.workspace = true
+vfs.workspace = true
 
 move-core-types.workspace = true

--- a/external-crates/move/crates/move-command-line-common/src/files.rs
+++ b/external-crates/move/crates/move-command-line-common/src/files.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, bail, *};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::{collections::BTreeMap, path::Path};
+use vfs::{error::VfsErrorKind, VfsPath, VfsResult};
 
 /// Result of sha256 hash of a file's contents.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
@@ -175,4 +176,87 @@ pub fn verify_and_create_named_address_mapping<T: Copy + std::fmt::Display + Eq>
     }
 
     Ok(mapping)
+}
+
+//**************************************************************************************************
+// Virtual file system support
+//**************************************************************************************************
+
+/// Determine if the virtual path at `vfs_path` exists distinguishing between whether the path did
+/// not exist, or if there were other errors in determining if the path existed.
+/// It implements the same functionality as try_exists above but for the virtual file system
+pub fn try_exists_vfs(vfs_path: &VfsPath) -> VfsResult<bool> {
+    use VfsResult as R;
+    match vfs_path.metadata() {
+        R::Ok(_) => R::Ok(true),
+        R::Err(e) if matches!(e.kind(), &VfsErrorKind::FileNotFound) => R::Ok(false),
+        R::Err(e) => R::Err(e),
+    }
+}
+
+/// - For each directory in `paths`, it will return all files that satisfy the predicate
+/// - Any file explicitly passed in `paths`, it will include that file in the result, regardless
+///   of the file extension
+/// It implements the same functionality as find_filenames above but for the virtual file system
+pub fn find_filenames_vfs<Predicate: FnMut(&VfsPath) -> bool>(
+    paths: &[VfsPath],
+    mut is_file_desired: Predicate,
+) -> anyhow::Result<Vec<VfsPath>> {
+    let mut result = vec![];
+
+    for p in paths {
+        if !try_exists_vfs(p)? {
+            anyhow::bail!("No such file or directory '{}'", p.as_str())
+        }
+        if p.is_file()? && is_file_desired(p) {
+            result.push(p.clone());
+            continue;
+        }
+        if !p.is_dir()? {
+            continue;
+        }
+        for entry in p.walk_dir()?.filter_map(|e| e.ok()) {
+            if !entry.is_file()? || !is_file_desired(&entry) {
+                continue;
+            }
+
+            result.push(entry);
+        }
+    }
+    Ok(result)
+}
+
+/// - For each directory in `paths`, it will return all files with the `MOVE_EXTENSION` found
+///   recursively in that directory
+/// - If `keep_specified_files` any file explicitly passed in `paths`, will be added to the result
+///   Otherwise, they will be discarded
+/// It implements the same functionality as find_move_filenames above but for the virtual file
+/// system
+pub fn find_move_filenames_vfs(
+    paths: &[VfsPath],
+    keep_specified_files: bool,
+) -> anyhow::Result<Vec<VfsPath>> {
+    if keep_specified_files {
+        let mut file_paths = vec![];
+        let mut other_paths = vec![];
+        for p in paths {
+            if p.is_file()? {
+                file_paths.push(p.clone());
+            } else {
+                other_paths.push(p.clone());
+            }
+        }
+        file_paths.extend(find_filenames_vfs(&other_paths, |path| {
+            path.extension()
+                .map(|e| e.as_str() == MOVE_EXTENSION)
+                .unwrap_or(false)
+        })?);
+        Ok(file_paths)
+    } else {
+        find_filenames_vfs(paths, |path| {
+            path.extension()
+                .map(|e| e.as_str() == MOVE_EXTENSION)
+                .unwrap_or(false)
+        })
+    }
 }

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow.workspace = true
 codespan-reporting.workspace = true
+dunce.workspace = true
 hex.workspace = true
 regex.workspace = true
 clap.workspace = true

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -17,7 +17,6 @@ clap.workspace = true
 petgraph.workspace = true
 tempfile.workspace = true
 once_cell.workspace = true
-pathdiff.workspace = true
 serde.workspace = true
 stacker.workspace = true
 vfs.workspace = true

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -16,8 +16,10 @@ clap.workspace = true
 petgraph.workspace = true
 tempfile.workspace = true
 once_cell.workspace = true
+pathdiff.workspace = true
 serde.workspace = true
 stacker.workspace = true
+vfs.workspace = true
 
 bcs.workspace = true
 

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 petgraph.workspace = true
 tempfile.workspace = true
 once_cell.workspace = true
+pathdiff.workspace = true
 serde.workspace = true
 stacker.workspace = true
 vfs.workspace = true

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -402,7 +402,7 @@ impl<'a> Compiler<'a> {
 fn canonicalize_source_paths(paths: &mut Vec<IndexedPackagePath>) {
     for p in paths {
         // dunce does a better job of canonicalization on Windows
-        if let Some(new_path) = dunce::canonicalize(p.path.as_str()).ok() {
+        if let Ok(new_path) = dunce::canonicalize(p.path.as_str()) {
             p.path = Symbol::from(new_path.to_string_lossy().to_string());
         } // else keep the path the same
     }

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -836,7 +836,7 @@ pub fn generate_interface_files(
             .to_string_lossy()
             .to_string();
         let vfs_path = deps_out_vfs.join(&file_path)?;
-        vfs_path.parent().create_dir()?;
+        vfs_path.parent().create_dir_all()?;
         vfs_path
             .create_file()?
             .write_all(interface_contents.as_bytes())?;

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -772,7 +772,6 @@ pub fn generate_interface_files(
         v
     };
     if mv_files.is_empty() {
-        eprintln!("EMPTY");
         return Ok(vec![]);
     }
 
@@ -814,12 +813,10 @@ pub fn generate_interface_files(
         let (id, interface_contents) =
             interface_generator::write_file_to_string(vfs.clone(), module_to_named_address, &path)?;
         let addr_dir = dir_path!(all_addr_dir.clone(), format!("{}", id.address()));
-        eprintln!("ADDR DIR {:?}", addr_dir);
         let file_path = file_path!(addr_dir.clone(), format!("{}", id.name()), MOVE_EXTENSION)
             .into_os_string()
             .into_string()
             .unwrap();
-        eprintln!("FILE PATH {}", file_path);
         let mut out_file = deps_out_vfs.create_file(&file_path)?;
         out_file.write_all(interface_contents.as_bytes())?;
 

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -287,7 +287,7 @@ impl<'a> Compiler<'a> {
             let Some(current_dir) = std::env::current_dir().ok() else {
                 return path;
             };
-            let Ok(current_dir_vfs) = vsf_root.join(&current_dir.to_string_lossy()) else {
+            let Ok(current_dir_vfs) = vsf_root.join(current_dir.to_string_lossy()) else {
                 return path;
             };
             let Some(new_path) = diff_paths(path.to_string(), current_dir_vfs.as_str()) else {

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -15,15 +15,15 @@ use crate::{
     expansion, hlir, interface_generator, naming, parser,
     parser::{comments::*, *},
     shared::{
-        find_filenames, CompilationEnv, Flags, IndexedPhysicalPackagePath, IndexedVfsPackagePath,
-        NamedAddressMap, NamedAddressMaps, NumericalAddress, PackageConfig, PackagePaths,
+        CompilationEnv, Flags, IndexedPhysicalPackagePath, IndexedVfsPackagePath, NamedAddressMap,
+        NamedAddressMaps, NumericalAddress, PackageConfig, PackagePaths,
     },
     to_bytecode,
     typing::{self, visitor::TypingVisitorObj},
     unit_test,
 };
 use move_command_line_common::files::{
-    MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
+    find_filenames_vfs, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
 };
 use move_core_types::language_storage::ModuleId as CompiledModuleId;
 use move_symbol_pool::Symbol;
@@ -759,7 +759,7 @@ pub fn generate_interface_files(
         } in other_file_locations
         {
             v.extend(
-                find_filenames(&[path], |path| {
+                find_filenames_vfs(&[path], |path| {
                     path.extension()
                         .map(|e| e.as_str() == MOVE_COMPILED_EXTENSION)
                         .unwrap_or(false)

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -823,7 +823,7 @@ pub fn generate_interface_files(
                 .to_string_lossy()
                 .to_string(),
         );
-        let vfs_path = deps_out_vfs.join(&canonicalize(&file_path))?;
+        let vfs_path = deps_out_vfs.join(&file_path)?;
         vfs_path.parent().create_dir_all()?;
         vfs_path
             .create_file()?

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -823,7 +823,7 @@ pub fn generate_interface_files(
                 .to_string_lossy()
                 .to_string(),
         );
-        let vfs_path = deps_out_vfs.join(&file_path)?;
+        let vfs_path = deps_out_vfs.join(file_path)?;
         vfs_path.parent().create_dir_all()?;
         vfs_path
             .create_file()?

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -15,8 +15,9 @@ use crate::{
     expansion, hlir, interface_generator, naming, parser,
     parser::{comments::*, *},
     shared::{
-        find_filenames, CompilationEnv, Flags, IndexedPackagePath, IndexedVfsPackagePath,
-        NamedAddressMap, NamedAddressMaps, NumericalAddress, PackageConfig, PackagePaths,
+        canonicalize, find_filenames, CompilationEnv, Flags, IndexedPackagePath,
+        IndexedVfsPackagePath, NamedAddressMap, NamedAddressMaps, NumericalAddress, PackageConfig,
+        PackagePaths,
     },
     to_bytecode,
     typing::{self, visitor::TypingVisitorObj},
@@ -823,7 +824,7 @@ pub fn generate_interface_files(
                 .to_string_lossy()
                 .to_string(),
         );
-        let vfs_path = deps_out_vfs.join(file_path)?;
+        let vfs_path = deps_out_vfs.join(canonicalize(file_path.as_str().to_owned()))?;
         vfs_path.parent().create_dir_all()?;
         vfs_path
             .create_file()?

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -15,7 +15,7 @@ use crate::{
     expansion, hlir, interface_generator, naming, parser,
     parser::{comments::*, *},
     shared::{
-        find_filenames, CompilationEnv, Flags, IndexedPackagePath, IndexedVfsPackagePath,
+        find_filenames, CompilationEnv, Flags, IndexedPhysicalPackagePath, IndexedVfsPackagePath,
         NamedAddressMap, NamedAddressMaps, NumericalAddress, PackageConfig, PackagePaths,
     },
     to_bytecode,
@@ -46,8 +46,8 @@ use vfs::{
 
 pub struct Compiler<'a> {
     maps: NamedAddressMaps,
-    targets: Vec<IndexedPackagePath>,
-    deps: Vec<IndexedPackagePath>,
+    targets: Vec<IndexedPhysicalPackagePath>,
+    deps: Vec<IndexedPhysicalPackagePath>,
     interface_files_dir_opt: Option<String>,
     pre_compiled_lib: Option<&'a FullyCompiledProgram>,
     compiled_module_named_address_mapping: BTreeMap<CompiledModuleId, String>,
@@ -120,7 +120,7 @@ impl<'a> Compiler<'a> {
             maps: &mut NamedAddressMaps,
             package_configs: &mut BTreeMap<Symbol, PackageConfig>,
             all_pkgs: Vec<PackagePaths<impl Into<Symbol>, impl Into<Symbol>>>,
-        ) -> anyhow::Result<Vec<IndexedPackagePath>> {
+        ) -> anyhow::Result<Vec<IndexedPhysicalPackagePath>> {
             let mut idx_paths = vec![];
             for PackagePaths {
                 name,
@@ -141,7 +141,7 @@ impl<'a> Compiler<'a> {
                         .map(|(k, v)| (k.into(), v))
                         .collect::<NamedAddressMap>(),
                 );
-                idx_paths.extend(paths.into_iter().map(|path| IndexedPackagePath {
+                idx_paths.extend(paths.into_iter().map(|path| IndexedPhysicalPackagePath {
                     package: name,
                     path: path.into(),
                     named_address_map: idx,

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -29,6 +29,7 @@ use csr::files::Files;
 use move_command_line_common::{env::read_env_var, files::FileHash};
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
+use pathdiff::diff_paths;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     io::Write,
@@ -163,10 +164,23 @@ fn output_diagnostics<W: WriteColor>(
     sources: &FilesSourceText,
     diags: Diagnostics,
 ) {
+    fn relativize_path(path: Symbol) -> Symbol {
+        let Some(current_dir) = std::env::current_dir().ok() else {
+            return path;
+        };
+        let Some(new_path) = diff_paths(path.to_string(), current_dir) else {
+            return path;
+        };
+        return Symbol::from(new_path.to_string_lossy().to_string());
+    }
+
     let mut files = SimpleFiles::new();
     let mut file_mapping = HashMap::new();
     for (fhash, (fname, source)) in sources {
-        let id = files.add(*fname, source.as_str());
+        // path relativization is needed as paths are initially canonicalized when using virtual
+        // file system and would show up as absolute paths in the test output which wouldn't be
+        // machine-agnostic
+        let id = files.add(relativize_path(*fname), source.as_str());
         file_mapping.insert(*fhash, id);
     }
     render_diagnostics(writer, &files, &file_mapping, diags);

--- a/external-crates/move/crates/move-compiler/src/interface_generator.rs
+++ b/external-crates/move/crates/move-compiler/src/interface_generator.rs
@@ -40,7 +40,7 @@ pub fn write_file_to_string(
 ) -> Result<(ModuleId, String)> {
     let mut f = vfs.join(compiled_module_file_input_path)?.open_file()?;
     let mut file_contents = vec![];
-    f.read(&mut file_contents)?;
+    f.read_to_end(&mut file_contents)?;
     let module = CompiledModule::deserialize_with_defaults(&file_contents).map_err(|e| {
         anyhow!(
             "Unable to deserialize module at '{}': {}",

--- a/external-crates/move/crates/move-compiler/src/interface_generator.rs
+++ b/external-crates/move/crates/move-compiler/src/interface_generator.rs
@@ -13,8 +13,8 @@ use move_binary_format::{
     },
 };
 use move_core_types::language_storage::ModuleId;
-use std::{collections::BTreeMap, sync::Arc};
-use vfs::filesystem::FileSystem;
+use std::collections::BTreeMap;
+use vfs::VfsPath;
 
 pub const NATIVE_INTERFACE: &str = "native_interface";
 
@@ -34,11 +34,11 @@ macro_rules! push {
 /// publically visible contents of the CompiledModule, represented in source language syntax
 /// Additionally, it returns the module id (address+name) of the module that was deserialized
 pub fn write_file_to_string(
-    vfs: Arc<Box<dyn FileSystem>>,
+    vfs: VfsPath,
     named_address_mapping: &BTreeMap<ModuleId, impl AsRef<str>>,
     compiled_module_file_input_path: &str,
 ) -> Result<(ModuleId, String)> {
-    let mut f = vfs.open_file(compiled_module_file_input_path)?;
+    let mut f = vfs.join(compiled_module_file_input_path)?.open_file()?;
     let mut file_contents = vec![];
     f.read(&mut file_contents)?;
     let module = CompiledModule::deserialize_with_defaults(&file_contents).map_err(|e| {

--- a/external-crates/move/crates/move-compiler/src/interface_generator.rs
+++ b/external-crates/move/crates/move-compiler/src/interface_generator.rs
@@ -34,17 +34,17 @@ macro_rules! push {
 /// publically visible contents of the CompiledModule, represented in source language syntax
 /// Additionally, it returns the module id (address+name) of the module that was deserialized
 pub fn write_file_to_string(
-    vfs: VfsPath,
     named_address_mapping: &BTreeMap<ModuleId, impl AsRef<str>>,
-    compiled_module_file_input_path: &str,
+    compiled_module_file_input_path: &VfsPath,
 ) -> Result<(ModuleId, String)> {
-    let mut f = vfs.join(compiled_module_file_input_path)?.open_file()?;
     let mut file_contents = vec![];
-    f.read_to_end(&mut file_contents)?;
+    compiled_module_file_input_path
+        .open_file()?
+        .read_to_end(&mut file_contents)?;
     let module = CompiledModule::deserialize_with_defaults(&file_contents).map_err(|e| {
         anyhow!(
             "Unable to deserialize module at '{}': {}",
-            compiled_module_file_input_path,
+            compiled_module_file_input_path.as_str(),
             e
         )
     })?;

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -178,12 +178,3 @@ fn parse_file(
     files.insert(file_hash, (fname, source_buffer));
     Ok((defs, comments, file_hash))
 }
-
-/// Canonicalize a file path.
-pub fn canonicalize(path: &Symbol) -> String {
-    let p = path.as_str();
-    match std::fs::canonicalize(p) {
-        Ok(s) => s.to_string_lossy().to_string(),
-        Err(_) => p.to_owned(),
-    }
-}

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -13,11 +13,11 @@ pub(crate) mod verification_attribute_filter;
 use crate::{
     diagnostics::FilesSourceText,
     parser::{self, ast::PackageDefinition, syntax::parse_file_string},
-    shared::{find_move_filenames, CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
+    shared::{CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
 };
 use anyhow::anyhow;
 use comments::*;
-use move_command_line_common::files::FileHash;
+use move_command_line_common::files::{find_move_filenames_vfs, FileHash};
 use move_symbol_pool::Symbol;
 use std::collections::{BTreeSet, HashMap};
 use vfs::VfsPath;
@@ -40,13 +40,15 @@ pub(crate) fn parse_program(
             named_address_map: named_address_mapping,
         } in paths_with_mapping
         {
-            res.extend(find_move_filenames(&[path], true)?.into_iter().map(|s| {
-                IndexedVfsPackagePath {
-                    package,
-                    path: s,
-                    named_address_map: named_address_mapping,
-                }
-            }));
+            res.extend(
+                find_move_filenames_vfs(&[path], true)?
+                    .into_iter()
+                    .map(|s| IndexedVfsPackagePath {
+                        package,
+                        path: s,
+                        named_address_map: named_address_mapping,
+                    }),
+            );
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -13,11 +13,11 @@ pub(crate) mod verification_attribute_filter;
 use crate::{
     diagnostics::FilesSourceText,
     parser::{self, ast::PackageDefinition, syntax::parse_file_string},
-    shared::{find_move_filenames, CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
+    shared::{CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
 };
 use anyhow::anyhow;
 use comments::*;
-use move_command_line_common::files::FileHash;
+use move_command_line_common::files::{find_move_filenames, FileHash};
 use move_symbol_pool::Symbol;
 use std::collections::{BTreeSet, HashMap};
 use vfs::VfsPath;
@@ -41,13 +41,18 @@ pub(crate) fn parse_program(
             named_address_map: named_address_mapping,
         } in paths_with_mapping
         {
-            res.extend(find_move_filenames(&[path], true)?.into_iter().map(|s| {
-                IndexedVfsPackagePath {
-                    package,
-                    path: s,
-                    named_address_map: named_address_mapping,
-                }
-            }));
+            res.extend(
+                find_move_filenames(&[path.as_str()], true)?
+                    .into_iter()
+                    .map(|s| {
+                        Ok(IndexedVfsPackagePath {
+                            package,
+                            path: path.root().join(s)?,
+                            named_address_map: named_address_mapping,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, anyhow::Error>>()?,
+            );
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -13,11 +13,11 @@ pub(crate) mod verification_attribute_filter;
 use crate::{
     diagnostics::FilesSourceText,
     parser::{self, ast::PackageDefinition, syntax::parse_file_string},
-    shared::{CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
+    shared::{find_move_filenames, CompilationEnv, IndexedVfsPackagePath, NamedAddressMaps},
 };
 use anyhow::anyhow;
 use comments::*;
-use move_command_line_common::files::{find_move_filenames, FileHash};
+use move_command_line_common::files::FileHash;
 use move_symbol_pool::Symbol;
 use std::collections::{BTreeSet, HashMap};
 use vfs::VfsPath;
@@ -41,18 +41,13 @@ pub(crate) fn parse_program(
             named_address_map: named_address_mapping,
         } in paths_with_mapping
         {
-            res.extend(
-                find_move_filenames(&[path.as_str()], true)?
-                    .into_iter()
-                    .map(|s| {
-                        Ok(IndexedVfsPackagePath {
-                            package,
-                            path: path.root().join(s)?,
-                            named_address_map: named_address_mapping,
-                        })
-                    })
-                    .collect::<Result<Vec<_>, anyhow::Error>>()?,
-            );
+            res.extend(find_move_filenames(&[path], true)?.into_iter().map(|s| {
+                IndexedVfsPackagePath {
+                    package,
+                    path: s,
+                    named_address_map: named_address_mapping,
+                }
+            }));
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn parse_program(
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic
-        res.sort_by(|p1, p2| p1.path.as_str().cmp(&p2.path.as_str()));
+        res.sort_by(|p1, p2| p1.path.as_str().cmp(p2.path.as_str()));
         Ok(res)
     }
 

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -29,7 +29,6 @@ pub(crate) fn parse_program(
     named_address_maps: NamedAddressMaps,
     targets: Vec<IndexedVfsPackagePath>,
     deps: Vec<IndexedVfsPackagePath>,
-    interface_files: Vec<IndexedVfsPackagePath>,
 ) -> anyhow::Result<(FilesSourceText, parser::ast::Program, CommentMap)> {
     fn find_move_filenames_with_address_mapping(
         paths_with_mapping: Vec<IndexedVfsPackagePath>,
@@ -83,20 +82,6 @@ pub(crate) fn parse_program(
         path,
         named_address_map,
     } in deps
-    {
-        let (defs, _, _) = parse_file(&path, compilation_env, &mut files, package)?;
-        lib_definitions.extend(defs.into_iter().map(|def| PackageDefinition {
-            package,
-            named_address_map,
-            def,
-        }));
-    }
-
-    for IndexedVfsPackagePath {
-        package,
-        path,
-        named_address_map,
-    } in interface_files
     {
         let (defs, _, _) = parse_file(&path, compilation_env, &mut files, package)?;
         lib_definitions.extend(defs.into_iter().map(|def| PackageDefinition {

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     typing::visitor::{TypingVisitor, TypingVisitorObj},
 };
 use clap::*;
+use move_command_line_common::files::MOVE_EXTENSION;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
@@ -27,6 +28,7 @@ use std::{
     rc::Rc,
     sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
 };
+use vfs::{error::VfsErrorKind, VfsError, VfsPath, VfsResult};
 
 pub mod ast_debug;
 pub mod known_attributes;
@@ -866,3 +868,122 @@ macro_rules! process_binops {
 }
 
 pub(crate) use process_binops;
+
+//**************************************************************************************************
+// Virtual file system support
+//**************************************************************************************************
+
+/// Same as `IndexedPackagePath` but the path is a virtual file system added/
+/// symbol.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexedVfsPackagePath {
+    pub package: Option<Symbol>,
+    pub path: VfsPath,
+    pub named_address_map: NamedAddressMapIndex,
+}
+
+pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, VfsError> {
+    fn canonicalize(p: String) -> String {
+        match dunce::canonicalize(&p) {
+            Ok(s) => s.to_string_lossy().to_string(),
+            Err(_) => p,
+        }
+    }
+
+    vfs_path.join(canonicalize(path))
+}
+
+impl IndexedPackagePath {
+    pub fn to_vfs_path(self, vfs_root: &VfsPath) -> Result<IndexedVfsPackagePath, VfsError> {
+        let IndexedPackagePath {
+            package,
+            path,
+            named_address_map,
+        } = self;
+
+        Ok(IndexedVfsPackagePath {
+            package,
+            path: vfs_path_from_str(path.to_string(), vfs_root)?,
+            named_address_map,
+        })
+    }
+}
+
+/// Determine if the virtual path at `vfs_path` exists distinguishing between whether the path did
+/// not exist, or if there were other errors in determining if the path existed.
+pub fn try_exists(vfs_path: &VfsPath) -> VfsResult<bool> {
+    use VfsResult as R;
+    match vfs_path.metadata() {
+        R::Ok(_) => R::Ok(true),
+        R::Err(e) if matches!(e.kind(), &VfsErrorKind::FileNotFound) => R::Ok(false),
+        R::Err(e) => R::Err(e),
+    }
+}
+
+/// - For each directory in `paths`, it will return all files that satisfy the predicate
+/// - Any file explicitly passed in `paths`, it will include that file in the result, regardless
+///   of the file extension
+/// It implements the same functionality as move-command-line-common::files::find_filenames but for
+/// the virtual file system
+pub fn find_filenames<Predicate: FnMut(&VfsPath) -> bool>(
+    paths: &[VfsPath],
+    mut is_file_desired: Predicate,
+) -> anyhow::Result<Vec<VfsPath>> {
+    let mut result = vec![];
+
+    for p in paths {
+        if !try_exists(p)? {
+            anyhow::bail!("No such file or directory '{}'", p.as_str())
+        }
+        if p.is_file()? && is_file_desired(p) {
+            result.push(p.clone());
+            continue;
+        }
+        if !p.is_dir()? {
+            continue;
+        }
+        for entry in p.walk_dir()?.into_iter().filter_map(|e| e.ok()) {
+            if !entry.is_file()? || !is_file_desired(&entry) {
+                continue;
+            }
+
+            result.push(entry);
+        }
+    }
+    Ok(result)
+}
+
+/// - For each directory in `paths`, it will return all files with the `MOVE_EXTENSION` found
+///   recursively in that directory
+/// - If `keep_specified_files` any file explicitly passed in `paths`, will be added to the result
+///   Otherwise, they will be discarded
+/// It implements the same functionality as move-command-line-common::files::find_move_filenames but
+/// for the virtual file system
+pub fn find_move_filenames(
+    paths: &[VfsPath],
+    keep_specified_files: bool,
+) -> anyhow::Result<Vec<VfsPath>> {
+    if keep_specified_files {
+        let mut file_paths = vec![];
+        let mut other_paths = vec![];
+        for p in paths {
+            if p.is_file()? {
+                file_paths.push(p.clone());
+            } else {
+                other_paths.push(p.clone());
+            }
+        }
+        file_paths.extend(find_filenames(&other_paths, |path| {
+            path.extension()
+                .map(|e| e.as_str() == MOVE_EXTENSION)
+                .unwrap_or(false)
+        })?);
+        Ok(file_paths)
+    } else {
+        find_filenames(paths, |path| {
+            path.extension()
+                .map(|e| e.as_str() == MOVE_EXTENSION)
+                .unwrap_or(false)
+        })
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -882,16 +882,16 @@ pub struct IndexedVfsPackagePath {
     pub named_address_map: NamedAddressMapIndex,
 }
 
-// we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
-// of the physical one) cannot handle relative paths
-pub fn canonicalize(p: String) -> String {
-    match std::fs::canonicalize(&p) {
-        Ok(s) => s.to_string_lossy().to_string(),
-        Err(_) => p,
-    }
-}
-
 pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, VfsError> {
+    // we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
+    // of the physical one) cannot handle relative paths
+    fn canonicalize(p: String) -> String {
+        match dunce::canonicalize(&p) {
+            Ok(s) => s.to_string_lossy().to_string(),
+            Err(_) => p,
+        }
+    }
+
     vfs_path.join(canonicalize(path))
 }
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -882,16 +882,16 @@ pub struct IndexedVfsPackagePath {
     pub named_address_map: NamedAddressMapIndex,
 }
 
-pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, VfsError> {
-    // we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
-    // of the physical one) cannot handle relative paths
-    fn canonicalize(p: String) -> String {
-        match std::fs::canonicalize(&p) {
-            Ok(s) => s.to_string_lossy().to_string(),
-            Err(_) => p,
-        }
+// we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
+// of the physical one) cannot handle relative paths
+pub fn canonicalize(p: String) -> String {
+    match std::fs::canonicalize(&p) {
+        Ok(s) => s.to_string_lossy().to_string(),
+        Err(_) => p,
     }
+}
 
+pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, VfsError> {
     vfs_path.join(canonicalize(path))
 }
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -944,7 +944,7 @@ pub fn find_filenames<Predicate: FnMut(&VfsPath) -> bool>(
         if !p.is_dir()? {
             continue;
         }
-        for entry in p.walk_dir()?.into_iter().filter_map(|e| e.ok()) {
+        for entry in p.walk_dir()?.filter_map(|e| e.ok()) {
             if !entry.is_file()? || !is_file_desired(&entry) {
                 continue;
             }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -886,7 +886,7 @@ pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, Vf
     // we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
     // of the physical one) cannot handle relative paths
     fn canonicalize(p: String) -> String {
-        match dunce::canonicalize(&p) {
+        match std::fs::canonicalize(&p) {
             Ok(s) => s.to_string_lossy().to_string(),
             Err(_) => p,
         }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -883,6 +883,8 @@ pub struct IndexedVfsPackagePath {
 }
 
 pub fn vfs_path_from_str(path: String, vfs_path: &VfsPath) -> Result<VfsPath, VfsError> {
+    // we need to canonicalized paths for virtual file systems as some of them (e.g., implementation
+    // of the physical one) cannot handle relative paths
     fn canonicalize(p: String) -> String {
         match dunce::canonicalize(&p) {
             Ok(s) => s.to_string_lossy().to_string(),


### PR DESCRIPTION
## Description 

This PR adds support for virtual file system, with the intention of allowing the compiler to build a package from files kept by the IDE in memory (this feature is upcoming).

It also removes a certain awkwardness from the compiler implementation where interface files had to be built in a temporary directory (now they are built in an in-memory file system).

It also fixes an existing bug (https://github.com/move-language/move/issues/1082) where source files used in the symbolicator (obtained from resolution graph) and source files used by the compiler could be modified between the two uses resulting in different file hashes which can ultimately lead to crash when translating diagnostics (generated by the compiler and using "compiler file hashes") using symbolicator source files (and "symbolicator file hashes")

## Test Plan 

All existing tests must pass. Also, manually tested the IDE no longer needs file saves to reflect changes in the file (e.g., compiler diagnostics appear as the code is being typed).