### PR TITLE
TxManager::enqueue does not need to return Result

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1015,7 +1015,7 @@ impl AuthorityState {
         let expected_effects_digest = effects.digest();
 
         self.transaction_manager
-            .enqueue(vec![transaction.clone()], epoch_store)?;
+            .enqueue(vec![transaction.clone()], epoch_store);
 
         let observed_effects = self
             .execution_cache
@@ -1061,7 +1061,7 @@ impl AuthorityState {
             // Shared object transactions need to be sequenced by Narwhal before enqueueing
             // for execution, done in AuthorityPerEpochStore::handle_consensus_transaction().
             // For owned object transactions, they can be enqueued for execution immediately.
-            self.enqueue_certificates_for_execution(vec![certificate.clone()], epoch_store)?;
+            self.enqueue_certificates_for_execution(vec![certificate.clone()], epoch_store);
         }
 
         let effects = self.notify_read_effects(certificate).await?;
@@ -1209,7 +1209,7 @@ impl AuthorityState {
         let digest = *certificate.digest();
 
         fail_point_if!("correlated-crash-process-certificate", || {
-            if sui_simulator::random::deterministic_probabilty_once(&digest, 0.01) {
+            if sui_simulator::random::deterministic_probability_once(&digest, 0.01) {
                 sui_simulator::task::kill_current_node(None);
             }
         });
@@ -2656,7 +2656,7 @@ impl AuthorityState {
         &self,
         certs: Vec<VerifiedCertificate>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<()> {
+    ) {
         self.transaction_manager
             .enqueue_certificates(certs, epoch_store)
     }

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -335,12 +335,10 @@ pub async fn enqueue_all_and_execute_all(
     authority: &AuthorityState,
     certificates: Vec<VerifiedCertificate>,
 ) -> Result<Vec<TransactionEffects>, SuiError> {
-    authority
-        .enqueue_certificates_for_execution(
-            certificates.clone(),
-            &authority.epoch_store_for_testing(),
-        )
-        .unwrap();
+    authority.enqueue_certificates_for_execution(
+        certificates.clone(),
+        &authority.epoch_store_for_testing(),
+    );
     let mut output = Vec::new();
     for cert in certificates {
         let effects = authority.notify_read_effects(&cert).await?;
@@ -353,12 +351,10 @@ pub async fn execute_sequenced_certificate_to_effects(
     authority: &AuthorityState,
     certificate: VerifiedCertificate,
 ) -> Result<(TransactionEffects, Option<ExecutionError>), SuiError> {
-    authority
-        .enqueue_certificates_for_execution(
-            vec![certificate.clone()],
-            &authority.epoch_store_for_testing(),
-        )
-        .unwrap();
+    authority.enqueue_certificates_for_execution(
+        vec![certificate.clone()],
+        &authority.epoch_store_for_testing(),
+    );
 
     let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
     let effects = result.inner().data().clone();
@@ -383,8 +379,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
 
     authority
         .transaction_manager()
-        .enqueue(certs, &authority.epoch_store_for_testing())
-        .unwrap();
+        .enqueue(certs, &authority.epoch_store_for_testing());
 }
 
 pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &VerifiedCertificate) {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -489,7 +489,7 @@ impl ValidatorService {
             // even when we are not returning effects to user
             if !certificate.contains_shared_object() {
                 self.state
-                    .enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store)?;
+                    .enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store);
             }
             return Ok(None);
         }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -458,12 +458,10 @@ impl CheckpointExecutor {
                 .expect("Acquiring shared locks for change_epoch tx cannot fail");
         }
 
-        self.tx_manager
-            .enqueue_with_expected_effects_digest(
-                vec![(change_epoch_tx.clone(), execution_digests.effects)],
-                &epoch_store,
-            )
-            .expect("Enqueueing change_epoch tx cannot fail");
+        self.tx_manager.enqueue_with_expected_effects_digest(
+            vec![(change_epoch_tx.clone(), execution_digests.effects)],
+            &epoch_store,
+        );
         handle_execution_effects(
             &self.state,
             vec![execution_digests],
@@ -1050,8 +1048,7 @@ async fn execute_transactions(
     }
 
     let exec_start = Instant::now();
-    transaction_manager
-        .enqueue_with_expected_effects_digest(executable_txns.clone(), &epoch_store)?;
+    transaction_manager.enqueue_with_expected_effects_digest(executable_txns.clone(), &epoch_store);
 
     handle_execution_effects(
         state,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -473,7 +473,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         fail_point_if!("correlated-crash-after-consensus-commit-boundary", || {
             let key = [commit_sub_dag_index, self.epoch_store.epoch()];
-            if sui_simulator::random::deterministic_probabilty(&key, 0.01) {
+            if sui_simulator::random::deterministic_probability(&key, 0.01) {
                 sui_simulator::task::kill_current_node(None);
             }
         });
@@ -511,9 +511,7 @@ impl AsyncTransactionScheduler {
     ) {
         while let Some(transactions) = recv.recv().await {
             let _guard = monitored_scope("ConsensusHandler::enqueue");
-            transaction_manager
-                .enqueue(transactions, &epoch_store)
-                .expect("transaction_manager::enqueue should not fail");
+            transaction_manager.enqueue(transactions, &epoch_store);
         }
     }
 }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -179,8 +179,7 @@ impl LocalAuthorityClient {
                     .verify_cert(certificate)
                     .await?;
                 //let certificate = certificate.verify(epoch_store.committee())?;
-                state
-                    .enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store)?;
+                state.enqueue_certificates_for_execution(vec![certificate.clone()], &epoch_store);
                 let effects = state.notify_read_effects(&certificate).await?;
                 state.sign_effects(effects, &epoch_store)?
             }

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -423,20 +423,16 @@ async fn test_execution_with_dependencies() {
 
     // Enqueue certs out of dependency order for executions.
     for cert in executed_shared_certs.iter().rev() {
-        authorities[3]
-            .enqueue_certificates_for_execution(
-                vec![cert.clone()],
-                &authorities[3].epoch_store_for_testing(),
-            )
-            .unwrap();
+        authorities[3].enqueue_certificates_for_execution(
+            vec![cert.clone()],
+            &authorities[3].epoch_store_for_testing(),
+        );
     }
     for cert in executed_owned_certs.iter().rev() {
-        authorities[3]
-            .enqueue_certificates_for_execution(
-                vec![cert.clone()],
-                &authorities[3].epoch_store_for_testing(),
-            )
-            .unwrap();
+        authorities[3].enqueue_certificates_for_execution(
+            vec![cert.clone()],
+            &authorities[3].epoch_store_for_testing(),
+        );
     }
 
     // All certs should get executed eventually.
@@ -761,7 +757,7 @@ async fn test_authority_txn_signing_pushback() {
     // Manually make the authority into overload state and reject 100% of traffic.
     authority_state.overload_info.set_overload(100);
 
-    // First, create a transaction to tranfer `gas_object1` to `recipient1`.
+    // First, create a transaction to transfer `gas_object1` to `recipient1`.
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let tx = make_transfer_object_transaction(
         gas_object1.compute_object_reference(),
@@ -888,7 +884,7 @@ async fn test_authority_txn_execution_pushback() {
     // Manually make the authority into overload state and reject 100% of traffic.
     authority_state.overload_info.set_overload(100);
 
-    // Create a transaction to tranfer `gas_object1` to `recipient`.
+    // Create a transaction to transfer `gas_object1` to `recipient`.
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let tx = make_transfer_object_transaction(
         gas_object1.compute_object_reference(),

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -87,9 +87,7 @@ async fn transaction_manager_basics() {
     transaction_manager.check_empty_for_testing();
 
     // Enqueue empty vec should not crash.
-    transaction_manager
-        .enqueue(vec![], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![], &state.epoch_store_for_testing());
     // TM should output no transaction.
     assert!(rx_ready_certificates
         .try_recv()
@@ -98,9 +96,7 @@ async fn transaction_manager_basics() {
     // Enqueue a transaction with existing gas object, empty input.
     let transaction = make_transaction(gas_objects[0].clone(), vec![]);
     let tx_start_time = Instant::now();
-    transaction_manager
-        .enqueue(vec![transaction.clone()], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     // TM should output the transaction eventually.
     let pending_certificate = rx_ready_certificates.recv().await.unwrap();
 
@@ -127,9 +123,7 @@ async fn transaction_manager_basics() {
         Object::with_id_owner_version_for_testing(ObjectID::random(), 0.into(), owner);
     let transaction = make_transaction(gas_object_new.clone(), vec![]);
     let tx_start_time = Instant::now();
-    transaction_manager
-        .enqueue(vec![transaction.clone()], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     // TM should output no transaction yet.
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates
@@ -139,9 +133,7 @@ async fn transaction_manager_basics() {
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // Duplicated enqueue is allowed.
-    transaction_manager
-        .enqueue(vec![transaction.clone()], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates
         .try_recv()
@@ -166,9 +158,7 @@ async fn transaction_manager_basics() {
     );
 
     // Re-enqueue the same transaction should not result in another output.
-    transaction_manager
-        .enqueue(vec![transaction.clone()], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates
         .try_recv()
@@ -294,17 +284,15 @@ async fn transaction_manager_object_dependency() {
         )
         .unwrap();
 
-    transaction_manager
-        .enqueue(
-            vec![
-                transaction_read_0.clone(),
-                transaction_read_1.clone(),
-                transaction_default.clone(),
-                transaction_read_2.clone(),
-            ],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![
+            transaction_read_0.clone(),
+            transaction_read_1.clone(),
+            transaction_default.clone(),
+            transaction_read_2.clone(),
+        ],
+        &state.epoch_store_for_testing(),
+    );
 
     // TM should output no transaction yet.
     sleep(Duration::from_secs(1)).await;
@@ -417,9 +405,7 @@ async fn transaction_manager_receiving_notify_commit() {
     for (i, (_, txn)) in object_arguments.iter().enumerate() {
         // TM should output no transaction yet since waiting on receiving object or
         // ImmOrOwnedObject input.
-        transaction_manager
-            .enqueue(vec![txn.clone()], &state.epoch_store_for_testing())
-            .unwrap();
+        transaction_manager.enqueue(vec![txn.clone()], &state.epoch_store_for_testing());
         sleep(Duration::from_secs(1)).await;
         assert!(rx_ready_certificates.try_recv().is_err());
         assert_eq!(transaction_manager.inflight_queue_len(), i + 1);
@@ -505,34 +491,28 @@ async fn transaction_manager_receiving_object_ready_notifications() {
     );
 
     // TM should output no transaction yet since waiting on receiving object.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction0.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction0.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // TM should output no transaction yet since waiting on receiving object.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction1.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction1.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
 
     // Duplicate enqueue of receiving object is allowed.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction0.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction0.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
@@ -610,35 +590,29 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
     );
 
     // TM should output no transaction yet since waiting on receiving object.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction0.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction0.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 1);
 
     // TM should output no transaction yet since waiting on receiving object.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction1.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction1.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 2);
 
-    // Different transaciton with a duplicate receiving object reference is allowed.
+    // Different transaction with a duplicate receiving object reference is allowed.
     // Both transaction's will be outputted once the receiving object is available.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction01.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction01.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     assert!(rx_ready_certificates.try_recv().is_err());
     assert_eq!(transaction_manager.inflight_queue_len(), 3);
@@ -649,7 +623,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
         &state.epoch_store_for_testing(),
     );
 
-    // TM should output both transactions dependening on the receiving object now that the
+    // TM should output both transactions depending on the receiving object now that the
     // transaction's receiving object has become available.
     rx_ready_certificates.recv().await.unwrap();
 
@@ -660,9 +634,7 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
 
     // Enqueue a transaction with a receiving object that is available at the time it is enqueued.
     // This should be immediately available.
-    transaction_manager
-        .enqueue(vec![tx1.clone()], &state.epoch_store_for_testing())
-        .unwrap();
+    transaction_manager.enqueue(vec![tx1.clone()], &state.epoch_store_for_testing());
     sleep(Duration::from_secs(1)).await;
     rx_ready_certificates.recv().await.unwrap();
 
@@ -725,24 +697,18 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
     );
 
     // TM should output no transaction yet since waiting on receiving object.
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction0.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction01.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
-    transaction_manager
-        .enqueue(
-            vec![receive_object_transaction1.clone()],
-            &state.epoch_store_for_testing(),
-        )
-        .unwrap();
+    transaction_manager.enqueue(
+        vec![receive_object_transaction0.clone()],
+        &state.epoch_store_for_testing(),
+    );
+    transaction_manager.enqueue(
+        vec![receive_object_transaction01.clone()],
+        &state.epoch_store_for_testing(),
+    );
+    transaction_manager.enqueue(
+        vec![receive_object_transaction1.clone()],
+        &state.epoch_store_for_testing(),
+    );
     sleep(Duration::from_secs(1)).await;
     rx_ready_certificates.recv().await.unwrap();
     rx_ready_certificates.recv().await.unwrap();

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -161,7 +161,7 @@ pub mod random {
 
     /// Given a value, produce a random probability using the value as a seed, with
     /// an additional seed that is constant only for the current test thread.
-    pub fn deterministic_probabilty<T: Hash>(value: T, chance: f32) -> bool {
+    pub fn deterministic_probability<T: Hash>(value: T, chance: f32) -> bool {
         thread_local! {
             // a random seed that is shared by the whole test process, so that equal `value`
             // inputs produce different outputs when the test seed changes
@@ -178,9 +178,9 @@ pub mod random {
             })
     }
 
-    /// Like deterministic_probabilty, but only returns true once for each unique value. May eventually
+    /// Like deterministic_probability, but only returns true once for each unique value. May eventually
     /// consume all memory if there are a large number of unique, failing values.
-    pub fn deterministic_probabilty_once<T: Hash + Serialize>(value: T, chance: f32) -> bool {
+    pub fn deterministic_probability_once<T: Hash + Serialize>(value: T, chance: f32) -> bool {
         thread_local! {
             static FAILING_VALUES: RefCell<HashSet<(msim::task::NodeId, Vec<u8>)>> = RefCell::new(HashSet::new());
         }
@@ -192,7 +192,7 @@ pub mod random {
             let mut failing_values = failing_values.borrow_mut();
             if failing_values.contains(&key) {
                 false
-            } else if deterministic_probabilty(value, chance) {
+            } else if deterministic_probability(value, chance) {
                 failing_values.insert(key);
                 true
             } else {


### PR DESCRIPTION
## Description 

To be consistent with all the other calls inside the function, where we always use expect.
It's also a bad practice to ignore the return value of some calls. Changing all of them to expect.
The core of this PR is in TransactionManager. All changes in other functions are due to the function signature change.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
