### PR TITLE
[gql][fix] Refactor dynamic fields query to use `build_objects_query`

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
@@ -1,0 +1,185 @@
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 19-61:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7600000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 63-65:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 67-67:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'create-checkpoint'. lines 69-69:
+Checkpoint created: 1
+
+task 5 'run-graphql'. lines 71-133:
+Response: {
+  "data": {
+    "latest": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "dof_added": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "before_dof_added": {
+      "version": 2,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    }
+  }
+}
+
+task 6 'run'. lines 135-135:
+mutated: object(0,0), object(2,0), object(2,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 7 'create-checkpoint'. lines 137-137:
+Checkpoint created: 2
+
+task 8 'run-graphql'. lines 139-189:
+Response: {
+  "data": {
+    "latest": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "before_reclaim_and_transfer_dof": {
+      "version": 3,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -1,0 +1,189 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The previous implementation sets the newer criteria when the parent version is provided by
+// filtering the newer subquery on `object_version <=` and
+// `object_status=ObjectStatus::WrappedOrDeleted`. However, this means that we erroneously return
+// the historical child that matches the filtering criteria if there are newer versions of the
+// dynamic object that were not `WrappedOrDeleted`. This tests that we do not return the child
+// object for the parent at version.
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 4             | reclaimed child from parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        transfer::public_transfer(reclaim_child(parent, name), recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  dof_added: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_dof_added: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,1) 42 @A
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_reclaim_and_transfer_dof: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
@@ -1,0 +1,205 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 22-64:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7600000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 66-69:
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4924800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 71-71:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'run'. lines 73-73:
+mutated: object(0,0), object(2,0), object(2,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 5 'run'. lines 75-75:
+created: object(5,0)
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 6 'run'. lines 77-77:
+mutated: object(0,0), object(2,0), object(2,2)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 7 'run'. lines 79-79:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 8 'create-checkpoint'. lines 81-81:
+Checkpoint created: 1
+
+task 9 'run-graphql'. lines 83-163:
+Response: {
+  "data": {
+    "latest": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "v2": {
+      "version": 2,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "v3": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "v4": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "v7": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
@@ -3,45 +3,45 @@ processed 10 tasks
 init:
 A: object(0,0)
 
-task 1 'publish'. lines 22-64:
+task 1 'publish'. lines 18-60:
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 7600000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2 'programmable'. lines 66-69:
+task 2 'programmable'. lines 62-65:
 created: object(2,0), object(2,1), object(2,2)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 4924800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3 'run'. lines 71-71:
+task 3 'run'. lines 67-67:
 created: object(3,0)
 mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
 
-task 4 'run'. lines 73-73:
+task 4 'run'. lines 69-69:
 mutated: object(0,0), object(2,0), object(2,1)
 deleted: object(3,0)
 gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
 
-task 5 'run'. lines 75-75:
+task 5 'run'. lines 71-71:
 created: object(5,0)
 mutated: object(0,0), object(2,0), object(2,2)
 gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
 
-task 6 'run'. lines 77-77:
+task 6 'run'. lines 73-73:
 mutated: object(0,0), object(2,0), object(2,2)
 deleted: object(5,0)
 gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
 
-task 7 'run'. lines 79-79:
+task 7 'run'. lines 75-75:
 created: object(3,0)
 mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
 
-task 8 'create-checkpoint'. lines 81-81:
+task 8 'create-checkpoint'. lines 77-77:
 Checkpoint created: 1
 
-task 9 'run-graphql'. lines 83-163:
+task 9 'run-graphql'. lines 79-159:
 Response: {
   "data": {
     "latest": {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test that we do not return the child object when it is not owned by the parent or when it is
+// wrapped.
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 4             | reclaimed child from parent
+// 4              | 5             | add child to another parent
+// 4              | 6             | reclaim child from another parent
+// 7              | 7             | add child to original parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        transfer::public_transfer(reclaim_child(parent, name), recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+//> 2: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,1) 42 @A
+
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,2) 42 @A
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v2: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v3: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v4: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v7: object(address: "@{obj_2_1}", version: 7) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -100,6 +100,7 @@ pub(crate) fn build_objects_query(
     rhs: i64,
     page: &Page<Cursor>,
     filter_fn: impl Fn(RawQuery) -> RawQuery,
+    newer_criteria: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     // Subquery to be used in `LEFT JOIN` against the inner queries for more recent object versions
     let mut newer = query!("SELECT object_id, object_version FROM objects_history");
@@ -107,6 +108,7 @@ pub(crate) fn build_objects_query(
         newer,
         format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
     );
+    newer = newer_criteria(newer);
 
     let mut snapshot_objs_inner = query!("SELECT * FROM objects_snapshot");
     snapshot_objs_inner = filter_fn(snapshot_objs_inner);

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -103,12 +103,10 @@ pub(crate) fn build_objects_query(
     newer_criteria: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     // Subquery to be used in `LEFT JOIN` against the inner queries for more recent object versions
-    let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-    newer = filter!(
-        newer,
+    let newer = newer_criteria(filter!(
+        query!("SELECT object_id, object_version FROM objects_history"),
         format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-    newer = newer_criteria(newer);
+    ));
 
     let mut snapshot_objs_inner = query!("SELECT * FROM objects_snapshot");
     snapshot_objs_inner = filter_fn(snapshot_objs_inner);

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -381,9 +381,14 @@ fn coins_query(
     rhs: i64,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
-    build_objects_query(View::Consistent, lhs, rhs, page, move |query| {
-        apply_filter(query, &coin_type, owner)
-    })
+    build_objects_query(
+        View::Consistent,
+        lhs,
+        rhs,
+        page,
+        move |query| apply_filter(query, &coin_type, owner),
+        move |newer| newer,
+    )
 }
 
 fn apply_filter(mut query: RawQuery, coin_type: &TypeTag, owner: Option<SuiAddress>) -> RawQuery {

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -367,10 +367,10 @@ fn dynamic_fields_query(
     // deleted while a child of the parent.
     if let Some(parent_version) = parent_version {
         newer = filter!(newer, format!("object_version <= {}", parent_version));
-        newer = filter!(
-            newer,
-            format!("object_status = {}", ObjectStatus::WrappedOrDeleted as i16)
-        );
+        // newer = filter!(
+        // newer,
+        // format!("object_status = {}", ObjectStatus::WrappedOrDeleted as i16)
+        // );
 
         let query = query!(
             r#"SELECT candidates.*
@@ -383,7 +383,8 @@ fn dynamic_fields_query(
             candidates,
             newer
         );
-        return filter!(query, "newer.object_status IS NULL");
+        // return filter!(query, "newer.object_status IS NULL");
+        return filter!(query, "newer.object_version IS NULL");
     }
 
     let query = query!(

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1371,7 +1371,14 @@ where
         View::Consistent
     };
 
-    build_objects_query(view, lhs, rhs, page, move |query| filter.apply(query))
+    build_objects_query(
+        view,
+        lhs,
+        rhs,
+        page,
+        move |query| filter.apply(query),
+        move |newer| newer,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

The dynamic fields of a parent object are further constrained in that their `object_version` cannot exceed the parent object's `object_version`. This currently manifests as additional filter conditions on the `newer` subquery, `WHERE object_version <= parent_version AND object_status=ObjectStatus::WrappedOrDeleted as i16`. On a revisit, this latter check on `object_status` is unnecessary and actually incorrect. If there are more recent versions of the object where its version is less than the parent version, we should always filter it out, because the `candidates` subquery will always select the latest object version that satisfies the filtering criteria. But the additional `object_status` check means that we'll erroneously return the historical child object even if later versions are not owned by the parent object, unless it was `WrappedOrDeleted`. New tests have been added to check this condition.

By simplifying the logic for dynamic field's `newer` subquery, we can modify the `build_objects_query` function a bit so that dynamic fields can reuse the consistent query implementation instead of rolling out its own. This allows the dynamic field query to take advantage of the same optimizations uncovered in previous investigations.

Also observed that dynamic fields resolution is heavily dependent on `sui-package-resolver`'s `type_layout` method. Resolving a dynamic field's `Name` and `Value` fields each require 1 call, so for n objects we make 2 * n calls. Resolving `contents` on `MoveValue` require an additional n calls, for a total of 2 * n + n calls. These n+1 queries make up the bulk of the remaining latency after the db roundtrips needed to fetch dynamic fields were optimized. This should be something that can be easily addressed by Dataloaders.

## Test Plan 

`dof_add_reclaim_transfer.move`, `dof_add_reclaim_transfer_reclaim_add.move`, manually running some queries that currently timeout in our production services.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
