### PR TITLE
Increase rocksdb thresholds which trigger slowdown

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2436,6 +2436,15 @@ pub fn default_db_options() -> DBOptions {
     // Set memtable bloomfilter.
     opt.set_memtable_prefix_bloom_ratio(0.02);
 
+    // disable write slowdowns due to pending l0 files
+    opt.set_level_zero_slowdown_writes_trigger(-1);
+    // set write stall from pending files to a much higher number (default is 24)
+    opt.set_level_zero_stop_writes_trigger(1024);
+    // set soft pending compaction bytes to a much higher number (default is 64 GB)
+    opt.set_soft_pending_compaction_bytes_limit(2048 * 1024 * 1024 * 1024);
+    // set hard pending compaction bytes to a much higher number (default is 256 GB)
+    opt.set_hard_pending_compaction_bytes_limit(4096 * 1024 * 1024 * 1024);
+
     DBOptions {
         options: opt,
         rw_options: ReadWriteOptions::default(),


### PR DESCRIPTION
## Description 

This PR is not meant for landing but just to test if system performance is any different under higher db slowdown thresholds
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
