### PR TITLE
[bench] Simplify checkpoint execution benchmark

### DIFF
--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -12,6 +12,7 @@ use futures::StreamExt;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::sync::Arc;
+use sui_config::node::RunWithRange;
 use sui_test_transaction_builder::PublishData;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
@@ -310,9 +311,10 @@ impl BenchmarkContext {
         info!("Building checkpoints");
         let validator = self.validator();
         let checkpoints = validator
-            .build_checkpoints(in_memory_store, transactions, effects, checkpoint_size)
+            .build_checkpoints(transactions, effects, checkpoint_size)
             .await;
         info!("Built {} checkpoints", checkpoints.len());
+        let last_checkpoint_seq = *checkpoints.last().unwrap().0.sequence_number();
         let (mut checkpoint_executor, checkpoint_sender) = validator.create_checkpoint_executor();
         for (checkpoint, contents) in checkpoints {
             let state = validator.get_validator();
@@ -337,7 +339,10 @@ impl BenchmarkContext {
         let start_time = std::time::Instant::now();
         info!("Starting checkpoint execution. You can now attach a profiler");
         checkpoint_executor
-            .run_epoch(validator.get_epoch_store().clone(), None)
+            .run_epoch(
+                validator.get_epoch_store().clone(),
+                Some(RunWithRange::Checkpoint(last_checkpoint_seq)),
+            )
             .await;
         let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
         info!(

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -86,30 +86,6 @@ impl InMemoryObjectStore {
 
         Ok(input_objects.into())
     }
-
-    pub(crate) fn read_objects_for_synchronous_execution(
-        &self,
-        input_object_kinds: &[InputObjectKind],
-    ) -> SuiResult<InputObjects> {
-        let mut input_objects = Vec::new();
-        for kind in input_object_kinds {
-            let obj: Option<Object> = match kind {
-                InputObjectKind::MovePackage(id) => self.get_package_object(id)?.map(|o| o.into()),
-                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    self.get_object_by_key(&objref.0, objref.1)?
-                }
-
-                InputObjectKind::SharedMoveObject { id, .. } => self.get_object(id)?,
-            };
-
-            input_objects.push(ObjectReadResult::new(
-                *kind,
-                obj.ok_or_else(|| kind.object_not_found_error())?.into(),
-            ));
-        }
-
-        Ok(input_objects.into())
-    }
 }
 
 impl ObjectStore for InMemoryObjectStore {

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -23,9 +23,7 @@ use sui_types::committee::Committee;
 use sui_types::crypto::{AccountKeyPair, AuthoritySignature, Signer};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::messages_checkpoint::{
-    EndOfEpochData, VerifiedCheckpoint, VerifiedCheckpointContents,
-};
+use sui_types::messages_checkpoint::{VerifiedCheckpoint, VerifiedCheckpointContents};
 use sui_types::messages_grpc::HandleTransactionResponse;
 use sui_types::mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider};
 use sui_types::object::Object;
@@ -177,20 +175,9 @@ impl SingleValidator {
     ) -> TransactionEffects {
         let tx_digest = transaction.digest();
         let input_objects = transaction.transaction_data().input_objects().unwrap();
-        let objects = if transaction
-            .data()
-            .intent_message()
-            .value
-            .is_end_of_epoch_tx()
-        {
-            store
-                .read_objects_for_synchronous_execution(&input_objects)
-                .unwrap()
-        } else {
-            store
-                .read_objects_for_execution(&*self.epoch_store, tx_digest, &input_objects)
-                .unwrap()
-        };
+        let objects = store
+            .read_objects_for_execution(&*self.epoch_store, tx_digest, &input_objects)
+            .unwrap();
 
         let executable = VerifiedExecutableTransaction::new_from_quorum_execution(
             VerifiedTransaction::new_unchecked(transaction),
@@ -233,7 +220,6 @@ impl SingleValidator {
 
     pub(crate) async fn build_checkpoints(
         &self,
-        in_memory_store: InMemoryObjectStore,
         transactions: Vec<Transaction>,
         mut all_effects: BTreeMap<TransactionDigest, TransactionEffects>,
         checkpoint_size: usize,
@@ -253,32 +239,10 @@ impl SingleValidator {
                 checkpoints.push((checkpoint, full_contents));
             }
         }
-        let gas_cost_summary = builder.epoch_rolling_gas_cost_summary();
-        let epoch_tx = VerifiedTransaction::new_change_epoch(
-            1,
-            self.epoch_store.protocol_version(),
-            gas_cost_summary.storage_cost,
-            gas_cost_summary.computation_cost,
-            gas_cost_summary.storage_rebate,
-            gas_cost_summary.non_refundable_storage_fee,
-            0,
-            vec![],
-        );
-        let epoch_effects = self
-            .execute_transaction_in_memory(in_memory_store, epoch_tx.clone().into_inner())
-            .await;
-        builder.push_transaction(epoch_tx, epoch_effects);
-        let (checkpoint, _, full_contents) = builder.build_end_of_epoch(
-            self,
-            0,
-            1,
-            EndOfEpochData {
-                next_epoch_committee: self.get_committee().voting_rights.clone(),
-                next_epoch_protocol_version: self.get_epoch_store().protocol_version(),
-                epoch_commitments: vec![],
-            },
-        );
-        checkpoints.push((checkpoint, full_contents));
+        if builder.size() > 0 {
+            let (checkpoint, _, full_contents) = builder.build(self, 0);
+            checkpoints.push((checkpoint, full_contents));
+        }
         checkpoints
     }
 


### PR DESCRIPTION
## Description 

Now that we support RunWithRange in checkpoint execution, there is no longer a need to construct end of epoch tx in the benchmark. Removing it.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
