### PR TITLE
[GraphQL] Add query logging when timing out

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -13,6 +13,7 @@ pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
+    pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
     pub const UNKNOWN: &str = "UNKNOWN";
 }
 

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -58,7 +58,7 @@ impl Extension for Timeout {
             .unwrap_or_else(|_| {
                 let query_id: &Uuid = ctx.data_unchecked();
                 let session_id: &SocketAddr = ctx.data_unchecked();
-                let error_code = code::REQUEST_TIMEOUT.to_string();
+                let error_code = code::REQUEST_TIMEOUT;
                 let guard = self.query.lock().unwrap();
                 let query = match guard.as_ref() {
                     Some(s) => s.as_str(),
@@ -68,7 +68,7 @@ impl Extension for Timeout {
                 error!(
                     %query_id,
                     %session_id,
-                    error_code,
+                    %error_code,
                     %query
                 );
                 Response::from_errors(vec![ServerError::new(

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{
-    extensions::{Extension, ExtensionContext, ExtensionFactory, NextRequest},
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextExecute},
     Response, ServerError,
 };
-use std::sync::Arc;
 use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::time::timeout;
+use tracing::error;
+use uuid::Uuid;
 
-use crate::config::ServiceConfig;
+use crate::{config::ServiceConfig, error::code, server::builder::QueryString};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Timeout;
@@ -22,15 +24,30 @@ impl ExtensionFactory for Timeout {
 
 #[async_trait::async_trait]
 impl Extension for Timeout {
-    async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> Response {
         let cfg = ctx
             .data::<ServiceConfig>()
             .expect("No service config provided in schema data");
         let request_timeout = Duration::from_millis(cfg.limits.request_timeout_ms);
-
-        timeout(request_timeout, next.run(ctx))
+        timeout(request_timeout, next.run(ctx, operation_name))
             .await
             .unwrap_or_else(|_| {
+                let query: &QueryString = ctx.data_unchecked();
+                let query = query.0.clone();
+                let query_id: &Uuid = ctx.data_unchecked();
+                let session_id: &SocketAddr = ctx.data_unchecked();
+                let error_code = code::REQUEST_TIMEOUT.to_string();
+                error!(
+                    %query_id,
+                    %session_id,
+                    error_code,
+                    "Query: {}", query
+                );
                 Response::from_errors(vec![ServerError::new(
                     format!(
                         "Request timed out. Limit: {}s",

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -47,7 +47,7 @@ use std::{any::Any, net::SocketAddr, time::Instant};
 use sui_graphql_rpc_headers::{LIMITS_HEADER, VERSION_HEADER};
 use sui_package_resolver::{PackageStoreWithLruCache, Resolver};
 use sui_sdk::SuiClientBuilder;
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::OnceCell;
 use tower::{Layer, Service};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{info, warn};
@@ -317,9 +317,7 @@ impl ServerBuilder {
             builder = builder.extension(QueryLimitsChecker::default());
         }
         if config.internal_features.query_timeout {
-            builder = builder.extension(Timeout {
-                query: Mutex::new(None),
-            });
+            builder = builder.extension(Timeout::default());
         }
         if config.internal_features.tracing {
             builder = builder.extension(Tracing);
@@ -468,7 +466,6 @@ pub mod tests {
     use simulacrum::Simulacrum;
     use std::sync::Arc;
     use std::time::Duration;
-    use tokio::sync::Mutex;
     use uuid::Uuid;
 
     async fn prep_cluster() -> ConnectionConfig {
@@ -560,9 +557,7 @@ pub mod tests {
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
                 })
-                .extension(Timeout {
-                    query: Mutex::new(None),
-                })
+                .extension(Timeout::default())
                 .build_schema();
 
             schema.execute("{ chainIdentifier }").await

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -554,10 +554,10 @@ pub mod tests {
                 .context_data(cfg)
                 .context_data(query_id())
                 .context_data(ip_address())
+                .extension(Timeout::default())
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
                 })
-                .extension(Timeout::default())
                 .build_schema();
 
             schema.execute("{ chainIdentifier }").await


### PR DESCRIPTION
## Description 

This PR enables logging of queries that time out. The logging uses the `error` macro together with a new error code, `REQUEST_TIMEOUT`.


Note, that the timeout extension function was switched to `parse_query` + `execute`. Execute one takes care of the time, parse query takes care of stringifying up the query (including resolving any passed, fragments, etc).

## Test Plan 

Existing tests, manually checking for errors when setting a small (500ms) timeout.
```bash
2024-02-28T23:25:23.373001Z ERROR sui_graphql_rpc::extensions::timeout: Query: {
  transactionBlocks(first: 50) {
    nodes {
      digest
    }
  }
} query_id=97a7adca-52dc-4e4e-9cdc-bfdaaf1d65ae session_id=127.0.0.1:52232 error_code="REQUEST_TIMEOUT"
```

```
2024-02-29T02:35:24.740291Z ERROR sui_graphql_rpc::extensions::timeout: query_id=44d9f1ec-e4df-488c-bd2a-a0b31d5bb203 session_id=127.0.0.1:59043 error_code="REQUEST_TIMEOUT" query=query { a:transactionBlocks(first: 10) { nodes { digest } } b:transactionBlocks(first: 50) { nodes { digest } } }
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
