### PR TITLE
add sui-node binary paths used in the past

### DIFF
--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -68,7 +68,13 @@ COPY --from=stagex/musl . /rootfs
 # but we expect them in /usr/lib
 COPY --from=stagex/gcc /usr/lib64/* /rootfs/usr/lib/
 
-COPY --from=build sui/target/release/sui-node /rootfs/usr/bin/sui-node
+# support current + legacy paths
+RUN mkdir -p /rootfs/opt/sui/bin
+RUN mkdir -p /rootfs/usr/local/bin
+COPY --from=build sui/target/release/sui-node /rootfs/opt/sui/bin/sui-node
+
+
+
 RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
 
 FROM scratch AS package
@@ -81,5 +87,5 @@ LABEL git-revision=${GIT_REVISION}
 
 COPY --from=install /rootfs /
 
-ENTRYPOINT ["/usr/bin/sui-node"]
-CMD ["--version"]
+RUN ln -s /opt/sui/bin/sui-node /usr/local/bin/sui-node
+


### PR DESCRIPTION
## Description 

Update `sui-node` path in Dockerfile to original path previously used.



## Test Plan 

* Run  [Build Sui Images Job
](https://github.com/MystenLabs/sui-operations/actions/workflows/dockerize-to-ecr.yml)
* Run commands to verify `sui-node` binary is accessible at expected path

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
