### PR TITLE
[easy] fix package path in test to be local

### DIFF
--- a/crates/sui/tests/data/ptb_complex_args_test_functions/Move.toml
+++ b/crates/sui/tests/data/ptb_complex_args_test_functions/Move.toml
@@ -2,7 +2,7 @@
 name = "test_functions"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
 
 [addresses]
 test_functions = "0x0"


### PR DESCRIPTION
## Description 

Fix the package path in the package to refer to the local sui-framework and not a network.

## Test Plan 

Existing tests/CI

