### PR TITLE
[bridge 58/n] handle eth message conversion and transaction builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11897,6 +11897,7 @@ dependencies = [
  "bcs",
  "clap",
  "const-str",
+ "enum_dispatch",
  "ethers",
  "eyre",
  "fastcrypto",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -48,6 +48,7 @@ shared-crypto.workspace = true
 backoff = { version = "0.4.0", features = [
   "futures",
 ] }
+enum_dispatch.workspace = true
 sui-json-rpc-api.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-bridge/src/encoding.rs
+++ b/crates/sui-bridge/src/encoding.rs
@@ -1,0 +1,809 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::AssetPriceUpdateAction;
+use crate::types::BlocklistCommitteeAction;
+use crate::types::BridgeAction;
+use crate::types::BridgeActionType;
+use crate::types::EmergencyAction;
+use crate::types::EthToSuiBridgeAction;
+use crate::types::EvmContractUpgradeAction;
+use crate::types::LimitUpdateAction;
+use crate::types::SuiToEthBridgeAction;
+use enum_dispatch::enum_dispatch;
+use ethers::types::Address as EthAddress;
+use sui_types::base_types::SUI_ADDRESS_LENGTH;
+
+pub const TOKEN_TRANSFER_MESSAGE_VERSION: u8 = 1;
+pub const COMMITTEE_BLOCKLIST_MESSAGE_VERSION: u8 = 1;
+pub const EMERGENCY_BUTTON_MESSAGE_VERSION: u8 = 1;
+pub const LIMIT_UPDATE_MESSAGE_VERSION: u8 = 1;
+pub const ASSET_PRICE_UPDATE_MESSAGE_VERSION: u8 = 1;
+pub const EVM_CONTRACT_UPGRADE_MESSAGE_VERSION: u8 = 1;
+
+pub const BRIDGE_MESSAGE_PREFIX: &[u8] = b"SUI_BRIDGE_MESSAGE";
+
+/// Encoded bridge message consists of the following fields:
+/// 1. Message type (1 byte)
+/// 2. Message version (1 byte)
+/// 3. Nonce (8 bytes in big endian)
+/// 4. Chain id (1 byte)
+/// 4. Payload (variable length)
+#[enum_dispatch]
+pub trait BridgeMessageEncoding {
+    /// Convert the entire message to bytes
+    fn as_bytes(&self) -> Vec<u8>;
+    /// Convert the payload piece to bytes
+    fn as_payload_bytes(&self) -> Vec<u8>;
+}
+
+impl BridgeMessageEncoding for SuiToEthBridgeAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let e = &self.sui_bridge_event;
+        // Add message type
+        bytes.push(BridgeActionType::TokenTransfer as u8);
+        // Add message version
+        bytes.push(TOKEN_TRANSFER_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&e.nonce.to_be_bytes());
+        // Add source chain id
+        bytes.push(e.sui_chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let e = &self.sui_bridge_event;
+
+        // Add source address length
+        bytes.push(SUI_ADDRESS_LENGTH as u8);
+        // Add source address
+        bytes.extend_from_slice(&e.sui_address.to_vec());
+        // Add dest chain id
+        bytes.push(e.eth_chain_id as u8);
+        // Add dest address length
+        bytes.push(EthAddress::len_bytes() as u8);
+        // Add dest address
+        bytes.extend_from_slice(e.eth_address.as_bytes());
+
+        // Add token id
+        bytes.push(e.token_id as u8);
+
+        // Add token amount
+        bytes.extend_from_slice(&e.amount_sui_adjusted.to_be_bytes());
+
+        bytes
+    }
+}
+
+impl BridgeMessageEncoding for EthToSuiBridgeAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let e = &self.eth_bridge_event;
+        // Add message type
+        bytes.push(BridgeActionType::TokenTransfer as u8);
+        // Add message version
+        bytes.push(TOKEN_TRANSFER_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&e.nonce.to_be_bytes());
+        // Add source chain id
+        bytes.push(e.eth_chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let e = &self.eth_bridge_event;
+
+        // Add source address length
+        bytes.push(EthAddress::len_bytes() as u8);
+        // Add source address
+        bytes.extend_from_slice(e.eth_address.as_bytes());
+        // Add dest chain id
+        bytes.push(e.sui_chain_id as u8);
+        // Add dest address length
+        bytes.push(SUI_ADDRESS_LENGTH as u8);
+        // Add dest address
+        bytes.extend_from_slice(&e.sui_address.to_vec());
+
+        // Add token id
+        bytes.push(e.token_id as u8);
+
+        // Add token amount
+        bytes.extend_from_slice(&e.sui_adjusted_amount.to_be_bytes());
+
+        bytes
+    }
+}
+
+impl BridgeMessageEncoding for BlocklistCommitteeAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::UpdateCommitteeBlocklist as u8);
+        // Add message version
+        bytes.push(COMMITTEE_BLOCKLIST_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        // Add blocklist type
+        bytes.push(self.blocklist_type as u8);
+        // Add length of updated members.
+        // Unwrap: It should not overflow given what we have today.
+        bytes.push(u8::try_from(self.blocklisted_members.len()).unwrap());
+
+        // Add list of updated members
+        // Members are represented as pubkey dervied evm addresses (20 bytes)
+        let members_bytes = self
+            .blocklisted_members
+            .iter()
+            .map(|m| m.to_eth_address().to_fixed_bytes().to_vec())
+            .collect::<Vec<_>>();
+        for members_bytes in members_bytes {
+            bytes.extend_from_slice(&members_bytes);
+        }
+
+        bytes
+    }
+}
+
+impl BridgeMessageEncoding for EmergencyAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::EmergencyButton as u8);
+        // Add message version
+        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        vec![self.action_type as u8]
+    }
+}
+
+impl BridgeMessageEncoding for LimitUpdateAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::LimitUpdate as u8);
+        // Add message version
+        bytes.push(LIMIT_UPDATE_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add sending chain id
+        bytes.push(self.sending_chain_id as u8);
+        // Add new usd limit
+        bytes.extend_from_slice(&self.new_usd_limit.to_be_bytes());
+        bytes
+    }
+}
+
+impl BridgeMessageEncoding for AssetPriceUpdateAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::AssetPriceUpdate as u8);
+        // Add message version
+        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add token id
+        bytes.push(self.token_id as u8);
+        // Add new usd limit
+        bytes.extend_from_slice(&self.new_usd_price.to_be_bytes());
+        bytes
+    }
+}
+
+impl BridgeMessageEncoding for EvmContractUpgradeAction {
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add message type
+        bytes.push(BridgeActionType::EvmContractUpgrade as u8);
+        // Add message version
+        bytes.push(EVM_CONTRACT_UPGRADE_MESSAGE_VERSION);
+        // Add nonce
+        bytes.extend_from_slice(&self.nonce.to_be_bytes());
+        // Add chain id
+        bytes.push(self.chain_id as u8);
+
+        // Add payload bytes
+        bytes.extend_from_slice(&self.as_payload_bytes());
+
+        bytes
+    }
+
+    fn as_payload_bytes(&self) -> Vec<u8> {
+        ethers::abi::encode(&[
+            ethers::abi::Token::Address(self.proxy_address),
+            ethers::abi::Token::Address(self.new_impl_address),
+            ethers::abi::Token::Bytes(self.call_data.clone()),
+        ])
+    }
+}
+
+impl BridgeAction {
+    /// Convert to message bytes to verify in Move and Solidity
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        // Add prefix
+        bytes.extend_from_slice(BRIDGE_MESSAGE_PREFIX);
+        // Add bytes from message itself
+        bytes.extend_from_slice(&self.as_bytes());
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::abi::EthToSuiTokenBridgeV1;
+    use crate::crypto::BridgeAuthorityPublicKeyBytes;
+    use crate::events::EmittedSuiToEthTokenBridgeV1;
+    use crate::types::BlocklistType;
+    use crate::types::EmergencyActionType;
+    use crate::types::USD_MULTIPLIER;
+    use ethers::abi::ParamType;
+    use ethers::types::{Address as EthAddress, TxHash};
+    use fastcrypto::encoding::Encoding;
+    use fastcrypto::encoding::Hex;
+    use fastcrypto::hash::HashFunction;
+    use fastcrypto::hash::Keccak256;
+    use fastcrypto::traits::ToFromBytes;
+    use prometheus::Registry;
+    use std::str::FromStr;
+    use sui_types::bridge::BridgeChainId;
+    use sui_types::{
+        base_types::{SuiAddress, TransactionDigest},
+        bridge::TokenId,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_bridge_message_encoding() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let nonce = 54321u64;
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_chain_id = BridgeChainId::SuiTestnet;
+        let sui_tx_event_index = 1u16;
+        let eth_chain_id = BridgeChainId::EthSepolia;
+        let sui_address = SuiAddress::random_for_testing_only();
+        let eth_address = EthAddress::random();
+        let token_id = TokenId::USDC;
+        let amount_sui_adjusted = 1_000_000;
+
+        let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
+            nonce,
+            sui_chain_id,
+            eth_chain_id,
+            sui_address,
+            eth_address,
+            token_id,
+            amount_sui_adjusted,
+        };
+
+        let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
+            sui_tx_digest,
+            sui_tx_event_index,
+            sui_bridge_event,
+        })
+        .to_bytes();
+
+        // Construct the expected bytes
+        let prefix_bytes = BRIDGE_MESSAGE_PREFIX.to_vec(); // len: 18
+        let message_type = vec![BridgeActionType::TokenTransfer as u8]; // len: 1
+        let message_version = vec![TOKEN_TRANSFER_MESSAGE_VERSION]; // len: 1
+        let nonce_bytes = nonce.to_be_bytes().to_vec(); // len: 8
+        let source_chain_id_bytes = vec![sui_chain_id as u8]; // len: 1
+
+        let sui_address_length_bytes = vec![SUI_ADDRESS_LENGTH as u8]; // len: 1
+        let sui_address_bytes = sui_address.to_vec(); // len: 32
+        let dest_chain_id_bytes = vec![eth_chain_id as u8]; // len: 1
+        let eth_address_length_bytes = vec![EthAddress::len_bytes() as u8]; // len: 1
+        let eth_address_bytes = eth_address.as_bytes().to_vec(); // len: 20
+
+        let token_id_bytes = vec![token_id as u8]; // len: 1
+        let token_amount_bytes = amount_sui_adjusted.to_be_bytes().to_vec(); // len: 8
+
+        let mut combined_bytes = Vec::new();
+        combined_bytes.extend_from_slice(&prefix_bytes);
+        combined_bytes.extend_from_slice(&message_type);
+        combined_bytes.extend_from_slice(&message_version);
+        combined_bytes.extend_from_slice(&nonce_bytes);
+        combined_bytes.extend_from_slice(&source_chain_id_bytes);
+        combined_bytes.extend_from_slice(&sui_address_length_bytes);
+        combined_bytes.extend_from_slice(&sui_address_bytes);
+        combined_bytes.extend_from_slice(&dest_chain_id_bytes);
+        combined_bytes.extend_from_slice(&eth_address_length_bytes);
+        combined_bytes.extend_from_slice(&eth_address_bytes);
+        combined_bytes.extend_from_slice(&token_id_bytes);
+        combined_bytes.extend_from_slice(&token_amount_bytes);
+
+        assert_eq!(combined_bytes, encoded_bytes);
+
+        // Assert fixed length
+        // TODO: for each action type add a test to assert the length
+        assert_eq!(
+            combined_bytes.len(),
+            18 + 1 + 1 + 8 + 1 + 1 + 32 + 1 + 20 + 1 + 1 + 8
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_regression_emitted_sui_to_eth_token_bridge_v1(
+    ) -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let sui_tx_digest = TransactionDigest::random();
+        let sui_tx_event_index = 1u16;
+
+        let nonce = 10u64;
+        let sui_chain_id = BridgeChainId::SuiTestnet;
+        let eth_chain_id = BridgeChainId::EthSepolia;
+        let sui_address = SuiAddress::from_str(
+            "0x0000000000000000000000000000000000000000000000000000000000000064",
+        )
+        .unwrap();
+        let eth_address =
+            EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
+        let token_id = TokenId::USDC;
+        let amount_sui_adjusted = 12345;
+
+        let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
+            nonce,
+            sui_chain_id,
+            eth_chain_id,
+            sui_address,
+            eth_address,
+            token_id,
+            amount_sui_adjusted,
+        };
+        let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
+            sui_tx_digest,
+            sui_tx_event_index,
+            sui_bridge_event,
+        })
+        .to_bytes();
+        assert_eq!(
+            encoded_bytes,
+            Hex::decode("5355495f4252494447455f4d4553534147450001000000000000000a012000000000000000000000000000000000000000000000000000000000000000640b1400000000000000000000000000000000000000c8030000000000003039").unwrap(),
+        );
+
+        let hash = Keccak256::digest(encoded_bytes).digest;
+        assert_eq!(
+            hash.to_vec(),
+            Hex::decode("6ab34c52b6264cbc12fe8c3874f9b08f8481d2e81530d136386646dbe2f8baf4")
+                .unwrap(),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_blocklist_update_v1() {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+
+        let pub_key_bytes = BridgeAuthorityPublicKeyBytes::from_bytes(
+            &Hex::decode("02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4")
+                .unwrap(),
+        )
+        .unwrap();
+        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+            nonce: 129,
+            chain_id: BridgeChainId::SuiLocalTest,
+            blocklist_type: BlocklistType::Blocklist,
+            blocklisted_members: vec![pub_key_bytes.clone()],
+        });
+        let bytes = blocklist_action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        01: msg type
+        01: msg version
+        0000000000000081: nonce
+        03: chain id
+        00: blocklist type
+        01: length of updated members
+        [
+            68b43fd906c0b8f024a18c56e06744f7c6157c65
+        ]: blocklisted members abi-encoded
+        */
+        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000008103000168b43fd906c0b8f024a18c56e06744f7c6157c65").unwrap());
+
+        let pub_key_bytes_2 = BridgeAuthorityPublicKeyBytes::from_bytes(
+            &Hex::decode("027f1178ff417fc9f5b8290bd8876f0a157a505a6c52db100a8492203ddd1d4279")
+                .unwrap(),
+        )
+        .unwrap();
+        // its evem address: 0xacaef39832cb995c4e049437a3e2ec6a7bad1ab5
+        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+            nonce: 68,
+            chain_id: BridgeChainId::SuiDevnet,
+            blocklist_type: BlocklistType::Unblocklist,
+            blocklisted_members: vec![pub_key_bytes.clone(), pub_key_bytes_2.clone()],
+        });
+        let bytes = blocklist_action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        01: msg type
+        01: msg version
+        0000000000000044: nonce
+        02: chain id
+        01: blocklist type
+        02: length of updated members
+        [
+            68b43fd906c0b8f024a18c56e06744f7c6157c65
+            acaef39832cb995c4e049437a3e2ec6a7bad1ab5
+        ]: blocklisted members abi-encoded
+        */
+        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000004402010268b43fd906c0b8f024a18c56e06744f7c6157c65acaef39832cb995c4e049437a3e2ec6a7bad1ab5").unwrap());
+
+        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+            nonce: 49,
+            chain_id: BridgeChainId::EthLocalTest,
+            blocklist_type: BlocklistType::Blocklist,
+            blocklisted_members: vec![pub_key_bytes.clone()],
+        });
+        let bytes = blocklist_action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        01: msg type
+        01: msg version
+        0000000000000031: nonce
+        0c: chain id
+        00: blocklist type
+        01: length of updated members
+        [
+            68b43fd906c0b8f024a18c56e06744f7c6157c65
+        ]: blocklisted members abi-encoded
+        */
+        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d455353414745010100000000000000310c000168b43fd906c0b8f024a18c56e06744f7c6157c65").unwrap());
+
+        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
+            nonce: 94,
+            chain_id: BridgeChainId::EthSepolia,
+            blocklist_type: BlocklistType::Unblocklist,
+            blocklisted_members: vec![pub_key_bytes.clone(), pub_key_bytes_2.clone()],
+        });
+        let bytes = blocklist_action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        01: msg type
+        01: msg version
+        000000000000005e: nonce
+        0b: chain id
+        01: blocklist type
+        02: length of updated members
+        [
+            00000000000000000000000068b43fd906c0b8f024a18c56e06744f7c6157c65
+            000000000000000000000000acaef39832cb995c4e049437a3e2ec6a7bad1ab5
+        ]: blocklisted members abi-encoded
+        */
+        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000005e0b010268b43fd906c0b8f024a18c56e06744f7c6157c65acaef39832cb995c4e049437a3e2ec6a7bad1ab5").unwrap());
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_emergency_action() {
+        let action = BridgeAction::EmergencyAction(EmergencyAction {
+            nonce: 55,
+            chain_id: BridgeChainId::SuiLocalTest,
+            action_type: EmergencyActionType::Pause,
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        02: msg type
+        01: msg version
+        0000000000000037: nonce
+        03: chain id
+        00: action type
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000370300").unwrap()
+        );
+
+        let action = BridgeAction::EmergencyAction(EmergencyAction {
+            nonce: 56,
+            chain_id: BridgeChainId::EthSepolia,
+            action_type: EmergencyActionType::Unpause,
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        02: msg type
+        01: msg version
+        0000000000000038: nonce
+        0b: chain id
+        01: action type
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000380b01").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_limit_update_action() {
+        let action = BridgeAction::LimitUpdateAction(LimitUpdateAction {
+            nonce: 15,
+            chain_id: BridgeChainId::SuiLocalTest,
+            sending_chain_id: BridgeChainId::EthLocalTest,
+            new_usd_limit: 1_000_000 * USD_MULTIPLIER, // $1M USD
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        03: msg type
+        01: msg version
+        000000000000000f: nonce
+        03: chain id
+        0c: sending chain id
+        00000002540be400: new usd limit
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode(
+                "5355495f4252494447455f4d4553534147450301000000000000000f030c00000002540be400"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_asset_price_update_action() {
+        let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
+            nonce: 266,
+            chain_id: BridgeChainId::SuiLocalTest,
+            token_id: TokenId::BTC,
+            new_usd_price: 100_000 * USD_MULTIPLIER, // $100k USD
+        });
+        let bytes = action.to_bytes();
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        04: msg type
+        01: msg version
+        000000000000010a: nonce
+        03: chain id
+        01: token id
+        000000003b9aca00: new usd price
+        */
+        assert_eq!(
+            bytes,
+            Hex::decode(
+                "5355495f4252494447455f4d4553534147450401000000000000010a0301000000003b9aca00"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_evm_contract_upgrade_action() {
+        // Calldata with only the function selector and no parameters: `function initializeV2()`
+        let function_signature = "initializeV2()";
+        let selector = &Keccak256::digest(function_signature).digest[0..4];
+        let call_data = selector.to_vec();
+        assert_eq!(Hex::encode(call_data.clone()), "5cd8a76b");
+
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data,
+        });
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        05: msg type
+        01: msg version
+        000000000000007b: nonce
+        0c: chain id
+        0000000000000000000000000606060606060606060606060606060606060606: proxy address
+        0000000000000000000000000909090909090909090909090909090909090909: new impl address
+
+        0000000000000000000000000000000000000000000000000000000000000060
+        0000000000000000000000000000000000000000000000000000000000000004
+        5cd8a76b00000000000000000000000000000000000000000000000000000000: call data
+        */
+        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c00000000000000000000000006060606060606060606060606060606060606060000000000000000000000000909090909090909090909090909090909090909000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000045cd8a76b00000000000000000000000000000000000000000000000000000000");
+
+        // Calldata with one parameter: `function newMockFunction(bool)`
+        let function_signature = "newMockFunction(bool)";
+        let selector = &Keccak256::digest(function_signature).digest[0..4];
+        let mut call_data = selector.to_vec();
+        call_data.extend(ethers::abi::encode(&[ethers::abi::Token::Bool(true)]));
+        assert_eq!(
+            Hex::encode(call_data.clone()),
+            "417795ef0000000000000000000000000000000000000000000000000000000000000001"
+        );
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data,
+        });
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        05: msg type
+        01: msg version
+        000000000000007b: nonce
+        0c: chain id
+        0000000000000000000000000606060606060606060606060606060606060606: proxy address
+        0000000000000000000000000909090909090909090909090909090909090909: new impl address
+
+        0000000000000000000000000000000000000000000000000000000000000060
+        0000000000000000000000000000000000000000000000000000000000000024
+        417795ef00000000000000000000000000000000000000000000000000000000
+        0000000100000000000000000000000000000000000000000000000000000000: call data
+        */
+        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000024417795ef000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000");
+
+        // Calldata with two parameters: `function newerMockFunction(bool, uint8)`
+        let function_signature = "newMockFunction(bool,uint8)";
+        let selector = &Keccak256::digest(function_signature).digest[0..4];
+        let mut call_data = selector.to_vec();
+        call_data.extend(ethers::abi::encode(&[
+            ethers::abi::Token::Bool(true),
+            ethers::abi::Token::Uint(42u8.into()),
+        ]));
+        assert_eq!(
+            Hex::encode(call_data.clone()),
+            "be8fc25d0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002a"
+        );
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data,
+        });
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        05: msg type
+        01: msg version
+        000000000000007b: nonce
+        0c: chain id
+        0000000000000000000000000606060606060606060606060606060606060606: proxy address
+        0000000000000000000000000909090909090909090909090909090909090909: new impl address
+
+        0000000000000000000000000000000000000000000000000000000000000060
+        0000000000000000000000000000000000000000000000000000000000000044
+        be8fc25d00000000000000000000000000000000000000000000000000000000
+        0000000100000000000000000000000000000000000000000000000000000000
+        0000002a00000000000000000000000000000000000000000000000000000000: call data
+        */
+        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044be8fc25d0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000");
+
+        // Empty calldate
+        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
+            nonce: 123,
+            chain_id: BridgeChainId::EthLocalTest,
+            proxy_address: EthAddress::repeat_byte(6),
+            new_impl_address: EthAddress::repeat_byte(9),
+            call_data: vec![],
+        });
+        /*
+        5355495f4252494447455f4d455353414745: prefix
+        05: msg type
+        01: msg version
+        000000000000007b: nonce
+        0c: chain id
+        0000000000000000000000000606060606060606060606060606060606060606: proxy address
+        0000000000000000000000000909090909090909090909090909090909090909: new impl address
+
+        0000000000000000000000000000000000000000000000000000000000000060
+        0000000000000000000000000000000000000000000000000000000000000000: call data
+        */
+        let data = action.to_bytes();
+        assert_eq!(Hex::encode(data.clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
+        let types = vec![ParamType::Address, ParamType::Address, ParamType::Bytes];
+        // Ensure that the call data (start from bytes 29) can be decoded
+        ethers::abi::decode(&types, &data[29..]).unwrap();
+    }
+
+    #[test]
+    fn test_bridge_message_encoding_regression_eth_to_sui_token_bridge_v1() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let eth_tx_hash = TxHash::random();
+        let eth_event_index = 1u16;
+
+        let nonce = 10u64;
+        let sui_chain_id = BridgeChainId::SuiTestnet;
+        let eth_chain_id = BridgeChainId::EthSepolia;
+        let sui_address = SuiAddress::from_str(
+            "0x0000000000000000000000000000000000000000000000000000000000000064",
+        )
+        .unwrap();
+        let eth_address =
+            EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
+        let token_id = TokenId::USDC;
+        let sui_adjusted_amount = 12345;
+
+        let eth_bridge_event = EthToSuiTokenBridgeV1 {
+            nonce,
+            sui_chain_id,
+            eth_chain_id,
+            sui_address,
+            eth_address,
+            token_id,
+            sui_adjusted_amount,
+        };
+        let encoded_bytes = BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
+            eth_tx_hash,
+            eth_event_index,
+            eth_bridge_event,
+        })
+        .to_bytes();
+
+        assert_eq!(
+            encoded_bytes,
+            Hex::decode("5355495f4252494447455f4d4553534147450001000000000000000a0b1400000000000000000000000000000000000000c801200000000000000000000000000000000000000000000000000000000000000064030000000000003039").unwrap(),
+        );
+
+        let hash = Keccak256::digest(encoded_bytes).digest;
+        assert_eq!(
+            hash.to_vec(),
+            Hex::decode("b352508c301a37bb1b68a75dd0fc42b6f692b2650818631c8f8a4d4d3e5bef46")
+                .unwrap(),
+        );
+        Ok(())
+    }
+}

--- a/crates/sui-bridge/src/eth_transaction_builder.rs
+++ b/crates/sui-bridge/src/eth_transaction_builder.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::abi::eth_bridge_limiter;
+use crate::abi::{eth_bridge_committee, eth_sui_bridge, EthBridgeCommittee, EthBridgeLimiter};
+use crate::error::{BridgeError, BridgeResult};
+use crate::types::{
+    AssetPriceUpdateAction, BlocklistCommitteeAction, BridgeCommitteeValiditySignInfo,
+    LimitUpdateAction, VerifiedCertifiedBridgeAction,
+};
+use crate::{
+    abi::EthSuiBridge,
+    types::{BridgeAction, EmergencyAction},
+};
+use ethers::core::k256::ecdsa::SigningKey;
+use ethers::middleware::SignerMiddleware;
+use ethers::prelude::*;
+use ethers::providers::{Http, Provider};
+use ethers::signers::Wallet;
+use ethers::types::Address as EthAddress;
+
+pub type EthSigner = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
+
+pub async fn build_eth_transaction(
+    contract_address: EthAddress,
+    signer: EthSigner,
+    action: VerifiedCertifiedBridgeAction,
+) -> BridgeResult<ContractCall<EthSigner, ()>> {
+    if !action.is_governace_action() {
+        return Err(BridgeError::ActionIsNotGovernanceAction(
+            action.data().clone(),
+        ));
+    }
+    let sigs = action.auth_sig();
+    match action.data() {
+        BridgeAction::EmergencyAction(action) => {
+            build_emergency_op_approve_transaction(contract_address, signer, action.clone(), sigs)
+                .await
+        }
+        BridgeAction::BlocklistCommitteeAction(action) => {
+            build_committee_blocklist_approve_transaction(
+                contract_address,
+                signer,
+                action.clone(),
+                sigs,
+            )
+            .await
+        }
+        BridgeAction::LimitUpdateAction(action) => {
+            build_limit_update_approve_transaction(contract_address, signer, action.clone(), sigs)
+                .await
+        }
+        BridgeAction::AssetPriceUpdateAction(action) => {
+            build_asset_price_update_approve_transaction(
+                contract_address,
+                signer,
+                action.clone(),
+                sigs,
+            )
+            .await
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub async fn build_emergency_op_approve_transaction(
+    contract_address: EthAddress,
+    signer: EthSigner,
+    action: EmergencyAction,
+    sigs: &BridgeCommitteeValiditySignInfo,
+) -> BridgeResult<ContractCall<EthSigner, ()>> {
+    let contract = EthSuiBridge::new(contract_address, signer.into());
+
+    let message: eth_sui_bridge::Message = action.clone().into();
+    let signatures = sigs
+        .signatures
+        .values()
+        .map(|sig| Bytes::from(sig.as_ref().to_vec()))
+        .collect::<Vec<_>>();
+    Ok(contract.execute_emergency_op_with_signatures(signatures, message))
+}
+
+pub async fn build_committee_blocklist_approve_transaction(
+    contract_address: EthAddress,
+    signer: EthSigner,
+    action: BlocklistCommitteeAction,
+    sigs: &BridgeCommitteeValiditySignInfo,
+) -> BridgeResult<ContractCall<EthSigner, ()>> {
+    let contract = EthBridgeCommittee::new(contract_address, signer.into());
+
+    let message: eth_bridge_committee::Message = action.clone().into();
+    let signatures = sigs
+        .signatures
+        .values()
+        .map(|sig| Bytes::from(sig.as_ref().to_vec()))
+        .collect::<Vec<_>>();
+    Ok(contract.update_blocklist_with_signatures(signatures, message))
+}
+
+pub async fn build_limit_update_approve_transaction(
+    contract_address: EthAddress,
+    signer: EthSigner,
+    action: LimitUpdateAction,
+    sigs: &BridgeCommitteeValiditySignInfo,
+) -> BridgeResult<ContractCall<EthSigner, ()>> {
+    let contract = EthBridgeLimiter::new(contract_address, signer.into());
+
+    let message: eth_bridge_limiter::Message = action.clone().into();
+    let signatures = sigs
+        .signatures
+        .values()
+        .map(|sig| Bytes::from(sig.as_ref().to_vec()))
+        .collect::<Vec<_>>();
+    Ok(contract.update_limit_with_signatures(signatures, message))
+}
+
+pub async fn build_asset_price_update_approve_transaction(
+    contract_address: EthAddress,
+    signer: EthSigner,
+    action: AssetPriceUpdateAction,
+    sigs: &BridgeCommitteeValiditySignInfo,
+) -> BridgeResult<ContractCall<EthSigner, ()>> {
+    let contract = EthBridgeLimiter::new(contract_address, signer.into());
+    let message: eth_bridge_limiter::Message = action.clone().into();
+    let signatures = sigs
+        .signatures
+        .values()
+        .map(|sig| Bytes::from(sig.as_ref().to_vec()))
+        .collect::<Vec<_>>();
+    Ok(contract.update_token_price_with_signatures(signatures, message))
+}
+
+// TODO contract upgrade
+
+// TODO: add tests for eth transaction building

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -6,6 +6,7 @@ pub mod action_executor;
 pub mod client;
 pub mod config;
 pub mod crypto;
+pub mod encoding;
 pub mod error;
 pub mod eth_client;
 pub mod eth_syncer;

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -6,8 +6,10 @@ use crate::crypto::BridgeAuthorityPublicKeyBytes;
 use crate::crypto::{
     BridgeAuthorityPublicKey, BridgeAuthorityRecoverableSignature, BridgeAuthoritySignInfo,
 };
+use crate::encoding::BridgeMessageEncoding;
 use crate::error::{BridgeError, BridgeResult};
 use crate::events::EmittedSuiToEthTokenBridgeV1;
+use enum_dispatch::enum_dispatch;
 use ethers::types::Address as EthAddress;
 use ethers::types::Log;
 use ethers::types::H256;
@@ -30,11 +32,11 @@ use sui_types::bridge::{
     APPROVAL_THRESHOLD_TOKEN_TRANSFER,
 };
 use sui_types::committee::CommitteeTrait;
+use sui_types::committee::EpochId;
 use sui_types::committee::StakeUnit;
 use sui_types::digests::{Digest, TransactionDigest};
 use sui_types::error::SuiResult;
 use sui_types::message_envelope::{Envelope, Message, VerifiedEnvelope};
-use sui_types::{base_types::SUI_ADDRESS_LENGTH, committee::EpochId};
 
 pub const BRIDGE_AUTHORITY_TOTAL_VOTING_POWER: u64 = 10000;
 
@@ -173,11 +175,6 @@ pub enum BridgeActionType {
     EvmContractUpgrade = 5,
 }
 
-pub const SUI_TX_DIGEST_LENGTH: usize = 32;
-pub const ETH_TX_HASH_LENGTH: usize = 32;
-
-pub const BRIDGE_MESSAGE_PREFIX: &[u8] = b"SUI_BRIDGE_MESSAGE";
-
 #[derive(Debug, PartialEq, Eq, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum BridgeActionStatus {
@@ -196,40 +193,6 @@ pub struct SuiToEthBridgeAction {
     pub sui_bridge_event: EmittedSuiToEthTokenBridgeV1,
 }
 
-impl SuiToEthBridgeAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let e = &self.sui_bridge_event;
-        // Add message type
-        bytes.push(BridgeActionType::TokenTransfer as u8);
-        // Add message version
-        bytes.push(TOKEN_TRANSFER_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&e.nonce.to_be_bytes());
-        // Add source chain id
-        bytes.push(e.sui_chain_id as u8);
-
-        // Add source address length
-        bytes.push(SUI_ADDRESS_LENGTH as u8);
-        // Add source address
-        bytes.extend_from_slice(&e.sui_address.to_vec());
-        // Add dest chain id
-        bytes.push(e.eth_chain_id as u8);
-        // Add dest address length
-        bytes.push(EthAddress::len_bytes() as u8);
-        // Add dest address
-        bytes.extend_from_slice(e.eth_address.as_bytes());
-
-        // Add token id
-        bytes.push(e.token_id as u8);
-
-        // Add token amount
-        bytes.extend_from_slice(&e.amount_sui_adjusted.to_be_bytes());
-
-        bytes
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct EthToSuiBridgeAction {
     // Digest of the transaction where the event was emitted
@@ -237,40 +200,6 @@ pub struct EthToSuiBridgeAction {
     // The index of the event in the transaction
     pub eth_event_index: u16,
     pub eth_bridge_event: EthToSuiTokenBridgeV1,
-}
-
-impl EthToSuiBridgeAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let e = &self.eth_bridge_event;
-        // Add message type
-        bytes.push(BridgeActionType::TokenTransfer as u8);
-        // Add message version
-        bytes.push(TOKEN_TRANSFER_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&e.nonce.to_be_bytes());
-        // Add source chain id
-        bytes.push(e.eth_chain_id as u8);
-
-        // Add source address length
-        bytes.push(EthAddress::len_bytes() as u8);
-        // Add source address
-        bytes.extend_from_slice(e.eth_address.as_bytes());
-        // Add dest chain id
-        bytes.push(e.sui_chain_id as u8);
-        // Add dest address length
-        bytes.push(SUI_ADDRESS_LENGTH as u8);
-        // Add dest address
-        bytes.extend_from_slice(&e.sui_address.to_vec());
-
-        // Add token id
-        bytes.push(e.token_id as u8);
-
-        // Add token amount
-        bytes.extend_from_slice(&e.sui_adjusted_amount.to_be_bytes());
-
-        bytes
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Hash)]
@@ -288,37 +217,6 @@ pub struct BlocklistCommitteeAction {
     pub blocklisted_members: Vec<BridgeAuthorityPublicKeyBytes>,
 }
 
-impl BlocklistCommitteeAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add message type
-        bytes.push(BridgeActionType::UpdateCommitteeBlocklist as u8);
-        // Add message version
-        bytes.push(COMMITTEE_BLOCKLIST_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&self.nonce.to_be_bytes());
-        // Add chain id
-        bytes.push(self.chain_id as u8);
-        // Add blocklist type
-        bytes.push(self.blocklist_type as u8);
-        // Add length of updated members.
-        // Unwrap: It should not overflow given what we have today.
-        bytes.push(u8::try_from(self.blocklisted_members.len()).unwrap());
-
-        // Add list of updated members
-        // Members are represented as pubkey dervied evm addresses (20 bytes)
-        let members_bytes = self
-            .blocklisted_members
-            .iter()
-            .map(|m| m.to_eth_address().to_fixed_bytes().to_vec())
-            .collect::<Vec<_>>();
-        for members_bytes in members_bytes {
-            bytes.extend_from_slice(&members_bytes);
-        }
-        bytes
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Hash)]
 #[repr(u8)]
 pub enum EmergencyActionType {
@@ -331,23 +229,6 @@ pub struct EmergencyAction {
     pub nonce: u64,
     pub chain_id: BridgeChainId,
     pub action_type: EmergencyActionType,
-}
-
-impl EmergencyAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add message type
-        bytes.push(BridgeActionType::EmergencyButton as u8);
-        // Add message version
-        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&self.nonce.to_be_bytes());
-        // Add chain id
-        bytes.push(self.chain_id as u8);
-        // Add action type
-        bytes.push(self.action_type as u8);
-        bytes
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -363,50 +244,12 @@ pub struct LimitUpdateAction {
     pub new_usd_limit: u64,
 }
 
-impl LimitUpdateAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add message type
-        bytes.push(BridgeActionType::LimitUpdate as u8);
-        // Add message version
-        bytes.push(LIMIT_UPDATE_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&self.nonce.to_be_bytes());
-        // Add chain id
-        bytes.push(self.chain_id as u8);
-        // Add sending chain id
-        bytes.push(self.sending_chain_id as u8);
-        // Add new usd limit
-        bytes.extend_from_slice(&self.new_usd_limit.to_be_bytes());
-        bytes
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct AssetPriceUpdateAction {
     pub nonce: u64,
     pub chain_id: BridgeChainId,
     pub token_id: TokenId,
     pub new_usd_price: u64,
-}
-
-impl AssetPriceUpdateAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add message type
-        bytes.push(BridgeActionType::AssetPriceUpdate as u8);
-        // Add message version
-        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&self.nonce.to_be_bytes());
-        // Add chain id
-        bytes.push(self.chain_id as u8);
-        // Add token id
-        bytes.push(self.token_id as u8);
-        // Add new usd limit
-        bytes.extend_from_slice(&self.new_usd_price.to_be_bytes());
-        bytes
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -418,31 +261,10 @@ pub struct EvmContractUpgradeAction {
     pub call_data: Vec<u8>,
 }
 
-impl EvmContractUpgradeAction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add message type
-        bytes.push(BridgeActionType::EvmContractUpgrade as u8);
-        // Add message version
-        bytes.push(EVM_CONTRACT_UPGRADE_MESSAGE_VERSION);
-        // Add nonce
-        bytes.extend_from_slice(&self.nonce.to_be_bytes());
-        // Add chain id
-        bytes.push(self.chain_id as u8);
-        // Add payload
-        let encoded = ethers::abi::encode(&[
-            ethers::abi::Token::Address(self.proxy_address),
-            ethers::abi::Token::Address(self.new_impl_address),
-            ethers::abi::Token::Bytes(self.call_data.clone()),
-        ]);
-        bytes.extend_from_slice(&encoded);
-        bytes
-    }
-}
-
 /// The type of actions Bridge Committee verify and sign off to execution.
 /// Its relationship with BridgeEvent is similar to the relationship between
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[enum_dispatch(BridgeMessageEncoding)]
 pub enum BridgeAction {
     /// Sui to Eth bridge action
     SuiToEthBridgeAction(SuiToEthBridgeAction),
@@ -453,48 +275,9 @@ pub enum BridgeAction {
     LimitUpdateAction(LimitUpdateAction),
     AssetPriceUpdateAction(AssetPriceUpdateAction),
     EvmContractUpgradeAction(EvmContractUpgradeAction),
-    // TODO: add other bridge actions such as blocklist & emergency button
 }
 
-pub const TOKEN_TRANSFER_MESSAGE_VERSION: u8 = 1;
-pub const COMMITTEE_BLOCKLIST_MESSAGE_VERSION: u8 = 1;
-pub const EMERGENCY_BUTTON_MESSAGE_VERSION: u8 = 1;
-pub const LIMIT_UPDATE_MESSAGE_VERSION: u8 = 1;
-pub const ASSET_PRICE_UPDATE_MESSAGE_VERSION: u8 = 1;
-pub const EVM_CONTRACT_UPGRADE_MESSAGE_VERSION: u8 = 1;
-
 impl BridgeAction {
-    /// Convert to message bytes that are verified in Move and Solidity
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        // Add prefix
-        bytes.extend_from_slice(BRIDGE_MESSAGE_PREFIX);
-        match self {
-            BridgeAction::SuiToEthBridgeAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::EthToSuiBridgeAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::BlocklistCommitteeAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::EmergencyAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::LimitUpdateAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::AssetPriceUpdateAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            }
-            BridgeAction::EvmContractUpgradeAction(a) => {
-                bytes.extend_from_slice(&a.to_bytes());
-            } // TODO add formats for other events
-        }
-        bytes
-    }
-
     // Digest of BridgeAction (with Keccak256 hasher)
     pub fn digest(&self) -> BridgeActionDigest {
         let mut hasher = Keccak256::default();
@@ -630,518 +413,12 @@ mod tests {
     use crate::test_utils::get_test_authority_and_key;
     use crate::test_utils::get_test_eth_to_sui_bridge_action;
     use crate::test_utils::get_test_sui_to_eth_bridge_action;
-    use ethers::abi::ParamType;
-    use ethers::types::{Address as EthAddress, TxHash};
-    use fastcrypto::encoding::Hex;
-    use fastcrypto::hash::HashFunction;
-    use fastcrypto::traits::ToFromBytes;
-    use fastcrypto::{encoding::Encoding, traits::KeyPair};
-    use prometheus::Registry;
-    use std::{collections::HashSet, str::FromStr};
-    use sui_types::{
-        base_types::{SuiAddress, TransactionDigest},
-        bridge::TokenId,
-        crypto::get_key_pair,
-    };
+    use ethers::types::Address as EthAddress;
+    use fastcrypto::traits::KeyPair;
+    use std::collections::HashSet;
+    use sui_types::{bridge::TokenId, crypto::get_key_pair};
 
     use super::*;
-
-    #[test]
-    fn test_bridge_message_encoding() -> anyhow::Result<()> {
-        telemetry_subscribers::init_for_testing();
-        let registry = Registry::new();
-        mysten_metrics::init_metrics(&registry);
-        let nonce = 54321u64;
-        let sui_tx_digest = TransactionDigest::random();
-        let sui_chain_id = BridgeChainId::SuiTestnet;
-        let sui_tx_event_index = 1u16;
-        let eth_chain_id = BridgeChainId::EthSepolia;
-        let sui_address = SuiAddress::random_for_testing_only();
-        let eth_address = EthAddress::random();
-        let token_id = TokenId::USDC;
-        let amount_sui_adjusted = 1_000_000;
-
-        let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
-            nonce,
-            sui_chain_id,
-            eth_chain_id,
-            sui_address,
-            eth_address,
-            token_id,
-            amount_sui_adjusted,
-        };
-
-        let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
-            sui_tx_digest,
-            sui_tx_event_index,
-            sui_bridge_event,
-        })
-        .to_bytes();
-
-        // Construct the expected bytes
-        let prefix_bytes = BRIDGE_MESSAGE_PREFIX.to_vec(); // len: 18
-        let message_type = vec![BridgeActionType::TokenTransfer as u8]; // len: 1
-        let message_version = vec![TOKEN_TRANSFER_MESSAGE_VERSION]; // len: 1
-        let nonce_bytes = nonce.to_be_bytes().to_vec(); // len: 8
-        let source_chain_id_bytes = vec![sui_chain_id as u8]; // len: 1
-
-        let sui_address_length_bytes = vec![SUI_ADDRESS_LENGTH as u8]; // len: 1
-        let sui_address_bytes = sui_address.to_vec(); // len: 32
-        let dest_chain_id_bytes = vec![eth_chain_id as u8]; // len: 1
-        let eth_address_length_bytes = vec![EthAddress::len_bytes() as u8]; // len: 1
-        let eth_address_bytes = eth_address.as_bytes().to_vec(); // len: 20
-
-        let token_id_bytes = vec![token_id as u8]; // len: 1
-        let token_amount_bytes = amount_sui_adjusted.to_be_bytes().to_vec(); // len: 8
-
-        let mut combined_bytes = Vec::new();
-        combined_bytes.extend_from_slice(&prefix_bytes);
-        combined_bytes.extend_from_slice(&message_type);
-        combined_bytes.extend_from_slice(&message_version);
-        combined_bytes.extend_from_slice(&nonce_bytes);
-        combined_bytes.extend_from_slice(&source_chain_id_bytes);
-        combined_bytes.extend_from_slice(&sui_address_length_bytes);
-        combined_bytes.extend_from_slice(&sui_address_bytes);
-        combined_bytes.extend_from_slice(&dest_chain_id_bytes);
-        combined_bytes.extend_from_slice(&eth_address_length_bytes);
-        combined_bytes.extend_from_slice(&eth_address_bytes);
-        combined_bytes.extend_from_slice(&token_id_bytes);
-        combined_bytes.extend_from_slice(&token_amount_bytes);
-
-        assert_eq!(combined_bytes, encoded_bytes);
-
-        // Assert fixed length
-        // TODO: for each action type add a test to assert the length
-        assert_eq!(
-            combined_bytes.len(),
-            18 + 1 + 1 + 8 + 1 + 1 + 32 + 1 + 20 + 1 + 1 + 8
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_bridge_message_encoding_regression_emitted_sui_to_eth_token_bridge_v1(
-    ) -> anyhow::Result<()> {
-        telemetry_subscribers::init_for_testing();
-        let registry = Registry::new();
-        mysten_metrics::init_metrics(&registry);
-        let sui_tx_digest = TransactionDigest::random();
-        let sui_tx_event_index = 1u16;
-
-        let nonce = 10u64;
-        let sui_chain_id = BridgeChainId::SuiTestnet;
-        let eth_chain_id = BridgeChainId::EthSepolia;
-        let sui_address = SuiAddress::from_str(
-            "0x0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap();
-        let eth_address =
-            EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
-        let token_id = TokenId::USDC;
-        let amount_sui_adjusted = 12345;
-
-        let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
-            nonce,
-            sui_chain_id,
-            eth_chain_id,
-            sui_address,
-            eth_address,
-            token_id,
-            amount_sui_adjusted,
-        };
-        let encoded_bytes = BridgeAction::SuiToEthBridgeAction(SuiToEthBridgeAction {
-            sui_tx_digest,
-            sui_tx_event_index,
-            sui_bridge_event,
-        })
-        .to_bytes();
-        assert_eq!(
-            encoded_bytes,
-            Hex::decode("5355495f4252494447455f4d4553534147450001000000000000000a012000000000000000000000000000000000000000000000000000000000000000640b1400000000000000000000000000000000000000c8030000000000003039").unwrap(),
-        );
-
-        let hash = Keccak256::digest(encoded_bytes).digest;
-        assert_eq!(
-            hash.to_vec(),
-            Hex::decode("6ab34c52b6264cbc12fe8c3874f9b08f8481d2e81530d136386646dbe2f8baf4")
-                .unwrap(),
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_bridge_message_encoding_blocklist_update_v1() {
-        telemetry_subscribers::init_for_testing();
-        let registry = Registry::new();
-        mysten_metrics::init_metrics(&registry);
-
-        let pub_key_bytes = BridgeAuthorityPublicKeyBytes::from_bytes(
-            &Hex::decode("02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4")
-                .unwrap(),
-        )
-        .unwrap();
-        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
-            nonce: 129,
-            chain_id: BridgeChainId::SuiLocalTest,
-            blocklist_type: BlocklistType::Blocklist,
-            blocklisted_members: vec![pub_key_bytes.clone()],
-        });
-        let bytes = blocklist_action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        01: msg type
-        01: msg version
-        0000000000000081: nonce
-        03: chain id
-        00: blocklist type
-        01: length of updated members
-        [
-            68b43fd906c0b8f024a18c56e06744f7c6157c65
-        ]: blocklisted members abi-encoded
-        */
-        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000008103000168b43fd906c0b8f024a18c56e06744f7c6157c65").unwrap());
-
-        let pub_key_bytes_2 = BridgeAuthorityPublicKeyBytes::from_bytes(
-            &Hex::decode("027f1178ff417fc9f5b8290bd8876f0a157a505a6c52db100a8492203ddd1d4279")
-                .unwrap(),
-        )
-        .unwrap();
-        // its evem address: 0xacaef39832cb995c4e049437a3e2ec6a7bad1ab5
-        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
-            nonce: 68,
-            chain_id: BridgeChainId::SuiDevnet,
-            blocklist_type: BlocklistType::Unblocklist,
-            blocklisted_members: vec![pub_key_bytes.clone(), pub_key_bytes_2.clone()],
-        });
-        let bytes = blocklist_action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        01: msg type
-        01: msg version
-        0000000000000044: nonce
-        02: chain id
-        01: blocklist type
-        02: length of updated members
-        [
-            68b43fd906c0b8f024a18c56e06744f7c6157c65
-            acaef39832cb995c4e049437a3e2ec6a7bad1ab5
-        ]: blocklisted members abi-encoded
-        */
-        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000004402010268b43fd906c0b8f024a18c56e06744f7c6157c65acaef39832cb995c4e049437a3e2ec6a7bad1ab5").unwrap());
-
-        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
-            nonce: 49,
-            chain_id: BridgeChainId::EthLocalTest,
-            blocklist_type: BlocklistType::Blocklist,
-            blocklisted_members: vec![pub_key_bytes.clone()],
-        });
-        let bytes = blocklist_action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        01: msg type
-        01: msg version
-        0000000000000031: nonce
-        0c: chain id
-        00: blocklist type
-        01: length of updated members
-        [
-            68b43fd906c0b8f024a18c56e06744f7c6157c65
-        ]: blocklisted members abi-encoded
-        */
-        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d455353414745010100000000000000310c000168b43fd906c0b8f024a18c56e06744f7c6157c65").unwrap());
-
-        let blocklist_action = BridgeAction::BlocklistCommitteeAction(BlocklistCommitteeAction {
-            nonce: 94,
-            chain_id: BridgeChainId::EthSepolia,
-            blocklist_type: BlocklistType::Unblocklist,
-            blocklisted_members: vec![pub_key_bytes.clone(), pub_key_bytes_2.clone()],
-        });
-        let bytes = blocklist_action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        01: msg type
-        01: msg version
-        000000000000005e: nonce
-        0b: chain id
-        01: blocklist type
-        02: length of updated members
-        [
-            00000000000000000000000068b43fd906c0b8f024a18c56e06744f7c6157c65
-            000000000000000000000000acaef39832cb995c4e049437a3e2ec6a7bad1ab5
-        ]: blocklisted members abi-encoded
-        */
-        assert_eq!(bytes, Hex::decode("5355495f4252494447455f4d4553534147450101000000000000005e0b010268b43fd906c0b8f024a18c56e06744f7c6157c65acaef39832cb995c4e049437a3e2ec6a7bad1ab5").unwrap());
-    }
-
-    #[test]
-    fn test_emergency_action_encoding() {
-        let action = BridgeAction::EmergencyAction(EmergencyAction {
-            nonce: 55,
-            chain_id: BridgeChainId::SuiLocalTest,
-            action_type: EmergencyActionType::Pause,
-        });
-        let bytes = action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        02: msg type
-        01: msg version
-        0000000000000037: nonce
-        03: chain id
-        00: action type
-        */
-        assert_eq!(
-            bytes,
-            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000370300").unwrap()
-        );
-
-        let action = BridgeAction::EmergencyAction(EmergencyAction {
-            nonce: 56,
-            chain_id: BridgeChainId::EthSepolia,
-            action_type: EmergencyActionType::Unpause,
-        });
-        let bytes = action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        02: msg type
-        01: msg version
-        0000000000000038: nonce
-        0b: chain id
-        01: action type
-        */
-        assert_eq!(
-            bytes,
-            Hex::decode("5355495f4252494447455f4d455353414745020100000000000000380b01").unwrap()
-        );
-    }
-
-    #[test]
-    fn test_limit_update_action_encoding() {
-        let action = BridgeAction::LimitUpdateAction(LimitUpdateAction {
-            nonce: 15,
-            chain_id: BridgeChainId::SuiLocalTest,
-            sending_chain_id: BridgeChainId::EthLocalTest,
-            new_usd_limit: 1_000_000 * USD_MULTIPLIER, // $1M USD
-        });
-        let bytes = action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        03: msg type
-        01: msg version
-        000000000000000f: nonce
-        03: chain id
-        0c: sending chain id
-        00000002540be400: new usd limit
-        */
-        assert_eq!(
-            bytes,
-            Hex::decode(
-                "5355495f4252494447455f4d4553534147450301000000000000000f030c00000002540be400"
-            )
-            .unwrap()
-        );
-    }
-
-    #[test]
-    fn test_asset_price_update_action_encoding() {
-        let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
-            nonce: 266,
-            chain_id: BridgeChainId::SuiLocalTest,
-            token_id: TokenId::BTC,
-            new_usd_price: 100_000 * USD_MULTIPLIER, // $100k USD
-        });
-        let bytes = action.to_bytes();
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        04: msg type
-        01: msg version
-        000000000000010a: nonce
-        03: chain id
-        01: token id
-        000000003b9aca00: new usd price
-        */
-        assert_eq!(
-            bytes,
-            Hex::decode(
-                "5355495f4252494447455f4d4553534147450401000000000000010a0301000000003b9aca00"
-            )
-            .unwrap()
-        );
-    }
-
-    #[test]
-    fn test_evm_contract_upgrade_action() {
-        // Calldata with only the function selector and no parameters: `function initializeV2()`
-        let function_signature = "initializeV2()";
-        let selector = &Keccak256::digest(function_signature).digest[0..4];
-        let call_data = selector.to_vec();
-        assert_eq!(Hex::encode(call_data.clone()), "5cd8a76b");
-
-        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
-            nonce: 123,
-            chain_id: BridgeChainId::EthLocalTest,
-            proxy_address: EthAddress::repeat_byte(6),
-            new_impl_address: EthAddress::repeat_byte(9),
-            call_data,
-        });
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        05: msg type
-        01: msg version
-        000000000000007b: nonce
-        0c: chain id
-        0000000000000000000000000606060606060606060606060606060606060606: proxy address
-        0000000000000000000000000909090909090909090909090909090909090909: new impl address
-
-        0000000000000000000000000000000000000000000000000000000000000060
-        0000000000000000000000000000000000000000000000000000000000000004
-        5cd8a76b00000000000000000000000000000000000000000000000000000000: call data
-        */
-        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c00000000000000000000000006060606060606060606060606060606060606060000000000000000000000000909090909090909090909090909090909090909000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000045cd8a76b00000000000000000000000000000000000000000000000000000000");
-
-        // Calldata with one parameter: `function newMockFunction(bool)`
-        let function_signature = "newMockFunction(bool)";
-        let selector = &Keccak256::digest(function_signature).digest[0..4];
-        let mut call_data = selector.to_vec();
-        call_data.extend(ethers::abi::encode(&[ethers::abi::Token::Bool(true)]));
-        assert_eq!(
-            Hex::encode(call_data.clone()),
-            "417795ef0000000000000000000000000000000000000000000000000000000000000001"
-        );
-        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
-            nonce: 123,
-            chain_id: BridgeChainId::EthLocalTest,
-            proxy_address: EthAddress::repeat_byte(6),
-            new_impl_address: EthAddress::repeat_byte(9),
-            call_data,
-        });
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        05: msg type
-        01: msg version
-        000000000000007b: nonce
-        0c: chain id
-        0000000000000000000000000606060606060606060606060606060606060606: proxy address
-        0000000000000000000000000909090909090909090909090909090909090909: new impl address
-
-        0000000000000000000000000000000000000000000000000000000000000060
-        0000000000000000000000000000000000000000000000000000000000000024
-        417795ef00000000000000000000000000000000000000000000000000000000
-        0000000100000000000000000000000000000000000000000000000000000000: call data
-        */
-        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000024417795ef000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000");
-
-        // Calldata with two parameters: `function newerMockFunction(bool, uint8)`
-        let function_signature = "newMockFunction(bool,uint8)";
-        let selector = &Keccak256::digest(function_signature).digest[0..4];
-        let mut call_data = selector.to_vec();
-        call_data.extend(ethers::abi::encode(&[
-            ethers::abi::Token::Bool(true),
-            ethers::abi::Token::Uint(42u8.into()),
-        ]));
-        assert_eq!(
-            Hex::encode(call_data.clone()),
-            "be8fc25d0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002a"
-        );
-        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
-            nonce: 123,
-            chain_id: BridgeChainId::EthLocalTest,
-            proxy_address: EthAddress::repeat_byte(6),
-            new_impl_address: EthAddress::repeat_byte(9),
-            call_data,
-        });
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        05: msg type
-        01: msg version
-        000000000000007b: nonce
-        0c: chain id
-        0000000000000000000000000606060606060606060606060606060606060606: proxy address
-        0000000000000000000000000909090909090909090909090909090909090909: new impl address
-
-        0000000000000000000000000000000000000000000000000000000000000060
-        0000000000000000000000000000000000000000000000000000000000000044
-        be8fc25d00000000000000000000000000000000000000000000000000000000
-        0000000100000000000000000000000000000000000000000000000000000000
-        0000002a00000000000000000000000000000000000000000000000000000000: call data
-        */
-        assert_eq!(Hex::encode(action.to_bytes().clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044be8fc25d0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000");
-
-        // Empty calldate
-        let action = BridgeAction::EvmContractUpgradeAction(EvmContractUpgradeAction {
-            nonce: 123,
-            chain_id: BridgeChainId::EthLocalTest,
-            proxy_address: EthAddress::repeat_byte(6),
-            new_impl_address: EthAddress::repeat_byte(9),
-            call_data: vec![],
-        });
-        /*
-        5355495f4252494447455f4d455353414745: prefix
-        05: msg type
-        01: msg version
-        000000000000007b: nonce
-        0c: chain id
-        0000000000000000000000000606060606060606060606060606060606060606: proxy address
-        0000000000000000000000000909090909090909090909090909090909090909: new impl address
-
-        0000000000000000000000000000000000000000000000000000000000000060
-        0000000000000000000000000000000000000000000000000000000000000000: call data
-        */
-        let data = action.to_bytes();
-        assert_eq!(Hex::encode(data.clone()), "5355495f4252494447455f4d4553534147450501000000000000007b0c0000000000000000000000000606060606060606060606060606060606060606000000000000000000000000090909090909090909090909090909090909090900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
-        let types = vec![ParamType::Address, ParamType::Address, ParamType::Bytes];
-        // Ensure that the call data (start from bytes 29) can be decoded
-        ethers::abi::decode(&types, &data[29..]).unwrap();
-    }
-
-    #[test]
-    fn test_bridge_message_encoding_regression_eth_to_sui_token_bridge_v1() -> anyhow::Result<()> {
-        telemetry_subscribers::init_for_testing();
-        let registry = Registry::new();
-        mysten_metrics::init_metrics(&registry);
-        let eth_tx_hash = TxHash::random();
-        let eth_event_index = 1u16;
-
-        let nonce = 10u64;
-        let sui_chain_id = BridgeChainId::SuiTestnet;
-        let eth_chain_id = BridgeChainId::EthSepolia;
-        let sui_address = SuiAddress::from_str(
-            "0x0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap();
-        let eth_address =
-            EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
-        let token_id = TokenId::USDC;
-        let sui_adjusted_amount = 12345;
-
-        let eth_bridge_event = EthToSuiTokenBridgeV1 {
-            nonce,
-            sui_chain_id,
-            eth_chain_id,
-            sui_address,
-            eth_address,
-            token_id,
-            sui_adjusted_amount,
-        };
-        let encoded_bytes = BridgeAction::EthToSuiBridgeAction(EthToSuiBridgeAction {
-            eth_tx_hash,
-            eth_event_index,
-            eth_bridge_event,
-        })
-        .to_bytes();
-
-        assert_eq!(
-            encoded_bytes,
-            Hex::decode("5355495f4252494447455f4d4553534147450001000000000000000a0b1400000000000000000000000000000000000000c801200000000000000000000000000000000000000000000000000000000000000064030000000000003039").unwrap(),
-        );
-
-        let hash = Keccak256::digest(encoded_bytes).digest;
-        assert_eq!(
-            hash.to_vec(),
-            Hex::decode("b352508c301a37bb1b68a75dd0fc42b6f692b2650818631c8f8a4d4d3e5bef46")
-                .unwrap(),
-        );
-        Ok(())
-    }
 
     #[test]
     fn test_bridge_committee_construction() -> anyhow::Result<()> {


### PR DESCRIPTION
## Description 

This PR adds ethereum transaction building and message conversion.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
