### PR TITLE
dapp-kit-docs: Documentation typo

### DIFF
--- a/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
+++ b/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
@@ -13,7 +13,7 @@ currently active network.
 
 ```tsx
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
-import { type SuiClientOptions } from '@mysten/sui.js/client';
+import { getFullnodeUrl } from '@mysten/sui.js/client';
 
 // Config options for the networks you want to connect to
 const { networkConfig } = createNetworkConfig({
@@ -49,7 +49,7 @@ The following example demonstrates a `SuiClientProvider` used as a controlled co
 
 ```tsx
 import { createNetworkConfig, SuiClientProvider } from '@mysten/dapp-kit';
-import { type SuiClientOptions } from '@mysten/sui.js/client';
+import { getFullnodeUrl } from '@mysten/sui.js/client';
 import { useState } from 'react';
 
 // Config options for the networks you want to connect to
@@ -81,7 +81,7 @@ The following example demonstrates how to create a custom `SuiClient`.
 
 ```tsx
 import { SuiClientProvider } from '@mysten/dapp-kit';
-import { SuiClient, SuiHTTPTransport, type SuiClientOptions } from '@mysten/sui.js/client';
+import { SuiClient, SuiHTTPTransport, getFullnodeUrl } from '@mysten/sui.js/client';
 
 // Config options for the networks you want to connect to
 const networks = {
@@ -166,7 +166,7 @@ to get the variables defined in your configuration.
 import { createNetworkConfig, SuiClientProvider } from '@mysten/dapp-kit';
 
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
-import { type SuiClientOptions } from '@mysten/sui.js/client';
+import { getFullnodeUrl } from '@mysten/sui.js/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Config options for the networks you want to connect to

--- a/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
+++ b/sdk/docs/pages/dapp-kit/sui-client-provider.mdx
@@ -81,7 +81,7 @@ The following example demonstrates how to create a custom `SuiClient`.
 
 ```tsx
 import { SuiClientProvider } from '@mysten/dapp-kit';
-import { SuiClient, SuiHTTPTransport, getFullnodeUrl } from '@mysten/sui.js/client';
+import { getFullnodeUrl, SuiClient, SuiHTTPTransport } from '@mysten/sui.js/client';
 
 // Config options for the networks you want to connect to
 const networks = {


### PR DESCRIPTION
From { type SuiClientOptions } to { getFullnodeUrl }

## Description 

Documentation change

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fix typo in examples in dapp-kit docs