### PR TITLE
[docs] Temporary fix for link not automatically generated

### DIFF
--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -17,7 +17,7 @@
 //! block and submit it to the fullnode(s)
 //! * [ReadApi] - provides functions for retrieving data about different
 //! objects and transactions
-//! * [TransactionBuilder] - provides functions for building transactions
+//! * <a href="../sui_transaction_builder/struct.TransactionBuilder.html" title="struct sui_transaction_builder::TransactionBuilder">TransactionBuilder</a> - provides functions for building transactions
 //!
 //! # Usage
 //! The main way to interact with the API is through the [SuiClientBuilder],


### PR DESCRIPTION
## Description 

This fixes the link not generating automatically during the GH action. Risk is small that the link location changes.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
