### PR TITLE
[sdk] Adds special .clock() and .denylist() hardcoded objects to tx builder

### DIFF
--- a/sdk/typescript/src/transactions/TransactionBlock.ts
+++ b/sdk/typescript/src/transactions/TransactionBlock.ts
@@ -352,6 +352,20 @@ export class TransactionBlock {
 		return this.object(Inputs.SharedObjectRef(...args));
 	}
 
+	/**
+	 * Special case for Clock 0x6 object reference.
+	 */
+	clock() {
+		return this.object('0x6');
+	}
+
+	/**
+	 * Special case for Denylist 0x403 object reference.
+	 */
+	denylist() {
+		return this.object('0x403');
+	}
+
 	/** Add a transaction to the transaction block. */
 	add(transaction: TransactionType) {
 		const index = this.#blockData.transactions.push(transaction);


### PR DESCRIPTION
## Description 

Adds `txb.clock()` and `txb.denylist()` special objects.

## Test Plan 

TBD

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
