### PR TITLE
[consensus] Add DagBuilder & DagParser V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ dependencies = [
  "mockall",
  "mysten-metrics",
  "mysten-network",
+ "nom",
  "parking_lot 0.12.1",
  "prometheus",
  "prost 0.12.3",
@@ -8026,9 +8027,9 @@ checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -215,28 +215,6 @@ impl<T> IndexMut<AuthorityIndex> for Vec<T> {
     }
 }
 
-impl From<&str> for AuthorityIndex {
-    fn from(value: &str) -> Self {
-        str_to_authority_index(value).unwrap()
-    }
-}
-// Helper function to convert a string representation (e.g., 'A' or '[26]') to an AuthorityIndex
-fn str_to_authority_index(input: &str) -> Option<AuthorityIndex> {
-    if input.starts_with('[') && input.ends_with(']') && input.len() > 2 {
-        input[1..input.len() - 1]
-            .parse::<u32>()
-            .ok()
-            .map(AuthorityIndex::new_for_test)
-    } else if input.len() == 1 && input.chars().next()?.is_ascii_uppercase() {
-        // Handle single uppercase ASCII alphabetic character
-        let alpha_char = input.chars().next().unwrap();
-        let index = alpha_char as u32 - 'A' as u32;
-        Some(AuthorityIndex::new_for_test(index))
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,23 +238,5 @@ mod tests {
         assert_eq!(committee.total_stake(), 45);
         assert_eq!(committee.quorum_threshold(), 31);
         assert_eq!(committee.validity_threshold(), 15);
-    }
-
-    #[test]
-    fn test_str_to_authority_index() {
-        assert_eq!(AuthorityIndex::from("A"), AuthorityIndex::new_for_test(0));
-        assert_eq!(AuthorityIndex::from("Z"), AuthorityIndex::new_for_test(25));
-        assert_eq!(
-            AuthorityIndex::from("[26]"),
-            AuthorityIndex::new_for_test(26)
-        );
-        assert_eq!(
-            AuthorityIndex::from("[100]"),
-            AuthorityIndex::new_for_test(100)
-        );
-        assert_eq!(str_to_authority_index("a"), None);
-        assert_eq!(str_to_authority_index("0"), None);
-        assert_eq!(str_to_authority_index(" "), None);
-        assert_eq!(str_to_authority_index("!"), None);
     }
 }

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -215,9 +215,32 @@ impl<T> IndexMut<AuthorityIndex> for Vec<T> {
     }
 }
 
+impl From<&str> for AuthorityIndex {
+    fn from(value: &str) -> Self {
+        str_to_authority_index(value).unwrap()
+    }
+}
+// Helper function to convert a string representation (e.g., 'A' or '[26]') to an AuthorityIndex
+fn str_to_authority_index(input: &str) -> Option<AuthorityIndex> {
+    if input.starts_with('[') && input.ends_with(']') && input.len() > 2 {
+        input[1..input.len() - 1]
+            .parse::<u32>()
+            .ok()
+            .map(AuthorityIndex::new_for_test)
+    } else if input.len() == 1 && input.chars().next()?.is_ascii_uppercase() {
+        // Handle single uppercase ASCII alphabetic character
+        let alpha_char = input.chars().next().unwrap();
+        let index = alpha_char as u32 - 'A' as u32;
+        Some(AuthorityIndex::new_for_test(index))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{local_committee_and_keys, Stake};
+    use super::*;
+    use crate::local_committee_and_keys;
 
     #[test]
     fn committee_basic() {
@@ -237,5 +260,23 @@ mod tests {
         assert_eq!(committee.total_stake(), 45);
         assert_eq!(committee.quorum_threshold(), 31);
         assert_eq!(committee.validity_threshold(), 15);
+    }
+
+    #[test]
+    fn test_str_to_authority_index() {
+        assert_eq!(AuthorityIndex::from("A"), AuthorityIndex::new_for_test(0));
+        assert_eq!(AuthorityIndex::from("Z"), AuthorityIndex::new_for_test(25));
+        assert_eq!(
+            AuthorityIndex::from("[26]"),
+            AuthorityIndex::new_for_test(26)
+        );
+        assert_eq!(
+            AuthorityIndex::from("[100]"),
+            AuthorityIndex::new_for_test(100)
+        );
+        assert_eq!(str_to_authority_index("a"), None);
+        assert_eq!(str_to_authority_index("0"), None);
+        assert_eq!(str_to_authority_index(" "), None);
+        assert_eq!(str_to_authority_index("!"), None);
     }
 }

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -25,6 +25,7 @@ quinn-proto.workspace = true
 mockall.workspace = true
 mysten-metrics.workspace = true
 mysten-network.workspace = true
+nom = "7.1.3"
 parking_lot.workspace = true
 prometheus.workspace = true
 prost.workspace = true

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -605,9 +605,11 @@ mod tests {
 
     use fastcrypto::error::FastCryptoError;
 
-    use crate::block::{SignedBlock, TestBlock};
-    use crate::context::Context;
-    use crate::error::ConsensusError;
+    use crate::{
+        block::{SignedBlock, TestBlock},
+        context::Context,
+        error::ConsensusError,
+    };
 
     #[test]
     fn test_sign_and_verify() {

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -7,13 +7,13 @@ use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::commit::CommitAPI;
-use crate::error::{ConsensusError, ConsensusResult};
 use crate::CommitConsumer;
 use crate::{
     block::{timestamp_utc_ms, BlockAPI, VerifiedBlock},
     commit::{load_committed_subdag_from_store, CommitIndex, CommittedSubDag},
     context::Context,
     dag_state::DagState,
+    error::{ConsensusError, ConsensusResult},
     linearizer::Linearizer,
     storage::Store,
 };
@@ -177,7 +177,7 @@ mod tests {
         dag_state::DagState,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
-        test_dag::{build_dag, get_all_leader_blocks},
+        test_dag::build_dag,
     };
 
     #[test]
@@ -209,8 +209,7 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -299,8 +298,7 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -436,8 +434,7 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -6,16 +6,15 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::commit::CommitAPI;
-use crate::CommitConsumer;
 use crate::{
     block::{timestamp_utc_ms, BlockAPI, VerifiedBlock},
-    commit::{load_committed_subdag_from_store, CommitIndex, CommittedSubDag},
+    commit::{load_committed_subdag_from_store, CommitAPI, CommitIndex, CommittedSubDag},
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     linearizer::Linearizer,
     storage::Store,
+    CommitConsumer,
 };
 
 /// Role of CommitObserver
@@ -177,7 +176,7 @@ mod tests {
         dag_state::DagState,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
-        test_dag::build_dag,
+        test_dag::{build_dag, get_all_uncommitted_leader_blocks},
     };
 
     #[test]
@@ -209,7 +208,8 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -298,7 +298,8 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -434,7 +435,8 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -668,6 +668,10 @@ impl DagState {
         self.genesis.values().cloned().collect()
     }
 
+    pub(crate) fn genesis_block_refs(&self) -> Vec<BlockRef> {
+        self.genesis.keys().cloned().collect()
+    }
+
     /// The last round that got evicted after a cache clean up operation. After this round we are
     /// guaranteed to have all the produced blocks from that authority. For any round that is
     /// <= `last_evicted_round` we don't have such guarantees as out of order blocks might exist.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -12,8 +12,6 @@ use std::{
 use consensus_config::AuthorityIndex;
 use tracing::error;
 
-#[cfg(test)]
-use crate::leader_schedule::LeaderSchedule;
 use crate::{
     block::{
         genesis_blocks, BlockAPI, BlockDigest, BlockRef, Round, Slot, VerifiedBlock, GENESIS_ROUND,
@@ -683,31 +681,6 @@ impl DagState {
     /// round <= the evict round have been cleaned up.
     fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
         commit_round.saturating_sub(cached_rounds)
-    }
-
-    // Leader blocks start from round 1 as we do not consider any blocks from genesis
-    // roudn as a leader block.
-    // TODO: confirm pipelined & multi-leader cases work properly
-    #[cfg(test)]
-    pub(crate) fn get_all_uncommitted_leader_blocks(
-        &self,
-        leader_schedule: LeaderSchedule,
-        num_rounds: u32,
-        wave_length: u32,
-        pipelined: bool,
-        num_leaders: u32,
-    ) -> Vec<VerifiedBlock> {
-        let mut blocks = Vec::new();
-        for round in 1..=num_rounds {
-            for leader_offset in 0..num_leaders {
-                if pipelined || round % wave_length == 0 {
-                    let slot = Slot::new(round, leader_schedule.elect_leader(round, leader_offset));
-                    let uncommitted_blocks = self.get_uncommitted_blocks_at_slot(slot);
-                    blocks.extend(uncommitted_blocks);
-                }
-            }
-        }
-        blocks
     }
 }
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -25,11 +25,23 @@ mod stake_aggregator;
 mod storage;
 mod subscriber;
 mod synchronizer;
-#[cfg(test)]
-mod test_dag;
 mod threshold_clock;
 mod transaction;
 mod universal_committer;
+
+#[cfg(test)]
+mod test_dag;
+#[cfg(test)]
+mod test_dag_builder;
+#[cfg(test)]
+mod test_dag_parser;
+
+#[cfg(test)]
+mod test_dag;
+#[cfg(test)]
+mod test_dag_builder;
+#[cfg(test)]
+mod test_dag_parser;
 
 pub use authority_node::{ConsensusAuthority, NetworkType};
 pub use block::{BlockAPI, Round};

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -36,13 +36,6 @@ mod test_dag_builder;
 #[cfg(test)]
 mod test_dag_parser;
 
-#[cfg(test)]
-mod test_dag;
-#[cfg(test)]
-mod test_dag_builder;
-#[cfg(test)]
-mod test_dag_parser;
-
 pub use authority_node::{ConsensusAuthority, NetworkType};
 pub use block::{BlockAPI, Round};
 pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag};

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -144,7 +144,7 @@ mod tests {
         context::Context,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
-        test_dag::{build_dag, get_all_leader_blocks},
+        test_dag::build_dag,
     };
 
     #[test]
@@ -162,8 +162,7 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -230,8 +229,7 @@ mod tests {
             leader_round_wave_1,
         ));
 
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule.clone(),
             leader_round_wave_1,
             wave_length,
@@ -287,8 +285,7 @@ mod tests {
             leader_round_wave_2,
         );
 
-        let leaders = get_all_leader_blocks(
-            dag_state.clone(),
+        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
             leader_schedule,
             leader_round_wave_2,
             wave_length,

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -144,7 +144,7 @@ mod tests {
         context::Context,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
-        test_dag::build_dag,
+        test_dag::{build_dag, get_all_uncommitted_leader_blocks},
     };
 
     #[test]
@@ -162,7 +162,8 @@ mod tests {
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
         build_dag(context.clone(), dag_state.clone(), None, num_rounds);
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule,
             num_rounds,
             DEFAULT_WAVE_LENGTH,
@@ -229,7 +230,8 @@ mod tests {
             leader_round_wave_1,
         ));
 
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule.clone(),
             leader_round_wave_1,
             wave_length,
@@ -285,7 +287,8 @@ mod tests {
             leader_round_wave_2,
         );
 
-        let leaders = dag_state.read().get_all_uncommitted_leader_blocks(
+        let leaders = get_all_uncommitted_leader_blocks(
+            dag_state.clone(),
             leader_schedule,
             leader_round_wave_2,
             wave_length,

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -1,22 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
-use std::ops::Range;
 use std::{
-    collections::{BTreeMap, BTreeSet},
-    ops::Bound::{Excluded, Included},
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    ops::{
+        Bound::{Excluded, Included},
+        Range,
+    },
 };
 
 use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use super::{CommitInfo, Store, WriteBatch};
-use crate::block::Slot;
-use crate::commit::{CommitAPI as _, TrustedCommit};
 use crate::{
-    block::{BlockAPI as _, BlockDigest, BlockRef, Round, VerifiedBlock},
-    commit::{CommitDigest, CommitIndex},
+    block::{BlockAPI as _, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
+    commit::{CommitAPI as _, CommitDigest, CommitIndex, TrustedCommit},
     error::ConsensusResult,
 };
 

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -12,9 +12,8 @@ use std::ops::Range;
 use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
-use crate::block::Slot;
 use crate::{
-    block::{BlockRef, Round, VerifiedBlock},
+    block::{BlockRef, Round, Slot, VerifiedBlock},
     commit::{CommitIndex, TrustedCommit},
     error::ConsensusResult,
 };

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -50,7 +50,7 @@ pub(crate) fn build_dag(
                 let base_ts = round as BlockTimestampMs * 1000;
                 let block = VerifiedBlock::new_for_test(
                     TestBlock::new(round, author_idx)
-                        .set_timestamp_ms(base_ts + (author_idx + round) as u64)
+                        .set_timestamp_ms(base_ts + author_idx as u64)
                         .set_ancestors(ancestors.clone())
                         .build(),
                 );

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -13,6 +13,8 @@ use crate::{
     leader_schedule::LeaderSchedule,
 };
 
+// todo: remove this once tests have been refactored to use DagBuilder/DagParser
+
 /// Build a fully interconnected dag up to the specified round. This function
 /// starts building the dag from the specified [`start`] parameter or from
 /// genesis if none are specified up to and including the specified round [`stop`]

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -7,10 +7,9 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use crate::{
-    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, Slot, TestBlock, VerifiedBlock},
+    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, TestBlock, VerifiedBlock},
     context::Context,
     dag_state::DagState,
-    leader_schedule::LeaderSchedule,
 };
 
 // todo: remove this once tests have been refactored to use DagBuilder/DagParser
@@ -85,26 +84,4 @@ pub(crate) fn build_dag_layer(
         dag_state.write().accept_block(block);
     }
     references
-}
-
-// TODO: confirm pipelined & multi-leader cases work properly
-pub(crate) fn get_all_leader_blocks(
-    dag_state: Arc<RwLock<DagState>>,
-    leader_schedule: LeaderSchedule,
-    num_rounds: u32,
-    wave_length: u32,
-    pipelined: bool,
-    num_leaders: u32,
-) -> Vec<VerifiedBlock> {
-    let mut blocks = Vec::new();
-    for round in 1..=num_rounds {
-        for leader_offset in 0..num_leaders {
-            if pipelined || round % wave_length == 0 {
-                let slot = Slot::new(round, leader_schedule.elect_leader(round, leader_offset));
-                let uncommitted_blocks = dag_state.read().get_uncommitted_blocks_at_slot(slot);
-                blocks.extend(uncommitted_blocks);
-            }
-        }
-    }
-    blocks
 }

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -7,9 +7,10 @@ use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
 use crate::{
-    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, TestBlock, VerifiedBlock},
+    block::{genesis_blocks, BlockRef, BlockTimestampMs, Round, Slot, TestBlock, VerifiedBlock},
     context::Context,
     dag_state::DagState,
+    leader_schedule::LeaderSchedule,
 };
 
 // todo: remove this once tests have been refactored to use DagBuilder/DagParser
@@ -84,4 +85,29 @@ pub(crate) fn build_dag_layer(
         dag_state.write().accept_block(block);
     }
     references
+}
+
+// Leader blocks start from round 1 as we do not consider any blocks from genesis
+// round as a leader block.
+// TODO: confirm pipelined & multi-leader cases work properly and interaction with
+// DagState flush
+pub(crate) fn get_all_uncommitted_leader_blocks(
+    dag_state: Arc<RwLock<DagState>>,
+    leader_schedule: LeaderSchedule,
+    num_rounds: u32,
+    wave_length: u32,
+    pipelined: bool,
+    num_leaders: u32,
+) -> Vec<VerifiedBlock> {
+    let mut blocks = Vec::new();
+    for round in 1..=num_rounds {
+        for leader_offset in 0..num_leaders {
+            if pipelined || round % wave_length == 0 {
+                let slot = Slot::new(round, leader_schedule.elect_leader(round, leader_offset));
+                let uncommitted_blocks = dag_state.read().get_uncommitted_blocks_at_slot(slot);
+                blocks.extend(uncommitted_blocks);
+            }
+        }
+    }
+    blocks
 }

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -19,9 +19,55 @@ use crate::{
     leader_schedule::LeaderSchedule,
 };
 
-/// DagBuilder
-// todo: Add usage doc comment
-
+/// DagBuilder API
+///
+/// Usage:
+///
+/// DAG Building
+/// ```
+/// let context = Arc::new(Context::new_for_test(4).0);
+/// let dag_builder = DagBuilder::new(context);
+/// dag_builder.layer(1).build(); // Round 1 is fully connected with parents by default.
+/// dag_builder.layers(2..10).build(); // Rounds 2 ~ 10 are fully connected with parents by default.
+/// dag_builder.layers(11).min_parent_links().build(); // Round 11 is minimally and randomly connected with parents, without weak links.
+/// dag_builder.layers(12).no_leader_block(0).build(); // Round 12 misses leader block. Other blocks are fully connected with parents.
+/// dag_builder.layers(13).no_leader_link(12, 0).build(); // Round 13 misses votes for leader block. Other blocks are fully connected with parents.
+/// dag_builder.layers(14).authorities(vec![3,5]).skip_block().build(); // Round 14 authorities 3 and 5 will not propose any block.
+/// dag_builder.layers(15).authorities(vec![3,5]).skip_ancestor_links(vec![1,2]).build(); // Round 15 authorities 3 and 5 will not link to ancestors 1 and 2
+/// dag_builder.layers(16).authorities(vec![3,5]).equivocate(3).build(); // Round 16 authorities 3 and 5 will produce 3 equivocating blocks.
+/// ```
+///
+/// Persisting to DagState by Layer
+/// ```
+/// let dag_state = Arc::new(RwLock::new(DagState::new(
+///    dag_builder.context.clone(),
+///    Arc::new(MemStore::new()),
+/// )));
+/// let context = Arc::new(Context::new_for_test(4).0);
+/// let dag_builder = DagBuilder::new(context);
+/// dag_builder.layer(1).build().persist_layers(dag_state.clone()); // persist the layer
+/// ```
+///
+/// Persisting entire DAG to DagState
+/// ```
+/// let dag_state = Arc::new(RwLock::new(DagState::new(
+///    dag_builder.context.clone(),
+///    Arc::new(MemStore::new()),
+/// )));
+/// let context = Arc::new(Context::new_for_test(4).0);
+/// let dag_builder = DagBuilder::new(context);
+/// dag_builder.layer(1).build();
+/// dag_builder.layers(2..10).build();
+/// dag_builder.persist_all_blocks(dag_state.clone()); // persist entire DAG
+/// ```
+///
+/// Printing DAG
+/// ```
+/// let context = Arc::new(Context::new_for_test(4).0);
+/// let dag_builder = DagBuilder::new(context);
+/// dag_builder.layer(1).build();
+/// dag_builder.print(); // pretty print the entire DAG
+/// ```
 #[allow(unused)]
 pub(crate) struct DagBuilder {
     pub context: Arc<Context>,
@@ -152,8 +198,7 @@ impl DagBuilder {
     }
 }
 
-/// LayerBuilder
-// todo: Add usage doc comment
+/// Refer to doc comments for [`DagBuilder`] for usage information.
 pub struct LayerBuilder<'a> {
     dag_builder: &'a mut DagBuilder,
 
@@ -319,7 +364,7 @@ impl<'a> LayerBuilder<'a> {
                     .collect()
             };
 
-            // todo: investigate if these configurations can be called in combination
+            // TODO: investigate if these configurations can be called in combination
             // for the same layer
             let mut connections = if self.fully_linked_ancestors {
                 self.configure_fully_linked_ancestors()
@@ -520,4 +565,4 @@ impl<'a> LayerBuilder<'a> {
     }
 }
 
-// todo: add unit tests
+// TODO: add unit tests

--- a/consensus/core/src/test_dag_parser.rs
+++ b/consensus/core/src/test_dag_parser.rs
@@ -1,0 +1,372 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use consensus_config::AuthorityIndex;
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while1, take_while_m_n},
+    character::complete::{char, digit1, multispace0, multispace1, space0, space1},
+    combinator::{map_res, opt},
+    multi::{many0, separated_list0},
+    sequence::{delimited, preceded, terminated, tuple},
+    IResult,
+};
+
+use crate::{
+    block::{BlockRef, Round, Slot},
+    test_dag_builder::DagBuilder,
+};
+
+/// DagParser
+// todo: Add usage doc comment
+
+pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
+    let (input, _) = tuple((tag("DAG"), multispace0, char('{')))(dag_string)?;
+
+    let (mut input, num_authors) = parse_genesis(input)?;
+    let mut dag_builder = DagBuilder::new(num_authors as usize);
+
+    // Parse subsequent rounds
+    loop {
+        match parse_round(input, &dag_builder) {
+            Ok((new_input, (round, connections))) => {
+                dag_builder.layer_with_connections(connections, round);
+                input = new_input
+            }
+            Err(nom::Err::Error(_)) | Err(nom::Err::Failure(_)) => break,
+            Err(nom::Err::Incomplete(needed)) => return Err(nom::Err::Incomplete(needed)),
+        }
+    }
+    let (input, _) = tuple((multispace0, char('}')))(input)?;
+
+    Ok((input, dag_builder))
+}
+
+fn parse_round<'a>(
+    input: &'a str,
+    dag_builder: &DagBuilder,
+) -> IResult<&'a str, (Round, Vec<(AuthorityIndex, Vec<BlockRef>)>)> {
+    let (input, _) = tuple((multispace0, tag("Round"), space1))(input)?;
+    let (input, round) = take_while1(|c: char| c.is_ascii_digit())(input)?;
+
+    let (input, connections) = alt((
+        |input| parse_fully_connected(input, dag_builder),
+        |input| parse_specified_connections(input, dag_builder),
+    ))(input)?;
+
+    Ok((input, (round.parse().unwrap(), connections)))
+}
+
+fn parse_fully_connected<'a>(
+    input: &'a str,
+    dag_builder: &DagBuilder,
+) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
+    let (input, _) = tuple((
+        space0,
+        char(':'),
+        space0,
+        char('{'),
+        space0,
+        char('*'),
+        space0,
+        char('}'),
+        opt(char(',')),
+    ))(input)?;
+
+    let ancestors = dag_builder.last_ancestors.clone();
+    let connections = dag_builder
+        .context
+        .committee
+        .authorities()
+        .map(|authority| (authority.0, ancestors.clone()))
+        .collect::<Vec<_>>();
+
+    Ok((input, connections))
+}
+
+fn parse_specified_connections<'a>(
+    input: &'a str,
+    dag_builder: &DagBuilder,
+) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
+    let (input, _) = tuple((space0, char(':'), space0, char('{'), multispace0))(input)?;
+
+    // parse specified connections
+    // case 1: all authorities; [*]
+    // case 2: specific included authorities; [A0, B0, C0]
+    // case 3: specific excluded authorities;  [-A0]
+    // case 4: mixed all authorities + specific included/excluded authorities; [*, A0]
+    // todo: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
+    let (input, authors_and_connections) = many0(parse_author_and_connections)(input)?;
+
+    let mut output = Vec::new();
+    for (author, connections) in authors_and_connections {
+        let mut block_refs = HashSet::new();
+        for connection in connections {
+            if connection == "*" {
+                block_refs.extend(dag_builder.last_ancestors.clone());
+            } else if connection.starts_with('-') {
+                let (input, _) = char('-')(connection)?;
+                let (_, slot) = parse_slot(input)?;
+                let stored_block_refs = get_blocks_from_store(slot, dag_builder);
+                block_refs.extend(dag_builder.last_ancestors.clone());
+
+                block_refs.retain(|ancestor| !stored_block_refs.contains(ancestor));
+            } else {
+                let input = connection;
+                let (_, slot) = parse_slot(input)?;
+                let stored_block_refs = get_blocks_from_store(slot, dag_builder);
+
+                block_refs.extend(stored_block_refs);
+            }
+        }
+        output.push((author, block_refs.into_iter().collect()));
+    }
+
+    let (input, _) = tuple((multispace0, char('}'), opt(char(','))))(input)?;
+
+    Ok((input, output))
+}
+
+fn get_blocks_from_store(slot: Slot, dag_builder: &DagBuilder) -> Vec<BlockRef> {
+    // note: special case for genesis blocks as they are not stored in
+    // dag_state.recent_blocks
+    let stored_block_refs = if slot.round == 0 {
+        dag_builder
+            .dag_state
+            .read()
+            .genesis_block_refs()
+            .into_iter()
+            .filter(|block| Slot::from(*block) == slot)
+            .collect::<Vec<_>>()
+    } else {
+        dag_builder
+            .dag_state
+            .read()
+            .get_uncommitted_blocks_at_slot(slot)
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>()
+    };
+    stored_block_refs
+}
+
+fn parse_author_and_connections(input: &str) -> IResult<&str, (AuthorityIndex, Vec<&str>)> {
+    // parse author
+    let (input, author) = preceded(
+        multispace0,
+        terminated(
+            take_while1(|c: char| c.is_alphabetic()),
+            preceded(opt(space0), tag("->")),
+        ),
+    )(input)?;
+
+    // parse connections
+    let (input, connections) = delimited(
+        preceded(opt(space0), char('[')),
+        separated_list0(tag(", "), parse_block),
+        terminated(char(']'), opt(char(','))),
+    )(input)?;
+    let (input, _) = opt(multispace1)(input)?;
+    Ok((input, (author.into(), connections)))
+}
+
+fn parse_block(input: &str) -> IResult<&str, &str> {
+    alt((
+        map_res(tag("*"), |s: &str| Ok::<_, nom::error::ErrorKind>(s)),
+        map_res(
+            take_while1(|c: char| c.is_alphanumeric() || c == '-'),
+            |s: &str| Ok::<_, nom::error::ErrorKind>(s),
+        ),
+    ))(input)
+}
+
+fn parse_genesis(input: &str) -> IResult<&str, u32> {
+    let (input, num_authorities) = preceded(
+        tuple((
+            multispace0,
+            tag("Round"),
+            space1,
+            char('0'),
+            space0,
+            char(':'),
+            space0,
+            char('{'),
+            space0,
+        )),
+        |i| parse_authority_count(i),
+    )(input)?;
+    let (input, _) = tuple((space0, char('}'), opt(char(','))))(input)?;
+
+    Ok((input, num_authorities))
+}
+
+fn parse_authority_count(input: &str) -> IResult<&str, u32> {
+    let (input, num_str) = digit1(input)?;
+    Ok((input, num_str.parse().unwrap()))
+}
+
+fn parse_slot(input: &str) -> IResult<&str, Slot> {
+    let parse_authority = map_res(
+        take_while_m_n(1, 1, |c: char| c.is_alphabetic() && c.is_uppercase()),
+        |letter: &str| Ok::<_, nom::error::ErrorKind>(AuthorityIndex::from(letter)),
+    );
+
+    let parse_round = map_res(digit1, |digits: &str| digits.parse::<Round>());
+
+    let mut parser = tuple((parse_authority, parse_round));
+
+    let (input, (authority, round)) = parser(input)?;
+    Ok((input, Slot::new(round, authority)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dag_parsing() {
+        telemetry_subscribers::init_for_testing();
+        let dag_str = "DAG { 
+            Round 0 : { 4 },
+            Round 1 : { * },
+            Round 2 : { * },
+            Round 3 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+                D -> [*],
+            },
+            Round 4 : {
+                A -> [A3, B3, C3],
+                B -> [A3, B3, C3],
+                C -> [A3, B3, C3],
+                D -> [*],
+            },
+            Round 5 : {
+                A -> [*],
+                B -> [-A4],
+                C -> [-A4],
+                D -> [-A4],
+            },
+            Round 6 : {
+                A -> [A3, B3, C3, A1, B1],
+                B -> [*, A0],
+                C -> [-A5],
+            }
+         }";
+        let result = parse_dag(dag_str);
+        assert!(result.is_ok());
+
+        let (_, dag_builder) = result.unwrap();
+        assert_eq!(dag_builder.dag_state.read().genesis_block_refs().len(), 4);
+    }
+
+    #[test]
+    fn test_genesis_round_parsing() {
+        let dag_str = "Round 0 : { 4 }";
+        let result = parse_genesis(dag_str);
+        assert!(result.is_ok());
+        let (_, num_authorities) = result.unwrap();
+
+        assert_eq!(num_authorities, 4);
+    }
+
+    #[test]
+    fn test_slot_parsing() {
+        let dag_str = "A0";
+        let result = parse_slot(dag_str);
+        assert!(result.is_ok());
+        let (_, slot) = result.unwrap();
+
+        assert_eq!(slot.authority, AuthorityIndex::from("A"));
+        assert_eq!(slot.round, 0);
+    }
+
+    #[test]
+    fn test_all_round_parsing() {
+        let dag_str = "Round 1 : { * }";
+        let dag_builder = DagBuilder::new(4);
+        let result = parse_round(dag_str, &dag_builder);
+        assert!(result.is_ok());
+        let (_, (round, connections)) = result.unwrap();
+
+        assert_eq!(round, 1);
+        for (i, (authority, references)) in connections.into_iter().enumerate() {
+            assert_eq!(authority, AuthorityIndex::new_for_test(i as u32));
+            assert_eq!(references, dag_builder.last_ancestors);
+        }
+    }
+
+    #[test]
+    fn test_specific_round_parsing() {
+        let dag_str = "Round 1 : {
+            A -> [A0, B0, C0, D0],
+            B -> [*, A0],
+            C -> [-A0],
+        }";
+        let dag_builder = DagBuilder::new(4);
+        let result = parse_round(dag_str, &dag_builder);
+        assert!(result.is_ok());
+        let (_, (round, connections)) = result.unwrap();
+
+        let skipped_slot = Slot::new_for_test(0, 0); // A0
+        let mut expected_references = vec![
+            dag_builder.last_ancestors.clone(),
+            dag_builder.last_ancestors.clone(),
+            dag_builder
+                .last_ancestors
+                .into_iter()
+                .filter(|ancestor| Slot::from(*ancestor) != skipped_slot)
+                .collect(),
+        ];
+
+        assert_eq!(round, 1);
+        for (i, (authority, mut references)) in connections.into_iter().enumerate() {
+            assert_eq!(authority, AuthorityIndex::new_for_test(i as u32));
+            references.sort();
+            expected_references[i].sort();
+            assert_eq!(references, expected_references[i]);
+        }
+    }
+
+    #[test]
+    fn test_parse_author_and_connections() {
+        let expected_authority = AuthorityIndex::from("A");
+
+        // case 1: all authorities
+        let dag_str = "A -> [*]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(actual_connections, ["*"]);
+
+        // case 2: specific included authorities
+        let dag_str = "A -> [A0, B0, C0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(actual_connections, ["A0", "B0", "C0"]);
+
+        // case 3: specific excluded authorities
+        let dag_str = "A -> [-A0, -B0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(actual_connections, ["-A0", "-B0"]);
+
+        // case 4: mixed all authorities + specific included/excluded authorities
+        let dag_str = "A -> [*, A0, -B0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(actual_connections, ["*", "A0", "-B0"]);
+
+        // todo: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
+    }
+}

--- a/consensus/core/src/test_dag_parser.rs
+++ b/consensus/core/src/test_dag_parser.rs
@@ -280,6 +280,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::block::BlockAPI;
 
     #[test]
     fn test_dag_parsing() {
@@ -318,6 +319,59 @@ mod tests {
         let (_, dag_builder) = result.unwrap();
         assert_eq!(dag_builder.genesis.len(), 4);
         assert_eq!(dag_builder.blocks.len(), 23);
+
+        // Check the blocks were correctly parsed in Round 6
+        let blocks_a6 = dag_builder
+            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(0)));
+        assert_eq!(blocks_a6.len(), 1);
+        let block_a6 = blocks_a6.first().unwrap();
+        assert_eq!(block_a6.round(), 6);
+        assert_eq!(block_a6.author(), AuthorityIndex::new_for_test(0));
+        assert_eq!(block_a6.ancestors().len(), 5);
+        let expected_block_a6_ancestor_slots = [
+            Slot::new(3, AuthorityIndex::new_for_test(0)),
+            Slot::new(3, AuthorityIndex::new_for_test(1)),
+            Slot::new(3, AuthorityIndex::new_for_test(2)),
+            Slot::new(1, AuthorityIndex::new_for_test(0)),
+            Slot::new(1, AuthorityIndex::new_for_test(1)),
+        ];
+        for ancestor in block_a6.ancestors() {
+            assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*ancestor)));
+        }
+
+        let blocks_b6 = dag_builder
+            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(1)));
+        assert_eq!(blocks_b6.len(), 1);
+        let block_b6 = blocks_b6.first().unwrap();
+        assert_eq!(block_b6.round(), 6);
+        assert_eq!(block_b6.author(), AuthorityIndex::new_for_test(1));
+        assert_eq!(block_b6.ancestors().len(), 5);
+        let expected_block_b6_ancestor_slots = [
+            Slot::new(5, AuthorityIndex::new_for_test(0)),
+            Slot::new(5, AuthorityIndex::new_for_test(1)),
+            Slot::new(5, AuthorityIndex::new_for_test(2)),
+            Slot::new(5, AuthorityIndex::new_for_test(3)),
+            Slot::new(0, AuthorityIndex::new_for_test(0)),
+        ];
+        for ancestor in block_b6.ancestors() {
+            assert!(expected_block_b6_ancestor_slots.contains(&Slot::from(*ancestor)));
+        }
+
+        let blocks_c6 = dag_builder
+            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(2)));
+        assert_eq!(blocks_c6.len(), 1);
+        let block_c6 = blocks_c6.first().unwrap();
+        assert_eq!(block_c6.round(), 6);
+        assert_eq!(block_c6.author(), AuthorityIndex::new_for_test(2));
+        assert_eq!(block_c6.ancestors().len(), 3);
+        let expected_block_c6_ancestor_slots = [
+            Slot::new(5, AuthorityIndex::new_for_test(1)),
+            Slot::new(5, AuthorityIndex::new_for_test(2)),
+            Slot::new(5, AuthorityIndex::new_for_test(3)),
+        ];
+        for ancestor in block_c6.ancestors() {
+            assert!(expected_block_c6_ancestor_slots.contains(&Slot::from(*ancestor)));
+        }
     }
 
     #[test]

--- a/consensus/core/src/test_dag_parser.rs
+++ b/consensus/core/src/test_dag_parser.rs
@@ -21,7 +21,36 @@ use crate::{
 };
 
 /// DagParser
-// todo: Add usage doc comment
+///
+/// Usage:
+///
+/// ```
+/// let dag_str = "DAG {
+///     Round 0 : { 4 },
+///     Round 1 : { * },
+///     Round 2 : { * },
+///     Round 3 : { * },
+///     Round 4 : {
+///         A -> [-D3],
+///         B -> [*],
+///         C -> [*],
+///         D -> [*],
+///     },
+///     Round 5 : {
+///         A -> [*],
+///         B -> [*],
+///         C -> [A4],
+///         D -> [A4],
+///     },
+///     Round 6 : { * },
+///     Round 7 : { * },
+///     Round 8 : { * },
+///     }";
+///
+/// let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag"); // parse DAG DSL
+/// dag_builder.print(); // print the parsed DAG
+/// dag_builder.persist_all_blocks(dag_state.clone()); // persist all blocks to DagState
+/// ```
 
 pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
     let (input, _) = tuple((tag("DAG"), multispace0, char('{')))(dag_string)?;
@@ -100,7 +129,7 @@ fn parse_specified_connections<'a>(
     // case 2: specific included authorities; [A0, B0, C0]
     // case 3: specific excluded authorities;  [-A0]
     // case 4: mixed all authorities + specific included/excluded authorities; [*, A0]
-    // todo: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
+    // TODO: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
     let (input, authors_and_connections) = many0(parse_author_and_connections)(input)?;
 
     let mut output = Vec::new();
@@ -397,7 +426,7 @@ mod tests {
         assert_eq!(actual_author, expected_authority);
         assert_eq!(actual_connections, ["*", "A0", "-B0"]);
 
-        // todo: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
+        // TODO: case 5: byzantine case of multiple blocks per slot; [*]; timestamp=1
     }
 
     #[test]

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -13,20 +13,24 @@ use crate::{
     dag_state::DagState,
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
+    test_dag_builder::DagBuilder,
+    test_dag_parser::parse_dag,
     universal_committer::universal_committer_builder::UniversalCommitterBuilder,
 };
 
 /// Commit one leader.
 #[test]
 fn direct_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+    let (mut dag_builder, committer) = basic_dag_builder_test_setup();
 
     // Build fully connected dag with empty blocks adding up to voting round of
     // wave 2 to the dag so that we have 2 completed waves and one incomplete wave.
     // note: waves & rounds are zero-indexed.
     let leader_round_wave_1 = committer.committers[0].leader_round(1);
     let voting_round_wave_2 = committer.committers[0].leader_round(2) + 1;
-    build_dag(context, dag_state, None, voting_round_wave_2);
+    dag_builder.layers(1..voting_round_wave_2).build();
+
+    dag_builder.print();
 
     // Genesis cert will not be included in commit sequence, marking it as last decided
     let last_decided = Slot::new_for_test(0, 0);
@@ -214,46 +218,32 @@ fn no_genesis_commit() {
     }
 }
 
-/// We directly skip the leader if it is missing.
+/// We directly skip the leader if there are enough non-votes (blames).
 #[test]
-fn no_leader() {
-    let (context, dag_state, committer) = basic_test_setup();
+fn direct_skip_no_leader_votes() {
+    let (mut dag_builder, committer) = basic_dag_builder_test_setup();
 
-    // Add enough blocks to finish wave 0.
+    // Add enough blocks to reach the leader round of wave 1.
     // note: waves & rounds are zero-indexed.
-    let decision_round_wave_0 = committer.committers[0].decision_round(0);
-    let references_decision_round_wave_0 = build_dag(
-        context.clone(),
-        dag_state.clone(),
-        None,
-        decision_round_wave_0,
-    );
+    let leader_round_wave_1 = committer.committers[0].leader_round(1);
+    dag_builder.layers(1..leader_round_wave_1).build();
 
     // Add enough blocks to reach the decision round of the first leader but without
-    // leader of wave 1. This is creating the scenario where there are no votes
-    // in the voting round of wave 1 for the leader of wave 1 because it is missing
-    // from the dag.
-    let leader_round_wave_1 = committer.committers[0].leader_round(1);
+    // votes for the leader of wave 1.
     let leader_wave_1 = committer.get_leaders(leader_round_wave_1)[0];
-
-    let connections = context
-        .committee
-        .authorities()
-        .filter(|&authority| authority.0 != leader_wave_1)
-        .map(|authority| (authority.0, references_decision_round_wave_0.clone()))
-        .collect::<Vec<_>>();
-    let voting_round_wave_1 = build_dag_layer(connections, dag_state.clone());
+    let voting_round_wave_1 = leader_round_wave_1 + 1;
+    dag_builder
+        .layer(voting_round_wave_1)
+        .no_leader_link(leader_round_wave_1, 0)
+        .build();
 
     let decision_round_wave_1 = committer.committers[0].decision_round(1);
-    build_dag(
-        context.clone(),
-        dag_state.clone(),
-        Some(voting_round_wave_1),
-        decision_round_wave_1,
-    );
+    dag_builder.layer(decision_round_wave_1).build();
+
+    dag_builder.print();
 
     // Ensure no blocks are committed because there are 2f+1 blame (non-votes) for
-    // the missing leader of wave 1.
+    // the leader of wave 1.
     let last_decided = Slot::new_for_test(0, 0);
     let sequence = committer.try_commit(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
@@ -267,40 +257,33 @@ fn no_leader() {
     }
 }
 
-/// We directly skip the leader if it has enough blame.
+/// We directly skip the leader if it is missing.
 #[test]
-fn direct_skip() {
-    let (context, dag_state, committer) = basic_test_setup();
+fn direct_skip_missing_leader_block() {
+    let (mut dag_builder, committer) = basic_dag_builder_test_setup();
 
-    // Add enough blocks to reach the leader round of wave 1.
+    // Add enough blocks to reach the decision round of wave 0
     // note: waves & rounds are zero-indexed.
-    let leader_round_wave_1 = committer.committers[0].leader_round(1);
-    let references_leader_round_wave_1 = build_dag(
-        context.clone(),
-        dag_state.clone(),
-        None,
-        leader_round_wave_1,
-    );
+    let decision_round_wave_0 = committer.committers[0].decision_round(0);
+    dag_builder.layers(1..decision_round_wave_0).build();
 
-    // Filter out the leader of wave 1 so that we can create blocks in voting
-    // round of wave 1 that do not include the leader of wave 1. Note that the
-    // leader does exist in the dag in this scenario.
-    let references_without_leader_1: Vec<_> = references_leader_round_wave_1
-        .into_iter()
-        .filter(|x| x.author != committer.get_leaders(leader_round_wave_1)[0])
-        .collect();
+    // Create a leader round in the dag without the leader block.
+    let leader_round_wave_1 = committer.committers[0].leader_round(1);
+    dag_builder
+        .layer(leader_round_wave_1)
+        .no_leader_block(0)
+        .build();
 
     // Add enough blocks to reach the decision round of wave 1.
+    let voting_round_wave_1 = leader_round_wave_1 + 1;
     let decision_round_wave_1 = committer.committers[0].decision_round(1);
-    build_dag(
-        context.clone(),
-        dag_state.clone(),
-        Some(references_without_leader_1),
-        decision_round_wave_1,
-    );
+    dag_builder
+        .layers(voting_round_wave_1..decision_round_wave_1)
+        .build();
 
-    // Ensure the leader is skipped because there are 2f+1 blame (non-votes) for
-    // the leader of wave 1.
+    dag_builder.print();
+
+    // Ensure the leader is skipped because the leader is missing.
     let last_committed = Slot::new_for_test(0, 0);
     let sequence = committer.try_commit(last_committed);
     tracing::info!("Commit sequence: {sequence:#?}");
@@ -320,88 +303,45 @@ fn direct_skip() {
 /// Indirect-commit the first leader.
 #[test]
 fn indirect_commit() {
-    let (context, dag_state, committer) = basic_test_setup();
+    telemetry_subscribers::init_for_testing();
+    // Dag Notes:
+    // - Fully connected up to the leader round of wave 1.
+    // - Only 2f+1 validators vote for the leader of wave 1.
+    // - Only f+1 validators certify the leader of wave 1.
+    // - The validators not part of the f+1 above will not certify the leader
+    // of wave 1.
+    // - Fully connected blocks to decide the leader of wave 2.
+    let dag_str = "DAG { 
+        Round 0 : { 4 },
+        Round 1 : { * },
+        Round 2 : { * },
+        Round 3 : { * },
+        Round 4 : {
+            A -> [-D3],
+            B -> [*],
+            C -> [*],
+            D -> [*],
+        },
+        Round 5 : {
+            A -> [*],
+            B -> [*],
+            C -> [A4],
+            D -> [A4],
+        },
+        Round 6 : { * },
+        Round 7 : { * },
+        Round 8 : { * },
+     }";
 
-    // Add enough blocks to reach the leader round of wave 1.
-    // note: waves & rounds are zero-indexed.
-    let leader_round_wave_1 = committer.committers[0].leader_round(1);
-    let references_leader_wave_1 = build_dag(
-        context.clone(),
-        dag_state.clone(),
-        None,
-        leader_round_wave_1,
-    );
+    let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+    dag_builder.print();
 
-    // Filter out the leader of wave 1.
-    let leader_wave_1 = committer.get_leaders(leader_round_wave_1)[0];
-    let references_without_leader_wave_1: Vec<_> = references_leader_wave_1
-        .iter()
-        .cloned()
-        .filter(|x| x.author != leader_wave_1)
-        .collect();
-
-    // Only 2f+1 validators vote for the leader of wave 1.
-    let connections_with_leader_wave_1 = context
-        .committee
-        .authorities()
-        .take(context.committee.quorum_threshold() as usize)
-        .map(|authority| (authority.0, references_leader_wave_1.clone()))
-        .collect();
-    let references_with_votes_for_leader_wave_1 =
-        build_dag_layer(connections_with_leader_wave_1, dag_state.clone());
-
-    // The validators not part of the 2f+1 above do not vote for the leader
-    // of wave 1
-    let connections_without_leader_wave_1 = context
-        .committee
-        .authorities()
-        .skip(context.committee.quorum_threshold() as usize)
-        .map(|authority| (authority.0, references_without_leader_wave_1.clone()))
-        .collect();
-    let references_without_votes_for_leader_wave_1 =
-        build_dag_layer(connections_without_leader_wave_1, dag_state.clone());
-
-    // Only f+1 validators certify the leader of wave 1.
-    let mut references_decision_round_wave_1 = Vec::new();
-
-    let connections_with_certs_for_leader_wave_1 = context
-        .committee
-        .authorities()
-        .take(context.committee.validity_threshold() as usize)
-        .map(|authority| (authority.0, references_with_votes_for_leader_wave_1.clone()))
-        .collect();
-    references_decision_round_wave_1.extend(build_dag_layer(
-        connections_with_certs_for_leader_wave_1,
-        dag_state.clone(),
-    ));
-
-    let references_voting_round_wave_1: Vec<_> = references_without_votes_for_leader_wave_1
-        .into_iter()
-        .chain(references_with_votes_for_leader_wave_1)
-        .take(context.committee.quorum_threshold() as usize)
-        .collect();
-
-    // The validators not part of the f+1 above will not certify the leader of wave 1.
-    let connections_without_votes_for_leader_1 = context
-        .committee
-        .authorities()
-        .skip(context.committee.validity_threshold() as usize)
-        .map(|authority| (authority.0, references_voting_round_wave_1.clone()))
-        .collect();
-    references_decision_round_wave_1.extend(build_dag_layer(
-        connections_without_votes_for_leader_1,
-        dag_state.clone(),
-    ));
-
-    // Add enough blocks to decide the leader of wave 2 connecting to the references
-    // manually constructed of the decision round of wave 1.
-    let decision_round_wave_2 = committer.committers[0].decision_round(2);
-    build_dag(
-        context.clone(),
-        dag_state.clone(),
-        Some(references_decision_round_wave_1),
-        decision_round_wave_2,
-    );
+    // Create committer without pipelining and only 1 leader per leader round
+    let committer =
+        UniversalCommitterBuilder::new(dag_builder.context.clone(), dag_builder.dag_state.clone())
+            .build();
+    // note: without pipelining or multi-leader enabled there should only be one committer.
+    assert!(committer.committers.len() == 1);
 
     // Ensure we indirectly commit the leader of wave 1 via the directly committed
     // leader of wave 2.
@@ -753,4 +693,19 @@ fn basic_test_setup() -> (
     assert!(committer.committers.len() == 1);
 
     (context, dag_state, committer)
+}
+
+// TODO: Make this the basic_test_setup()
+fn basic_dag_builder_test_setup() -> (DagBuilder, super::UniversalCommitter) {
+    telemetry_subscribers::init_for_testing();
+    let dag_builder = DagBuilder::new(4);
+
+    // Create committer without pipelining and only 1 leader per leader round
+    let committer =
+        UniversalCommitterBuilder::new(dag_builder.context.clone(), dag_builder.dag_state.clone())
+            .build();
+    // note: without pipelining or multi-leader enabled there should only be one committer.
+    assert!(committer.committers.len() == 1);
+
+    (dag_builder, committer)
 }

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -234,8 +234,7 @@ fn direct_skip_no_leader_votes() {
     let voting_round_wave_1 = leader_round_wave_1 + 1;
     dag_builder
         .layer(voting_round_wave_1)
-        .no_leader_link(leader_round_wave_1, 0)
-        .build();
+        .no_leader_link(leader_round_wave_1, vec![]);
 
     let decision_round_wave_1 = committer.committers[0].decision_round(1);
     dag_builder.layer(decision_round_wave_1).build();
@@ -271,7 +270,7 @@ fn direct_skip_missing_leader_block() {
     let leader_round_wave_1 = committer.committers[0].leader_round(1);
     dag_builder
         .layer(leader_round_wave_1)
-        .no_leader_block(0)
+        .no_leader_block(vec![])
         .build();
 
     // Add enough blocks to reach the decision round of wave 1.
@@ -698,7 +697,7 @@ fn basic_test_setup() -> (
 // TODO: Make this the basic_test_setup()
 fn basic_dag_builder_test_setup() -> (DagBuilder, super::UniversalCommitter) {
     telemetry_subscribers::init_for_testing();
-    let dag_builder = DagBuilder::new(4);
+    let dag_builder = DagBuilder::new(Context::new_for_test(4).0);
 
     // Create committer without pipelining and only 1 leader per leader round
     let committer =


### PR DESCRIPTION
## Description 

Add `DagBuilder` API and Dag DSL that can be parsed via `DagParser` module.

### DagBuilder API
```
let dag_builder = DagBuilder::new(num_authorities); 
dag_builder.layer(1).build(); // Round 1 is fully connected with parents by default.
dag_builder.layers(2..10).build(); // Rounds 2 ~ 10 are fully connected with parents by default.
dag_builder.layers(11).min_parent_links().build(); // Round 11 is minimally and randomly connected with parents, without weak links.
dag_builder.layers(12).no_leader_block(0).build(); // Round 12 misses leader block. Other blocks are fully connected with parents.
dag_builder.layers(13).no_leader_link(12, 0).build(); // Round 13 misses votes for leader block. Other blocks are fully connected with parents.
dag_builder.layers(14).authorities(vec![3,5]).skip_block().build(); // Round 14 authorities 3 and 5 will not propose any block.
dag_builder.layers(15).authorities(vec![3,5]).skip_ancestor_links(vec![1,2]).build(); // Round 15 authorities 3 and 5 will not link to ancestors 1 and 2
dag_builder.layers(16).authorities(vec![3,5]).equivocate(3).build(); // Round 16 authorities 3 and 5 will produce 3 equivocating blocks.
```
- calling `.build()` will write blocks to dag state.
- todo: finish implementation for `random_weak_links()`
- `dag_builder.blocks `has all the blocks to be retrieved for additional testing
- `dag_builder.print()` will pretty print the constructed dag, i.e.
```
DAG {
Round 1 : 
    Block A1(otYgq5ty3gLz5XNmp+gkj6lRsr1MXHPH8eUrB5TRqSw=)(1001ms;[A0(XQ0/ISCOxrPDK4Xl1TW4BHE797ZYVZoQBYycTZ/Sx5o=), B0(O0Mjg1TlElvBC9yfxJDZeSXnGZopE6Qn8Cv6xTRVRx4=), C0(W/YWKrKixuuhVd+ucuyGHegk9gSkObZiRxdrYq1ijm4=), D0(pwrloftpTl5TN3/5UyvH/Ku0oVU1PxpkNzg73Uz+rIA=)];0;v)
    Block B1(FnRBfqZV0pNQO2rL1XbLnijISvJPWSaFX3o35CY11+c=)(1002ms;[A0(XQ0/ISCOxrPDK4Xl1TW4BHE797ZYVZoQBYycTZ/Sx5o=), B0(O0Mjg1TlElvBC9yfxJDZeSXnGZopE6Qn8Cv6xTRVRx4=), C0(W/YWKrKixuuhVd+ucuyGHegk9gSkObZiRxdrYq1ijm4=), D0(pwrloftpTl5TN3/5UyvH/Ku0oVU1PxpkNzg73Uz+rIA=)];0;v)
    Block C1(PCIpbD4F5jgZNj4SEHpiQNDkihl8mhkhHQfhBPW1LsA=)(1003ms;[A0(XQ0/ISCOxrPDK4Xl1TW4BHE797ZYVZoQBYycTZ/Sx5o=), B0(O0Mjg1TlElvBC9yfxJDZeSXnGZopE6Qn8Cv6xTRVRx4=), C0(W/YWKrKixuuhVd+ucuyGHegk9gSkObZiRxdrYq1ijm4=), D0(pwrloftpTl5TN3/5UyvH/Ku0oVU1PxpkNzg73Uz+rIA=)];0;v)
    Block D1(FXa/64rtmX4fHea21XL1rm28xFib3IDgSw6zHpNvWNY=)(1004ms;[A0(XQ0/ISCOxrPDK4Xl1TW4BHE797ZYVZoQBYycTZ/Sx5o=), B0(O0Mjg1TlElvBC9yfxJDZeSXnGZopE6Qn8Cv6xTRVRx4=), C0(W/YWKrKixuuhVd+ucuyGHegk9gSkObZiRxdrYq1ijm4=), D0(pwrloftpTl5TN3/5UyvH/Ku0oVU1PxpkNzg73Uz+rIA=)];0;v)
Round 2 : 
    Block A2(zrcEl6WAMUiT1a463jhovInUBpYSX1r9ZYsdyKe1Mrs=)(2002ms;[A1(otYgq5ty3gLz5XNmp+gkj6lRsr1MXHPH8eUrB5TRqSw=), B1(FnRBfqZV0pNQO2rL1XbLnijISvJPWSaFX3o35CY11+c=), C1(PCIpbD4F5jgZNj4SEHpiQNDkihl8mhkhHQfhBPW1LsA=), D1(FXa/64rtmX4fHea21XL1rm28xFib3IDgSw6zHpNvWNY=)];0;v)
    Block B2(Gn1w4RCXN+o5X5hsW+Z85/ZUJmD+LdGI4/vkjSCdgQI=)(2003ms;[A1(otYgq5ty3gLz5XNmp+gkj6lRsr1MXHPH8eUrB5TRqSw=), B1(FnRBfqZV0pNQO2rL1XbLnijISvJPWSaFX3o35CY11+c=), C1(PCIpbD4F5jgZNj4SEHpiQNDkihl8mhkhHQfhBPW1LsA=), D1(FXa/64rtmX4fHea21XL1rm28xFib3IDgSw6zHpNvWNY=)];0;v)
    Block C2(zXTiZ9tvD1tyZQBzEwiELizzOH4UoaDlYeHnufN6d6w=)(2004ms;[A1(otYgq5ty3gLz5XNmp+gkj6lRsr1MXHPH8eUrB5TRqSw=), B1(FnRBfqZV0pNQO2rL1XbLnijISvJPWSaFX3o35CY11+c=), C1(PCIpbD4F5jgZNj4SEHpiQNDkihl8mhkhHQfhBPW1LsA=), D1(FXa/64rtmX4fHea21XL1rm28xFib3IDgSw6zHpNvWNY=)];0;v)
    Block D2(WZV+pvnmcOQBY87nPAQZAXUGo1vs2JnYHCVNSvaOWNE=)(2005ms;[A1(otYgq5ty3gLz5XNmp+gkj6lRsr1MXHPH8eUrB5TRqSw=), B1(FnRBfqZV0pNQO2rL1XbLnijISvJPWSaFX3o35CY11+c=), C1(PCIpbD4F5jgZNj4SEHpiQNDkihl8mhkhHQfhBPW1LsA=), D1(FXa/64rtmX4fHea21XL1rm28xFib3IDgSw6zHpNvWNY=)];0;v)
Round 3 : 
    Block A3(OhYZrKR85wAXtUQwZX+Yh8IWGot6QOPdrBwIaL36+cU=)(3003ms;[A2(zrcEl6WAMUiT1a463jhovInUBpYSX1r9ZYsdyKe1Mrs=), B2(Gn1w4RCXN+o5X5hsW+Z85/ZUJmD+LdGI4/vkjSCdgQI=), C2(zXTiZ9tvD1tyZQBzEwiELizzOH4UoaDlYeHnufN6d6w=), D2(WZV+pvnmcOQBY87nPAQZAXUGo1vs2JnYHCVNSvaOWNE=)];0;v)
    Block B3(3WY5JizOmQm6yrOvwgfMFJOov5bt6VnjAPVpe3Lb2fc=)(3004ms;[A2(zrcEl6WAMUiT1a463jhovInUBpYSX1r9ZYsdyKe1Mrs=), B2(Gn1w4RCXN+o5X5hsW+Z85/ZUJmD+LdGI4/vkjSCdgQI=), C2(zXTiZ9tvD1tyZQBzEwiELizzOH4UoaDlYeHnufN6d6w=), D2(WZV+pvnmcOQBY87nPAQZAXUGo1vs2JnYHCVNSvaOWNE=)];0;v)
    Block C3(F110IA17XMGfN6zlfluVpd8fHlzlk8IfgyJFJog7R7Y=)(3005ms;[A2(zrcEl6WAMUiT1a463jhovInUBpYSX1r9ZYsdyKe1Mrs=), B2(Gn1w4RCXN+o5X5hsW+Z85/ZUJmD+LdGI4/vkjSCdgQI=), C2(zXTiZ9tvD1tyZQBzEwiELizzOH4UoaDlYeHnufN6d6w=), D2(WZV+pvnmcOQBY87nPAQZAXUGo1vs2JnYHCVNSvaOWNE=)];0;v)
    Block D3(r9Z0F6YCEQP6FIuCmYgiE/I60HAPi1qPN0xkzci3OH4=)(3006ms;[A2(zrcEl6WAMUiT1a463jhovInUBpYSX1r9ZYsdyKe1Mrs=), B2(Gn1w4RCXN+o5X5hsW+Z85/ZUJmD+LdGI4/vkjSCdgQI=), C2(zXTiZ9tvD1tyZQBzEwiELizzOH4UoaDlYeHnufN6d6w=), D2(WZV+pvnmcOQBY87nPAQZAXUGo1vs2JnYHCVNSvaOWNE=)];0;v)
Round 4 : 
    Block A4(0btWl7oo1vjr+9XlQRqCbVJzcFQwqym0MOxeD7dJ0Lo=)(4004ms;[A3(OhYZrKR85wAXtUQwZX+Yh8IWGot6QOPdrBwIaL36+cU=), B3(3WY5JizOmQm6yrOvwgfMFJOov5bt6VnjAPVpe3Lb2fc=), C3(F110IA17XMGfN6zlfluVpd8fHlzlk8IfgyJFJog7R7Y=), D3(r9Z0F6YCEQP6FIuCmYgiE/I60HAPi1qPN0xkzci3OH4=)];0;v)
    Block B4(URFOcNxMBns0CBox4WHrMTfC9Fycn7j06mPc67bRuQg=)(4005ms;[A3(OhYZrKR85wAXtUQwZX+Yh8IWGot6QOPdrBwIaL36+cU=), B3(3WY5JizOmQm6yrOvwgfMFJOov5bt6VnjAPVpe3Lb2fc=), C3(F110IA17XMGfN6zlfluVpd8fHlzlk8IfgyJFJog7R7Y=), D3(r9Z0F6YCEQP6FIuCmYgiE/I60HAPi1qPN0xkzci3OH4=)];0;v)
    Block C4(nqsRar0k6OQxmB3Gmegq34M60eInZcXdjxmKwBb4ZQ0=)(4006ms;[A3(OhYZrKR85wAXtUQwZX+Yh8IWGot6QOPdrBwIaL36+cU=), B3(3WY5JizOmQm6yrOvwgfMFJOov5bt6VnjAPVpe3Lb2fc=), C3(F110IA17XMGfN6zlfluVpd8fHlzlk8IfgyJFJog7R7Y=), D3(r9Z0F6YCEQP6FIuCmYgiE/I60HAPi1qPN0xkzci3OH4=)];0;v)
    Block D4(cLn1H9E0NaiiFRK5Am8Bm8b7NFFcdaKQbdaO9X2P3bg=)(4007ms;[A3(OhYZrKR85wAXtUQwZX+Yh8IWGot6QOPdrBwIaL36+cU=), B3(3WY5JizOmQm6yrOvwgfMFJOov5bt6VnjAPVpe3Lb2fc=), C3(F110IA17XMGfN6zlfluVpd8fHlzlk8IfgyJFJog7R7Y=), D3(r9Z0F6YCEQP6FIuCmYgiE/I60HAPi1qPN0xkzci3OH4=)];0;v)
Round 5 : 
    Block A5(2TyDCA7zQ6M6LFgHIVMPodOieoNbdwGf5CuwDEWyIxg=)(5005ms;[A4(0btWl7oo1vjr+9XlQRqCbVJzcFQwqym0MOxeD7dJ0Lo=), B4(URFOcNxMBns0CBox4WHrMTfC9Fycn7j06mPc67bRuQg=), C4(nqsRar0k6OQxmB3Gmegq34M60eInZcXdjxmKwBb4ZQ0=), D4(cLn1H9E0NaiiFRK5Am8Bm8b7NFFcdaKQbdaO9X2P3bg=)];0;v)
    Block B5(yqbdpP3wSZXR0VwQS2U9IQwHWD+RpbCRtPbNx/Csnvc=)(5006ms;[A4(0btWl7oo1vjr+9XlQRqCbVJzcFQwqym0MOxeD7dJ0Lo=), B4(URFOcNxMBns0CBox4WHrMTfC9Fycn7j06mPc67bRuQg=), C4(nqsRar0k6OQxmB3Gmegq34M60eInZcXdjxmKwBb4ZQ0=), D4(cLn1H9E0NaiiFRK5Am8Bm8b7NFFcdaKQbdaO9X2P3bg=)];0;v)
    Block C5(dUuoHsDUpEBu3kwUcrJ6xN210UiFxYanLqnLeg5suyk=)(5007ms;[A4(0btWl7oo1vjr+9XlQRqCbVJzcFQwqym0MOxeD7dJ0Lo=), B4(URFOcNxMBns0CBox4WHrMTfC9Fycn7j06mPc67bRuQg=), C4(nqsRar0k6OQxmB3Gmegq34M60eInZcXdjxmKwBb4ZQ0=), D4(cLn1H9E0NaiiFRK5Am8Bm8b7NFFcdaKQbdaO9X2P3bg=)];0;v)
    Block D5(TKqYtHz/KVYQOII4Iggr+JB4DU/0/U9GcEW+j9v/aL0=)(5008ms;[A4(0btWl7oo1vjr+9XlQRqCbVJzcFQwqym0MOxeD7dJ0Lo=), B4(URFOcNxMBns0CBox4WHrMTfC9Fycn7j06mPc67bRuQg=), C4(nqsRar0k6OQxmB3Gmegq34M60eInZcXdjxmKwBb4ZQ0=), D4(cLn1H9E0NaiiFRK5Am8Bm8b7NFFcdaKQbdaO9X2P3bg=)];0;v)
Round 6 : 
    Block A6(luf/p0Q4l8TTqfmZdi5+ioJOR8d1BuOrPGXqxs1Vh4E=)(6006ms;[A5(2TyDCA7zQ6M6LFgHIVMPodOieoNbdwGf5CuwDEWyIxg=), B5(yqbdpP3wSZXR0VwQS2U9IQwHWD+RpbCRtPbNx/Csnvc=), C5(dUuoHsDUpEBu3kwUcrJ6xN210UiFxYanLqnLeg5suyk=), D5(TKqYtHz/KVYQOII4Iggr+JB4DU/0/U9GcEW+j9v/aL0=)];0;v)
    Block B6(6LaW2zW6P4y9FOqsdh0Vx3vVrjFzbcu69iC1OxfDmMY=)(6007ms;[A5(2TyDCA7zQ6M6LFgHIVMPodOieoNbdwGf5CuwDEWyIxg=), B5(yqbdpP3wSZXR0VwQS2U9IQwHWD+RpbCRtPbNx/Csnvc=), C5(dUuoHsDUpEBu3kwUcrJ6xN210UiFxYanLqnLeg5suyk=), D5(TKqYtHz/KVYQOII4Iggr+JB4DU/0/U9GcEW+j9v/aL0=)];0;v)
    Block C6(v+SNVAiEe8m9X0W47l9tP8Zg4jUg2+RLqTSWdguLMFo=)(6008ms;[A5(2TyDCA7zQ6M6LFgHIVMPodOieoNbdwGf5CuwDEWyIxg=), B5(yqbdpP3wSZXR0VwQS2U9IQwHWD+RpbCRtPbNx/Csnvc=), C5(dUuoHsDUpEBu3kwUcrJ6xN210UiFxYanLqnLeg5suyk=), D5(TKqYtHz/KVYQOII4Iggr+JB4DU/0/U9GcEW+j9v/aL0=)];0;v)
    Block D6(T9Wk1U9aj+X+NNH5mBBsHumTHTBfN85mvjy+HQKCFPs=)(6009ms;[A5(2TyDCA7zQ6M6LFgHIVMPodOieoNbdwGf5CuwDEWyIxg=), B5(yqbdpP3wSZXR0VwQS2U9IQwHWD+RpbCRtPbNx/Csnvc=), C5(dUuoHsDUpEBu3kwUcrJ6xN210UiFxYanLqnLeg5suyk=), D5(TKqYtHz/KVYQOII4Iggr+JB4DU/0/U9GcEW+j9v/aL0=)];0;v)
Round 7 : 
    Block A7(o/lGD0z5GLCGMLo8dpWWYCMe8caXFw6fCuCU/s4bH7E=)(7007ms;[A6(luf/p0Q4l8TTqfmZdi5+ioJOR8d1BuOrPGXqxs1Vh4E=), B6(6LaW2zW6P4y9FOqsdh0Vx3vVrjFzbcu69iC1OxfDmMY=), C6(v+SNVAiEe8m9X0W47l9tP8Zg4jUg2+RLqTSWdguLMFo=), D6(T9Wk1U9aj+X+NNH5mBBsHumTHTBfN85mvjy+HQKCFPs=)];0;v)
    Block B7(pCDmeRSHh8yGcTWPZGGqVDodKa9yoebkCskUZ8jKmZE=)(7008ms;[A6(luf/p0Q4l8TTqfmZdi5+ioJOR8d1BuOrPGXqxs1Vh4E=), B6(6LaW2zW6P4y9FOqsdh0Vx3vVrjFzbcu69iC1OxfDmMY=), C6(v+SNVAiEe8m9X0W47l9tP8Zg4jUg2+RLqTSWdguLMFo=), D6(T9Wk1U9aj+X+NNH5mBBsHumTHTBfN85mvjy+HQKCFPs=)];0;v)
    Block C7(dn90kGjh8rjZ/ekUeUXqLF2X8Uh+1/azMyCUpyZgcIA=)(7009ms;[A6(luf/p0Q4l8TTqfmZdi5+ioJOR8d1BuOrPGXqxs1Vh4E=), B6(6LaW2zW6P4y9FOqsdh0Vx3vVrjFzbcu69iC1OxfDmMY=), C6(v+SNVAiEe8m9X0W47l9tP8Zg4jUg2+RLqTSWdguLMFo=), D6(T9Wk1U9aj+X+NNH5mBBsHumTHTBfN85mvjy+HQKCFPs=)];0;v)
    Block D7(BaO6lh9kpHHjCqzxA1KYx/0fe7PCYxyOZxCEcbu6k/4=)(7010ms;[A6(luf/p0Q4l8TTqfmZdi5+ioJOR8d1BuOrPGXqxs1Vh4E=), B6(6LaW2zW6P4y9FOqsdh0Vx3vVrjFzbcu69iC1OxfDmMY=), C6(v+SNVAiEe8m9X0W47l9tP8Zg4jUg2+RLqTSWdguLMFo=), D6(T9Wk1U9aj+X+NNH5mBBsHumTHTBfN85mvjy+HQKCFPs=)];0;v)
}
```

### DagParser

Example Dag 
```
let dag_str = "DAG { 
        Round 0 : { 4 },
        Round 1 : { * },
        Round 2 : { * },
        Round 3 : { * },
        Round 4 : {
            A -> [-D3],
            B -> [*],
            C -> [*],
            D -> [*],
        },
        Round 5 : {
            A -> [*],
            B -> [*],
            C -> [A4],
            D -> [A4],
        },
        Round 6 : { * },
        Round 7 : { * },
        Round 8 : { * },
     }"
     
// will parse dag dsl & write interpreted dag to dag state.
test_dag_parser::parse_dag(dag_str)?
```

- `Round 0 : { n }`:  A special genesis case where `n` initializes how many authorities are to be include in the committee
- `{ * }`: Fully connected layer to ancestors from previous round
-  `A -> [-D3]`: Exclude specified ancestors for an authority
-  `A -> [D3]`: Include specified ancestor for an authority
-  `A -> [*]`: Include all specified ancestors for an authority
-  todo: add option for specifying equivocating slots



## Test Plan 

Still need to add more unit tests for `DagBuilder`
