### PR TITLE
[Cherry-pick] Add query logging when timing out (#16455) - cherry pick into graphql release

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -13,6 +13,7 @@ pub(crate) mod code {
     pub const BAD_REQUEST: &str = "BAD_REQUEST";
     pub const BAD_USER_INPUT: &str = "BAD_USER_INPUT";
     pub const INTERNAL_SERVER_ERROR: &str = "INTERNAL_SERVER_ERROR";
+    pub const REQUEST_TIMEOUT: &str = "REQUEST_TIMEOUT";
     pub const UNKNOWN: &str = "UNKNOWN";
 }
 

--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -2,35 +2,75 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::{
-    extensions::{Extension, ExtensionContext, ExtensionFactory, NextRequest},
-    Response, ServerError,
+    extensions::{Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery},
+    parser::types::ExecutableDocument,
+    Response, ServerError, ServerResult,
 };
-use std::sync::Arc;
+use async_graphql_value::Variables;
+use std::sync::Mutex;
 use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::time::timeout;
+use tracing::error;
+use uuid::Uuid;
 
-use crate::config::ServiceConfig;
+use crate::{config::ServiceConfig, error::code};
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct Timeout;
+#[derive(Debug, Default)]
+pub(crate) struct Timeout {
+    pub query: Mutex<Option<String>>,
+}
 
 impl ExtensionFactory for Timeout {
     fn create(&self) -> Arc<dyn Extension> {
-        Arc::new(Timeout)
+        Arc::new(Timeout {
+            query: Mutex::new(None),
+        })
     }
 }
 
 #[async_trait::async_trait]
 impl Extension for Timeout {
-    async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
+    async fn parse_query(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        query: &str,
+        variables: &Variables,
+        next: NextParseQuery<'_>,
+    ) -> ServerResult<ExecutableDocument> {
+        let document = next.run(ctx, query, variables).await?;
+        *self.query.lock().unwrap() = Some(ctx.stringify_execute_doc(&document, variables));
+        Ok(document)
+    }
+
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> Response {
         let cfg = ctx
             .data::<ServiceConfig>()
             .expect("No service config provided in schema data");
         let request_timeout = Duration::from_millis(cfg.limits.request_timeout_ms);
-
-        timeout(request_timeout, next.run(ctx))
+        timeout(request_timeout, next.run(ctx, operation_name))
             .await
             .unwrap_or_else(|_| {
+                let query_id: &Uuid = ctx.data_unchecked();
+                let session_id: &SocketAddr = ctx.data_unchecked();
+                let error_code = code::REQUEST_TIMEOUT;
+                let guard = self.query.lock().unwrap();
+                let query = match guard.as_ref() {
+                    Some(s) => s.as_str(),
+                    None => "",
+                };
+
+                error!(
+                    %query_id,
+                    %session_id,
+                    %error_code,
+                    %query
+                );
                 Response::from_errors(vec![ServerError::new(
                     format!(
                         "Request timed out. Limit: {}s",

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -317,7 +317,7 @@ impl ServerBuilder {
             builder = builder.extension(QueryLimitsChecker::default());
         }
         if config.internal_features.query_timeout {
-            builder = builder.extension(Timeout);
+            builder = builder.extension(Timeout::default());
         }
         if config.internal_features.tracing {
             builder = builder.extension(Tracing);
@@ -551,10 +551,10 @@ pub mod tests {
                 .context_data(cfg)
                 .context_data(query_id())
                 .context_data(ip_address())
+                .extension(Timeout::default())
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
                 })
-                .extension(Timeout)
                 .build_schema();
 
             schema.execute("{ chainIdentifier }").await


### PR DESCRIPTION
## Description 

This PR enables logging of queries that time out. The logging uses the `error` macro together with a new error code, `REQUEST_TIMEOUT`.

Note, that the timeout extension logic was switched to use `parse_query`
and `execute` instead of `request`. Execute one takes care of the timeout, parse query takes care of stringifying up the query (including resolving any passed variables, fragments, etc).

## Test Plan 

Existing tests, manually checking for errors when setting a small (500ms) timeout.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Enabled logging of queries that time out.