### PR TITLE
【docs】Fix Rust sample code for subscribing to events

### DIFF
--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -193,15 +193,17 @@ subscribeEvent {
 
 ```rust
 use futures::StreamExt;
-use sui_sdk::rpc_types::SuiEventFilter;
-use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_sdk::rpc_types::EventFilter;
+use sui_sdk::SuiClientBuilder;
+use anyhow::Result;
 
 #[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClientBuilder::default().build(
-      "https://fullnode.devnet.sui.io:443",
-    ).await.unwrap();
-    let mut subscribe_all = sui.event_api().subscribe_event(SuiEventFilter::All(vec![])).await?;
+async fn main() -> Result<()> {
+    let sui = SuiClientBuilder::default()
+        .ws_url("wss://fullnode.mainnet.sui.io:443")
+        .build("https://fullnode.mainnet.sui.io:443")
+        .await.unwrap();
+    let mut subscribe_all = sui.event_api().subscribe_event(EventFilter::All(vec![])).await?;
     loop {
         println!("{:?}", subscribe_all.next().await);
     }


### PR DESCRIPTION
## Description 

Fixed the Rust sample code for subscribing to events as it was no longer working.
https://docs.sui.io/guides/developer/sui-101/using-events#rust-sdk

- `SuiEventFilter` -> `EventFilter`
  - The `SuiEventFilter` type no longer exists.
- Set WebSocket URL
  - Subscription only supported by WebSocket client.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
