### PR TITLE
[cli] Fix panic when no arg is given in client ptb

### DIFF
--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -54,6 +54,10 @@ pub struct Summary {
 impl PTB {
     /// Parses and executes the PTB with the sender as the current active address
     pub async fn execute(self, context: &mut WalletContext) -> Result<(), Error> {
+        if self.args.is_empty() {
+            ptb_description().print_help().unwrap();
+            return Ok(());
+        }
         let source_string = to_source_string(self.args.clone());
 
         // Tokenize once to detect help flags


### PR DESCRIPTION
## Description 

This PR fixes the edge case of not providing any arguments when calling `sui client ptb`, which currently panics.


## Test Plan 

`sui client ptb` | `sui client ptb --` 

**Before**
```
~ % sui client ptb
2024-03-01T04:48:11.873626Z ERROR telemetry_subscribers: panicked at crates/sui/src/client_ptb/error.rs:180:34:
attempt to subtract with overflow panic.file="crates/sui/src/client_ptb/error.rs" panic.line=180 panic.column=34
thread 'main' panicked at crates/sui/src/client_ptb/error.rs:180:34:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**After**
```
~ % sui client ptb
Build, preview, and execute programmable transaction blocks. Depending on your shell, you might have to use quotes around arrays or other passed values. Use --help to see examples for how to use
the core functionality of this command.
[...]
```
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The `sui client ptb` will now show the help menu, if no args are passed.