### PR TITLE
Delete async when new wallet context in sui sdk

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -327,7 +327,7 @@ impl Cluster for Box<dyn Cluster + Send + Sync> {
     }
 }
 
-pub async fn new_wallet_context_from_cluster(
+pub fn new_wallet_context_from_cluster(
     cluster: &(dyn Cluster + Sync + Send),
     key_pair: AccountKeyPair,
 ) -> WalletContext {
@@ -360,12 +360,10 @@ pub async fn new_wallet_context_from_cluster(
         wallet_config_path
     );
 
-    WalletContext::new(&wallet_config_path, None, None)
-        .await
-        .unwrap_or_else(|e| {
-            panic!(
-                "Failed to init wallet context from path {:?}, error: {e}",
-                wallet_config_path
-            )
-        })
+    WalletContext::new(&wallet_config_path, None, None).unwrap_or_else(|e| {
+        panic!(
+            "Failed to init wallet context from path {:?}, error: {e}",
+            wallet_config_path
+        )
+    })
 }

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -30,8 +30,7 @@ impl FaucetClientFactory {
                     .expect("Expect local faucet key for local cluster")
                     .copy();
                 let wallet_context = new_wallet_context_from_cluster(cluster, key)
-                    .instrument(info_span!("init_wallet_context_for_faucet"))
-                    .await;
+                    .instrument(info_span!("init_wallet_context_for_faucet"));
 
                 let prom_registry = prometheus::Registry::new();
                 let config = FaucetConfig::default();

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -12,7 +12,7 @@ use sui_faucet::{
 };
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
-use tracing::{debug, info, info_span, Instrument};
+use tracing::{debug, info};
 use uuid::Uuid;
 
 pub struct FaucetClientFactory;

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -30,7 +30,7 @@ impl FaucetClientFactory {
                     .expect("Expect local faucet key for local cluster")
                     .copy();
                 let wallet_context = new_wallet_context_from_cluster(cluster, key)
-                    .instrument(info_span!("init_wallet_context_for_faucet"));
+                    .instrument(info_span!("init_wallet_context_for_faucet")).await;
 
                 let prom_registry = prometheus::Registry::new();
                 let config = FaucetConfig::default();

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -29,8 +29,7 @@ impl FaucetClientFactory {
                     .local_faucet_key()
                     .expect("Expect local faucet key for local cluster")
                     .copy();
-                let wallet_context = new_wallet_context_from_cluster(cluster, key)
-                    .instrument(info_span!("init_wallet_context_for_faucet")).await;
+                let wallet_context = new_wallet_context_from_cluster(cluster, key);
 
                 let prom_registry = prometheus::Registry::new();
                 let config = FaucetConfig::default();

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -24,8 +24,7 @@ impl WalletClient {
     pub async fn new_from_cluster(cluster: &(dyn Cluster + Sync + Send)) -> Self {
         let key = cluster.user_key();
         let address: SuiAddress = key.public().into();
-        let wallet_context = new_wallet_context_from_cluster(cluster, key)
-            .instrument(info_span!("init_wallet_context_for_test_user")).await;
+        let wallet_context = new_wallet_context_from_cluster(cluster, key);
 
         let rpc_url = String::from(cluster.fullnode_url());
         info!("Use fullnode rpc: {}", &rpc_url);

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -25,8 +25,7 @@ impl WalletClient {
         let key = cluster.user_key();
         let address: SuiAddress = key.public().into();
         let wallet_context = new_wallet_context_from_cluster(cluster, key)
-            .instrument(info_span!("init_wallet_context_for_test_user"))
-            .await;
+            .instrument(info_span!("init_wallet_context_for_test_user"));
 
         let rpc_url = String::from(cluster.fullnode_url());
         info!("Use fullnode rpc: {}", &rpc_url);

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -11,7 +11,7 @@ use sui_sdk::{SuiClient, SuiClientBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{KeypairTraits, Signature};
 use sui_types::transaction::TransactionData;
-use tracing::{info, info_span, Instrument};
+use tracing::info;
 
 pub struct WalletClient {
     wallet_context: WalletContext,

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -25,7 +25,7 @@ impl WalletClient {
         let key = cluster.user_key();
         let address: SuiAddress = key.public().into();
         let wallet_context = new_wallet_context_from_cluster(cluster, key)
-            .instrument(info_span!("init_wallet_context_for_test_user"));
+            .instrument(info_span!("init_wallet_context_for_test_user")).await;
 
         let rpc_url = String::from(cluster.fullnode_url());
         info!("Use fullnode rpc: {}", &rpc_url);

--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -12,8 +12,8 @@ use sui_types::{base_types::ObjectID, gas_coin::GasCoin, transaction::Transactio
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
-    let mut wallet = create_wallet_context(60).await?;
+fn main() -> Result<(), anyhow::Error> {
+    let mut wallet = create_wallet_context(60)?;
     let active_address = wallet
         .active_address()
         .map_err(|err| FaucetError::Wallet(err.to_string()))?;
@@ -123,8 +123,8 @@ async fn _merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), a
     Ok(())
 }
 
-pub async fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
+pub fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
-    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs)), None).await
+    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs)), None)
 }

--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -12,7 +12,7 @@ use sui_types::{base_types::ObjectID, gas_coin::GasCoin, transaction::Transactio
 use tracing::info;
 
 #[tokio::main]
-fn main() -> Result<(), anyhow::Error> {
+async fn main() -> Result<(), anyhow::Error> {
     let mut wallet = create_wallet_context(60)?;
     let active_address = wallet
         .active_address()

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), anyhow::Error> {
         ..
     } = config;
 
-    let context = create_wallet_context(wallet_client_timeout_secs).await?;
+    let context = create_wallet_context(wallet_client_timeout_secs)?;
 
     let prom_binding = PROM_PORT_ADDR.parse().unwrap();
     info!("Starting Prometheus HTTP endpoint at {}", prom_binding);
@@ -285,7 +285,7 @@ async fn request_gas(
     }
 }
 
-async fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
+fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
     WalletContext::new(
@@ -293,7 +293,6 @@ async fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyho
         Some(Duration::from_secs(timeout_secs)),
         Some(1000),
     )
-    .await
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {

--- a/crates/sui-oracle/src/main.rs
+++ b/crates/sui-oracle/src/main.rs
@@ -30,8 +30,7 @@ async fn main() -> anyhow::Result<()> {
         // TODO make this configurable
         Some(Duration::from_secs(10)), // request times out after 10 secs
         None,
-    )
-    .await?;
+    )?;
 
     // Init metrics server
     let registry_service = start_prometheus_server(config.metrics_address);

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -56,7 +56,7 @@ pub async fn setup_for_write() -> Result<(SuiClient, SuiAddress, SuiAddress), an
     if coin.is_none() {
         request_tokens_from_faucet(active_address, &client).await?;
     }
-    let wallet = retrieve_wallet().await?;
+    let wallet = retrieve_wallet()?;
     let addresses = wallet.get_addresses();
     let addresses = addresses
         .into_iter()
@@ -78,7 +78,7 @@ pub async fn setup_for_write() -> Result<(SuiClient, SuiAddress, SuiAddress), an
 pub async fn setup_for_read() -> Result<(SuiClient, SuiAddress), anyhow::Error> {
     let client = SuiClientBuilder::default().build_testnet().await?;
     println!("Sui testnet version is: {}", client.api_version());
-    let mut wallet = retrieve_wallet().await?;
+    let mut wallet = retrieve_wallet()?;
     assert!(wallet.get_addresses().len() >= 2);
     let active_address = wallet.active_address()?;
 
@@ -267,7 +267,7 @@ pub async fn split_coin_digest(
     Ok(transaction_response.digest)
 }
 
-pub async fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
+pub fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     let keystore_path = sui_config_dir()?.join(SUI_KEYSTORE_FILENAME);
 
@@ -311,8 +311,7 @@ pub async fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     client_config.active_address = Some(default_active_address);
     client_config.save(&wallet_conf)?;
 
-    let wallet =
-        WalletContext::new(&wallet_conf, Some(std::time::Duration::from_secs(60)), None).await?;
+    let wallet = WalletContext::new(&wallet_conf, Some(std::time::Duration::from_secs(60)), None)?;
 
     Ok(wallet)
 }

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -29,7 +29,7 @@ pub struct WalletContext {
 }
 
 impl WalletContext {
-    pub async fn new(
+    pub fn new(
         config_path: &Path,
         request_timeout: Option<std::time::Duration>,
         max_concurrent_requests: Option<u64>,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -273,7 +273,7 @@ impl SuiCommand {
             SuiCommand::Console { config } => {
                 let config = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config, false).await?;
-                let context = WalletContext::new(&config, None, None).await?;
+                let context = WalletContext::new(&config, None, None)?;
                 start_console(context, &mut stdout(), &mut stderr()).await
             }
             SuiCommand::Client {
@@ -284,7 +284,7 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None, None).await?;
+                let mut context = WalletContext::new(&config_path, None, None)?;
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
@@ -303,7 +303,7 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None, None).await?;
+                let mut context = WalletContext::new(&config_path, None, None)?;
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context).await?.print(!json);
                 } else {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -980,7 +980,7 @@ impl TestClusterBuilder {
             .unwrap();
 
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
-        let wallet = WalletContext::new(&wallet_conf, None, None).await.unwrap();
+        let wallet = WalletContext::new(&wallet_conf, None, None).unwrap();
 
         TestCluster {
             swarm,


### PR DESCRIPTION
## Description 

Fix #16458 

## Test Plan 



---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The `WalletContext::new` method does not have any asynchronous dependencies, and thus it does not need to be defined as an asynchronous function. This PR is a breaking change that modifies the signature of `WalletContext::new` into a synchronous function. Users that depend on `WalletContext::new` will need to update callsites accordingly by dropping the `.await`.

