### PR TITLE
[bridge 46/n] replace remaining env ids in Bridge Node

### DIFF
--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -24,8 +24,11 @@ use sui_json_rpc_types::{
 use sui_sdk::{SuiClient as SuiSdkClient, SuiClientBuilder};
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
+use sui_types::bridge;
+use sui_types::bridge::BridgeCommitteeSummary;
 use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::bridge::BridgeRecordDyanmicField;
+use sui_types::bridge::BridgeSummary;
 use sui_types::bridge::MoveTypeBridgeCommittee;
 use sui_types::bridge::MoveTypeCommitteeMember;
 use sui_types::collection_types::LinkedTableNode;
@@ -59,32 +62,6 @@ use crate::events::SuiBridgeEvent;
 use crate::retry_with_max_delay;
 use crate::types::BridgeActionStatus;
 use crate::types::{BridgeAction, BridgeAuthority, BridgeCommittee};
-
-// TODO: once we have bridge package on sui framework, we can hardcode the actual
-// bridge dynamic field object id (not 0x9 or dynamic field wrapper) and update
-// along with software upgrades.
-// Or do we always retrieve from 0x9? We can figure this out before the first uggrade.
-fn get_bridge_object_id() -> &'static ObjectID {
-    static BRIDGE_OBJ_ID: OnceCell<ObjectID> = OnceCell::new();
-    BRIDGE_OBJ_ID.get_or_init(|| {
-        let bridge_object_id =
-            std::env::var("BRIDGE_OBJECT_ID").expect("Expect BRIDGE_OBJECT_ID env var set");
-        ObjectID::from_hex_literal(&bridge_object_id)
-            .expect("BRIDGE_OBJECT_ID must be a valid hex string")
-    })
-}
-
-// object id of BridgeRecord, this is wrapped in the bridge inner object.
-// TODO: once we have bridge package on sui framework, we can hardcode the actual id.
-fn get_bridge_record_id() -> &'static ObjectID {
-    static BRIDGE_RECORD_ID: OnceCell<ObjectID> = OnceCell::new();
-    BRIDGE_RECORD_ID.get_or_init(|| {
-        let bridge_record_id =
-            std::env::var("BRIDGE_RECORD_ID").expect("Expect BRIDGE_RECORD_ID env var set");
-        ObjectID::from_hex_literal(&bridge_record_id)
-            .expect("BRIDGE_RECORD_ID must be a valid hex string")
-    })
-}
 
 pub struct SuiClient<P> {
     inner: P,
@@ -170,22 +147,32 @@ where
             .ok_or(BridgeError::BridgeEventNotActionable)
     }
 
-    // TODO: expose this API to jsonrpc like system state query
+    // TODO: cache this
+    pub async fn get_bridge_record_id(&self) -> BridgeResult<ObjectID> {
+        self.inner
+            .get_bridge_summary()
+            .await
+            .map_err(|e| BridgeError::InternalError(format!("Can't get bridge committee: {e}")))
+            .map(|bridge_summary| bridge_summary.bridge_records_id)
+    }
+
     pub async fn get_bridge_committee(&self) -> BridgeResult<BridgeCommittee> {
-        let move_type_bridge_committee =
-            self.inner.get_bridge_committee().await.map_err(|e| {
+        let bridge_summary =
+            self.inner.get_bridge_summary().await.map_err(|e| {
                 BridgeError::InternalError(format!("Can't get bridge committee: {e}"))
             })?;
+        let move_type_bridge_committee = bridge_summary.committee;
+
         let mut authorities = vec![];
         // TODO: move this to MoveTypeBridgeCommittee
-        for member in move_type_bridge_committee.members.contents {
+        for (_, member) in move_type_bridge_committee.members {
             let MoveTypeCommitteeMember {
                 sui_address,
                 bridge_pubkey_bytes,
                 voting_power,
                 http_rest_url,
                 blocklisted,
-            } = member.value;
+            } = member;
             let pubkey = BridgeAuthorityPublicKey::from_bytes(&bridge_pubkey_bytes)?;
             let base_url = from_utf8(&http_rest_url).unwrap_or_else(|e| {
                 warn!(
@@ -216,8 +203,16 @@ where
         action: &BridgeAction,
     ) -> BridgeActionStatus {
         loop {
+            let Ok(bridge_records_id) =
+                retry_with_max_delay!(self.get_bridge_record_id(), Duration::from_secs(600))
+            else {
+                // TODO: add metrics and fire alert
+                error!("Failed to get bridge records id");
+                continue;
+            };
             let Ok(status) = retry_with_max_delay!(
-                self.inner.get_token_transfer_action_onchain_status(action),
+                self.inner
+                    .get_token_transfer_action_onchain_status(bridge_records_id, action),
                 Duration::from_secs(600)
             ) else {
                 // TODO: add metrics and fire alert
@@ -259,7 +254,7 @@ pub trait SuiClientInner: Send + Sync {
 
     async fn get_mutable_bridge_object_arg(&self) -> Result<ObjectArg, Self::Error>;
 
-    async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error>;
+    async fn get_bridge_summary(&self) -> Result<BridgeSummary, Self::Error>;
 
     async fn execute_transaction_block_with_effects(
         &self,
@@ -268,6 +263,7 @@ pub trait SuiClientInner: Send + Sync {
 
     async fn get_token_transfer_action_onchain_status(
         &self,
+        bridge_records_id: ObjectID,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError>;
 
@@ -320,16 +316,13 @@ impl SuiClientInner for SuiSdkClient {
         })
     }
 
-    // TODO: Add a test for this
-    async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error> {
-        let object_id = *get_bridge_object_id();
-        let bcs_bytes = self.read_api().get_move_object_bcs(object_id).await?;
-        let bridge_dynamic_field: BridgeInnerDynamicField = bcs::from_bytes(&bcs_bytes)?;
-        Ok(bridge_dynamic_field.value.committee)
+    async fn get_bridge_summary(&self) -> Result<BridgeSummary, Self::Error> {
+        self.http().get_latest_bridge().await.map_err(|e| e.into())
     }
 
     async fn get_token_transfer_action_onchain_status(
         &self,
+        bridge_records_id: ObjectID,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {
         match &action {
@@ -348,7 +341,7 @@ impl SuiClientInner for SuiSdkClient {
         let status_object_id = match self
             .read_api()
             .get_dynamic_field_object(
-                *get_bridge_record_id(),
+                bridge_records_id,
                 DynamicFieldName {
                     type_: TypeTag::from_str(&format!(
                         "{:?}::message::BridgeMessageKey",
@@ -586,12 +579,13 @@ mod tests {
             .await
             .unwrap();
         let arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+        let bridge_records_id = sui_client.get_bridge_record_id().await.unwrap();
 
         let action = get_test_sui_to_eth_bridge_action(None, None, None, None);
 
         let status = sui_client
             .inner
-            .get_token_transfer_action_onchain_status(&action)
+            .get_token_transfer_action_onchain_status(bridge_records_id, &action)
             .await
             .unwrap();
         assert_eq!(status, BridgeActionStatus::RecordNotFound);
@@ -619,7 +613,7 @@ mod tests {
 
         let status = sui_client
             .inner
-            .get_token_transfer_action_onchain_status(&action)
+            .get_token_transfer_action_onchain_status(bridge_records_id, &action)
             .await
             .unwrap();
         assert_eq!(status, BridgeActionStatus::Pending);

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -12,7 +12,7 @@ use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_json_rpc_types::{EventFilter, EventPage, SuiEvent};
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
-use sui_types::bridge::MoveTypeBridgeCommittee;
+use sui_types::bridge::BridgeSummary;
 use sui_types::digests::TransactionDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -187,12 +187,21 @@ impl SuiClientInner for SuiMockClient {
         Ok(DUMMY_MUTALBE_BRIDGE_OBJECT_ARG)
     }
 
-    async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error> {
-        unimplemented!()
+    async fn get_bridge_summary(&self) -> Result<BridgeSummary, Self::Error> {
+        Ok(BridgeSummary {
+            bridge_version: 0,
+            message_version: 0,
+            chain_id: 0,
+            sequence_nums: vec![],
+            bridge_records_id: ObjectID::random(),
+            is_frozen: false,
+            committee: Default::default(),
+        })
     }
 
     async fn get_token_transfer_action_onchain_status(
         &self,
+        _bridge_records_id: ObjectID,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {
         Ok(self

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -320,11 +320,7 @@ pub async fn publish_bridge_package(context: &WalletContext) -> BTreeMap<TokenId
         .await
         .unwrap();
     let bridge_inner_object: BridgeInnerDynamicField = bcs::from_bytes(&bcs_bytes).unwrap();
-    let bridge_record_id = bridge_inner_object.value.bridge_records.id;
-
-    // TODO: remove once we don't rely on env var to get package id
-    std::env::set_var("BRIDGE_RECORD_ID", bridge_record_id.to_string());
-    std::env::set_var("BRIDGE_OBJECT_ID", bridge_inner_object_ref.0.to_string());
+    let _bridge_record_id = bridge_inner_object.value.bridge_records.id;
 
     treasury_caps
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1359,7 +1359,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "36",
+              "maxSupportedProtocolVersion": "37",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,
@@ -1367,6 +1367,7 @@
                 "advance_to_highest_supported_protocol_version": false,
                 "allow_receiving_object_id": false,
                 "ban_entry_init": false,
+                "bridge": false,
                 "commit_root_state_digest": false,
                 "consensus_order_end_of_epoch_last": true,
                 "disable_invariant_violation_check_in_swap_loc": false,
@@ -8517,6 +8518,30 @@
             "properties": {
               "AuthenticatorStateExpire": {
                 "$ref": "#/components/schemas/SuiAuthenticatorStateExpire"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "BridgeStateCreate"
+            ],
+            "properties": {
+              "BridgeStateCreate": {
+                "$ref": "#/components/schemas/CheckpointDigest"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "BridgeCommitteeUpdate"
+            ],
+            "properties": {
+              "BridgeCommitteeUpdate": {
+                "$ref": "#/components/schemas/SequenceNumber"
               }
             },
             "additionalProperties": false

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -249,7 +249,7 @@ pub struct MoveTypeCommitteeMemberRegistration {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BridgeCommitteeSummary {
     pub members: Vec<(Vec<u8>, MoveTypeCommitteeMember)>,
@@ -258,7 +258,7 @@ pub struct BridgeCommitteeSummary {
 
 /// Rust version of the Move committee::CommitteeMember type.
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveTypeCommitteeMember {
     pub sui_address: SuiAddress,


### PR DESCRIPTION
## Description 

replace both `BRIDGE_OBJECT_ID` and `BRIDGE_RECORD_ID` with `get_bridge_summary` RPC API

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
