### PR TITLE
[Consensus 2.0] use DagState for block proposal in Core

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -14,6 +14,13 @@ use serde::{Deserialize, Serialize};
 /// should not need to specify any field, except db_path.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Parameters {
+    /// The number of rounds of blocks to be kept in the Dag state cache per authority. The larger
+    /// the number the more the blocks that will be kept in memory allowing minimising any potential
+    /// disk access. Should be careful when tuning this parameter as it could be quite memory expensive.
+    /// Value should be at minimum 50 rounds to ensure node performance and protocol advance.
+    #[serde(default = "Parameters::default_dag_state_cached_rounds")]
+    pub dag_state_cached_rounds: u32,
+
     /// Time to wait for parent round leader before sealing a block.
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
@@ -35,6 +42,10 @@ pub struct Parameters {
 }
 
 impl Parameters {
+    pub fn default_dag_state_cached_rounds() -> u32 {
+        100
+    }
+
     pub fn default_leader_timeout() -> Duration {
         Duration::from_millis(250)
     }
@@ -61,6 +72,7 @@ impl Parameters {
 impl Default for Parameters {
     fn default() -> Self {
         Self {
+            dag_state_cached_rounds: Parameters::default_dag_state_cached_rounds(),
             leader_timeout: Parameters::default_leader_timeout(),
             min_round_delay: Parameters::default_min_round_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -2,6 +2,7 @@
 source: consensus/config/tests/parameters_test.rs
 expression: parameters
 ---
+dag_state_cached_rounds: 100
 leader_timeout:
   secs: 0
   nanos: 250000000

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -140,12 +140,8 @@ where
         let block_manager =
             BlockManager::new(context.clone(), dag_state.clone(), block_verifier.clone());
 
-        let commit_observer = CommitObserver::new(
-            context.clone(),
-            commit_consumer,
-            dag_state.clone(),
-            store.clone(),
-        );
+        let commit_observer =
+            CommitObserver::new(context.clone(), commit_consumer, dag_state.clone(), store);
 
         let core = Core::new(
             context.clone(),
@@ -155,7 +151,6 @@ where
             core_signals,
             protocol_keypair,
             dag_state.clone(),
-            store,
         );
 
         let (core_dispatcher, core_thread_handle) =

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -27,10 +27,10 @@ use crate::error::ConsensusResult;
 use crate::{commit::CommitRef, context::Context};
 use crate::{ensure, error::ConsensusError};
 
+pub(crate) const GENESIS_ROUND: Round = 0;
+
 /// Round number of a block.
 pub type Round = u32;
-
-pub const GENESIS_ROUND: Round = 0;
 
 /// Block proposal timestamp in milliseconds.
 pub type BlockTimestampMs = u64;
@@ -82,6 +82,7 @@ pub trait BlockAPI {
     fn ancestors(&self) -> &[BlockRef];
     fn transactions(&self) -> &[Transaction];
     fn commit_votes(&self) -> &[CommitRef];
+    fn slot(&self) -> Slot;
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
@@ -157,6 +158,10 @@ impl BlockAPI for BlockV1 {
 
     fn commit_votes(&self) -> &[CommitRef] {
         &self.commit_votes
+    }
+
+    fn slot(&self) -> Slot {
+        Slot::new(self.round, self.author)
     }
 }
 
@@ -255,7 +260,7 @@ impl AsRef<[u8]> for BlockDigest {
 /// Slot is the position of blocks in the DAG. It can contain 0, 1 or multiple blocks
 /// from the same authority at the same round.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Default, Hash)]
-pub(crate) struct Slot {
+pub struct Slot {
     pub round: Round,
     pub authority: AuthorityIndex,
 }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -7,23 +7,23 @@ use std::{
     time::Duration,
 };
 
-use consensus_config::{AuthorityIndex, ProtocolKeyPair};
+use consensus_config::ProtocolKeyPair;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use tokio::sync::{broadcast, watch};
 use tracing::warn;
 
+use crate::stake_aggregator::{QuorumThreshold, StakeAggregator};
 use crate::{
     block::{
-        genesis_blocks, timestamp_utc_ms, Block, BlockAPI, BlockRef, BlockTimestampMs, BlockV1,
-        Round, SignedBlock, Slot, VerifiedBlock,
+        timestamp_utc_ms, Block, BlockAPI, BlockRef, BlockTimestampMs, BlockV1, Round, SignedBlock,
+        Slot, VerifiedBlock,
     },
     block_manager::BlockManager,
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    storage::Store,
     threshold_clock::ThresholdClock,
     transaction::TransactionConsumer,
     universal_committer::{
@@ -43,17 +43,19 @@ pub(crate) struct Core {
     context: Arc<Context>,
     /// The threshold clock that is used to keep track of the current round
     threshold_clock: ThresholdClock,
-    /// The last produced block
-    last_proposed_block: VerifiedBlock,
     /// The consumer to use in order to pull transactions to be included for the next proposals
     transaction_consumer: TransactionConsumer,
-    /// The pending ancestors to be included in proposals organised by round.
-    pending_ancestors: BTreeMap<Round, Vec<VerifiedBlock>>,
     /// The block manager which is responsible for keeping track of the DAG dependencies when processing new blocks
     /// and accept them or suspend if we are missing their causal history
     block_manager: BlockManager,
     /// Used to make commit decisions for leader blocks in the dag.
     committer: UniversalCommitter,
+    /// The last produced block
+    last_proposed_block: VerifiedBlock,
+    /// The blocks of the last included ancestors per authority. This vector is basically used as a
+    /// watermark in order to include in the next block proposal only ancestors of higher rounds.
+    /// By default, is initialised with `None` values.
+    last_included_ancestors: Vec<Option<BlockRef>>,
     /// The last decided leader returned from the universal committer. Important to note
     /// that this does not signify that the leader has been persisted yet as it still has
     /// to go through CommitObserver and persist the commit in store. On recovery/restart
@@ -68,8 +70,6 @@ pub(crate) struct Core {
     block_signer: ProtocolKeyPair,
     /// Keeping track of state of the DAG, including blocks, commits and last committed rounds.
     dag_state: Arc<RwLock<DagState>>,
-    /// The node's storage.
-    store: Arc<dyn Store>,
 }
 
 impl Core {
@@ -81,14 +81,7 @@ impl Core {
         signals: CoreSignals,
         block_signer: ProtocolKeyPair,
         dag_state: Arc<RwLock<DagState>>,
-        store: Arc<dyn Store>,
     ) -> Self {
-        let all_genesis_blocks = genesis_blocks(context.clone());
-        let my_genesis_block = all_genesis_blocks
-            .iter()
-            .find(|block| block.author() == context.own_index)
-            .expect("Own block at genesis must be present")
-            .clone();
         let last_decided_leader = dag_state.read().last_commit_leader();
 
         let committer = UniversalCommitterBuilder::new(context.clone(), dag_state.clone())
@@ -96,12 +89,30 @@ impl Core {
             .with_pipeline(true)
             .build();
 
+        // Recover the last proposed block
+        let last_proposed_block = dag_state
+            .read()
+            .get_last_block_for_authority(context.own_index);
+
+        // Recover the last included ancestor rounds based on the last proposed block. That will allow
+        // to perform the next block proposal by using ancestor blocks of higher rounds and avoid
+        // re-including blocks that have been already included in the last (or earlier) block proposal.
+        // This is only strongly guaranteed for a quorum of ancestors. It is still possible to re-include
+        // a block from an authority which hadn't been added as part of the last proposal hence its
+        // latest included ancestor is not accurately captured here. This is considered a small deficiency,
+        // and it mostly matters just for this next proposal without any actual penalties in performance
+        // or block proposal.
+        let mut last_included_ancestors = vec![None; context.committee.size()];
+        for ancestor in last_proposed_block.ancestors() {
+            last_included_ancestors[ancestor.author] = Some(*ancestor);
+        }
+
         Self {
             context: context.clone(),
-            threshold_clock: ThresholdClock::new(0, context),
-            last_proposed_block: my_genesis_block,
+            threshold_clock: ThresholdClock::new(0, context.clone()),
+            last_proposed_block,
             transaction_consumer,
-            pending_ancestors: BTreeMap::new(),
+            last_included_ancestors,
             block_manager,
             committer,
             last_decided_leader,
@@ -109,38 +120,18 @@ impl Core {
             signals,
             block_signer,
             dag_state,
-            store,
         }
-        .recover(all_genesis_blocks)
+        .recover()
     }
 
-    fn recover(mut self, genesis_blocks: Vec<VerifiedBlock>) -> Self {
-        // We always need the genesis blocks as a starter point since we might not have advanced yet at all.
-        let mut all_blocks = genesis_blocks;
-
-        // Now fetch the proposed blocks per authority for their last two rounds.
-        let context = self.context.clone();
-        for (index, _authority) in context.committee.authorities() {
-            let blocks = self
-                .store
-                .scan_last_blocks_by_author(index, 2)
-                .expect("Storage error while recovering Core");
-            all_blocks.extend(blocks);
-        }
-
-        // Recover the last proposed block
-        self.last_proposed_block = all_blocks
-            .iter()
-            .filter(|block| block.author() == context.own_index)
-            .max_by_key(|block| block.round())
-            .cloned()
-            .expect("At least one block - even genesis - should be present");
-
-        // Accept all blocks but make sure that only the last quorum round blocks and onwards are kept.
-        self.add_accepted_blocks(all_blocks, Some(0));
+    fn recover(mut self) -> Self {
+        // Recover the last available quorum to correctly advance the threshold clock.
+        let last_quorum = self.dag_state.read().last_quorum();
+        self.add_accepted_blocks(last_quorum);
         // Try to commit and propose, since they may not have run after the last storage write.
         self.try_commit().unwrap();
         self.try_propose(true).unwrap();
+
         self
     }
 
@@ -157,7 +148,7 @@ impl Core {
 
         if !accepted_blocks.is_empty() {
             // Now add accepted blocks to the threshold clock and pending ancestors list.
-            self.add_accepted_blocks(accepted_blocks, None);
+            self.add_accepted_blocks(accepted_blocks);
 
             self.try_commit()?;
 
@@ -169,15 +160,8 @@ impl Core {
     }
 
     /// Adds/processed all the newly `accepted_blocks`. We basically try to move the threshold clock and add them to the
-    /// pending ancestors list. The `pending_ancestors_retain_rounds` if defined then the method will retain on the pending ancestors
-    /// only the `pending_ancestors_retain_rounds` from the last formed quorum round. For example if set to zero (0), then
-    /// we'll strictly keep in the pending ancestors list the blocks of round >= last_quorum_round. If not defined, so None
-    /// is provided, then all the pending ancestors will be kep until the next block proposal.
-    fn add_accepted_blocks(
-        &mut self,
-        accepted_blocks: Vec<VerifiedBlock>,
-        pending_ancestors_retain_rounds: Option<u32>,
-    ) {
+    /// pending ancestors list.
+    fn add_accepted_blocks(&mut self, accepted_blocks: Vec<VerifiedBlock>) {
         // Advance the threshold clock. If advanced to a new round then send a signal that a new quorum has been received.
         if let Some(new_round) = self
             .threshold_clock
@@ -193,25 +177,6 @@ impl Core {
             .node_metrics
             .threshold_clock_round
             .set(self.threshold_clock.get_round() as i64);
-
-        for accepted_block in accepted_blocks {
-            self.pending_ancestors
-                .entry(accepted_block.round())
-                .or_default()
-                .push(accepted_block);
-        }
-
-        // TODO: we might need to consider the following:
-        // 1. Add some sort of protection from bulk catch ups - or intentional validator attack - that is flooding us with
-        // many blocks, so we don't spam the pending_ancestors list and OOM
-        // 2. Probably it doesn't make much sense to keep blocks around from too many rounds ago to reference as the data
-        // might not be relevant any more.
-        if let Some(retain_ancestor_rounds_from_quorum) = pending_ancestors_retain_rounds {
-            let last_quorum = self.threshold_clock.get_round().saturating_sub(1);
-            self.pending_ancestors.retain(|round, _| {
-                *round >= last_quorum.saturating_sub(retain_ancestor_rounds_from_quorum)
-            });
-        }
     }
 
     /// Force creating a new block for the dictated round. This is used when a leader timeout occurs.
@@ -306,10 +271,6 @@ impl Core {
 
         // Add to the threshold clock and pending ancestors
         self.threshold_clock.add_block(verified_block.reference());
-        self.pending_ancestors
-            .entry(verified_block.round())
-            .or_default()
-            .push(verified_block.clone());
 
         // Accept the block into BlockManager and DagState.
         let (accepted_blocks, missing) = self
@@ -355,19 +316,50 @@ impl Core {
         self.block_manager.missing_blocks()
     }
 
-    /// Retrieves the next ancestors to propose to form a block at `clock_round` round. Also the `block_timestamp` is provided
+    /// Retrieves the next ancestors to propose to form a block at `clock_round` round. Also, the `block_timestamp` is provided
     /// to sanity check that everything that goes into the proposal is ensured to have a timestamp < block_timestamp
     fn ancestors_to_propose(
         &mut self,
         clock_round: Round,
         block_timestamp: BlockTimestampMs,
     ) -> Vec<BlockRef> {
-        // Now take all the ancestors up to the clock_round (excluded) and then remove them from the map.
+        // Now take the ancestors before the clock_round (excluded) for each authority.
         let ancestors = self
-            .pending_ancestors
-            .range(0..clock_round)
-            .flat_map(|(_, blocks)| blocks)
+            .dag_state
+            .read()
+            .get_last_cached_block_per_authority(clock_round);
+        assert_eq!(
+            ancestors.len(),
+            self.context.committee.size(),
+            "Fatal error, number of returned ancestors don't match committee size."
+        );
+
+        // Propose only ancestors of higher rounds than what has already been proposed
+        let ancestors = ancestors
+            .into_iter()
+            .flat_map(|block| {
+                if let Some(last_block_ref) = self.last_included_ancestors[block.author()] {
+                    return (last_block_ref.round < block.round()).then_some(block);
+                }
+                Some(block)
+            })
             .collect::<Vec<_>>();
+
+        // Update the last included ancestor block refs
+        for ancestor in &ancestors {
+            self.last_included_ancestors[ancestor.author()] = Some(ancestor.reference());
+        }
+
+        // TODO: this is for temporary sanity check - we might want to remove later on
+        let mut quorum = StakeAggregator::<QuorumThreshold>::new();
+        for ancestor in ancestors
+            .iter()
+            .filter(|block| block.round() == clock_round - 1)
+        {
+            quorum.add(ancestor.author(), &self.context.committee);
+        }
+
+        assert!(quorum.reached_threshold(&self.context.committee), "Fatal error, quorum not reached for parent round when proposing for round {}. Possible mismatch between DagState and Core.", clock_round);
 
         // Ensure that timestamps are correct
         ancestors.iter().for_each(|block|{
@@ -385,17 +377,13 @@ impl Core {
         // Keep block refs to propose in a map, so even if somehow a byzantine node managed to provide blocks that don't
         // form a valid chain we can still pick one block per author.
         let mut to_propose = BTreeMap::new();
-        for block in ancestors.into_iter() {
+        for block in &ancestors {
             if !all_ancestors_parents.contains(&block.reference()) {
                 to_propose.insert(block.author(), block.reference());
             }
         }
 
         assert!(!to_propose.is_empty());
-
-        // Now clean up the pending ancestors
-        self.pending_ancestors
-            .retain(|round, _blocks| *round >= clock_round);
 
         // always include our last proposed block in front of the vector and make sure that we do not
         // double insert.
@@ -413,27 +401,28 @@ impl Core {
     /// TODO: we can leverage some additional signal here in order to more cleverly manipulate later the leader timeout
     /// Ex if we already have one leader - the first in order - we might don't want to wait as much.
     fn last_quorum_leaders_exist(&self) -> bool {
-        // TODO: check that we are ready to produce a new block. This will mainly check that the leaders of the previous
-        // quorum exist.
         let quorum_round = self.threshold_clock.get_round().saturating_sub(1);
 
-        let leaders = self.leaders(quorum_round);
-        if let Some(ancestors) = self.pending_ancestors.get(&quorum_round) {
+        let dag_state = self.dag_state.read();
+        for leader in self.leaders(quorum_round) {
             // Search for all the leaders. If at least one is not found, then return false.
             // A linear search should be fine here as the set of elements is not expected to be small enough and more sophisticated
             // data structures might not give us much here.
-            return leaders.iter().all(|leader| {
-                ancestors
-                    .iter()
-                    .any(|entry| entry.reference().author == *leader)
-            });
+            if !dag_state.contains_cached_block_at_slot(leader) {
+                return false;
+            }
         }
-        false
+
+        true
     }
 
     /// Returns the leaders of the provided round.
-    fn leaders(&self, round: Round) -> Vec<AuthorityIndex> {
-        self.committer.get_leaders(round)
+    fn leaders(&self, round: Round) -> Vec<Slot> {
+        self.committer
+            .get_leaders(round)
+            .into_iter()
+            .map(|authority_index| Slot::new(round, authority_index))
+            .collect()
     }
 
     fn last_proposed_timestamp_ms(&self) -> BlockTimestampMs {
@@ -516,7 +505,7 @@ impl CoreSignalsReceivers {
 mod test {
     use std::{collections::BTreeSet, time::Duration};
 
-    use consensus_config::{local_committee_and_keys, Parameters, Stake};
+    use consensus_config::{local_committee_and_keys, AuthorityIndex, Parameters, Stake};
     use sui_protocol_config::ProtocolConfig;
     use tokio::{
         sync::mpsc::{unbounded_channel, UnboundedReceiver},
@@ -525,10 +514,11 @@ mod test {
 
     use super::*;
     use crate::{
+        block::genesis_blocks,
         block::TestBlock,
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI as _,
-        storage::{mem_store::MemStore, WriteBatch},
+        storage::{mem_store::MemStore, Store, WriteBatch},
         transaction::TransactionClient,
         CommitConsumer, CommitIndex,
     };
@@ -598,7 +588,6 @@ mod test {
             signals,
             key_pairs.remove(context.own_index.value()).1,
             dag_state.clone(),
-            store.clone(),
         );
 
         // New round should be 5
@@ -709,7 +698,6 @@ mod test {
             signals,
             key_pairs.remove(context.own_index.value()).1,
             dag_state.clone(),
-            store.clone(),
         );
 
         // New round should be 4
@@ -790,7 +778,6 @@ mod test {
             signals,
             key_pairs.remove(context.own_index.value()).1,
             dag_state.clone(),
-            store.clone(),
         );
 
         // Send some transactions
@@ -889,7 +876,6 @@ mod test {
             signals,
             key_pairs.remove(context.own_index.value()).1,
             dag_state.clone(),
-            store.clone(),
         );
 
         let mut expected_ancestors = BTreeSet::new();
@@ -949,7 +935,7 @@ mod test {
         for round in 1..=3 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _signal_receivers, _, _) in cores.iter_mut() {
+            for (core, _signal_receivers, _, _, _) in cores.iter_mut() {
                 core.add_blocks(last_round_blocks.clone()).unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -973,27 +959,26 @@ mod test {
 
         // Try to create the blocks for round 4 by calling the try_propose() method. No block should be created as the
         // leader - authority 3 - hasn't proposed any block.
-        for (core, _, _, _) in cores.iter_mut() {
+        for (core, _, _, _, _) in cores.iter_mut() {
             core.add_blocks(last_round_blocks.clone()).unwrap();
             assert!(core.try_propose(false).unwrap().is_none());
         }
 
         // Now try to create the blocks for round 4 via the leader timeout method which should
         // ignore any leader checks or min round delay.
-        for (core, _, _, _) in cores.iter_mut() {
+        for (core, _, _, _, store) in cores.iter_mut() {
             assert!(core.force_new_block(4).unwrap().is_some());
             assert_eq!(core.last_proposed_round(), 4);
 
             // Check commits have been persisted to store
-            let last_commit = core
-                .store
+            let last_commit = store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
             // There are 1 leader rounds with rounds completed up to and including
             // round 4
             assert_eq!(last_commit.index(), 1);
-            let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
+            let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
             assert_eq!(all_stored_commits.len(), 1);
         }
     }
@@ -1011,7 +996,7 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, signal_receivers, block_receiver, _) in &mut cores {
+            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
                 // Wait for min round delay to allow blocks to be proposed.
                 sleep(default_params.min_round_delay).await;
                 // add the blocks from last round
@@ -1057,10 +1042,9 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
 
-        for (core, _, _, _) in cores {
+        for (_, _, _, _, store) in cores {
             // Check commits have been persisted to store
-            let last_commit = core
-                .store
+            let last_commit = store
                 .read_last_commit()
                 .unwrap()
                 .expect("last commit should be set");
@@ -1068,7 +1052,7 @@ mod test {
             // round 9. Round 10 blocks will only include their own blocks, so the
             // 8th leader will not be committed.
             assert_eq!(last_commit.index(), 7);
-            let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
+            let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
             assert_eq!(all_stored_commits.len(), 7);
         }
     }
@@ -1089,7 +1073,7 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
-            for (core, _, _, _) in &mut cores {
+            for (core, _, _, _, _) in &mut cores {
                 // do not produce any block for authority 3
                 if core.context.own_index == excluded_authority {
                     continue;
@@ -1113,7 +1097,7 @@ mod test {
         // Now send all the produced blocks to core of authority 3. It should produce a new block. If no compression would
         // be applied the we should expect all the previous blocks to be referenced from round 0..=10. However, since compression
         // is applied only the last round's (10) blocks should be referenced + the authority's block of round 0.
-        let (core, _, _, _) = &mut cores[excluded_authority];
+        let (core, _, _, _, store) = &mut cores[excluded_authority];
         // Wait for min round delay to allow blocks to be proposed.
         sleep(default_params.min_round_delay).await;
         // add blocks to trigger proposal.
@@ -1133,8 +1117,7 @@ mod test {
         }
 
         // Check commits have been persisted to store
-        let last_commit = core
-            .store
+        let last_commit = store
             .read_last_commit()
             .unwrap()
             .expect("last commit should be set");
@@ -1142,7 +1125,7 @@ mod test {
         // round 10. However because there were no blocks produced for authority 3
         // 2 leader rounds will be skipped.
         assert_eq!(last_commit.index(), 6);
-        let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
+        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
         assert_eq!(all_stored_commits.len(), 6);
     }
 
@@ -1156,6 +1139,7 @@ mod test {
         CoreSignalsReceivers,
         broadcast::Receiver<VerifiedBlock>,
         UnboundedReceiver<CommittedSubDag>,
+        Arc<impl Store>,
     )> {
         let mut cores = Vec::new();
 
@@ -1199,10 +1183,15 @@ mod test {
                 signals,
                 block_signer,
                 dag_state,
-                store,
             );
 
-            cores.push((core, signal_receivers, block_receiver, commit_receiver));
+            cores.push((
+                core,
+                signal_receivers,
+                block_receiver,
+                commit_receiver,
+                store,
+            ));
         }
         cores
     }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -212,7 +212,7 @@ mod test {
             context.clone(),
             CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
-            store.clone(),
+            store,
         );
         let core = Core::new(
             context.clone(),
@@ -222,7 +222,6 @@ mod test {
             signals,
             key_pairs.remove(context.own_index.value()).1,
             dag_state,
-            store,
         );
 
         let (core_dispatcher, handle) = ChannelCoreThreadDispatcher::start(core, context);

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -12,15 +12,14 @@ use std::{
 use consensus_config::AuthorityIndex;
 use tracing::error;
 
+use crate::block::GENESIS_ROUND;
+use crate::stake_aggregator::{QuorumThreshold, StakeAggregator};
 use crate::{
     block::{genesis_blocks, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRef, TrustedCommit},
     context::Context,
     storage::{Store, WriteBatch},
 };
-
-/// Rounds of recently committed blocks cached in memory, per authority.
-const CACHED_ROUNDS: Round = 100;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommited and last committed blocks are cached in memory.
@@ -62,11 +61,15 @@ pub(crate) struct DagState {
 
     // Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
+
+    // The number of cached rounds
+    cached_rounds: Round,
 }
 
 impl DagState {
     /// Initializes DagState from storage.
     pub(crate) fn new(context: Arc<Context>, store: Arc<dyn Store>) -> Self {
+        let cached_rounds = context.parameters.dag_state_cached_rounds as Round;
         let num_authorities = context.committee.size();
 
         let genesis = genesis_blocks(context.clone())
@@ -100,14 +103,15 @@ impl DagState {
             blocks_to_write: vec![],
             commits_to_write: vec![],
             store,
+            cached_rounds,
         };
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
             let authority_index = state.context.committee.to_authority_index(i).unwrap();
             let blocks = state
                 .store
-                .scan_blocks_by_author(authority_index, round.saturating_sub(CACHED_ROUNDS))
-                .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+                .scan_blocks_by_author(authority_index, Self::evict_round(round, cached_rounds) + 1)
+                .unwrap();
             for block in blocks {
                 state.update_block_metadata(&block);
             }
@@ -173,7 +177,7 @@ impl DagState {
         let mut missing = Vec::new();
 
         for (index, block_ref) in block_refs.iter().enumerate() {
-            if block_ref.round == 0 {
+            if block_ref.round == GENESIS_ROUND {
                 // Allow the caller to handle the invalid genesis ancestor error.
                 if let Some(block) = self.genesis.get(block_ref) {
                     blocks[index] = Some(block.clone());
@@ -290,6 +294,102 @@ impl DagState {
     pub(crate) fn contains_block(&self, block_ref: &BlockRef) -> bool {
         let blocks = self.contains_blocks(vec![*block_ref]);
         blocks.first().cloned().unwrap()
+    }
+
+    /// Retrieves the last block proposed for the specified `authority`. If no block is found in cache
+    /// then the genesis block is returned as no other block has been received from that authority.
+    pub(crate) fn get_last_block_for_authority(&self, authority: AuthorityIndex) -> VerifiedBlock {
+        if let Some(last) = self.recent_refs[authority].last() {
+            return self
+                .recent_blocks
+                .get(last)
+                .expect("Block should be found in recent blocks")
+                .clone();
+        }
+
+        // if none exists, then fallback to genesis
+        let (_, genesis_block) = self
+            .genesis
+            .iter()
+            .find(|(block_ref, _)| block_ref.author == authority)
+            .expect("Genesis should be found for authority {authority_index}");
+        genesis_block.clone()
+    }
+
+    /// Returns the last block proposed per authority with `round < end_round`.
+    /// The method is guaranteed to return results only when the `end_round` is not earlier of the
+    /// available cached data for each authority, otherwise the method will panic - it's the caller's
+    /// responsibility to ensure that is not requesting filtering for earlier rounds .
+    /// In case of equivocation for an authority's last slot only one block will be returned (the last in order).
+    pub(crate) fn get_last_cached_block_per_authority(
+        &self,
+        end_round: Round,
+    ) -> Vec<VerifiedBlock> {
+        // init with the genesis blocks as fallback
+        let mut blocks = self.genesis.values().cloned().collect::<Vec<_>>();
+
+        if end_round == GENESIS_ROUND {
+            panic!(
+                "Attempted to retrieve blocks earlier than the genesis round which is not possible"
+            );
+        }
+
+        if end_round == GENESIS_ROUND + 1 {
+            return blocks;
+        }
+
+        for (authority_index, block_refs) in self.recent_refs.iter().enumerate() {
+            let authority_index = self
+                .context
+                .committee
+                .to_authority_index(authority_index)
+                .unwrap();
+
+            let last_evicted_round = self.authority_evict_round(authority_index);
+            if end_round.saturating_sub(1) <= last_evicted_round {
+                panic!("Attempted to request for blocks of rounds < {end_round}, when the last evicted round is {last_evicted_round} for authority {authority_index}", );
+            }
+
+            if let Some(block_ref) = block_refs
+                .range((
+                    Included(BlockRef::new(
+                        last_evicted_round + 1,
+                        authority_index,
+                        BlockDigest::MIN,
+                    )),
+                    Excluded(BlockRef::new(end_round, authority_index, BlockDigest::MIN)),
+                ))
+                .next_back()
+            {
+                let block = self
+                    .recent_blocks
+                    .get(block_ref)
+                    .expect("Block should exist in recent blocks");
+
+                blocks[authority_index] = block.clone();
+            }
+        }
+
+        blocks.into_iter().collect()
+    }
+
+    /// Checks whether a block exists in the slot. The method checks only against the cached data.
+    /// If the user asks for a slot that is not within the cached data then a panic is thrown.
+    pub(crate) fn contains_cached_block_at_slot(&self, slot: Slot) -> bool {
+        // Always return true for genesis slots.
+        if slot.round == GENESIS_ROUND {
+            return true;
+        }
+
+        if slot.round <= self.authority_evict_round(slot.authority) {
+            panic!("Attempted to check for slot {slot} that is <= the last evicted round {} for the authority", self.authority_evict_round(slot.authority));
+        }
+
+        let mut result = self.recent_refs[slot.authority].range((
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MAX)),
+        ));
+        result.next().is_some()
     }
 
     /// Checks whether the required blocks are in cache, if exist, or otherwise will check in store. The method is not caching
@@ -413,16 +513,8 @@ impl DagState {
         self.last_committed_rounds.clone()
     }
 
-    /// Highest round where a block is committed, which is last commit's leader round.
-    fn last_commit_round(&self) -> Round {
-        match &self.last_commit {
-            Some(commit) => commit.leader().round,
-            None => 0,
-        }
-    }
-
     /// After each flush, DagState becomes persisted in storage and it expected to recover
-    /// all internal states from stroage after restarts.
+    /// all internal states from storage after restarts.
     pub(crate) fn flush(&mut self) {
         // Flush buffered data to storage.
         let blocks = std::mem::take(&mut self.blocks_to_write);
@@ -451,7 +543,7 @@ impl DagState {
             .zip(self.last_committed_rounds.iter())
         {
             while let Some(block_ref) = authority_refs.first() {
-                if block_ref.round < last_committed_round.saturating_sub(CACHED_ROUNDS) {
+                if block_ref.round <= Self::evict_round(*last_committed_round, self.cached_rounds) {
                     self.recent_blocks.remove(block_ref);
                     authority_refs.pop_first();
                 } else {
@@ -460,13 +552,66 @@ impl DagState {
             }
         }
     }
+
+    /// Detects and returns the blocks of the round that forms the last quorum. The method will return
+    /// the quorum even if that's genesis.
+    pub(crate) fn last_quorum(&self) -> Vec<VerifiedBlock> {
+        // the quorum should exist either on the highest accepted round or the one before. If we fail to detect
+        // a quorum then it means that our DAG has advanced with missing causal history.
+        for round in
+            (self.highest_accepted_round.saturating_sub(1)..=self.highest_accepted_round).rev()
+        {
+            if round == GENESIS_ROUND {
+                return self.genesis_blocks();
+            }
+            let mut quorum = StakeAggregator::<QuorumThreshold>::new();
+
+            // Since the minimum wave length is 3 we expect to find a quorum in the uncommitted rounds.
+            let blocks = self.get_uncommitted_blocks_at_round(round);
+            for block in &blocks {
+                if quorum.add(block.author(), &self.context.committee) {
+                    return blocks;
+                }
+            }
+        }
+
+        panic!("Fatal error, no quorum has been detected in our DAG on the last two rounds.");
+    }
+
+    pub(crate) fn genesis_blocks(&self) -> Vec<VerifiedBlock> {
+        self.genesis.values().cloned().collect()
+    }
+
+    /// Highest round where a block is committed, which is last commit's leader round.
+    fn last_commit_round(&self) -> Round {
+        match &self.last_commit {
+            Some(commit) => commit.leader().round,
+            None => 0,
+        }
+    }
+
+    /// The last round that got evicted after a cache clean up operation. After this round we are
+    /// guaranteed to have all the produced blocks from that authority. For any round that is
+    /// <= `last_evicted_round` we don't have such guarantees as out of order blocks might exist.
+    fn authority_evict_round(&self, authority_index: AuthorityIndex) -> Round {
+        let commit_round = self.last_committed_rounds[authority_index];
+        Self::evict_round(commit_round, self.cached_rounds)
+    }
+
+    /// Calculates the last eviction round based on the provided `commit_round`. Any blocks with
+    /// round <= the evict round have been cleaned up.
+    fn evict_round(commit_round: Round, cached_rounds: Round) -> Round {
+        commit_round.saturating_sub(cached_rounds)
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use parking_lot::RwLock;
     use std::vec;
 
     use super::*;
+    use crate::test_dag::build_dag;
     use crate::{
         block::{BlockDigest, BlockRef, BlockTimestampMs, TestBlock, VerifiedBlock},
         storage::{mem_store::MemStore, WriteBatch},
@@ -737,7 +882,12 @@ mod test {
 
     #[test]
     fn test_contains_blocks_in_cache_or_store() {
-        let (context, _) = Context::new_for_test(4);
+        /// Only keep elements up to 2 rounds before the last committed round
+        const CACHED_ROUNDS: Round = 2;
+
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
@@ -777,16 +927,31 @@ mod test {
         let mut expected = vec![true; (num_rounds * num_authorities) as usize];
         assert_eq!(result, expected);
 
+        // Attempt to check the same via the contains slot method
+        for block_ref in block_refs.clone() {
+            let slot = block_ref.into();
+            let found = dag_state.contains_cached_block_at_slot(slot);
+            assert!(found, "A block should be found at slot {}", slot);
+        }
+
         // Now try to ask also for one block ref that is neither in cache nor in store
         block_refs.insert(
             3,
             BlockRef::new(11, AuthorityIndex::new_for_test(3), BlockDigest::default()),
         );
-        let result = dag_state.contains_blocks(block_refs);
+        let result = dag_state.contains_blocks(block_refs.clone());
 
         // Then all should be found apart from the last one
         expected.insert(3, false);
-        assert_eq!(result, expected);
+        assert_eq!(result, expected.clone());
+
+        // Attempt to check the same for via the contains slot method
+        for block_ref in block_refs.clone() {
+            let slot = block_ref.into();
+            let found = dag_state.contains_cached_block_at_slot(slot);
+
+            assert_eq!(expected.remove(0), found);
+        }
     }
 
     #[test]
@@ -942,5 +1107,205 @@ mod test {
 
         // Last commit index should be 5.
         assert_eq!(dag_state.last_commit_index(), 5);
+    }
+
+    #[test]
+    fn test_get_cached_last_block_per_authority() {
+        // GIVEN
+        const CACHED_ROUNDS: Round = 2;
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create no blocks for authority 0
+        // Create one block (round 1) for authority 1
+        // Create two blocks (rounds 1,2) for authority 2
+        // Create three blocks (rounds 1,2,3) for authority 3
+        let mut all_blocks = Vec::new();
+        for author in 1..=3 {
+            for round in 1..=author {
+                let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
+                all_blocks.push(block.clone());
+                dag_state.accept_block(block);
+            }
+        }
+
+        dag_state.add_commit(TrustedCommit::new_for_test(
+            1 as CommitIndex,
+            CommitDigest::MIN,
+            all_blocks.last().unwrap().reference(),
+            all_blocks
+                .into_iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        ));
+
+        // WHEN search for the latest blocks
+        let end_round = 4;
+        let last_blocks = dag_state.get_last_cached_block_per_authority(end_round);
+
+        // THEN
+        assert_eq!(last_blocks[0].round(), 0);
+        assert_eq!(last_blocks[1].round(), 1);
+        assert_eq!(last_blocks[2].round(), 2);
+        assert_eq!(last_blocks[3].round(), 3);
+
+        // WHEN we flush the DagState - after adding a commit with all the blocks, we expect this to trigger
+        // a clean up in the internal cache. That will keep the all the blocks with rounds >= authority_commit_round - CACHED_ROUND.
+        dag_state.flush();
+
+        // AND we request before round 3
+        let end_round = 3;
+        let last_blocks = dag_state.get_last_cached_block_per_authority(end_round);
+
+        // THEN
+        assert_eq!(last_blocks[0].round(), 0);
+        assert_eq!(last_blocks[1].round(), 1);
+        assert_eq!(last_blocks[2].round(), 2);
+        assert_eq!(last_blocks[3].round(), 2);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Attempted to request for blocks of rounds < 2, when the last evicted round is 1 for authority C"
+    )]
+    fn test_get_cached_last_block_per_authority_requesting_out_of_round_range() {
+        // GIVEN
+        const CACHED_ROUNDS: Round = 1;
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create no blocks for authority 0
+        // Create one block (round 1) for authority 1
+        // Create two blocks (rounds 1,2) for authority 2
+        // Create three blocks (rounds 1,2,3) for authority 3
+        let mut all_blocks = Vec::new();
+        for author in 1..=3 {
+            for round in 1..=author {
+                let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
+                all_blocks.push(block.clone());
+                dag_state.accept_block(block);
+            }
+        }
+
+        dag_state.add_commit(TrustedCommit::new_for_test(
+            1 as CommitIndex,
+            CommitDigest::MIN,
+            all_blocks.last().unwrap().reference(),
+            all_blocks
+                .into_iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        ));
+
+        // Flush the store so we keep in memory only the last 1 round from the last commit for each
+        // authority.
+        dag_state.flush();
+
+        // THEN the method should panic, as some authorities have already evicted rounds <= round 2
+        let end_round = 2;
+        dag_state.get_last_cached_block_per_authority(end_round);
+    }
+
+    #[test]
+    fn test_last_quorum() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        // WHEN no blocks exist then genesis should be returned
+        {
+            let genesis = genesis_blocks(context.clone());
+
+            assert_eq!(dag_state.read().last_quorum(), genesis);
+        }
+
+        // WHEN a fully connected DAG up to round 4 is created, then round 4 blocks should be returned as quorum
+        {
+            let round_4_blocks = build_dag(context, dag_state.clone(), None, 4);
+
+            let last_quorum = dag_state.read().last_quorum();
+
+            assert_eq!(
+                last_quorum
+                    .into_iter()
+                    .map(|block| block.reference())
+                    .collect::<Vec<_>>(),
+                round_4_blocks
+            );
+        }
+
+        // WHEN adding one more block at round 5, still round 4 should be returned as quorum
+        {
+            let block = VerifiedBlock::new_for_test(TestBlock::new(5, 0).build());
+            dag_state.write().accept_block(block);
+
+            let round_4_blocks = dag_state.read().get_uncommitted_blocks_at_round(4);
+
+            let last_quorum = dag_state.read().last_quorum();
+
+            assert_eq!(last_quorum, round_4_blocks);
+        }
+    }
+
+    #[test]
+    fn test_last_block_for_authority() {
+        // GIVEN
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        // WHEN no blocks exist then genesis should be returned
+        {
+            let genesis = genesis_blocks(context.clone());
+            let my_genesis = genesis
+                .into_iter()
+                .find(|block| block.author() == context.own_index)
+                .unwrap();
+
+            assert_eq!(
+                dag_state
+                    .read()
+                    .get_last_block_for_authority(context.own_index),
+                my_genesis
+            );
+        }
+
+        // WHEN adding some blocks for authorities, only the last ones should be returned
+        {
+            // add blocks up to round 4
+            build_dag(context.clone(), dag_state.clone(), None, 4);
+
+            // add block 5 for authority 0
+            let block = VerifiedBlock::new_for_test(TestBlock::new(5, 0).build());
+            dag_state.write().accept_block(block);
+
+            let block = dag_state
+                .read()
+                .get_last_block_for_authority(AuthorityIndex::new_for_test(0));
+            assert_eq!(block.round(), 5);
+
+            for (authority_index, _) in context.committee.authorities() {
+                let block = dag_state
+                    .read()
+                    .get_last_block_for_authority(authority_index);
+
+                if authority_index.value() == 0 {
+                    assert_eq!(block.round(), 5);
+                } else {
+                    assert_eq!(block.round(), 4);
+                }
+            }
+        }
     }
 }

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -50,6 +50,10 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
         T::is_threshold(committee, self.stake)
     }
 
+    pub(crate) fn reached_threshold(&self, committee: &Committee) -> bool {
+        T::is_threshold(committee, self.stake)
+    }
+
     pub(crate) fn clear(&mut self) {
         self.votes.clear();
         self.stake = 0;

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -12,6 +12,7 @@ use std::ops::Range;
 use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
+use crate::block::Slot;
 use crate::{
     block::{BlockRef, Round, VerifiedBlock},
     commit::{CommitIndex, TrustedCommit},
@@ -29,6 +30,9 @@ pub(crate) trait Store: Send + Sync {
     /// Checks if blocks exist in the store.
     fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
 
+    /// Checks whether there is any block at the given slot
+    fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool>;
+
     /// Reads blocks for an authority, from start_round.
     fn scan_blocks_by_author(
         &self,
@@ -36,12 +40,14 @@ pub(crate) trait Store: Send + Sync {
         start_round: Round,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
-    /// Reads an author's blocks from the last produced round up to `num_of_rounds` before (assuming such many rounds exist) in
-    /// round ascending order.
+    // The method returns the last `num_of_rounds` rounds blocks by author in round ascending order.
+    // When a `before_round` is defined then the blocks of round `<=before_round` are returned. If not
+    // then the max value for round will be used as cut off.
     fn scan_last_blocks_by_author(
         &self,
         author: AuthorityIndex,
         num_of_rounds: u64,
+        before_round: Option<Round>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     /// Reads the last commit.

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 
 use super::{mem_store::MemStore, rocksdb_store::RocksDBStore, Store, WriteBatch};
 use crate::{
-    block::{BlockDigest, BlockRef, TestBlock, VerifiedBlock},
+    block::{BlockAPI, BlockDigest, BlockRef, Slot, TestBlock, VerifiedBlock},
     commit::{CommitDigest, TrustedCommit},
 };
 
@@ -101,6 +101,20 @@ async fn read_and_contain_blocks(
         assert!(!contain_blocks[1]);
         assert!(contain_blocks[2]);
     }
+
+    {
+        for block in &written_blocks {
+            let found = store
+                .contains_block_at_slot(block.slot())
+                .expect("Read blocks should not fail");
+            assert!(found);
+        }
+
+        let found = store
+            .contains_block_at_slot(Slot::new(10, AuthorityIndex::new_for_test(0)))
+            .expect("Read blocks should not fail");
+        assert!(!found);
+    }
 }
 
 #[rstest]
@@ -171,7 +185,7 @@ async fn scan_blocks(
 
     {
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 2, "{:?}", scanned_blocks);
         assert_eq!(
@@ -180,7 +194,7 @@ async fn scan_blocks(
         );
 
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 0);
     }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 use tokio::time::{error::Elapsed, sleep, sleep_until, timeout, Instant};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::block::{BlockRef, SignedBlock, VerifiedBlock};
 use crate::block_verifier::BlockVerifier;
@@ -237,6 +237,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             }
                         }
                     }
+                },
+                else => {
+                    info!("Fetching blocks from authority {peer_index} task will now abort.");
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Description 

Using the DagState to figure out the ancestors to include in next block proposal instead of caching them in Core. Similarly use DagState to figure out whether the leader of previous round exist. Also the Store is no longer used in `Core` and the `DagState` is solely used instead.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
