### PR TITLE
[suiop] add type for services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14031,7 +14031,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "suiop-cli"
 publish = false
-version = "0.1.8"
+version = "0.1.9"
 
 [lib]
 name = "suioplib"

--- a/crates/suiop-cli/src/cli/pulumi/init.rs
+++ b/crates/suiop-cli/src/cli/pulumi/init.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info, warn};
 
 pub enum ProjectType {
     App,
+    Service,
     Basic,
     CronJob,
 }
@@ -30,8 +31,11 @@ impl ProjectType {
         });
         // create dir
         let project_subdir = match self {
-            Self::App | Self::CronJob => "apps",
-            Self::Basic => "services",
+            Self::App | Self::CronJob => "apps".to_owned(),
+            Self::Service => "services".to_owned(),
+            Self::Basic => Text::new("project subdir (under sui-operations/pulumi/):")
+                .prompt()
+                .expect("couldn't get subdir"),
         };
         let project_dir = get_pulumi_dir()?.join(project_subdir).join(&project_name);
         let mut project_opts = vec![];
@@ -49,8 +53,8 @@ impl ProjectType {
             ))
         } else {
             match self {
-                Self::App => {
-                    info!("creating k8s containerized application");
+                Self::App | Self::Service => {
+                    info!("creating k8s containerized application/service");
                     create_mysten_k8s_project(
                         &project_name,
                         &project_dir,
@@ -144,7 +148,7 @@ fn run_pulumi_new_from_template(
         project_dir_str.bright_purple()
     );
     let template_dir = match project_type {
-        ProjectType::App => "app-go",
+        ProjectType::App | ProjectType::Service => "app-go",
         ProjectType::CronJob => "cronjob-go",
         _ => "app-go",
     };

--- a/crates/suiop-cli/src/cli/pulumi/mod.rs
+++ b/crates/suiop-cli/src/cli/pulumi/mod.rs
@@ -25,6 +25,9 @@ pub enum PulumiAction {
         #[arg(short, long, group = "type")]
         app: bool,
 
+        #[arg(short, long, group = "type")]
+        service: bool,
+
         /// initialize barebones project (default)
         #[arg(short, long, group = "type")]
         basic: bool,
@@ -48,6 +51,7 @@ pub async fn pulumi_cmd(args: &PulumiArgs) -> Result<()> {
     match &args.action {
         PulumiAction::InitProject {
             app,
+            service,
             basic,
             cronjob,
             kms,
@@ -56,10 +60,11 @@ pub async fn pulumi_cmd(args: &PulumiArgs) -> Result<()> {
             if *kms {
                 ensure_gcloud()?;
             }
-            let project_type = match (app, basic, cronjob) {
-                (true, false, false) => ProjectType::App,
-                (false, false, true) => ProjectType::CronJob,
-                (_, _, _) => ProjectType::Basic,
+            let project_type = match (app, service, basic, cronjob) {
+                (false, true, false, false) => ProjectType::Service,
+                (true, false, false, false) => ProjectType::App,
+                (false, false, false, true) => ProjectType::CronJob,
+                (_, _, _, _) => ProjectType::Basic,
             };
             project_type.create_project(kms, project_name.clone())
         }


### PR DESCRIPTION
## Description 

Make it so we can create pulumi projects in the services dir

## Test Plan 

```
» suiop p i --service --project-name source-service                                                   
2024-02-27T16:37:38.736654Z  INFO suioplib::cli::pulumi::init: creating k8s containerized application/service                
2024-02-27T16:37:38.736699Z  INFO suioplib::cli::pulumi::init: creating project directory at /Users/jkjensen/mysten/sui-operations/pulumi/services/source-service                                                                                         
2024-02-27T16:37:38.736831Z  INFO suioplib::cli::pulumi::init: creating new pulumi project in /Users/jkjensen/mysten/sui-operations/pulumi/services/source-service
2024-02-27T16:37:38.736834Z  INFO suioplib::cli::pulumi::init: extra pulumi options added:                                   
2024-02-27T16:37:38.741522Z  INFO suioplib::cli::pulumi::init: running command: pulumi new /Users/jkjensen/mysten/sui-operations/pulumi/templates/app-go --dir /Users/jkjensen/mysten/sui-operations/pulumi/services/source-service -d "pulumi project for
 source-service" --name "source-service"  --stack mysten/dev  
Created project 'source-service'                                                                                             
                                                                                                                             
Created stack 'dev'                                           
                                                                                                                                                                                                                                                          
aws:region: the aws region to push images to (us-west-2):                                                                    
gcp:project: the GCP project to place GKE Ingress load balancer (dev=>k8s-clusters-397521, production=>cryptic-bolt-398315) (k8s-clusters-397521): cryptic-bolt-398315 
k8s_region: the kubernetes region to deploy to (ewr | dev | production | zk-dev) (dev): production 
path_to_dockerfile: the path within the repository to the dockerfile you want to build from (Dockerfile): docker/sui-source-service/Dockerfile 
Saved config                       
                                                              
Installing dependencies...                                                                                                                                                                                                                                

Finished installing dependencies

Your new project is ready to go! ✨

To perform an initial deployment, run 'cd source-service', then, run `pulumi up`

2024-02-27T16:38:11.903809Z  INFO suioplib::cli::pulumi::init: running `cd /Users/jkjensen/mysten/sui-operations/pulumi/services/source-service && go mod tidy` to make sure all Golang dependencies are installed.
2024-02-27T16:38:11.986438Z  INFO suioplib::cli::pulumi::init: your new project is ready to go!
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
