### PR TITLE
Always create new registry in test_concurrent_readers

### DIFF
--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -798,10 +798,8 @@ async fn test_concurrent_readers() {
     });
 
     let store = init_authority_store().await;
-    let cache = Arc::new(WritebackCache::new_for_tests(
-        store.clone(),
-        default_registry(),
-    ));
+    let registry = prometheus::Registry::new(); // One time registry for testing.
+    let cache = Arc::new(WritebackCache::new_for_tests(store.clone(), &registry));
 
     let mut s = Scenario::new_with_store_and_cache(store.clone(), cache.clone());
     let mut txns = Vec::new();


### PR DESCRIPTION
## Description 

`MSIM_TEST_NUM=40 RUST_LOG=off cargo simtest test_concurrent_readers` passed after this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
