### PR TITLE
[Consensus 2.0] propagate errors from Core to upstream

### DIFF
--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -212,7 +212,10 @@ mod test {
             Broadcaster::new(context.clone(), network_client.clone(), &signals_receiver);
 
         let block = VerifiedBlock::new_for_test(TestBlock::new(9, 1).build());
-        core_signals.new_block(block.clone()).unwrap();
+        assert!(
+            core_signals.new_block(block.clone()),
+            "No subscriber active to receive the block"
+        );
 
         sleep(Duration::from_secs(1)).await;
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -584,7 +584,7 @@ mod test {
         }
 
         // Run commit rule.
-        core.try_commit();
+        core.try_commit().ok();
         let last_commit = store
             .read_last_commit()
             .unwrap()
@@ -691,7 +691,7 @@ mod test {
         }
 
         // Run commit rule.
-        core.try_commit();
+        core.try_commit().ok();
         let last_commit = store
             .read_last_commit()
             .unwrap()

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -163,7 +163,7 @@ mod tests {
         let _handle = LeaderTimeoutTask::start(dispatcher.clone(), &signal_receivers, context);
 
         // send a signal that a new round has been produced.
-        signals.new_round(10).unwrap();
+        signals.new_round(10);
 
         // wait enough until a force_new_block has been received
         sleep(2 * leader_timeout).await;
@@ -206,11 +206,11 @@ mod tests {
 
         // now send some signals with some small delay between them, but not enough so every round
         // manages to timeout and call the force new block method.
-        signals.new_round(13).unwrap();
+        signals.new_round(13);
         sleep(leader_timeout / 2).await;
-        signals.new_round(14).unwrap();
+        signals.new_round(14);
         sleep(leader_timeout / 2).await;
-        signals.new_round(15).unwrap();
+        signals.new_round(15);
         sleep(2 * leader_timeout).await;
 
         // only the last one should be received


### PR DESCRIPTION
## Description 

Propagates the errors from Core to upstream components (namely CoreThread) to handle. When the error is a `Shutdown` one then we close the core loop and exit, otherwise we panic as it is deemed a fatal one. Since we are doing this I've also propagated an error from the commit observer to follow a uniform approach.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
