### PR TITLE
[CLI/PTB] Check for help flags after lexing

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client_ptb::ptb::{ptb_description, PTB};
+use crate::client_ptb::ptb::PTB;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::{Debug, Display, Formatter, Write},
@@ -1594,13 +1594,7 @@ impl SuiClientCommands {
                 SuiClientCommandResult::VerifySource
             }
             SuiClientCommands::PTB(ptb) => {
-                if ptb.args.contains(&"--help".to_string()) {
-                    ptb_description().print_long_help().unwrap();
-                } else if ptb.args.contains(&"-h".to_string()) || ptb.args.is_empty() {
-                    ptb_description().print_help().unwrap();
-                } else {
-                    ptb.execute(context).await?;
-                }
+                ptb.execute(context).await?;
                 SuiClientCommandResult::NoOutput
             }
         });

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__tokenize_commands.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__tokenize_commands.snap
@@ -1,0 +1,46 @@
+---
+source: crates/sui/src/client_ptb/lexer.rs
+expression: lex(cmds)
+---
+[
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 5,
+        },
+        value: Lexeme(
+            Command,
+            "f00",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 6,
+            end: 15,
+        },
+        value: Lexeme(
+            Command,
+            "Bar_baz",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 16,
+            end: 25,
+        },
+        value: Lexeme(
+            Command,
+            "qux-quy",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 25,
+            end: 25,
+        },
+        value: Lexeme(
+            Eof,
+            "",
+        ),
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__tokenize_flags.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__tokenize_flags.snap
@@ -1,0 +1,56 @@
+---
+source: crates/sui/src/client_ptb/lexer.rs
+expression: lex(flags)
+---
+[
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 2,
+        },
+        value: Lexeme(
+            Flag,
+            "h",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 3,
+            end: 5,
+        },
+        value: Lexeme(
+            Flag,
+            "a",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 6,
+            end: 8,
+        },
+        value: Lexeme(
+            Flag,
+            "Z",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 9,
+            end: 11,
+        },
+        value: Lexeme(
+            Flag,
+            "1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 11,
+            end: 11,
+        },
+        value: Lexeme(
+            Eof,
+            "",
+        ),
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__unexpected_dash_dash.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__lexer__tests__unexpected_dash_dash.snap
@@ -1,16 +1,16 @@
 ---
 source: crates/sui/src/client_ptb/lexer.rs
-expression: tokens
+expression: lex(unexpected)
 ---
 [
     Spanned {
         span: Span {
             start: 0,
-            end: 2,
+            end: 1,
         },
         value: Lexeme(
             Unexpected,
-            "--",
+            "-",
         ),
     },
 ]

--- a/crates/sui/src/client_ptb/token.rs
+++ b/crates/sui/src/client_ptb/token.rs
@@ -15,6 +15,8 @@ pub struct Lexeme<'t>(
 pub enum Token {
     /// --[a-zA-Z0-9_-]+
     Command,
+    /// -[a-zA-Z0-9]
+    Flag,
     /// [a-zA-Z_][a-zA-Z0-9_-]*
     Ident,
     /// [1-9][0-9_]*
@@ -84,6 +86,7 @@ impl<'a> fmt::Display for Lexeme<'a> {
 
         match self.0 {
             T::Command => write!(f, "command '--{}'", self.1),
+            T::Flag => write!(f, "flag '-{}'", self.1),
             T::Ident => write!(f, "identifier '{}'", self.1),
             T::Number => write!(f, "number '{}'", self.1),
             T::HexNumber => write!(f, "hexadecimal number '0x{}'", self.1),
@@ -112,6 +115,7 @@ impl fmt::Display for Token {
         use Token as T;
         match self {
             T::Command => write!(f, "a command"),
+            T::Flag => write!(f, "a flag"),
             T::Ident => write!(f, "an identifier"),
             T::Number => write!(f, "a number"),
             T::HexNumber => write!(f, "a hexadecimal number"),


### PR DESCRIPTION
## Description

Make help flag detection more robust by doing it after tokenisation, so that the help flag is treated consistently like other `--commands` or `-f`lags.

This PR also introduces a new notion of a `-f`lag to the lexer (which is only used for `-h` at the moment).

## Test Plan

New unit tests:

```
crates/sui$ cargo nextest run -- lexer
```

Trying the command:

```
sui$ cargo run --bin sui -- --help
sui$ cargo run --bin sui -- -h
```