### PR TITLE
[Consensus] vote on commits and persist votes in store

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -143,7 +143,8 @@ where
         let commit_observer = CommitObserver::new(
             context.clone(),
             commit_consumer.sender,
-            commit_consumer.last_processed_index,
+            commit_consumer.last_processed_commit_round,
+            commit_consumer.last_processed_commit_index,
             dag_state.clone(),
             store.clone(),
         );
@@ -445,9 +446,7 @@ mod tests {
         let network_keypair = keypairs[own_index].0.copy();
 
         let (sender, _receiver) = unbounded_channel();
-        let commit_consumer = CommitConsumer::new(
-            sender, 0, // last_processed_index
-        );
+        let commit_consumer = CommitConsumer::new(sender, 0, 0);
 
         let authority = ConsensusAuthority::start(
             own_index,
@@ -539,9 +538,7 @@ mod tests {
             let network_keypair = keypairs[index].0.copy();
 
             let (sender, receiver) = unbounded_channel();
-            let commit_consumer = CommitConsumer::new(
-                sender, 0, // last_processed_index
-            );
+            let commit_consumer = CommitConsumer::new(sender, 0, 0);
             output_receivers.push(receiver);
 
             let authority = ConsensusAuthority::start(

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -142,9 +142,7 @@ where
 
         let commit_observer = CommitObserver::new(
             context.clone(),
-            commit_consumer.sender,
-            commit_consumer.last_processed_commit_round,
-            commit_consumer.last_processed_commit_index,
+            commit_consumer,
             dag_state.clone(),
             store.clone(),
         );

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -162,7 +162,6 @@ impl TrustedCommit {
     pub(crate) fn reference(&self) -> CommitRef {
         CommitRef {
             index: self.index(),
-            round: self.leader().round,
             digest: self.digest(),
         }
     }
@@ -235,11 +234,9 @@ impl fmt::Debug for CommitDigest {
     }
 }
 
-/// Uniquely identifies a commit via digest, with its position (round and index).
-/// NOTE: Round is included to help with checking if a Commit is the 1st of its round.
+/// Uniquely identifies a commit with its index and digest.
 #[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CommitRef {
-    pub round: Round,
     pub index: CommitIndex,
     pub digest: CommitDigest,
 }
@@ -348,6 +345,8 @@ pub struct CommitConsumer {
     pub last_processed_commit_round: Round,
     // Index of the last commit that the consumer has processed. This is useful for
     // crash/recovery so mysticeti can replay the commits from the next index.
+    // First commit in the replayed sequence will have index last_processed_commit_index + 1.
+    // Set 0 to replay from the start (as generated commit sequence starts at index = 1).
     pub last_processed_commit_index: CommitIndex,
 }
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::block::Round;
 use crate::commit::CommitAPI;
 use crate::error::{ConsensusError, ConsensusResult};
 use crate::{
@@ -42,10 +43,11 @@ impl CommitObserver {
     pub(crate) fn new(
         context: Arc<Context>,
         sender: UnboundedSender<CommittedSubDag>,
-        // Last CommitIndex that has been successfully processed by the output channel.
-        // First commit in the replayed sequence will have index last_processed_index + 1.
-        // Set to 0 to replay from the start (as normal sequence starts at index = 1).
-        last_processed_index: CommitIndex,
+        // Last Round and CommitIndex that has been successfully processed by the output channel.
+        // First commit in the replayed sequence will have index last_processed_commit_index + 1.
+        // Set both to 0 to replay from the start (as normal sequence starts at index = 1).
+        last_processed_commit_round: Round,
+        last_processed_commit_index: CommitIndex,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
     ) -> Self {
@@ -56,7 +58,7 @@ impl CommitObserver {
             store,
         };
 
-        observer.send_missing_commits(last_processed_index);
+        observer.recover_and_send_commits(last_processed_commit_round, last_processed_commit_index);
         observer
     }
 
@@ -88,7 +90,12 @@ impl CommitObserver {
         Ok(sent_sub_dags)
     }
 
-    fn send_missing_commits(&mut self, last_processed_index: CommitIndex) {
+    fn recover_and_send_commits(
+        &mut self,
+        last_processed_commit_round: Round,
+        last_processed_commit_index: CommitIndex,
+    ) {
+        // TODO: remove this check, to allow consensus to regenerate commits?
         let last_commit = self
             .store
             .read_last_commit()
@@ -97,34 +104,37 @@ impl CommitObserver {
         if let Some(last_commit) = last_commit {
             let last_commit_index = last_commit.index();
 
-            assert!(last_commit_index >= last_processed_index);
-            if last_commit_index == last_processed_index {
+            assert!(last_commit_index >= last_processed_commit_index);
+            if last_commit_index == last_processed_commit_index {
                 return;
             }
         };
 
-        // We should not send the last processed commit again, so last_processed_index++
+        // We should not send the last processed commit again, so last_processed_commit_index+1
         let unsent_commits = self
             .store
-            .scan_commits(last_processed_index + 1)
+            .scan_commits(
+                (last_processed_commit_round, last_processed_commit_index + 1),
+                (Round::MAX, CommitIndex::MAX),
+            )
             .expect("Scanning commits should not fail");
 
+        // Resend all the committed subdags to the consensus output channel
+        // for all the commits above the last processed index.
+        let mut last_sent_commit_index = last_processed_commit_index;
         for commit in unsent_commits {
-            // Resend all the committed subdags to the consensus output channel
-            // for all the commits above the last processed index.
-            assert!(commit.index() > last_processed_index);
-            let committed_subdag = load_committed_subdag_from_store(self.store.as_ref(), commit);
+            // Commit index must be continuous.
+            assert_eq!(commit.index(), last_sent_commit_index + 1);
 
-            // Failures in sender.send() are assumed to be permanent
-            if let Err(err) = self.sender.send(committed_subdag) {
-                tracing::error!(
-                    "Failed to send committed sub-dag, probably due to shutdown: {:?}",
-                    err
-                );
-                // TODO: revisit this to see if we should pass error/shutdown signal
-                // back to core.
-                break;
-            }
+            let committed_subdag = load_committed_subdag_from_store(self.store.as_ref(), commit);
+            self.sender.send(committed_subdag).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to send commit during recovery, probably due to shutdown: {:?}",
+                    e
+                )
+            });
+
+            last_sent_commit_index += 1;
         }
     }
 
@@ -190,13 +200,15 @@ mod tests {
             mem_store.clone(),
         )));
         let leader_schedule = LeaderSchedule::new(context.clone());
-        let last_processed_index = 0;
+        let last_processed_commit_round = 0;
+        let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();
 
         let mut observer = CommitObserver::new(
             context.clone(),
             sender,
-            last_processed_index,
+            last_processed_commit_round,
+            last_processed_commit_index,
             dag_state.clone(),
             mem_store.clone(),
         );
@@ -259,14 +271,16 @@ mod tests {
         // Check commits have been persisted to storage
         let last_commit = mem_store.read_last_commit().unwrap().unwrap();
         assert_eq!(last_commit.index(), commits.last().unwrap().commit_index);
-        let all_stored_commits = mem_store.scan_commits(0).unwrap();
+        let all_stored_commits = mem_store
+            .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
+            .unwrap();
         assert_eq!(all_stored_commits.len(), leaders.len());
         let blocks_existence = mem_store.contains_blocks(&expected_stored_refs).unwrap();
         assert!(blocks_existence.iter().all(|exists| *exists));
     }
 
     #[test]
-    fn test_send_missing_commits_from_index() {
+    fn test_recover_and_send_commits() {
         telemetry_subscribers::init_for_testing();
         let num_authorities = 4;
         let context = Arc::new(Context::new_for_test(num_authorities).0);
@@ -276,13 +290,15 @@ mod tests {
             mem_store.clone(),
         )));
         let leader_schedule = LeaderSchedule::new(context.clone());
-        let last_processed_index = 0;
+        let last_processed_commit_round = 0;
+        let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();
 
         let mut observer = CommitObserver::new(
             context.clone(),
             sender.clone(),
-            last_processed_index,
+            last_processed_commit_round,
+            last_processed_commit_index,
             dag_state.clone(),
             mem_store.clone(),
         );
@@ -301,7 +317,9 @@ mod tests {
 
         // Commit first batch of leaders (2) and "receive" the subdags as the
         // consumer of the consensus output channel.
-        let expected_last_processed_index = 2;
+        let expected_last_processed_index: usize = 2;
+        let expected_last_processed_round =
+            expected_last_processed_index as u32 * DEFAULT_WAVE_LENGTH;
         let mut commits = observer
             .handle_commit(
                 leaders
@@ -372,6 +390,7 @@ mod tests {
         let _observer = CommitObserver::new(
             context.clone(),
             sender,
+            expected_last_processed_round as Round,
             expected_last_processed_index as CommitIndex,
             dag_state.clone(),
             mem_store.clone(),
@@ -404,13 +423,15 @@ mod tests {
             mem_store.clone(),
         )));
         let leader_schedule = LeaderSchedule::new(context.clone());
-        let last_processed_index = 0;
+        let last_processed_commit_round = 0;
+        let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();
 
         let mut observer = CommitObserver::new(
             context.clone(),
             sender.clone(),
-            last_processed_index,
+            last_processed_commit_round,
+            last_processed_commit_index,
             dag_state.clone(),
             mem_store.clone(),
         );
@@ -429,7 +450,9 @@ mod tests {
 
         // Commit all of the leaders and "receive" the subdags as the consumer of
         // the consensus output channel.
-        let expected_last_processed_index = 3;
+        let expected_last_processed_index: usize = 3;
+        let expected_last_processed_round =
+            expected_last_processed_index as u32 * DEFAULT_WAVE_LENGTH;
         let commits = observer.handle_commit(leaders.clone()).unwrap();
 
         // Check commits sent over consensus output channel is accurate
@@ -458,6 +481,7 @@ mod tests {
         let _observer = CommitObserver::new(
             context.clone(),
             sender,
+            expected_last_processed_round as Round,
             expected_last_processed_index as CommitIndex,
             dag_state.clone(),
             mem_store.clone(),

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -530,7 +530,7 @@ mod test {
         commit::CommitAPI as _,
         storage::{mem_store::MemStore, WriteBatch},
         transaction::TransactionClient,
-        CommitIndex,
+        CommitConsumer, CommitIndex,
     };
 
     /// Recover Core and continue proposing from the last round which forms a quorum.
@@ -576,9 +576,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),
-            sender.clone(),
-            0, // last_processed_commit_round
-            0, // last_processed_commit_index
+            CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
             store.clone(),
         );
@@ -633,9 +631,7 @@ mod test {
         // as soon as the new block for round 5 is proposed.
         assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
-        let all_stored_commits = store
-            .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
-            .unwrap();
+        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
     }
 
@@ -691,9 +687,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),
-            sender.clone(),
-            0, // last_processed_commit_round
-            0, // last_processed_commit_index
+            CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
             store.clone(),
         );
@@ -751,9 +745,7 @@ mod test {
         // as the new block for round 4 is proposed.
         assert_eq!(last_commit.index(), 2);
         assert_eq!(dag_state.read().last_commit_index(), 2);
-        let all_stored_commits = store
-            .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
-            .unwrap();
+        let all_stored_commits = store.scan_commits(0..CommitIndex::MAX).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
     }
 
@@ -785,9 +777,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),
-            sender.clone(),
-            0, // last_processed_commit_round
-            0, // last_processed_commit_index
+            CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
             store.clone(),
         );
@@ -886,9 +876,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),
-            sender.clone(),
-            0, // last_processed_commit_round
-            0, // last_processed_commit_index
+            CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
             store.clone(),
         );
@@ -1005,10 +993,7 @@ mod test {
             // There are 1 leader rounds with rounds completed up to and including
             // round 4
             assert_eq!(last_commit.index(), 1);
-            let all_stored_commits = core
-                .store
-                .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
-                .unwrap();
+            let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
             assert_eq!(all_stored_commits.len(), 1);
         }
     }
@@ -1083,10 +1068,7 @@ mod test {
             // round 9. Round 10 blocks will only include their own blocks, so the
             // 8th leader will not be committed.
             assert_eq!(last_commit.index(), 7);
-            let all_stored_commits = core
-                .store
-                .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
-                .unwrap();
+            let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
             assert_eq!(all_stored_commits.len(), 7);
         }
     }
@@ -1160,10 +1142,7 @@ mod test {
         // round 10. However because there were no blocks produced for authority 3
         // 2 leader rounds will be skipped.
         assert_eq!(last_commit.index(), 6);
-        let all_stored_commits = core
-            .store
-            .scan_commits((0, 0), (Round::MAX, CommitIndex::MAX))
-            .unwrap();
+        let all_stored_commits = core.store.scan_commits(0..CommitIndex::MAX).unwrap();
         assert_eq!(all_stored_commits.len(), 6);
     }
 
@@ -1205,9 +1184,7 @@ mod test {
             let (commit_sender, commit_receiver) = unbounded_channel();
             let commit_observer = CommitObserver::new(
                 context.clone(),
-                commit_sender.clone(),
-                0, // last_processed_commit_round
-                0, // last_processed_commit_index
+                CommitConsumer::new(commit_sender.clone(), 0, 0),
                 dag_state.clone(),
                 store.clone(),
             );

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -188,6 +188,7 @@ mod test {
         dag_state::DagState,
         storage::mem_store::MemStore,
         transaction::{TransactionClient, TransactionConsumer},
+        CommitConsumer,
     };
 
     #[tokio::test]
@@ -209,9 +210,7 @@ mod test {
         let (sender, _receiver) = unbounded_channel();
         let commit_observer = CommitObserver::new(
             context.clone(),
-            sender.clone(),
-            0, // last_processed_commit_round
-            0, // last_processed_commit_index
+            CommitConsumer::new(sender.clone(), 0, 0),
             dag_state.clone(),
             store.clone(),
         );

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -210,7 +210,8 @@ mod test {
         let commit_observer = CommitObserver::new(
             context.clone(),
             sender.clone(),
-            0, // last_processed_index
+            0, // last_processed_commit_round
+            0, // last_processed_commit_index
             dag_state.clone(),
             store.clone(),
         );

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -16,6 +16,9 @@ pub enum ConsensusError {
     #[error("Error deserializing block: {0}")]
     MalformedBlock(bcs::Error),
 
+    #[error("Error deserializing commit: {0}")]
+    MalformedCommit(bcs::Error),
+
     #[error("Error serializing: {0}")]
     SerializationFailure(bcs::Error),
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -29,6 +29,6 @@ mod transaction;
 mod universal_committer;
 
 pub use authority_node::ConsensusAuthority;
-pub use block::BlockAPI;
+pub use block::{BlockAPI, Round};
 pub use commit::{CommitConsumer, CommitIndex, CommittedSubDag};
 pub use transaction::{TransactionClient, TransactionVerifier, ValidationError};

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -102,7 +102,7 @@ impl Linearizer {
             sub_dag.sort();
 
             // Buffer commit in dag state for persistence later.
-            let commit = TrustedCommit::new_trusted(Commit::new(
+            let commit = Commit::new(
                 sub_dag.commit_index,
                 sub_dag.leader,
                 sub_dag
@@ -114,7 +114,11 @@ impl Linearizer {
                         block_ref
                     })
                     .collect(),
-            ));
+            );
+            let serialized = commit
+                .serialize()
+                .unwrap_or_else(|e| panic!("Failed to serialize commit: {}", e));
+            let commit = TrustedCommit::new_trusted(commit, serialized);
             self.dag_state.write().add_commit(commit.clone());
             committed_sub_dags.push(sub_dag);
         }

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -88,6 +88,7 @@ impl Linearizer {
             // Grab latest commit state from dag state
             let dag_state = self.dag_state.read();
             let last_commit_index = dag_state.last_commit_index();
+            let last_commit_digest = dag_state.last_commit_digest();
             let mut last_committed_rounds = dag_state.last_committed_rounds();
             drop(dag_state);
 
@@ -104,6 +105,7 @@ impl Linearizer {
             // Buffer commit in dag state for persistence later.
             let commit = Commit::new(
                 sub_dag.commit_index,
+                last_commit_digest,
                 sub_dag.leader,
                 sub_dag
                     .blocks
@@ -138,7 +140,7 @@ impl Linearizer {
 mod tests {
     use super::*;
     use crate::{
-        commit::{CommitAPI as _, DEFAULT_WAVE_LENGTH},
+        commit::{CommitAPI as _, CommitDigest, DEFAULT_WAVE_LENGTH},
         context::Context,
         leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
@@ -250,6 +252,7 @@ mod tests {
         let mut last_commit_index = 1;
         let first_commit_data = TrustedCommit::new_for_test(
             last_commit_index,
+            CommitDigest::MIN,
             first_leader.reference(),
             blocks.clone(),
         );
@@ -300,6 +303,7 @@ mod tests {
         let second_leader = leaders[1].clone();
         let expected_second_commit = TrustedCommit::new_for_test(
             last_commit_index,
+            CommitDigest::MIN,
             second_leader.reference(),
             blocks.clone(),
         );

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod rocksdb_store;
 #[cfg(test)]
 mod store_tests;
 
+use std::ops::Range;
+
 use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
 
@@ -46,11 +48,7 @@ pub(crate) trait Store: Send + Sync {
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>>;
 
     /// Reads all commits from start (inclusive) until end (exclusive).
-    fn scan_commits(
-        &self,
-        start: (Round, CommitIndex),
-        end: (Round, CommitIndex),
-    ) -> ConsensusResult<Vec<TrustedCommit>>;
+    fn scan_commits(&self, range: Range<CommitIndex>) -> ConsensusResult<Vec<TrustedCommit>>;
 
     /// Reads the last commit info, including last committed round per authority.
     fn read_last_commit_info(&self) -> ConsensusResult<Option<CommitInfo>>;

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use super::{mem_store::MemStore, rocksdb_store::RocksDBStore, Store, WriteBatch};
 use crate::{
     block::{BlockDigest, BlockRef, TestBlock, VerifiedBlock},
-    commit::TrustedCommit,
+    commit::{CommitDigest, TrustedCommit},
 };
 
 /// Test fixture for store tests. Wraps around various store implementations.
@@ -203,21 +203,25 @@ async fn read_and_scan_commits(
     let written_commits = vec![
         TrustedCommit::new_for_test(
             1,
+            CommitDigest::MIN,
             BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             2,
+            CommitDigest::MIN,
             BlockRef::new(2, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             3,
+            CommitDigest::MIN,
             BlockRef::new(3, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),
         TrustedCommit::new_for_test(
             4,
+            CommitDigest::MIN,
             BlockRef::new(4, AuthorityIndex::new_for_test(0), BlockDigest::default()),
             vec![],
         ),

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -244,14 +244,14 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits((20, 20), (25, 25))
+            .scan_commits(20..25)
             .expect("Scan commits should not fail");
         assert!(scanned_commits.is_empty(), "{:?}", scanned_commits);
     }
 
     {
         let scanned_commits = store
-            .scan_commits((3, 3), (5, 5))
+            .scan_commits(3..5)
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 2, "{:?}", scanned_commits);
         assert_eq!(
@@ -262,7 +262,7 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits((0, 0), (3, 3))
+            .scan_commits(0..3)
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 2, "{:?}", scanned_commits);
         assert_eq!(
@@ -273,7 +273,7 @@ async fn read_and_scan_commits(
 
     {
         let scanned_commits = store
-            .scan_commits((0, 0), (5, 5))
+            .scan_commits(0..5)
             .expect("Scan commits should not fail");
         assert_eq!(scanned_commits.len(), 4, "{:?}", scanned_commits);
         assert_eq!(scanned_commits, written_commits,);

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -210,6 +210,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ExecutionState for ConsensusHandl
             .await;
     }
 
+    fn last_executed_sub_dag_round(&self) -> u64 {
+        self.last_consensus_stats.index.last_committed_round
+    }
+
     fn last_executed_sub_dag_index(&self) -> u64 {
         self.last_consensus_stats.index.sub_dag_index
     }

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use consensus_config::{AuthorityIndex, Committee, Parameters};
-use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority};
+use consensus_core::{CommitConsumer, CommitIndex, ConsensusAuthority, Round};
 use fastcrypto::traits::KeyPair;
 use mysten_metrics::{RegistryID, RegistryService};
 use narwhal_executor::ExecutionState;
@@ -130,6 +130,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         let consumer = CommitConsumer::new(
             commit_sender,
             // TODO(mysticeti): remove dependency on narwhal executor
+            consensus_handler.last_executed_sub_dag_round() as Round,
             consensus_handler.last_executed_sub_dag_index() as CommitIndex,
         );
 

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -37,7 +37,10 @@ pub trait ExecutionState {
     /// Execute the transaction and atomically persist the consensus index.
     async fn handle_consensus_output(&mut self, consensus_output: ConsensusOutput);
 
-    /// Load the last executed sub-dag index from storage
+    /// The last executed sub-dag / commit leader round.
+    fn last_executed_sub_dag_round(&self) -> u64;
+
+    /// The last executed sub-dag / commit index.
     fn last_executed_sub_dag_index(&self) -> u64;
 }
 

--- a/narwhal/node/src/execution_state.rs
+++ b/narwhal/node/src/execution_state.rs
@@ -36,6 +36,10 @@ impl ExecutionState for SimpleExecutionState {
         }
     }
 
+    fn last_executed_sub_dag_round(&self) -> u64 {
+        0
+    }
+
     fn last_executed_sub_dag_index(&self) -> u64 {
         0
     }


### PR DESCRIPTION
## Description 

This is the write path for commit certification. It is kept simple: each block can contain one or more `CommitRef` that includes commit leader round, index and digest. For each commit, all votes on it are recorded in storage when blocks containing commit votes are persisted.

## Test Plan 

Unit tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
