### PR TITLE
[bridge 45/n] replace env ids in Bridge Node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11875,6 +11875,7 @@ dependencies = [
  "shared-crypto",
  "sui-common",
  "sui-config",
+ "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-sdk",
  "sui-test-transaction-builder",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -47,6 +47,7 @@ rand.workspace = true
 workspace-hack.workspace = true
 lru.workspace = true
 shared-crypto.workspace = true
+sui-json-rpc-api.workspace = true
 
 [dev-dependencies]
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 
 use crate::error::BridgeError;
 use crate::error::BridgeResult;
-use crate::sui_transaction_builder::get_bridge_package_id;
 use crate::types::BridgeAction;
 use crate::types::BridgeActionType;
 use crate::types::BridgeChainId;
@@ -25,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::SuiAddress;
 use sui_types::digests::TransactionDigest;
+use sui_types::BRIDGE_PACKAGE_ID;
 
 // This is the event structure defined and emitted in Move
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -125,7 +125,7 @@ impl TryFrom<MoveTokenBridgeEvent> for EmittedSuiToEthTokenBridgeV1 {
 pub fn get_bridge_event_struct_tag() -> &'static str {
     static BRIDGE_EVENT_STRUCT_TAG: OnceCell<String> = OnceCell::new();
     BRIDGE_EVENT_STRUCT_TAG.get_or_init(|| {
-        let bridge_package_id = *get_bridge_package_id();
+        let bridge_package_id = BRIDGE_PACKAGE_ID;
         format!("0x{}::bridge::TokenBridgeEvent", bridge_package_id.to_hex())
     })
 }

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -152,7 +152,9 @@ async fn start_client_components(
         client_config.key,
         client_config.sui_address,
         client_config.gas_object_ref.0,
-    );
+    )
+    .await
+    .expect("Failed to create bridge action executor");
 
     let orchestrator =
         BridgeOrchestrator::new(sui_client, sui_events_rx, eth_events_rx, store.clone());

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -329,9 +329,6 @@ mod tests {
         let registry = Registry::new();
         mysten_metrics::init_metrics(&registry);
 
-        // TODO: remove once we don't rely on env var to get package id
-        std::env::set_var("BRIDGE_PACKAGE_ID", "0x0b");
-
         let temp_dir = tempfile::tempdir().unwrap();
         let store = BridgeOrchestratorTables::new(temp_dir.path());
 

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -418,8 +418,6 @@ mod tests {
             amount: 12345,
         };
 
-        // TODO: remove once we don't rely on env var to get package id
-        std::env::set_var("BRIDGE_PACKAGE_ID", "0x0b");
         init_all_struct_tags();
 
         let mut sui_event_1 = SuiEvent::random_for_testing();

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -4,10 +4,6 @@
 // TODO remove when integrated
 #![allow(unused)]
 
-use std::str::from_utf8;
-use std::str::FromStr;
-use std::time::Duration;
-
 use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::response::sse::Event;
@@ -16,6 +12,10 @@ use fastcrypto::traits::KeyPair;
 use fastcrypto::traits::ToFromBytes;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use std::str::from_utf8;
+use std::str::FromStr;
+use std::time::Duration;
+use sui_json_rpc_api::BridgeReadApiClient;
 use sui_json_rpc_types::{EventFilter, Page, SuiData, SuiEvent};
 use sui_json_rpc_types::{
     EventPage, SuiObjectDataOptions, SuiTransactionBlockResponse,
@@ -23,6 +23,7 @@ use sui_json_rpc_types::{
 };
 use sui_sdk::{SuiClient as SuiSdkClient, SuiClientBuilder};
 use sui_types::base_types::ObjectRef;
+use sui_types::base_types::SequenceNumber;
 use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::bridge::BridgeRecordDyanmicField;
 use sui_types::bridge::MoveTypeBridgeCommittee;
@@ -36,8 +37,11 @@ use sui_types::error::UserInputError;
 use sui_types::event;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{Object, Owner};
+use sui_types::transaction::ObjectArg;
 use sui_types::transaction::Transaction;
 use sui_types::TypeTag;
+use sui_types::BRIDGE_PACKAGE_ID;
+use sui_types::SUI_BRIDGE_OBJECT_ID;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     digests::TransactionDigest,
@@ -53,7 +57,6 @@ use crate::crypto::BridgeAuthorityPublicKey;
 use crate::error::{BridgeError, BridgeResult};
 use crate::events::SuiBridgeEvent;
 use crate::retry_with_max_delay;
-use crate::sui_transaction_builder::get_bridge_package_id;
 use crate::types::BridgeActionStatus;
 use crate::types::{BridgeAction, BridgeAuthority, BridgeCommittee};
 
@@ -114,6 +117,13 @@ where
         Ok(())
     }
 
+    pub async fn get_mutable_bridge_object_arg(&self) -> BridgeResult<ObjectArg> {
+        self.inner
+            .get_mutable_bridge_object_arg()
+            .await
+            .map_err(|e| BridgeError::Generic(format!("Can't get mutable bridge object arg: {e}")))
+    }
+
     /// Query emitted Events that are defined in the given Move Module.
     pub async fn query_events_by_module(
         &self,
@@ -149,7 +159,7 @@ where
         let event = events
             .get(event_idx as usize)
             .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
-        if event.type_.address.as_ref() != get_bridge_package_id().as_ref() {
+        if event.type_.address.as_ref() != BRIDGE_PACKAGE_ID.as_ref() {
             return Err(BridgeError::BridgeEventInUnrecognizedSuiPackage);
         }
         let bridge_event = SuiBridgeEvent::try_from_sui_event(event)?
@@ -247,6 +257,8 @@ pub trait SuiClientInner: Send + Sync {
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, Self::Error>;
 
+    async fn get_mutable_bridge_object_arg(&self) -> Result<ObjectArg, Self::Error>;
+
     async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error>;
 
     async fn execute_transaction_block_with_effects(
@@ -296,6 +308,18 @@ impl SuiClientInner for SuiSdkClient {
             .await
     }
 
+    async fn get_mutable_bridge_object_arg(&self) -> Result<ObjectArg, Self::Error> {
+        let initial_shared_version = self
+            .http()
+            .get_bridge_object_initial_shared_version()
+            .await?;
+        Ok(ObjectArg::SharedObject {
+            id: SUI_BRIDGE_OBJECT_ID,
+            initial_shared_version: SequenceNumber::from_u64(initial_shared_version),
+            mutable: true,
+        })
+    }
+
     // TODO: Add a test for this
     async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error> {
         let object_id = *get_bridge_object_id();
@@ -312,7 +336,7 @@ impl SuiClientInner for SuiSdkClient {
             BridgeAction::SuiToEthBridgeAction(_) | BridgeAction::EthToSuiBridgeAction(_) => (),
             _ => return Err(BridgeError::ActionIsNotTokenTransferAction),
         };
-        let package_id = *get_bridge_package_id();
+        let package_id = BRIDGE_PACKAGE_ID;
         let key = serde_json::json!(
             {
                 // u64 is represented as string
@@ -417,7 +441,6 @@ mod tests {
         sui_mock_client::SuiMockClient,
         test_utils::{
             bridge_token, get_test_sui_to_eth_bridge_action, mint_tokens, publish_bridge_package,
-            transfer_treasury_cap,
         },
         types::{BridgeActionType, BridgeChainId, SuiToEthBridgeAction, TokenId},
     };
@@ -468,9 +491,6 @@ mod tests {
             token_type: sanitized_event_1.token_id as u8,
             amount: sanitized_event_1.amount,
         };
-
-        // TODO: remove once we don't rely on env var to get package id
-        std::env::set_var("BRIDGE_PACKAGE_ID", "0x0b");
 
         let mut sui_event_1 = SuiEvent::random_for_testing();
         sui_event_1.type_ = SuiToEthTokenBridgeV1.get().unwrap().clone();
@@ -554,7 +574,6 @@ mod tests {
             .unwrap_err();
     }
 
-    // TODO: resume this test once we fully migrate move code to sui-framework
     #[ignore]
     #[tokio::test]
     async fn test_get_action_onchain_status_for_sui_to_eth_transfer() {
@@ -566,6 +585,7 @@ mod tests {
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
             .unwrap();
+        let arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
 
         let action = get_test_sui_to_eth_bridge_action(None, None, None, None);
 
@@ -586,11 +606,9 @@ mod tests {
         )
         .await;
 
-        transfer_treasury_cap(context, treasury_cap_obj_ref, TokenId::USDC).await;
-
         let recv_address = EthAddress::random();
         let bridge_event =
-            bridge_token(context, recv_address, usdc_coin_obj_ref, TokenId::USDC).await;
+            bridge_token(context, recv_address, usdc_coin_obj_ref, TokenId::USDC, arg).await;
         assert_eq!(bridge_event.nonce, 0);
         assert_eq!(bridge_event.sui_chain_id, BridgeChainId::SuiLocalTest);
         assert_eq!(bridge_event.eth_chain_id, BridgeChainId::EthLocalTest);

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -4,6 +4,7 @@
 //! A mock implementation of Sui JSON-RPC client.
 
 use crate::error::{BridgeError, BridgeResult};
+use crate::test_utils::DUMMY_MUTALBE_BRIDGE_OBJECT_ARG;
 use async_trait::async_trait;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
@@ -16,6 +17,7 @@ use sui_types::digests::TransactionDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::Owner;
+use sui_types::transaction::ObjectArg;
 use sui_types::transaction::Transaction;
 use sui_types::Identifier;
 
@@ -179,6 +181,10 @@ impl SuiClientInner for SuiMockClient {
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, Self::Error> {
         Ok(self.latest_checkpoint_sequence_number)
+    }
+
+    async fn get_mutable_bridge_object_arg(&self) -> Result<ObjectArg, Self::Error> {
+        Ok(DUMMY_MUTALBE_BRIDGE_OBJECT_ARG)
     }
 
     async fn get_bridge_committee(&self) -> Result<MoveTypeBridgeCommittee, Self::Error> {

--- a/crates/sui-bridge/src/sui_syncer.rs
+++ b/crates/sui-bridge/src/sui_syncer.rs
@@ -8,11 +8,11 @@ use crate::{
     error::BridgeResult,
     retry_with_max_delay,
     sui_client::{SuiClient, SuiClientInner},
-    sui_transaction_builder::get_bridge_package_id,
 };
 use mysten_metrics::spawn_logged_monitored_task;
 use std::{collections::HashMap, sync::Arc};
 use sui_json_rpc_types::SuiEvent;
+use sui_types::BRIDGE_PACKAGE_ID;
 use sui_types::{event::EventID, Identifier};
 use tokio::{
     task::JoinHandle,
@@ -93,7 +93,7 @@ where
         loop {
             interval.tick().await;
             let Ok(events) = retry_with_max_delay!(
-                sui_client.query_events_by_module(*get_bridge_package_id(), module.clone(), cursor),
+                sui_client.query_events_by_module(BRIDGE_PACKAGE_ID, module.clone(), cursor),
                 Duration::from_secs(600)
             ) else {
                 tracing::error!("Failed to query events from sui client after retry");
@@ -162,7 +162,7 @@ mod tests {
 
         // Module Foo has new events
         let mut event_1: SuiEvent = SuiEvent::random_for_testing();
-        let package_id = *get_bridge_package_id();
+        let package_id = BRIDGE_PACKAGE_ID;
         event_1.type_.address = package_id.into();
         event_1.type_.module = module_foo.clone();
         let module_foo_events_1: sui_json_rpc_types::Page<SuiEvent, EventID> = EventPage {
@@ -225,11 +225,6 @@ mod tests {
         cursor: EventID,
         events: EventPage,
     ) {
-        mock.add_event_response(
-            *get_bridge_package_id(),
-            module.clone(),
-            cursor,
-            events.clone(),
-        );
+        mock.add_event_response(BRIDGE_PACKAGE_ID, module.clone(), cursor, events.clone());
     }
 }

--- a/crates/sui-e2e-tests/tests/bridge_tests.rs
+++ b/crates/sui-e2e-tests/tests/bridge_tests.rs
@@ -58,12 +58,11 @@ async fn test_create_bridge_state_object() {
 
 #[tokio::test]
 async fn test_committee_registration() {
-    let test_cluster = TestClusterBuilder::new()
+    let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
         .with_protocol_version(37.into())
         .with_epoch_duration_ms(10000)
         .build()
         .await;
-
     let ref_gas_price = test_cluster.get_reference_gas_price().await;
     let bridge_shared_version = get_bridge_obj_initial_shared_version(
         test_cluster
@@ -189,15 +188,20 @@ async fn test_committee_registration() {
     );
 }
 
-// A test to make sure bridge_api is compatible
 #[tokio::test]
-async fn test_bridge_api_get_latest_bridge() {
-    let test_cluster = TestClusterBuilder::new()
+async fn test_bridge_api_compatibility() {
+    let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
         .with_protocol_version(37.into())
+        .with_epoch_duration_ms(10000)
         .build()
         .await;
 
     let client = test_cluster.rpc_client();
     client.get_latest_bridge().await.unwrap();
     // TODO: assert fields in summary
+
+    client
+        .get_bridge_object_initial_shared_version()
+        .await
+        .unwrap();
 }

--- a/crates/sui-framework/docs/bridge/committee.md
+++ b/crates/sui-framework/docs/bridge/committee.md
@@ -261,6 +261,15 @@
 
 
 
+<a name="0xb_committee_ECommitteeAlreadyInitiated"></a>
+
+
+
+<pre><code><b>const</b> <a href="committee.md#0xb_committee_ECommitteeAlreadyInitiated">ECommitteeAlreadyInitiated</a>: u64 = 7;
+</code></pre>
+
+
+
 <a name="0xb_committee_EDuplicatedSignature"></a>
 
 
@@ -417,8 +426,11 @@
     http_rest_url: <a href="dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext
 ) {
+    // We disallow registration after <a href="committee.md#0xb_committee">committee</a> initiated in v1
+    <b>assert</b>!(<a href="dependencies/sui-framework/vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&self.members), <a href="committee.md#0xb_committee_ECommitteeAlreadyInitiated">ECommitteeAlreadyInitiated</a>);
+    // Ensure pubkey is valid
     <b>assert</b>!(<a href="dependencies/move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&bridge_pubkey_bytes) == <a href="committee.md#0xb_committee_ECDSA_COMPRESSED_PUBKEY_LENGTH">ECDSA_COMPRESSED_PUBKEY_LENGTH</a>, <a href="committee.md#0xb_committee_EInvalidPubkeyLength">EInvalidPubkeyLength</a>);
-    // sender must be the same sender that created the <a href="dependencies/sui-system/validator.md#0x3_validator">validator</a> <a href="dependencies/sui-framework/object.md#0x2_object">object</a>
+    // sender must be the same sender that created the <a href="dependencies/sui-system/validator.md#0x3_validator">validator</a> <a href="dependencies/sui-framework/object.md#0x2_object">object</a>, this is <b>to</b> prevent DDoS from non-<a href="dependencies/sui-system/validator.md#0x3_validator">validator</a> actor.
     <b>let</b> sender = <a href="dependencies/sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
     <b>let</b> validators = <a href="dependencies/sui-system/sui_system.md#0x3_sui_system_active_validator_addresses">sui_system::active_validator_addresses</a>(system_state);
 

--- a/crates/sui-json-rpc-api/src/bridge.rs
+++ b/crates/sui-json-rpc-api/src/bridge.rs
@@ -13,4 +13,9 @@ pub trait BridgeReadApi {
     /// Returns the latest BridgeSummary
     #[method(name = "getLatestBridge")]
     async fn get_latest_bridge(&self) -> RpcResult<BridgeSummary>;
+
+    /// Returns the initial shared version of the bridge object, usually
+    /// for the purpose of constructing an ObjectArg in a transaction.
+    #[method(name = "getBridgeObjectInitialSharedVersion")]
+    async fn get_bridge_object_initial_shared_version(&self) -> RpcResult<u64>;
 }


### PR DESCRIPTION
## Description 

1. replace `BRIDGE_PACKAGE_ID` env var to 0xb
2. replace `ROOT_BRIDGE_OBJECT_ID` env var to 0x9
3. replace `ROOT_BRIDGE_OBJECT_INITIAL_SHARED_VERSION` env var with bridge_api RPC call

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
