### PR TITLE
[move] Remove parsing for specs

### DIFF
--- a/external-crates/move/crates/move-compiler/src/expansion/alias_map_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/alias_map_builder.rs
@@ -129,8 +129,7 @@ impl AliasMapBuilder {
             } => match kind {
                 // constants and functions are not in the leading access namespace
                 ModuleMemberKind::Constant
-                | ModuleMemberKind::Function
-                | ModuleMemberKind::Schema => remove_dup(module_members, alias),
+                | ModuleMemberKind::Function => remove_dup(module_members, alias),
                 // structs are in the leading access namespace in addition to the module members
                 // namespace
                 ModuleMemberKind::Struct => {
@@ -188,8 +187,7 @@ impl AliasMapBuilder {
             } => match kind {
                 // constants and functions are not in the leading access namespace
                 ModuleMemberKind::Constant
-                | ModuleMemberKind::Function
-                | ModuleMemberKind::Schema => {
+                | ModuleMemberKind::Function => {
                     let entry = (MemberEntry::Member(ident, member), is_implicit);
                     module_members.add(alias, entry).unwrap();
                 }

--- a/external-crates/move/crates/move-compiler/src/expansion/alias_map_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/alias_map_builder.rs
@@ -128,8 +128,9 @@ impl AliasMapBuilder {
                 module_members,
             } => match kind {
                 // constants and functions are not in the leading access namespace
-                ModuleMemberKind::Constant
-                | ModuleMemberKind::Function => remove_dup(module_members, alias),
+                ModuleMemberKind::Constant | ModuleMemberKind::Function => {
+                    remove_dup(module_members, alias)
+                }
                 // structs are in the leading access namespace in addition to the module members
                 // namespace
                 ModuleMemberKind::Struct => {
@@ -186,8 +187,7 @@ impl AliasMapBuilder {
                 module_members,
             } => match kind {
                 // constants and functions are not in the leading access namespace
-                ModuleMemberKind::Constant
-                | ModuleMemberKind::Function => {
+                ModuleMemberKind::Constant | ModuleMemberKind::Function => {
                     let entry = (MemberEntry::Member(ident, member), is_implicit);
                     module_members.add(alias, entry).unwrap();
                 }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -198,9 +198,6 @@ pub enum FunctionBody_ {
 }
 pub type FunctionBody = Spanned<FunctionBody_>;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct SpecId(usize);
-
 #[derive(PartialEq, Clone, Debug)]
 pub struct Function {
     pub warning_filter: WarningFilters,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -217,7 +217,10 @@ impl<'env, 'map> Context<'env, 'map> {
             } else {
                 Uncategorized::DeprecatedWillBeRemoved
             },
-            (loc, "Specification blocks are deprecated and are no longer used")
+            (
+                loc,
+                "Specification blocks are deprecated and are no longer used"
+            )
         )
     }
 }
@@ -2103,7 +2106,6 @@ fn aliases_from_member(
             Some(P::ModuleMember::Struct(s))
         }
         P::ModuleMember::Spec(s) => Some(P::ModuleMember::Spec(s)),
-
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -187,7 +187,7 @@ pub enum ModuleMember {
     Use(UseDecl),
     Friend(FriendDecl),
     Constant(Constant),
-    Spec(SpecBlock),
+    Spec(Spanned<String>),
 }
 
 //**************************************************************************************************
@@ -296,129 +296,6 @@ pub struct Constant {
     pub name: ConstantName,
     pub value: Exp,
 }
-
-//**************************************************************************************************
-// Specification Blocks
-//**************************************************************************************************
-
-// Specification block:
-//    SpecBlock = "spec" <SpecBlockTarget> "{" SpecBlockMember* "}"
-#[derive(Debug, Clone, PartialEq)]
-pub struct SpecBlock_ {
-    pub attributes: Vec<Attributes>,
-    pub target: SpecBlockTarget,
-    pub uses: Vec<UseDecl>,
-    pub members: Vec<SpecBlockMember>,
-}
-
-pub type SpecBlock = Spanned<SpecBlock_>;
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum SpecBlockTarget_ {
-    Code,
-    Module,
-    Member(Name, Option<Box<FunctionSignature>>),
-    Schema(Name, Vec<(Name, Vec<Ability>)>),
-}
-
-pub type SpecBlockTarget = Spanned<SpecBlockTarget_>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PragmaProperty_ {
-    pub name: Name,
-    pub value: Option<PragmaValue>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PragmaValue {
-    Literal(Value),
-    Ident(NameAccessChain),
-}
-
-pub type PragmaProperty = Spanned<PragmaProperty_>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SpecApplyPattern_ {
-    pub visibility: Option<Visibility>,
-    pub name_pattern: Vec<SpecApplyFragment>,
-    pub type_parameters: Vec<(Name, Vec<Ability>)>,
-}
-
-pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SpecApplyFragment_ {
-    Wildcard,
-    NamePart(Name),
-}
-
-pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
-
-#[derive(Debug, Clone, PartialEq)]
-#[allow(clippy::large_enum_variant)]
-pub enum SpecBlockMember_ {
-    Condition {
-        kind: SpecConditionKind,
-        properties: Vec<PragmaProperty>,
-        exp: Exp,
-        additional_exps: Vec<Exp>,
-    },
-    Function {
-        uninterpreted: bool,
-        name: FunctionName,
-        signature: FunctionSignature,
-        body: FunctionBody,
-    },
-    Variable {
-        is_global: bool,
-        name: Name,
-        type_parameters: Vec<(Name, Vec<Ability>)>,
-        type_: Type,
-        init: Option<Exp>,
-    },
-    Let {
-        name: Name,
-        post_state: bool,
-        def: Exp,
-    },
-    Update {
-        lhs: Exp,
-        rhs: Exp,
-    },
-    Include {
-        properties: Vec<PragmaProperty>,
-        exp: Exp,
-    },
-    Apply {
-        exp: Exp,
-        patterns: Vec<SpecApplyPattern>,
-        exclusion_patterns: Vec<SpecApplyPattern>,
-    },
-    Pragma {
-        properties: Vec<PragmaProperty>,
-    },
-}
-
-pub type SpecBlockMember = Spanned<SpecBlockMember_>;
-
-// Specification condition kind.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub enum SpecConditionKind_ {
-    Assert,
-    Assume,
-    Decreases,
-    AbortsIf,
-    AbortsWith,
-    SucceedsIf,
-    Modifies,
-    Emits,
-    Ensures,
-    Requires,
-    Invariant(Vec<(Name, Vec<Ability>)>),
-    InvariantUpdate(Vec<(Name, Vec<Ability>)>),
-    Axiom(Vec<(Name, Vec<Ability>)>),
-}
-pub type SpecConditionKind = Spanned<SpecConditionKind_>;
 
 //**************************************************************************************************
 // Types
@@ -685,7 +562,7 @@ pub enum Exp_ {
     Annotate(Box<Exp>, Type),
 
     // spec { ... }
-    Spec(SpecBlock),
+    Spec(Spanned<String>),
 
     // Internal node marking an error was added to the error list
     // This is here so the pass can continue even when an error is hit
@@ -1201,7 +1078,7 @@ impl AstDebug for ModuleMember {
             ModuleMember::Use(u) => u.ast_debug(w),
             ModuleMember::Friend(f) => f.ast_debug(w),
             ModuleMember::Constant(c) => c.ast_debug(w),
-            ModuleMember::Spec(s) => s.ast_debug(w),
+            ModuleMember::Spec(s) => w.write(&s.value),
         }
     }
 }
@@ -1318,216 +1195,6 @@ impl AstDebug for StructDefinition {
                 });
             }),
             StructFields::Native(_) => (),
-        }
-    }
-}
-
-impl AstDebug for SpecBlock_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        w.write("spec ");
-        self.target.ast_debug(w);
-        w.write("{");
-        w.semicolon(&self.members, |w, m| m.ast_debug(w));
-        w.write("}");
-    }
-}
-
-impl AstDebug for SpecBlockTarget_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        match self {
-            SpecBlockTarget_::Code => {}
-            SpecBlockTarget_::Module => w.write("module "),
-            SpecBlockTarget_::Member(name, sign_opt) => {
-                w.write(name.value);
-                if let Some(sign) = sign_opt {
-                    sign.ast_debug(w);
-                }
-            }
-            SpecBlockTarget_::Schema(n, tys) => {
-                w.write(&format!("schema {}", n.value));
-                if !tys.is_empty() {
-                    w.write("<");
-                    w.list(tys, ", ", |w, ty| {
-                        ty.ast_debug(w);
-                        true
-                    });
-                    w.write(">");
-                }
-            }
-        }
-    }
-}
-
-impl AstDebug for SpecConditionKind_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        use SpecConditionKind_::*;
-        match self {
-            Assert => w.write("assert "),
-            Assume => w.write("assume "),
-            Decreases => w.write("decreases "),
-            AbortsIf => w.write("aborts_if "),
-            AbortsWith => w.write("aborts_with "),
-            SucceedsIf => w.write("succeeds_if "),
-            Modifies => w.write("modifies "),
-            Emits => w.write("emits "),
-            Ensures => w.write("ensures "),
-            Requires => w.write("requires "),
-            Invariant(ty_params) => {
-                w.write("invariant");
-                ty_params.ast_debug(w);
-                w.write(" ")
-            }
-            InvariantUpdate(ty_params) => {
-                w.write("invariant");
-                ty_params.ast_debug(w);
-                w.write(" update ")
-            }
-            Axiom(ty_params) => {
-                w.write("axiom");
-                ty_params.ast_debug(w);
-                w.write(" ")
-            }
-        }
-    }
-}
-
-impl AstDebug for SpecBlockMember_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        match self {
-            SpecBlockMember_::Condition {
-                kind,
-                properties: _,
-                exp,
-                additional_exps,
-            } => {
-                kind.ast_debug(w);
-                exp.ast_debug(w);
-                w.list(additional_exps, ",", |w, e| {
-                    e.ast_debug(w);
-                    true
-                });
-            }
-            SpecBlockMember_::Function {
-                uninterpreted,
-                signature,
-                name,
-                body,
-            } => {
-                if *uninterpreted {
-                    w.write("uninterpreted ");
-                } else if let FunctionBody_::Native = &body.value {
-                    w.write("native ");
-                }
-                w.write("fun ");
-                w.write(&format!("{}", name));
-                signature.ast_debug(w);
-                match &body.value {
-                    FunctionBody_::Defined(body) => w.block(|w| body.ast_debug(w)),
-                    FunctionBody_::Native => w.writeln(";"),
-                }
-            }
-            SpecBlockMember_::Variable {
-                is_global,
-                name,
-                type_parameters,
-                type_,
-                init: _,
-            } => {
-                if *is_global {
-                    w.write("global ");
-                } else {
-                    w.write("local");
-                }
-                w.write(&format!("{}", name));
-                type_parameters.ast_debug(w);
-                w.write(": ");
-                type_.ast_debug(w);
-            }
-            SpecBlockMember_::Update { lhs, rhs } => {
-                w.write("update ");
-                lhs.ast_debug(w);
-                w.write(" = ");
-                rhs.ast_debug(w);
-            }
-            SpecBlockMember_::Let {
-                name,
-                post_state,
-                def,
-            } => {
-                w.write(&format!(
-                    "let {}{} = ",
-                    if *post_state { "post " } else { "" },
-                    name
-                ));
-                def.ast_debug(w);
-            }
-            SpecBlockMember_::Include { properties: _, exp } => {
-                w.write("include ");
-                exp.ast_debug(w);
-            }
-            SpecBlockMember_::Apply {
-                exp,
-                patterns,
-                exclusion_patterns,
-            } => {
-                w.write("apply ");
-                exp.ast_debug(w);
-                w.write(" to ");
-                w.list(patterns, ", ", |w, p| {
-                    p.ast_debug(w);
-                    true
-                });
-                if !exclusion_patterns.is_empty() {
-                    w.write(" exclude ");
-                    w.list(exclusion_patterns, ", ", |w, p| {
-                        p.ast_debug(w);
-                        true
-                    });
-                }
-            }
-            SpecBlockMember_::Pragma { properties } => {
-                w.write("pragma ");
-                w.list(properties, ", ", |w, p| {
-                    p.ast_debug(w);
-                    true
-                });
-            }
-        }
-    }
-}
-
-impl AstDebug for SpecApplyPattern_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        w.list(&self.name_pattern, "", |w, f| {
-            f.ast_debug(w);
-            true
-        });
-        if !self.type_parameters.is_empty() {
-            w.write("<");
-            self.type_parameters.ast_debug(w);
-            w.write(">");
-        }
-    }
-}
-
-impl AstDebug for SpecApplyFragment_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        match self {
-            SpecApplyFragment_::Wildcard => w.write("*"),
-            SpecApplyFragment_::NamePart(n) => w.write(n.value),
-        }
-    }
-}
-
-impl AstDebug for PragmaProperty_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        w.write(self.name.value);
-        if let Some(value) = &self.value {
-            w.write(" = ");
-            match value {
-                PragmaValue::Literal(l) => l.ast_debug(w),
-                PragmaValue::Ident(i) => i.ast_debug(w),
-            }
         }
     }
 }
@@ -1967,9 +1634,7 @@ impl AstDebug for Exp_ {
                 w.write(")");
             }
             E::Spec(s) => {
-                w.write("spec {");
-                s.ast_debug(w);
-                w.write("}");
+                w.write(&s.value);
             }
             E::UnresolvedError => w.write("_|_"),
         }

--- a/external-crates/move/crates/move-compiler/src/parser/filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/filter.rs
@@ -2,7 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_ir_types::location::sp;
 use move_symbol_pool::Symbol;
 
 use crate::parser::ast as P;
@@ -56,14 +55,6 @@ pub trait FilterContext {
             None
         } else {
             Some(struct_def)
-        }
-    }
-
-    fn filter_map_spec(&mut self, spec: P::SpecBlock_) -> Option<P::SpecBlock_> {
-        if self.should_remove_by_attributes(&spec.attributes) {
-            None
-        } else {
-            Some(spec)
         }
     }
 
@@ -220,9 +211,7 @@ fn filter_module_member<T: FilterContext>(
     match module_member {
         PM::Function(func_def) => context.filter_map_function(func_def).map(PM::Function),
         PM::Struct(struct_def) => context.filter_map_struct(struct_def).map(PM::Struct),
-        PM::Spec(sp!(spec_loc, spec)) => context
-            .filter_map_spec(spec)
-            .map(|new_spec| PM::Spec(sp(spec_loc, new_spec))),
+        x @ PM::Spec(_) => Some(x),
         PM::Use(use_decl) => context.filter_map_use(use_decl).map(PM::Use),
         PM::Friend(friend_decl) => context.filter_map_friend(friend_decl).map(PM::Friend),
         PM::Constant(constant) => context.filter_map_constant(constant).map(PM::Constant),

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -3161,6 +3161,7 @@ fn parse_module_member(context: &mut Context) -> Result<ModuleMember, ErrCase> {
         Tok::Invariant => {
             context.tokens.match_doc_comments();
             let spec_string = consume_spec_string(context)?;
+            consume_token(context.tokens, Tok::Semicolon)?;
             Ok(ModuleMember::Spec(spec_string))
         }
         Tok::Spec => {
@@ -3262,12 +3263,6 @@ fn consume_spec_string(context: &mut Context) -> Result<Spanned<String>, Box<Dia
         } else if tok == Tok::RBrace {
             count -= 1;
         }
-        context.tokens.advance()?;
-    }
-
-    // consume semi-colon if present
-    if context.tokens.peek() == Tok::Semicolon {
-        s.push_str(context.tokens.content());
         context.tokens.advance()?;
     }
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_spec_schema_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_spec_schema_name.exp
@@ -4,11 +4,5 @@ warning[W00001]: DEPRECATED. will be removed
 2 │ ╭     spec schema foo<T> {
 3 │ │         ensures true;
 4 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
-
-error[E02010]: invalid name
-  ┌─ tests/move_check/expansion/invalid_spec_schema_name.move:2:17
-  │
-2 │     spec schema foo<T> {
-  │                 ^^^ Invalid schema name 'foo'. Schema names must start with 'A'..'Z'
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_in_spec_context.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_in_spec_context.exp
@@ -6,11 +6,11 @@ warning[W00001]: DEPRECATED. will be removed
 5 │ │             spec {};
 6 │ │         }
 7 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_block_in_spec_context.move:10:9
    │
 10 │         spec {};
-   │         ^^^^^^^ Specification blocks are deprecated
+   │         ^^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_uses.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_uses.exp
@@ -5,5 +5,5 @@ warning[W00001]: DEPRECATED. will be removed
 11 │ │         use 0x2::M::{S as R, R as S};
 12 │ │         ensures exists<S<u64>>(0x1) == exists<R>(0x1);
 13 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_uses_shadows_defines.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_block_uses_shadows_defines.exp
@@ -8,5 +8,5 @@ warning[W00001]: DEPRECATED. will be removed
    · │
 16 │ │         ensures exists<S<u64>>(0x1) == exists<R>(0x1);
 17 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_function_member_conflicts.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_function_member_conflicts.exp
@@ -4,16 +4,7 @@ warning[W00001]: DEPRECATED. will be removed
 4 │ ╭     spec module {
 5 │ │         fun Foo(): bool { true }
 6 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:7:12
-  │
-5 │         fun Foo(): bool { true }
-  │             --- Alias previously defined here
-6 │     }
-7 │     struct Foo {}
-  │            ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:11:5
@@ -21,7 +12,7 @@ warning[W00001]: DEPRECATED. will be removed
 11 │ ╭     spec module {
 12 │ │         fun Foo(): bool { true }
 13 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:14:5
@@ -29,16 +20,7 @@ warning[W00001]: DEPRECATED. will be removed
 14 │ ╭     spec schema Foo<T> {
 15 │ │         ensures true;
 16 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:14:17
-   │
-12 │         fun Foo(): bool { true }
-   │             --- Alias previously defined here
-13 │     }
-14 │     spec schema Foo<T> {
-   │                 ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:20:5
@@ -46,16 +28,7 @@ warning[W00001]: DEPRECATED. will be removed
 20 │ ╭     spec module {
 21 │ │         fun Foo(): bool { true }
 22 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:23:9
-   │
-21 │         fun Foo(): bool { true }
-   │             --- Alias previously defined here
-22 │     }
-23 │     fun Foo() {}
-   │         ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:27:5
@@ -63,16 +36,7 @@ warning[W00001]: DEPRECATED. will be removed
 27 │ ╭     spec module {
 28 │ │         fun foo(): bool { true }
 29 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:30:9
-   │
-28 │         fun foo(): bool { true }
-   │             --- Alias previously defined here
-29 │     }
-30 │     fun foo() {}
-   │         ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:34:5
@@ -80,7 +44,7 @@ warning[W00001]: DEPRECATED. will be removed
 34 │ ╭     spec module {
 35 │ │         fun foo(): bool { true }
 36 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:37:5
@@ -88,14 +52,5 @@ warning[W00001]: DEPRECATED. will be removed
 37 │ ╭     spec module {
 38 │ │         fun foo(): bool { true }
 39 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_function_member_conflicts.move:38:13
-   │
-35 │         fun foo(): bool { true }
-   │             --- Alias previously defined here
-   ·
-38 │         fun foo(): bool { true }
-   │             ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_schema_member_conflicts.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/spec_schema_member_conflicts.exp
@@ -4,16 +4,7 @@ warning[W00001]: DEPRECATED. will be removed
 4 │ ╭     spec schema Foo<T> {
 5 │ │         ensures true;
 6 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:7:12
-  │
-4 │     spec schema Foo<T> {
-  │                 --- Alias previously defined here
-  ·
-7 │     struct Foo {}
-  │            ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:11:5
@@ -21,7 +12,7 @@ warning[W00001]: DEPRECATED. will be removed
 11 │ ╭     spec schema Foo<T> {
 12 │ │         ensures true;
 13 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:14:5
@@ -29,16 +20,7 @@ warning[W00001]: DEPRECATED. will be removed
 14 │ ╭     spec schema Foo<T> {
 15 │ │         ensures true;
 16 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:14:17
-   │
-11 │     spec schema Foo<T> {
-   │                 --- Alias previously defined here
-   ·
-14 │     spec schema Foo<T> {
-   │                 ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:20:5
@@ -46,16 +28,7 @@ warning[W00001]: DEPRECATED. will be removed
 20 │ ╭     spec schema Foo<T> {
 21 │ │         ensures true;
 22 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:23:9
-   │
-20 │     spec schema Foo<T> {
-   │                 --- Alias previously defined here
-   ·
-23 │     fun Foo() {}
-   │         ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:27:5
@@ -63,7 +36,7 @@ warning[W00001]: DEPRECATED. will be removed
 27 │ ╭     spec schema Foo<T> {
 28 │ │         ensures true;
 29 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:30:5
@@ -71,14 +44,5 @@ warning[W00001]: DEPRECATED. will be removed
 30 │ ╭     spec module {
 31 │ │         fun Foo(): bool { false }
 32 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_check/expansion/spec_schema_member_conflicts.move:31:13
-   │
-27 │     spec schema Foo<T> {
-   │                 --- Alias previously defined here
-   ·
-31 │         fun Foo(): bool { false }
-   │             ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_inner_scope_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_inner_scope_invalid.exp
@@ -4,7 +4,7 @@ warning[W00001]: DEPRECATED. will be removed
 12 │ ╭     spec schema Foo<T> {
 13 │ │         ensures true;
 14 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 error[E03011]: invalid use of reserved name
    ┌─ tests/move_check/expansion/use_inner_scope_invalid.move:17:23
@@ -18,9 +18,12 @@ error[E02010]: invalid name
 18 │         use 0x2::M::{S1 as s1, Foo as foo};
    │                            ^^ Invalid struct alias name 's1'. Struct alias names must start with 'A'..'Z'
 
-error[E02010]: invalid name
-   ┌─ tests/move_check/expansion/use_inner_scope_invalid.move:18:39
+error[E03003]: unbound module member
+   ┌─ tests/move_check/expansion/use_inner_scope_invalid.move:18:32
    │
+ 2 │ module M {
+   │        - Module '0x2::M' declared here
+   ·
 18 │         use 0x2::M::{S1 as s1, Foo as foo};
-   │                                       ^^^ Invalid schema alias name 'foo'. Schema alias names must start with 'A'..'Z'
+   │                                ^^^ Invalid 'use'. Unbound member 'Foo' in module '0x2::M'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_inner_scope_shadows.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_inner_scope_shadows.exp
@@ -4,5 +4,5 @@ warning[W00001]: DEPRECATED. will be removed
 12 │ ╭     spec schema Foo<T> {
 13 │ │         ensures true;
 14 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_function.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_function.exp
@@ -5,23 +5,25 @@ warning[W00001]: DEPRECATED. will be removed
 4 │ │         fun foo(): bool { true }
 5 │ │         fun bar(): bool { true }
 6 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
-warning[W09001]: unused alias
+error[E03003]: unbound module member
    ┌─ tests/move_check/expansion/use_spec_function.move:10:18
    │
+ 2 │ module X {
+   │        - Module '0x2::X' declared here
+   ·
 10 │     use 0x2::X::{foo, bar as baz};
-   │                  ^^^ Unused 'use' of alias 'foo'. Consider removing it
-   │
-   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   │                  ^^^ Invalid 'use'. Unbound member 'foo' in module '0x2::X'
 
-warning[W09001]: unused alias
-   ┌─ tests/move_check/expansion/use_spec_function.move:10:30
+error[E03003]: unbound module member
+   ┌─ tests/move_check/expansion/use_spec_function.move:10:23
    │
+ 2 │ module X {
+   │        - Module '0x2::X' declared here
+   ·
 10 │     use 0x2::X::{foo, bar as baz};
-   │                              ^^^ Unused 'use' of alias 'baz'. Consider removing it
-   │
-   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   │                       ^^^ Invalid 'use'. Unbound member 'bar' in module '0x2::X'
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/use_spec_function.move:14:5
@@ -30,5 +32,5 @@ warning[W00001]: DEPRECATED. will be removed
 15 │ │         ensures foo();
 16 │ │         ensures baz();
 17 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_function_as_normal_function.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_function_as_normal_function.exp
@@ -1,11 +1,11 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/expansion/use_spec_function_as_normal_function.move:4:16
-  │
-4 │         define foo(): bool { true }
-  │                ^^^
-  │                │
-  │                Unexpected 'foo'
-  │                Expected ':'
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/expansion/use_spec_function_as_normal_function.move:3:5
+  │  
+3 │ ╭     spec module {
+4 │ │         define foo(): bool { true }
+5 │ │         define bar(): bool { true }
+6 │ │     }
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 error[E03003]: unbound module member
    ┌─ tests/move_check/expansion/use_spec_function_as_normal_function.move:10:18

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema.exp
@@ -4,7 +4,7 @@ warning[W00001]: DEPRECATED. will be removed
 3 │ ╭     spec schema Foo<T> {
 4 │ │         ensures true;
 5 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/expansion/use_spec_schema.move:7:5
@@ -12,23 +12,25 @@ warning[W00001]: DEPRECATED. will be removed
 7 │ ╭     spec schema Bar<T> {
 8 │ │         ensures true;
 9 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
-warning[W09001]: unused alias
+error[E03003]: unbound module member
    ┌─ tests/move_check/expansion/use_spec_schema.move:13:18
    │
+ 2 │ module X {
+   │        - Module '0x2::X' declared here
+   ·
 13 │     use 0x2::X::{Foo, Bar as Baz};
-   │                  ^^^ Unused 'use' of alias 'Foo'. Consider removing it
-   │
-   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   │                  ^^^ Invalid 'use'. Unbound member 'Foo' in module '0x2::X'
 
-warning[W09001]: unused alias
-   ┌─ tests/move_check/expansion/use_spec_schema.move:13:30
+error[E03003]: unbound module member
+   ┌─ tests/move_check/expansion/use_spec_schema.move:13:23
    │
+ 2 │ module X {
+   │        - Module '0x2::X' declared here
+   ·
 13 │     use 0x2::X::{Foo, Bar as Baz};
-   │                              ^^^ Unused 'use' of alias 'Baz'. Consider removing it
-   │
-   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   │                       ^^^ Invalid 'use'. Unbound member 'Bar' in module '0x2::X'
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/use_spec_schema.move:18:5
@@ -37,5 +39,5 @@ warning[W00001]: DEPRECATED. will be removed
 19 │ │         apply Foo<S> to t;
 20 │ │         apply Baz<S> to t;
 21 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema_as_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema_as_struct.exp
@@ -4,11 +4,20 @@ warning[W00001]: DEPRECATED. will be removed
 3 │ ╭     spec schema Foo<T> {
 4 │ │         ensures true;
 5 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 error[E03003]: unbound module member
+  ┌─ tests/move_check/expansion/use_spec_schema_as_struct.move:9:17
+  │
+2 │ module X {
+  │        - Module '0x2::X' declared here
+  ·
+9 │     use 0x2::X::Foo;
+  │                 ^^^ Invalid 'use'. Unbound member 'Foo' in module '0x2::X'
+
+error[E03004]: unbound type
    ┌─ tests/move_check/expansion/use_spec_schema_as_struct.move:10:14
    │
 10 │     fun t(): Foo<u64> {
-   │              ^^^ Invalid module access. Unbound struct 'Foo' in module '0x2::X'
+   │              ^^^ Unbound type 'Foo' in current scope
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema_invalid_as.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/use_spec_schema_invalid_as.exp
@@ -4,13 +4,16 @@ warning[W00001]: DEPRECATED. will be removed
 3 │ ╭     spec schema Foo<T> {
 4 │ │         ensures true;
 5 │ │     }
-  │ ╰─────^ Specification blocks are deprecated
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 
-error[E02010]: invalid name
-  ┌─ tests/move_check/expansion/use_spec_schema_invalid_as.move:9:25
+error[E03003]: unbound module member
+  ┌─ tests/move_check/expansion/use_spec_schema_invalid_as.move:9:18
   │
+2 │ module X {
+  │        - Module '0x2::X' declared here
+  ·
 9 │     use 0x2::X::{Foo as foo};
-  │                         ^^^ Invalid schema alias name 'foo'. Schema alias names must start with 'A'..'Z'
+  │                  ^^^ Invalid 'use'. Unbound member 'Foo' in module '0x2::X'
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/expansion/use_spec_schema_invalid_as.move:12:5
@@ -18,5 +21,5 @@ warning[W00001]: DEPRECATED. will be removed
 12 │ ╭     spec t {
 13 │ │         apply foo<S> to t;
 14 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_lambda_return_missing.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_lambda_return_missing.exp
@@ -1,9 +1,6 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/spec_lambda_return_missing.move:2:22
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/parser/spec_lambda_return_missing.move:2:10
   │
 2 │     spec fun do(f: ||) { }
-  │                      ^
-  │                      │
-  │                      Unexpected ')'
-  │                      Expected a type name
+  │          ^^^^^^^^^^^^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_emits_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_emits_fail.exp
@@ -1,9 +1,8 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/spec_parsing_emits_fail.move:3:19
-  │
-3 │         emits _msg;
-  │                   ^
-  │                   │
-  │                   Unexpected ';'
-  │                   Expected 'to'
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/parser/spec_parsing_emits_fail.move:2:5
+  │  
+2 │ ╭     spec with_emits {
+3 │ │         emits _msg;
+4 │ │     }
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_generic_condition_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_generic_condition_fail.exp
@@ -1,9 +1,8 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/spec_parsing_generic_condition_fail.move:3:16
-  │
-3 │         ensures<T> exists<T>(0x1) <==> exists<T>(0x1);
-  │                ^
-  │                │
-  │                Unexpected '<'
-  │                Expected an expression term
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/parser/spec_parsing_generic_condition_fail.move:2:5
+  │  
+2 │ ╭     spec schema InvalidGenericEnsures {
+3 │ │         ensures<T> exists<T>(0x1) <==> exists<T>(0x1);
+4 │ │     }
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_implies_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_implies_fail.exp
@@ -2,5 +2,5 @@ error[E00002]: DEPRECATED. unexpected spec item
   ┌─ tests/move_check/parser/spec_parsing_implies_fail.move:3:15
   │
 3 │       let _ = x ==> x;
-  │               ^^^^^^^ Specification blocks are deprecated
+  │               ^^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
@@ -10,7 +10,7 @@ error[E00002]: DEPRECATED. unexpected spec item
   ┌─ tests/move_check/parser/spec_parsing_index_fail.move:3:15
   │
 3 │       let _ = x[1];
-  │               ^^^^ Specification blocks are deprecated
+  │               ^^^^ Specification blocks are deprecated and are no longer used
   │
   = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha'
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_inside_fun.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_inside_fun.exp
@@ -12,13 +12,13 @@ warning[W00001]: DEPRECATED. will be removed
 4 │ ╭         spec {
 5 │ │             assume x > 42;
 6 │ │         };
-  │ ╰─────────^ Specification blocks are deprecated
+  │ ╰─────────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:9:17
   │
 9 │         while ({spec {assert x < 42;}; n < 64}) {
-  │                 ^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated
+  │                 ^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:10:13
@@ -27,7 +27,7 @@ warning[W00001]: DEPRECATED. will be removed
 11 │ │                 assert x > 42;
 12 │ │                 assert 0 < x;
 13 │ │             };
-   │ ╰─────────────^ Specification blocks are deprecated
+   │ ╰─────────────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:18:9
@@ -35,7 +35,7 @@ warning[W00001]: DEPRECATED. will be removed
 18 │ ╭         spec {
 19 │ │             assert x > 42;
 20 │ │         };
-   │ ╰─────────^ Specification blocks are deprecated
+   │ ╰─────────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:24:13
@@ -44,13 +44,13 @@ warning[W00001]: DEPRECATED. will be removed
 25 │ │                 assert x > 42;
 26 │ │                 assert 0 < x;
 27 │ │             };
-   │ ╰─────────────^ Specification blocks are deprecated
+   │ ╰─────────────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:9
    │
 32 │         spec {} + 1;
-   │         ^^^^^^^ Specification blocks are deprecated
+   │         ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:32:9
@@ -82,7 +82,7 @@ warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:9
    │
 33 │         spec {} && spec {};
-   │         ^^^^^^^ Specification blocks are deprecated
+   │         ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:9
@@ -97,7 +97,7 @@ warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:20
    │
 33 │         spec {} && spec {};
-   │                    ^^^^^^^ Specification blocks are deprecated
+   │                    ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:33:20
@@ -122,5 +122,5 @@ warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_inside_fun.move:34:14
    │
 34 │         &mut spec {};
-   │              ^^^^^^^ Specification blocks are deprecated
+   │              ^^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_ok.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_ok.exp
@@ -8,7 +8,7 @@ warning[W00001]: DEPRECATED. will be removed
    · │
 23 │ │         }
 24 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:34:5
@@ -18,7 +18,7 @@ warning[W00001]: DEPRECATED. will be removed
 36 │ │         invariant x > 0;
 37 │ │         invariant x == y;
 38 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:40:5
@@ -26,7 +26,7 @@ warning[W00001]: DEPRECATED. will be removed
 40 │ ╭     spec with_aborts_if {
 41 │ │       aborts_if x == 0;
 42 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:47:5
@@ -34,7 +34,7 @@ warning[W00001]: DEPRECATED. will be removed
 47 │ ╭     spec with_ensures {
 48 │ │         ensures RET == x + 1;
 49 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:54:5
@@ -42,7 +42,7 @@ warning[W00001]: DEPRECATED. will be removed
 54 │ ╭     spec using_block {
 55 │ │         ensures RET = {let y = x; y + 1};
 56 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:61:5
@@ -51,7 +51,7 @@ warning[W00001]: DEPRECATED. will be removed
 62 │ │     {
 63 │ │         ensures all(x, |y, z| x + y + z);
 64 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:69:5
@@ -59,7 +59,7 @@ warning[W00001]: DEPRECATED. will be removed
 69 │ ╭     spec using_index_and_range {
 70 │ │         ensures RET = x[1] && x[0..3];
 71 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:76:5
@@ -68,7 +68,7 @@ warning[W00001]: DEPRECATED. will be removed
 77 │ │         ensures x > 0 ==> RET == x - 1;
 78 │ │         ensures x == 0 ==> RET == x;
 79 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/parser/spec_parsing_ok.move:84:5
@@ -78,7 +78,7 @@ warning[W00001]: DEPRECATED. will be removed
 86 │ │         emits _msg to _guid if true;
 87 │ │         emits _msg to _guid if x > 7;
 88 │ │     }
-   │ ╰─────^ Specification blocks are deprecated
+   │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:93:5
@@ -90,7 +90,7 @@ warning[W00001]: DEPRECATED. will be removed
     · │
  99 │ │         invariant update Self::generic<u64> = 24;
 100 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:104:5
@@ -99,7 +99,7 @@ warning[W00001]: DEPRECATED. will be removed
 105 │ │         ensures generic<T> == 1;
 106 │ │         ensures Self::generic<T> == 1;
 107 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:109:5
@@ -108,7 +108,7 @@ warning[W00001]: DEPRECATED. will be removed
 110 │ │         requires global<X>(0x0).f == global<X>(0x1).f;
 111 │ │         ensures global<X>(0x0).f == global<X>(0x1).f;
 112 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:114:5
@@ -116,7 +116,7 @@ warning[W00001]: DEPRECATED. will be removed
 114 │ ╭     spec some_generic {
 115 │ │         include ModuleInvariant<T, T>{foo:bar, x:y};
 116 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:118:5
@@ -126,7 +126,7 @@ warning[W00001]: DEPRECATED. will be removed
 120 │ │         apply ModuleInvariant<X, Y> to *foo*<Y, X>, bar except public *, internal baz<X>;
 121 │ │         pragma do_not_verify, timeout = 60;
 122 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:124:5
@@ -138,7 +138,7 @@ warning[W00001]: DEPRECATED. will be removed
 128 │ │         invariant<X: key> exists<X>(0x0) <==> exists<X>(0x0);
 129 │ │         invariant<X: key, Y: key> exists<X>(0x0) && exists<Y>(0x1) <==> exists<Y>(0x1) && exists<X>(0x0);
 130 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
     ┌─ tests/move_check/parser/spec_parsing_ok.move:132:5
@@ -150,5 +150,5 @@ warning[W00001]: DEPRECATED. will be removed
 136 │ │         fun spec_fun_identity<T>(x: T): T;
 137 │ │         axiom<T> forall x: T: spec_fun_identity(x) == x;
 138 │ │     }
-    │ ╰─────^ Specification blocks are deprecated
+    │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_quantifier_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_quantifier_fail.exp
@@ -1,9 +1,8 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/spec_parsing_quantifier_fail.move:3:33
-  │
-3 │         invariant forall x: num y: num : x == y;
-  │                                 ^
-  │                                 │
-  │                                 Unexpected 'y'
-  │                                 Expected ':'
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/parser/spec_parsing_quantifier_fail.move:2:5
+  │  
+2 │ ╭     spec module {
+3 │ │         invariant forall x: num y: num : x == y;
+4 │ │     }
+  │ ╰─────^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_range_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_range_fail.exp
@@ -2,5 +2,5 @@ error[E00002]: DEPRECATED. unexpected spec item
   ┌─ tests/move_check/parser/spec_parsing_range_fail.move:3:15
   │
 3 │       let _ = 1 .. 2;
-  │               ^^^^^^ Specification blocks are deprecated
+  │               ^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/spec_block_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/spec_block_fail.exp
@@ -2,7 +2,7 @@ warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/typing/spec_block_fail.move:3:10
   │
 3 │         (spec {}: u64);
-  │          ^^^^^^^ Specification blocks are deprecated
+  │          ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04007]: incompatible types
   ┌─ tests/move_check/typing/spec_block_fail.move:3:19
@@ -18,7 +18,7 @@ warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/typing/spec_block_fail.move:4:10
   │
 4 │         (spec {}: &u64);
-  │          ^^^^^^^ Specification blocks are deprecated
+  │          ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04007]: incompatible types
   ┌─ tests/move_check/typing/spec_block_fail.move:4:19
@@ -34,7 +34,7 @@ warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/typing/spec_block_fail.move:5:10
   │
 5 │         (spec {}: (u64, u64));
-  │          ^^^^^^^ Specification blocks are deprecated
+  │          ^^^^^^^ Specification blocks are deprecated and are no longer used
 
 error[E04007]: incompatible types
   ┌─ tests/move_check/typing/spec_block_fail.move:5:19

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/spec_block_ok.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/spec_block_ok.exp
@@ -2,5 +2,5 @@ warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/typing/spec_block_ok.move:3:10
   │
 3 │         (spec {}: ())
-  │          ^^^^^^^ Specification blocks are deprecated
+  │          ^^^^^^^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/verification/specs_are_not_errors.exp
@@ -2,7 +2,7 @@ warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/verification/specs_are_not_errors.move:4:5
   │
 4 │     spec foo {}
-  │     ^^^^^^^^^^^ Specification blocks are deprecated
+  │     ^^^^^^^^^^^ Specification blocks are deprecated and are no longer used
 
 warning[W00001]: DEPRECATED. will be removed
   ┌─ tests/move_check/verification/specs_are_not_errors.move:7:7
@@ -14,5 +14,5 @@ warning[W00001]: DEPRECATED. will be removed
    ┌─ tests/move_check/verification/specs_are_not_errors.move:12:9
    │
 12 │ spec a::m {
-   │         ^ Specification blocks are deprecated
+   │         ^ Specification blocks are deprecated and are no longer used
 

--- a/external-crates/move/crates/move-stackless-bytecode/tests/escape_analysis/struct_eq.exp
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/escape_analysis/struct_eq.exp
@@ -45,4 +45,4 @@ warning: DEPRECATED. will be removed
   ┌─ tests/escape_analysis/struct_eq.move:5:5
   │
 5 │     invariant forall s: S: s == S { f: 10 };
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated and are no longer used

--- a/external-crates/move/crates/move-stackless-bytecode/tests/escape_analysis/struct_eq.exp
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/escape_analysis/struct_eq.exp
@@ -45,4 +45,4 @@ warning: DEPRECATED. will be removed
   ┌─ tests/escape_analysis/struct_eq.move:5:5
   │
 5 │     invariant forall s: S: s == S { f: 10 };
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated and are no longer used
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specification blocks are deprecated and are no longer used


### PR DESCRIPTION
## Description 

Remove parser support for specs, we still consume the string however, and add it into the AST for later error reporting. But the parsing logic is gone, and we now simply consume the string. 

## Test Plan 

Update existing tests, and make sure the updates to the tests look right. 


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
