### PR TITLE
[docs] Add CLI PTB item in the CLI reference page.

### DIFF
--- a/docs/content/references/cli.mdx
+++ b/docs/content/references/cli.mdx
@@ -20,6 +20,7 @@ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch <BRA
 There are a number of top-level commands available, but the five most useful to users are the following. Use the `help` flag for the commands that are not documented yet. For example, `sui validator --help`.  
 
 - **[Sui Client CLI](./cli/client.mdx):** Use the `sui client` commands to interact with the Sui network.
+- **[Sui Client PTB CLI](./cli/ptb.mdx):** Use the `sui client ptb` command to build and execute PTBs.
 - **[Sui Console CLI](./cli/console.mdx):** Use `sui console` to open an interactive console with the currently active network.
 - **[Sui Keytool CLI](./cli/keytool.mdx):** Use the `sui keytool` commands to access cryptography utilities.
 - **[Sui Move CLI](./cli/move.mdx):** Use the `sui move` commands to work with the Move programming language.


### PR DESCRIPTION
## Description 

Fixes missing CLI PTB item in the CLI commands reference list.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
