### PR TITLE
Turn on overload protection at signing by default

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -718,7 +718,7 @@ pub struct AuthorityOverloadConfig {
 
     // When set to true, transaction signing may be rejected when the validator
     // is overloaded.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default = "default_check_system_overload_at_signing")]
     pub check_system_overload_at_signing: bool,
 
     // When set to true, transaction execution may be rejected when the validator
@@ -757,6 +757,10 @@ fn default_safe_transaction_ready_rate() -> u32 {
     100
 }
 
+fn default_check_system_overload_at_signing() -> bool {
+    true
+}
+
 impl Default for AuthorityOverloadConfig {
     fn default() -> Self {
         Self {
@@ -768,7 +772,7 @@ impl Default for AuthorityOverloadConfig {
             min_load_shedding_percentage_above_hard_limit:
                 default_min_load_shedding_percentage_above_hard_limit(),
             safe_transaction_ready_rate: default_safe_transaction_ready_rate(),
-            check_system_overload_at_signing: false,
+            check_system_overload_at_signing: true,
             check_system_overload_at_execution: false,
         }
     }

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -44,8 +44,8 @@ impl AuthorityOverloadInfo {
 }
 
 const STEADY_OVERLOAD_REDUCTION_PERCENTAGE: u32 = 10;
-const EXECUTION_RATE_RATIO_FOR_COMPARISON: f64 = 0.9;
-const ADDITIONAL_LOAD_SHEDDING: f64 = 0.1;
+const EXECUTION_RATE_RATIO_FOR_COMPARISON: f64 = 0.95;
+const ADDITIONAL_LOAD_SHEDDING: f64 = 0.02;
 
 // The update interval of the random seed used to determine whether a txn should be rejected.
 const SEED_UPDATE_DURATION_SECS: u64 = 30;

--- a/crates/sui-core/src/overload_monitor.rs
+++ b/crates/sui-core/src/overload_monitor.rs
@@ -325,11 +325,11 @@ mod tests {
 
     #[test]
     pub fn test_calculate_load_shedding_ratio() {
-        assert_eq!(calculate_load_shedding_percentage(90.0, 100.1), 0);
-        assert_eq!(calculate_load_shedding_percentage(90.0, 100.0), 10);
-        assert_eq!(calculate_load_shedding_percentage(100.0, 100.0), 20);
-        assert_eq!(calculate_load_shedding_percentage(110.0, 100.0), 28);
-        assert_eq!(calculate_load_shedding_percentage(180.0, 100.0), 60);
+        assert_eq!(calculate_load_shedding_percentage(95.0, 100.1), 0);
+        assert_eq!(calculate_load_shedding_percentage(95.0, 100.0), 2);
+        assert_eq!(calculate_load_shedding_percentage(100.0, 100.0), 7);
+        assert_eq!(calculate_load_shedding_percentage(110.0, 100.0), 16);
+        assert_eq!(calculate_load_shedding_percentage(180.0, 100.0), 49);
         assert_eq!(calculate_load_shedding_percentage(100.0, 0.0), 100);
         assert_eq!(calculate_load_shedding_percentage(0.0, 1.0), 0);
     }
@@ -360,7 +360,7 @@ mod tests {
         // protection.
         assert_eq!(
             check_overload_signals(&config, 0, Duration::from_secs(2), 100.0, 100.0),
-            (true, 20)
+            (true, 7)
         );
 
         // When execution queueing latency hits hard limit, start more aggressive overload
@@ -374,7 +374,7 @@ mod tests {
         // is higher than min_load_shedding_percentage_above_hard_limit.
         assert_eq!(
             check_overload_signals(&config, 0, Duration::from_secs(11), 240.0, 100.0),
-            (true, 73)
+            (true, 62)
         );
 
         // When execution queueing latency hits hard limit, but transaction ready rate
@@ -393,7 +393,7 @@ mod tests {
         // When the system is already shedding 50% of load, and the current txn ready rate
         // and execution rate require another 20%, the final shedding rate is 60%.
         assert_eq!(
-            check_overload_signals(&config, 50, Duration::from_secs(2), 100.0, 100.0),
+            check_overload_signals(&config, 50, Duration::from_secs(2), 116.0, 100.0),
             (true, 60)
         );
 
@@ -704,7 +704,7 @@ mod tests {
         let executor = start_executor(1000.0, rx, stop_rx, state.clone());
 
         sleep_and_print_stats(state.clone(), 15).await;
-        for _ in 0..8 {
+        for _ in 0..16 {
             // Regularly send out a burst of request.
             burst_tx.send(10000).unwrap();
             sleep_and_print_stats(state.clone(), 5).await;

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -852,8 +852,10 @@ async fn test_authority_txn_execution_pushback() {
     let gas_object2 = Object::with_owner_for_testing(sender);
 
     // Initialize an AuthorityState. Disable overload monitor by setting max_load_shedding_percentage to 0;
+    // Set check_system_overload_at_signing to false to disable load shedding at signing, this we are testing load shedding at execution.
     // Set check_system_overload_at_execution to true.
     let overload_config = AuthorityOverloadConfig {
+        check_system_overload_at_signing: false,
         check_system_overload_at_execution: true,
         max_load_shedding_percentage: 0,
         ..Default::default()

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -126,6 +126,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -249,6 +250,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -372,6 +374,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -495,6 +498,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -618,6 +622,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -741,6 +746,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -864,6 +870,7 @@ validator_configs:
       max-load-shedding-percentage: 95
       min-load-shedding-percentage-above-hard-limit: 50
       safe-transaction-ready-rate: 100
+      check-system-overload-at-signing: true
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=
@@ -871,4 +878,3 @@ account_keys:
   - mfPjCoE6SX0Sl84MnmNS/LS+tfPpkn7I8tziuk2g0WM=
   - 5RWlYF22jS9i76zLl8jP2D3D8GC5ht+IP1dWUBGZxi8=
 genesis: "[fake genesis]"
-


### PR DESCRIPTION
## Description 

Also update parameters to be less aggressive. Works better at higher throughput based on experiments.

## Test Plan 

Testnet experiments show no regression

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
