### PR TITLE
[cli] Remove OnceCell as it seems to cause issues with test coverage

### DIFF
--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -14,11 +14,7 @@ const TEST_DIR: &str = "tests";
 async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
     use sui::client_ptb::ptb::{to_source_string, PTB};
     use sui::client_ptb::{error::build_error_reports, ptb::PTBPreview};
-    use test_cluster::TestCluster;
     use test_cluster::TestClusterBuilder;
-    use tokio::sync::OnceCell;
-
-    static CLUSTER: OnceCell<TestCluster> = OnceCell::const_new();
 
     let _ = miette::set_hook(Box::new(|_| {
         Box::new(
@@ -62,9 +58,7 @@ async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
     ));
 
     // === BUILD PTB ===
-    let test_cluster = CLUSTER
-        .get_or_init(|| TestClusterBuilder::new().build())
-        .await;
+    let test_cluster = TestClusterBuilder::new().build().await;
 
     let context = &test_cluster.wallet;
     let client = context.get_client().await?;


### PR DESCRIPTION
## Description 

This PR changes the way TestCluster is created by removing the `OnceCell` as it seems to be creating some issues with files not being found when test coverage is ran. It is a temporary fix until we understand better why we get SIGSEGV and SIGABR signals when tests run.

## Test Plan 

Existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
