### PR TITLE
[cli-ptb] Add "did you mean" for misspelled commands

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -52,6 +52,23 @@ pub const KEYWORDS: &[&str] = &[
     ADDRESS, BOOL, VECTOR, SOME, NONE, GAS, U8, U16, U32, U64, U128, U256,
 ];
 
+pub const COMMANDS: &[&str] = &[
+    TRANSFER_OBJECTS,
+    SPLIT_COINS,
+    MERGE_COINS,
+    MAKE_MOVE_VEC,
+    MOVE_CALL,
+    PUBLISH,
+    UPGRADE,
+    ASSIGN,
+    PREVIEW,
+    WARN_SHADOWS,
+    GAS_BUDGET,
+    SUMMARY,
+    GAS_COIN,
+    JSON,
+];
+
 pub fn is_keyword(s: &str) -> bool {
     KEYWORDS.contains(&s)
 }

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -1029,7 +1029,7 @@ pub fn to_ordinal_contraction(num: usize) -> String {
     format!("{}{}", num, suffix)
 }
 
-fn find_did_you_means<'a>(
+pub(crate) fn find_did_you_means<'a>(
     needle: &str,
     haystack: impl IntoIterator<Item = &'a str>,
 ) -> Vec<&'a str> {
@@ -1055,7 +1055,9 @@ fn find_did_you_means<'a>(
     results
 }
 
-fn display_did_you_mean(possibles: Vec<&str>) -> Option<String> {
+pub(crate) fn display_did_you_mean<S: AsRef<str> + std::fmt::Display>(
+    possibles: Vec<S>,
+) -> Option<String> {
     if possibles.is_empty() {
         return None;
     }

--- a/crates/sui/tests/ptb_files/parsing/invalid_commands.ptb
+++ b/crates/sui/tests/ptb_files/parsing/invalid_commands.ptb
@@ -1,0 +1,6 @@
+--move-cal
+--assing
+--assig
+--splitcoins
+--move-vec
+--transfer-object

--- a/crates/sui/tests/snapshots/ptb_files_tests__invalid_commands.ptb.snap
+++ b/crates/sui/tests/snapshots/ptb_files_tests__invalid_commands.ptb.snap
@@ -1,0 +1,72 @@
+---
+source: crates/sui/tests/ptb_files_tests.rs
+expression: "results.join(\"\\n\")"
+---
+ === ERRORS AFTER PARSING INPUT COMMANDS === 
+  × Error when processing PTB
+   ╭─[1:1]
+ 1 │ --move-cal
+   · ─────┬────
+   ·      ╰── Unknown command '--move-cal'
+ 2 │ --assing
+   ╰────
+  help: Did you mean '--move-call'?
+
+  × Error when processing PTB
+   ╭─[2:1]
+ 1 │ --move-cal
+ 2 │ --assing
+   · ────┬───
+   ·     ╰── Unknown command '--assing'
+ 3 │ --assig
+   ╰────
+  help: Did you mean '--assign'?
+
+  × Error when processing PTB
+   ╭─[3:1]
+ 2 │ --assing
+ 3 │ --assig
+   · ───┬───
+   ·    ╰── Unknown command '--assig'
+ 4 │ --splitcoins
+   ╰────
+  help: Did you mean '--assign'?
+
+  × Error when processing PTB
+   ╭─[4:1]
+ 3 │ --assig
+ 4 │ --splitcoins
+   · ──────┬─────
+   ·       ╰── Unknown command '--splitcoins'
+ 5 │ --move-vec
+   ╰────
+  help: Did you mean '--split-coins'?
+
+  × Error when processing PTB
+   ╭─[5:1]
+ 4 │ --splitcoins
+ 5 │ --move-vec
+   · ─────┬────
+   ·      ╰── Unknown command '--move-vec'
+ 6 │ --transfer-object 
+   ╰────
+  help: Did you mean '--move-call'?
+
+  × Error when processing PTB
+   ╭─[6:1]
+ 5 │ --move-vec
+ 6 │ --transfer-object 
+   · ────────┬────────
+   ·         ╰── Unknown command '--transfer-object'
+   ╰────
+  help: Did you mean '--transfer-objects'?
+
+  × Error when processing PTB
+   ╭─[6:18]
+ 5 │ --move-vec
+ 6 │ --transfer-object 
+   ·                  ▲
+   ·                  ╰── Gas budget not set.
+   ╰────
+  help: Use --gas-budget <u64> to set a gas budget
+


### PR DESCRIPTION
## Description 

Adds help messages for misspelled PTB commands:

<img width="269" alt="Screenshot 2024-03-04 at 4 30 40 PM" src="https://github.com/MystenLabs/sui/assets/2895723/abe3d3ce-e878-48d7-9851-5a9a21773e08">


## Test Plan 

Added a test to make sure we properly report suggested names

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Suggest the closes valid command if an invalid command name is encountered in CLI PTBs. 
