### PR TITLE
[client-ptb] Properly handle mutability around shared objects by value

### DIFF
--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -447,7 +447,8 @@ impl<'a> PTBBuilder<'a> {
         // Otherwise it's ambiguous what the value should be, and we need to turn to the signature
         // to determine it.
         let mut is_receiving = false;
-        let mut is_mutable = false;
+        // A value is mutable by default.
+        let mut is_mutable = true;
 
         // traverse the types in the signature to see if the argument is an object argument or not,
         // and also determine if it's a receiving argument or not.
@@ -461,7 +462,11 @@ impl<'a> PTBBuilder<'a> {
                         error!(loc, "Not enough type parameters supplied for Move call");
                     }
                 }
+                SignatureToken::Reference(_) => {
+                    is_mutable = false;
+                }
                 SignatureToken::MutableReference(_) => {
+                    // Not strictly needed, but for clarity
                     is_mutable = true;
                 }
                 SignatureToken::Bool
@@ -473,8 +478,9 @@ impl<'a> PTBBuilder<'a> {
                 | SignatureToken::Vector(_)
                 | SignatureToken::U16
                 | SignatureToken::U32
-                | SignatureToken::U256
-                | SignatureToken::Reference(_) => {}
+                | SignatureToken::U256 => {
+                    is_mutable = false;
+                }
             }
         }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -295,6 +295,22 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         .execute(context)
         .await?;
 
+    let delete_object_ptb_string = format!(
+        r#"
+         --assign p @{package_id_str}
+         --assign s @{shared_id_str}
+         # Use the shared object by immutable reference first
+         --move-call "p::test_module::use_immut" s 
+         --move-call "p::test_module::delete_shared_object" s
+         --gas-budget 100000000
+        "#
+    );
+
+    let args = shlex::split(&delete_object_ptb_string).unwrap();
+    sui::client_ptb::ptb::PTB { args: args.clone() }
+        .execute(context)
+        .await?;
+
     Ok(())
 }
 

--- a/crates/sui/tests/data/ptb_complex_args_test_functions/sources/test_module.move
+++ b/crates/sui/tests/data/ptb_complex_args_test_functions/sources/test_module.move
@@ -31,4 +31,9 @@ module test_functions::test_module {
     public fun use_utf8_string(_: US) {
         // do nothing
     }
+
+    public fun delete_shared_object(shared: Shared) {
+        let Shared { id } = shared;
+        object::delete(id);
+    }
 }


### PR DESCRIPTION
## Description 

Update the PTB builder to properly handle shared objects that are taken by value.

## Test Plan 

Added a test for this case.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
