### PR TITLE
[Consensus] remove `allow(unused)` and `allow(dead_code)`

### DIFF
--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -19,7 +19,6 @@ use crate::{
 #[path = "tests/base_committer_tests.rs"]
 mod base_committer_tests;
 
-#[allow(unused)]
 pub(crate) struct BaseCommitterOptions {
     /// TODO: Re-evaluate if we want this to be configurable after running experiments.
     /// The length of a wave (minimum 3)
@@ -48,7 +47,6 @@ impl Default for BaseCommitterOptions {
 /// the method `try_direct_decide` and `try_indirect_decide` can be called at any
 /// time and any number of times (it is idempotent) to determine whether a leader
 /// can be committed or skipped.
-#[allow(unused)]
 pub(crate) struct BaseCommitter {
     /// The per-epoch configuration of this authority.
     context: Arc<Context>,
@@ -397,7 +395,6 @@ impl Display for BaseCommitter {
 /// that has no leader or round offset. Which indicates single leader & pipelining
 /// disabled.
 #[cfg(test)]
-#[allow(unused)]
 mod base_committer_builder {
     use super::*;
 
@@ -410,7 +407,7 @@ mod base_committer_builder {
     }
 
     impl BaseCommitterBuilder {
-        pub fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
             Self {
                 context,
                 dag_state,
@@ -420,22 +417,25 @@ mod base_committer_builder {
             }
         }
 
-        pub fn with_wave_length(mut self, wave_length: u32) -> Self {
+        #[allow(unused)]
+        pub(crate) fn with_wave_length(mut self, wave_length: u32) -> Self {
             self.wave_length = wave_length;
             self
         }
 
-        pub fn with_leader_offset(mut self, leader_offset: u32) -> Self {
+        #[allow(unused)]
+        pub(crate) fn with_leader_offset(mut self, leader_offset: u32) -> Self {
             self.leader_offset = leader_offset;
             self
         }
 
-        pub fn with_round_offset(mut self, round_offset: u32) -> Self {
+        #[allow(unused)]
+        pub(crate) fn with_round_offset(mut self, round_offset: u32) -> Self {
             self.round_offset = round_offset;
             self
         }
 
-        pub fn build(self) -> BaseCommitter {
+        pub(crate) fn build(self) -> BaseCommitter {
             let options = BaseCommitterOptions {
                 wave_length: DEFAULT_WAVE_LENGTH,
                 leader_offset: 0,

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -160,7 +160,6 @@ pub struct BlockRef {
     pub digest: BlockDigest,
 }
 
-#[allow(unused)]
 impl BlockRef {
     pub fn new(round: Round, author: AuthorityIndex, digest: BlockDigest) -> Self {
         Self {
@@ -289,7 +288,6 @@ impl fmt::Debug for Slot {
 ///
 /// Note: `BlockDigest` is computed over this struct, so any added field (without `#[serde(skip)]`)
 /// will affect the values of `BlockDigest` and `BlockRef`.
-#[allow(unused)]
 #[derive(Deserialize, Serialize)]
 pub(crate) struct SignedBlock {
     inner: Block,
@@ -529,7 +527,6 @@ pub(crate) struct TestBlock {
     block: BlockV1,
 }
 
-#[allow(unused)]
 #[cfg(test)]
 impl TestBlock {
     pub(crate) fn new(round: Round, author: u32) -> Self {

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -290,15 +290,14 @@ impl BlockManager {
         None
     }
 
-    #[allow(dead_code)]
     /// Returns all the blocks that are currently missing and needed in order to accept suspended
     /// blocks.
     pub(crate) fn missing_blocks(&self) -> BTreeSet<BlockRef> {
         self.missing_blocks.clone()
     }
 
-    #[allow(dead_code)]
     /// Returns all the suspended blocks whose causal history we miss hence we can't accept them yet.
+    #[cfg(test)]
     pub(crate) fn suspended_blocks(&self) -> Vec<BlockRef> {
         self.suspended_blocks.keys().cloned().collect()
     }

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -30,7 +30,6 @@ pub(crate) const MINIMUM_WAVE_LENGTH: Round = 3;
 
 /// The consensus protocol operates in 'waves'. Each wave is composed of a leader
 /// round, at least one voting round, and one decision round.
-#[allow(unused)]
 pub(crate) type WaveNumber = u32;
 
 /// Versioned representation of a consensus commit.
@@ -156,7 +155,6 @@ pub struct CommittedSubDag {
     pub commit_index: CommitIndex,
 }
 
-#[allow(unused)]
 impl CommittedSubDag {
     /// Create new (empty) sub-dag.
     pub fn new(
@@ -238,7 +236,6 @@ pub fn load_committed_subdag_from_store(
     CommittedSubDag::new(leader_block_ref, blocks, timestamp_ms, commit.index())
 }
 
-#[allow(unused)]
 pub struct CommitConsumer {
     // A channel to send the committed sub dags through
     pub sender: UnboundedSender<CommittedSubDag>,
@@ -260,7 +257,6 @@ impl CommitConsumer {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[allow(unused)]
 pub(crate) enum Decision {
     Direct,
     Indirect,
@@ -269,7 +265,6 @@ pub(crate) enum Decision {
 /// The status of every leader output by the committers. While the core only cares
 /// about committed leaders, providing a richer status allows for easier debugging,
 /// testing, and composition with advanced commit strategies.
-#[allow(unused)]
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum LeaderStatus {
     Commit(VerifiedBlock),
@@ -277,7 +272,6 @@ pub(crate) enum LeaderStatus {
     Undecided(Slot),
 }
 
-#[allow(unused)]
 impl LeaderStatus {
     pub(crate) fn round(&self) -> Round {
         match self {
@@ -316,7 +310,7 @@ impl LeaderStatus {
     pub fn into_committed_block(self) -> Option<VerifiedBlock> {
         match self {
             Self::Commit(block) => Some(block),
-            Self::Skip(leader) => None,
+            Self::Skip(_leader) => None,
             Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
         }
     }

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -28,8 +28,6 @@ use crate::{
 /// is sent to the consumer.
 /// - When CommitObserver is initialized a last processed commit index can be used
 /// to ensure any missing commits are re-sent.
-
-#[allow(unused)]
 pub(crate) struct CommitObserver {
     context: Arc<Context>,
     /// Component to deterministically collect subdags for committed leaders.
@@ -40,7 +38,6 @@ pub(crate) struct CommitObserver {
     store: Arc<dyn Store>,
 }
 
-#[allow(unused)]
 impl CommitObserver {
     pub(crate) fn new(
         context: Arc<Context>,

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -16,7 +16,6 @@ use crate::metrics::Metrics;
 
 /// Context contains per-epoch configuration and metrics shared by all components
 /// of this authority.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct Context {
     /// Index of this authority in the committee.
@@ -31,7 +30,6 @@ pub(crate) struct Context {
     pub metrics: Arc<Metrics>,
 }
 
-#[allow(dead_code)]
 impl Context {
     pub(crate) fn new(
         own_index: AuthorityIndex,
@@ -87,18 +85,6 @@ impl Context {
     #[cfg(test)]
     pub(crate) fn with_parameters(mut self, parameters: Parameters) -> Self {
         self.parameters = parameters;
-        self
-    }
-
-    #[cfg(test)]
-    pub(crate) fn with_protocol_config(mut self, protocol_config: ProtocolConfig) -> Self {
-        self.protocol_config = protocol_config;
-        self
-    }
-
-    #[cfg(test)]
-    pub(crate) fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
-        self.metrics = metrics;
         self
     }
 }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -34,7 +34,6 @@ use crate::{
 // TODO: Move to protocol config once initial value is finalized.
 const NUM_LEADERS_PER_ROUND: usize = 1;
 
-#[allow(dead_code)]
 pub(crate) struct Core {
     context: Arc<Context>,
     /// The threshold clock that is used to keep track of the current round
@@ -68,7 +67,6 @@ pub(crate) struct Core {
     store: Arc<dyn Store>,
 }
 
-#[allow(dead_code)]
 impl Core {
     pub(crate) fn new(
         context: Arc<Context>,
@@ -421,13 +419,13 @@ impl Core {
         self.last_proposed_block.round()
     }
 
+    #[cfg(test)]
     fn last_proposed_block(&self) -> &VerifiedBlock {
         &self.last_proposed_block
     }
 }
 
 /// Senders of signals from Core, for outputs and events (ex new block produced).
-#[allow(dead_code)]
 pub(crate) struct CoreSignals {
     tx_block_broadcast: broadcast::Sender<VerifiedBlock>,
     new_round_sender: watch::Sender<Round>,
@@ -437,7 +435,6 @@ impl CoreSignals {
     // TODO: move to Parameters.
     const BROADCAST_BACKLOG_CAPACITY: usize = 1000;
 
-    #[allow(dead_code)]
     pub fn new() -> (Self, CoreSignalsReceivers) {
         let (tx_block_broadcast, _rx_block_broadcast) =
             broadcast::channel::<VerifiedBlock>(Self::BROADCAST_BACKLOG_CAPACITY);
@@ -477,12 +474,10 @@ impl CoreSignals {
 /// Intentially un-clonable. Comonents should only subscribe to channels they need.
 pub(crate) struct CoreSignalsReceivers {
     tx_block_broadcast: broadcast::Sender<VerifiedBlock>,
-    #[allow(dead_code)]
     new_round_receiver: watch::Receiver<Round>,
 }
 
 impl CoreSignalsReceivers {
-    #[allow(dead_code)]
     pub(crate) fn block_broadcast_receiver(&self) -> broadcast::Receiver<VerifiedBlock> {
         self.tx_block_broadcast.subscribe()
     }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -46,14 +46,12 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError>;
 }
 
-#[allow(unused)]
 pub(crate) struct CoreThreadHandle {
     sender: metered_channel::Sender<CoreThreadCommand>,
     join_handle: thread::JoinHandle<()>,
 }
 
 impl CoreThreadHandle {
-    #[allow(unused)]
     pub fn stop(self) {
         // drop the sender, that will force all the other weak senders to not able to upgrade.
         drop(self.sender);
@@ -61,7 +59,6 @@ impl CoreThreadHandle {
     }
 }
 
-#[allow(unused)]
 struct CoreThread {
     core: Core,
     receiver: metered_channel::Receiver<CoreThreadCommand>,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 
 /// Rounds of recently committed blocks cached in memory, per authority.
-#[allow(unused)]
 const CACHED_ROUNDS: Round = 100;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
@@ -30,7 +29,6 @@ const CACHED_ROUNDS: Round = 100;
 ///
 /// Note: DagState should be wrapped with Arc<parking_lot::RwLock<_>>, to allow
 /// concurrent access from multiple components.
-#[allow(unused)]
 pub(crate) struct DagState {
     context: Arc<Context>,
 
@@ -62,7 +60,6 @@ pub(crate) struct DagState {
     store: Arc<dyn Store>,
 }
 
-#[allow(unused)]
 impl DagState {
     /// Initializes DagState from storage.
     pub(crate) fn new(context: Arc<Context>, store: Arc<dyn Store>) -> Self {
@@ -218,7 +215,7 @@ impl DagState {
         // or support reading from storage while limiting storage reads to edge cases.
 
         let mut blocks = vec![];
-        for (block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block) in self.recent_blocks.range((
             Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
             Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MAX)),
         )) {
@@ -235,7 +232,7 @@ impl DagState {
         }
 
         let mut blocks = vec![];
-        for (block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block) in self.recent_blocks.range((
             Included(BlockRef::new(round, AuthorityIndex::ZERO, BlockDigest::MIN)),
             Excluded(BlockRef::new(
                 round + 1,

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -11,7 +11,6 @@ use typed_store::TypedStoreError;
 use crate::block::{BlockRef, BlockTimestampMs, Round};
 
 /// Errors that can occur when processing blocks, reading from storage, or encountering shutdown.
-#[allow(unused)]
 #[derive(Clone, Debug, Error)]
 pub enum ConsensusError {
     #[error("Error deserializing block: {0}")]
@@ -109,7 +108,6 @@ pub enum ConsensusError {
     Shutdown,
 }
 
-#[allow(unused)]
 pub type ConsensusResult<T> = Result<T, ConsensusError>;
 
 #[macro_export]

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -18,7 +18,6 @@ pub(crate) struct LeaderSchedule {
     context: Arc<Context>,
 }
 
-#[allow(unused)]
 impl LeaderSchedule {
     pub fn new(context: Arc<Context>) -> Self {
         Self { context }

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -12,14 +12,12 @@ use crate::{
 };
 
 /// Expand a committed sequence of leader into a sequence of sub-dags.
-#[allow(unused)]
 #[derive(Clone)]
 pub(crate) struct Linearizer {
     /// In memory block store representing the dag state
     dag_state: Arc<RwLock<DagState>>,
 }
 
-#[allow(unused)]
 impl Linearizer {
     pub(crate) fn new(dag_state: Arc<RwLock<DagState>>) -> Self {
         Self { dag_state }
@@ -89,7 +87,7 @@ impl Linearizer {
         for leader_block in committed_leaders {
             // Grab latest commit state from dag state
             let dag_state = self.dag_state.read();
-            let mut last_commit_index = dag_state.last_commit_index();
+            let last_commit_index = dag_state.last_commit_index();
             let mut last_committed_rounds = dag_state.last_committed_rounds();
             drop(dag_state);
 

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -38,7 +38,6 @@ impl AnemoClient {
     const SEND_BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
     const FETCH_BLOCK_TIMEOUT: Duration = Duration::from_secs(15);
 
-    #[allow(unused)]
     pub(crate) fn new(context: Arc<Context>) -> Self {
         Self {
             context,

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -25,15 +25,11 @@ impl CommitteeThreshold for ValidityThreshold {
     }
 }
 
-#[allow(unused)]
-
 pub(crate) struct StakeAggregator<T> {
     votes: HashSet<AuthorityIndex>,
     stake: Stake,
     _phantom: PhantomData<T>,
 }
-
-#[allow(unused)]
 
 impl<T: CommitteeThreshold> StakeAggregator<T> {
     pub(crate) fn new() -> Self {

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -44,7 +44,6 @@ impl MemStore {
     }
 }
 
-#[allow(unused)]
 impl Store for MemStore {
     fn write(
         &self,

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -44,7 +44,6 @@ enum Command {
     },
 }
 
-#[allow(dead_code)]
 pub(crate) struct SynchronizerHandle {
     commands_sender: Sender<Command>,
     tasks: Mutex<JoinSet<()>>,
@@ -76,7 +75,6 @@ impl SynchronizerHandle {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,

--- a/consensus/core/src/threshold_clock.rs
+++ b/consensus/core/src/threshold_clock.rs
@@ -9,16 +9,12 @@ use crate::{
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
-#[allow(unused)]
-
 pub(crate) struct ThresholdClock {
     aggregator: StakeAggregator<QuorumThreshold>,
     round: Round,
     last_quorum_ts: Instant,
     context: Arc<Context>,
 }
-
-#[allow(unused)]
 
 impl ThresholdClock {
     pub(crate) fn new(round: Round, context: Arc<Context>) -> Self {
@@ -30,13 +26,9 @@ impl ThresholdClock {
         }
     }
 
-    pub(crate) fn last_quorum_ts(&self) -> Instant {
-        self.last_quorum_ts
-    }
-
     /// Add the block references that have been successfully processed and advance the round accordingly. If the round
     /// has indeed advanced then the new round is returned, otherwise None is returned.
-    pub(crate) fn add_blocks(&mut self, mut blocks: Vec<BlockRef>) -> Option<Round> {
+    pub(crate) fn add_blocks(&mut self, blocks: Vec<BlockRef>) -> Option<Round> {
         let previous_round = self.round;
         for block_ref in blocks {
             self.add_block(block_ref);

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -77,7 +77,6 @@ impl TransactionConsumer {
 }
 
 #[derive(Clone)]
-#[allow(dead_code)]
 pub struct TransactionClient {
     sender: metered_channel::Sender<Transaction>,
     max_transaction_size: u64,
@@ -92,7 +91,6 @@ pub enum ClientError {
     OversizedTransaction(u64, u64),
 }
 
-#[allow(dead_code)]
 impl TransactionClient {
     pub(crate) fn new(context: Arc<Context>) -> (Self, metered_channel::Receiver<Transaction>) {
         let (sender, receiver) = channel_with_total(
@@ -140,7 +138,6 @@ pub trait TransactionVerifier: Send + Sync + 'static {
     ) -> Result<(), ValidationError>;
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum ValidationError {
     #[error("Invalid transaction: {0}")]

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -25,7 +25,6 @@ mod pipelined_committer_tests;
 /// A universal committer uses a collection of committers to commit a sequence of leaders.
 /// It can be configured to use a combination of different commit strategies, including
 /// multi-leaders, backup leaders, and pipelines.
-#[allow(unused)]
 pub(crate) struct UniversalCommitter {
     /// The per-epoch configuration of this authority.
     context: Arc<Context>,
@@ -129,7 +128,6 @@ impl UniversalCommitter {
 
 /// A builder for a universal committer. By default, the builder creates a single
 /// base committer, that is, a single leader and no pipeline.
-#[allow(unused)]
 pub(crate) mod universal_committer_builder {
     use super::*;
     use crate::{
@@ -159,6 +157,7 @@ pub(crate) mod universal_committer_builder {
             }
         }
 
+        #[allow(unused)]
         pub(crate) fn with_wave_length(mut self, wave_length: Round) -> Self {
             self.wave_length = wave_length;
             self


### PR DESCRIPTION
## Description 

Non-test code should all get used now.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
