### PR TITLE
sdk: export toZkLoginPublicIdentifier

### DIFF
--- a/.changeset/six-garlics-dress.md
+++ b/.changeset/six-garlics-dress.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zklogin': minor
+---
+
+Expose toZkLoginPublicIdentifier function

--- a/sdk/typescript/src/zklogin/index.ts
+++ b/sdk/typescript/src/zklogin/index.ts
@@ -4,5 +4,5 @@
 export { getZkLoginSignature, parseZkLoginSignature } from './signature.js';
 export { toBigEndianBytes } from './utils.js';
 export { computeZkLoginAddressFromSeed } from './address.js';
-export { ZkLoginPublicIdentifier } from './publickey.js';
+export { toZkLoginPublicIdentifier, ZkLoginPublicIdentifier } from './publickey.js';
 export type { ZkLoginSignatureInputs } from './bcs.js';


### PR DESCRIPTION
## Description 

an useful function to export for deriving multisig address from zklogin account. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
