### PR TITLE
[bridge 48/n] types: introduce a few more constants and move things to sui-types/bridge.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13891,6 +13891,7 @@ dependencies = [
  "nonempty",
  "num-bigint 0.4.4",
  "num-traits",
+ "num_enum 0.6.1",
  "once_cell",
  "prometheus",
  "proptest",

--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{BridgeError, BridgeResult};
 use crate::types::{BridgeAction, EthToSuiBridgeAction};
-use crate::types::{BridgeChainId, EthLog, TokenId};
+use crate::types::{EthLog, TokenId};
 use ethers::{
     abi::RawLog,
     contract::{abigen, EthLogDecode},
@@ -11,6 +11,7 @@ use ethers::{
 };
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::SuiAddress;
+use sui_types::bridge::BridgeChainId;
 
 // TODO: write a macro to handle variants
 

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -167,22 +167,22 @@ impl BridgeClient {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::test_utils::run_mock_bridge_server;
     use crate::{
         abi::EthToSuiTokenBridgeV1,
         crypto::BridgeAuthoritySignInfo,
         events::EmittedSuiToEthTokenBridgeV1,
         server::mock_handler::BridgeRequestMockHandler,
         test_utils::{get_test_authority_and_key, get_test_sui_to_eth_bridge_action},
-        types::{BridgeChainId, SignedBridgeAction, TokenId},
+        types::{SignedBridgeAction, TokenId},
     };
+    use ethers::types::Address as EthAddress;
+    use ethers::types::TxHash;
     use fastcrypto::hash::{HashFunction, Keccak256};
     use fastcrypto::traits::KeyPair;
     use prometheus::Registry;
-
-    use super::*;
-    use crate::test_utils::run_mock_bridge_server;
-    use ethers::types::Address as EthAddress;
-    use ethers::types::TxHash;
+    use sui_types::bridge::BridgeChainId;
     use sui_types::{base_types::SuiAddress, crypto::get_key_pair, digests::TransactionDigest};
 
     #[tokio::test]

--- a/crates/sui-bridge/src/crypto.rs
+++ b/crates/sui-bridge/src/crypto.rs
@@ -171,15 +171,14 @@ mod tests {
     use crate::events::EmittedSuiToEthTokenBridgeV1;
     use crate::test_utils::{get_test_authority_and_key, get_test_sui_to_eth_bridge_action};
     use crate::types::SignedBridgeAction;
-    use crate::types::{
-        BridgeAction, BridgeAuthority, BridgeChainId, SuiToEthBridgeAction, TokenId,
-    };
+    use crate::types::{BridgeAction, BridgeAuthority, SuiToEthBridgeAction, TokenId};
     use ethers::types::Address as EthAddress;
     use fastcrypto::traits::{KeyPair, ToFromBytes};
     use prometheus::Registry;
     use std::str::FromStr;
     use std::sync::Arc;
     use sui_types::base_types::SuiAddress;
+    use sui_types::bridge::BridgeChainId;
     use sui_types::crypto::get_key_pair;
     use sui_types::digests::TransactionDigest;
 

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -12,7 +12,6 @@ use crate::error::BridgeError;
 use crate::error::BridgeResult;
 use crate::types::BridgeAction;
 use crate::types::BridgeActionType;
-use crate::types::BridgeChainId;
 use crate::types::SuiToEthBridgeAction;
 use crate::types::TokenId;
 use ethers::types::Address as EthAddress;
@@ -23,6 +22,8 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::SuiAddress;
+use sui_types::bridge::BridgeChainId;
+
 use sui_types::digests::TransactionDigest;
 use sui_types::BRIDGE_PACKAGE_ID;
 
@@ -196,7 +197,6 @@ pub mod tests {
     use super::MoveTokenBridgeEvent;
     use crate::types::BridgeAction;
     use crate::types::BridgeActionType;
-    use crate::types::BridgeChainId;
     use crate::types::SuiToEthBridgeAction;
     use crate::types::TokenId;
     use ethers::types::Address as EthAddress;
@@ -205,6 +205,7 @@ pub mod tests {
     use sui_json_rpc_types::SuiEvent;
     use sui_types::base_types::ObjectID;
     use sui_types::base_types::SuiAddress;
+    use sui_types::bridge::BridgeChainId;
     use sui_types::digests::TransactionDigest;
     use sui_types::event::EventID;
     use sui_types::Identifier;

--- a/crates/sui-bridge/src/server/governance_verifier.rs
+++ b/crates/sui-bridge/src/server/governance_verifier.rs
@@ -51,10 +51,9 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::get_test_sui_to_eth_bridge_action,
-        types::{
-            BridgeAction, BridgeChainId, EmergencyAction, EmergencyActionType, LimitUpdateAction,
-        },
+        types::{BridgeAction, EmergencyAction, EmergencyActionType, LimitUpdateAction},
     };
+    use sui_types::bridge::BridgeChainId;
 
     #[tokio::test]
     async fn test_governance_verifier() {

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -329,12 +329,12 @@ mod tests {
             get_test_log_and_action, get_test_sui_to_eth_bridge_action, mock_last_finalized_block,
         },
         types::{
-            BridgeActionType, BridgeChainId, EmergencyAction, EmergencyActionType,
-            LimitUpdateAction, TokenId,
+            BridgeActionType, EmergencyAction, EmergencyActionType, LimitUpdateAction, TokenId,
         },
     };
     use ethers::types::{Address as EthAddress, TransactionReceipt};
     use sui_json_rpc_types::SuiEvent;
+    use sui_types::bridge::BridgeChainId;
     use sui_types::{base_types::SuiAddress, crypto::get_key_pair};
 
     #[tokio::test]

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     server::handler::{BridgeRequestHandler, BridgeRequestHandlerTrait},
     types::{
         AssetPriceUpdateAction, BlocklistCommitteeAction, BlocklistType, BridgeAction,
-        BridgeChainId, EmergencyAction, EmergencyActionType, EvmContractUpgradeAction,
-        LimitUpdateAction, SignedBridgeAction, TokenId,
+        EmergencyAction, EmergencyActionType, EvmContractUpgradeAction, LimitUpdateAction,
+        SignedBridgeAction, TokenId,
     },
 };
 use axum::{
@@ -25,6 +25,7 @@ use fastcrypto::{
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
+use sui_types::bridge::BridgeChainId;
 
 pub mod governance_verifier;
 pub mod handler;

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -433,7 +433,7 @@ mod tests {
         test_utils::{
             bridge_token, get_test_sui_to_eth_bridge_action, mint_tokens, publish_bridge_package,
         },
-        types::{BridgeActionType, BridgeChainId, SuiToEthBridgeAction, TokenId},
+        types::{BridgeActionType, SuiToEthBridgeAction, TokenId},
     };
     use ethers::{
         abi::Token,
@@ -445,6 +445,7 @@ mod tests {
     use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
     use std::{collections::HashSet, str::FromStr};
+    use sui_types::bridge::BridgeChainId;
     use test_cluster::TestClusterBuilder;
 
     use super::*;

--- a/crates/sui-bridge/src/test_utils.rs
+++ b/crates/sui-bridge/src/test_utils.rs
@@ -11,7 +11,7 @@ use crate::{
     events::EmittedSuiToEthTokenBridgeV1,
     server::mock_handler::BridgeRequestMockHandler,
     types::{
-        BridgeAction, BridgeAuthority, BridgeChainId, EthToSuiBridgeAction, SignedBridgeAction,
+        BridgeAction, BridgeAuthority, EthToSuiBridgeAction, SignedBridgeAction,
         SuiToEthBridgeAction, TokenId,
     },
 };
@@ -35,6 +35,7 @@ use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SequenceNumber;
+use sui_types::bridge::BridgeChainId;
 use sui_types::bridge::BridgeInnerDynamicField;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -19,6 +19,9 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 use std::collections::{BTreeMap, BTreeSet};
+use sui_types::bridge::{
+    BridgeChainId, BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER, BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER,
+};
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::StakeUnit;
 use sui_types::digests::{Digest, TransactionDigest};
@@ -54,8 +57,8 @@ pub struct BridgeCommittee {
 impl BridgeCommittee {
     pub fn new(members: Vec<BridgeAuthority>) -> BridgeResult<Self> {
         let mut members_map = BTreeMap::new();
-        let mut total_stake = 0;
         let mut total_blocklisted_stake = 0;
+        let mut total_stake = 0;
         for member in members {
             let public_key = BridgeAuthorityPublicKeyBytes::from(&member.pubkey);
             if members_map.contains_key(&public_key) {
@@ -64,16 +67,21 @@ impl BridgeCommittee {
                 ));
             }
             // TODO: should we disallow identical network addresses?
-            total_stake += member.voting_power;
             if member.is_blocklisted {
                 total_blocklisted_stake += member.voting_power;
             }
+            total_stake += member.voting_power;
             members_map.insert(public_key, member);
         }
-        if total_stake != BRIDGE_AUTHORITY_TOTAL_VOTING_POWER {
-            return Err(BridgeError::InvalidBridgeCommittee(
-                "Total voting power does not equal to 10000".into(),
-            ));
+        if total_stake < BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER {
+            return Err(BridgeError::InvalidBridgeCommittee(format!(
+                "Total voting power is below minimal {BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER}"
+            )));
+        }
+        if total_stake > BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER {
+            return Err(BridgeError::InvalidBridgeCommittee(format!(
+                "Total voting power is above maximal {BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER}"
+            )));
         }
         Ok(Self {
             members: members_map,
@@ -162,19 +170,6 @@ pub const SUI_TX_DIGEST_LENGTH: usize = 32;
 pub const ETH_TX_HASH_LENGTH: usize = 32;
 
 pub const BRIDGE_MESSAGE_PREFIX: &[u8] = b"SUI_BRIDGE_MESSAGE";
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Hash)]
-#[repr(u8)]
-pub enum BridgeChainId {
-    SuiMainnet = 0,
-    SuiTestnet = 1,
-    SuiDevnet = 2,
-    SuiLocalTest = 3,
-
-    EthMainnet = 10,
-    EthSepolia = 11,
-    EthLocalTest = 12,
-}
 
 #[derive(
     Copy,
@@ -1145,16 +1140,16 @@ mod tests {
 
     #[test]
     fn test_bridge_committee_construction() -> anyhow::Result<()> {
-        let (mut authority, _, _) = get_test_authority_and_key(10000, 9999);
+        let (mut authority, _, _) = get_test_authority_and_key(8000, 9999);
         // This is ok
         let _ = BridgeCommittee::new(vec![authority.clone()]).unwrap();
 
-        // This is not ok - total voting power != 10000
-        authority.voting_power = 9999;
+        // This is not ok - total voting power < BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER
+        authority.voting_power = BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER - 1;
         let _ = BridgeCommittee::new(vec![authority.clone()]).unwrap_err();
 
-        // This is not ok - total voting power != 10000
-        authority.voting_power = 10001;
+        // This is not ok - total voting power > BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER
+        authority.voting_power = BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER + 1;
         let _ = BridgeCommittee::new(vec![authority.clone()]).unwrap_err();
 
         // This is ok

--- a/crates/sui-e2e-tests/tests/bridge_tests.rs
+++ b/crates/sui-e2e-tests/tests/bridge_tests.rs
@@ -65,7 +65,7 @@ async fn test_committee_registration() {
     telemetry_subscribers::init_for_testing();
     let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
         .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(20000)
         .build()
         .await;
     let ref_gas_price = test_cluster.get_reference_gas_price().await;

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -22,7 +22,7 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::base_types::{
     ExecutionDigests, ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxContext,
 };
-use sui_types::bridge::{BRIDGE_CREATE_FUNCTION_NAME, BRIDGE_MODULE_NAME};
+use sui_types::bridge::{BridgeChainId, BRIDGE_CREATE_FUNCTION_NAME, BRIDGE_MODULE_NAME};
 use sui_types::committee::Committee;
 use sui_types::crypto::{
     AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignInfoTrait,
@@ -1130,8 +1130,9 @@ pub fn generate_genesis_system_object(
             let bridge_uid = builder
                 .input(CallArg::Pure(UID::new(SUI_BRIDGE_OBJECT_ID).to_bcs_bytes()))
                 .unwrap();
-            // Hardcoding chain id to devnet
-            let bridge_chain_id = builder.pure(2u8).unwrap();
+            // TODO(bridge): this needs to be passed in as a parameter for next testnet regenesis
+            // Hardcoding chain id to SuiLocalTest
+            let bridge_chain_id = builder.pure(BridgeChainId::SuiLocalTest).unwrap();
             builder.programmable_move_call(
                 BRIDGE_ADDRESS.into(),
                 BRIDGE_MODULE_NAME.to_owned(),

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -13,6 +13,7 @@ bincode.workspace = true
 bcs.workspace = true
 byteorder.workspace = true
 consensus-config.workspace = true
+num_enum.workspace = true
 im.workspace = true
 itertools.workspace = true
 nonempty.workspace = true

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -4,6 +4,7 @@
 use enum_dispatch::enum_dispatch;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
+use num_enum::TryFromPrimitive;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -37,6 +38,22 @@ pub const BRIDGE_CREATE_FUNCTION_NAME: &IdentStr = ident_str!("create");
 pub const BRIDGE_INIT_COMMITTEE_FUNCTION_NAME: &IdentStr = ident_str!("init_bridge_committee");
 
 pub const BRIDGE_SUPPORTED_ASSET: &[&str] = &["btc", "eth", "usdc", "usdt"];
+
+pub const BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER: u64 = 7500; // out of 10000 (75%)
+pub const BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER: u64 = 10000; // (100%)
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Hash)]
+#[repr(u8)]
+pub enum BridgeChainId {
+    SuiMainnet = 0,
+    SuiTestnet = 1,
+    SuiDevnet = 2,
+    SuiLocalTest = 3,
+
+    EthMainnet = 10,
+    EthSepolia = 11,
+    EthLocalTest = 12,
+}
 
 pub fn get_bridge_obj_initial_shared_version(
     object_store: &dyn ObjectStore,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -37,8 +37,10 @@ mod checked {
         AUTHENTICATOR_STATE_MODULE_NAME, AUTHENTICATOR_STATE_UPDATE_FUNCTION_NAME,
     };
     use sui_types::base_types::SequenceNumber;
+    use sui_types::bridge::BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER;
     use sui_types::bridge::{
-        BRIDGE_CREATE_FUNCTION_NAME, BRIDGE_INIT_COMMITTEE_FUNCTION_NAME, BRIDGE_MODULE_NAME,
+        BridgeChainId, BRIDGE_CREATE_FUNCTION_NAME, BRIDGE_INIT_COMMITTEE_FUNCTION_NAME,
+        BRIDGE_MODULE_NAME,
     };
     use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
     use sui_types::committee::EpochId;
@@ -1016,11 +1018,12 @@ mod checked {
             .expect("Unable to create Bridge object UID!");
 
         let bridge_chain_id = if chain_id == get_mainnet_chain_identifier() {
-            0u8
+            BridgeChainId::SuiMainnet as u8
         } else if chain_id == get_testnet_chain_identifier() {
-            1u8
+            BridgeChainId::SuiTestnet as u8
         } else {
-            2u8
+            // How do we distinguish devnet from other test envs?
+            BridgeChainId::SuiLocalTest as u8
         };
 
         let bridge_chain_id = builder.pure(bridge_chain_id).unwrap();
@@ -1060,7 +1063,9 @@ mod checked {
         // Hardcoding min stake participation to 75.00%
         // TODO: We need to set a correct value or make this configurable.
         let min_stake_participation_percentage = builder
-            .input(CallArg::Pure(bcs::to_bytes(&7500u64).unwrap()))
+            .input(CallArg::Pure(
+                bcs::to_bytes(&BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER).unwrap(),
+            ))
             .unwrap();
 
         builder.programmable_move_call(


### PR DESCRIPTION
## Description 

1, introduce a few more constants and move things to sui-types/bridge.rs
2, relax the total voting power = 10k requirement, in case of not all validators opt in.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
