### PR TITLE
Move EC ops - skip validation of already validated group elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.7"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=812767c939e96f2f03f0faf13388e1cb48696726#812767c939e96f2f03f0faf13388e1cb48696726"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a499d84d07cbe33014531249f6ceeff85664502d#a499d84d07cbe33014531249f6ceeff85664502d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=812767c939e96f2f03f0faf13388e1cb48696726#812767c939e96f2f03f0faf13388e1cb48696726"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a499d84d07cbe33014531249f6ceeff85664502d#a499d84d07cbe33014531249f6ceeff85664502d"
 dependencies = [
  "quote 1.0.35",
  "syn 1.0.107",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=812767c939e96f2f03f0faf13388e1cb48696726#812767c939e96f2f03f0faf13388e1cb48696726"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a499d84d07cbe33014531249f6ceeff85664502d#a499d84d07cbe33014531249f6ceeff85664502d"
 dependencies = [
  "bcs",
  "digest 0.10.6",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.2"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=812767c939e96f2f03f0faf13388e1cb48696726#812767c939e96f2f03f0faf13388e1cb48696726"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a499d84d07cbe33014531249f6ceeff85664502d#a499d84d07cbe33014531249f6ceeff85664502d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -546,9 +546,9 @@ move-stackless-bytecode = { path = "external-crates/move/crates/move-stackless-b
 move-symbol-pool = { path = "external-crates/move/crates/move-symbol-pool" }
 move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "812767c939e96f2f03f0faf13388e1cb48696726" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "812767c939e96f2f03f0faf13388e1cb48696726" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "812767c939e96f2f03f0faf13388e1cb48696726", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a499d84d07cbe33014531249f6ceeff85664502d" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a499d84d07cbe33014531249f6ceeff85664502d" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a499d84d07cbe33014531249f6ceeff85664502d", package = "fastcrypto-zkp" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7" }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
@@ -205,6 +205,12 @@ module sui::bls12381_tests {
 
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
+    fun test_invalid_scalar_empty() {
+        let _ = bls12381::scalar_from_bytes(&vector[]);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_invalid_scalar_too_short() {
         let _ = bls12381::scalar_from_bytes(&SHORT_SCALAR_BYTES);
     }
@@ -270,7 +276,9 @@ module sui::bls12381_tests {
         let msg2 = b"321";
         let hash1 = bls12381::hash_to_g1(&msg1);
         let hash2 = bls12381::hash_to_g1(&msg2);
+        let hash3 = bls12381::hash_to_g1(&msg1);
         assert!(group_ops::equal(&hash1, &hash2) == false, 0);
+        assert!(group_ops::equal(&hash1, &hash3), 0);
     }
 
     #[test]
@@ -310,6 +318,12 @@ module sui::bls12381_tests {
 
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
+    fun test_invalid_g1_empty() {
+        let _ = bls12381::g1_from_bytes(&vector[]);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_invalid_g1_too_long() {
         let _ = bls12381::g1_from_bytes(&LONG_G1_BYTES);
     }
@@ -322,6 +336,11 @@ module sui::bls12381_tests {
         let _ = bls12381::g1_div(&a, &b);
     }
 
+    #[test]
+    #[expected_failure(abort_code = group_ops::EInvalidInput)]
+    fun test_invalid_g1_empty_msg() {
+        let _ = bls12381::hash_to_g1(&vector[]);
+    }
 
     #[test]
     fun test_g2_ops() {
@@ -362,7 +381,9 @@ module sui::bls12381_tests {
         let msg2 = b"321";
         let hash1 = bls12381::hash_to_g2(&msg1);
         let hash2 = bls12381::hash_to_g2(&msg2);
+        let hash3 = bls12381::hash_to_g2(&msg1);
         assert!(group_ops::equal(&hash1, &hash2) == false, 0);
+        assert!(group_ops::equal(&hash1, &hash3), 0);
     }
 
     #[test]
@@ -396,6 +417,12 @@ module sui::bls12381_tests {
 
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
+    fun test_invalid_g2_empty() {
+        let _ = bls12381::g2_from_bytes(&vector[]);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_invalid_g2_too_short() {
         let _ = bls12381::g2_from_bytes(&SHORT_G2_BYTES);
     }
@@ -412,6 +439,12 @@ module sui::bls12381_tests {
         let a = bls12381::scalar_from_u64(0);
         let b = bls12381::g2_generator();
         let _ = bls12381::g2_div(&a, &b);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = group_ops::EInvalidInput)]
+    fun test_invalid_g2_empty_msg() {
+        let _ = bls12381::hash_to_g2(&vector[]);
     }
 
 
@@ -487,7 +520,7 @@ module sui::bls12381_tests {
         while (i < 20) {
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g1_mul(&base_scalar, &g);
-            let exponent_scalar = bls12381::scalar_from_u64(i+100);
+            let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g1_mul(&exponent_scalar, &base);
             vector::push_back(&mut elements, base);
             vector::push_back(&mut scalars, exponent_scalar);
@@ -541,10 +574,11 @@ module sui::bls12381_tests {
         let g = bls12381::g1_generator();
         let scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
         let elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
-        while (i < 34) { // this limit is defined in the protocol config
+        while (i < 34) {
+            // this limit is defined in the protocol config
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g1_mul(&base_scalar, &g);
-            let exponent_scalar = bls12381::scalar_from_u64(i+100);
+            let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g1_mul(&exponent_scalar, &base);
             vector::push_back(&mut elements, base);
             vector::push_back(&mut scalars, exponent_scalar);
@@ -565,7 +599,7 @@ module sui::bls12381_tests {
         while (i < 20) {
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g2_mul(&base_scalar, &g);
-            let exponent_scalar = bls12381::scalar_from_u64(i+100);
+            let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g2_mul(&exponent_scalar, &base);
             vector::push_back(&mut elements, base);
             vector::push_back(&mut scalars, exponent_scalar);
@@ -624,6 +658,8 @@ module sui::bls12381_tests {
         assert_eq(bls12381::pairing(&g1_3, &g2_5), gt_5);
 
         assert_eq(bls12381::pairing(&bls12381::g1_identity(), &bls12381::g2_identity()), bls12381::gt_identity());
+        assert_eq(bls12381::pairing(&bls12381::g1_generator(), &bls12381::g2_identity()), bls12381::gt_identity());
+        assert_eq(bls12381::pairing(&bls12381::g1_identity(), &bls12381::g2_generator()), bls12381::gt_identity());
     }
 
     #[test]
@@ -633,7 +669,7 @@ module sui::bls12381_tests {
         let sig = x"908e345f2e2803cd941ae88c218c96194233c9053fa1bca52124787d3cca141c36429d7652435a820c72992d5eee6317";
 
         let pk = bls12381::g2_from_bytes(&pk);
-        let sig= bls12381::g1_from_bytes(&sig);
+        let sig = bls12381::g1_from_bytes(&sig);
         let hashed_msg = bls12381::hash_to_g1(&msg);
 
         let pairing1 = bls12381::pairing(&sig, &bls12381::g2_generator());
@@ -652,7 +688,7 @@ module sui::bls12381_tests {
         let msg = drand_message(prev_sig, round);
 
         let pk = bls12381::g1_from_bytes(&pk);
-        let sig= bls12381::g2_from_bytes(&sig);
+        let sig = bls12381::g2_from_bytes(&sig);
         let hashed_msg = bls12381::hash_to_g2(&msg);
 
         let pairing1 = bls12381::pairing(&bls12381::g1_generator(), &sig);

--- a/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
@@ -4,7 +4,8 @@ use crate::object_runtime::ObjectRuntime;
 use crate::NativesCostTable;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{
-    bls12381 as bls, GroupElement, HashToGroupElement, MultiScalarMul, Pairing,
+    bls12381 as bls, FromTrustedByteArray, GroupElement, HashToGroupElement, MultiScalarMul,
+    Pairing,
 };
 use fastcrypto::serde_helpers::ToFromByteArray;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
@@ -114,14 +115,22 @@ impl Groups {
     }
 }
 
-fn parse<G: ToFromByteArray<S>, const S: usize>(e: &[u8]) -> FastCryptoResult<G> {
+fn parse_untrusted<G: ToFromByteArray<S> + FromTrustedByteArray<S>, const S: usize>(
+    e: &[u8],
+) -> FastCryptoResult<G> {
     G::from_byte_array(e.try_into().map_err(|_| FastCryptoError::InvalidInput)?)
+}
+
+fn parse_trusted<G: ToFromByteArray<S> + FromTrustedByteArray<S>, const S: usize>(
+    e: &[u8],
+) -> FastCryptoResult<G> {
+    G::from_trusted_byte_array(e.try_into().map_err(|_| FastCryptoError::InvalidInput)?)
 }
 
 // Binary operations with 2 different types.
 fn binary_op_diff<
-    G1: ToFromByteArray<S1>,
-    G2: ToFromByteArray<S2>,
+    G1: ToFromByteArray<S1> + FromTrustedByteArray<S1>,
+    G2: ToFromByteArray<S2> + FromTrustedByteArray<S2>,
     const S1: usize,
     const S2: usize,
 >(
@@ -129,14 +138,14 @@ fn binary_op_diff<
     a1: &[u8],
     a2: &[u8],
 ) -> FastCryptoResult<Vec<u8>> {
-    let e1 = parse::<G1, S1>(a1)?;
-    let e2 = parse::<G2, S2>(a2)?;
+    let e1 = parse_trusted::<G1, S1>(a1)?;
+    let e2 = parse_trusted::<G2, S2>(a2)?;
     let result = op(e1, e2)?;
     Ok(result.to_byte_array().to_vec())
 }
 
 // Binary operations with the same type.
-fn binary_op<G: ToFromByteArray<S>, const S: usize>(
+fn binary_op<G: ToFromByteArray<S> + FromTrustedByteArray<S>, const S: usize>(
     op: impl Fn(G, G) -> FastCryptoResult<G>,
     a1: &[u8],
     a2: &[u8],
@@ -180,15 +189,15 @@ pub fn internal_validate(
     let result = match Groups::from_u8(group_type) {
         Some(Groups::BLS12381Scalar) => {
             native_charge_gas_early_exit_option!(context, cost_params.bls12381_decode_scalar_cost);
-            parse::<bls::Scalar, { bls::Scalar::BYTE_LENGTH }>(&bytes).is_ok()
+            parse_untrusted::<bls::Scalar, { bls::Scalar::BYTE_LENGTH }>(&bytes).is_ok()
         }
         Some(Groups::BLS12381G1) => {
             native_charge_gas_early_exit_option!(context, cost_params.bls12381_decode_g1_cost);
-            parse::<bls::G1Element, { bls::G1Element::BYTE_LENGTH }>(&bytes).is_ok()
+            parse_untrusted::<bls::G1Element, { bls::G1Element::BYTE_LENGTH }>(&bytes).is_ok()
         }
         Some(Groups::BLS12381G2) => {
             native_charge_gas_early_exit_option!(context, cost_params.bls12381_decode_g2_cost);
-            parse::<bls::G2Element, { bls::G2Element::BYTE_LENGTH }>(&bytes).is_ok()
+            parse_untrusted::<bls::G2Element, { bls::G2Element::BYTE_LENGTH }>(&bytes).is_ok()
         }
         _ => false,
     };
@@ -558,8 +567,11 @@ fn multi_scalar_mul<G, const SCALAR_SIZE: usize, const POINT_SIZE: usize>(
     points: &Vec<u8>,
 ) -> PartialVMResult<NativeResult>
 where
-    G: GroupElement + ToFromByteArray<POINT_SIZE> + MultiScalarMul,
-    G::ScalarType: ToFromByteArray<SCALAR_SIZE>,
+    G: GroupElement
+        + ToFromByteArray<POINT_SIZE>
+        + FromTrustedByteArray<POINT_SIZE>
+        + MultiScalarMul,
+    G::ScalarType: ToFromByteArray<SCALAR_SIZE> + FromTrustedByteArray<SCALAR_SIZE>,
 {
     if points.is_empty()
         || scalars.is_empty()
@@ -580,7 +592,7 @@ where
     );
     let scalars = scalars
         .chunks(SCALAR_SIZE)
-        .map(parse::<G::ScalarType, { SCALAR_SIZE }>)
+        .map(parse_trusted::<G::ScalarType, { SCALAR_SIZE }>)
         .collect::<Result<Vec<_>, _>>();
 
     native_charge_gas_early_exit_option!(
@@ -589,7 +601,7 @@ where
     );
     let points = points
         .chunks(POINT_SIZE)
-        .map(parse::<G, { POINT_SIZE }>)
+        .map(parse_trusted::<G, { POINT_SIZE }>)
         .collect::<Result<Vec<_>, _>>();
 
     if let (Ok(scalars), Ok(points)) = (scalars, points) {
@@ -715,8 +727,8 @@ pub fn internal_pairing(
     let result = match Groups::from_u8(group_type) {
         Some(Groups::BLS12381G1) => {
             native_charge_gas_early_exit_option!(context, cost_params.bls12381_pairing_cost);
-            parse::<bls::G1Element, { bls::G1Element::BYTE_LENGTH }>(&e1).and_then(|e1| {
-                parse::<bls::G2Element, { bls::G2Element::BYTE_LENGTH }>(&e2).map(|e2| {
+            parse_trusted::<bls::G1Element, { bls::G1Element::BYTE_LENGTH }>(&e1).and_then(|e1| {
+                parse_trusted::<bls::G2Element, { bls::G2Element::BYTE_LENGTH }>(&e2).map(|e2| {
                     let e3 = e1.pairing(&e2);
                     e3.to_byte_array().to_vec()
                 })


### PR DESCRIPTION
## Description 

Move EC ops - skip validation of already validated group elements. This is purely an internal performance optimization.
Also adding a few more small tests.

## Test Plan 

Existing unit tests pass

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
