### PR TITLE
[docs] Fix broken link

### DIFF
--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -17,7 +17,7 @@
 //! block and submit it to the fullnode(s)
 //! * [ReadApi] - provides functions for retrieving data about different
 //! objects and transactions
-//! * [TransactionBuilder] - provides functions for building transactions
+//! * <a href="../sui_transaction_builder/struct.TransactionBuilder.html" title="struct sui_transaction_builder::TransactionBuilder">TransactionBuilder</a> - provides functions for building transactions
 //!
 //! # Usage
 //! The main way to interact with the API is through the [SuiClientBuilder],

--- a/docs/content/standards/coin.mdx
+++ b/docs/content/standards/coin.mdx
@@ -25,8 +25,6 @@ The documentation refers to fungible tokens created on Sui using the Coin standa
 
 ::: 
 
-{@include: ../snippets/coin-token-apis.mdx}
-
 ## Treasury capability
 
 When you create a coin using the `coin::create_currency` function, the publisher of the smart contract that creates the coin receives a `TreasuryCap` object. The `TreasuryCap` object is required to mint new coins or to burn current ones. Consequently, only addresses that have access to this object are able to maintain the coin supply on the Sui network. 


### PR DESCRIPTION
## Description 

This is a temporary fix for the link not autogenerating with the GH process. Generates locally, but not with the GH action.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
