### PR TITLE
[data ingestion] simple workflow helper

### DIFF
--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -23,8 +23,8 @@ tracing.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 url.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-tempfile.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }

--- a/crates/sui-data-ingestion-core/src/executor.rs
+++ b/crates/sui-data-ingestion-core/src/executor.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper};
+use crate::progress_store::{
+    ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore,
+};
 use crate::reader::CheckpointReader;
 use crate::worker_pool::WorkerPool;
 use crate::DataIngestionMetrics;
@@ -9,6 +11,7 @@ use crate::Worker;
 use anyhow::Result;
 use futures::Future;
 use mysten_metrics::spawn_monitored_task;
+use prometheus::Registry;
 use std::path::PathBuf;
 use std::pin::Pin;
 use sui_types::full_checkpoint_content::CheckpointData;
@@ -98,4 +101,31 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         }
         Ok(self.progress_store.stats())
     }
+}
+
+pub async fn setup_single_workflow<W: Worker + 'static>(
+    worker: W,
+    remote_store_url: String,
+    initial_checkpoint_number: CheckpointSequenceNumber,
+    concurrency: usize,
+) -> Result<(
+    impl Future<Output = Result<ExecutorProgress>>,
+    oneshot::Sender<()>,
+)> {
+    let (exit_sender, exit_receiver) = oneshot::channel();
+    let metrics = DataIngestionMetrics::new(&Registry::new());
+    let progress_store = ShimProgressStore(initial_checkpoint_number);
+    let mut executor = IndexerExecutor::new(progress_store, 1, metrics);
+    let worker_pool = WorkerPool::new(worker, "workflow".to_string(), concurrency);
+    executor.register(worker_pool).await?;
+    Ok((
+        executor.run(
+            tempfile::tempdir()?.into_path(),
+            Some(remote_store_url),
+            vec![],
+            100,
+            exit_receiver,
+        ),
+        exit_sender,
+    ))
 }

--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -11,7 +11,7 @@ mod worker_pool;
 
 use anyhow::Result;
 use async_trait::async_trait;
-pub use executor::{IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS};
+pub use executor::{setup_single_workflow, IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS};
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore};
 use sui_types::full_checkpoint_content::CheckpointData;

--- a/crates/sui-data-ingestion-core/src/progress_store/mod.rs
+++ b/crates/sui-data-ingestion-core/src/progress_store/mod.rs
@@ -66,3 +66,15 @@ impl<P: ProgressStore> ProgressStoreWrapper<P> {
         self.pending_state.clone()
     }
 }
+
+pub struct ShimProgressStore(pub u64);
+
+#[async_trait]
+impl ProgressStore for ShimProgressStore {
+    async fn load(&mut self, _: String) -> Result<CheckpointSequenceNumber> {
+        Ok(self.0)
+    }
+    async fn save(&mut self, _: String, _: CheckpointSequenceNumber) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
The PR introduces a helper function to execute a simple workflow (a single type of job) from a remote bucket, starting from a specified checkpoint (progress store is mocked).
It aims to minimize unnecessary complexity when setting up a new data ingestion pipeline for external developers




