### PR TITLE
[gql][fix] Refactor dynamic fields query to use `build_objects_query`

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
@@ -1,0 +1,185 @@
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 19-61:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7600000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 63-65:
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 67-67:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'create-checkpoint'. lines 69-69:
+Checkpoint created: 1
+
+task 5 'run-graphql'. lines 71-133:
+Response: {
+  "data": {
+    "latest": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "dof_added": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "before_dof_added": {
+      "version": 2,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    }
+  }
+}
+
+task 6 'run'. lines 135-135:
+mutated: object(0,0), object(2,0), object(2,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 7 'create-checkpoint'. lines 137-137:
+Checkpoint created: 2
+
+task 8 'run-graphql'. lines 139-189:
+Response: {
+  "data": {
+    "latest": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "before_reclaim_and_transfer_dof": {
+      "version": 3,
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.exp
@@ -29,7 +29,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "cursor": "IFLEiy6EeIFKCNATHJv3mquR0we0oGGZFPVgGoMWee1oAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -37,7 +37,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
                     "count": "0"
                   }
                 }
@@ -53,7 +53,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
               "count": "0"
             }
           }
@@ -64,7 +64,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "cursor": "IFLEiy6EeIFKCNATHJv3mquR0we0oGGZFPVgGoMWee1oAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -72,7 +72,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
                     "count": "0"
                   }
                 }
@@ -88,7 +88,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
               "count": "0"
             }
           }
@@ -100,7 +100,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IHB93fIsN+8qYmh2e8qi2dYWI1h4U84FXfZeIbtbAHNkAQAAAAAAAAA=",
+            "cursor": "IFLEiy6EeIFKCNATHJv3mquR0we0oGGZFPVgGoMWee1oAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -108,7 +108,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+                    "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
                     "count": "0"
                   }
                 }
@@ -124,7 +124,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
               "count": "0"
             }
           }
@@ -174,7 +174,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x5c14290c81288409b639ee8d0e82b901805c608ae7cfcba4c1eb65f9be7270f5",
+              "id": "0x1ba9766b570ea7e0ac0468a97512c5086071a1aa883d6aa0deebbabbd1e9533d",
               "count": "0"
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -1,0 +1,189 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The previous implementation sets the newer criteria when the parent version is provided by
+// filtering the newer subquery on `object_version <=` and
+// `object_status=ObjectStatus::WrappedOrDeleted`. However, this means that we erroneously return
+// the historical child that matches the filtering criteria if there are newer versions of the
+// dynamic object that were not `WrappedOrDeleted`. This tests that we do not return the child
+// object for the parent at version.
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 4             | reclaimed child from parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        transfer::public_transfer(reclaim_child(parent, name), recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  dof_added: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_dof_added: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,1) 42 @A
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  before_reclaim_and_transfer_dof: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -23,12 +23,12 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    public struct Parent has key, store {
+    struct Parent has key, store {
         id: UID,
         count: u64
     }
 
-    public struct Child has key, store {
+    struct Child has key, store {
         id: UID,
         count: u64,
     }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
@@ -1,0 +1,205 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 18-60:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7600000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 62-65:
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4924800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 67-67:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 4 'run'. lines 69-69:
+mutated: object(0,0), object(2,0), object(2,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 5 'run'. lines 71-71:
+created: object(5,0)
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 6 'run'. lines 73-73:
+mutated: object(0,0), object(2,0), object(2,2)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 3610000,  storage_rebate: 6004152, non_refundable_storage_fee: 60648
+
+task 7 'run'. lines 75-75:
+created: object(3,0)
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6064800,  storage_rebate: 3573900, non_refundable_storage_fee: 36100
+
+task 8 'create-checkpoint'. lines 77-77:
+Checkpoint created: 1
+
+task 9 'run-graphql'. lines 79-159:
+Response: {
+  "data": {
+    "latest": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "owner_view": {
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "v2": {
+      "version": 2,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "v3": {
+      "version": 3,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    },
+    "v4": {
+      "version": 4,
+      "dynamicFields": {
+        "edges": []
+      },
+      "dynamicObjectField": null
+    },
+    "v7": {
+      "version": 7,
+      "dynamicFields": {
+        "edges": [
+          {
+            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "node": {
+              "name": {
+                "bcs": "KgAAAAAAAAA="
+              },
+              "value": {
+                "contents": {
+                  "json": {
+                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "count": "0"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dynamicObjectField": {
+        "name": {
+          "bcs": "KgAAAAAAAAA="
+        },
+        "value": {
+          "contents": {
+            "json": {
+              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "count": "0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.exp
@@ -49,7 +49,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "cursor": "IPU9pKfjqTwVDZ/2Zj48Zd2iAgpcRh1IXbk4vCArOZAxAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -57,7 +57,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
                     "count": "0"
                   }
                 }
@@ -73,7 +73,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
               "count": "0"
             }
           }
@@ -84,7 +84,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "cursor": "IPU9pKfjqTwVDZ/2Zj48Zd2iAgpcRh1IXbk4vCArOZAxAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -92,7 +92,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
                     "count": "0"
                   }
                 }
@@ -108,7 +108,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
               "count": "0"
             }
           }
@@ -127,7 +127,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "cursor": "IPU9pKfjqTwVDZ/2Zj48Zd2iAgpcRh1IXbk4vCArOZAxAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -135,7 +135,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
                     "count": "0"
                   }
                 }
@@ -151,7 +151,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
               "count": "0"
             }
           }
@@ -170,7 +170,7 @@ Response: {
       "dynamicFields": {
         "edges": [
           {
-            "cursor": "IPjkgtu1tAl2nwpZTarwY5SpUNoXbOtyOf1moAR6BchnAQAAAAAAAAA=",
+            "cursor": "IPU9pKfjqTwVDZ/2Zj48Zd2iAgpcRh1IXbk4vCArOZAxAQAAAAAAAAA=",
             "node": {
               "name": {
                 "bcs": "KgAAAAAAAAA="
@@ -178,7 +178,7 @@ Response: {
               "value": {
                 "contents": {
                   "json": {
-                    "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+                    "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
                     "count": "0"
                   }
                 }
@@ -194,7 +194,7 @@ Response: {
         "value": {
           "contents": {
             "json": {
-              "id": "0x8a18baec9ec0856c739cb0fe1d960c6941de585745e25bf4cb457f36be3e772d",
+              "id": "0xf6eb4e795d8a08ddc40a810bc88d92da2cd6243a61df885a47a0ba1ad04e4e28",
               "count": "0"
             }
           }

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test that we do not return the child object when it is not owned by the parent or when it is
+// wrapped.
+
+// parent version | child version | status
+// ---------------|---------------|--------
+// 2              | 2             | created parent and child
+// 3              | 3             | added child to parent
+// 4              | 4             | reclaimed child from parent
+// 4              | 5             | add child to another parent
+// 4              | 6             | reclaim child from another parent
+// 7              | 7             | add child to original parent
+
+//# init --addresses Test=0x0 --accounts A --simulator
+
+//# publish
+module Test::M1 {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    public struct Parent has key, store {
+        id: UID,
+        count: u64
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        count: u64,
+    }
+
+    public entry fun parent(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public entry fun child(recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Child { id: object::new(ctx), count: 0 },
+            recipient
+        )
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, name: u64) {
+        ofield::add(&mut parent.id, name, child);
+    }
+
+    public fun reclaim_child(parent: &mut Parent, name: u64): Child {
+        ofield::remove(&mut parent.id, name)
+    }
+
+    public fun reclaim_and_transfer_child(parent: &mut Parent, name: u64, recipient: address) {
+        transfer::public_transfer(reclaim_child(parent, name), recipient)
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: Test::M1::child(Input(0));
+//> 1: Test::M1::parent(Input(0));
+//> 2: Test::M1::parent(Input(0));
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,1) 42 @A
+
+//# run Test::M1::add_child --sender A --args object(2,2) object(2,0) 42
+
+//# run Test::M1::reclaim_and_transfer_child --sender A --args object(2,2) 42 @A
+
+//# run Test::M1::add_child --sender A --args object(2,1) object(2,0) 42
+
+//# create-checkpoint
+
+//# run-graphql
+fragment DynamicFieldSelect on DynamicField {
+  name {
+    bcs
+  }
+  value {
+    ... on MoveObject {
+      contents {
+        json
+      }
+    }
+    ... on MoveValue {
+      json
+    }
+  }
+}
+
+fragment DynamicFieldsSelect on DynamicFieldConnection {
+  edges {
+    cursor
+    node {
+      ...DynamicFieldSelect
+    }
+  }
+}
+
+{
+  latest: object(address: "@{obj_2_1}") {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  owner_view: owner(address: "@{obj_2_1}") {
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v2: object(address: "@{obj_2_1}", version: 2) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v3: object(address: "@{obj_2_1}", version: 3) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v4: object(address: "@{obj_2_1}", version: 4) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+  v7: object(address: "@{obj_2_1}", version: 7) {
+    version
+    dynamicFields {
+      ...DynamicFieldsSelect
+    }
+    dynamicObjectField(name: {type: "u64", bcs: "KgAAAAAAAAA="}) {
+        ...DynamicFieldSelect
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
@@ -22,12 +22,12 @@ module Test::M1 {
     use sui::tx_context::TxContext;
     use sui::transfer;
 
-    public struct Parent has key, store {
+    struct Parent has key, store {
         id: UID,
         count: u64
     }
 
-    public struct Child has key, store {
+    struct Child has key, store {
         id: UID,
         count: u64,
     }

--- a/crates/sui-graphql-rpc/src/consistency.rs
+++ b/crates/sui-graphql-rpc/src/consistency.rs
@@ -100,13 +100,13 @@ pub(crate) fn build_objects_query(
     rhs: i64,
     page: &Page<Cursor>,
     filter_fn: impl Fn(RawQuery) -> RawQuery,
+    newer_criteria: impl Fn(RawQuery) -> RawQuery,
 ) -> RawQuery {
     // Subquery to be used in `LEFT JOIN` against the inner queries for more recent object versions
-    let mut newer = query!("SELECT object_id, object_version FROM objects_history");
-    newer = filter!(
-        newer,
+    let newer = newer_criteria(filter!(
+        query!("SELECT object_id, object_version FROM objects_history"),
         format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
+    ));
 
     let mut snapshot_objs_inner = query!("SELECT * FROM objects_snapshot");
     snapshot_objs_inner = filter_fn(snapshot_objs_inner);

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -381,9 +381,14 @@ fn coins_query(
     rhs: i64,
     page: &Page<object::Cursor>,
 ) -> RawQuery {
-    build_objects_query(View::Consistent, lhs, rhs, page, move |query| {
-        apply_filter(query, &coin_type, owner)
-    })
+    build_objects_query(
+        View::Consistent,
+        lhs,
+        rhs,
+        page,
+        move |query| apply_filter(query, &coin_type, owner),
+        move |newer| newer,
+    )
 }
 
 fn apply_filter(mut query: RawQuery, coin_type: &TypeTag, owner: Option<SuiAddress>) -> RawQuery {

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -4,8 +4,8 @@
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use move_core_types::annotated_value::{self as A, MoveStruct};
-use sui_indexer::models::objects::StoredHistoryObject;
-use sui_indexer::types::OwnerType;
+use sui_indexer::models_v2::objects::StoredHistoryObject;
+use sui_indexer::types_v2::OwnerType;
 use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 

--- a/crates/sui-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/sui-graphql-rpc/src/types/dynamic_field.rs
@@ -4,8 +4,8 @@
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
 use move_core_types::annotated_value::{self as A, MoveStruct};
-use sui_indexer::models_v2::objects::StoredHistoryObject;
-use sui_indexer::types_v2::{ObjectStatus, OwnerType};
+use sui_indexer::models::objects::StoredHistoryObject;
+use sui_indexer::types::OwnerType;
 use sui_package_resolver::Resolver;
 use sui_types::dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo, DynamicFieldType};
 
@@ -15,12 +15,12 @@ use super::type_filter::ExactTypeFilter;
 use super::{
     base64::Base64, move_object::MoveObject, move_value::MoveValue, sui_address::SuiAddress,
 };
-use crate::consistency::consistent_range;
+use crate::consistency::{build_objects_query, consistent_range, View};
 use crate::context_data::package_cache::PackageCache;
 use crate::data::{Db, QueryExecutor};
 use crate::error::Error;
+use crate::filter;
 use crate::raw_query::RawQuery;
-use crate::{filter, query};
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
@@ -211,7 +211,7 @@ impl DynamicField {
                 let result = page.paginate_raw_query::<StoredHistoryObject>(
                     conn,
                     rhs,
-                    dynamic_fields_query(parent, parent_version, lhs as i64, rhs as i64),
+                    dynamic_fields_query(parent, parent_version, lhs as i64, rhs as i64, &page),
                 )?;
 
                 Ok(Some((result, rhs)))
@@ -319,85 +319,32 @@ pub fn extract_field_from_move_struct(
 /// [`lhs`, `rhs`] is returned, conditioned on the fact that there is not a more recent version of
 /// the field.
 ///
-/// If `parent_version` is provided, the latest version that is less than or equal to the parent
-/// version is returned, conditioned on the fact that there is not a more recent `WrappedOrDeleted`
-/// version of the field that is greater than the matched child but less than or equal to the parent
-/// version.
+/// If `parent_version` is provided, it is used to bound both the `candidates` and `newer` objects
+/// subqueries. This is because the dynamic fields of a parent at version v are dynamic fields owned
+/// by the parent whose versions are <= v. Unlike object ownership, where owned and owner objects
+/// can have arbitrary `object_version`s, dynamic fields on a parent cannot have a version greater
+/// than its parent.
 fn dynamic_fields_query(
     parent: SuiAddress,
     parent_version: Option<u64>,
     lhs: i64,
     rhs: i64,
+    page: &Page<object::Cursor>,
 ) -> RawQuery {
-    // Construct the filtered inner query - apply the same filtering criteria to both
-    // objects_snapshot and objects_history tables.
-    let mut snapshot_objs = query!(r#"SELECT * FROM objects_snapshot"#);
-    snapshot_objs = apply_filter(snapshot_objs, parent, parent_version);
-
-    // Additionally filter objects_history table for results between the available range, or
-    // checkpoint_viewed_at, if provided.
-    let mut history_objs = query!(r#"SELECT * FROM objects_history"#);
-    history_objs = apply_filter(history_objs, parent, parent_version);
-    history_objs = filter!(
-        history_objs,
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-
-    // Combine the two queries, and select the most recent version of each object.
-    let candidates = query!(
-        r#"SELECT DISTINCT ON (object_id) * FROM (({}) UNION ALL ({})) o"#,
-        snapshot_objs,
-        history_objs
+    build_objects_query(
+        View::Consistent,
+        lhs,
+        rhs,
+        page,
+        move |query| apply_filter(query, parent, parent_version),
+        move |newer| {
+            if let Some(parent_version) = parent_version {
+                filter!(newer, format!("object_version <= {}", parent_version))
+            } else {
+                newer
+            }
+        },
     )
-    .order_by("object_id")
-    .order_by("object_version DESC");
-
-    let mut newer = query!("SELECT object_id, object_version, object_status FROM objects_history");
-    newer = filter!(
-        newer,
-        format!(r#"checkpoint_sequence_number BETWEEN {} AND {}"#, lhs, rhs)
-    );
-
-    // Even though the `parent_version` is provided, because it serves as an upper bound instead of
-    // a strict equality, it is possible for the dynamic field to have been deleted but still show
-    // up in the results. This is because deleted objects only have `object_id`, `object_status, and
-    // `checkpoint_sequence_number`. We need to additionally left join on any objects that have a
-    // more recent version and where the `object_status` is `WrappedOrDeleted`. However, because we
-    // know the `parent_version`, we know that if a more recent deleted version exists, that it was
-    // deleted while a child of the parent.
-    if let Some(parent_version) = parent_version {
-        newer = filter!(newer, format!("object_version <= {}", parent_version));
-        newer = filter!(
-            newer,
-            format!("object_status = {}", ObjectStatus::WrappedOrDeleted as i16)
-        );
-
-        let query = query!(
-            r#"SELECT candidates.*
-                FROM ({}) candidates
-                LEFT JOIN ({}) newer
-                ON (
-                    candidates.object_id = newer.object_id
-                    AND candidates.object_version < newer.object_version
-                )"#,
-            candidates,
-            newer
-        );
-        return filter!(query, "newer.object_status IS NULL");
-    }
-
-    let query = query!(
-        r#"SELECT candidates.*
-            FROM ({}) candidates
-            LEFT JOIN ({}) newer
-            ON (
-                candidates.object_id = newer.object_id
-                AND candidates.object_version < newer.object_version
-            )"#,
-        candidates,
-        newer
-    );
-    filter!(query, "newer.object_version IS NULL")
 }
 
 fn apply_filter(query: RawQuery, parent: SuiAddress, parent_version: Option<u64>) -> RawQuery {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -1373,7 +1373,14 @@ where
         View::Consistent
     };
 
-    build_objects_query(view, lhs, rhs, page, move |query| filter.apply(query))
+    build_objects_query(
+        view,
+        lhs,
+        rhs,
+        page,
+        move |query| filter.apply(query),
+        move |newer| newer,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

Cherry-pick of #16433 to fix dynamic fields query implementation.

## Test Plan 

dof_add_reclaim_transfer.move, dof_add_reclaim_transfer_reclaim_add.move, manually running some queries that currently timeout in our production services.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
