### PR TITLE
Add `#[rename = name]` attribute.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15105,6 +15105,7 @@ name = "typed-store-derive"
 version = "0.3.0"
 dependencies = [
  "eyre",
+ "itertools 0.10.5",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "rocksdb",

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::quote;
@@ -16,6 +17,8 @@ use syn::{
 const DEFAULT_DB_OPTIONS_CUSTOM_FN: &str = "typed_store::rocks::default_db_options";
 // Custom function which returns the option and overrides the defaults for this table
 const DB_OPTIONS_CUSTOM_FUNCTION: &str = "default_options_override_fn";
+// Use a different name for the column than the identifier
+const DB_OPTIONS_RENAME: &str = "rename";
 
 /// Options can either be simplified form or
 enum GeneralTableOptions {
@@ -34,6 +37,7 @@ fn extract_struct_info(
     allowed_map_type_names: HashSet<String>,
 ) -> (
     Vec<Ident>,
+    Vec<Ident>,
     Vec<AngleBracketedGenericArguments>,
     Vec<GeneralTableOptions>,
     String,
@@ -46,17 +50,19 @@ fn extract_struct_info(
     let allowed_strs = allowed_strs.join(" or ");
 
     let info = input.fields.iter().map(|f| {
-        let attrs: Vec<_> = f
+        let attrs: BTreeMap<_, _> = f
             .attrs
             .iter()
-            .filter(|a| a.path.is_ident(DB_OPTIONS_CUSTOM_FUNCTION))
+            .filter(|a| {
+                a.path.is_ident(DB_OPTIONS_CUSTOM_FUNCTION) || a.path.is_ident(DB_OPTIONS_RENAME)
+            })
+            .map(|a| (a.path.get_ident().unwrap().to_string(), a))
             .collect();
-        let options = if attrs.is_empty() {
-            GeneralTableOptions::default()
+
+        let options = if let Some(options) = attrs.get(DB_OPTIONS_CUSTOM_FUNCTION) {
+            GeneralTableOptions::OverrideFunction(get_options_override_function(options).unwrap())
         } else {
-            GeneralTableOptions::OverrideFunction(
-                get_options_override_function(attrs.first().unwrap()).unwrap(),
-            )
+            GeneralTableOptions::default()
         };
 
         let ty = &f.ty;
@@ -72,10 +78,24 @@ fn extract_struct_info(
             let type_str = format!("{}", &type_info.ident);
             // Rough way to check that this is map_type_name
             if allowed_map_type_names.contains(&type_str) {
-                return (
-                    (f.ident.as_ref().unwrap().clone(), type_str),
-                    (inner_type, options),
-                );
+                let field_name = f.ident.as_ref().unwrap().clone();
+                let path_name = if let Some(rename) = attrs.get(DB_OPTIONS_RENAME) {
+                    match rename.parse_meta().expect("Cannot parse meta of attribute") {
+                        Meta::NameValue(val) => {
+                            if let Lit::Str(s) = val.lit {
+                                // convert to ident
+                                s.parse().expect("Rename value must be identifier")
+                            } else {
+                                panic!("Expected string value for rename")
+                            }
+                        }
+                        _ => panic!("Expected string value for rename"),
+                    }
+                } else {
+                    field_name.clone()
+                };
+
+                return ((field_name, path_name, type_str), (inner_type, options));
             } else {
                 panic!("All struct members must be of type {allowed_strs}");
             }
@@ -84,7 +104,8 @@ fn extract_struct_info(
     });
 
     let (field_info, inner_types_with_opts): (Vec<_>, Vec<_>) = info.unzip();
-    let (field_names, simple_field_type_names): (Vec<_>, Vec<_>) = field_info.into_iter().unzip();
+    let (field_names, path_names, simple_field_type_names): (Vec<_>, Vec<_>, Vec<_>) =
+        field_info.into_iter().multiunzip();
 
     // Check for homogeneous types
     if let Some(first) = simple_field_type_names.first() {
@@ -101,6 +122,7 @@ fn extract_struct_info(
 
     (
         field_names,
+        path_names,
         inner_types,
         options,
         simple_field_type_names.first().unwrap().clone(),
@@ -280,7 +302,7 @@ fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
 /// //     bad_field: u32,
 /// // #}
 
-#[proc_macro_derive(DBMapUtils, attributes(default_options_override_fn))]
+#[proc_macro_derive(DBMapUtils, attributes(default_options_override_fn, rename))]
 pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     let name = &input.ident;
@@ -295,7 +317,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
         .collect();
 
     // TODO: use `parse_quote` over `parse()`
-    let (field_names, inner_types, derived_table_options, simple_field_type_name_str) =
+    let (field_names, path_names, inner_types, derived_table_options, simple_field_type_name_str) =
         extract_struct_info(input.clone(), allowed_strs);
 
     let (key_names, value_names): (Vec<_>, Vec<_>) = inner_types
@@ -357,7 +379,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
             pub fn build(&self) -> typed_store::rocks::DBMapTableConfigMap {
                 typed_store::rocks::DBMapTableConfigMap::new([
                     #(
-                        (stringify!(#field_names).to_owned(), self.#field_names.clone()),
+                        (stringify!(#path_names).to_owned(), self.#field_names.clone()),
                     )*
                 ].into_iter().collect())
             }
@@ -405,12 +427,12 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     let opt_cfs = match tables_db_options_override {
                         None => [
                             #(
-                                (stringify!(#field_names).to_owned(), #default_options_override_fn_names()),
+                                (stringify!(#path_names).to_owned(), #default_options_override_fn_names()),
                             )*
                         ],
                         Some(o) => [
                             #(
-                                (stringify!(#field_names).to_owned(), o.to_map().get(stringify!(#field_names)).unwrap().clone()),
+                                (stringify!(#path_names).to_owned(), o.to_map().get(stringify!(#path_names)).unwrap().clone()),
                             )*
                         ]
                     };
@@ -429,7 +451,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                             #field_names
                         ),*
                 ) = (#(
-                        DBMap::#inner_types::reopen(&db, Some(stringify!(#field_names)), rwopt_cfs.get(stringify!(#field_names)).unwrap_or(&typed_store::rocks::ReadWriteOptions::default())).expect(&format!("Cannot open {} CF.", stringify!(#field_names))[..])
+                        DBMap::#inner_types::reopen(&db, Some(stringify!(#path_names)), rwopt_cfs.get(stringify!(#path_names)).unwrap_or(&typed_store::rocks::ReadWriteOptions::default())).expect(&format!("Cannot open {} CF.", stringify!(#path_names))[..])
                     ),*);
 
                 Self {
@@ -664,7 +686,7 @@ pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
 
     // TODO: use `parse_quote` over `parse()`
     // TODO: Eventually this should return a Vec<Vec<GeneralTableOptions>> to capture default table options for each column type i.e. RockDB, TestDB, etc
-    let (field_names, inner_types, derived_table_options, simple_field_type_name_str) =
+    let (field_names, path_names, inner_types, derived_table_options, simple_field_type_name_str) =
         extract_struct_info(input.clone(), allowed_strs);
 
     let (key_names, value_names): (Vec<_>, Vec<_>) = inner_types


### PR DESCRIPTION
This allows us to change the rust identifier of a table without changing the underlying pathname

Here is a diff of the generated code for the RenameTables1 and RenameTables2, to show exactly which pieces of the output this changes: https://gist.github.com/mystenmark/34e8416b2b7770766fc00fe5036744bb
