### PR TITLE
[GraphQL] Extract header through axum's extractor rather than manually

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -13,8 +13,7 @@ use async_graphql::parser::types::{
 use async_graphql::{value, Name, Pos, Positioned, Response, ServerResult, Value, Variables};
 use async_graphql_value::Value as GqlValue;
 use axum::headers;
-use axum::http::HeaderName;
-use axum::http::HeaderValue;
+use axum::http::{header::HeaderName, HeaderValue};
 use once_cell::sync::Lazy;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::net::SocketAddr;


### PR DESCRIPTION
## Description 

This PR uses axum's TypedHeader to extract the `ShowUsage` header from the request.

## Test Plan 

Existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
