### PR TITLE
[CI] use stable rust for doc CI

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -22,15 +22,11 @@ jobs:
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.7
         with:
           profile: minimal
-          # Upgrade below after the workspace upgrades to Rust 1.72 or later.
-          # https://substrate.stackexchange.com/a/9069
-          toolchain: nightly-2023-06-15
+          toolchain: stable
           override: true
 
       - name: Generate documentation
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # pin@v1.0.3
-        env:
-          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
         with:
           command: doc
           args: --workspace --exclude "sui-benchmark" --no-deps


### PR DESCRIPTION
## Description 

Use stable Rust for doc CI, instead of nightly. Nightly is inherently unstable and pinning to a specific nightly version can break too. For generating index page, maybe they can be done as a one-off command / workflow instead.

## Test Plan 

https://github.com/MystenLabs/sui/actions/runs/8055670229/job/22003035280

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
