### PR TITLE
move lock: rewind when creating new lock file from copy

### DIFF
--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use source_package::{layout::SourcePackageLayout, parsed_manifest::DependencyKind};
 use std::{
     collections::BTreeMap,
-    io::{BufRead, Seek, SeekFrom, Write},
+    io::{BufRead, Write},
     path::{Path, PathBuf},
 };
 
@@ -274,7 +274,6 @@ impl BuildConfig {
         };
         let install_dir = self.install_dir.as_ref().unwrap_or(path).to_owned();
         let mut lock = LockFile::from(install_dir, lock_file)?;
-        lock.seek(SeekFrom::Start(0))?;
         update_compiler_toolchain(
             &mut lock,
             compiler_version,

--- a/external-crates/move/crates/move-package/src/lock_file/mod.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/mod.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::{self, File},
-    io::Write,
+    io::{Seek, SeekFrom, Write},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
@@ -75,6 +75,7 @@ impl LockFile {
             .context("Creating lock file")?;
         let lock_string = std::fs::read_to_string(lock_file)?;
         lock.write_all(lock_string.as_bytes())?;
+        lock.seek(SeekFrom::Start(0))?;
 
         Ok(LockFile { file: lock })
     }


### PR DESCRIPTION
## Description 

Setup for test in follow up PR: https://github.com/MystenLabs/sui/pull/16445. When getting a lock file handle it's useful for it to be set to the beginning for reads rather than the caller needing to rewind it (or forgetting to and not seeing content when reading from the handle).

## Test Plan 

Covered by existing test that exercises these functions together.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
