### PR TITLE
[move-ide] Improve code build times in the IDE

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -669,42 +669,17 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
- "crossterm_winapi 0.8.0",
+ "crossterm_winapi",
  "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
+ "mio",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.9.0",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
  "winapi",
 ]
 
@@ -1490,19 +1465,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
@@ -1511,15 +1473,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1630,7 +1583,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.4.1",
- "crossterm 0.21.0",
+ "crossterm",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-disassembler",
@@ -2267,15 +2220,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "widestring",
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
  "winapi",
 ]
 
@@ -3204,7 +3148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
+ "mio",
  "signal-hook",
 ]
 
@@ -3521,7 +3465,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.6",
+ "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -3650,13 +3594,13 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "tui"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.22.1",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1184,34 +1184,31 @@ fn file_sources(
     resolved_graph
         .package_table
         .iter()
-        .flat_map(|(rpkg_name, rpkg)| {
-            rpkg.get_sources(
-                &resolved_graph.build_options,
-                *rpkg_name != resolved_graph.root_package(),
-            )
-            .unwrap()
-            .iter()
-            .map(|f| {
-                // dunce does a better job of canonicalization on Windows
-                let fname = dunce::canonicalize(f.as_str())
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| f.to_string());
-                let mut contents = String::new();
-                // there is a fair number of unwraps here but if we can't read the files
-                // that by all accounts should be in the file system, then there is not much
-                // we can do so it's better to fail so that we can investigate
-                let vfs_file_path = overlay_fs.join(fname.as_str()).unwrap();
-                let mut vfs_file = vfs_file_path.open_file().unwrap();
-                let _ = vfs_file.read_to_string(&mut contents);
-                let fhash = FileHash::new(&contents);
-                // write to top layer of the overlay file system so that the content
-                // is immutable for the duration of compilation and symbolication
-                let _ = vfs_file_path.parent().create_dir_all();
-                let mut vfs_file = vfs_file_path.create_file().unwrap();
-                let _ = vfs_file.write_all(contents.as_bytes());
-                (fhash, (Symbol::from(fname), contents))
-            })
-            .collect::<BTreeMap<_, _>>()
+        .flat_map(|(_, rpkg)| {
+            rpkg.get_sources(&resolved_graph.build_options)
+                .unwrap()
+                .iter()
+                .map(|f| {
+                    // dunce does a better job of canonicalization on Windows
+                    let fname = dunce::canonicalize(f.as_str())
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| f.to_string());
+                    let mut contents = String::new();
+                    // there is a fair number of unwraps here but if we can't read the files
+                    // that by all accounts should be in the file system, then there is not much
+                    // we can do so it's better to fail so that we can investigate
+                    let vfs_file_path = overlay_fs.join(fname.as_str()).unwrap();
+                    let mut vfs_file = vfs_file_path.open_file().unwrap();
+                    let _ = vfs_file.read_to_string(&mut contents);
+                    let fhash = FileHash::new(&contents);
+                    // write to top layer of the overlay file system so that the content
+                    // is immutable for the duration of compilation and symbolication
+                    let _ = vfs_file_path.parent().create_dir_all();
+                    let mut vfs_file = vfs_file_path.create_file().unwrap();
+                    let _ = vfs_file.write_all(contents.as_bytes());
+                    (fhash, (Symbol::from(fname), contents))
+                })
+                .collect::<BTreeMap<_, _>>()
         })
         .collect()
 }

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -164,7 +164,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
         .package_table
         .iter()
         .flat_map(|(_, rpkg)| {
-            rpkg.get_sources(&resolution_graph.build_options)
+            rpkg.get_sources(&resolution_graph.build_options, /* deps_only */ false)
                 .unwrap()
                 .iter()
                 .map(|fname| {

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -164,7 +164,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
         .package_table
         .iter()
         .flat_map(|(_, rpkg)| {
-            rpkg.get_sources(&resolution_graph.build_options, /* deps_only */ false)
+            rpkg.get_sources(&resolution_graph.build_options)
                 .unwrap()
                 .iter()
                 .map(|fname| {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -783,7 +783,10 @@ fn module_(
             P::ModuleMember::Use(_) => unreachable!(),
             P::ModuleMember::Friend(f) => friend(context, &mut friends, f),
             P::ModuleMember::Function(mut f) => {
-                if !context.is_source_definition && f.macro_.is_none() {
+                if (!context.is_source_definition && f.macro_.is_none())
+                    || (context.env().flags().is_ide()
+                        && context.env().package_config(package_name).is_dependency)
+                {
                     f.body.value = P::FunctionBody_::Native
                 }
                 function(

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -630,6 +630,9 @@ pub struct Flags {
     /// included only in tests, without creating the unit test code regular tests do.
     #[clap(skip)]
     keep_testing_functions: bool,
+
+    #[clap(skip)]
+    ide: bool,
 }
 
 impl Flags {
@@ -641,6 +644,7 @@ impl Flags {
             warnings_are_errors: false,
             silence_warnings: false,
             keep_testing_functions: false,
+            ide: false,
         }
     }
 
@@ -652,6 +656,7 @@ impl Flags {
             warnings_are_errors: false,
             silence_warnings: false,
             keep_testing_functions: false,
+            ide: false,
         }
     }
 
@@ -683,6 +688,10 @@ impl Flags {
         }
     }
 
+    pub fn set_ide(self, value: bool) -> Self {
+        Self { ide: value, ..self }
+    }
+
     pub fn is_empty(&self) -> bool {
         self == &Self::empty()
     }
@@ -709,6 +718,10 @@ impl Flags {
 
     pub fn silence_warnings(&self) -> bool {
         self.silence_warnings
+    }
+
+    pub fn is_ide(&self) -> bool {
+        self.ide
     }
 }
 

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -151,10 +151,7 @@ impl BuildPlan {
                     .get(&package_name)
                     .unwrap();
                 let mut dep_source_paths = dep_package
-                    .get_sources(
-                        &self.resolution_graph.build_options,
-                        /* for_deps */ true,
-                    )
+                    .get_sources(&self.resolution_graph.build_options)
                     .unwrap();
                 let mut source_available = true;
                 // If source is empty, search bytecode(mv) files

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -151,7 +151,10 @@ impl BuildPlan {
                     .get(&package_name)
                     .unwrap();
                 let mut dep_source_paths = dep_package
-                    .get_sources(&self.resolution_graph.build_options)
+                    .get_sources(
+                        &self.resolution_graph.build_options,
+                        /* for_deps */ true,
+                    )
                     .unwrap();
                 let mut source_available = true;
                 // If source is empty, search bytecode(mv) files

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -826,7 +826,7 @@ pub(crate) fn make_source_and_deps_for_compiler(
         named_address_mapping_for_compiler(&root.resolved_table),
         &root.renaming,
     );
-    let sources = root.get_sources(&resolution_graph.build_options, /* deps_only */ false)?;
+    let sources = root.get_sources(&resolution_graph.build_options)?;
     let source_package_paths = PackagePaths {
         name: Some((
             root.source_package.package.name,

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -592,7 +592,9 @@ impl CompiledPackage {
             compiled_docs,
         };
 
-        compiled_package.save_to_disk(project_root.join(CompiledPackageLayout::Root.path()))?;
+        if !resolution_graph.build_options.ide_mode {
+            compiled_package.save_to_disk(project_root.join(CompiledPackageLayout::Root.path()))?;
+        }
 
         Ok(compiled_package)
     }
@@ -824,7 +826,7 @@ pub(crate) fn make_source_and_deps_for_compiler(
         named_address_mapping_for_compiler(&root.resolved_table),
         &root.renaming,
     );
-    let sources = root.get_sources(&resolution_graph.build_options)?;
+    let sources = root.get_sources(&resolution_graph.build_options, /* deps_only */ false)?;
     let source_package_paths = PackagePaths {
         name: Some((
             root.source_package.package.name,

--- a/external-crates/move/crates/move-package/src/compilation/model_builder.rs
+++ b/external-crates/move/crates/move-package/src/compilation/model_builder.rs
@@ -56,10 +56,7 @@ impl ModelBuilder {
                     return None;
                 }
                 let mut dep_source_paths = pkg
-                    .get_sources(
-                        &self.resolution_graph.build_options,
-                        /* deps_only */ true,
-                    )
+                    .get_sources(&self.resolution_graph.build_options)
                     .unwrap();
                 let mut source_available = true;
                 // If source is empty, search bytecode(mv) files

--- a/external-crates/move/crates/move-package/src/compilation/model_builder.rs
+++ b/external-crates/move/crates/move-package/src/compilation/model_builder.rs
@@ -56,7 +56,10 @@ impl ModelBuilder {
                     return None;
                 }
                 let mut dep_source_paths = pkg
-                    .get_sources(&self.resolution_graph.build_options)
+                    .get_sources(
+                        &self.resolution_graph.build_options,
+                        /* deps_only */ true,
+                    )
                     .unwrap();
                 let mut source_available = true;
                 // If source is empty, search bytecode(mv) files

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -103,6 +103,11 @@ pub struct BuildConfig {
     /// If `true`, disable linters
     #[clap(long, global = true)]
     pub no_lint: bool,
+
+    /// Compile in 'IDE' mode to omit/alter some operations when building for IDE-related purposes
+    /// to improve IDE performance
+    #[clap(skip)]
+    pub ide_mode: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -270,6 +270,7 @@ impl BuildConfig {
         flags
             .set_warnings_are_errors(self.warnings_are_errors)
             .set_silence_warnings(self.silence_warnings)
+            .set_ide(self.ide_mode)
     }
 
     pub fn update_lock_file_toolchain_version(

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{bail, Context, Result};
 use move_command_line_common::files::{
-    extension_equals, find_filenames, find_move_filenames, FileHash, MOVE_COMPILED_EXTENSION,
+    extension_equals, find_filenames, find_move_filenames, MOVE_COMPILED_EXTENSION,
 };
 use move_compiler::command_line::DEFAULT_OUTPUT_DIR;
 use move_compiler::{diagnostics::WarningFilters, shared::PackageConfig};
@@ -12,7 +12,6 @@ use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -309,23 +308,6 @@ impl ResolvedGraph {
             .into_iter()
     }
 
-    pub fn file_sources(&self) -> BTreeMap<FileHash, (FileName, String)> {
-        self.package_table
-            .iter()
-            .flat_map(|(_, rpkg)| {
-                rpkg.get_sources(&self.build_options)
-                    .unwrap()
-                    .iter()
-                    .map(|fname| {
-                        let contents = fs::read_to_string(fname.as_str()).unwrap();
-                        let fhash = FileHash::new(&contents);
-                        (fhash, (*fname, contents))
-                    })
-                    .collect::<BTreeMap<_, _>>()
-            })
-            .collect()
-    }
-
     pub fn contains_renaming(&self) -> Option<PackageName> {
         // Make sure no renamings have been performed
         self.package_table
@@ -492,8 +474,8 @@ impl Package {
             .collect()
     }
 
-    pub fn get_sources(&self, config: &BuildConfig) -> Result<Vec<FileName>> {
-        let places_to_look = source_paths_for_config(&self.package_path, config);
+    pub fn get_sources(&self, config: &BuildConfig, deps_only: bool) -> Result<Vec<FileName>> {
+        let places_to_look = source_paths_for_config(&self.package_path, config, deps_only);
         Ok(find_move_filenames(&places_to_look, false)?
             .into_iter()
             .map(FileName::from)
@@ -543,7 +525,11 @@ impl Package {
     }
 }
 
-fn source_paths_for_config(package_path: &Path, config: &BuildConfig) -> Vec<PathBuf> {
+fn source_paths_for_config(
+    package_path: &Path,
+    config: &BuildConfig,
+    deps_only: bool,
+) -> Vec<PathBuf> {
     let mut places_to_look = Vec::new();
     let mut add_path = |layout_path: SourcePackageLayout| {
         let path = package_path.join(layout_path.path());
@@ -556,7 +542,8 @@ fn source_paths_for_config(package_path: &Path, config: &BuildConfig) -> Vec<Pat
     add_path(SourcePackageLayout::Sources);
     add_path(SourcePackageLayout::Scripts);
 
-    if config.dev_mode {
+    if config.dev_mode && !(config.ide_mode && deps_only) {
+        // don't include these if building deps for IDE
         add_path(SourcePackageLayout::Examples);
         add_path(SourcePackageLayout::Tests);
     }
@@ -565,7 +552,8 @@ fn source_paths_for_config(package_path: &Path, config: &BuildConfig) -> Vec<Pat
 }
 
 fn package_digest_for_config(package_path: &Path, config: &BuildConfig) -> Result<PackageDigest> {
-    let mut source_paths = source_paths_for_config(package_path, config);
+    let mut source_paths =
+        source_paths_for_config(package_path, config, /* deps_only */ false);
     source_paths.push(package_path.join(SourcePackageLayout::Manifest.path()));
     compute_digest(&source_paths)
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.compiled
@@ -24,5 +24,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move.resolved
@@ -122,6 +122,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move.resolved
@@ -103,6 +103,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move.resolved
@@ -101,6 +101,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move.resolved
@@ -107,6 +107,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move.resolved
@@ -123,6 +123,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move.resolved
@@ -149,6 +149,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move.resolved
@@ -105,6 +105,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move.resolved
@@ -141,6 +141,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move.resolved
@@ -157,6 +157,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move.resolved
@@ -157,6 +157,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move.resolved
@@ -157,6 +157,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move.resolved
@@ -133,6 +133,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move.resolved
@@ -133,6 +133,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move.resolved
@@ -75,6 +75,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move.resolved
@@ -113,6 +113,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move.resolved
@@ -83,6 +83,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move.resolved
@@ -71,6 +71,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move.resolved
@@ -71,6 +71,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move.resolved
@@ -71,6 +71,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move.compiled
@@ -28,5 +28,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.resolved
@@ -79,6 +79,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move.resolved
@@ -113,6 +113,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "More": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move.resolved
@@ -53,6 +53,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move.resolved
@@ -33,6 +33,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.compiled
@@ -27,5 +27,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move.resolved
@@ -97,6 +97,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move.resolved
@@ -105,6 +105,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move.resolved
@@ -75,6 +75,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move.resolved
@@ -103,6 +103,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move.resolved
@@ -121,6 +121,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move.resolved
@@ -123,6 +123,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move.resolved
@@ -103,6 +103,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move.resolved
@@ -111,6 +111,7 @@ ResolvedGraph {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
+++ b/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move.compiled
@@ -26,5 +26,6 @@ CompiledPackageInfo {
         warnings_are_errors: false,
         additional_named_addresses: {},
         no_lint: false,
+        ide_mode: false,
     },
 }


### PR DESCRIPTION
## Description 

Source code build times in the IDE, while quite fast, causes a noticeable difference between re-build trigger (e.g., modification in the file) and re-build finish (e.g., when the user observes the build diagnostics).

This PR mitigates this problem in two ways:
- elides compilation of files in `tests` and `examples` directories of the root package dependencies
- elides saving files to disk at the end of compilation (as in the IDE it's the side-effects of the compilation that matter)

Note that `tests` and `examples` directories are not included "by default" but if they are actually opened in the IDE for inspection, the compilation for those will actually happen and symbols for them will be computed and available.

## Test Plan 

Verified that build times drop by more than 50% when including Move stdlib and Sui framework code as dependencies.
