### PR TITLE
Update index.mdx

### DIFF
--- a/sdk/docs/pages/dapp-kit/index.mdx
+++ b/sdk/docs/pages/dapp-kit/index.mdx
@@ -30,7 +30,7 @@ respective pages.
 
 ```tsx
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
-import { type SuiClientOptions } from '@mysten/sui.js/client';
+import { getFullnodeUrl, type SuiClientOptions } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to


### PR DESCRIPTION


## Description 

Noticed this line 
import { type SuiClientOptions } from '@mysten/sui.js/client'; should be updated to 
import { getFullnodeUrl, type SuiClientOptions } from '@mysten/sui.js/client';

because getFullnodeUrl is used later on.

Recommendation is to update this file to reflect the README https://github.com/MystenLabs/sui/tree/f9dd2b1e12507ee0ba5861ca616fbfe3fadd098d/sdk/dapp-kit


### Type of Change (Check all that apply)
- [x ] user-visible impact
