### PR TITLE
[execution-layer] Update logic for execution-layer cuts to work with no workspace hack

### DIFF
--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -153,7 +153,6 @@ def do_cut(args):
 
     clean_up_cut(args.feature)
     update_toml(args.feature, Path() / "sui-execution" / "Cargo.toml")
-    update_toml(args.feature, Path() / ".config" / "hakari.toml")
     generate_impls(args.feature, impl_module)
 
     with open(Path() / "sui-execution" / "src" / "lib.rs", mode="w") as lib:

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -34,6 +34,7 @@ move-bytecode-verifier-v1 = { path = "../external-crates/move/move-execution/v1/
 move-vm-runtime-latest = { path = "../external-crates/move/crates/move-vm-runtime", package = "move-vm-runtime" }
 move-vm-runtime-v0 = { path = "../external-crates/move/move-execution/v0/move-vm/runtime" }
 move-vm-runtime-v1 = { path = "../external-crates/move/move-execution/v1/crates/move-vm-runtime" }
+# move-vm-runtime-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-runtime" }
 
 [dev-dependencies]
 cargo_metadata = "0.15.4"


### PR DESCRIPTION
## Description 

Removal of workspace hack caused some issues with the existing logic for cutting a new execution layer. So this gets things back to a working state. 

## Test Plan 

Did a cut locally and ensured it worked. CI

