### PR TITLE
[Consensus] add `TrustedCommit` type

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -49,7 +49,6 @@ pub struct Transaction {
     data: Bytes,
 }
 
-#[allow(dead_code)]
 impl Transaction {
     pub fn new(data: Vec<u8>) -> Self {
         Self { data: data.into() }
@@ -403,7 +402,7 @@ impl Deref for SignedBlock {
 }
 
 /// VerifiedBlock allows full access to its content.
-/// It should be relatively cheap to copy.
+/// Note: clone() is relatively cheap with most underlying data refcounted.
 #[derive(Clone)]
 pub struct VerifiedBlock {
     block: Arc<SignedBlock>,

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -26,7 +26,7 @@ pub(crate) const MINIMUM_WAVE_LENGTH: Round = 3;
 pub(crate) type WaveNumber = u32;
 
 /// Index of the commit.
-pub(crate) type CommitIndex = u64;
+pub type CommitIndex = u32;
 
 /// Specifies one consensus commit.
 /// It is stored on disk, so it does not contain blocks which are stored individually.
@@ -148,12 +148,14 @@ pub struct CommitConsumer {
     pub sender: UnboundedSender<CommittedSubDag>,
     // The last commit index that the consumer has processed. This is useful for
     // crash/recovery so mysticeti can replay the commits from `last_processed_index + 1`.
-    pub last_processed_index: u64,
+    pub last_processed_index: CommitIndex,
 }
 
-#[allow(unused)]
 impl CommitConsumer {
-    pub fn new(sender: UnboundedSender<CommittedSubDag>, last_processed_index: u64) -> Self {
+    pub fn new(
+        sender: UnboundedSender<CommittedSubDag>,
+        last_processed_index: CommitIndex,
+    ) -> Self {
         Self {
             sender,
             last_processed_index,

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::Deref,
+    sync::Arc,
+};
 
 use consensus_config::AuthorityIndex;
+use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -11,6 +16,9 @@ use crate::{
     block::{BlockAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock},
     storage::Store,
 };
+
+/// Index of a commit among all consensus commits.
+pub type CommitIndex = u32;
 
 /// Default wave length for all committers. A longer wave length increases the
 /// chance of committing the leader under asynchrony at the cost of latency in
@@ -25,31 +33,110 @@ pub(crate) const MINIMUM_WAVE_LENGTH: Round = 3;
 #[allow(unused)]
 pub(crate) type WaveNumber = u32;
 
-/// Index of the commit.
-pub type CommitIndex = u32;
-
-/// Specifies one consensus commit.
-/// It is stored on disk, so it does not contain blocks which are stored individually.
-// TODO: store internal data in a refcounted and versioned struct.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-pub struct Commit {
-    /// Index of the commit.
-    /// First commit after genesis has an index of 1, then every next commit has an index incremented by 1.
-    pub index: CommitIndex,
-    /// A reference to the the commit leader.
-    pub leader: BlockRef,
-    /// Refs to committed blocks, in the commit order.
-    pub blocks: Vec<BlockRef>,
+/// Versioned representation of a consensus commit.
+///
+/// Commit is used to persist commit metadata for recovery. It is also exchanged over the network.
+/// To balance being functional and succinct, a field must meet these requirements to be added
+/// to the struct:
+/// - helps with recoverying CommittedSubDag locally and for peers catching up.
+/// - cannot be derived from a sequence of Commits and other persisted values.
+///
+/// For example, transactions in blocks should not be included in Commit, because they can be
+/// retrieved from blocks specified in Commit. Last committed round per authority also should not
+/// be included, because it can be derived from the latest value in storage and the additional
+/// sequence of Commits.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[enum_dispatch(CommitAPI)]
+pub(crate) enum Commit {
+    V1(CommitV1),
 }
 
 impl Commit {
     /// Create a new commit.
-    pub fn new(index: CommitIndex, leader: BlockRef, blocks: Vec<BlockRef>) -> Self {
-        Self {
+    pub(crate) fn new(index: CommitIndex, leader: BlockRef, blocks: Vec<BlockRef>) -> Self {
+        Commit::V1(CommitV1 {
             index,
             leader,
             blocks,
+        })
+    }
+}
+
+/// Accessors for Commit.
+#[enum_dispatch]
+pub(crate) trait CommitAPI {
+    fn index(&self) -> CommitIndex;
+    fn leader(&self) -> BlockRef;
+    fn blocks(&self) -> &[BlockRef];
+}
+
+/// Specifies one consensus commit.
+/// It is stored on disk, so it does not contain blocks which are stored individually.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub(crate) struct CommitV1 {
+    /// Index of the commit.
+    /// First commit after genesis has an index of 1, then every next commit has an index incremented by 1.
+    index: CommitIndex,
+    /// A reference to the the commit leader.
+    leader: BlockRef,
+    /// Refs to committed blocks, in the commit order.
+    blocks: Vec<BlockRef>,
+}
+
+impl CommitAPI for CommitV1 {
+    fn index(&self) -> CommitIndex {
+        self.index
+    }
+
+    fn leader(&self) -> BlockRef {
+        self.leader
+    }
+
+    fn blocks(&self) -> &[BlockRef] {
+        &self.blocks
+    }
+}
+
+/// A commit is trusted when it is produced locally or certified by a quorum of authorities.
+/// Blocks referenced by TrustedCommit are assumed to be valid.
+/// Only trusted Commit can be sent to execution.
+///
+/// Note: clone() is relatively cheap with the underlying data refcounted.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TrustedCommit {
+    inner: Arc<Commit>,
+    // TODO: store digest and serialized bytes.
+}
+
+impl TrustedCommit {
+    pub(crate) fn new_trusted(commit: Commit) -> Self {
+        Self {
+            inner: Arc::new(commit),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        index: CommitIndex,
+        leader: BlockRef,
+        blocks: Vec<BlockRef>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Commit::new(index, leader, blocks)),
+        }
+    }
+
+    pub(crate) fn inner(&self) -> &Commit {
+        &self.inner
+    }
+}
+
+/// Allow easy access on the underlying Commit.
+impl Deref for TrustedCommit {
+    type Target = Commit;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -127,11 +214,11 @@ impl fmt::Debug for CommittedSubDag {
 // Recovers the full CommittedSubDag from block store, based on Commit.
 pub fn load_committed_subdag_from_store(
     block_store: &dyn Store,
-    commit_data: Commit,
+    commit: TrustedCommit,
 ) -> CommittedSubDag {
     let mut leader_block_idx = None;
     let commit_blocks = block_store
-        .read_blocks(&commit_data.blocks)
+        .read_blocks(commit.blocks())
         .expect("We should have the block referenced in the commit data");
     let blocks = commit_blocks
         .into_iter()
@@ -139,7 +226,7 @@ pub fn load_committed_subdag_from_store(
         .map(|(idx, commit_block_opt)| {
             let commit_block =
                 commit_block_opt.expect("We should have the block referenced in the commit data");
-            if commit_block.reference() == commit_data.leader {
+            if commit_block.reference() == commit.leader() {
                 leader_block_idx = Some(idx);
             }
             commit_block
@@ -148,7 +235,7 @@ pub fn load_committed_subdag_from_store(
     let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
     let leader_block_ref = blocks[leader_block_idx].reference();
     let timestamp_ms = blocks[leader_block_idx].timestamp_ms();
-    CommittedSubDag::new(leader_block_ref, blocks, timestamp_ms, commit_data.index)
+    CommittedSubDag::new(leader_block_ref, blocks, timestamp_ms, commit.index())
 }
 
 #[allow(unused)]
@@ -305,7 +392,7 @@ mod tests {
         let leader_block = leader.unwrap();
         let leader_ref = leader_block.reference();
         let commit_index = 1;
-        let commit = Commit::new(commit_index, leader_ref, blocks.clone());
+        let commit = TrustedCommit::new_for_test(commit_index, leader_ref, blocks.clone());
 
         let subdag = load_committed_subdag_from_store(store.as_ref(), commit);
         assert_eq!(subdag.leader, leader_ref);

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::commit::CommitAPI;
 use crate::error::{ConsensusError, ConsensusResult};
 use crate::{
     block::{timestamp_utc_ms, BlockAPI, VerifiedBlock},
@@ -97,7 +98,7 @@ impl CommitObserver {
             .expect("Reading the last commit should not fail");
 
         if let Some(last_commit) = last_commit {
-            let last_commit_index = last_commit.index;
+            let last_commit_index = last_commit.index();
 
             assert!(last_commit_index >= last_processed_index);
             if last_commit_index == last_processed_index {
@@ -114,7 +115,7 @@ impl CommitObserver {
         for commit in unsent_commits {
             // Resend all the committed subdags to the consensus output channel
             // for all the commits above the last processed index.
-            assert!(commit.index > last_processed_index);
+            assert!(commit.index() > last_processed_index);
             let committed_subdag = load_committed_subdag_from_store(self.store.as_ref(), commit);
 
             // Failures in sender.send() are assumed to be permanent
@@ -260,7 +261,7 @@ mod tests {
 
         // Check commits have been persisted to storage
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
-        assert_eq!(last_commit.index, commits.last().unwrap().commit_index);
+        assert_eq!(last_commit.index(), commits.last().unwrap().commit_index);
         let all_stored_commits = mem_store.scan_commits(0).unwrap();
         assert_eq!(all_stored_commits.len(), leaders.len());
         let blocks_existence = mem_store.contains_blocks(&expected_stored_refs).unwrap();
@@ -331,7 +332,7 @@ mod tests {
         // Check last stored commit is correct
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
         assert_eq!(
-            last_commit.index,
+            last_commit.index(),
             expected_last_processed_index as CommitIndex
         );
 
@@ -367,7 +368,7 @@ mod tests {
         // that was sent over the channel regardless of how the consumer handled
         // the commit on their end.
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
-        assert_eq!(last_commit.index, expected_last_sent_index as CommitIndex);
+        assert_eq!(last_commit.index(), expected_last_sent_index as CommitIndex);
 
         // Re-create commit observer starting from index 2 which represents the
         // last processed index from the consumer over consensus output channel
@@ -451,7 +452,7 @@ mod tests {
         // Check last stored commit is correct
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
         assert_eq!(
-            last_commit.index,
+            last_commit.index(),
             expected_last_processed_index as CommitIndex
         );
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -242,7 +242,7 @@ mod tests {
                 expected_stored_refs.push(block.reference());
                 assert!(block.round() <= leaders[idx].round());
             }
-            assert_eq!(subdag.commit_index, idx as u64 + 1);
+            assert_eq!(subdag.commit_index, idx as CommitIndex + 1);
         }
 
         // Check commits sent over consensus output channel is accurate

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -502,8 +502,8 @@ mod test {
 
     use super::*;
     use crate::{
-        block::TestBlock, block_verifier::NoopBlockVerifier, storage::mem_store::MemStore,
-        transaction::TransactionClient,
+        block::TestBlock, block_verifier::NoopBlockVerifier, commit::CommitAPI as _,
+        storage::mem_store::MemStore, transaction::TransactionClient,
     };
 
     /// Recover Core and continue proposing from the last round which forms a quorum.
@@ -603,7 +603,7 @@ mod test {
         // There were no commits prior to the core starting up but there was completed
         // rounds up to and including round 4. So we should commit leaders in round 1 & 2
         // as soon as the new block for round 5 is proposed.
-        assert_eq!(last_commit.index, 2);
+        assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
         let all_stored_commits = store.scan_commits(0).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
@@ -718,7 +718,7 @@ mod test {
         // There were no commits prior to the core starting up but there was completed
         // rounds up to round 4. So we should commit leaders in round 1 & 2 as soon
         // as the new block for round 4 is proposed.
-        assert_eq!(last_commit.index, 2);
+        assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
         let all_stored_commits = store.scan_commits(0).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
@@ -950,7 +950,7 @@ mod test {
                 .expect("last commit should be set");
             // There are 1 leader rounds with rounds completed up to and including
             // round 4
-            assert_eq!(last_commit.index, 1);
+            assert_eq!(last_commit.index(), 1);
             let all_stored_commits = core.store.scan_commits(0).unwrap();
             assert_eq!(all_stored_commits.len(), 1);
         }
@@ -1021,7 +1021,7 @@ mod test {
             // There are 8 leader rounds with rounds completed up to and including
             // round 9. Round 10 blocks will only include their own blocks, so the
             // 8th leader will not be committed.
-            assert_eq!(last_commit.index, 7);
+            assert_eq!(last_commit.index(), 7);
             let all_stored_commits = core.store.scan_commits(0).unwrap();
             assert_eq!(all_stored_commits.len(), 7);
         }
@@ -1090,7 +1090,7 @@ mod test {
         // There are 8 leader rounds with rounds completed up to and including
         // round 10. However because there were no blocks produced for authority 3
         // 2 leader rounds will be skipped.
-        assert_eq!(last_commit.index, 6);
+        assert_eq!(last_commit.index(), 6);
         let all_stored_commits = core.store.scan_commits(0).unwrap();
         assert_eq!(all_stored_commits.len(), 6);
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -390,10 +390,7 @@ impl DagState {
 
     /// Last committed round per authority.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
-        match &self.last_commit {
-            Some(commit) => commit.last_committed_rounds.clone(),
-            None => vec![0; self.context.committee.size()],
-        }
+        self.last_committed_rounds.clone()
     }
 
     /// After each flush, DagState becomes persisted in storage and it expected to recover
@@ -838,11 +835,11 @@ mod test {
                 let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
                 blocks.push(block);
             }
-            commits.push(Commit {
-                index: round as CommitIndex,
-                leader: blocks.last().unwrap().reference(),
-                ..Default::default()
-            });
+            commits.push(Commit::new(
+                round as CommitIndex,
+                blocks.last().unwrap().reference(),
+                vec![],
+            ));
         }
 
         // Add the blocks from first 5 rounds and first 5 commits to the dag state

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -30,5 +30,5 @@ mod universal_committer;
 
 pub use authority_node::ConsensusAuthority;
 pub use block::BlockAPI;
-pub use commit::{CommitConsumer, CommittedSubDag};
+pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -191,7 +191,7 @@ mod tests {
             for block in subdag.blocks.iter() {
                 assert!(block.round() <= leaders[idx].round());
             }
-            assert_eq!(subdag.commit_index, idx as u64 + 1);
+            assert_eq!(subdag.commit_index, idx as CommitIndex + 1);
         }
     }
 

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -11,7 +11,7 @@ use consensus_config::AuthorityIndex;
 
 use crate::{
     block::{BlockRef, Round, VerifiedBlock},
-    commit::{Commit, CommitIndex},
+    commit::{CommitIndex, TrustedCommit},
     error::ConsensusResult,
 };
 
@@ -21,7 +21,7 @@ pub(crate) trait Store: Send + Sync {
     fn write(
         &self,
         blocks: Vec<VerifiedBlock>,
-        commits: Vec<Commit>,
+        commits: Vec<TrustedCommit>,
         last_committed_rounds: Vec<Round>,
     ) -> ConsensusResult<()>;
 
@@ -47,10 +47,10 @@ pub(crate) trait Store: Send + Sync {
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     /// Reads the last commit.
-    fn read_last_commit(&self) -> ConsensusResult<Option<Commit>>;
+    fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>>;
 
     /// Reads all commits from start_commit_index.
-    fn scan_commits(&self, start_commit_index: CommitIndex) -> ConsensusResult<Vec<Commit>>;
+    fn scan_commits(&self, start_commit_index: CommitIndex) -> ConsensusResult<Vec<TrustedCommit>>;
 
     /// Reads the last committed rounds per authority.
     fn read_last_committed_rounds(&self) -> ConsensusResult<Vec<Round>>;

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -74,7 +74,7 @@ impl RocksDBStore {
         let (blocks, digests_by_authorities, commits, last_committed_rounds) = reopen!(&rocksdb,
             Self::BLOCKS_CF;<(Round, AuthorityIndex, BlockDigest), bytes::Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockDigest), ()>,
-            Self::COMMITS_CF;<u64, Commit>,
+            Self::COMMITS_CF;<CommitIndex, Commit>,
             Self::LAST_COMMITTED_ROUNDS_CF;<(), Vec<Round>>
         );
 

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -16,6 +16,7 @@ use typed_store::{
 };
 
 use super::Store;
+use crate::commit::{CommitAPI as _, TrustedCommit};
 use crate::{
     block::{BlockDigest, BlockRef, Round, SignedBlock, VerifiedBlock},
     commit::{Commit, CommitIndex},
@@ -29,6 +30,7 @@ pub(crate) struct RocksDBStore {
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockDigest), ()>,
     /// Maps commit index to content.
+    // TODO: Use Bytes for value. Add CommitDigest to key.
     commits: DBMap<CommitIndex, Commit>,
     /// Stores the last committed rounds per authority.
     last_committed_rounds: DBMap<(), Vec<Round>>,
@@ -92,7 +94,7 @@ impl Store for RocksDBStore {
     fn write(
         &self,
         blocks: Vec<VerifiedBlock>,
-        commits: Vec<Commit>,
+        commits: Vec<TrustedCommit>,
         last_committed_rounds: Vec<Round>,
     ) -> ConsensusResult<()> {
         let mut batch = self.blocks.batch();
@@ -111,7 +113,7 @@ impl Store for RocksDBStore {
             );
         }
         for commit in commits {
-            batch.insert_batch(&self.commits, [(commit.index, commit)]);
+            batch.insert_batch(&self.commits, [(commit.index(), commit.inner())]);
         }
         batch.insert_batch(&self.last_committed_rounds, [((), last_committed_rounds)]);
         batch.write()?;
@@ -203,22 +205,22 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
-    fn read_last_commit(&self) -> ConsensusResult<Option<Commit>> {
+    fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {
         let Some(commit) = self.commits.safe_iter().skip_to_last().next() else {
             return Ok(None);
         };
         let (_, commit) = commit?;
-        Ok(Some(commit))
+        Ok(Some(TrustedCommit::new_trusted(commit)))
     }
 
-    fn scan_commits(&self, start_commit_index: CommitIndex) -> ConsensusResult<Vec<Commit>> {
+    fn scan_commits(&self, start_commit_index: CommitIndex) -> ConsensusResult<Vec<TrustedCommit>> {
         let mut commits = vec![];
         for commit in self
             .commits
             .safe_range_iter((Included(start_commit_index), Unbounded))
         {
             let (_, commit) = commit?;
-            commits.push(commit);
+            commits.push(TrustedCommit::new_trusted(commit));
         }
         Ok(commits)
     }

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -197,26 +197,26 @@ async fn read_and_scan_commits(
     }
 
     let written_commits = vec![
-        Commit {
-            index: 1,
-            leader: BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
-            ..Default::default()
-        },
-        Commit {
-            index: 2,
-            leader: BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockDigest::default()),
-            ..Default::default()
-        },
-        Commit {
-            index: 3,
-            leader: BlockRef::new(3, AuthorityIndex::new_for_test(0), BlockDigest::default()),
-            ..Default::default()
-        },
-        Commit {
-            index: 4,
-            leader: BlockRef::new(4, AuthorityIndex::new_for_test(0), BlockDigest::default()),
-            ..Default::default()
-        },
+        Commit::new(
+            1,
+            BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            vec![],
+        ),
+        Commit::new(
+            2,
+            BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            vec![],
+        ),
+        Commit::new(
+            3,
+            BlockRef::new(3, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            vec![],
+        ),
+        Commit::new(
+            4,
+            BlockRef::new(4, AuthorityIndex::new_for_test(0), BlockDigest::default()),
+            vec![],
+        ),
     ];
     store
         .write(vec![], written_commits.clone(), vec![])

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use super::{mem_store::MemStore, rocksdb_store::RocksDBStore, Store};
 use crate::{
     block::{BlockDigest, BlockRef, TestBlock, VerifiedBlock},
-    commit::Commit,
+    commit::TrustedCommit,
 };
 
 /// Test fixture for store tests. Wraps around various store implementations.
@@ -197,22 +197,22 @@ async fn read_and_scan_commits(
     }
 
     let written_commits = vec![
-        Commit::new(
+        TrustedCommit::new_for_test(
             1,
             BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
-        Commit::new(
+        TrustedCommit::new_for_test(
             2,
             BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
-        Commit::new(
+        TrustedCommit::new_for_test(
             3,
             BlockRef::new(3, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
-        Commit::new(
+        TrustedCommit::new_for_test(
             4,
             BlockRef::new(4, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -210,7 +210,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ExecutionState for ConsensusHandl
             .await;
     }
 
-    async fn last_executed_sub_dag_index(&self) -> u64 {
+    fn last_executed_sub_dag_index(&self) -> u64 {
         self.last_consensus_stats.index.sub_dag_index
     }
 }

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
-use consensus_core::{CommitConsumer, ConsensusAuthority};
+use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority};
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::{RegistryID, RegistryService};
 use narwhal_executor::ExecutionState;
@@ -130,7 +130,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         let consumer = CommitConsumer::new(
             commit_sender,
             // TODO(mysticeti): remove dependency on narwhal executor
-            consensus_handler.last_executed_sub_dag_index().await,
+            consensus_handler.last_executed_sub_dag_index() as CommitIndex,
         );
 
         // TODO(mysticeti): Investigate if we need to return potential errors from

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -136,7 +136,7 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
     }
 
     fn commit_sub_dag_index(&self) -> u64 {
-        self.commit_index
+        self.commit_index.into()
     }
 
     fn transactions(&self) -> ConsensusOutputTransactions {

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -38,7 +38,7 @@ pub trait ExecutionState {
     async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput);
 
     /// Load the last executed sub-dag index from storage
-    async fn last_executed_sub_dag_index(&self) -> u64;
+    fn last_executed_sub_dag_index(&self) -> u64;
 }
 
 /// A client subscribing to the consensus output and executing every transaction.
@@ -96,7 +96,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
     // whether the execution has been interrupted and there are still batches/transactions
     // that need to be sent for execution.
 
-    let last_executed_sub_dag_index = execution_state.last_executed_sub_dag_index().await;
+    let last_executed_sub_dag_index = execution_state.last_executed_sub_dag_index();
 
     let compressed_sub_dags =
         consensus_store.read_committed_sub_dags_from(&last_executed_sub_dag_index)?;

--- a/narwhal/node/src/execution_state.rs
+++ b/narwhal/node/src/execution_state.rs
@@ -36,7 +36,7 @@ impl ExecutionState for SimpleExecutionState {
         }
     }
 
-    async fn last_executed_sub_dag_index(&self) -> u64 {
+    fn last_executed_sub_dag_index(&self) -> u64 {
         0
     }
 }


### PR DESCRIPTION
## Description 

Add a `TrustedCommit` type that contains refcounted and versioned internal data.
In future, uncertified commit received from peers will be stored in another type.

`TrustedCommit` internal layout will evolve in future PRs. Digest, serialized bytes and certifier fields will be added. How commits are stored will also evolve.

## Test Plan 

CI.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
