### PR TITLE
Deterministic Build using StageX

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ target/
 *.md
 build/
 storage/
+docker/

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -1,36 +1,85 @@
-# Build application
-#
-# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
-# and build the application.
-FROM rust:1.75-bullseye AS builder
 ARG PROFILE=release
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
-WORKDIR "$WORKDIR/sui"
-RUN apt-get update && apt-get install -y cmake clang
-
-COPY Cargo.toml Cargo.lock ./
-COPY consensus consensus
-COPY crates crates
-COPY sui-execution sui-execution
-COPY narwhal narwhal
-COPY external-crates external-crates
-
-RUN cargo build --profile ${PROFILE} --bin sui-node
-
-# Production Image
-FROM debian:bullseye-slim AS runtime
-# Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
-ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
-ARG PROFILE=release
-WORKDIR "$WORKDIR/sui"
-# Both bench and release profiles copy from release dir
-COPY --from=builder /sui/target/release/sui-node /opt/sui/bin/sui-node
-# Support legacy usages of /usr/local/bin/sui-node
-COPY --from=builder /sui/target/release/sui-node /usr/local/bin
-
 ARG BUILD_DATE
 ARG GIT_REVISION
-LABEL build-date=$BUILD_DATE
-LABEL git-revision=$GIT_REVISION
+ARG RUST_VERSION=1.76.0
+
+FROM scratch AS base
+
+FROM stagex/rust:${RUST_VERSION} AS rust
+FROM base AS fetch
+
+COPY --from=stagex/busybox . /
+COPY --from=stagex/musl . /
+COPY --from=rust . /
+
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/libunwind . /
+COPY --from=stagex/openssl . /
+COPY --from=stagex/zlib . /
+
+# NOTE: Necessary for `cargo fetch`, but CA trust is not relied upon
+COPY --from=stagex/ca-certificates . /
+
+# HACK: gcc puts things in /usr/lib64 
+COPY --from=stagex/gcc /usr/lib64/* /usr/lib/
+
+COPY . /sui
+
+WORKDIR sui
+
+RUN cargo fetch
+
+FROM fetch AS build
+
+# Rust build deps
+
+COPY --from=stagex/binutils . /
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/make . /
+COPY --from=stagex/musl . /
+
+# Sui build deps
+
+COPY --from=stagex/clang . /
+COPY --from=stagex/linux-headers . /
+
+ARG PROFILE
+ARG GIT_REVISION
+
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS='-C target-feature=-crt-static -C codegen-units=1'
+ENV GIT_REVISION=${GIT_REVISION}
+ENV PROFILE=${PROFILE}
+
+RUN --network=none cargo build --frozen --profile ${PROFILE} --bin sui-node
+
+FROM scratch AS install
+
+COPY --from=stagex/busybox . /
+
+COPY --from=stagex/busybox . /rootfs
+COPY --from=stagex/libunwind . /rootfs
+COPY --from=stagex/gcc . /rootfs
+COPY --from=stagex/musl . /rootfs
+
+# HACK: In the current release of stagex, gcc puts things in /usr/lib64,
+# but we expect them in /usr/lib
+COPY --from=stagex/gcc /usr/lib64/* /rootfs/usr/lib/
+
+COPY --from=build sui/target/release/sui-node /rootfs/usr/bin/sui-node
+RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
+
+FROM scratch AS package
+
+ARG PROFILE
+ARG GIT_REVISION
+
+LABEL build-date=${BUILD_DATE}
+LABEL git-revision=${GIT_REVISION}
+
+COPY --from=install /rootfs /
+
+ENTRYPOINT ["/usr/bin/sui-node"]
+CMD ["--version"]

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -7,6 +7,7 @@ set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+OCI_OUTPUT="$REPO_ROOT/build/oci"
 DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
@@ -26,10 +27,15 @@ echo "Dockerfile: \t$DOCKERFILE"
 echo "docker context: $REPO_ROOT"
 echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
+echo "output directory: \t$OCI_OUTPUT"
 echo
+
+export DOCKER_BUILDKIT=1
+export SOURCE_DATE_EPOCH=1
 
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg PROFILE="$PROFILE" \
+  --output type=oci,rewrite-timestamp=true,force-compression=true,tar=false,dest=$OCI_OUTPUT/sui-node,name=sui-node \
 	"$@"


### PR DESCRIPTION
## Description 

This uses the stagex toolchain (see: https://codeberg.org/stagex/stagex) to build the`sui-node` container.

### What is stagex?

[stagex](https://codeberg.org/stagex/stagex) starts with 256 bytes of x86 assembly and deterministically reproduces every dependency necessary to build modern software. Every release of stagex is coordinated such that only if two maintainers with a separate hardware stack are able to reproduce the _entire_ toolchain, will the containers be published. As such, stagex can be built locally to get the _exact_ same images that exist in Docker Hub (when using Docker 25.x with containerd snapshotter).

This pull request uses the stagex toolchain and the stagex Containerfile workflow to build a deterministic OCI image. The image may be loaded to Docker using:

```sh
# Import into Docker
env -C build/oci/sui-node tar c . | docker load

# Verify Sui loads by printing version
docker run sui-node
```

The choice of the OCI output format is to ensure reproducibility, as Docker's image format has occasional quirks depending on the machine it runs on, but we've yet to experience a hardware configuration that has yet to reproduce using Docker 25.x and the containerd snapshotter.

Please note that the resulting image hash is dependent on the content `ADD`ed in the Containerfile, so any modifications to any files that aren't exempted in `.dockerignore` will result in a new image hash.

## Test Plan 

Run `sh docker/sui-node/build.sh`, and compare the built hash:

```
 => exporting to oci image format
 => => exporting layers
 => => exporting manifest sha256:d82d09740b6e1e49742d2190766e285868f5eb42177af95423a352107bd8e43f
 => => exporting config sha256:40c360768857f5e23f2361872a04d6a7d99aad17d488703e9a368b90f4dda00f
```

Run `docker system prune` to clear the build cache, and run `sh docker/sui-node/build.sh` again.