### PR TITLE
[Consensus] `DagState` persistence

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -329,7 +329,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         // For now ask dag state directly
-        let blocks = self.dag_state.read().get_blocks(block_refs)?;
+        let blocks = self.dag_state.read().get_blocks(&block_refs);
 
         // Return the serialised blocks
         let result = blocks

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -107,6 +107,7 @@ where
             "Starting authority {}\n{:#?}\n{:#?}\n{:?}",
             own_index, committee, parameters, protocol_config.version
         );
+        assert!(committee.is_valid_index(own_index));
         let context = Arc::new(Context::new(
             own_index,
             committee,

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -200,8 +200,8 @@ impl BaseCommitter {
             let ancestor = self
                 .dag_state
                 .read()
-                .get_uncommitted_block(ancestor)
-                .expect("We should have the whole sub-dag by now");
+                .get_block(ancestor)
+                .unwrap_or_else(|| panic!("Block not found in storage: {:?}", ancestor));
             if let Some(support) = self.find_supported_block(leader_slot, &ancestor) {
                 return Some(support);
             }
@@ -237,8 +237,8 @@ impl BaseCommitter {
                 let potential_vote = self
                     .dag_state
                     .read()
-                    .get_uncommitted_block(reference)
-                    .expect("We should have the whole sub-dag by now");
+                    .get_block(reference)
+                    .unwrap_or_else(|| panic!("Block not found in storage: {:?}", reference));
                 let is_vote = self.is_vote(&potential_vote, leader_block);
                 all_votes.insert(*reference, is_vote);
                 is_vote
@@ -288,7 +288,7 @@ impl BaseCommitter {
         let potential_certificates = self
             .dag_state
             .read()
-            .ancestors_at_uncommitted_round(anchor, decision_round);
+            .ancestors_at_round(anchor, decision_round);
 
         // Use those potential certificates to determine which (if any) of the target leader
         // blocks can be committed.

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -213,7 +213,7 @@ mod test {
 
         let block = VerifiedBlock::new_for_test(TestBlock::new(9, 1).build());
         assert!(
-            core_signals.new_block(block.clone()),
+            core_signals.new_block(block.clone()).is_ok(),
             "No subscriber active to receive the block"
         );
 

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -52,8 +52,8 @@ impl Broadcaster {
                 index,
             ));
         }
-        // When there is no peer (in tests), keep a subscriber to the block broadcast channel
-        // so Core can continue to function.
+        // When there is only one authority in committee (in tests), add a noop subscriber to the
+        // block broadcast channel so Core can continue to function.
         if senders.is_empty() {
             senders.spawn(Self::drop_blocks(
                 signals_receiver.block_broadcast_receiver(),

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -30,7 +30,7 @@ pub(crate) type CommitIndex = u64;
 
 /// Specifies one consensus commit.
 /// It is stored on disk, so it does not contain blocks which are stored individually.
-#[allow(unused)]
+// TODO: store internal data in a refcounted and versioned struct. Remove last_committed_rounds.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct Commit {
     /// Index of the commit.
@@ -262,7 +262,7 @@ mod tests {
             })
             .map(|block| (block.reference(), block))
             .unzip();
-        store.write(genesis, vec![]).unwrap();
+        store.write(genesis, vec![], vec![]).unwrap();
         blocks.append(&mut genesis_references.clone());
 
         let mut ancestors = genesis_references;
@@ -277,7 +277,7 @@ mod tests {
                         .set_ancestors(ancestors.clone())
                         .build(),
                 );
-                store.write(vec![block.clone()], vec![]).unwrap();
+                store.write(vec![block.clone()], vec![], vec![]).unwrap();
                 new_ancestors.push(block.reference());
                 blocks.push(block.reference());
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -76,13 +76,17 @@ impl CommitObserver {
                     "Failed to send committed sub-dag, probably due to shutdown: {err:?}"
                 );
                 return Err(ConsensusError::Shutdown);
-            } else {
-                sent_sub_dags.push(committed_sub_dag);
             }
+            tracing::debug!(
+                "Sending to execution commit {} leader {}",
+                committed_sub_dag.commit_index,
+                committed_sub_dag.leader
+            );
+            sent_sub_dags.push(committed_sub_dag);
         }
 
         self.report_metrics(&sent_sub_dags);
-        tracing::debug!("Committed & sent {sent_sub_dags:#?}");
+        tracing::trace!("Committed & sent {sent_sub_dags:#?}");
         Ok(sent_sub_dags)
     }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -129,8 +129,10 @@ impl Core {
             .expect("At least one block - even genesis - should be present");
 
         // Accept all blocks but make sure that only the last quorum round blocks and onwards are kept.
-        // TODO: run commit and propose logic, or just use add_blocks() instead of add_accepted_blocks().
         self.add_accepted_blocks(all_blocks, Some(0));
+        // Try to commit and propose, since they may not have run after last storage write and crash.
+        self.try_commit().unwrap();
+        self.try_propose(false).unwrap();
         self
     }
 
@@ -149,7 +151,6 @@ impl Core {
             // Now add accepted blocks to the threshold clock and pending ancestors list.
             self.add_accepted_blocks(accepted_blocks, None);
 
-            // TODO: Add optimization for added blocks that do not achieve quorum for a round.
             self.try_commit()?;
 
             // Try to propose now since there are new blocks accepted.
@@ -223,10 +224,7 @@ impl Core {
         ignore_leaders_check: bool,
     ) -> ConsensusResult<Option<VerifiedBlock>> {
         if let Some(block) = self.try_new_block(ignore_leaders_check) {
-            // TODO: Add optimization for added blocks that do not achieve quorum for a round.
             self.try_commit()?;
-            // Signal that a new block is created, and broadcast it.
-            self.signals.new_block_ready(block.reference());
             self.signals.new_block(block.clone())?;
             return Ok(Some(block));
         }
@@ -304,6 +302,7 @@ impl Core {
 
     /// Runs commit rule to attempt to commit additional blocks from the DAG.
     fn try_commit(&mut self) -> ConsensusResult<Vec<CommittedSubDag>> {
+        // TODO: Add optimization to abort early without quorum for a round.
         let sequenced_leaders = self.committer.try_commit(self.last_decided_leader);
 
         if let Some(last) = sequenced_leaders.last() {
@@ -422,7 +421,6 @@ impl Core {
 pub(crate) struct CoreSignals {
     tx_block_broadcast: broadcast::Sender<VerifiedBlock>,
     new_round_sender: watch::Sender<Round>,
-    block_ready_sender: watch::Sender<Option<BlockRef>>,
 }
 
 impl CoreSignals {
@@ -433,18 +431,15 @@ impl CoreSignals {
     pub fn new() -> (Self, CoreSignalsReceivers) {
         let (tx_block_broadcast, _rx_block_broadcast) =
             broadcast::channel::<VerifiedBlock>(Self::BROADCAST_BACKLOG_CAPACITY);
-        let (block_ready_sender, block_ready_receiver) = watch::channel(None);
         let (new_round_sender, new_round_receiver) = watch::channel(0);
 
         let me = Self {
             tx_block_broadcast: tx_block_broadcast.clone(),
-            block_ready_sender,
             new_round_sender,
         };
 
         let receivers = CoreSignalsReceivers {
             tx_block_broadcast,
-            block_ready_receiver,
             new_round_receiver,
         };
 
@@ -461,11 +456,6 @@ impl CoreSignals {
         Ok(())
     }
 
-    /// Sends a signal to all the waiters that a new block has been produced.
-    pub fn new_block_ready(&mut self, block: BlockRef) {
-        let _ = self.block_ready_sender.send_replace(Some(block));
-    }
-
     /// Sends a signal that threshold clock has advanced to new round. The `round_number` is the round at which the
     /// threshold clock has advanced to.
     pub fn new_round(&mut self, round_number: Round) {
@@ -478,7 +468,6 @@ impl CoreSignals {
 pub(crate) struct CoreSignalsReceivers {
     tx_block_broadcast: broadcast::Sender<VerifiedBlock>,
     #[allow(dead_code)]
-    block_ready_receiver: watch::Receiver<Option<BlockRef>>,
     new_round_receiver: watch::Receiver<Round>,
 }
 
@@ -486,11 +475,6 @@ impl CoreSignalsReceivers {
     #[allow(dead_code)]
     pub(crate) fn block_broadcast_receiver(&self) -> broadcast::Receiver<VerifiedBlock> {
         self.tx_block_broadcast.subscribe()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn block_ready_receiver(&self) -> watch::Receiver<Option<BlockRef>> {
-        self.block_ready_receiver.clone()
     }
 
     pub(crate) fn new_round_receiver(&self) -> watch::Receiver<Round> {
@@ -561,6 +545,8 @@ mod test {
 
         // Now spin up core
         let (signals, signal_receivers) = CoreSignals::new();
+        // Need at least one subscriber to the block broadcast channel.
+        let mut block_receiver = signal_receivers.block_broadcast_receiver();
         let mut core = Core::new(
             context.clone(),
             transaction_consumer,
@@ -576,10 +562,10 @@ mod test {
         let mut new_round = signal_receivers.new_round_receiver();
         assert_eq!(*new_round.borrow_and_update(), 5);
 
-        // When trying to propose now we should propose block for round 5
-        let proposed_block = core
-            .try_propose(true)
-            .unwrap()
+        // Block for round 5 should have been proposed.
+        let proposed_block = block_receiver
+            .recv()
+            .await
             .expect("A block should have been created");
         assert_eq!(proposed_block.round(), 5);
         let ancestors = proposed_block.ancestors();
@@ -667,6 +653,8 @@ mod test {
 
         // Now spin up core
         let (signals, signal_receivers) = CoreSignals::new();
+        // Need at least one subscriber to the block broadcast channel.
+        let mut block_receiver = signal_receivers.block_broadcast_receiver();
         let mut core = Core::new(
             context.clone(),
             transaction_consumer,
@@ -683,9 +671,9 @@ mod test {
         assert_eq!(*new_round.borrow_and_update(), 4);
 
         // When trying to propose now we should propose block for round 4
-        let proposed_block = core
-            .try_propose(true)
-            .unwrap()
+        let proposed_block = block_receiver
+            .recv()
+            .await
             .expect("A block should have been created");
         assert_eq!(proposed_block.round(), 4);
         let ancestors = proposed_block.ancestors();
@@ -732,7 +720,9 @@ mod test {
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
-        let (signals, _signal_receivers) = CoreSignals::new();
+        let (signals, signal_receivers) = CoreSignals::new();
+        // Need at least one subscriber to the block broadcast channel.
+        let mut block_receiver = signal_receivers.block_broadcast_receiver();
 
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
@@ -771,9 +761,9 @@ mod test {
         }
 
         // trigger the try_new_block - that should return now a new block
-        let block = core
-            .try_propose(false)
-            .unwrap()
+        let block = block_receiver
+            .recv()
+            .await
             .expect("A new block should have been created");
 
         // A new block created - assert the details
@@ -826,7 +816,9 @@ mod test {
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
-        let (signals, _signal_receivers) = CoreSignals::new();
+        let (signals, signal_receivers) = CoreSignals::new();
+        // Need at least one subscriber to the block broadcast channel.
+        let _block_receiver = signal_receivers.block_broadcast_receiver();
 
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
@@ -885,20 +877,20 @@ mod test {
     async fn test_core_try_new_block_leader_timeout() {
         telemetry_subscribers::init_for_testing();
         // Create the cores for all authorities
-        let cores = create_cores(vec![1, 1, 1, 1]);
+        let mut all_cores = create_cores(vec![1, 1, 1, 1]);
 
-        // Create blocks for rounds 1..=3 from all Cores except Core of authority 3, so we miss the block from it. As
+        // Create blocks for rounds 1..=3 from all Cores except last Core of authority 3, so we miss the block from it. As
         // it will be the leader of round 3 then no-one will be able to progress to round 4 unless we explicitly trigger
         // the block creation.
         // create the cores and their signals for all the authorities
-        let mut cores = cores.into_iter().take(3).collect::<Vec<_>>();
+        let (_last_core, cores) = all_cores.split_last_mut().unwrap();
 
         // Now iterate over a few rounds and ensure the corresponding signals are created while network advances
         let mut last_round_blocks = Vec::new();
         for round in 1..=3 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _signal_receivers, _) in &mut cores {
+            for (core, _signal_receivers, _, _) in cores.iter_mut() {
                 core.add_blocks(last_round_blocks.clone()).unwrap();
 
                 assert_eq!(core.last_proposed_round(), round);
@@ -911,13 +903,13 @@ mod test {
 
         // Try to create the blocks for round 4 by calling the try_new_block method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
-        for (core, _, _) in &mut cores {
+        for (core, _, _, _) in cores.iter_mut() {
             core.add_blocks(last_round_blocks.clone()).unwrap();
             assert!(core.try_propose(false).unwrap().is_none());
         }
 
         // Now try to create the blocks for round 4 via the leader timeout method which should ignore any leader checks
-        for (core, _, _) in &mut cores {
+        for (core, _, _, _) in cores.iter_mut() {
             assert!(core.force_new_block(4).unwrap().is_some());
             assert_eq!(core.last_proposed_round(), 4);
 
@@ -946,7 +938,7 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, signal_receivers, _) in &mut cores {
+            for (core, signal_receivers, block_receiver, _) in &mut cores {
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
                 core.add_blocks(last_round_blocks.clone()).unwrap();
@@ -959,15 +951,13 @@ mod test {
                 .await;
                 assert_eq!(new_round, round);
 
-                // Check that a new block has been proposed
-                let block_ref = receive(
-                    Duration::from_secs(1),
-                    signal_receivers.block_ready_receiver(),
-                )
-                .await
-                .unwrap();
-                assert_eq!(block_ref.round, round);
-                assert_eq!(block_ref.author, core.context.own_index);
+                // Check that a new block has been proposed.
+                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(block.round(), round);
+                assert_eq!(block.author(), core.context.own_index);
 
                 // append the new block to this round blocks
                 this_round_blocks.push(core.last_proposed_block().clone());
@@ -992,7 +982,7 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (core, _, _) in cores {
+        for (core, _, _, _) in cores {
             // Check commits have been persisted to store
             let last_commit = core
                 .store
@@ -1022,7 +1012,7 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _, _) in &mut cores {
+            for (core, _, _, _) in &mut cores {
                 // do not produce any block for authority 3
                 if core.context.own_index == excluded_authority {
                     continue;
@@ -1046,17 +1036,17 @@ mod test {
         // Now send all the produced blocks to core of authority 3. It should produce a new block. If no compression would
         // be applied the we should expect all the previous blocks to be referenced from round 0..=10. However, since compression
         // is applied only the last round's (10) blocks should be referenced + the authority's block of round 0.
-        let (core, _, _) = &mut cores[excluded_authority];
+        let (core, _, _, _) = &mut cores[excluded_authority];
         core.add_blocks(all_blocks).unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks of round 10 for the other peers, and
-        // to round 0 for its own block.
+        // to round 1 for its own block (created after recovery).
         let block = core.last_proposed_block();
         assert_eq!(block.round(), 11);
         assert_eq!(block.ancestors().len(), 4);
         for block_ref in block.ancestors() {
             if block_ref.author == excluded_authority {
-                assert_eq!(block_ref.round, 0);
+                assert_eq!(block_ref.round, 1);
             } else {
                 assert_eq!(block_ref.round, 10);
             }
@@ -1078,11 +1068,13 @@ mod test {
 
     /// Creates cores for the specified number of authorities for their corresponding stakes. The method returns the
     /// cores and their respective signal receivers are returned in `AuthorityIndex` order asc.
+    // TODO: return a test fixture instead.
     fn create_cores(
         authorities: Vec<Stake>,
     ) -> Vec<(
         Core,
         CoreSignalsReceivers,
+        broadcast::Receiver<VerifiedBlock>,
         UnboundedReceiver<CommittedSubDag>,
     )> {
         let mut cores = Vec::new();
@@ -1102,11 +1094,13 @@ mod test {
             let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
             let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
             let (signals, signal_receivers) = CoreSignals::new();
+            // Need at least one subscriber to the block broadcast channel.
+            let block_receiver = signal_receivers.block_broadcast_receiver();
 
-            let (sender, receiver) = unbounded_channel();
+            let (commit_sender, commit_receiver) = unbounded_channel();
             let commit_observer = CommitObserver::new(
                 context.clone(),
-                sender.clone(),
+                commit_sender.clone(),
                 0, // last_processed_index
                 dag_state.clone(),
                 store.clone(),
@@ -1125,7 +1119,7 @@ mod test {
                 store,
             );
 
-            cores.push((core, signal_receivers, receiver));
+            cores.push((core, signal_receivers, block_receiver, commit_receiver));
         }
         cores
     }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -200,8 +200,8 @@ mod test {
         let block_manager = BlockManager::new(context.clone(), dag_state.clone());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
-        let (signals, _signal_receivers) = CoreSignals::new();
-
+        let (signals, signal_receivers) = CoreSignals::new();
+        let _block_receiver = signal_receivers.block_broadcast_receiver();
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -10,12 +10,12 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
+use tracing::error;
 
 use crate::{
     block::{Block, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
     commit::{Commit, CommitIndex},
     context::Context,
-    error::ConsensusResult,
     storage::Store,
 };
 
@@ -34,25 +34,32 @@ const CACHED_ROUNDS: Round = 100;
 pub(crate) struct DagState {
     context: Arc<Context>,
 
-    // Caches blocks within CACHED_ROUNDS from the last committed round per authority.
-    // Note: uncommitted blocks will always be in memory.
+    // The genesis blocks
+    genesis: BTreeMap<BlockRef, VerifiedBlock>,
+
+    // Contains recent blocks within CACHED_ROUNDS from the last committed round per authority.
+    // Note: all uncommitted blocks are kept in memory.
     recent_blocks: BTreeMap<BlockRef, VerifiedBlock>,
 
-    // Accepted blocks have their refs cached. Cached refs are never removed until restart.
+    // Contains block refs of recent_blocks.
     // Each element in the Vec corresponds to the authority with the index.
-    cached_refs: Vec<BTreeSet<BlockRef>>,
-
-    // Last consensus commit of the dag.
-    last_commit: Option<Commit>,
+    recent_refs: Vec<BTreeSet<BlockRef>>,
 
     // Highest round of blocks accepted.
     highest_accepted_round: Round,
 
+    // Last consensus commit of the dag.
+    last_commit: Option<Commit>,
+
+    // Last committed rounds per authority.
+    last_committed_rounds: Vec<Round>,
+
+    // Buffered data to be flushed to storage.
+    buffered_blocks: Vec<VerifiedBlock>,
+    buffered_commits: Vec<Commit>,
+
     // Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
-
-    // The genesis blocks
-    genesis: BTreeMap<BlockRef, VerifiedBlock>,
 }
 
 #[allow(unused)]
@@ -60,11 +67,6 @@ impl DagState {
     /// Initializes DagState from storage.
     pub(crate) fn new(context: Arc<Context>, store: Arc<dyn Store>) -> Self {
         let num_authorities = context.committee.size();
-        let last_commit = store.read_last_commit().unwrap();
-        let last_committed_rounds = match &last_commit {
-            Some(commit) => commit.last_committed_rounds.clone(),
-            None => vec![0; num_authorities],
-        };
 
         let (_, genesis) = Block::genesis(context.clone());
         let genesis = genesis
@@ -72,14 +74,31 @@ impl DagState {
             .map(|block| (block.reference(), block))
             .collect();
 
+        let last_commit = store
+            .read_last_commit()
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+        let last_committed_rounds = {
+            let rounds = store
+                .read_last_committed_rounds()
+                .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+            if rounds.is_empty() {
+                vec![0; num_authorities]
+            } else {
+                rounds
+            }
+        };
+
         let mut state = Self {
             context,
-            recent_blocks: BTreeMap::new(),
-            cached_refs: vec![BTreeSet::new(); num_authorities],
-            last_commit,
-            highest_accepted_round: 0,
-            store,
             genesis,
+            recent_blocks: BTreeMap::new(),
+            recent_refs: vec![BTreeSet::new(); num_authorities],
+            highest_accepted_round: 0,
+            last_commit,
+            last_committed_rounds: last_committed_rounds.clone(),
+            buffered_blocks: vec![],
+            buffered_commits: vec![],
+            store,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
@@ -87,9 +106,9 @@ impl DagState {
             let blocks = state
                 .store
                 .scan_blocks_by_author(authority_index, round.saturating_sub(CACHED_ROUNDS))
-                .unwrap();
+                .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
             for block in blocks {
-                state.accept_block(block);
+                state.update_block_metadata(&block);
             }
         }
 
@@ -98,8 +117,16 @@ impl DagState {
 
     /// Accepts a block into DagState and keeps it in memory.
     pub(crate) fn accept_block(&mut self, block: VerifiedBlock) {
+        assert_ne!(
+            block.round(),
+            0,
+            "Genesis block should not be accepted into DAG."
+        );
+
         let block_ref = block.reference();
-        let block_round = block.round();
+        if self.contains_block(&block_ref) {
+            return;
+        }
 
         // TODO: Move this check to core
         // Ensure we don't write multiple blocks per slot for our own index
@@ -111,9 +138,16 @@ impl DagState {
                 block(s) {existing_blocks:#?} already exists."
             );
         }
-        self.recent_blocks.insert(block_ref, block);
-        self.cached_refs[block_ref.author].insert(block_ref);
-        self.highest_accepted_round = max(self.highest_accepted_round, block_round);
+        self.update_block_metadata(&block);
+        self.buffered_blocks.push(block);
+    }
+
+    /// Updates internal metadata for a block.
+    fn update_block_metadata(&mut self, block: &VerifiedBlock) {
+        let block_ref = block.reference();
+        self.recent_blocks.insert(block_ref, block.clone());
+        self.recent_refs[block_ref.author].insert(block_ref);
+        self.highest_accepted_round = max(self.highest_accepted_round, block.round());
     }
 
     /// Accepts a blocks into DagState and keeps it in memory.
@@ -123,28 +157,52 @@ impl DagState {
         }
     }
 
-    /// Gets a copy of an uncommitted block. Returns None if not found.
-    /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
-    pub(crate) fn get_uncommitted_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
-        self.recent_blocks.get(reference).cloned()
+    /// Gets a block by checking cached recent blocks then storage.
+    /// Returns None when the block is not found.
+    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
+        self.get_blocks(&[*reference]).pop().unwrap()
     }
 
-    /// Gets a copy of the uncommitted blocks. Returns None for each block not found.
-    /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
-    pub(crate) fn get_uncommitted_blocks(
-        &self,
-        references: Vec<BlockRef>,
-    ) -> Vec<Option<VerifiedBlock>> {
-        references
-            .into_iter()
-            .map(|reference| self.recent_blocks.get(&reference).cloned())
-            .collect()
+    /// Gets blocks by checking cached recent blocks in memory then storage.
+    /// An element is None when the corresponding block is not found.
+    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+        let mut blocks = vec![None; block_refs.len()];
+        let mut missing = Vec::new();
+
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if let Some(block) = self.recent_blocks.get(block_ref) {
+                blocks[index] = Some(block.clone());
+            } else {
+                missing.push((index, block_ref));
+            }
+        }
+
+        if missing.is_empty() {
+            return blocks;
+        }
+
+        let missing_refs = missing
+            .iter()
+            .map(|(_, block_ref)| **block_ref)
+            .collect::<Vec<_>>();
+        let store_results = self
+            .store
+            .read_blocks(&missing_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+
+        for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
+            blocks[index] = result;
+        }
+
+        blocks
     }
 
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlock> {
-        // TODO: evauluate if we should panic `if slot.round <= last_commit_round`
+        // TODO: either panic below when the slot is below the last committed round,
+        // or support reading from storage and limit storage usage only to edge cases.
+
         let mut blocks = vec![];
         for (block_ref, block) in self.recent_blocks.range((
             Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
@@ -155,6 +213,8 @@ impl DagState {
         blocks
     }
 
+    /// Gets all uncommitted blocks in a round.
+    /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_blocks_at_round(&self, round: Round) -> Vec<VerifiedBlock> {
         if round <= self.last_commit_round() {
             panic!("Round {} have committed blocks!", round);
@@ -175,24 +235,12 @@ impl DagState {
     }
 
     /// Gets all ancestors in the history of a block at a certain round.
-    /// The round must be higher than the last committed round.
-    pub(crate) fn ancestors_at_uncommitted_round(
+    pub(crate) fn ancestors_at_round(
         &self,
         later_block: &VerifiedBlock,
         earlier_round: Round,
     ) -> Vec<VerifiedBlock> {
-        if earlier_round <= self.last_commit_round() {
-            panic!("Round {} have committed blocks!", earlier_round);
-        }
-        if earlier_round >= later_block.round() {
-            panic!(
-                "Round {} is not earlier than block {}!",
-                earlier_round,
-                later_block.reference()
-            );
-        }
-
-        // Use BTreeSet to iterate through ancestors of later_block in round desc order.
+        // Iterate through ancestors of later_block in round descending order.
         let mut linked: BTreeSet<BlockRef> = later_block.ancestors().iter().cloned().collect();
         while !linked.is_empty() {
             let round = linked.last().unwrap().round;
@@ -201,8 +249,8 @@ impl DagState {
                 break;
             }
             let block_ref = linked.pop_last().unwrap();
-            let Some(block) = self.recent_blocks.get(&block_ref) else {
-                panic!("Block {:?} should be available in memory!", block_ref);
+            let Some(block) = self.get_block(&block_ref) else {
+                panic!("Block {:?} should exist in DAG!", block_ref);
             };
             linked.extend(block.ancestors().iter().cloned());
         }
@@ -216,87 +264,81 @@ impl DagState {
                 Unbounded,
             ))
             .map(|r| {
-                self.recent_blocks
-                    .get(r)
-                    .unwrap_or_else(|| panic!("Block {:?} should be available in memory!", r))
+                self.get_block(r)
+                    .unwrap_or_else(|| panic!("Block {:?} should exist in DAG!", r))
                     .clone()
             })
             .collect()
     }
 
-    /// Returns the requested blocks by looking into the cache first, and for any non found block into the store.
-    pub(crate) fn get_blocks(
-        &self,
-        block_refs: Vec<BlockRef>,
-    ) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
-        let mut blocks = vec![None; block_refs.len()];
-        let mut missing = Vec::new();
-
-        for (index, block_ref) in block_refs.into_iter().enumerate() {
-            if let Some(block) = self.recent_blocks.get(&block_ref) {
-                blocks[index] = Some(block.clone());
-            } else {
-                missing.push((index, block_ref));
-            }
-        }
-
-        if missing.is_empty() {
-            return Ok(blocks);
-        }
-
-        let missing_refs = missing
-            .iter()
-            .map(|(_, block_ref)| *block_ref)
-            .collect::<Vec<_>>();
-        let store_results = self.store.read_blocks(&missing_refs)?;
-
-        for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
-            blocks[index] = result;
-        }
-
-        Ok(blocks)
-    }
-
-    pub(crate) fn contains_block(&self, block_ref: &BlockRef) -> ConsensusResult<bool> {
-        let blocks = self.contains_blocks(vec![*block_ref])?;
-        Ok(blocks.first().cloned().expect("Result should be present"))
+    pub(crate) fn contains_block(&self, block_ref: &BlockRef) -> bool {
+        let blocks = self.contains_blocks(vec![*block_ref]);
+        blocks.first().cloned().unwrap()
     }
 
     /// Checks whether the required blocks are in cache, if exist, or otherwise will check in store. The method is not caching
     /// back the results, so its expensive if keep asking for cache missing blocks.
-    pub(crate) fn contains_blocks(&self, block_refs: Vec<BlockRef>) -> ConsensusResult<Vec<bool>> {
-        let mut blocks = vec![false; block_refs.len()];
+    pub(crate) fn contains_blocks(&self, block_refs: Vec<BlockRef>) -> Vec<bool> {
+        let mut exist = vec![false; block_refs.len()];
         let mut missing = Vec::new();
 
         for (index, block_ref) in block_refs.into_iter().enumerate() {
-            if self.cached_refs[block_ref.author].contains(&block_ref)
+            if self.recent_refs[block_ref.author].contains(&block_ref)
                 || self.genesis.contains_key(&block_ref)
             {
-                blocks[index] = true;
+                exist[index] = true;
             } else {
                 missing.push((index, block_ref));
             }
         }
 
         if missing.is_empty() {
-            return Ok(blocks);
+            return exist;
         }
 
         let missing_refs = missing
             .iter()
             .map(|(_, block_ref)| *block_ref)
             .collect::<Vec<_>>();
-        let store_results = self.store.contains_blocks(&missing_refs)?;
+        let store_results = self
+            .store
+            .contains_blocks(&missing_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
 
         for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
-            blocks[index] = result;
+            exist[index] = result;
         }
 
-        Ok(blocks)
+        exist
     }
 
     pub(crate) fn highest_accepted_round(&self) -> Round {
         self.highest_accepted_round
+    }
+
+    // Buffers a new commit in memory and updates last committed rounds.
+    // REQUIRED: must not skip over any commit index.
+    pub(crate) fn add_commit(&mut self, commit: Commit) {
+        if let Some(last_commit) = &self.last_commit {
+            if commit.index <= last_commit.index {
+                error!(
+                    "New commit index {} <= last commit index {}!",
+                    commit.index, last_commit.index
+                );
+                return;
+            }
+            assert_eq!(commit.index, last_commit.index + 1);
+        } else {
+            assert_eq!(commit.index, 1);
+        }
+        self.last_commit = Some(commit.clone());
+        for block_ref in commit.blocks.iter() {
+            self.last_committed_rounds[block_ref.author] = max(
+                self.last_committed_rounds[block_ref.author],
+                block_ref.round,
+            );
+        }
+        self.buffered_commits.push(commit);
     }
 
     /// Index of the last commit.
@@ -329,26 +371,33 @@ impl DagState {
         }
     }
 
-    // Write commits to store. Commits should be provided in commit order, meaning
-    // the last element in commits is the new last_commit.
-    pub(crate) fn write_commits(
-        &mut self,
-        commits: Vec<Commit>,
-        committed_blocks: Vec<VerifiedBlock>,
-    ) {
-        assert!(!commits.is_empty());
-        let last_commit = commits.last().unwrap().clone();
-        self.store
-            .write(committed_blocks, commits)
-            .expect("Writing commits to store should not fail");
-        self.set_last_commit(last_commit);
-    }
-
-    pub(crate) fn set_last_commit(&mut self, commit: Commit) {
-        if let Some(last_commit) = &self.last_commit {
-            assert!(commit.index >= last_commit.index);
+    /// After each flush, DagState becomes persisted in storage and it expected to recover
+    /// all internal states from stroage after restarts.
+    pub(crate) fn flush(&mut self) {
+        // Flush buffered data to storage.
+        let blocks = std::mem::take(&mut self.buffered_blocks);
+        let commits = std::mem::take(&mut self.buffered_commits);
+        if blocks.is_empty() && commits.is_empty() {
+            return;
         }
-        self.last_commit = Some(commit);
+        self.store
+            .write(blocks, commits, self.last_committed_rounds.clone())
+            .unwrap_or_else(|e| panic!("Failed to write to storage: {:?}", e));
+        // Clean up old cached data. After flushing, all cached blocks are guaranteed to be persisted.
+        for (authority_refs, last_committed_round) in self
+            .recent_refs
+            .iter_mut()
+            .zip(self.last_committed_rounds.iter())
+        {
+            while let Some(block_ref) = authority_refs.first() {
+                if block_ref.round < last_committed_round.saturating_sub(CACHED_ROUNDS) {
+                    self.recent_blocks.remove(block_ref);
+                    authority_refs.pop_first();
+                } else {
+                    break;
+                }
+            }
+        }
     }
 
     /// Highest round where a block is committed, which is last commit's leader round.
@@ -371,7 +420,7 @@ mod test {
     };
 
     #[test]
-    fn get_unncommitted_blocks() {
+    fn get_blocks() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -407,13 +456,13 @@ mod test {
 
         // Check uncommitted blocks that exist.
         for (r, block) in &blocks {
-            assert_eq!(dag_state.get_uncommitted_block(r), Some(block.clone()));
+            assert_eq!(&dag_state.get_block(r).unwrap(), block);
         }
 
         // Check uncommitted blocks that do not exist.
         let last_ref = blocks.keys().last().unwrap();
         assert!(dag_state
-            .get_uncommitted_block(&BlockRef::new(
+            .get_block(&BlockRef::new(
                 last_ref.round,
                 last_ref.author,
                 BlockDigest::MIN
@@ -616,7 +665,7 @@ mod test {
         }
 
         // Check ancestors connected to anchor.
-        let ancestors = dag_state.ancestors_at_uncommitted_round(&anchor, 11);
+        let ancestors = dag_state.ancestors_at_round(&anchor, 11);
         let mut ancestors_refs: Vec<BlockRef> = ancestors.iter().map(|b| b.reference()).collect();
         ancestors_refs.sort();
         let mut expected_refs = vec![
@@ -655,7 +704,7 @@ mod test {
         // Now write in store the blocks from first 4 rounds and the rest to the dag state
         blocks.clone().into_iter().for_each(|block| {
             if block.round() <= 4 {
-                store.write(vec![block], vec![]).unwrap();
+                store.write(vec![block], vec![], vec![]).unwrap();
             } else {
                 dag_state.accept_blocks(vec![block]);
             }
@@ -667,7 +716,7 @@ mod test {
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
-        let result = dag_state.contains_blocks(block_refs.clone()).unwrap();
+        let result = dag_state.contains_blocks(block_refs.clone());
 
         // Ensure everything is found
         let mut expected = vec![true; (num_rounds * num_authorities) as usize];
@@ -678,7 +727,7 @@ mod test {
             3,
             BlockRef::new(11, AuthorityIndex::new_for_test(3), BlockDigest::default()),
         );
-        let result = dag_state.contains_blocks(block_refs).unwrap();
+        let result = dag_state.contains_blocks(block_refs);
 
         // Then all should be found apart from the last one
         expected.insert(3, false);
@@ -707,7 +756,7 @@ mod test {
         // Now write in store the blocks from first 4 rounds and the rest to the dag state
         blocks.clone().into_iter().for_each(|block| {
             if block.round() <= 4 {
-                store.write(vec![block], vec![]).unwrap();
+                store.write(vec![block], vec![], vec![]).unwrap();
             } else {
                 dag_state.accept_blocks(vec![block]);
             }
@@ -719,7 +768,7 @@ mod test {
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
-        let result = dag_state.get_blocks(block_refs.clone()).unwrap();
+        let result = dag_state.get_blocks(&block_refs);
 
         let mut expected = blocks
             .into_iter()
@@ -734,7 +783,7 @@ mod test {
             3,
             BlockRef::new(11, AuthorityIndex::new_for_test(3), BlockDigest::default()),
         );
-        let result = dag_state.get_blocks(block_refs).unwrap();
+        let result = dag_state.get_blocks(&block_refs);
 
         // Then all should be found apart from the last one
         expected.insert(3, None);

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -160,7 +160,9 @@ impl DagState {
     /// Gets a block by checking cached recent blocks then storage.
     /// Returns None when the block is not found.
     pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
-        self.get_blocks(&[*reference]).pop().unwrap()
+        self.get_blocks(&[*reference])
+            .pop()
+            .expect("Exactly one element should be returned")
     }
 
     /// Gets blocks by checking cached recent blocks in memory then storage.
@@ -206,8 +208,8 @@ impl DagState {
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are checked.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlock> {
-        // TODO: either panic below when the slot is below the last committed round,
-        // or support reading from storage and limit storage usage only to edge cases.
+        // TODO: either panic below when the slot is at or below the last committed round,
+        // or support reading from storage while limiting storage reads to edge cases.
 
         let mut blocks = vec![];
         for (block_ref, block) in self.recent_blocks.range((

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -48,8 +48,8 @@ pub(crate) struct NodeMetrics {
     pub invalid_blocks: IntCounterVec,
     pub block_timestamp_drift_wait_ms: IntCounterVec,
     pub broadcaster_rtt_estimate_ms: IntGaugeVec,
-
-    // Commit Metrics
+    pub dag_state_store_read_count: IntCounterVec,
+    pub dag_state_store_write_count: IntCounter,
     pub last_decided_leader_round: IntGauge,
     pub last_committed_leader_round: IntGauge,
     pub decided_leaders_total: IntCounterVec,
@@ -133,8 +133,19 @@ impl NodeMetrics {
                 registry,
             )
             .unwrap(),
-
-            // Commit Metrics
+            dag_state_store_read_count: register_int_counter_vec_with_registry!(
+                "dag_state_store_read_count",
+                "Number of times DagState needs to read from store per operation type",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
+            dag_state_store_write_count: register_int_counter_with_registry!(
+                "dag_state_store_write_count",
+                "Number of times DagState needs to write to store",
+                registry,
+            )
+            .unwrap(),
             last_decided_leader_round: register_int_gauge_with_registry!(
                 "last_decided_leader_round",
                 "The last round where a commit decision was made.",

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -18,7 +18,12 @@ use crate::{
 /// A common interface for consensus storage.
 pub(crate) trait Store: Send + Sync {
     /// Writes blocks and consensus commits to store.
-    fn write(&self, blocks: Vec<VerifiedBlock>, commits: Vec<Commit>) -> ConsensusResult<()>;
+    fn write(
+        &self,
+        blocks: Vec<VerifiedBlock>,
+        commits: Vec<Commit>,
+        last_committed_rounds: Vec<Round>,
+    ) -> ConsensusResult<()>;
 
     /// Reads blocks for the given refs.
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
@@ -46,4 +51,7 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads all commits from start_commit_index.
     fn scan_commits(&self, start_commit_index: CommitIndex) -> ConsensusResult<Vec<Commit>>;
+
+    /// Reads the last committed rounds per authority.
+    fn read_last_committed_rounds(&self) -> ConsensusResult<Vec<Round>>;
 }

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -51,7 +51,7 @@ async fn read_and_contain_blocks(
         VerifiedBlock::new_for_test(TestBlock::new(1, 2).build()),
         VerifiedBlock::new_for_test(TestBlock::new(2, 3).build()),
     ];
-    store.write(written_blocks.clone(), vec![]).unwrap();
+    store.write(written_blocks.clone(), vec![], vec![]).unwrap();
 
     {
         let refs = vec![written_blocks[0].reference()];
@@ -118,7 +118,7 @@ async fn scan_blocks(
         VerifiedBlock::new_for_test(TestBlock::new(13, 2).build()),
         VerifiedBlock::new_for_test(TestBlock::new(13, 1).build()),
     ];
-    store.write(written_blocks.clone(), vec![]).unwrap();
+    store.write(written_blocks.clone(), vec![], vec![]).unwrap();
 
     {
         let scanned_blocks = store
@@ -144,7 +144,9 @@ async fn scan_blocks(
         VerifiedBlock::new_for_test(TestBlock::new(15, 1).build()),
         VerifiedBlock::new_for_test(TestBlock::new(16, 3).build()),
     ];
-    store.write(additional_blocks.clone(), vec![]).unwrap();
+    store
+        .write(additional_blocks.clone(), vec![], vec![])
+        .unwrap();
 
     {
         let scanned_blocks = store
@@ -216,7 +218,9 @@ async fn read_and_scan_commits(
             ..Default::default()
         },
     ];
-    store.write(vec![], written_commits.clone()).unwrap();
+    store
+        .write(vec![], written_commits.clone(), vec![])
+        .unwrap();
 
     {
         let last_commit = store

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -292,7 +292,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want
         // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
         // will take care of that.
-        let _ = core_dispatcher
+        let _missing_blocks = core_dispatcher
             .add_blocks(verified_blocks)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -34,10 +34,7 @@ pub(crate) fn build_dag(
         }
         None => {
             let (_my_genesis_block, genesis) = Block::genesis(context.clone());
-            let references = genesis.iter().map(|x| x.reference()).collect::<Vec<_>>();
-            dag_state.write().accept_blocks(genesis);
-
-            references
+            genesis.iter().map(|x| x.reference()).collect::<Vec<_>>()
         }
     };
 

--- a/consensus/core/src/tests/base_committer_tests.rs
+++ b/consensus/core/src/tests/base_committer_tests.rs
@@ -36,8 +36,8 @@ fn try_direct_commit() {
     let incomplete_wave_leader_round = 6;
     build_dag(context, dag_state, None, voting_round_wave_2);
 
-    // Leader rounds are the first rounds of each wave. In this case rounds 0, 3 & 6.
-    let mut leader_rounds: Vec<u32> = (0..num_rounds_in_dag)
+    // Leader rounds are the first rounds of each wave. In this case rounds 3 & 6.
+    let mut leader_rounds: Vec<u32> = (1..num_rounds_in_dag)
         .map(|r| committer.leader_round(r))
         .collect::<HashSet<_>>()
         .into_iter()
@@ -57,7 +57,7 @@ fn try_direct_commit() {
             if let LeaderStatus::Commit(ref committed_block) = leader_status {
                 assert_eq!(committed_block.author(), leader.authority)
             } else {
-                panic!("Expected a committed leader")
+                panic!("Expected a committed leader at round {}", round)
             };
         } else {
             // The base committer should mark the potential leader in r6 as undecided


### PR DESCRIPTION
## Description 

`DagState::flush()` persists blocks, commits and last committed rounds known to `DagState`. It is efficient in only writing out the delta from the last `flush()` to storage. It must be called before proposing a block to peers, and sending committed blocks to execution.

Additionally,
- When getting blocks by refs, check storage if they are not found in memory.
- Crash on storage errors in DagState, because callers to DagState can only panic on these errors as well.
- Clean up old blocks after each flush.
- Try to propose and commit immediately after Core recovery.

## Test Plan 

Unit tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
