### PR TITLE
【docs】Fix broken code block in event usage documentation

### DIFF
--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -42,9 +42,12 @@ With the dependency added, you can use the `emit` function to fire an event when
 /// Take coin from `DonutShop` and transfer it to tx sender.
 /// Requires authorization with `ShopOwnerCap`.
 public fun collect_profits( _: &ShopOwnerCap, shop: &mut DonutShop, ctx: &mut TxContext ) {
-let amount = balance::value(&shop.balance);
-let profits = coin::take(&mut shop.balance, amount, ctx);
-// simply create new type instance and emit it event::emit(ProfitsCollected { amount }); transfer::public_transfer(profits, tx_context::sender(ctx)) }
+    let amount = balance::value(&shop.balance);
+    let profits = coin::take(&mut shop.balance, amount, ctx);
+    // simply create new type instance and emit it.
+    event::emit(ProfitsCollected { amount });
+    transfer::public_transfer(profits, tx_context::sender(ctx));
+}
 ```
 
 ## Subscribe to events in Move

--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -54,7 +54,7 @@ public fun collect_profits( _: &ShopOwnerCap, shop: &mut DonutShop, ctx: &mut Tx
 
 Firing events is not very useful in a vacuum. You also need the ability to listen for those events so that you can act on them. In Sui, you subscribe to those events and provide logic that triggers when the event fires.
 
-Sui Full nodes support subscribe functionality using JSON-RPC notifications transmitted through the WebSocket API. You can interact with the RPC directly ([suix_subscribeEvent](/sui-api-ref#suix_subscribeEvent), [suix_subscribeTransaction](/sui-api-ref#suix_subscribeTransaction) or you can use an SDK like the Sui TypeScript SDK. The following excerpt from one of the examples uses the TypeScript SDK to create an asynchronous subscription to the filter identified in the filter.
+Sui Full nodes support subscribe functionality using JSON-RPC notifications transmitted through the WebSocket API. You can interact with the RPC directly ([suix_subscribeEvent](/sui-api-ref#suix_subscribeEvent), [suix_subscribeTransaction](/sui-api-ref#suix_subscribeTransaction)) or you can use an SDK like the Sui TypeScript SDK. The following excerpt from one of the examples uses the TypeScript SDK to create an asynchronous subscription to the filter identified in the filter.
 
 ```move
 let unsubscribe = await provider.subscribeEvent({


### PR DESCRIPTION
## Description 

fix a code block in this page.
https://docs.sui.io/guides/developer/sui-101/using-events

before
```
/// Take coin from `DonutShop` and transfer it to tx sender.
/// Requires authorization with `ShopOwnerCap`.
public fun collect_profits( _: &ShopOwnerCap, shop: &mut DonutShop, ctx: &mut TxContext ) {
let amount = balance::value(&shop.balance);
let profits = coin::take(&mut shop.balance, amount, ctx);
// simply create new type instance and emit it event::emit(ProfitsCollected { amount }); transfer::public_transfer(profits, tx_context::sender(ctx)) }
```

after
```
/// Take coin from `DonutShop` and transfer it to tx sender.
/// Requires authorization with `ShopOwnerCap`.
public fun collect_profits( _: &ShopOwnerCap, shop: &mut DonutShop, ctx: &mut TxContext ) {
    let amount = balance::value(&shop.balance);
    let profits = coin::take(&mut shop.balance, amount, ctx);
    // simply create new type instance and emit it.
    event::emit(ProfitsCollected { amount });
    transfer::public_transfer(profits, tx_context::sender(ctx));
}

```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
