### PR TITLE
[cli] Move the call to help description after tokenization

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1594,13 +1594,7 @@ impl SuiClientCommands {
                 SuiClientCommandResult::VerifySource
             }
             SuiClientCommands::PTB(ptb) => {
-                if ptb.args.contains(&"--help".to_string()) {
-                    ptb_description().print_long_help().unwrap();
-                } else if ptb.args.contains(&"-h".to_string()) || ptb.args.is_empty() {
-                    ptb_description().print_help().unwrap();
-                } else {
-                    ptb.execute(context).await?;
-                }
+                ptb.execute(context).await?;
                 SuiClientCommandResult::NoOutput
             }
         });

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -31,6 +31,8 @@ pub const GAS_BUDGET: &str = "gas-budget";
 pub const SUMMARY: &str = "summary";
 pub const GAS_COIN: &str = "gas-coin";
 pub const JSON: &str = "json";
+pub const HELP: &str = "help";
+pub const SHORT_HELP: &str = "h";
 
 // Types
 pub const U8: &str = "u8";
@@ -78,6 +80,7 @@ pub struct Program {
 /// flag was set, json output was set, etc.
 #[derive(Debug, Clone)]
 pub struct ProgramMetadata {
+    pub help_set: bool,
     pub preview_set: bool,
     pub summary_set: bool,
     pub gas_object_id: Option<Spanned<ObjectID>>,

--- a/crates/sui/src/client_ptb/lexer.rs
+++ b/crates/sui/src/client_ptb/lexer.rs
@@ -8,14 +8,18 @@ use super::{
     token::{Lexeme, Token as T},
 };
 
-pub struct Lexer<'l, I: Iterator<Item = &'l str>> {
+#[derive(Clone)]
+pub struct Lexer<'l, I: Iterator<Item = &'l str>>
+where
+    I: Clone,
+{
     pub buf: &'l str,
     pub tokens: I,
     pub offset: usize,
     pub done: Option<Spanned<Lexeme<'l>>>,
 }
 
-impl<'l, I: Iterator<Item = &'l str>> Lexer<'l, I> {
+impl<'l, I: Iterator<Item = &'l str> + Clone> Lexer<'l, I> {
     pub fn new(mut tokens: I) -> Option<Self> {
         let Some(buf) = tokens.next() else {
             return None;
@@ -206,7 +210,7 @@ impl<'l, I: Iterator<Item = &'l str>> Lexer<'l, I> {
     }
 }
 
-impl<'l, I: Iterator<Item = &'l str>> Iterator for Lexer<'l, I> {
+impl<'l, I: Iterator<Item = &'l str> + Clone> Iterator for Lexer<'l, I> {
     type Item = Spanned<Lexeme<'l>>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
## Description 

This PR improves the reliability of the `sui client ptb --help` command. The check for the help flag being set will be done after tokenization and before parsing. Unfortunately, there is some `async_trait` high level error that makes the whole thing not compile...

## Test Plan 
👀 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
