### PR TITLE
migrate sui stdlib to move 2024

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/Move.lock
+++ b/crates/sui-framework/packages/move-stdlib/Move.lock
@@ -2,10 +2,10 @@
 
 [move]
 version = 0
-manifest_digest = "3FF3771B6F639B5D249A1D55EF826B1F6D5CC7C85A69CED739AF49E6B3CAAE71"
+manifest_digest = "405BD6967F4F9F42077B12CCED7649A28B2FD4674D9B8B09669FDD0135019838"
 deps_digest = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
 
 [move.toolchain-version]
-compiler-version = "1.17.0"
+compiler-version = "1.20.0"
 edition = "legacy"
 flavor = "sui"

--- a/crates/sui-framework/packages/move-stdlib/Move.toml
+++ b/crates/sui-framework/packages/move-stdlib/Move.toml
@@ -2,6 +2,7 @@
 name = "MoveStdlib"
 version = "1.5.0"
 published-at = "0x1"
+edition = "2024.alpha"
 
 [addresses]
 std = "0x1"

--- a/crates/sui-framework/packages/move-stdlib/Move.toml
+++ b/crates/sui-framework/packages/move-stdlib/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "MoveStdlib"
-version = "1.5.0"
+version = "1.6.0"
 published-at = "0x1"
 edition = "2024.alpha"
 

--- a/crates/sui-framework/packages/move-stdlib/sources/ascii.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/ascii.move
@@ -15,12 +15,12 @@ module std::ascii {
     /// be printable. To determine if a `String` contains only "printable"
     /// characters you should use the `all_characters_printable` predicate
     /// defined in this module.
-    struct String has copy, drop, store {
+    public struct String has copy, drop, store {
         bytes: vector<u8>,
     }
 
     /// An ASCII character.
-    struct Char has copy, drop, store {
+    public struct Char has copy, drop, store {
         byte: u8,
     }
 
@@ -46,7 +46,7 @@ module std::ascii {
     /// characters. Otherwise returns `None`.
     public fun try_string(bytes: vector<u8>): Option<String> {
         let len = vector::length(&bytes);
-        let i = 0;
+        let mut i = 0;
         while (i < len) {
             let possible_byte = *vector::borrow(&bytes, i);
             if (!is_valid_char(possible_byte)) return option::none();
@@ -59,7 +59,7 @@ module std::ascii {
     /// Returns `false` otherwise. Not all `String`s are printable strings.
     public fun all_characters_printable(string: &String): bool {
         let len = vector::length(&string.bytes);
-        let i = 0;
+        let mut i = 0;
         while (i < len) {
             let byte = *vector::borrow(&string.bytes, i);
             if (!is_printable_char(byte)) return false;

--- a/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/bit_vector.move
@@ -14,7 +14,7 @@ module std::bit_vector {
     /// The maximum allowed bitvector size
     const MAX_SIZE: u64 = 1024;
 
-    struct BitVector has copy, drop, store {
+    public struct BitVector has copy, drop, store {
         length: u64,
         bit_field: vector<bool>,
     }
@@ -22,8 +22,8 @@ module std::bit_vector {
     public fun new(length: u64): BitVector {
         assert!(length > 0, ELENGTH);
         assert!(length < MAX_SIZE, ELENGTH);
-        let counter = 0;
-        let bit_field = vector::empty();
+        let mut counter = 0;
+        let mut bit_field = vector::empty();
         while (counter < length) {
             vector::push_back(&mut bit_field, false);
             counter = counter + 1;
@@ -54,14 +54,14 @@ module std::bit_vector {
     public fun shift_left(bitvector: &mut BitVector, amount: u64) {
         if (amount >= bitvector.length) {
            let len = vector::length(&bitvector.bit_field);
-           let i = 0;
+           let mut i = 0;
            while (i < len) {
                let elem = vector::borrow_mut(&mut bitvector.bit_field, i);
                *elem = false;
                i = i + 1;
            };
         } else {
-            let i = amount;
+            let mut i = amount;
 
             while (i < bitvector.length) {
                 if (is_index_set(bitvector, i)) set(bitvector, i - amount)
@@ -95,7 +95,7 @@ module std::bit_vector {
     /// sequence, then `0` is returned.
     public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
         assert!(start_index < bitvector.length, EINDEX);
-        let index = start_index;
+        let mut index = start_index;
 
         // Find the greatest index in the vector such that all indices less than it are set.
         while (index < bitvector.length) {

--- a/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
@@ -15,7 +15,7 @@ module std::fixed_point32 {
     /// floating-point has less than 16 decimal digits of precision, so
     /// be careful about using floating-point to convert these values to
     /// decimal.
-    struct FixedPoint32 has copy, drop, store { value: u64 }
+    public struct FixedPoint32 has copy, drop, store { value: u64 }
 
     ///> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
     const MAX_U64: u128 = 18446744073709551615;

--- a/crates/sui-framework/packages/move-stdlib/sources/option.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/option.move
@@ -7,7 +7,7 @@ module std::option {
 
     /// Abstraction of a value that may or may not be present. Implemented with a vector of size
     /// zero or one because Move bytecode does not have ADTs.
-    struct Option<Element> has copy, drop, store {
+    public struct Option<Element> has copy, drop, store {
         vec: vector<Element>
     }
 
@@ -115,7 +115,7 @@ module std::option {
 
     /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
     public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
-        let Option { vec } = t;
+        let Option { mut vec } = t;
         if (vector::is_empty(&vec)) default
         else vector::pop_back(&mut vec)
     }
@@ -124,7 +124,7 @@ module std::option {
     /// Aborts if `t` does not hold a value
     public fun destroy_some<Element>(t: Option<Element>): Element {
         assert!(is_some(&t), EOPTION_NOT_SET);
-        let Option { vec } = t;
+        let Option { mut vec } = t;
         let elem = vector::pop_back(&mut vec);
         vector::destroy_empty(vec);
         elem

--- a/crates/sui-framework/packages/move-stdlib/sources/string.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/string.move
@@ -14,7 +14,7 @@ module std::string {
     const EINVALID_INDEX: u64 = 2;
 
     /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
-    struct String has copy, drop, store {
+    public struct String has copy, drop, store {
         bytes: vector<u8>,
     }
 
@@ -76,7 +76,7 @@ module std::string {
         let bytes = &s.bytes;
         assert!(at <= vector::length(bytes) && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
         let l = length(s);
-        let front = sub_string(s, 0, at);
+        let mut front = sub_string(s, 0, at);
         let end = sub_string(s, at, l);
         append(&mut front, o);
         append(&mut front, end);

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -27,7 +27,7 @@ module std::type_name {
     /// The type is not from a package/module. It is a primitive type.
     const ENonModuleType: u64 = 0;
 
-    struct TypeName has copy, drop, store {
+    public struct TypeName has copy, drop, store {
         /// String representation of the type. All types are represented
         /// using their source syntax:
         /// "u8", "u64", "bool", "address", "vector", and so on for primitive types.
@@ -86,8 +86,8 @@ module std::type_name {
         // Base16 (string) representation of an address has 2 symbols per byte.
         let len = address::length() * 2;
         let str_bytes = ascii::as_bytes(&self.name);
-        let addr_bytes = vector[];
-        let i = 0;
+        let mut addr_bytes = vector[];
+        let mut i = 0;
 
         // Read `len` bytes from the type name and push them to addr_bytes.
         while (i < len) {
@@ -107,9 +107,9 @@ module std::type_name {
         assert!(!is_primitive(self), ENonModuleType);
 
         // Starts after address and a double colon: `<addr as HEX>::`
-        let i = address::length() * 2 + 2;
+        let mut i = address::length() * 2 + 2;
         let str_bytes = ascii::as_bytes(&self.name);
-        let module_name = vector[];
+        let mut module_name = vector[];
 
         loop {
             let char = vector::borrow(str_bytes, i);

--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -11,9 +11,9 @@ module std::ascii_tests {
 
     #[test]
     fun test_ascii_chars() {
-        let i = 0;
+        let mut i = 0;
         let end = 128;
-        let vec = vector::empty();
+        let mut vec = vector::empty();
 
         while (i < end) {
             assert!(ascii::is_valid_char(i), 0);
@@ -29,9 +29,9 @@ module std::ascii_tests {
 
     #[test]
     fun test_ascii_push_chars() {
-        let i = 0;
+        let mut i = 0;
         let end = 128;
-        let str = ascii::string(vector::empty());
+        let mut str = ascii::string(vector::empty());
 
         while (i < end) {
             ascii::push_char(&mut str, ascii::char(i));
@@ -45,9 +45,9 @@ module std::ascii_tests {
 
     #[test]
     fun test_ascii_push_char_pop_char() {
-        let i = 0;
+        let mut i = 0;
         let end = 128;
-        let str = ascii::string(vector::empty());
+        let mut str = ascii::string(vector::empty());
 
         while (i < end) {
             ascii::push_char(&mut str, ascii::char(i));
@@ -67,9 +67,9 @@ module std::ascii_tests {
 
     #[test]
     fun test_printable_chars() {
-        let i = 0x20;
+        let mut i = 0x20;
         let end = 0x7E;
-        let vec = vector::empty();
+        let mut vec = vector::empty();
 
         while (i <= end) {
             assert!(ascii::is_printable_char(i), 0);
@@ -95,7 +95,7 @@ module std::ascii_tests {
 
     #[test]
     fun test_invalid_ascii_characters() {
-        let i = 128u8;
+        let mut i = 128u8;
         let end = 255u8;
         while (i < end) {
             let try_str = ascii::try_string(vector::singleton(i));
@@ -106,7 +106,7 @@ module std::ascii_tests {
 
     #[test]
     fun test_nonvisible_chars() {
-        let i = 0;
+        let mut i = 0;
         let end = 0x09;
         while (i < end) {
             let str = ascii::string(vector::singleton(i));
@@ -114,7 +114,7 @@ module std::ascii_tests {
             i = i + 1;
         };
 
-        let i = 0x0B;
+        let mut i = 0x0B;
         let end = 0x0F;
         while (i <= end) {
             let str = ascii::string(vector::singleton(i));

--- a/crates/sui-framework/packages/move-stdlib/tests/bcs_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bcs_tests.move
@@ -7,13 +7,13 @@
 module std::bcs_tests {
     use std::bcs;
 
-    struct Box<T> has copy, drop, store { x: T }
-    struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
-    struct Box7<T> has copy, drop, store { x: Box3<Box3<T>> }
-    struct Box15<T> has copy, drop, store { x: Box7<Box7<T>> }
-    struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
-    struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
-    struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
+    public struct Box<T> has copy, drop, store { x: T }
+    public struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
+    public struct Box7<T> has copy, drop, store { x: Box3<Box3<T>> }
+    public struct Box15<T> has copy, drop, store { x: Box7<Box7<T>> }
+    public struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
+    public struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
+    public struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
 
     #[test]
     fun bcs_address() {

--- a/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
@@ -9,13 +9,13 @@ module std::bit_vector_tests {
 
     #[test_only]
     fun test_bitvector_set_unset_of_size(k: u64) {
-        let bitvector = bit_vector::new(k);
-        let index = 0;
+        let mut bitvector = bit_vector::new(k);
+        let mut index = 0;
         while (index < k) {
             bit_vector::set(&mut bitvector, index);
             assert!(bit_vector::is_index_set(&bitvector, index), 0);
             index = index + 1;
-            let index_to_right = index;
+            let mut index_to_right = index;
             while (index_to_right < k) {
                 assert!(!bit_vector::is_index_set(&bitvector, index_to_right), 1);
                 index_to_right = index_to_right + 1;
@@ -28,7 +28,7 @@ module std::bit_vector_tests {
             bit_vector::unset(&mut bitvector, index);
             assert!(!bit_vector::is_index_set(&bitvector, index), 0);
             index = index + 1;
-            let index_to_right = index;
+            let mut index_to_right = index;
             while (index_to_right < k) {
                 assert!(bit_vector::is_index_set(&bitvector, index_to_right), 1);
                 index_to_right = index_to_right + 1;
@@ -39,21 +39,21 @@ module std::bit_vector_tests {
     #[test]
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun set_bit_out_of_bounds() {
-        let bitvector = bit_vector::new(bit_vector::word_size());
+        let mut bitvector = bit_vector::new(bit_vector::word_size());
         bit_vector::set(&mut bitvector, bit_vector::word_size());
     }
 
     #[test]
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun unset_bit_out_of_bounds() {
-        let bitvector = bit_vector::new(bit_vector::word_size());
+        let mut bitvector = bit_vector::new(bit_vector::word_size());
         bit_vector::unset(&mut bitvector, bit_vector::word_size());
     }
 
     #[test]
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun index_bit_out_of_bounds() {
-        let bitvector = bit_vector::new(bit_vector::word_size());
+        let mut bitvector = bit_vector::new(bit_vector::word_size());
         bit_vector::is_index_set(&mut bitvector, bit_vector::word_size());
     }
 
@@ -75,7 +75,7 @@ module std::bit_vector_tests {
 
     #[test]
     fun longest_sequence_one_set_zero_index() {
-        let bitvector = bit_vector::new(100);
+        let mut bitvector = bit_vector::new(100);
         bit_vector::set(&mut bitvector, 1);
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 0, 0);
     }
@@ -88,7 +88,7 @@ module std::bit_vector_tests {
 
     #[test]
     fun longest_sequence_two_set_nonzero_index() {
-        let bitvector = bit_vector::new(100);
+        let mut bitvector = bit_vector::new(100);
         bit_vector::set(&mut bitvector, 50);
         bit_vector::set(&mut bitvector, 52);
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 51) == 0, 0);
@@ -96,8 +96,8 @@ module std::bit_vector_tests {
 
     #[test]
     fun longest_sequence_with_break() {
-        let bitvector = bit_vector::new(100);
-        let i = 0;
+        let mut bitvector = bit_vector::new(100);
+        let mut i = 0;
         while (i < 20) {
             bit_vector::set(&mut bitvector, i);
             i = i + 1;
@@ -116,9 +116,9 @@ module std::bit_vector_tests {
     #[test]
     fun test_shift_left() {
         let bitlen = 97;
-        let bitvector = bit_vector::new(bitlen);
+        let mut bitvector = bit_vector::new(bitlen);
 
-        let i = 0;
+        let mut i = 0;
         while (i < bitlen) {
             bit_vector::set(&mut bitvector, i);
             i = i + 1;
@@ -137,7 +137,7 @@ module std::bit_vector_tests {
     fun test_shift_left_specific_amount() {
         let bitlen = 300;
         let shift_amount = 133;
-        let bitvector = bit_vector::new(bitlen);
+        let mut bitvector = bit_vector::new(bitlen);
 
         bit_vector::set(&mut bitvector, 201);
         assert!(bit_vector::is_index_set(&bitvector, 201), 0);
@@ -149,7 +149,7 @@ module std::bit_vector_tests {
         // Make sure this shift clears all the bits
         bit_vector::shift_left(&mut bitvector, bitlen  - 1);
 
-        let i = 0;
+        let mut i = 0;
         while (i < bitlen) {
             assert!(!bit_vector::is_index_set(&bitvector, i), 3);
             i = i + 1;
@@ -161,9 +161,9 @@ module std::bit_vector_tests {
         let bitlen = 50;
         let chosen_index = 24;
         let shift_amount = 3;
-        let bitvector = bit_vector::new(bitlen);
+        let mut bitvector = bit_vector::new(bitlen);
 
-        let i = 0;
+        let mut i = 0;
 
         while (i < bitlen) {
             bit_vector::set(&mut bitvector, i);
@@ -191,9 +191,9 @@ module std::bit_vector_tests {
     #[test]
     fun shift_left_at_size() {
         let bitlen = 133;
-        let bitvector = bit_vector::new(bitlen);
+        let mut bitvector = bit_vector::new(bitlen);
 
-        let i = 0;
+        let mut i = 0;
         while (i < bitlen) {
             bit_vector::set(&mut bitvector, i);
             i = i + 1;
@@ -210,7 +210,7 @@ module std::bit_vector_tests {
     #[test]
     fun shift_left_more_than_size() {
         let bitlen = 133;
-        let bitvector = bit_vector::new(bitlen);
+        let mut bitvector = bit_vector::new(bitlen);
         bit_vector::shift_left(&mut bitvector, bitlen);
     }
 

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -49,7 +49,7 @@ module std::option_tests {
 
     #[test]
     fun borrow_mut_some() {
-        let some = option::some(1);
+        let mut some = option::some(1);
         let ref = option::borrow_mut(&mut some);
         *ref = 10;
         assert!(*option::borrow(&some) == 10, 0);
@@ -79,7 +79,7 @@ module std::option_tests {
 
     #[test]
     fun extract_some() {
-        let opt = option::some(1);
+        let mut opt = option::some(1);
         assert!(option::extract(&mut opt) == 1, 0);
         assert!(option::is_none(&opt), 1);
     }
@@ -92,21 +92,21 @@ module std::option_tests {
 
     #[test]
     fun swap_some() {
-        let some = option::some(5);
+        let mut some = option::some(5);
         assert!(option::swap(&mut some, 1) == 5, 0);
         assert!(*option::borrow(&some) == 1, 1);
     }
 
     #[test]
     fun swap_or_fill_some() {
-        let some = option::some(5);
+        let mut some = option::some(5);
         assert!(option::swap_or_fill(&mut some, 1) == option::some(5), 0);
         assert!(*option::borrow(&some) == 1, 1);
     }
 
     #[test]
     fun swap_or_fill_none() {
-        let none = option::none();
+        let mut none = option::none();
         assert!(option::swap_or_fill(&mut none, 1) == option::none(), 0);
         assert!(*option::borrow(&none) == 1, 1);
     }
@@ -119,7 +119,7 @@ module std::option_tests {
 
     #[test]
     fun fill_none() {
-        let none = option::none<u64>();
+        let mut none = option::none<u64>();
         option::fill(&mut none, 3);
         assert!(option::is_some(&none), 0);
         assert!(*option::borrow(&none) == 3, 1);
@@ -161,7 +161,7 @@ module std::option_tests {
 
     #[test]
     fun into_vec_some() {
-        let v = option::to_vec(option::some<u64>(0));
+        let mut v = option::to_vec(option::some<u64>(0));
         assert!(vector::length(&v) == 1, 0);
         let x = vector::pop_back(&mut v);
         assert!(x == 0, 1);

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -69,14 +69,14 @@ module std::string_tests {
 
     #[test]
     fun test_append() {
-        let s = string::utf8(b"abcd");
+        let mut s = string::utf8(b"abcd");
         string::append(&mut s, string::utf8(b"ef"));
         assert!(s == string::utf8(b"abcdef"), 22)
     }
 
     #[test]
     fun test_insert() {
-        let s = string::utf8(b"abcd");
+        let mut s = string::utf8(b"abcd");
         string::insert(&mut s, 1, string::utf8(b"xy"));
         assert!(s == string::utf8(b"axybcd"), 22)
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/type_name_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/type_name_tests.move
@@ -10,11 +10,11 @@ module 0xA::type_name_tests {
     #[test_only]
     use std::ascii::string;
 
-    struct TestStruct {}
+    public struct TestStruct {}
 
-    struct TestGenerics<phantom T> { }
+    public struct TestGenerics<phantom T> { }
 
-    struct TestMultiGenerics<phantom T1, phantom T2, phantom T3> { }
+    public struct TestMultiGenerics<phantom T1, phantom T2, phantom T3> { }
 
     #[test]
     fun test_primitive_types() {

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -7,9 +7,9 @@
 module std::vector_tests {
     use std::vector as V;
 
-    struct R has store { }
-    struct Droppable has drop {}
-    struct NotDroppable {}
+    public struct R has store { }
+    public struct Droppable has drop {}
+    public struct NotDroppable {}
 
     #[test]
     fun test_singleton_contains() {
@@ -32,7 +32,7 @@ module std::vector_tests {
 
     #[test]
     fun append_empties_is_empty() {
-        let v1 = V::empty<u64>();
+        let mut v1 = V::empty<u64>();
         let v2 = V::empty<u64>();
         V::append(&mut v1, v2);
         assert!(V::is_empty(&v1), 0);
@@ -40,8 +40,8 @@ module std::vector_tests {
 
     #[test]
     fun append_respects_order_empty_lhs() {
-        let v1 = V::empty();
-        let v2 = V::empty();
+        let mut v1 = V::empty();
+        let mut v2 = V::empty();
         V::push_back(&mut v2, 0);
         V::push_back(&mut v2, 1);
         V::push_back(&mut v2, 2);
@@ -57,7 +57,7 @@ module std::vector_tests {
 
     #[test]
     fun append_respects_order_empty_rhs() {
-        let v1 = V::empty();
+        let mut v1 = V::empty();
         let v2 = V::empty();
         V::push_back(&mut v1, 0);
         V::push_back(&mut v1, 1);
@@ -74,8 +74,8 @@ module std::vector_tests {
 
     #[test]
     fun append_respects_order_nonempty_rhs_lhs() {
-        let v1 = V::empty();
-        let v2 = V::empty();
+        let mut v1 = V::empty();
+        let mut v2 = V::empty();
         V::push_back(&mut v1, 0);
         V::push_back(&mut v1, 1);
         V::push_back(&mut v1, 2);
@@ -87,7 +87,7 @@ module std::vector_tests {
         V::append(&mut v1, v2);
         assert!(!V::is_empty(&v1), 0);
         assert!(V::length(&v1) == 8, 1);
-        let i = 0;
+        let mut i = 0;
         while (i < 8) {
             assert!(*V::borrow(&v1, i) == i, i);
             i = i + 1;
@@ -97,14 +97,14 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun borrow_out_of_range() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 7);
         V::borrow(&v, 1);
     }
 
     #[test]
     fun vector_contains() {
-        let vec = V::empty();
+        let mut vec = V::empty();
         assert!(!V::contains(&vec, &0), 1);
 
         V::push_back(&mut vec, 0);
@@ -131,7 +131,7 @@ module std::vector_tests {
 
     #[test]
     fun destroy_empty_with_pops() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 42);
         V::pop_back(&mut v);
         V::destroy_empty(v);
@@ -140,14 +140,14 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 3, location = Self)]
     fun destroy_non_empty() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 42);
         V::destroy_empty(v);
     }
 
     #[test]
     fun get_set_work() {
-        let vec = V::empty();
+        let mut vec = V::empty();
         V::push_back(&mut vec, 0);
         V::push_back(&mut vec, 1);
         assert!(*V::borrow(&vec, 1) == 1, 0);
@@ -161,13 +161,13 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 2, location = Self)]
     fun pop_out_of_range() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::pop_back(&mut v);
     }
 
     #[test]
     fun swap_different_indices() {
-        let vec = V::empty();
+        let mut vec = V::empty();
         V::push_back(&mut vec, 0);
         V::push_back(&mut vec, 1);
         V::push_back(&mut vec, 2);
@@ -182,7 +182,7 @@ module std::vector_tests {
 
     #[test]
     fun swap_same_index() {
-        let vec = V::empty();
+        let mut vec = V::empty();
         V::push_back(&mut vec, 0);
         V::push_back(&mut vec, 1);
         V::push_back(&mut vec, 2);
@@ -196,7 +196,7 @@ module std::vector_tests {
 
     #[test]
     fun remove_singleton_vector() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         assert!(V::remove(&mut v, 0) == 0, 0);
         assert!(V::length(&v) == 0, 0);
@@ -204,7 +204,7 @@ module std::vector_tests {
 
     #[test]
     fun remove_nonsingleton_vector() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -219,7 +219,7 @@ module std::vector_tests {
 
     #[test]
     fun remove_nonsingleton_vector_last_elem() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -235,21 +235,21 @@ module std::vector_tests {
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun remove_empty_vector() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::remove(&mut v, 0);
     }
 
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun remove_out_of_bound_index() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::push_back(&mut v, 0);
         V::remove(&mut v, 1);
     }
 
     #[test]
     fun reverse_vector_empty() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         let is_empty = V::is_empty(&v);
         V::reverse(&mut v);
         assert!(is_empty == V::is_empty(&v), 0);
@@ -257,7 +257,7 @@ module std::vector_tests {
 
     #[test]
     fun reverse_singleton_vector() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         assert!(*V::borrow(&v, 0) == 0, 1);
         V::reverse(&mut v);
@@ -266,7 +266,7 @@ module std::vector_tests {
 
     #[test]
     fun reverse_vector_nonempty_even_length() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -287,7 +287,7 @@ module std::vector_tests {
 
     #[test]
     fun reverse_vector_nonempty_odd_length_non_singleton() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -306,14 +306,14 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun swap_empty() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::swap(&mut v, 0, 0);
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun swap_out_of_range() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
 
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
@@ -326,13 +326,13 @@ module std::vector_tests {
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun swap_remove_empty() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::swap_remove(&mut v, 0);
     }
 
     #[test]
     fun swap_remove_singleton() {
-        let v = V::empty<u64>();
+        let mut v = V::empty<u64>();
         V::push_back(&mut v, 0);
         assert!(V::swap_remove(&mut v, 0) == 0, 0);
         assert!(V::is_empty(&v), 1);
@@ -340,7 +340,7 @@ module std::vector_tests {
 
     #[test]
     fun swap_remove_inside_vector() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -362,7 +362,7 @@ module std::vector_tests {
 
     #[test]
     fun swap_remove_end_of_vector() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::push_back(&mut v, 1);
         V::push_back(&mut v, 2);
@@ -384,14 +384,14 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = std::vector)]
     fun swap_remove_out_of_range() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 0);
         V::swap_remove(&mut v, 1);
     }
 
     #[test]
     fun push_back_and_borrow() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, 7);
         assert!(!V::is_empty(&v), 0);
         assert!(V::length(&v) == 1, 1);
@@ -413,7 +413,7 @@ module std::vector_tests {
 
     #[test]
     fun index_of_nonempty_not_has() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, false);
         let (has, index) = V::index_of(&v, &true);
         assert!(!has, 0);
@@ -422,7 +422,7 @@ module std::vector_tests {
 
     #[test]
     fun index_of_nonempty_has() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, false);
         V::push_back(&mut v, true);
         let (has, index) = V::index_of(&v, &true);
@@ -433,7 +433,7 @@ module std::vector_tests {
     // index_of will return the index first occurence that is equal
     #[test]
     fun index_of_nonempty_has_multiple_occurences() {
-        let v = V::empty();
+        let mut v = V::empty();
         V::push_back(&mut v, false);
         V::push_back(&mut v, true);
         V::push_back(&mut v, true);
@@ -444,9 +444,9 @@ module std::vector_tests {
 
     #[test]
     fun length() {
-        let empty = V::empty();
+        let mut empty = V::empty();
         assert!(V::length(&empty) == 0, 0);
-        let i = 0;
+        let mut i = 0;
         let max_len = 42;
         while (i < max_len) {
             V::push_back(&mut empty, i);
@@ -457,8 +457,8 @@ module std::vector_tests {
 
     #[test]
     fun pop_push_back() {
-        let v = V::empty();
-        let i = 0;
+        let mut v = V::empty();
+        let mut i = 0;
         let max_len = 42;
 
         while (i < max_len) {
@@ -473,8 +473,8 @@ module std::vector_tests {
     }
 
     #[test_only]
-    fun test_natives_with_type<T>(x1: T, x2: T): (T, T) {
-        let v = V::empty();
+    fun test_natives_with_type<T>(mut x1: T, mut x2: T): (T, T) {
+        let mut v = V::empty();
         assert!(V::length(&v) == 0, 0);
         V::push_back(&mut v, x1);
         assert!(V::length(&v) == 1, 1);
@@ -511,26 +511,26 @@ module std::vector_tests {
 
     #[test]
     fun test_insert() {
-        let v = vector[7];
+        let mut v = vector[7];
         V::insert(&mut v, 6, 0);
         assert!(v == vector[6, 7], 0);
 
-        let v = vector[7, 9];
+        let mut v = vector[7, 9];
         V::insert(&mut v, 8, 1);
         assert!(v == vector[7, 8, 9], 0);
 
-        let v = vector[6, 7];
+        let mut v = vector[6, 7];
         V::insert(&mut v, 5, 0);
         assert!(v == vector[5, 6, 7], 0);
 
-        let v = vector[5, 6, 8];
+        let mut v = vector[5, 6, 8];
         V::insert(&mut v, 7, 2);
         assert!(v == vector[5, 6, 7, 8], 0);
     }
 
     #[test]
     fun insert_at_end() {
-        let v = vector[];
+        let mut v = vector[];
         V::insert(&mut v, 6, 0);
         assert!(v == vector[6], 0);
 
@@ -541,14 +541,14 @@ module std::vector_tests {
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun insert_out_of_range() {
-        let v = vector[7];
+        let mut v = vector[7];
         V::insert(&mut v, 6, 2);
     }
 
     #[test]
     fun size_limit_ok() {
-        let v = V::empty();
-        let i = 0;
+        let mut v = V::empty();
+        let mut i = 0;
         // Limit is currently 1024 * 54
         let max_len = 1024 * 53;
 
@@ -561,8 +561,8 @@ module std::vector_tests {
     #[test]
     #[expected_failure(out_of_gas, location = Self)]
     fun size_limit_fail() {
-        let v = V::empty();
-        let i = 0;
+        let mut v = V::empty();
+        let mut i = 0;
         // Choose value beyond limit
         let max_len = 1024 * 1024;
 


### PR DESCRIPTION
## Description 

This converts move-stdlib to use `2024.alpha` via the mgiration script. 

## Test Plan 

All tests should still work as expected.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
