### PR TITLE
indexer: fix sync-from-async call logic error

### DIFF
--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -228,7 +228,10 @@ impl IndexerApiServer for IndexerApi {
         parent_object_id: ObjectID,
         name: DynamicFieldName,
     ) -> RpcResult<SuiObjectResponse> {
-        let name_bcs_value = self.inner.bcs_name_from_dynamic_field_name(&name)?;
+        let name_bcs_value = self
+            .inner
+            .bcs_name_from_dynamic_field_name_in_blocking_task(&name)
+            .await?;
 
         // Try as Dynamic Field
         let id = sui_types::dynamic_field::derive_dynamic_field_id(

--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -1334,7 +1334,7 @@ impl IndexerReader {
         Ok(objects)
     }
 
-    pub fn bcs_name_from_dynamic_field_name(
+    fn bcs_name_from_dynamic_field_name(
         &self,
         name: &DynamicFieldName,
     ) -> Result<Vec<u8>, IndexerError> {
@@ -1343,6 +1343,15 @@ impl IndexerReader {
         let sui_json_value = sui_json::SuiJsonValue::new(name.value.clone())?;
         let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
         Ok(name_bcs_value)
+    }
+
+    pub async fn bcs_name_from_dynamic_field_name_in_blocking_task(
+        &self,
+        name: &DynamicFieldName,
+    ) -> Result<Vec<u8>, IndexerError> {
+        let name = name.clone();
+        self.spawn_blocking(move |this| this.bcs_name_from_dynamic_field_name(&name))
+            .await
     }
 
     fn get_object_refs(


### PR DESCRIPTION
Fix an issue where a blocking indexer call was being made from an async context, causing a runtime panic.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
