### PR TITLE
[Package Resolver] Function parameters and signature instantiation

### DIFF
--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     #[error("Package has no modules: {0}")]
     EmptyPackage(AccountAddress),
 
+    #[error("Function not found: {0}::{1}::{2}")]
+    FunctionNotFound(AccountAddress, String, String),
+
     #[error("Linkage not found for package: {0}")]
     LinkageNotFound(AccountAddress),
 

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__function_parameters.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__function_parameters.snap
@@ -1,0 +1,39 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "format!(\"c0::m::foo: {foo:#?}\\n\\\n             c0::m::bar: {bar:#?}\\n\\\n             c0::m::baz: {baz:#?}\")"
+---
+c0::m::foo: []
+c0::m::bar: [
+    OpenSignature {
+        ref_: Some(
+            Immutable,
+        ),
+        body: Datatype(
+            DatatypeRef {
+                package: 00000000000000000000000000000000000000000000000000000000000000c0,
+                module: "m",
+                name: "T0",
+            },
+            [],
+        ),
+    },
+    OpenSignature {
+        ref_: Some(
+            Mutable,
+        ),
+        body: Datatype(
+            DatatypeRef {
+                package: 00000000000000000000000000000000000000000000000000000000000000a1,
+                module: "n",
+                name: "T1",
+            },
+            [],
+        ),
+    },
+]
+c0::m::baz: [
+    OpenSignature {
+        ref_: None,
+        body: U8,
+    },
+]

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__signature_instantiation.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__signature_instantiation.snap
@@ -1,0 +1,34 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: "sig.instantiate(&[T::U64, T::Bool]).unwrap()"
+---
+Struct(
+    StructTag {
+        address: 0000000000000000000000000000000000000000000000000000000000000002,
+        module: Identifier(
+            "table",
+        ),
+        name: Identifier(
+            "Table",
+        ),
+        type_params: [
+            Bool,
+            Vector(
+                Struct(
+                    StructTag {
+                        address: 0000000000000000000000000000000000000000000000000000000000000001,
+                        module: Identifier(
+                            "option",
+                        ),
+                        name: Identifier(
+                            "Option",
+                        ),
+                        type_params: [
+                            U64,
+                        ],
+                    },
+                ),
+            ),
+        ],
+    },
+)


### PR DESCRIPTION
## Description

Add an API to get function parameter signatures, with package IDs relocated, and a separate API for instantiating an open parameter signature to get a (closed) signature.

## Test Plan

New unit tests:

```
sui-package-resolver$ cargo nextest run
```