### PR TITLE
[gql][1/n][adjust-limits] Adjust limits to support json-rpc-compatible ts sdk shim layer

### DIFF
--- a/crates/sui-graphql-rpc/README.md
+++ b/crates/sui-graphql-rpc/README.md
@@ -51,3 +51,9 @@ Launch GraphiQL IDE at: http://127.0.0.1:8000
 
 ### Launching the server w/ indexer
 For local dev, it might be useful to spin up an indexer as well. Instructions are at [Running standalone indexer](../sui-indexer/README.md#running-standalone-indexer).
+
+## Compatibility with json-rpc
+
+`cargo run --bin sui-test-validator -- --with-indexer --pg-port 5432 --pg-db-name sui_indexer_v2 --graphql-host 127.0.0.1 --graphql-port 9125`
+
+`pnpm --filter @mysten/graphql-transport test:e2e`

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -10,13 +10,18 @@ use sui_json_rpc::name_service::NameServiceConfig;
 use crate::functional_group::FunctionalGroup;
 
 // TODO: calculate proper cost limits
-const MAX_QUERY_DEPTH: u32 = 15;
-const MAX_QUERY_NODES: u32 = 50;
+
+/// These values are set to support TS SDK shim layer queries for json-rpc compatibility.
+const MAX_QUERY_NODES: u32 = 300;
+const MAX_QUERY_PAYLOAD_SIZE: u32 = 5_000;
+
+const MAX_QUERY_DEPTH: u32 = 20;
 const MAX_OUTPUT_NODES: u64 = 100_000; // Maximum number of output nodes allowed in the response
-const MAX_QUERY_PAYLOAD_SIZE: u32 = 2_000;
 const MAX_DB_QUERY_COST: u64 = 20_000; // Max DB query cost (normally f64) truncated
 const DEFAULT_PAGE_SIZE: u64 = 20; // Default number of elements allowed on a page of a connection
 const MAX_PAGE_SIZE: u64 = 50; // Maximum number of elements allowed on a page of a connection
+
+/// The following limits reflect the max values set in the ProtocolConfig.
 const MAX_TYPE_ARGUMENT_DEPTH: u32 = 16;
 const MAX_TYPE_ARGUMENT_WIDTH: u32 = 32;
 const MAX_TYPE_NODES: u32 = 256;
@@ -93,15 +98,6 @@ pub struct Limits {
 }
 
 impl Limits {
-    pub fn default_for_simulator_testing() -> Self {
-        Self {
-            max_query_nodes: 500,
-            max_query_depth: 20,
-            max_query_payload_size: 5_000,
-            ..Self::default()
-        }
-    }
-
     /// Extract limits for the package resolver.
     pub fn package_resolver_limits(&self) -> sui_package_resolver::Limits {
         sui_package_resolver::Limits {

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::ConnectionConfig;
-use crate::config::Limits;
 use crate::config::ServerConfig;
 use crate::config::ServiceConfig;
 use crate::server::graphiql_server::start_graphiql_server;
@@ -158,11 +157,7 @@ pub async fn start_graphql_server_with_fn_rpc(
 ) -> JoinHandle<()> {
     let mut server_config = ServerConfig {
         connection: graphql_connection_config,
-        service: ServiceConfig {
-            // Use special limits for testing
-            limits: Limits::default_for_simulator_testing(),
-            ..ServiceConfig::default()
-        },
+        service: ServiceConfig::default(),
         ..ServerConfig::default()
     };
     if let Some(fn_rpc_url) = fn_rpc_url {


### PR DESCRIPTION
## Description 

Some queries in the ts sdk shim layer exceed the defaults set by sui-graphql-rpc today, so we raise them here. Also remove the special init fn for simulator testing, so we don't run into these discrepancies in the future. 

## Test Plan 

existing tests pass

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
