### PR TITLE
[sui-proxy] switch config.inventory_hostname to an env var

### DIFF
--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -12,7 +12,6 @@ use tracing::debug;
 #[serde(rename_all = "kebab-case")]
 pub struct ProxyConfig {
     pub network: String,
-    pub inventory_hostname: String,
     pub listen_address: SocketAddr,
     pub remote_write: RemoteWriteConfig,
     pub dynamic_peers: DynamicPeerValidationConfig,

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -1,5 +1,4 @@
 network: joenet
-inventory-hostname: joenet-local
 listen-address: 127.0.0.1:8080
 remote-write:
   url: http://unittest.abcd.io/api/v1/push

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use anyhow::Result;
 use clap::Parser;
+use std::env;
 use sui_proxy::config::ProxyConfig;
 use sui_proxy::{
     admin::{
@@ -102,7 +102,8 @@ async fn main() -> Result<()> {
     let app = app(
         Labels {
             network: config.network,
-            inventory_hostname: config.inventory_hostname,
+            inventory_hostname: env::var("INVENTORY_HOSTNAME")
+                .expect("INVENTORY_HOSTNAME not found in environment"),
         },
         client,
         histogram_relay,


### PR DESCRIPTION
## Description 
needed for gke to convey the "hostname info" that sui-proxy runs on

## Test Plan 
missing var:
![image](https://github.com/MystenLabs/sui/assets/123987499/68af8f90-4439-441f-b432-5be6eb48bfa9)

with var:
![image](https://github.com/MystenLabs/sui/assets/123987499/f915c0d4-50b2-416d-ba1d-9aba3ee9863b)

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
