### PR TITLE
update whoami for advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15495,6 +15495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15636,11 +15642,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 


### PR DESCRIPTION
## Description 

```
1380 │ whoami 1.3.0 registry+https://github.com/rust-lang/crates.io-index
     │ ------------------------------------------------------------------ security vulnerability detected
     │
     = ID: RUSTSEC-2024-0020
     = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0020
     = With older versions of the whoami crate, calling the `username` function leads to an immediate stack
       buffer overflow on illumos and Solaris. Denial of service and data corruption have both been
       observed in the wild, and the issue is possibly exploitable as well.

       This also affects any other Unix platforms that aren't any of: `linux`, `macos`, `freebsd`,
       `dragonfly`, `bitrig`, `openbsd`, `netbsd`.

       This issue has been addressed in whoami 1.5.0.

       For more information, see [this GitHub issue](https://github.com/ardaku/whoami/issues/91).
     = Announcement: https://github.com/ardaku/whoami/issues/91
     = Solution: Upgrade to >=1.5.0 (try `cargo update -p whoami`)
```
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
