### PR TITLE
[bridge 56/n] update abi and eth event structs

### DIFF
--- a/crates/sui-bridge/abi/bridge_committee.json
+++ b/crates/sui-bridge/abi/bridge_committee.json
@@ -1,34 +1,84 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "previousAdmin",
-        "type": "address"
+        "internalType": "address[]",
+        "name": "updatedMembers",
+        "type": "address[]"
       },
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
+        "internalType": "bool",
+        "name": "isBlocklisted",
+        "type": "bool"
       }
     ],
-    "name": "AdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "beacon",
-        "type": "address"
-      }
-    ],
-    "name": "BeaconUpgraded",
+    "name": "BlocklistUpdated",
     "type": "event"
   },
   {
@@ -36,25 +86,12 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "uint8",
+        "internalType": "uint64",
         "name": "version",
-        "type": "uint8"
+        "type": "uint64"
       }
     ],
     "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "message",
-        "type": "bytes"
-      }
-    ],
-    "name": "MessageProcessed",
     "type": "event"
   },
   {
@@ -72,11 +109,81 @@
   },
   {
     "inputs": [],
-    "name": "BLOCKLIST_STAKE_REQUIRED",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "committeeMember",
+        "type": "address"
+      }
+    ],
+    "name": "blocklist",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBlocklisted",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "committee",
+    "outputs": [
+      {
+        "internalType": "contract IBridgeCommittee",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "committeeMember",
+        "type": "address"
+      }
+    ],
+    "name": "committeeIndex",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "index",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "committeeMember",
+        "type": "address"
+      }
+    ],
+    "name": "committeeStake",
     "outputs": [
       {
         "internalType": "uint16",
-        "name": "",
+        "name": "stakeAmount",
         "type": "uint16"
       }
     ],
@@ -85,12 +192,12 @@
   },
   {
     "inputs": [],
-    "name": "COMMITTEE_UPGRADE_STAKE_REQUIRED",
+    "name": "config",
     "outputs": [
       {
-        "internalType": "uint16",
+        "internalType": "contract IBridgeConfig",
         "name": "",
-        "type": "uint16"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -100,93 +207,17 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_config",
         "type": "address"
-      }
-    ],
-    "name": "blocklist",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "committee",
-    "outputs": [
-      {
-        "internalType": "uint16",
-        "name": "",
-        "type": "uint16"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes",
-        "name": "payload",
-        "type": "bytes"
-      }
-    ],
-    "name": "decodeBlocklistPayload",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
       },
       {
         "internalType": "address[]",
-        "name": "",
-        "type": "address[]"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes",
-        "name": "payload",
-        "type": "bytes"
-      }
-    ],
-    "name": "decodeUpgradePayload",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "_committee",
+        "name": "committee",
         "type": "address[]"
       },
       {
         "internalType": "uint16[]",
-        "name": "stakes",
+        "name": "stake",
         "type": "uint16[]"
       }
     ],
@@ -199,7 +230,7 @@
     "inputs": [
       {
         "internalType": "uint8",
-        "name": "",
+        "name": "messageType",
         "type": "uint8"
       }
     ],
@@ -207,7 +238,7 @@
     "outputs": [
       {
         "internalType": "uint64",
-        "name": "",
+        "name": "nonce",
         "type": "uint64"
       }
     ],
@@ -262,12 +293,75 @@
             "type": "bytes"
           }
         ],
-        "internalType": "struct Messages.Message",
+        "internalType": "struct BridgeMessage.Message",
         "name": "message",
         "type": "tuple"
       }
     ],
     "name": "updateBlocklistWithSignatures",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "signatures",
+        "type": "bytes[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "messageType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint8",
+            "name": "version",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint64",
+            "name": "nonce",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint8",
+            "name": "chainID",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "payload",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct BridgeMessage.Message",
+        "name": "message",
+        "type": "tuple"
+      }
+    ],
+    "name": "upgradeWithSignatures",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -307,73 +401,13 @@
             "type": "bytes"
           }
         ],
-        "internalType": "struct Messages.Message",
+        "internalType": "struct BridgeMessage.Message",
         "name": "message",
         "type": "tuple"
       }
     ],
-    "name": "upgradeCommitteeWithSignatures",
+    "name": "verifySignatures",
     "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      }
-    ],
-    "name": "upgradeTo",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newImplementation",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "upgradeToAndCall",
-    "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes[]",
-        "name": "signatures",
-        "type": "bytes[]"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "messageHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint16",
-        "name": "requiredStake",
-        "type": "uint16"
-      }
-    ],
-    "name": "verifyMessageSignatures",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
     "stateMutability": "view",
     "type": "function"
   }

--- a/crates/sui-bridge/abi/bridge_config.json
+++ b/crates/sui-bridge/abi/bridge_config.json
@@ -1,0 +1,203 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_chainID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_supportedTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint8[]",
+        "name": "_supportedChains",
+        "type": "uint8[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "chainID",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertERC20ToSuiDecimal",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount",
+        "type": "uint64"
+      }
+    ],
+    "name": "convertSuiToERC20Decimal",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      }
+    ],
+    "name": "getSuiDecimal",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      }
+    ],
+    "name": "getTokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainId",
+        "type": "uint8"
+      }
+    ],
+    "name": "isChainSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      }
+    ],
+    "name": "isTokenSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainId",
+        "type": "uint8"
+      }
+    ],
+    "name": "supportedChains",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSupported",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      }
+    ],
+    "name": "supportedTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8",
+        "name": "suiDecimal",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/crates/sui-bridge/abi/bridge_limiter.json
+++ b/crates/sui-bridge/abi/bridge_limiter.json
@@ -28,16 +28,6 @@
   },
   {
     "inputs": [],
-    "name": "EnforcedPause",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExpectedPause",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "FailedInnerCall",
     "type": "error"
   },
@@ -49,6 +39,28 @@
   {
     "inputs": [],
     "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
     "type": "error"
   },
   {
@@ -77,6 +89,44 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint8",
+        "name": "tokenId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "price",
+        "type": "uint64"
+      }
+    ],
+    "name": "AssetPriceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "hourUpdated",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "HourlyTransferAmountUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint64",
         "name": "version",
         "type": "uint64"
@@ -90,61 +140,18 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Paused",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
         "internalType": "uint8",
         "name": "sourceChainID",
         "type": "uint8"
       },
       {
-        "indexed": true,
+        "indexed": false,
         "internalType": "uint64",
-        "name": "nonce",
+        "name": "newLimit",
         "type": "uint64"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint8",
-        "name": "destinationChainID",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "tokenID",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "erc20AdjustedAmount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "senderAddress",
-        "type": "bytes"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "recipientAddress",
-        "type": "address"
       }
     ],
-    "name": "TokensClaimed",
+    "name": "LimitUpdated",
     "type": "event"
   },
   {
@@ -152,61 +159,18 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "uint8",
-        "name": "sourceChainID",
-        "type": "uint8"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint64",
-        "name": "nonce",
-        "type": "uint64"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint8",
-        "name": "destinationChainID",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "tokenID",
-        "type": "uint8"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "suiAdjustedAmount",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
         "internalType": "address",
-        "name": "senderAddress",
+        "name": "previousOwner",
         "type": "address"
       },
       {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "recipientAddress",
-        "type": "bytes"
-      }
-    ],
-    "name": "TokensDeposited",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
-        "name": "account",
+        "name": "newOwner",
         "type": "address"
       }
     ],
-    "name": "Unpaused",
+    "name": "OwnershipTransferred",
     "type": "event"
   },
   {
@@ -246,39 +210,74 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
-      },
-      {
-        "internalType": "bytes",
-        "name": "recipientAddress",
-        "type": "bytes"
-      },
-      {
-        "internalType": "uint8",
-        "name": "destinationChainID",
-        "type": "uint8"
       }
     ],
-    "name": "bridgeERC20",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "name": "calculateAmountInUSD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
       {
-        "internalType": "bytes",
-        "name": "recipientAddress",
-        "type": "bytes"
-      },
-      {
         "internalType": "uint8",
-        "name": "destinationChainID",
+        "name": "chainID",
         "type": "uint8"
       }
     ],
-    "name": "bridgeETH",
-    "outputs": [],
-    "stateMutability": "payable",
+    "name": "calculateWindowAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "total",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "chainHourTimestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "chainHourlyTransferAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalAmountBridged",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      }
+    ],
+    "name": "chainLimits",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "totalLimit",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -295,48 +294,40 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "currentHour",
+    "outputs": [
       {
-        "internalType": "bytes[]",
-        "name": "signatures",
-        "type": "bytes[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint8",
-            "name": "messageType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint8",
-            "name": "version",
-            "type": "uint8"
-          },
-          {
-            "internalType": "uint64",
-            "name": "nonce",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint8",
-            "name": "chainID",
-            "type": "uint8"
-          },
-          {
-            "internalType": "bytes",
-            "name": "payload",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct BridgeMessage.Message",
-        "name": "message",
-        "type": "tuple"
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
       }
     ],
-    "name": "executeEmergencyOpWithSignatures",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hourTimestamp",
+        "type": "uint32"
+      }
+    ],
+    "name": "getChainHourTimestampKey",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -347,56 +338,24 @@
         "type": "address"
       },
       {
-        "internalType": "address",
-        "name": "_vault",
-        "type": "address"
+        "internalType": "uint256[]",
+        "name": "_tokenPrices",
+        "type": "uint256[]"
       },
       {
-        "internalType": "address",
-        "name": "_limiter",
-        "type": "address"
+        "internalType": "uint8[]",
+        "name": "chainIDs",
+        "type": "uint8[]"
       },
       {
-        "internalType": "address",
-        "name": "_wETH",
-        "type": "address"
+        "internalType": "uint64[]",
+        "name": "_totalLimits",
+        "type": "uint64[]"
       }
     ],
     "name": "initialize",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "nonce",
-        "type": "uint64"
-      }
-    ],
-    "name": "isTransferProcessed",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "isProcessed",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "limiter",
-    "outputs": [
-      {
-        "internalType": "contract IBridgeLimiter",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -419,13 +378,32 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "paused",
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      }
+    ],
+    "name": "oldestChainTimestamp",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "uint32",
+        "name": "oldestHourTimestamp",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
         "name": "",
-        "type": "bool"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -442,6 +420,68 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordBridgeTransfers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      }
+    ],
+    "name": "tokenPrices",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenPrice",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -484,7 +524,52 @@
         "type": "tuple"
       }
     ],
-    "name": "transferBridgedTokensWithSignatures",
+    "name": "updateLimitWithSignatures",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "signatures",
+        "type": "bytes[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "messageType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint8",
+            "name": "version",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint64",
+            "name": "nonce",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint8",
+            "name": "chainID",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "payload",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct BridgeMessage.Message",
+        "name": "message",
+        "type": "tuple"
+      }
+    ],
+    "name": "updateTokenPriceWithSignatures",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -553,26 +638,53 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "vault",
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "willAmountExceedLimit",
     "outputs": [
       {
-        "internalType": "contract IBridgeVault",
+        "internalType": "bool",
         "name": "",
-        "type": "address"
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "wETH",
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "chainID",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "willUSDAmountExceedLimit",
     "outputs": [
       {
-        "internalType": "contract IWETH9",
+        "internalType": "bool",
         "name": "",
-        "type": "address"
+        "type": "bool"
       }
     ],
     "stateMutability": "view",

--- a/crates/sui-bridge/abi/bridge_vault.json
+++ b/crates/sui-bridge/abi/bridge_vault.json
@@ -11,6 +11,28 @@
     "type": "constructor"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -28,10 +50,6 @@
     ],
     "name": "OwnershipTransferred",
     "type": "event"
-  },
-  {
-    "stateMutability": "payable",
-    "type": "fallback"
   },
   {
     "inputs": [],
@@ -62,7 +80,7 @@
       },
       {
         "internalType": "address",
-        "name": "targetAddress",
+        "name": "recipientAddress",
         "type": "address"
       },
       {
@@ -80,7 +98,7 @@
     "inputs": [
       {
         "internalType": "address payable",
-        "name": "targetAddress",
+        "name": "recipientAddress",
         "type": "address"
       },
       {

--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -26,6 +26,30 @@ abigen!(
     event_derives(serde::Deserialize, serde::Serialize)
 );
 
+abigen!(
+    EthBridgeCommittee,
+    "abi/bridge_committee.json",
+    event_derives(serde::Deserialize, serde::Serialize)
+);
+
+abigen!(
+    EthBridgeVault,
+    "abi/bridge_vault.json",
+    event_derives(serde::Deserialize, serde::Serialize)
+);
+
+abigen!(
+    EthBridgeLimiter,
+    "abi/bridge_limiter.json",
+    event_derives(serde::Deserialize, serde::Serialize)
+);
+
+abigen!(
+    EthBridgeConfig,
+    "abi/bridge_config.json",
+    event_derives(serde::Deserialize, serde::Serialize)
+);
+
 impl EthBridgeEvent {
     pub fn try_from_eth_log(log: &EthLog) -> Option<EthBridgeEvent> {
         let raw_log = RawLog {
@@ -51,7 +75,7 @@ impl EthBridgeEvent {
         match self {
             EthBridgeEvent::EthSuiBridgeEvents(event) => {
                 match event {
-                    EthSuiBridgeEvents::TokensBridgedToSuiFilter(event) => {
+                    EthSuiBridgeEvents::TokensDepositedFilter(event) => {
                         let bridge_event = match EthToSuiTokenBridgeV1::try_from(&event) {
                             Ok(bridge_event) => bridge_event,
                             // This only happens when solidity code does not align with rust code.
@@ -59,7 +83,7 @@ impl EthBridgeEvent {
                             // We log error here.
                             // TODO: add metrics and alert
                             Err(e) => {
-                                tracing::error!(?eth_tx_hash, eth_event_index, "Failed to convert TokensBridgedToSui log to EthToSuiTokenBridgeV1. This indicates incorrect parameters or a bug in the code: {:?}. Err: {:?}", event, e);
+                                tracing::error!(?eth_tx_hash, eth_event_index, "Failed to convert TokensDepositedFilter log to EthToSuiTokenBridgeV1. This indicates incorrect parameters or a bug in the code: {:?}. Err: {:?}", event, e);
                                 return None;
                             }
                         };
@@ -70,14 +94,19 @@ impl EthBridgeEvent {
                             eth_bridge_event: bridge_event,
                         }))
                     }
-                    _ => None,
+                    EthSuiBridgeEvents::TokensClaimedFilter(_event) => None,
+                    EthSuiBridgeEvents::PausedFilter(_event) => None,
+                    EthSuiBridgeEvents::UnpausedFilter(_event) => None,
+                    EthSuiBridgeEvents::UpgradedFilter(_event) => None,
+                    EthSuiBridgeEvents::InitializedFilter(_event) => None,
                 }
             }
         }
     }
 }
 
-// Sanity checked version of TokensBridgedToSuiFilter
+/// The event emitted when tokens are deposited into the bridge on Ethereum.
+/// Sanity checked version of TokensDepositedFilter
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Hash)]
 pub struct EthToSuiTokenBridgeV1 {
     pub nonce: u64,
@@ -86,20 +115,20 @@ pub struct EthToSuiTokenBridgeV1 {
     pub sui_address: SuiAddress,
     pub eth_address: EthAddress,
     pub token_id: TokenId,
-    pub amount: u64,
+    pub sui_adjusted_amount: u64,
 }
 
-impl TryFrom<&TokensBridgedToSuiFilter> for EthToSuiTokenBridgeV1 {
+impl TryFrom<&TokensDepositedFilter> for EthToSuiTokenBridgeV1 {
     type Error = BridgeError;
-    fn try_from(event: &TokensBridgedToSuiFilter) -> BridgeResult<Self> {
+    fn try_from(event: &TokensDepositedFilter) -> BridgeResult<Self> {
         Ok(Self {
             nonce: event.nonce,
             sui_chain_id: BridgeChainId::try_from(event.destination_chain_id)?,
             eth_chain_id: BridgeChainId::try_from(event.source_chain_id)?,
-            sui_address: SuiAddress::from_bytes(event.target_address.as_ref())?,
-            eth_address: event.source_address,
-            token_id: TokenId::try_from(event.token_code)?,
-            amount: event.sui_adjusted_amount,
+            sui_address: SuiAddress::from_bytes(event.recipient_address.as_ref())?,
+            eth_address: event.sender_address,
+            token_id: TokenId::try_from(event.token_id)?,
+            sui_adjusted_amount: event.sui_adjusted_amount,
         })
     }
 }

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -379,7 +379,7 @@ mod tests {
                 eth_chain_id: BridgeChainId::EthSepolia,
                 eth_address: EthAddress::random(),
                 token_id: TokenId::USDT,
-                amount: 1,
+                amount_sui_adjusted: 1,
             },
         });
         assert_eq!(
@@ -402,7 +402,7 @@ mod tests {
                 sui_chain_id: BridgeChainId::SuiDevnet,
                 sui_address: SuiAddress::random_for_testing_only(),
                 token_id: TokenId::USDT,
-                amount: 1,
+                sui_adjusted_amount: 1,
             },
         });
 

--- a/crates/sui-bridge/src/crypto.rs
+++ b/crates/sui-bridge/src/crypto.rs
@@ -331,7 +331,7 @@ mod tests {
                 eth_address: EthAddress::from_str("0xb18f79Fe671db47393315fFDB377Da4Ea1B7AF96")
                     .unwrap(),
                 token_id: TokenId::ETH,
-                amount: 100000u64,
+                amount_sui_adjusted: 100000u64,
             },
         });
         let sig = BridgeAuthoritySignInfo {

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -36,7 +36,7 @@ pub struct MoveTokenBridgeEvent {
     pub target_chain: u8,
     pub target_address: Vec<u8>,
     pub token_type: u8,
-    pub amount: u64,
+    pub amount_sui_adjusted: u64,
 }
 
 // Sanitized version of MoveTokenBridgeEvent
@@ -48,7 +48,8 @@ pub struct EmittedSuiToEthTokenBridgeV1 {
     pub sui_address: SuiAddress,
     pub eth_address: EthAddress,
     pub token_id: TokenId,
-    pub amount: u64,
+    // The amount of tokens deposited with decimal points on Sui side
+    pub amount_sui_adjusted: u64,
 }
 
 impl TryFrom<MoveTokenBridgeEvent> for EmittedSuiToEthTokenBridgeV1 {
@@ -116,7 +117,7 @@ impl TryFrom<MoveTokenBridgeEvent> for EmittedSuiToEthTokenBridgeV1 {
             sui_address,
             eth_address,
             token_id,
-            amount: event.amount,
+            amount_sui_adjusted: event.amount_sui_adjusted,
         })
     }
 }
@@ -217,7 +218,7 @@ pub mod tests {
             eth_chain_id: BridgeChainId::EthSepolia,
             eth_address: EthAddress::random(),
             token_id: TokenId::Sui,
-            amount: 100,
+            amount_sui_adjusted: 100,
         };
         let emitted_event = MoveTokenBridgeEvent {
             message_type: BridgeActionType::TokenTransfer as u8,
@@ -227,7 +228,7 @@ pub mod tests {
             target_chain: sanitized_event.eth_chain_id as u8,
             target_address: sanitized_event.eth_address.as_bytes().to_vec(),
             token_type: sanitized_event.token_id as u8,
-            amount: sanitized_event.amount,
+            amount_sui_adjusted: sanitized_event.amount_sui_adjusted,
         };
 
         let tx_digest = TransactionDigest::random();

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -151,7 +151,6 @@ where
                 continue;
             }
 
-            // TODO: skip events that are not already processed (in DB and on chain)
             let bridge_events = logs
                 .iter()
                 .map(EthBridgeEvent::try_from_eth_log)
@@ -166,6 +165,7 @@ where
                 }
                 // Unwrap safe: checked above
                 let bridge_event = opt_bridge_event.unwrap();
+                info!("Observed Eth bridge event: {:?}", bridge_event);
 
                 if let Some(action) =
                     bridge_event.try_into_bridge_action(log.tx_hash, log.log_index_in_tx)

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -420,7 +420,7 @@ mod tests {
             target_chain: BridgeChainId::EthLocalTest as u8,
             target_address: EthAddress::random().as_bytes().to_vec(),
             token_type: TokenId::USDC as u8,
-            amount: 12345,
+            amount_sui_adjusted: 12345,
         };
 
         init_all_struct_tags();

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -491,7 +491,7 @@ mod tests {
             eth_chain_id: BridgeChainId::EthSepolia,
             eth_address: Address::random(),
             token_id: TokenId::Sui,
-            amount: 100,
+            amount_sui_adjusted: 100,
         };
         let emitted_event_1 = MoveTokenBridgeEvent {
             message_type: BridgeActionType::TokenTransfer as u8,
@@ -501,7 +501,7 @@ mod tests {
             target_chain: sanitized_event_1.eth_chain_id as u8,
             target_address: sanitized_event_1.eth_address.as_bytes().to_vec(),
             token_type: sanitized_event_1.token_id as u8,
-            amount: sanitized_event_1.amount,
+            amount_sui_adjusted: sanitized_event_1.amount_sui_adjusted,
         };
 
         let mut sui_event_1 = SuiEvent::random_for_testing();
@@ -654,13 +654,13 @@ mod tests {
         assert_eq!(bridge_event.eth_address, eth_recv_address);
         assert_eq!(bridge_event.sui_address, sender);
         assert_eq!(bridge_event.token_id, TokenId::USDC);
-        assert_eq!(bridge_event.amount, usdc_amount);
+        assert_eq!(bridge_event.amount_sui_adjusted, usdc_amount);
 
         let action = get_test_sui_to_eth_bridge_action(
             None,
             None,
             Some(bridge_event.nonce),
-            Some(bridge_event.amount),
+            Some(bridge_event.amount_sui_adjusted),
             Some(bridge_event.sui_address),
             Some(bridge_event.eth_address),
             Some(TokenId::USDC),

--- a/crates/sui-bridge/src/sui_transaction_builder.rs
+++ b/crates/sui-bridge/src/sui_transaction_builder.rs
@@ -126,7 +126,7 @@ fn build_token_bridge_approve_transaction(
                     bridge_event.eth_chain_id,
                     bridge_event.eth_address.to_fixed_bytes().to_vec(),
                     bridge_event.token_id,
-                    bridge_event.amount,
+                    bridge_event.amount_sui_adjusted,
                 )
             }
             BridgeAction::EthToSuiBridgeAction(a) => {
@@ -138,7 +138,7 @@ fn build_token_bridge_approve_transaction(
                     bridge_event.sui_chain_id,
                     bridge_event.sui_address.to_vec(),
                     bridge_event.token_id,
-                    bridge_event.amount,
+                    bridge_event.sui_adjusted_amount,
                 )
             }
             _ => unreachable!(),
@@ -552,7 +552,7 @@ mod tests {
             None,
             None,
             Some(bridge_event.nonce),
-            Some(bridge_event.amount),
+            Some(bridge_event.amount_sui_adjusted),
             Some(bridge_event.sui_address),
             Some(bridge_event.eth_address),
             Some(TokenId::USDC),

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -224,7 +224,7 @@ impl SuiToEthBridgeAction {
         bytes.push(e.token_id as u8);
 
         // Add token amount
-        bytes.extend_from_slice(&e.amount.to_be_bytes());
+        bytes.extend_from_slice(&e.amount_sui_adjusted.to_be_bytes());
 
         bytes
     }
@@ -267,7 +267,7 @@ impl EthToSuiBridgeAction {
         bytes.push(e.token_id as u8);
 
         // Add token amount
-        bytes.extend_from_slice(&e.amount.to_be_bytes());
+        bytes.extend_from_slice(&e.sui_adjusted_amount.to_be_bytes());
 
         bytes
     }
@@ -659,7 +659,7 @@ mod tests {
         let sui_address = SuiAddress::random_for_testing_only();
         let eth_address = EthAddress::random();
         let token_id = TokenId::USDC;
-        let amount = 1_000_000;
+        let amount_sui_adjusted = 1_000_000;
 
         let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
             nonce,
@@ -668,7 +668,7 @@ mod tests {
             sui_address,
             eth_address,
             token_id,
-            amount,
+            amount_sui_adjusted,
         };
 
         let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
@@ -692,7 +692,7 @@ mod tests {
         let eth_address_bytes = eth_address.as_bytes().to_vec(); // len: 20
 
         let token_id_bytes = vec![token_id as u8]; // len: 1
-        let token_amount_bytes = amount.to_be_bytes().to_vec(); // len: 8
+        let token_amount_bytes = amount_sui_adjusted.to_be_bytes().to_vec(); // len: 8
 
         let mut combined_bytes = Vec::new();
         combined_bytes.extend_from_slice(&prefix_bytes);
@@ -738,7 +738,7 @@ mod tests {
         let eth_address =
             EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
         let token_id = TokenId::USDC;
-        let amount = 12345;
+        let amount_sui_adjusted = 12345;
 
         let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
             nonce,
@@ -747,7 +747,7 @@ mod tests {
             sui_address,
             eth_address,
             token_id,
-            amount,
+            amount_sui_adjusted,
         };
         let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
             sui_tx_digest,
@@ -1111,7 +1111,7 @@ mod tests {
         let eth_address =
             EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
         let token_id = TokenId::USDC;
-        let amount = 12345;
+        let sui_adjusted_amount = 12345;
 
         let eth_bridge_event = EthToSuiTokenBridgeV1 {
             nonce,
@@ -1120,7 +1120,7 @@ mod tests {
             sui_address,
             eth_address,
             token_id,
-            amount,
+            sui_adjusted_amount,
         };
         let encoded_bytes = BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
             eth_tx_hash,


### PR DESCRIPTION
## Description 

Use the latest abi from solidity and update the structs

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
