### PR TITLE
Cg/hagent into sui node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12951,6 +12951,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "serde",
+ "serde_json",
  "snap",
  "sui-archival",
  "sui-config",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -634,7 +634,7 @@ pub struct HealthCheckConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub listen_port: Option<i64>,
+    pub listen_address: Option<SocketAddr>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -167,6 +167,9 @@ pub struct NodeConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_with_range: Option<RunWithRange>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_check_config: Option<HealthCheckConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
@@ -619,6 +622,19 @@ impl AuthorityStorePruningConfig {
     pub fn set_killswitch_tombstone_pruning(&mut self, killswitch_tombstone_pruning: bool) {
         self.killswitch_tombstone_pruning = killswitch_tombstone_pruning;
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct HealthCheckConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -52,6 +52,7 @@ fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true
 workspace-hack.workspace = true
 move-vm-profiler.workspace = true
+serde_json.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-node/src/health_check.rs
+++ b/crates/sui-node/src/health_check.rs
@@ -1,0 +1,166 @@
+use mysten_metrics::RegistryService;
+use sui_config::node::HealthCheckConfig;
+
+use axum::routing::get;
+use axum::{http::StatusCode, Extension, Json, Router};
+use serde_json::json;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::Notify;
+use tracing::{error, info};
+
+#[derive(Clone)]
+enum HealthStatus {
+    HEALTHY,
+    UNHEALTHY,
+}
+
+#[derive(Clone)]
+enum ReadyStatus {
+    READY,
+    NOTREADY,
+}
+
+#[derive(Clone)]
+pub struct HealthService {
+    metric_registry_service: RegistryService,
+    health_status: Arc<RwLock<HealthStatus>>,
+    ready_status: Arc<RwLock<ReadyStatus>>,
+}
+
+impl HealthService {
+    pub fn new(metric_registry_service: RegistryService) -> HealthService {
+        HealthService {
+            metric_registry_service,
+            health_status: Arc::new(RwLock::new(HealthStatus::UNHEALTHY)),
+            ready_status: Arc::new(RwLock::new(ReadyStatus::NOTREADY)),
+        }
+    }
+
+    pub async fn monitor_and_update_status(&self, notify: Arc<Notify>) {
+        // read from channel for metrics push tick, need to fallback to other timer if metrics
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            tokio::select! {
+                // prefer notify channel on selects
+                biased;
+
+                _ = notify.notified() => {
+                    self.set_ready_status();
+                },
+                _ = interval.tick() => {
+                    info!("interval tick in health check - checking checkpoint metrics");
+                    self.set_ready_status();
+                }
+            }
+        }
+    }
+
+    fn set_ready_status(&self) {
+        let max_lag: u64 = 300;
+        let metrics_families = self.metric_registry_service.gather_all();
+        // Iterate over metric families to find our counter
+        for family in metrics_families {
+            // also need last_executed_checkpoint_timestamp
+            if family.get_name() == "last_executed_checkpoint_timestamp_ms" {
+                // Found our metric family, now extract metric data
+                for metric in family.get_metric() {
+                    let last_executed_checkpoint_ts_ms = metric.get_gauge().get_value() as u64;
+                    if is_delay_greater_than_max_lag(last_executed_checkpoint_ts_ms, max_lag) {
+                        info!("server not ready due to last executed checkpoint lag");
+                        let mut ready_status = self.ready_status.write().unwrap();
+                        *ready_status = ReadyStatus::NOTREADY;
+                        return;
+                    } else {
+                        let mut ready_status = self.ready_status.write().unwrap();
+                        info!("server ready");
+                        *ready_status = ReadyStatus::READY;
+                    };
+                }
+            }
+        }
+    }
+}
+
+async fn health_check_handler(
+    Extension(health_service): Extension<HealthService>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match health_service.health_status.read() {
+        Ok(health_status) => match *health_status {
+            HealthStatus::HEALTHY => (StatusCode::OK, Json(json!({"status": "ok"}))),
+            HealthStatus::UNHEALTHY => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"status": "unhealthy"})),
+            ),
+        },
+        Err(e) => {
+            error!("error when reading health status {}", e);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"status": "unknown"})),
+            )
+        }
+    }
+}
+
+async fn ready_check_handler(
+    Extension(health_service): Extension<HealthService>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match health_service.ready_status.read() {
+        Ok(ready_status) => match *ready_status {
+            ReadyStatus::READY => (StatusCode::OK, Json(json!({"status": "ready"}))),
+            ReadyStatus::NOTREADY => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"status": "not ready"})),
+            ),
+        },
+        Err(e) => {
+            error!("error when reading ready status {}", e);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"status": "unknown"})),
+            )
+        }
+    }
+}
+
+pub async fn start_health_checks(
+    registry_service: RegistryService,
+    notify: Arc<Notify>,
+    config: Option<HealthCheckConfig>,
+) {
+    // start basic health check endpoints
+    let mut health_service = HealthService::new(registry_service);
+
+    //tokio::spawn(async move {
+    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8000);
+    let app = Router::new()
+        .route("/health", get(health_check_handler))
+        .route("/ready", get(ready_check_handler))
+        .layer(Extension(health_service.clone()));
+
+    tokio::spawn(async move {
+        health_service.monitor_and_update_status(notify).await;
+    });
+
+    axum::Server::bind(&socket)
+        .serve(app.into_make_service())
+        .await
+        .unwrap()
+}
+
+fn is_delay_greater_than_max_lag(unix_timestamp: u64, max_lag: u64) -> bool {
+    let timestamp_time = UNIX_EPOCH + Duration::from_secs(unix_timestamp);
+    match SystemTime::now().duration_since(timestamp_time) {
+        Ok(duration_since_timestamp) => {
+            // Compare the duration
+            duration_since_timestamp > Duration::from_secs(max_lag)
+        }
+        Err(_) => {
+            // SystemTime::now() is earlier than the unix timestamp
+            // This could happen if the system clock is changed
+            false
+        }
+    }
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -125,6 +125,7 @@ use crate::metrics::{GrpcMetrics, SuiNodeMetrics};
 
 pub mod admin;
 mod handle;
+pub mod health_check;
 pub mod metrics;
 
 pub struct ValidatorComponents {

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -139,14 +139,15 @@ fn main() {
     runtimes.sui_node.spawn(async move {
         match &config.health_check_config {
             Some(health_config) => {
+                let config_clone = config.clone();
                 if health_config.enable.unwrap_or(false) == true {
                     let registry_service_clone = registry_service.clone();
                     tokio::spawn(async move {
-                        sui_node::health_check::start_health_checks(registry_service_clone, notify, health_check_config).await;
+                        sui_node::health_check::start_health_checks(registry_service_clone, notify, config_clone.health_check_config).await;
                     });
                 }
             },
-            None => { info!("health check configed not enabled"); },
+            None => { info!("health check config not enabled"); },
         }
         match sui_node::SuiNode::start_async(&config, registry_service, Some(rpc_runtime)).await {
             Ok(sui_node) => node_once_cell_clone

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -190,6 +190,7 @@ impl ValidatorConfigBuilder {
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
             overload_threshold_config: self.overload_threshold_config.unwrap_or_default(),
             run_with_range: None,
+            health_check_config: None,
         }
     }
 
@@ -436,6 +437,7 @@ impl FullnodeConfigBuilder {
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
             overload_threshold_config: Default::default(),
             run_with_range: self.run_with_range,
+            health_check_config: None,
         }
     }
 }


### PR DESCRIPTION
## Description 

This PR adds an optional health check service that executes on startup. The health check service provides healthy and ready endpoints frequently used in k8s services. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
