### PR TITLE
[gql][performance-tuning][1/n] add `checkpoints_epoch_sequence_number` index to support graphql checkpoint queries

### DIFF
--- a/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
@@ -24,6 +24,5 @@ CREATE TABLE checkpoints
     end_of_epoch_data                   bytea
 );
 
-CREATE INDEX checkpoints_epoch ON checkpoints (epoch);
-CREATE INDEX checkpoints_epoch_sequence_number ON checkpoints (epoch, sequence_number);
+CREATE INDEX checkpoints_epoch ON checkpoints (epoch, sequence_number);
 CREATE INDEX checkpoints_digest ON checkpoints USING HASH (checkpoint_digest);

--- a/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044044_checkpoints/up.sql
@@ -25,4 +25,5 @@ CREATE TABLE checkpoints
 );
 
 CREATE INDEX checkpoints_epoch ON checkpoints (epoch);
+CREATE INDEX checkpoints_epoch_sequence_number ON checkpoints (epoch, sequence_number);
 CREATE INDEX checkpoints_digest ON checkpoints USING HASH (checkpoint_digest);


### PR DESCRIPTION
## Description 
We have an index on `checkpoints` on the `epoch` field, but this is not used by the query planner to support queries from graphql, since we always have an additional filter on `sequence_number`, either from the high watermark, or from the cursor when paginating through checkpoints. This results in a query that essentially iteratively scans through the pkey index. Even though the estimated cost is low, the actual runtime is significant since we do a great deal of filtering.
```
defaultdb=> explain analyze select * from checkpoints where epoch = 321 order by sequence_number limit 3;
                                                                      QUERY PLAN         
------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.44..108.48 rows=3 width=647) (actual time=6813.203..6813.206 rows=3 loops=1)
   ->  Index Scan using checkpoints_pkey on checkpoints  (cost=0.44..3331788.13 rows=92510 width=647) (actual time=6813.201..6813.203 rows=3 loops=1)
         Filter: (epoch = 321)
         Rows Removed by Filter: 27370785
 Planning Time: 0.143 ms
 Execution Time: 6813.227 ms
```

By adding this index on `(epoch, sequence_number)`, we can make the graphql query much more efficient. 
```
defaultdb=> explain analyze select * from checkpoints where epoch = 321 order by sequence_number limit 3;
                                                                     QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.56..6.02 rows=3 width=647) (actual time=0.033..0.039 rows=3 loops=1)
   ->  Index Scan using epoch_sequence_number on checkpoints  (cost=0.56..162507.83 rows=89307 width=647) (actual time=0.032..0.037 rows=3 loops=1)
         Index Cond: (epoch = 321)
 Planning Time: 0.432 ms
 Execution Time: 0.056 ms
(5 rows)
```

From experimental runs, this drops the runtime of a graphql query like below from >15s down to ~1 second.
```
{
  epoch(id: 291) {
    epochId
    startTimestamp
    endTimestamp
    totalStakeRewards
    referenceGasPrice
    first: checkpoints(first: 1) {
      nodes {
        sequenceNumber
      }
    }
  }
}
```



## Test Plan 

Existing tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
