### PR TITLE
[DO NOT LAND] Debug gcs object store get request hanging

### DIFF
--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -900,11 +900,13 @@ pub async fn download_formal_snapshot(
     let (sender, mut receiver) = mpsc::channel(num_parallel_downloads);
 
     let snapshot_handle = tokio::spawn(async move {
+        info!("TESTING -- starting snapshot handle");
         let local_store_config = ObjectStoreConfig {
             object_store: Some(ObjectStoreType::File),
             directory: Some(snapshot_dir_clone.to_path_buf()),
             ..Default::default()
         };
+        info!("TESTING -- finished creating store config");
         let mut reader = StateSnapshotReaderV1::new(
             epoch,
             &snapshot_store_config,
@@ -915,6 +917,8 @@ pub async fn download_formal_snapshot(
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));
+        info!("TESTING -- snapshot store config: {:?}", snapshot_store_config);
+        info!("TESTING -- created snapshot reader successfully");
         reader
             .read(&perpetual_db_clone, abort_registration, Some(sender))
             .await


### PR DESCRIPTION
## Description 
 
This problem manifests during formal snapshot restore where we never begin downloading object refs. We believe this is leading to a root state hash mismatch during restore, as we derive the hash from an empty state accumulator in this case. It seems the problem is that sui-tool hangs indefinitely while trying to download any object refs from gcs remote store. This happens across older snapshots as well (ones that we didn't recently backfill), and does not occur for R2 for example

## Test Plan 

```
GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH=<sa_path> \
AWS_ARCHIVE_ACCESS_KEY_ID=<access_key> \
AWS_ARCHIVE_SECRET_ACCESS_KEY=<secret_key> \
AWS_ARCHIVE_REGION=us-west-2 \
./target/release/sui-tool download-formal-snapshot --epoch 315 \
--genesis /opt/sui/config/mainnet/genesis.blob --network mainnet \
--path /opt/sui/db/authorities_db/full_node_db --num-parallel-downloads 50 \
--snapshot-bucket-type=gcs --verbose
```

Reproed against commit hash `d3241a93915360f20e0313929522fafb2f382de1`, but believe it will fail irrespective of commit hash

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
