### PR TITLE
[move-2024] Slighlty improve type mismatch errors in syntax index errors

### DIFF
--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/index_syntax_methods_return_mismatch.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/index_syntax_methods_return_mismatch.exp
@@ -36,7 +36,10 @@ error[E04034]: 'syntax' method types differ
    │                                         ^^^^ This index function returns type '&u64'
    ·
 62 │     public fun borrow_q_mut(s: &mut S, i: u64): &mut u32 {
-   │                                                 -------- This mutable index function returns type '&mut u32'
+   │                                                 --------
+   │                                                 │
+   │                                                 Expected this mutable index function to return type '&mut u64'
+   │                                                 It returns type '&mut u32'
    │
    = These functions must return the same type, differing only by mutability
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/primitive_index_invalid_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/primitive_index_invalid_2.exp
@@ -2,10 +2,13 @@ error[E04034]: 'syntax' method types differ
   ┌─ tests/move_2024/typing/primitive_index_invalid_2.move:5:64
   │
 5 │     native public fun vborrow<Element>(v: &vector<Element>, i: u64): &Element;
-  │                                                                ^^^ This index function expects type 'u64'
+  │                                                                ^^^ This parameter has type 'u64'
 6 │     #[syntax(index)]
 7 │     native public fun vborrow_mut<Element>(v: &mut vector<Element>, i: u32): &mut Element;
-  │                                                                        --- This mutable index function expects type 'u32'
+  │                                                                        ---
+  │                                                                        │
+  │                                                                        Expected this parameter to have type 'u64'
+  │                                                                        It has type 'u32'
   │
   = Index operation non-subject parameter types must match exactly
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_invalid.exp
@@ -2,10 +2,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:7:39
    │
  7 │     public fun borrow<T>(s: &S<T>, i: u64): &u64 { abort 0 }
-   │                                       ^^^ This index function expects type 'u64'
+   │                                       ^^^ This parameter has type 'u64'
    ·
 11 │     public fun borrow_mut<T>(s: &mut S<T>, i: T): &mut u64 { abort 0 }
-   │                                               - This mutable index function expects type 'T'
+   │                                               -
+   │                                               │
+   │                                               Expected this parameter to have type 'u64'
+   │                                               It has type 'T'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -24,10 +27,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:34:39
    │
 34 │     public fun borrow<T>(s: &S<T>, i: u64, j: T): &T { abort 0 }
-   │                                       ^^^ This index function expects type 'u64'
+   │                                       ^^^ This parameter has type 'u64'
    ·
 38 │     public fun borrow_mut<T>(s: &mut S<T>, i: u32, j: T): &mut T { abort 0 }
-   │                                               --- This mutable index function expects type 'u32'
+   │                                               ---
+   │                                               │
+   │                                               Expected this parameter to have type 'u64'
+   │                                               It has type 'u32'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -46,10 +52,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:62:41
    │
 62 │     public fun borrow<T,Q>(s: &S<T>, i: u64, j: Q): &T { abort 0 }
-   │                                         ^^^ This index function expects type 'u64'
+   │                                         ^^^ This parameter has type 'u64'
    ·
 66 │     public fun borrow_mut<T,Q>(s: &mut S<T>, i: u32, j: T): &mut T { abort 0 }
-   │                                                 --- This mutable index function expects type 'u32'
+   │                                                 ---
+   │                                                 │
+   │                                                 Expected this parameter to have type 'u64'
+   │                                                 It has type 'u32'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -57,10 +66,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:62:49
    │
 62 │     public fun borrow<T,Q>(s: &S<T>, i: u64, j: Q): &T { abort 0 }
-   │                                                 ^ This index function expects type 'Q'
+   │                                                 ^ This parameter has type 'Q'
    ·
 66 │     public fun borrow_mut<T,Q>(s: &mut S<T>, i: u32, j: T): &mut T { abort 0 }
-   │                                                         - This mutable index function expects type 'T'
+   │                                                         -
+   │                                                         │
+   │                                                         Expected this parameter to have type 'Q'
+   │                                                         It has type 'T'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -68,10 +80,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:76:41
    │
 76 │     public fun borrow<T,R>(s: &S<T>, i: R, j: T): &T { abort 0 }
-   │                                         ^ This index function expects type 'R'
+   │                                         ^ This parameter has type 'R'
    ·
 80 │     public fun borrow_mut<T,R>(s: &mut S<T>, i: T, j: T): &mut T { abort 0 }
-   │                                                 - This mutable index function expects type 'T'
+   │                                                 -
+   │                                                 │
+   │                                                 Expected this parameter to have type 'R'
+   │                                                 It has type 'T'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -79,10 +94,13 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:90:39
    │
 90 │     public fun borrow<T>(s: &S<T>, i: u64): &T {
-   │                                       ^^^ This index function expects type 'u64'
+   │                                       ^^^ This parameter has type 'u64'
    ·
 95 │     public fun borrow_mut<T>(s: &mut S<T>, i: u32): &mut T {
-   │                                               --- This mutable index function expects type 'u32'
+   │                                               ---
+   │                                               │
+   │                                               Expected this parameter to have type 'u64'
+   │                                               It has type 'u32'
    │
    = Index operation non-subject parameter types must match exactly
 
@@ -90,10 +108,13 @@ error[E04034]: 'syntax' method types differ
     ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:107:39
     │
 107 │     public fun borrow<T>(s: &S<T>, i: &u64, j: T): &T { abort 0 }
-    │                                       ^^^^ This index function expects type '&u64'
+    │                                       ^^^^ This parameter has type '&u64'
     ·
 111 │     public fun borrow_mut<T>(s: &mut S<T>, i: &mut u64, j: T): &mut T { abort 0 }
-    │                                               -------- This mutable index function expects type '&mut u64'
+    │                                               --------
+    │                                               │
+    │                                               Expected this parameter to have type '&u64'
+    │                                               It has type '&mut u64'
     │
     = Index operation non-subject parameter types must match exactly
 
@@ -101,10 +122,13 @@ error[E04034]: 'syntax' method types differ
     ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:121:48
     │
 121 │     public fun borrow<T>(s: &S<T>, i: &u64, j: &T): &T { abort 0 }
-    │                                                ^^ This index function expects type '&T'
+    │                                                ^^ This parameter has type '&T'
     ·
 125 │     public fun borrow_mut<T>(s: &mut S<T>, i: &u64, j: &mut T): &mut T { abort 0 }
-    │                                                        ------ This mutable index function expects type '&mut T'
+    │                                                        ------
+    │                                                        │
+    │                                                        Expected this parameter to have type '&T'
+    │                                                        It has type '&mut T'
     │
     = Index operation non-subject parameter types must match exactly
 
@@ -112,10 +136,13 @@ error[E04034]: 'syntax' method types differ
     ┌─ tests/move_2024/typing/syntax_methods_args_invalid.move:135:48
     │
 135 │     public fun borrow<T>(s: &S<T>, i: &u64, j: &mut T): &T { abort 0 }
-    │                                                ^^^^^^ This index function expects type '&mut T'
+    │                                                ^^^^^^ This parameter has type '&mut T'
     ·
 139 │     public fun borrow_mut<T>(s: &mut S<T>, i: &u64, j: &T): &mut T { abort 0 }
-    │                                                        -- This mutable index function expects type '&T'
+    │                                                        --
+    │                                                        │
+    │                                                        Expected this parameter to have type '&mut T'
+    │                                                        It has type '&T'
     │
     = Index operation non-subject parameter types must match exactly
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_polymorphic_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_polymorphic_invalid.exp
@@ -2,10 +2,13 @@ error[E04034]: 'syntax' method types differ
   ┌─ tests/move_2024/typing/syntax_methods_args_polymorphic_invalid.move:6:43
   │
 6 │     public fun borrow<T,Q>(_s: &S<T>, _j: Q): &T { abort 0 }
-  │                                           ^ This index function expects type 'Q'
+  │                                           ^ This parameter has type 'Q'
   ·
 9 │     public fun borrow_mut<T,Q>(_s: &mut S<T>, _j: T): &mut T { abort 0 }
-  │                                                   - This mutable index function expects type 'T'
+  │                                                   -
+  │                                                   │
+  │                                                   Expected this parameter to have type 'Q'
+  │                                                   It has type 'T'
   │
   = Index operation non-subject parameter types must match exactly
 
@@ -18,8 +21,10 @@ error[E04034]: 'syntax' method types differ
    │                          Type parameter T appears in position 2 here
 15 │     #[syntax(index)]
 16 │     public fun borrow_muAt<T,Q>(_s: &mut A<T>, _j: T): &mut T { abort 0 }
-   │                            -        --------- This mutable index function subject has type '&mut a::invalid::A<T>'
-   │                            │         
+   │                            -        ---------
+   │                            │        │
+   │                            │        Expected this mutable index function subject to have type '&mut a::invalid::A<Q>'
+   │                            │        It has type '&mut a::invalid::A<T>'
    │                            Type parameter T appears in position 1 here
    │
    = Type parameters must be used the same by position, not name
@@ -29,13 +34,15 @@ error[E04034]: 'syntax' method types differ
    ┌─ tests/move_2024/typing/syntax_methods_args_polymorphic_invalid.move:14:44
    │
 14 │     public fun borrowA<Q,T>(_s: &A<T>, _j: T): &Q { abort 0 }
-   │                          -                 ^ This index function expects type 'T'
+   │                          -                 ^ This parameter has type 'T'
    │                          │                  
    │                          Type parameter T appears in position 2 here
 15 │     #[syntax(index)]
 16 │     public fun borrow_muAt<T,Q>(_s: &mut A<T>, _j: T): &mut T { abort 0 }
-   │                            -                       - This mutable index function expects type 'T'
-   │                            │                        
+   │                            -                       -
+   │                            │                       │
+   │                            │                       Expected this parameter to have type 'Q'
+   │                            │                       It has type 'T'
    │                            Type parameter T appears in position 1 here
    │
    = Type parameters must be used the same by position, not name

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_polymorphic_invalid_positional.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/syntax_methods_args_polymorphic_invalid_positional.exp
@@ -2,13 +2,15 @@ error[E04034]: 'syntax' method types differ
   ┌─ tests/move_2024/typing/syntax_methods_args_polymorphic_invalid_positional.move:6:45
   │
 6 │     public fun borrow_a<Q,T>(_s: &A<Q>, _j: T): &Q { abort 0 }
-  │                           -                 ^ This index function expects type 'T'
+  │                           -                 ^ This parameter has type 'T'
   │                           │                  
   │                           Type parameter T appears in position 2 here
   ·
 9 │     public fun borrow_mut_a<T,Q>(_s: &mut A<T>, _j: T): &mut T { abort 0 }
-  │                             -                       - This mutable index function expects type 'T'
-  │                             │                        
+  │                             -                       -
+  │                             │                       │
+  │                             │                       Expected this parameter to have type 'Q'
+  │                             │                       It has type 'T'
   │                             Type parameter T appears in position 1 here
   │
   = Type parameters must be used the same by position, not name
@@ -23,8 +25,10 @@ error[E04034]: 'syntax' method types differ
    │                           Type parameter T appears in position 2 here
    ·
 17 │     public fun borrow_mut_b<T,Q>(_s: &mut B<T>, _j: T): &mut T { abort 0 }
-   │                             -                           ------ This mutable index function returns type '&mut T'
-   │                             │                            
+   │                             -                           ------
+   │                             │                           │
+   │                             │                           Expected this mutable index function to return type '&mut Q'
+   │                             │                           It returns type '&mut T'
    │                             Type parameter T appears in position 1 here
    │
    = Type parameters must be used the same by position, not name
@@ -39,8 +43,10 @@ error[E04034]: 'syntax' method types differ
    │                           Type parameter T appears in position 2 here
    ·
 25 │     public fun borrow_mut_c<T,Q>(_s: &mut C<T>, _j: T): &mut T { abort 0 }
-   │                             -        --------- This mutable index function subject has type '&mut a::invalid::C<T>'
-   │                             │         
+   │                             -        ---------
+   │                             │        │
+   │                             │        Expected this mutable index function subject to have type '&mut a::invalid::C<Q>'
+   │                             │        It has type '&mut a::invalid::C<T>'
    │                             Type parameter T appears in position 1 here
    │
    = Type parameters must be used the same by position, not name


### PR DESCRIPTION
## Description 

This does a bit more work in syntax index function checking to produce nicer errors when types disagree.

## Test Plan 

Updated expectation files

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
