### PR TITLE
[1.19] Lower Move compiler stack size

### DIFF
--- a/external-crates/move/crates/move-compiler/src/lib.rs
+++ b/external-crates/move/crates/move-compiler/src/lib.rs
@@ -10,7 +10,7 @@ extern crate move_ir_types;
 #[macro_use(symbol)]
 extern crate move_symbol_pool;
 
-pub const STACK_LIMIT: usize = 42 * 1_000_000_000;
+pub const STACK_LIMIT: usize = 1_000_000_000;
 
 macro_rules! with_large_stack {
     ($e:expr) => {


### PR DESCRIPTION
## Description 

- Hopefully reduce the chance of this stacker approach from causing issues when building. Longterm, we will need to be more granular when growing the stack.

## Test Plan 

- @nikos-kitmeridis verified the fix addressed his issue

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fixed the likelihood of `sui` failing to build due to stack sizing issues. 