### PR TITLE
[bench] Properly sign transactions in single node benchmark

### DIFF
--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -18,7 +18,9 @@ use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::messages_grpc::HandleTransactionResponse;
 use sui_types::mock_checkpoint_builder::ValidatorKeypairProvider;
-use sui_types::transaction::{CertifiedTransaction, SignedTransaction, Transaction};
+use sui_types::transaction::{
+    CertifiedTransaction, SignedTransaction, Transaction, VerifiedTransaction,
+};
 use tracing::info;
 
 pub struct BenchmarkContext {
@@ -155,6 +157,7 @@ impl BenchmarkContext {
     pub(crate) async fn certify_transactions(
         &self,
         transactions: Vec<Transaction>,
+        skip_signing: bool,
     ) -> Vec<CertifiedTransaction> {
         info!("Creating transaction certificates");
         let tasks: FuturesUnordered<_> = transactions
@@ -163,8 +166,23 @@ impl BenchmarkContext {
                 let validator = self.validator();
                 tokio::spawn(async move {
                     let committee = validator.get_committee();
-                    let validator = validator.get_validator();
-                    let sig = SignedTransaction::sign(0, &tx, &*validator.secret, validator.name);
+                    let validator_state = validator.get_validator();
+                    let sig = if skip_signing {
+                        SignedTransaction::sign(
+                            0,
+                            &tx,
+                            &*validator_state.secret,
+                            validator_state.name,
+                        )
+                    } else {
+                        let verified_tx = VerifiedTransaction::new_unchecked(tx.clone());
+                        validator_state
+                            .handle_transaction(validator.get_epoch_store(), verified_tx)
+                            .await
+                            .unwrap()
+                            .status
+                            .into_signed_for_testing()
+                    };
                     CertifiedTransaction::new(tx.into_data(), vec![sig], committee).unwrap()
                 })
             })
@@ -177,8 +195,9 @@ impl BenchmarkContext {
         &self,
         transactions: Vec<Transaction>,
         print_sample_tx: bool,
+        skip_signing: bool,
     ) {
-        let mut transactions = self.certify_transactions(transactions).await;
+        let mut transactions = self.certify_transactions(transactions, skip_signing).await;
         if print_sample_tx {
             self.execute_sample_transaction(transactions.pop().unwrap().into_unsigned())
                 .await;

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -33,6 +33,12 @@ pub struct Command {
     pub print_sample_tx: bool,
     #[arg(
         long,
+        default_value_t = false,
+        help = "If true, skip signing on the validators, instead, creating certificates directly using validator secrets"
+    )]
+    pub skip_signing: bool,
+    #[arg(
+        long,
         default_value = "baseline",
         ignore_case = true,
         help = "Which component to benchmark"

--- a/crates/sui-single-node-benchmark/src/lib.rs
+++ b/crates/sui-single-node-benchmark/src/lib.rs
@@ -23,6 +23,7 @@ pub async fn run_benchmark(
     component: Component,
     checkpoint_size: usize,
     print_sample_tx: bool,
+    skip_signing: bool,
 ) {
     let mut ctx = BenchmarkContext::new(
         workload.clone(),
@@ -47,7 +48,7 @@ pub async fn run_benchmark(
                 .await;
         }
         _ => {
-            ctx.benchmark_transaction_execution(transactions, print_sample_tx)
+            ctx.benchmark_transaction_execution(transactions, print_sample_tx, skip_signing)
                 .await;
         }
     }

--- a/crates/sui-single-node-benchmark/src/main.rs
+++ b/crates/sui-single-node-benchmark/src/main.rs
@@ -19,6 +19,7 @@ async fn main() {
         args.component,
         args.checkpoint_size,
         args.print_sample_tx,
+        args.skip_signing,
     )
     .await;
 

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -10,44 +10,49 @@ use sui_single_node_benchmark::workload::Workload;
 
 #[sim_test]
 async fn benchmark_non_move_transactions_smoke_test() {
-    for component in Component::iter() {
-        run_benchmark(
-            Workload::new(
-                10,
-                WorkloadKind::PTB {
-                    num_transfers: 2,
-                    use_native_transfer: true,
-                    num_dynamic_fields: 0,
-                    computation: 0,
-                },
-            ),
-            component,
-            1000,
-            false,
-        )
-        .await;
+    for skip_signing in [true, false] {
+        for component in Component::iter() {
+            run_benchmark(
+                Workload::new(
+                    10,
+                    WorkloadKind::PTB {
+                        num_transfers: 2,
+                        use_native_transfer: true,
+                        num_dynamic_fields: 0,
+                        computation: 0,
+                    },
+                ),
+                component,
+                1000,
+                false,
+                skip_signing,
+            )
+            .await;
+        }
     }
 }
 
 #[sim_test]
 async fn benchmark_move_transactions_smoke_test() {
-    // This test makes sure that the benchmark runs.
-    for component in Component::iter() {
-        run_benchmark(
-            Workload::new(
-                10,
-                WorkloadKind::PTB {
-                    num_transfers: 2,
-                    use_native_transfer: false,
-                    num_dynamic_fields: 1,
-                    computation: 1,
-                },
-            ),
-            component,
-            1000,
-            false,
-        )
-        .await;
+    for skip_signing in [true, false] {
+        for component in Component::iter() {
+            run_benchmark(
+                Workload::new(
+                    10,
+                    WorkloadKind::PTB {
+                        num_transfers: 2,
+                        use_native_transfer: false,
+                        num_dynamic_fields: 1,
+                        computation: 1,
+                    },
+                ),
+                component,
+                1000,
+                false,
+                skip_signing,
+            )
+            .await;
+        }
     }
 }
 
@@ -71,6 +76,7 @@ async fn benchmark_publish_from_source() {
             ),
             component,
             1000,
+            false,
             false,
         )
         .await;
@@ -97,6 +103,7 @@ async fn benchmark_publish_from_bytecode() {
             ),
             component,
             1000,
+            false,
             false,
         )
         .await;


### PR DESCRIPTION
## Description 

When forming a cert, properly sign the transaction on the validator.
This will make it possible to measure performance changes with transaction lock cache.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
