### PR TITLE
Fix dir prefix that is used for backfills

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -25,7 +25,8 @@ use crate::analytics_metrics::AnalyticsMetrics;
 use crate::handlers::AnalyticsHandler;
 use crate::writers::AnalyticsWriter;
 use crate::{
-    AnalyticsIndexerConfig, FileMetadata, MaxCheckpointReader, ParquetSchema, EPOCH_DIR_PREFIX,
+    join_paths, AnalyticsIndexerConfig, FileMetadata, MaxCheckpointReader, ParquetSchema,
+    EPOCH_DIR_PREFIX,
 };
 
 pub struct AnalyticsProcessor<S: Serialize + ParquetSchema> {
@@ -281,9 +282,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
         from: Arc<DynObjectStore>,
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
-        let remote_dest = prefix
-            .map(|p| p.child(path.to_string()))
-            .unwrap_or(path.clone());
+        let remote_dest = join_paths(prefix, &path);
         info!("Syncing file to remote: {:?}", &remote_dest);
         copy_file(&path, &remote_dest, &from, &to).await?;
         fs::remove_file(path_to_filesystem(dir, &path)?)?;

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -527,6 +527,7 @@ impl Processor {
 pub async fn read_store_for_checkpoint(
     remote_store_config: ObjectStoreConfig,
     file_type: FileType,
+    dir_prefix: Option<Path>,
 ) -> Result<CheckpointSequenceNumber> {
     let remote_object_store = remote_store_config.make()?;
     let remote_store_is_empty = remote_object_store
@@ -536,7 +537,8 @@ pub async fn read_store_for_checkpoint(
         .common_prefixes
         .is_empty();
     info!("Remote store is empty: {remote_store_is_empty}");
-    let prefix = file_type.dir_prefix();
+    let file_type_prefix = file_type.dir_prefix();
+    let prefix = join_paths(dir_prefix, &file_type_prefix);
     let epoch_dirs = find_all_dirs_with_epoch_prefix(&remote_object_store, Some(&prefix)).await?;
     let epoch = epoch_dirs.last_key_value().map(|(k, _v)| *k).unwrap_or(0);
     let epoch_prefix = prefix.child(format!("epoch_{}", epoch));
@@ -874,7 +876,12 @@ pub async fn get_starting_checkpoint_seq_num(
     let checkpoint = if let Some(starting_checkpoint_seq_num) = config.starting_checkpoint_seq_num {
         starting_checkpoint_seq_num
     } else {
-        read_store_for_checkpoint(config.remote_store_config.clone(), file_type).await?
+        read_store_for_checkpoint(
+            config.remote_store_config.clone(),
+            file_type,
+            config.remote_store_path_prefix,
+        )
+        .await?
     };
     Ok(checkpoint)
 }
@@ -894,4 +901,15 @@ pub async fn make_analytics_processor(
         FileType::DynamicField => make_dynamic_field_processor(config, metrics).await,
         FileType::WrappedObject => make_wrapped_object_processor(config, metrics).await,
     }
+}
+
+pub fn join_paths(base: Option<Path>, child: &Path) -> Path {
+    base.map(|p| {
+        let mut out_path = p.clone();
+        for part in child.parts() {
+            out_path = out_path.child(part)
+        }
+        out_path
+    })
+    .unwrap_or(child.clone())
 }


### PR DESCRIPTION
## Description 

The dir prefix path is today not acknowledged during the setup phase where pipeline starts from a particular checkpoint. This will cause the pipeline to re-run from the same checkpoint when doing backfills. This PR fixes the particular issue.

## Test Plan 

Ran locally, verified the path used during re-run is the backfill path (not the main path)
