### PR TITLE
docs dapp-kit code example fix wrong import

### DIFF
--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -30,7 +30,7 @@ respective pages.
 
 ```tsx
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
-import { type SuiClientOptions } from '@mysten/sui.js/client';
+import { getFullnodeUrl } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to


### PR DESCRIPTION
From `{ type SuiClientOptions}` to `{ getFullnodeUrl }`

## Description 

Documentation change

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fix dapp-kit docs code-example