### PR TITLE
[move-ide] IDE VFS fix to guarantee in-execution immutability

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/vfs.rs
+++ b/external-crates/move/crates/move-analyzer/src/vfs.rs
@@ -68,7 +68,7 @@ pub fn on_text_document_sync_notification(
         };
         if first_access {
             // create all directories on first access, otherwise file creation will fail
-            let _ = vfs_path.parent().create_dir();
+            let _ = vfs_path.parent().create_dir_all();
         }
         let Some(vfs_file) = vfs_path.create_file().ok() else {
             eprintln!("Could not create file at {:?}", vfs_path);


### PR DESCRIPTION
## Description 

This fixes a bug related to a misunderstanding on how VFS's overlay file system works. (a read-only layer has to be created explicitly, rather than being automatically provided by the overlay file system).

## Test Plan 

All tests must pass
