### PR TITLE
[Doc] simplify instructions to build sui-sdk doc

### DIFF
--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -38,33 +38,13 @@ async fn main() -> Result<(), anyhow::Error> {
 
 ### Building documentation locally
 
-You can also build the documentation locally. To do so, open a Terminal or Console to the `sui/crates/sui-sdk` directory:
+You can also build the documentation locally. To do so,
 
-1. Use the `rustup toolchain` command to install the `nightly` release channel.
+1. Open a Terminal or Console and go to the `sui/crates/sui-sdk` directory.
 
-   ```rust
-   rustup toolchain install nightly
-   ```
+1. Run `cargo doc` to build the documentation into the `sui/target` directory. Take note of location of the generated file from the last line of the output, e.g. `Generated /Users/foo/sui/target/doc/sui_sdk/index.html`
 
-1. Use the `rustup override` command to set the `nightly` release channel as active.
-
-   ```rust
-   rustup override set nightly
-   ```
-
-1. Use `cargo doc` with the following `RUSTDOCFLAGS` set to build the documentation into the `sui/target` directory.  
-
-   ```rust
-   RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps
-   ```
-
-1. Open the `sui/target/doc/sui_sdk/index.html` file with a browser, like Chrome.
-
-1. After building the docs, use the `rustup override` command again to return to the default toolchain.
-
-   ```rust
-   rustup override unset
-   ```
+1. Open the `sui/target/doc/sui_sdk/index.html` file from above with a browser, like Chrome.
 
 ## Rust SDK examples
 

--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -42,7 +42,7 @@ You can also build the documentation locally. To do so,
 
 1. Open a Terminal or Console and go to the `sui/crates/sui-sdk` directory.
 
-1. Run `cargo doc` to build the documentation into the `sui/target` directory. Take note of location of the generated file from the last line of the output, e.g. `Generated /Users/foo/sui/target/doc/sui_sdk/index.html`
+1. Run `cargo doc` to build the documentation into the `sui/target` directory. Take note of location of the generated file from the last line of the output, for example `Generated /Users/foo/sui/target/doc/sui_sdk/index.html`.
 
 1. Open the `sui/target/doc/sui_sdk/index.html` file from above with a browser, like Chrome.
 

--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -44,7 +44,7 @@ You can also build the documentation locally. To do so,
 
 1. Run `cargo doc` to build the documentation into the `sui/target` directory. Take note of location of the generated file from the last line of the output, for example `Generated /Users/foo/sui/target/doc/sui_sdk/index.html`.
 
-1. Open the `sui/target/doc/sui_sdk/index.html` file from above with a browser, like Chrome.
+1. Use a web browser, like Chrome, to open the `index.html` file at the location your console reported in the previous step.
 
 ## Rust SDK examples
 

--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -40,11 +40,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
 You can also build the documentation locally. To do so,
 
-1. Open a Terminal or Console and go to the `sui/crates/sui-sdk` directory.
+1. Clone the `sui` repo locally. Open a Terminal or Console and go to the `sui/crates/sui-sdk` directory.
 
 1. Run `cargo doc` to build the documentation into the `sui/target` directory. Take note of location of the generated file from the last line of the output, for example `Generated /Users/foo/sui/target/doc/sui_sdk/index.html`.
 
-1. Use a web browser, like Chrome, to open the `index.html` file at the location your console reported in the previous step.
+1. Use a web browser, like Chrome, to open the `.../target/doc/sui_sdk/index.html` file at the location your console reported in the previous step.
 
 ## Rust SDK examples
 


### PR DESCRIPTION
## Description 

When building doc for only one crate, it is unnecessary to enable building workspace index page.

## Test Plan 

Tried out the instructions locally.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
