### PR TITLE
[bridge 49/n] use devInpsect to get on chain status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14342,12 +14342,15 @@ name = "test-cluster"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
  "move-binary-format",
  "prometheus",
  "rand 0.8.5",
+ "sui-bridge",
  "sui-config",
  "sui-core",
  "sui-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -581,6 +581,7 @@ sui-analytics-indexer-derive = { path = "crates/sui-analytics-indexer-derive" }
 sui-archival = { path = "crates/sui-archival" }
 sui-authority-aggregation = { path = "crates/sui-authority-aggregation" }
 sui-benchmark = { path = "crates/sui-benchmark" }
+sui-bridge = { path = "crates/sui-bridge" }
 sui-cluster-test = { path = "crates/sui-cluster-test" }
 sui-common = { path = "crates/sui-common" }
 sui-config = { path = "crates/sui-config" }

--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -220,8 +220,8 @@ where
                 true
             }
             // Although theoretically a legit SuiToEthBridgeAction should not have
-            // status `RecordNotFound`
-            BridgeActionStatus::Pending | BridgeActionStatus::RecordNotFound => false,
+            // status `NotFound`
+            BridgeActionStatus::Pending | BridgeActionStatus::NotFound => false,
         }
     }
 
@@ -790,6 +790,9 @@ mod tests {
             Some(sui_tx_event_index),
             None,
             None,
+            None,
+            None,
+            None,
         );
         mock_bridge_authority_signing_errors(
             vec![&mock0, &mock1, &mock2, &mock3],
@@ -962,6 +965,9 @@ mod tests {
         let action = get_test_sui_to_eth_bridge_action(
             Some(sui_tx_digest),
             Some(sui_tx_event_index),
+            None,
+            None,
+            None,
             None,
             None,
         );

--- a/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
+++ b/crates/sui-bridge/src/client/bridge_authority_aggregator.rs
@@ -328,6 +328,9 @@ mod tests {
             Some(sui_tx_event_index),
             Some(nonce),
             Some(amount),
+            None,
+            None,
+            None,
         );
 
         // All authorities return signatures
@@ -422,6 +425,9 @@ mod tests {
             Some(sui_tx_event_index),
             Some(nonce),
             Some(amount),
+            None,
+            None,
+            None,
         );
 
         // Only mock authority 2 and 3 to return signatures, such that if BridgeAuthorityAggregator
@@ -554,6 +560,9 @@ mod tests {
             Some(sui_tx_event_index),
             Some(nonce),
             Some(amount),
+            None,
+            None,
+            None,
         );
 
         let sig_0 = sign_action_with_key(&action, &secrets[0]);

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -193,7 +193,8 @@ mod tests {
 
         let pubkey_bytes = BridgeAuthorityPublicKeyBytes::from(&pubkey);
         let committee = Arc::new(BridgeCommittee::new(vec![authority.clone()]).unwrap());
-        let action = get_test_sui_to_eth_bridge_action(None, Some(1), Some(1), Some(100));
+        let action =
+            get_test_sui_to_eth_bridge_action(None, Some(1), Some(1), Some(100), None, None, None);
 
         // Ok
         let client = BridgeClient::new(pubkey_bytes.clone(), committee).unwrap();
@@ -270,8 +271,15 @@ mod tests {
         let tx_digest = TransactionDigest::random();
         let event_idx = 4;
 
-        let action =
-            get_test_sui_to_eth_bridge_action(Some(tx_digest), Some(event_idx), Some(1), Some(100));
+        let action = get_test_sui_to_eth_bridge_action(
+            Some(tx_digest),
+            Some(event_idx),
+            Some(1),
+            Some(100),
+            None,
+            None,
+            None,
+        );
         let sig = BridgeAuthoritySignInfo::new(&action, &secret);
         let signed_event = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig.clone());
         mock_handler.add_sui_event_response(tx_digest, event_idx, Ok(signed_event.clone()));
@@ -283,8 +291,15 @@ mod tests {
             .unwrap();
 
         // mismatched action would fail, this could happen when the authority fetched the wrong event
-        let action2 =
-            get_test_sui_to_eth_bridge_action(Some(tx_digest), Some(event_idx), Some(2), Some(200));
+        let action2 = get_test_sui_to_eth_bridge_action(
+            Some(tx_digest),
+            Some(event_idx),
+            Some(2),
+            Some(200),
+            None,
+            None,
+            None,
+        );
         let wrong_sig = BridgeAuthoritySignInfo::new(&action2, &secret);
         let wrong_signed_action =
             SignedBridgeAction::new_from_data_and_sig(action2.clone(), wrong_sig.clone());

--- a/crates/sui-bridge/src/crypto.rs
+++ b/crates/sui-bridge/src/crypto.rs
@@ -199,7 +199,7 @@ mod tests {
         let committee = BridgeCommittee::new(vec![authority1.clone(), authority2.clone()]).unwrap();
 
         let action: BridgeAction =
-            get_test_sui_to_eth_bridge_action(None, Some(1), Some(1), Some(100));
+            get_test_sui_to_eth_bridge_action(None, Some(1), Some(1), Some(100), None, None, None);
 
         let sig = BridgeAuthoritySignInfo::new(&action, &secret);
 
@@ -218,7 +218,7 @@ mod tests {
         ));
 
         let mismatched_action: BridgeAction =
-            get_test_sui_to_eth_bridge_action(None, Some(2), Some(3), Some(4));
+            get_test_sui_to_eth_bridge_action(None, Some(2), Some(3), Some(4), None, None, None);
         // Verification should fail - mismatched action
         assert!(matches!(
             verify_signed_bridge_action(
@@ -233,7 +233,7 @@ mod tests {
 
         // Signature is invalid (signed over different message), verification should fail
         let action2: BridgeAction =
-            get_test_sui_to_eth_bridge_action(None, Some(3), Some(5), Some(77));
+            get_test_sui_to_eth_bridge_action(None, Some(3), Some(5), Some(77), None, None, None);
 
         let invalid_sig = BridgeAuthoritySignInfo::new(&action2, &secret);
         let signed_action = SignedBridgeAction::new_from_data_and_sig(action.clone(), invalid_sig);

--- a/crates/sui-bridge/src/server/governance_verifier.rs
+++ b/crates/sui-bridge/src/server/governance_verifier.rs
@@ -91,7 +91,7 @@ mod tests {
         );
 
         // Token transfer action is not allowed
-        let action_4 = get_test_sui_to_eth_bridge_action(None, None, None, None);
+        let action_4 = get_test_sui_to_eth_bridge_action(None, None, None, None, None, None, None);
         assert!(matches!(
             GovernanceVerifier::new(vec![action_1, action_2, action_4.clone()]).unwrap_err(),
             BridgeError::ActionIsNotGovernanceAction(..)

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -362,8 +362,15 @@ mod tests {
             .await;
         assert!(entry_.unwrap().lock().await.is_none());
 
-        let action =
-            get_test_sui_to_eth_bridge_action(Some(sui_tx_digest), Some(sui_event_idx), None, None);
+        let action = get_test_sui_to_eth_bridge_action(
+            Some(sui_tx_digest),
+            Some(sui_event_idx),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         let sig = BridgeAuthoritySignInfo::new(&action, &signer);
         let signed_action = SignedBridgeAction::new_from_data_and_sig(action.clone(), sig);
         entry.lock().await.replace(Ok(signed_action));
@@ -596,7 +603,7 @@ mod tests {
         ));
 
         // Non governace action is not signable
-        let action_4 = get_test_sui_to_eth_bridge_action(None, None, None, None);
+        let action_4 = get_test_sui_to_eth_bridge_action(None, None, None, None, None, None, None);
         assert!(matches!(
             signer_with_cache.sign(action_4.clone()).await.unwrap_err(),
             BridgeError::ActionIsNotGovernanceAction(..)

--- a/crates/sui-bridge/src/storage.rs
+++ b/crates/sui-bridge/src/storage.rs
@@ -151,9 +151,25 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = BridgeOrchestratorTables::new(temp_dir.path());
 
-        let action1 = get_test_sui_to_eth_bridge_action(None, Some(0), Some(99), Some(10000));
+        let action1 = get_test_sui_to_eth_bridge_action(
+            None,
+            Some(0),
+            Some(99),
+            Some(10000),
+            None,
+            None,
+            None,
+        );
 
-        let action2 = get_test_sui_to_eth_bridge_action(None, Some(2), Some(100), Some(10000));
+        let action2 = get_test_sui_to_eth_bridge_action(
+            None,
+            Some(2),
+            Some(100),
+            Some(10000),
+            None,
+            None,
+            None,
+        );
 
         // in the beginning it's empty
         let actions = store.get_all_pending_actions().unwrap();

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -16,6 +16,7 @@ use std::str::from_utf8;
 use std::str::FromStr;
 use std::time::Duration;
 use sui_json_rpc_api::BridgeReadApiClient;
+use sui_json_rpc_types::DevInspectResults;
 use sui_json_rpc_types::{EventFilter, Page, SuiData, SuiEvent};
 use sui_json_rpc_types::{
     EventPage, SuiObjectDataOptions, SuiTransactionBlockResponse,
@@ -25,6 +26,7 @@ use sui_sdk::{SuiClient as SuiSdkClient, SuiClientBuilder};
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::bridge;
+use sui_types::bridge::get_bridge;
 use sui_types::bridge::BridgeCommitteeSummary;
 use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::bridge::BridgeRecordDyanmicField;
@@ -40,8 +42,14 @@ use sui_types::error::UserInputError;
 use sui_types::event;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{Object, Owner};
+use sui_types::transaction::Argument;
+use sui_types::transaction::CallArg;
+use sui_types::transaction::Command;
 use sui_types::transaction::ObjectArg;
+use sui_types::transaction::ProgrammableMoveCall;
+use sui_types::transaction::ProgrammableTransaction;
 use sui_types::transaction::Transaction;
+use sui_types::transaction::TransactionKind;
 use sui_types::TypeTag;
 use sui_types::BRIDGE_PACKAGE_ID;
 use sui_types::SUI_BRIDGE_OBJECT_ID;
@@ -65,7 +73,9 @@ pub struct SuiClient<P> {
     inner: P,
 }
 
-impl SuiClient<SuiSdkClient> {
+pub type SuiBridgeClient = SuiClient<SuiSdkClient>;
+
+impl SuiBridgeClient {
     pub async fn new(rpc_url: &str) -> anyhow::Result<Self> {
         let inner = SuiClientBuilder::default().build(rpc_url).await?;
         let self_ = Self { inner };
@@ -92,6 +102,7 @@ where
         Ok(())
     }
 
+    // TODO(bridge): cache this
     pub async fn get_mutable_bridge_object_arg(&self) -> BridgeResult<ObjectArg> {
         self.inner
             .get_mutable_bridge_object_arg()
@@ -143,6 +154,13 @@ where
         bridge_event
             .try_into_bridge_action(*tx_digest, event_idx)
             .ok_or(BridgeError::BridgeEventNotActionable)
+    }
+
+    pub async fn get_bridge_summary(&self) -> BridgeResult<BridgeSummary> {
+        self.inner
+            .get_bridge_summary()
+            .await
+            .map_err(|e| BridgeError::InternalError(format!("Can't get bridge committee: {e}")))
     }
 
     // TODO: cache this
@@ -201,16 +219,17 @@ where
         action: &BridgeAction,
     ) -> BridgeActionStatus {
         loop {
-            let Ok(Ok(bridge_records_id)) =
-                retry_with_max_elapsed_time!(self.get_bridge_record_id(), Duration::from_secs(30))
-            else {
+            let Ok(Ok(bridge_object_arg)) = retry_with_max_elapsed_time!(
+                self.get_mutable_bridge_object_arg(),
+                Duration::from_secs(30)
+            ) else {
                 // TODO: add metrics and fire alert
-                error!("Failed to get bridge records id");
+                error!("Failed to get bridge object arg");
                 continue;
             };
             let Ok(Ok(status)) = retry_with_max_elapsed_time!(
                 self.inner
-                    .get_token_transfer_action_onchain_status(bridge_records_id, action),
+                    .get_token_transfer_action_onchain_status(bridge_object_arg, action),
                 Duration::from_secs(30)
             ) else {
                 // TODO: add metrics and fire alert
@@ -261,7 +280,7 @@ pub trait SuiClientInner: Send + Sync {
 
     async fn get_token_transfer_action_onchain_status(
         &self,
-        bridge_records_id: ObjectID,
+        bridge_object_arg: ObjectArg,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError>;
 
@@ -320,66 +339,63 @@ impl SuiClientInner for SuiSdkClient {
 
     async fn get_token_transfer_action_onchain_status(
         &self,
-        bridge_records_id: ObjectID,
+        bridge_object_arg: ObjectArg,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {
-        match &action {
-            BridgeAction::SuiToEthBridgeAction(_) | BridgeAction::EthToSuiBridgeAction(_) => (),
-            _ => return Err(BridgeError::ActionIsNotTokenTransferAction),
+        let pt = ProgrammableTransaction {
+            inputs: vec![
+                CallArg::Object(bridge_object_arg),
+                CallArg::Pure(bcs::to_bytes(&(action.chain_id() as u8)).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&action.seq_number()).unwrap()),
+            ],
+            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: BRIDGE_PACKAGE_ID,
+                module: Identifier::new("bridge").unwrap(),
+                function: Identifier::new("get_token_transfer_action_status").unwrap(),
+                type_arguments: vec![],
+                arguments: vec![Argument::Input(0), Argument::Input(1), Argument::Input(2)],
+            }))],
         };
-        let package_id = BRIDGE_PACKAGE_ID;
-        let key = serde_json::json!(
-            {
-                // u64 is represented as string
-                "bridge_seq_num": action.seq_number().to_string(),
-                "message_type": action.action_type() as u8,
-                "source_chain": action.chain_id() as u8,
-            }
-        );
-        let status_object_id = match self
+        let kind = TransactionKind::programmable(pt.clone());
+        let resp = self
             .read_api()
-            .get_dynamic_field_object(
-                bridge_records_id,
-                DynamicFieldName {
-                    type_: TypeTag::from_str(&format!(
-                        "{:?}::message::BridgeMessageKey",
-                        package_id
-                    ))
-                    .unwrap(),
-                    value: key.clone(),
-                },
-            )
-            .await?
-            .into_object()
-        {
-            Ok(object) => object.object_id,
-            Err(SuiObjectResponseError::DynamicFieldNotFound { .. }) => {
-                return Ok(BridgeActionStatus::RecordNotFound)
-            }
-            other => {
-                return Err(BridgeError::Generic(format!(
-                    "Can't get bridge action record dynamic field {:?}: {:?}",
-                    key, other
-                )))
-            }
-        };
-
-        // get_dynamic_field_object does not return bcs, so we have to issue anothe query
-        let bcs_bytes = self
-            .read_api()
-            .get_move_object_bcs(status_object_id)
+            .dev_inspect_transaction_block(SuiAddress::ZERO, kind, None, None, None)
             .await?;
-        let status_object: BridgeRecordDyanmicField = bcs::from_bytes(&bcs_bytes)?;
+        let DevInspectResults {
+            results, effects, ..
+        } = resp;
+        let Some(results) = results else {
+            return Err(BridgeError::Generic(format!(
+                "Can't get token transfer action status (empty results). effects: {:?}",
+                effects
+            )));
+        };
+        let return_values = &results
+            .first()
+            .ok_or(BridgeError::Generic(format!(
+                "Can't get token transfer action status, results: {:?}",
+                results
+            )))?
+            .return_values;
+        let (value_bytes, _type_tag) =
+            return_values.first().ok_or(BridgeError::Generic(format!(
+                "Can't get token transfer action status, results: {:?}",
+                results
+            )))?;
+        let status = bcs::from_bytes::<u8>(value_bytes).map_err(|_e| {
+            BridgeError::Generic(format!(
+                "Can't parse token transfer action status as u8: {:?}",
+                results
+            ))
+        })?;
+        let status = BridgeActionStatus::try_from(status).map_err(|_e| {
+            BridgeError::Generic(format!(
+                "Can't parse token transfer action status as BridgeActionStatus: {:?}",
+                results
+            ))
+        })?;
 
-        if status_object.value.value.claimed {
-            return Ok(BridgeActionStatus::Claimed);
-        }
-
-        if status_object.value.value.verified_signatures.is_some() {
-            return Ok(BridgeActionStatus::Approved);
-        }
-
-        return Ok(BridgeActionStatus::Pending);
+        return Ok(status);
     }
 
     async fn execute_transaction_block_with_effects(
@@ -431,7 +447,8 @@ mod tests {
         events::{EmittedSuiToEthTokenBridgeV1, MoveTokenBridgeEvent},
         sui_mock_client::SuiMockClient,
         test_utils::{
-            bridge_token, get_test_sui_to_eth_bridge_action, mint_tokens, publish_bridge_package,
+            approve_token_bridge_with_validator_secrets, bridge_token,
+            get_test_eth_to_sui_bridge_action, get_test_sui_to_eth_bridge_action,
         },
         types::{BridgeActionType, SuiToEthBridgeAction, TokenId},
     };
@@ -445,6 +462,8 @@ mod tests {
     use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
     use std::{collections::HashSet, str::FromStr};
+    use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+    use sui_sdk::wallet_context;
     use sui_types::bridge::BridgeChainId;
     use test_cluster::TestClusterBuilder;
 
@@ -566,62 +585,118 @@ mod tests {
             .unwrap_err();
     }
 
+    // Test get_action_onchain_status.
+    // Use validator secrets to bridge USDC from Ethereum initially.
+    // TODO: we need an e2e test for this with published solidity contract and committee with BridgeNodes
     #[ignore]
     #[tokio::test]
     async fn test_get_action_onchain_status_for_sui_to_eth_transfer() {
-        let mut test_cluster = TestClusterBuilder::new().build().await;
-        let context = &mut test_cluster.wallet;
-        let sender = context.active_address().unwrap();
-
-        let treasury_caps = publish_bridge_package(context).await;
+        telemetry_subscribers::init_for_testing();
+        let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
+            .with_protocol_version(37.into())
+            .with_epoch_duration_ms(5000)
+            .build_with_bridge()
+            .await;
         let sui_client = SuiClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
             .unwrap();
-        let arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
-        let bridge_records_id = sui_client.get_bridge_record_id().await.unwrap();
+        let bridge_authority_keys = test_cluster.bridge_authority_keys.take().unwrap();
 
-        let action = get_test_sui_to_eth_bridge_action(None, None, None, None);
+        // Return once the bridge committee is initialized. Return immediately if it's already the case.
+        // Otherwise wait until the next epoch. This call should be called after proper bridge committee setup,
+        // such as `build_with_bridge`.
+        // Note: We don't call `sui_client.get_bridge_committee` here because it will err if the committee
+        // is not initialized during the construction of `BridgeCommittee`.
+        let committee = sui_client.get_bridge_summary().await.unwrap().committee;
+        if committee.members.is_empty() {
+            test_cluster.wait_for_epoch(None).await;
+        }
+        let context = &mut test_cluster.wallet;
+        let sender = context.active_address().unwrap();
+        let summary = sui_client.inner.get_bridge_summary().await.unwrap();
+        let usdc_amount = 5000000;
+        let bridge_object_arg = sui_client.get_mutable_bridge_object_arg().await.unwrap();
+
+        // 1. Create a Eth -> Sui Transfer (recipient is sender address), approve with validator secrets and assert its status to be Claimed
+        let action = get_test_eth_to_sui_bridge_action(None, Some(usdc_amount), Some(sender));
+        let usdc_object_ref = approve_token_bridge_with_validator_secrets(
+            context,
+            bridge_object_arg,
+            action.clone(),
+            &bridge_authority_keys,
+            Some(sender),
+        )
+        .await
+        .unwrap();
 
         let status = sui_client
             .inner
-            .get_token_transfer_action_onchain_status(bridge_records_id, &action)
+            .get_token_transfer_action_onchain_status(bridge_object_arg, &action)
             .await
             .unwrap();
-        assert_eq!(status, BridgeActionStatus::RecordNotFound);
+        assert_eq!(status, BridgeActionStatus::Claimed);
 
-        // mint 1000 USDC
-        let amount = 1_000_000_000u64;
-        let (treasury_cap_obj_ref, usdc_coin_obj_ref) = mint_tokens(
+        // 2. Create a Sui -> Eth Transfer, approve with validator secrets and assert its status to be Approved
+        // We need to actually send tokens to bridge to initialize the record.
+        let eth_recv_address = EthAddress::random();
+        let bridge_event = bridge_token(
             context,
-            treasury_caps[&TokenId::USDC],
-            amount,
+            eth_recv_address,
+            usdc_object_ref,
             TokenId::USDC,
+            bridge_object_arg,
         )
         .await;
-
-        let recv_address = EthAddress::random();
-        let bridge_event =
-            bridge_token(context, recv_address, usdc_coin_obj_ref, TokenId::USDC, arg).await;
         assert_eq!(bridge_event.nonce, 0);
         assert_eq!(bridge_event.sui_chain_id, BridgeChainId::SuiLocalTest);
         assert_eq!(bridge_event.eth_chain_id, BridgeChainId::EthLocalTest);
-        assert_eq!(bridge_event.eth_address, recv_address);
+        assert_eq!(bridge_event.eth_address, eth_recv_address);
         assert_eq!(bridge_event.sui_address, sender);
         assert_eq!(bridge_event.token_id, TokenId::USDC);
-        assert_eq!(bridge_event.amount, amount);
+        assert_eq!(bridge_event.amount, usdc_amount);
+
+        let action = get_test_sui_to_eth_bridge_action(
+            None,
+            None,
+            Some(bridge_event.nonce),
+            Some(bridge_event.amount),
+            Some(bridge_event.sui_address),
+            Some(bridge_event.eth_address),
+            Some(TokenId::USDC),
+        );
+        let status = sui_client
+            .inner
+            .get_token_transfer_action_onchain_status(bridge_object_arg, &action)
+            .await
+            .unwrap();
+        // At this point, the record is created and the status is Pending
+        assert_eq!(status, BridgeActionStatus::Pending);
+
+        // Approve it and assert its status to be Approved
+        approve_token_bridge_with_validator_secrets(
+            context,
+            bridge_object_arg,
+            action.clone(),
+            &bridge_authority_keys,
+            None,
+        )
+        .await;
 
         let status = sui_client
             .inner
-            .get_token_transfer_action_onchain_status(bridge_records_id, &action)
+            .get_token_transfer_action_onchain_status(bridge_object_arg, &action)
             .await
             .unwrap();
-        assert_eq!(status, BridgeActionStatus::Pending);
+        assert_eq!(status, BridgeActionStatus::Approved);
 
-        // TODO: run bridge committee and approve the action, then assert status is Approved
-    }
-
-    #[tokio::test]
-    async fn test_get_action_onchain_status_for_eth_to_sui_transfer() {
-        // TODO: init an eth -> sui transfer, run bridge committee, approve the action, then assert status is Approved/Claimed
+        // 3. Create a random action and assert its status as NotFound
+        let action =
+            get_test_sui_to_eth_bridge_action(None, None, Some(100), None, None, None, None);
+        let status = sui_client
+            .inner
+            .get_token_transfer_action_onchain_status(bridge_object_arg, &action)
+            .await
+            .unwrap();
+        assert_eq!(status, BridgeActionStatus::NotFound);
     }
 }

--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -201,7 +201,7 @@ impl SuiClientInner for SuiMockClient {
 
     async fn get_token_transfer_action_onchain_status(
         &self,
-        _bridge_records_id: ObjectID,
+        _bridge_object_arg: ObjectArg,
         action: &BridgeAction,
     ) -> Result<BridgeActionStatus, BridgeError> {
         Ok(self

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -7,7 +7,9 @@ use fastcrypto::traits::ToFromBytes;
 use move_core_types::ident_str;
 use once_cell::sync::OnceCell;
 use sui_types::gas_coin::GAS;
+use sui_types::transaction::CallArg;
 use sui_types::BRIDGE_PACKAGE_ID;
+
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -167,8 +169,9 @@ fn build_token_bridge_approve_transaction(
         ],
     );
 
-    // Unwrap: this should not fail
+    // Unwrap: these should not fail
     let arg_bridge = builder.obj(bridge_object_arg).unwrap();
+    let arg_clock = builder.input(CallArg::CLOCK_IMM).unwrap();
 
     let mut sig_bytes = vec![];
     for (_, sig) in sigs.signatures {
@@ -195,7 +198,7 @@ fn build_token_bridge_approve_transaction(
             sui_types::bridge::BRIDGE_MODULE_NAME.to_owned(),
             ident_str!("claim_and_transfer_token").to_owned(),
             vec![get_sui_token_type_tag(token_type)],
-            vec![arg_bridge, source_chain, seq_num],
+            vec![arg_bridge, arg_clock, source_chain, seq_num],
         );
     }
 
@@ -205,7 +208,7 @@ fn build_token_bridge_approve_transaction(
         client_address,
         vec![*gas_object_ref],
         pt,
-        15_000_000,
+        100_000_000,
         // TODO: use reference gas price
         1500,
     ))

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -5,7 +5,10 @@ use crate::abi::EthToSuiTokenBridgeV1;
 use crate::eth_mock_provider::EthMockProvider;
 use crate::events::SuiBridgeEvent;
 use crate::server::mock_handler::run_mock_server;
-use crate::sui_transaction_builder::get_sui_token_type_tag;
+use crate::sui_transaction_builder::{build_transaction, get_sui_token_type_tag};
+use crate::types::{
+    BridgeCommitteeValiditySignInfo, CertifiedBridgeAction, VerifiedCertifiedBridgeAction,
+};
 use crate::{
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKey, BridgeAuthoritySignInfo},
     events::EmittedSuiToEthTokenBridgeV1,
@@ -28,19 +31,17 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use sui_config::local_ip_utils;
-use sui_json_rpc_types::ObjectChange;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
 use sui_types::bridge::BridgeChainId;
-use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::{base_types::SuiAddress, crypto::get_key_pair, digests::TransactionDigest};
-use sui_types::{BRIDGE_PACKAGE_ID, SUI_BRIDGE_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID};
+use sui_types::{BRIDGE_PACKAGE_ID, SUI_BRIDGE_OBJECT_ID};
 use tokio::task::JoinHandle;
 
 pub const DUMMY_MUTALBE_BRIDGE_OBJECT_ARG: ObjectArg = ObjectArg::SharedObject {
@@ -69,11 +70,15 @@ pub fn get_test_authority_and_key(
     (authority, pubkey, kp)
 }
 
+// TODO: make a builder for this
 pub fn get_test_sui_to_eth_bridge_action(
     sui_tx_digest: Option<TransactionDigest>,
     sui_tx_event_index: Option<u16>,
     nonce: Option<u64>,
     amount: Option<u64>,
+    sender_address: Option<SuiAddress>,
+    recipient_address: Option<EthAddress>,
+    token_id: Option<TokenId>,
 ) -> BridgeAction {
     BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
         sui_tx_digest: sui_tx_digest.unwrap_or_else(TransactionDigest::random),
@@ -81,11 +86,31 @@ pub fn get_test_sui_to_eth_bridge_action(
         sui_bridge_event: EmittedSuiToEthTokenBridgeV1 {
             nonce: nonce.unwrap_or_default(),
             sui_chain_id: BridgeChainId::SuiLocalTest,
-            sui_address: SuiAddress::random_for_testing_only(),
+            sui_address: sender_address.unwrap_or_else(SuiAddress::random_for_testing_only),
             eth_chain_id: BridgeChainId::EthLocalTest,
-            eth_address: EthAddress::random(),
-            token_id: TokenId::Sui,
+            eth_address: recipient_address.unwrap_or_else(EthAddress::random),
+            token_id: token_id.unwrap_or(TokenId::USDC),
             amount: amount.unwrap_or(100_000),
+        },
+    })
+}
+
+pub fn get_test_eth_to_sui_bridge_action(
+    nonce: Option<u64>,
+    amount: Option<u64>,
+    sui_address: Option<SuiAddress>,
+) -> BridgeAction {
+    BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
+        eth_tx_hash: TxHash::random(),
+        eth_event_index: 0,
+        eth_bridge_event: EthToSuiTokenBridgeV1 {
+            eth_chain_id: BridgeChainId::EthLocalTest,
+            nonce: nonce.unwrap_or_default(),
+            sui_chain_id: BridgeChainId::SuiLocalTest,
+            token_id: TokenId::USDC,
+            amount: amount.unwrap_or(100_000),
+            sui_address: sui_address.unwrap_or_else(SuiAddress::random_for_testing_only),
+            eth_address: EthAddress::random(),
         },
     })
 }
@@ -252,121 +277,6 @@ pub fn get_test_log_and_action(
     (log, bridge_action)
 }
 
-pub async fn publish_bridge_package(context: &WalletContext) -> BTreeMap<TokenId, ObjectRef> {
-    let (sender, gas_object) = context.get_one_gas_object().await.unwrap().unwrap();
-    let gas_price = context.get_reference_gas_price().await.unwrap();
-
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend(["..", "..", "examples", "move", "bridge"]);
-
-    let txn = context.sign_transaction(
-        &TestTransactionBuilder::new(sender, gas_object, gas_price)
-            .publish(path)
-            .build(),
-    );
-    let resp = context.execute_transaction_must_succeed(txn).await;
-    let object_changes = resp.object_changes.unwrap();
-    let _package_id = object_changes
-        .iter()
-        .find(|change| matches!(change, ObjectChange::Published { .. }))
-        .map(|change| change.object_id())
-        .unwrap();
-
-    let mut treasury_caps = BTreeMap::new();
-    object_changes.iter().for_each(|change| {
-        if let ObjectChange::Created { object_type, .. } = change {
-            let object_type_str = object_type.to_string();
-            if object_type_str.contains("TreasuryCap") {
-                if object_type_str.contains("BTC") {
-                    treasury_caps.insert(TokenId::BTC, change.object_ref());
-                } else if object_type_str.contains("ETH") {
-                    treasury_caps.insert(TokenId::ETH, change.object_ref());
-                } else if object_type_str.contains("USDC") {
-                    treasury_caps.insert(TokenId::USDC, change.object_ref());
-                } else if object_type_str.contains("USDT") {
-                    treasury_caps.insert(TokenId::USDT, change.object_ref());
-                }
-            }
-        }
-    });
-
-    let _root_bridge_object_ref = object_changes
-        .iter()
-        .find(|change| match change {
-            ObjectChange::Created {
-                object_type, owner, ..
-            } => {
-                object_type.to_string().contains("Bridge") && matches!(owner, Owner::Shared { .. })
-            }
-            _ => false,
-        })
-        .map(|change| change.object_ref())
-        .unwrap();
-
-    let bridge_inner_object_ref = object_changes
-        .iter()
-        .find(|change| match change {
-            ObjectChange::Created { object_type, .. } => {
-                object_type.to_string().contains("BridgeInner")
-            }
-            _ => false,
-        })
-        .map(|change| change.object_ref())
-        .unwrap();
-
-    let client = context.get_client().await.unwrap();
-    let bcs_bytes = client
-        .read_api()
-        .get_move_object_bcs(bridge_inner_object_ref.0)
-        .await
-        .unwrap();
-    let bridge_inner_object: BridgeInnerDynamicField = bcs::from_bytes(&bcs_bytes).unwrap();
-    let _bridge_record_id = bridge_inner_object.value.bridge_records.id;
-
-    treasury_caps
-}
-
-pub async fn mint_tokens(
-    context: &mut WalletContext,
-    treasury_cap_ref: ObjectRef,
-    amount: u64,
-    token_id: TokenId,
-) -> (ObjectRef, ObjectRef) {
-    let rgp = context.get_reference_gas_price().await.unwrap();
-    let sender = context.active_address().unwrap();
-    let gas_obj_ref = context.get_one_gas_object().await.unwrap().unwrap().1;
-    let tx = TestTransactionBuilder::new(sender, gas_obj_ref, rgp)
-        .move_call(
-            SUI_FRAMEWORK_PACKAGE_ID,
-            "coin",
-            "mint_and_transfer",
-            vec![
-                CallArg::Object(ObjectArg::ImmOrOwnedObject(treasury_cap_ref)),
-                CallArg::Pure(bcs::to_bytes(&amount).unwrap()),
-                CallArg::Pure(sender.to_vec()),
-            ],
-        )
-        .with_type_args(vec![get_sui_token_type_tag(token_id)])
-        .build();
-    let signed_tn = context.sign_transaction(&tx);
-    let resp = context.execute_transaction_must_succeed(signed_tn).await;
-    let object_changes = resp.object_changes.unwrap();
-
-    let treasury_cap_obj_ref = object_changes
-        .iter()
-        .find(|change| matches!(change, ObjectChange::Mutated { object_type, .. } if object_type.to_string().contains("TreasuryCap")))
-        .map(|change| change.object_ref())
-        .unwrap();
-
-    let minted_coin_obj_ref = object_changes
-        .iter()
-        .find(|change| matches!(change, ObjectChange::Created { .. }))
-        .map(|change| change.object_ref())
-        .unwrap();
-
-    (treasury_cap_obj_ref, minted_coin_obj_ref)
-}
-
 pub async fn bridge_token(
     context: &mut WalletContext,
     recv_address: EthAddress,
@@ -403,4 +313,74 @@ pub async fn bridge_token(
     match bridge_events.remove(0) {
         SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => event,
     }
+}
+
+/// Returns a VerifiedCertifiedBridgeAction with signatures from the given
+/// BridgeAction and BridgeAuthorityKeyPair
+pub fn get_certified_action_with_validator_secrets(
+    action: BridgeAction,
+    secrets: &Vec<BridgeAuthorityKeyPair>,
+) -> VerifiedCertifiedBridgeAction {
+    let mut sigs = BTreeMap::new();
+    for secret in secrets {
+        let signed_action = sign_action_with_key(&action, secret);
+        sigs.insert(secret.public().into(), signed_action.into_sig().signature);
+    }
+    let certified_action = CertifiedBridgeAction::new_from_data_and_sig(
+        action,
+        BridgeCommitteeValiditySignInfo { signatures: sigs },
+    );
+    VerifiedCertifiedBridgeAction::new_from_verified(certified_action)
+}
+
+/// Approve a bridge action with the given validator secrets. Return the
+/// newly created token object reference if `expected_token_receiver` is Some
+/// (only relevant when the action is eth -> Sui transfer),
+/// Otherwise return None.
+/// Note: for sui -> eth transfers, the actual deposit needs to be recorded.
+/// Use `bridge_token` to do it.
+// TODO(bridge): It appears this function is very slow (particularly, `execute_transaction_must_succeed`).
+// Investigate why.
+pub async fn approve_token_bridge_with_validator_secrets(
+    wallet_context: &mut WalletContext,
+    bridge_obj_org: ObjectArg,
+    // TODO: add `token_recipient()` for `BridgeAction` so we don't need `expected_token_receiver`
+    action: BridgeAction,
+    validator_secrets: &Vec<BridgeAuthorityKeyPair>,
+    // Only relevant for eth -> sui transfers when token will be dropped to the recipient
+    expected_token_receiver: Option<SuiAddress>,
+) -> Option<ObjectRef> {
+    let action_certificate = get_certified_action_with_validator_secrets(action, validator_secrets);
+    let sui_address = wallet_context.active_address().unwrap();
+    let gas_obj_ref = wallet_context
+        .get_one_gas_object()
+        .await
+        .unwrap()
+        .unwrap()
+        .1;
+    let tx_data = build_transaction(
+        sui_address,
+        &gas_obj_ref,
+        action_certificate,
+        bridge_obj_org,
+    )
+    .unwrap();
+    let signed_tx = wallet_context.sign_transaction(&tx_data);
+    let resp = wallet_context
+        .execute_transaction_must_succeed(signed_tx)
+        .await;
+
+    // If `expected_token_receiver` is None, return
+    expected_token_receiver?;
+
+    let expected_token_receiver = expected_token_receiver.unwrap();
+    for created in resp.effects.unwrap().created() {
+        if created.owner == Owner::AddressOwner(expected_token_receiver) {
+            return Some(created.reference.to_object_ref());
+        }
+    }
+    panic!(
+        "Didn't find the creted object owned by {}",
+        expected_token_receiver
+    );
 }

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -193,12 +193,13 @@ pub enum TokenId {
     USDT = 4,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum BridgeActionStatus {
-    RecordNotFound,
-    Pending,
-    Approved,
-    Claimed,
+    Pending = 0,
+    Approved = 1,
+    Claimed = 2,
+    NotFound = 3,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -229,6 +229,14 @@ impl BridgeTrait for BridgeInnerV1 {
                     .into_iter()
                     .map(|e| (e.key, e.value))
                     .collect(),
+                member_registration: self
+                    .committee
+                    .member_registrations
+                    .contents
+                    .into_iter()
+                    .map(|e| (e.key, e.value))
+                    .collect(),
+                last_committee_update_epoch: self.committee.last_committee_update_epoch,
             },
             bridge_records_id: self.bridge_records.id,
             is_frozen: self.frozen,
@@ -250,7 +258,10 @@ pub struct MoveTypeBridgeCommittee {
     pub last_committee_update_epoch: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+/// Rust version of the Move committee::CommitteeMemberRegistration type.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct MoveTypeCommitteeMemberRegistration {
     pub sui_address: SuiAddress,
     pub bridge_pubkey_bytes: Vec<u8>,
@@ -262,6 +273,8 @@ pub struct MoveTypeCommitteeMemberRegistration {
 #[serde(rename_all = "camelCase")]
 pub struct BridgeCommitteeSummary {
     pub members: Vec<(Vec<u8>, MoveTypeCommitteeMember)>,
+    pub member_registration: Vec<(SuiAddress, MoveTypeCommitteeMemberRegistration)>,
+    pub last_committee_update_epoch: u64,
 }
 
 /// Rust version of the Move committee::CommitteeMember type.

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+bcs.workspace = true
+fastcrypto.workspace = true
 futures.workspace = true
 tracing.workspace = true
 jsonrpsee.workspace = true
@@ -19,12 +21,14 @@ sui-framework.workspace = true
 sui-swarm-config.workspace = true
 sui-json-rpc.workspace = true
 sui-json-rpc-types.workspace = true
+sui-json-rpc-api.workspace = true
 sui-node.workspace = true
 sui-protocol-config.workspace = true
 sui-swarm.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
 prometheus.workspace = true
 sui-keys.workspace = true
+sui-bridge.workspace = true
 sui-sdk.workspace = true
 sui-test-transaction-builder.workspace = true
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::traits::ToFromBytes;
 use futures::{future::join_all, StreamExt};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::WsClient;
@@ -10,15 +11,20 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use sui_bridge::crypto::BridgeAuthorityKeyPair;
 use sui_config::node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange};
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{NodeConfig, PersistedConfig, SUI_KEYSTORE_FILENAME};
 use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_client::NetworkAuthorityClient;
+use sui_json_rpc_api::BridgeReadApiClient;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_json_rpc_types::{
-    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, TransactionFilter,
+    SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+    TransactionFilter,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_node::SuiNodeHandle;
@@ -38,8 +44,12 @@ use sui_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConf
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ConciseableName;
 use sui_types::base_types::{AuthorityName, ObjectID, ObjectRef, SuiAddress};
+use sui_types::bridge::get_bridge_obj_initial_shared_version;
+use sui_types::bridge::BridgeSummary;
+use sui_types::bridge::BRIDGE_MODULE_NAME;
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::{Committee, EpochId};
+use sui_types::crypto::get_key_pair;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -47,12 +57,18 @@ use sui_types::error::SuiResult;
 use sui_types::governance::MIN_VALIDATOR_JOINING_STAKE_MIST;
 use sui_types::message_envelope::Message;
 use sui_types::object::Object;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::SuiSystemStateTrait;
+use sui_types::transaction::CallArg;
 use sui_types::transaction::{
-    CertifiedTransaction, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+    CertifiedTransaction, ObjectArg, Transaction, TransactionData, TransactionDataAPI,
+    TransactionKind,
 };
+use sui_types::Identifier;
+use sui_types::BRIDGE_PACKAGE_ID;
+use sui_types::SUI_BRIDGE_OBJECT_ID;
 use tokio::time::{timeout, Instant};
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info};
@@ -96,6 +112,8 @@ pub struct TestCluster {
     pub swarm: Swarm,
     pub wallet: WalletContext,
     pub fullnode_handle: FullNodeHandle,
+
+    pub bridge_authority_keys: Option<Vec<BridgeAuthorityKeyPair>>,
 }
 
 impl TestCluster {
@@ -998,7 +1016,124 @@ impl TestClusterBuilder {
             swarm,
             wallet,
             fullnode_handle,
+            bridge_authority_keys: None,
         }
+    }
+
+    pub async fn build_with_bridge(self) -> TestCluster {
+        let mut test_cluster = self.build().await;
+        let ref_gas_price = test_cluster.get_reference_gas_price().await;
+        let bridge_shared_version = get_bridge_obj_initial_shared_version(
+            test_cluster
+                .fullnode_handle
+                .sui_node
+                .state()
+                .get_object_store(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let mut bridge_authority_keys = vec![];
+
+        // Register bridge authorities
+        let mut tasks = vec![];
+        for node in test_cluster.swarm.active_validators() {
+            let validator_address = node.config.sui_address();
+            // 1, send some gas to validator
+            let sender = test_cluster.get_address_0();
+            let tx = test_cluster
+                .test_transaction_builder_with_sender(sender)
+                .await
+                .transfer_sui(Some(1000000000), validator_address)
+                .build();
+            let response = test_cluster.sign_and_execute_transaction(&tx).await;
+            assert_eq!(
+                &SuiExecutionStatus::Success,
+                response.effects.unwrap().status()
+            );
+
+            // 2, create committee registration tx
+            let coins = test_cluster
+                .sui_client()
+                .coin_read_api()
+                .get_coins(validator_address, None, None, None)
+                .await
+                .unwrap();
+            let gas = coins.data.first().unwrap();
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let bridge = builder
+                .obj(ObjectArg::SharedObject {
+                    id: SUI_BRIDGE_OBJECT_ID,
+                    initial_shared_version: bridge_shared_version,
+                    mutable: true,
+                })
+                .unwrap();
+            let system_state = builder.obj(ObjectArg::SUI_SYSTEM_MUT).unwrap();
+            let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+            let pub_key = kp.public().as_bytes().to_vec();
+            bridge_authority_keys.push(kp);
+            let bridge_pubkey = builder
+                .input(CallArg::Pure(bcs::to_bytes(&pub_key).unwrap()))
+                .unwrap();
+            let url = builder
+                .input(CallArg::Pure(
+                    bcs::to_bytes("bridge_test_url".as_bytes()).unwrap(),
+                ))
+                .unwrap();
+
+            builder.programmable_move_call(
+                BRIDGE_PACKAGE_ID,
+                BRIDGE_MODULE_NAME.into(),
+                Identifier::from_str("committee_registration").unwrap(),
+                vec![],
+                vec![bridge, system_state, bridge_pubkey, url],
+            );
+
+            let data = TransactionData::new_programmable(
+                validator_address,
+                vec![gas.object_ref()],
+                builder.finish(),
+                1000000000,
+                ref_gas_price,
+            );
+
+            let tx = Transaction::from_data_and_signer(
+                data,
+                vec![node.config.account_key_pair.keypair()],
+            );
+            tasks.push(
+                test_cluster
+                    .sui_client()
+                    .quorum_driver_api()
+                    .execute_transaction_block(
+                        tx,
+                        SuiTransactionBlockResponseOptions::new().with_effects(),
+                        None,
+                    ),
+            );
+        }
+        // The tx may fail if a member tries to register when the committee is already finalized.
+        // In that case, we just need to check the committee members is not empty since once
+        // the committee is finalized, it should not be empty.
+        let responses = join_all(tasks).await;
+        let mut has_failure = false;
+        for response in responses {
+            if response.unwrap().effects.unwrap().status() != &SuiExecutionStatus::Success {
+                has_failure = true;
+            }
+        }
+        if has_failure {
+            let bridge_summary: BridgeSummary = test_cluster
+                .sui_client()
+                .http()
+                .get_latest_bridge()
+                .await
+                .unwrap();
+            assert_ne!(bridge_summary.committee.members.len(), 0);
+        }
+
+        test_cluster.bridge_authority_keys = Some(bridge_authority_keys);
+        test_cluster
     }
 
     /// Start a Swarm and set up WalletConfig


### PR DESCRIPTION
## Description 

reimplement `get_token_transfer_action_onchain_status` with dev_inspect

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
