### PR TITLE
[move-2024] Automatic Referencing in Equality

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/eq_refs.move
@@ -1,0 +1,268 @@
+//# init --edition 2024.alpha
+
+//# publish
+module 0x42::m {
+
+    public struct S has copy, drop { t: u64 }
+
+    public fun make_s(t: u64): S {
+        S { t }
+    }
+
+        public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun tnum_0(): bool {
+       0 == &0
+    }
+
+    public fun tnum_1(): bool {
+       &0 == &0
+    }
+
+    public fun tnum_2(): bool {
+        let a = 0;
+        let b = &mut 0;
+        let c = &0;
+        a == b && b == c && a == c
+    }
+
+
+}
+
+//# run
+module 0x42::main {
+
+    fun main() {
+        let s_val = 0x42::m::make_s(42);
+        let s_ref = &(0x42::m::make_s(42));
+        let s_mut = &mut (0x42::m::make_s(42));
+
+        assert!(0x42::m::test_0(s_val, s_val), 0);
+        assert!(0x42::m::test_1(s_val, s_ref), 1);
+        assert!(0x42::m::test_2(s_val, s_mut), 2);
+        assert!(0x42::m::test_3(s_ref, s_val), 3);
+        assert!(0x42::m::test_4(s_ref, s_ref), 4);
+        assert!(0x42::m::test_5(s_ref, s_mut), 5);
+        assert!(0x42::m::test_6(s_mut, s_val), 6);
+        assert!(0x42::m::test_7(s_mut, s_ref), 7);
+        // assert!(0x42::m::test_8(s_mut, s_mut), 8);
+        assert!(0x42::m::test_9(s_val, s_val, s_val), 9);
+        assert!(0x42::m::test_10(s_val, s_val, s_ref), 10);
+        assert!(0x42::m::test_11(s_val, s_val, s_mut), 11);
+        assert!(0x42::m::test_12(s_val, s_ref, s_val), 12);
+        assert!(0x42::m::test_13(s_val, s_ref, s_ref), 13);
+        assert!(0x42::m::test_14(s_val, s_ref, s_mut), 14);
+        assert!(0x42::m::test_15(s_val, s_mut, s_val), 15);
+        assert!(0x42::m::test_16(s_val, s_mut, s_ref), 16);
+        // assert!(0x42::m::test_17(s_val, s_mut, s_mut), 17);
+        assert!(0x42::m::test_18(s_ref, s_val, s_val), 18);
+        assert!(0x42::m::test_19(s_ref, s_val, s_ref), 19);
+        assert!(0x42::m::test_20(s_ref, s_val, s_mut), 20);
+        assert!(0x42::m::test_21(s_ref, s_ref, s_val), 21);
+        assert!(0x42::m::test_22(s_ref, s_ref, s_ref), 22);
+        assert!(0x42::m::test_23(s_ref, s_ref, s_mut), 23);
+        assert!(0x42::m::test_24(s_ref, s_mut, s_val), 24);
+        assert!(0x42::m::test_25(s_ref, s_mut, s_ref), 25);
+        // assert!(0x42::m::test_26(s_ref, s_mut, s_mut), 26);
+        assert!(0x42::m::test_27(s_mut, s_val, s_val), 27);
+        assert!(0x42::m::test_28(s_mut, s_val, s_ref), 28);
+        // assert!(0x42::m::test_29(s_mut, s_val, s_mut), 29);
+        assert!(0x42::m::test_30(s_mut, s_ref, s_val), 30);
+        assert!(0x42::m::test_31(s_mut, s_ref, s_ref), 31);
+        // assert!(0x42::m::test_32(s_mut, s_ref, s_mut), 32);
+        // assert!(0x42::m::test_33(s_mut, s_mut, s_val), 33);
+        // assert!(0x42::m::test_34(s_mut, s_mut, s_ref), 34);
+        // assert!(0x42::m::test_35(s_mut, s_mut, s_mut), 35);
+
+        let s2_val = 0x42::m::make_s(2);
+        let s2_ref = &(0x42::m::make_s(2));
+        let s2_mut = &mut (0x42::m::make_s(2));
+
+        let s3_val = 0x42::m::make_s(3);
+        let s3_ref = &(0x42::m::make_s(3));
+        let s3_mut = &mut (0x42::m::make_s(3));
+
+        assert!(!0x42::m::test_0(s_val, s2_val), 36);
+        assert!(!0x42::m::test_1(s_val, s2_ref), 37);
+        assert!(!0x42::m::test_2(s_val, s2_mut), 38);
+        assert!(!0x42::m::test_3(s_ref, s2_val), 39);
+        assert!(!0x42::m::test_4(s_ref, s2_ref), 40);
+        assert!(!0x42::m::test_5(s_ref, s2_mut), 41);
+        assert!(!0x42::m::test_6(s_mut, s2_val), 42);
+        assert!(!0x42::m::test_7(s_mut, s2_ref), 43);
+        assert!(!0x42::m::test_8(s_mut, s2_mut), 44);
+        assert!(!0x42::m::test_9(s_val, s2_val, s3_val), 45);
+        assert!(!0x42::m::test_10(s_val, s2_val, s3_ref), 46);
+        assert!(!0x42::m::test_11(s_val, s2_val, s3_mut), 47);
+        assert!(!0x42::m::test_12(s_val, s2_ref, s3_val), 48);
+        assert!(!0x42::m::test_13(s_val, s2_ref, s3_ref), 49);
+        assert!(!0x42::m::test_14(s_val, s2_ref, s3_mut), 50);
+        assert!(!0x42::m::test_15(s_val, s2_mut, s3_val), 51);
+        assert!(!0x42::m::test_16(s_val, s2_mut, s3_ref), 52);
+        assert!(!0x42::m::test_17(s_val, s2_mut, s3_mut), 53);
+        assert!(!0x42::m::test_18(s_ref, s2_val, s3_val), 54);
+        assert!(!0x42::m::test_19(s_ref, s2_val, s3_ref), 55);
+        assert!(!0x42::m::test_20(s_ref, s2_val, s3_mut), 56);
+        assert!(!0x42::m::test_21(s_ref, s2_ref, s3_val), 57);
+        assert!(!0x42::m::test_22(s_ref, s2_ref, s3_ref), 58);
+        assert!(!0x42::m::test_23(s_ref, s2_ref, s3_mut), 59);
+        assert!(!0x42::m::test_24(s_ref, s2_mut, s3_val), 60);
+        assert!(!0x42::m::test_25(s_ref, s2_mut, s3_ref), 61);
+        assert!(!0x42::m::test_26(s_ref, s2_mut, s3_mut), 62);
+        assert!(!0x42::m::test_27(s_mut, s2_val, s3_val), 63);
+        assert!(!0x42::m::test_28(s_mut, s2_val, s3_ref), 64);
+        assert!(!0x42::m::test_29(s_mut, s2_val, s3_mut), 65);
+        assert!(!0x42::m::test_30(s_mut, s2_ref, s3_val), 66);
+        assert!(!0x42::m::test_31(s_mut, s2_ref, s3_ref), 67);
+        assert!(!0x42::m::test_32(s_mut, s2_ref, s3_mut), 68);
+        assert!(!0x42::m::test_33(s_mut, s2_mut, s3_val), 69);
+        assert!(!0x42::m::test_34(s_mut, s2_mut, s3_ref), 70);
+        assert!(!0x42::m::test_35(s_mut, s2_mut, s3_mut), 71);
+
+        assert!(0x42::m::tnum_0(), 101);
+        assert!(0x42::m::tnum_1(), 102);
+        assert!(0x42::m::tnum_2(), 103);
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -41,6 +41,7 @@ pub enum FeatureGate {
     MacroFuns,
     Move2024Migration,
     SyntaxMethods,
+    Autoborrow,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -122,6 +123,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::MacroFuns,
     FeatureGate::Move2024Optimizations,
     FeatureGate::SyntaxMethods,
+    FeatureGate::Autoborrow,
 ];
 
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
@@ -217,6 +219,7 @@ impl FeatureGate {
             FeatureGate::MacroFuns => "'macro' functions are",
             FeatureGate::Move2024Migration => "Move 2024 migration is",
             FeatureGate::SyntaxMethods => "'syntax' methods are",
+            FeatureGate::Autoborrow => "Automatic borrowing is",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -41,7 +41,7 @@ pub enum FeatureGate {
     MacroFuns,
     Move2024Migration,
     SyntaxMethods,
-    Autoborrow,
+    AutoborrowEq,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord, Default)]
@@ -123,7 +123,7 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::MacroFuns,
     FeatureGate::Move2024Optimizations,
     FeatureGate::SyntaxMethods,
-    FeatureGate::Autoborrow,
+    FeatureGate::AutoborrowEq,
 ];
 
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
@@ -219,7 +219,7 @@ impl FeatureGate {
             FeatureGate::MacroFuns => "'macro' functions are",
             FeatureGate::Move2024Migration => "Move 2024 migration is",
             FeatureGate::SyntaxMethods => "'syntax' methods are",
-            FeatureGate::Autoborrow => "Automatic borrowing is",
+            FeatureGate::AutoborrowEq => "Automatic borrowing is",
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2061,6 +2061,7 @@ fn join_impl(
             subst.insert(new_tvar, other.clone());
             join_tvar(subst, case, other.loc, new_tvar, *loc, *id)
         }
+
         (sp!(_, UnresolvedError), other) | (other, sp!(_, UnresolvedError)) => {
             Ok((subst, other.clone()))
         }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2061,7 +2061,6 @@ fn join_impl(
             subst.insert(new_tvar, other.clone());
             join_tvar(subst, case, other.loc, new_tvar, *loc, *id)
         }
-
         (sp!(_, UnresolvedError), other) | (other, sp!(_, UnresolvedError)) => {
             Ok((subst, other.clone()))
         }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.exp
@@ -1,0 +1,132 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:12:17
+   │
+12 │         (0: u8) == (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '=='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:13:11
+   │
+13 │         0 == false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '=='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:21:9
+   │
+ 3 │     public struct R has key {
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+20 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+21 │         r == r;
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:21:14
+   │
+ 3 │     public struct R has key {
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+20 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+21 │         r == r;
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:25:9
+   │
+25 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │  │
+   │         │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:25:35
+   │
+25 │         G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^
+   │                                   │  │
+   │                                   │  The type '0x8675309::M::G0<0x8675309::M::R>' can have the ability 'drop' but the type argument '0x8675309::M::R' does not have the required ability 'drop'
+   │                                   '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                                   The type '0x8675309::M::G0<0x8675309::M::R>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/eq_invalid.move:27:9
+   │
+27 │         G2{} == G2{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/eq_invalid.move:27:17
+   │
+27 │         G2{} == G2{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:28:9
+   │
+ 7 │     public struct G1<T: key> { f: T }
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G1{ f: t } == G1{ f: t };
+   │         ^^^^^^^^^^
+   │         │
+   │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<T>' does not have the ability 'drop'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_invalid.move:28:23
+   │
+ 7 │     public struct G1<T: key> { f: T }
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G1{ f: t } == G1{ f: t };
+   │                       ^^^^^^^^^^
+   │                       │
+   │                       '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                       The type '0x8675309::M::G1<T>' does not have the ability 'drop'
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/eq_invalid.move:32:9
+   │
+32 │         () == ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Incompatible arguments to '=='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/eq_invalid.move:33:9
+   │
+33 │         (0, 1) == (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:34:19
+   │
+34 │         (1, 2, 3) == (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '=='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_invalid.move:35:16
+   │
+35 │         (0, 1) == (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '=='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
@@ -1,0 +1,37 @@
+module 0x8675309::M {
+    public struct S { u: u64 }
+    public struct R has key {
+        f: u64
+    }
+    public struct G0<T> has drop { f: T }
+    public struct G1<T: key> { f: T }
+    public struct G2<phantom T> has drop {}
+
+
+    fun t0(mut s: S, s_ref: &S, s_mut: &mut S) {
+        (0: u8) == (1: u128);
+        0 == false;
+        &0 == 1;
+        1 == &0;
+        s == s_ref;
+        s_mut == s;
+    }
+
+    fun t1(r: R) {
+        r == r;
+    }
+
+    fun t3<T: copy + key>(t: T) {
+        G0<R>{ f: R { f: 1 } } == G0<R>{ f: R { f: 1 } };
+        // can be dropped, but cannot infer type
+        G2{} == G2{};
+        G1{ f: t } == G1{ f: t };
+    }
+
+    fun t4() {
+        () == ();
+        (0, 1) == (0, 1);
+        (1, 2, 3) == (0, 1);
+        (0, 1) == (1, 2, 3);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_invalid.move
@@ -8,7 +8,7 @@ module 0x8675309::M {
     public struct G2<phantom T> has drop {}
 
 
-    fun t0(mut s: S, s_ref: &S, s_mut: &mut S) {
+    fun t0(s: S, s_ref: &S, s_mut: &mut S) {
         (0: u8) == (1: u128);
         0 == false;
         &0 == 1;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
@@ -1,0 +1,74 @@
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:18:11
+   │
+15 │         let x: T<u64> = any();
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+16 │         let y: &T<bool> = abort 0;
+   │                   ---- Found: 'bool'. It is not compatible with the other type.
+17 │         let z: &mut T<bool> = abort 0;
+18 │         x == y && x == z
+   │           ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:18:21
+   │
+15 │         let x: T<u64> = any();
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+16 │         let y: &T<bool> = abort 0;
+17 │         let z: &mut T<bool> = abort 0;
+   │                       ---- Found: 'bool'. It is not compatible with the other type.
+18 │         x == y && x == z
+   │                     ^^ Incompatible arguments to '=='
+
+error[E04024]: invalid usage of immutable variable
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:33:19
+   │
+30 │         let x = any();
+   │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
+   ·
+33 │         x == y && x == z;
+   │                   ^ Invalid mutable borrow of immutable variable 'x'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:31
+   │
+45 │         let a: &T<u64> = abort 0;
+   │                   --- Found: 'u64'. It is not compatible with the other type.
+46 │         let b: &mut T<u64> = abort 0;
+47 │         let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+   │                             ---- Found: 'bool'. It is not compatible with the other type.
+48 │         a == b && c == d && a == c && b == d
+   │                               ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:41
+   │
+46 │         let b: &mut T<u64> = abort 0;
+   │                       --- Found: 'u64'. It is not compatible with the other type.
+47 │         let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+   │                                       ---- Found: 'bool'. It is not compatible with the other type.
+48 │         a == b && c == d && a == c && b == d
+   │                                         ^^ Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:73:11
+   │
+72 │         let x: T<u64> = option_take(&mut c);
+   │                  --- Found: 'u64'. It is not compatible with the other type.
+73 │         x == &mut T { q: false };
+   │           ^^             ----- Found: 'bool'. It is not compatible with the other type.
+   │           │               
+   │           Incompatible arguments to '=='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/eq_ref_tvars.move:74:9
+   │
+72 │         let x: T<u64> = option_take(&mut c);
+   │                  --- Expected: 'u64'
+73 │         x == &mut T { q: false };
+74 │         option_fill(&mut c, T { q: false });
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                          │
+   │         │                          Given: 'bool'
+   │         Invalid call of 'a::m::option_fill'. Invalid argument for parameter '_e'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.exp
@@ -20,15 +20,6 @@ error[E04007]: incompatible types
 18 │         x == y && x == z
    │                     ^^ Incompatible arguments to '=='
 
-error[E04024]: invalid usage of immutable variable
-   ┌─ tests/move_2024/typing/eq_ref_tvars.move:33:19
-   │
-30 │         let x = any();
-   │             - To use the variable mutably, it must be declared 'mut', e.g. 'mut x'
-   ·
-33 │         x == y && x == z;
-   │                   ^ Invalid mutable borrow of immutable variable 'x'
-
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/eq_ref_tvars.move:48:31
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
@@ -1,0 +1,98 @@
+module a::m {
+
+    public struct T<Q> has drop { q: Q }
+
+    fun any<T>(): T { abort 0 }
+
+    fun globals00(): bool {
+        let mut x: T<u64> = any();
+        let y: &T<u64> = abort 0;
+        let z: &mut T<u64> = abort 0;
+        x == y && x == z
+    }
+
+    fun globals01(): bool {
+        let x: T<u64> = any();
+        let y: &T<bool> = abort 0;
+        let z: &mut T<bool> = abort 0;
+        x == y && x == z
+    }
+
+    fun globals02(): u64 {
+        let mut x = any();
+        let y = &any();
+        let z = &mut any();
+        x == y && x == z;
+        (x : u64)
+    }
+
+    fun globals03(): u64 {
+        let x = any();
+        let y = &any();
+        let z = &mut any();
+        x == y && x == z;
+        (x : u64)
+    }
+
+    fun locals00(): bool {
+        let a: &T<u64> = abort 0;
+        let b: &mut T<u64> = abort 0;
+        let (c, d): (&mut T<u64>, &T<u64>) = abort 0;
+        a == b && c == d && a == c && b == d
+    }
+
+    fun locals01(): bool {
+        let a: &T<u64> = abort 0;
+        let b: &mut T<u64> = abort 0;
+        let (c, d): (&mut T<bool>, &T<bool>) = abort 0;
+        a == b && c == d && a == c && b == d
+    }
+
+    fun locals02(): bool {
+        let mut x = abort 0;
+        let y = &(abort 0);
+        let z = &mut (abort 0);
+        x == y && x == z;
+        let _ = (x : u64);
+        x == y && x == z
+    }
+
+    fun options00(): bool {
+        let mut c = option_none();
+        c == c;
+        let mut x: T<u64> = option_take(&mut c);
+        x == &mut T { q: 5 };
+        option_fill(&mut c, T { q: 10 });
+        x == x
+    }
+
+    fun options01(): bool {
+        let mut c = option_none();
+        c == c;
+        let x: T<u64> = option_take(&mut c);
+        x == &mut T { q: false };
+        option_fill(&mut c, T { q: false });
+        x == x
+    }
+
+    fun options02(): T<u64> {
+        let mut c = option_none();
+        c == c;
+        let mut x = option_take(&mut c);
+        x == &mut T { q: 5 };
+        option_fill(&mut c, T { q: 10 });
+        x == x;
+        x
+    }
+
+    // Approximation of options for typing
+
+    public struct Option<T> has copy, drop { value: T }
+
+    public fun option_none<Element>(): Option<Element> { abort 0 }
+
+    public fun option_fill<Element>(_t: &mut Option<Element>, _e: Element) { abort 0 }
+
+    public fun option_take<Element>(_t: &mut Option<Element>): Element { abort 0 }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_ref_tvars.move
@@ -5,7 +5,7 @@ module a::m {
     fun any<T>(): T { abort 0 }
 
     fun globals00(): bool {
-        let mut x: T<u64> = any();
+        let x: T<u64> = any();
         let y: &T<u64> = abort 0;
         let z: &mut T<u64> = abort 0;
         x == y && x == z
@@ -19,7 +19,7 @@ module a::m {
     }
 
     fun globals02(): u64 {
-        let mut x = any();
+        let x = any();
         let y = &any();
         let z = &mut any();
         x == y && x == z;
@@ -49,7 +49,7 @@ module a::m {
     }
 
     fun locals02(): bool {
-        let mut x = abort 0;
+        let x = abort 0;
         let y = &(abort 0);
         let z = &mut (abort 0);
         x == y && x == z;
@@ -60,7 +60,7 @@ module a::m {
     fun options00(): bool {
         let mut c = option_none();
         c == c;
-        let mut x: T<u64> = option_take(&mut c);
+        let x: T<u64> = option_take(&mut c);
         x == &mut T { q: 5 };
         option_fill(&mut c, T { q: 10 });
         x == x
@@ -78,7 +78,7 @@ module a::m {
     fun options02(): T<u64> {
         let mut c = option_none();
         c == c;
-        let mut x = option_take(&mut c);
+        let x = option_take(&mut c);
         x == &mut T { q: 5 };
         option_fill(&mut c, T { q: 10 });
         x == x;

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct.move
@@ -1,0 +1,149 @@
+module 0x42::a {
+
+    public struct S has drop, copy {}
+
+    public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.exp
@@ -1,0 +1,623 @@
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:6:9
+  │
+3 │     public struct S has copy {}
+  │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+4 │ 
+5 │     public fun test_0(a: S, b: S): bool {
+  │                          - The type '0x42::a::S' does not have the ability 'drop'
+6 │         a == b
+  │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+  ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:6:14
+  │
+3 │     public struct S has copy {}
+  │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+4 │ 
+5 │     public fun test_0(a: S, b: S): bool {
+  │                                - The type '0x42::a::S' does not have the ability 'drop'
+6 │         a == b
+  │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:10:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+ 9 │     public fun test_1(a: S, b: &S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+10 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:14:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │     public fun test_2(a: S, b: &mut S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+14 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:18:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+17 │     public fun test_3(a: &S, b: S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+18 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:22:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     public fun test_6(a: &mut S, b: S): bool {
+   │                                  -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                  │   
+   │                                  The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+22 │         a == b
+   │         ^^^^^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                          - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                       -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                       │   
+   │                       The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                             -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                             │   
+   │                             The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+26 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                          - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:26:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+25 │     public fun test_9(a: S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+26 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+30 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                                 - The type '0x42::a::S' does not have the ability 'drop'
+30 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+30 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:30:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+29 │     public fun test_10(a: S, b: S, c: &S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+30 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:9
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+34 │         a == b && b == c && a == c
+   │         ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:14
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                                 - The type '0x42::a::S' does not have the ability 'drop'
+34 │         a == b && b == c && a == c
+   │              ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+34 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:34:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+33 │     public fun test_11(a: S, b: S, c: &mut S): bool {
+   │                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                              │   
+   │                              The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+34 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+38 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                                     -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                     │   
+   │                                     The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+38 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+38 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:38:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+37 │     public fun test_12(a: S, b: &S, c: S): bool {
+   │                                        - The type '0x42::a::S' does not have the ability 'drop'
+38 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:42:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+41 │     public fun test_13(a: S, b: &S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+42 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:46:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+45 │     public fun test_14(a: S, b: &S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+46 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+50 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                                         -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                         │   
+   │                                         The parameter 'c' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+50 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:29
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                           - The type '0x42::a::S' does not have the ability 'drop'
+50 │         a == b && b == c && a == c
+   │                             ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:50:34
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+49 │     public fun test_15(a: S, b: &mut S, c: S): bool {
+   │                                            - The type '0x42::a::S' does not have the ability 'drop'
+50 │         a == b && b == c && a == c
+   │                                  ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:54:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+53 │     public fun test_16(a: S, b: &mut S, c: &S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+54 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:58:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+57 │     public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+   │                        -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                        │   
+   │                        The parameter 'a' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+58 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                  - The type '0x42::a::S' does not have the ability 'drop'
+62 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                        - The type '0x42::a::S' does not have the ability 'drop'
+62 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+62 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:62:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+61 │     public fun test_18(a: &S, b: S, c: S): bool {
+   │                                     -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                     │   
+   │                                     The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+62 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:66:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+65 │     public fun test_19(a: &S, b: S, c: &S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+66 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:70:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+69 │     public fun test_20(a: &S, b: S, c: &mut S): bool {
+   │                               -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                               │   
+   │                               The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+70 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:74:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+73 │     public fun test_21(a: &S, b: &S, c: S): bool {
+   │                                      -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                      │   
+   │                                      The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+74 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:78:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+77 │     public fun test_24(a: &S, b: &mut S, c: S): bool {
+   │                                          -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                          │   
+   │                                          The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+78 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:19
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                      - The type '0x42::a::S' does not have the ability 'drop'
+82 │         a == b && b == c && a == c
+   │                   ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:24
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                            - The type '0x42::a::S' does not have the ability 'drop'
+82 │         a == b && b == c && a == c
+   │                        ^ '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' might still contain a value. The value does not have the 'drop' ability and must be consumed before the function returns
+82 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:82:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+81 │     public fun test_27(a: &mut S, b: S, c: S): bool {
+   │                                         -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                         │   
+   │                                         The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+82 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:86:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+85 │     public fun test_28(a: &mut S, b: S, c: &S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+86 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:90:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+89 │     public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+   │                                   -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                   │   
+   │                                   The parameter 'b' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+90 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:94:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+93 │     public fun test_30(a: &mut S, b: &S, c: S): bool {
+   │                                          -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                          │   
+   │                                          The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+94 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move:98:26
+   │
+ 3 │     public struct S has copy {}
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+97 │     public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+   │                                              -  - The type '0x42::a::S' does not have the ability 'drop'
+   │                                              │   
+   │                                              The parameter 'c' still contains a value. The value does not have the 'drop' ability and must be consumed before the function returns
+98 │         a == b && b == c && a == c
+   │                          ^^ Invalid return
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_invalid_no_drop.move
@@ -1,0 +1,101 @@
+module 0x42::a {
+
+    public struct S has copy {}
+
+    public fun test_0(a: S, b: S): bool {
+        a == b
+    }
+
+    public fun test_1(a: S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_2(a: S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_3(a: &S, b: S): bool {
+        a == b
+    }
+
+    public fun test_6(a: &mut S, b: S): bool {
+        a == b
+    }
+
+    public fun test_9(a: S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_10(a: S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_11(a: S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_12(a: S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_13(a: S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_14(a: S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_15(a: S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_16(a: S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_17(a: S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_18(a: &S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_19(a: &S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_20(a: &S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_21(a: &S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_24(a: &S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_27(a: &mut S, b: S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_28(a: &mut S, b: S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_29(a: &mut S, b: S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_30(a: &mut S, b: &S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_33(a: &mut S, b: &mut S, c: S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_no_drop.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/eq_refs_struct_no_drop.move
@@ -1,0 +1,53 @@
+module 0x42::a {
+
+    public struct S has copy {}
+
+    public fun test_4(a: &S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_5(a: &S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_7(a: &mut S, b: &S): bool {
+        a == b
+    }
+
+    public fun test_8(a: &mut S, b: &mut S): bool {
+        a == b
+    }
+
+    public fun test_22(a: &S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_23(a: &S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_25(a: &S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_26(a: &S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_31(a: &mut S, b: &S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_32(a: &mut S, b: &S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_34(a: &mut S, b: &mut S, c: &S): bool {
+        a == b && b == c && a == c
+    }
+
+    public fun test_35(a: &mut S, b: &mut S, c: &mut S): bool {
+        a == b && b == c && a == c
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
@@ -1,0 +1,209 @@
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:2:5
+  │
+2 │     struct S { u: u64 }
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:3:5
+  │
+3 │     struct R {
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:6:5
+  │
+6 │     struct G0<phantom T> has drop {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:7:5
+  │
+7 │     struct G1<phantom T: key> {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E01003]: invalid modifier
+  ┌─ tests/move_2024/typing/neq_invalid.move:8:5
+  │
+8 │     struct G2<phantom T> {}
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:13:17
+   │
+13 │         (0: u8) != (1: u128);
+   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+   │             │   │       
+   │             │   Incompatible arguments to '!='
+   │             Found: 'u8'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:14:11
+   │
+14 │         0 != false;
+   │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
+   │         │ │   
+   │         │ Incompatible arguments to '!='
+   │         Found: integer. It is not compatible with the other type.
+
+error[E04024]: invalid usage of immutable variable
+   ┌─ tests/move_2024/typing/neq_invalid.move:18:18
+   │
+12 │     fun t0(s: S, s_ref: &S, s_mut: &mut S) {
+   │            - To use the variable mutably, it must be declared 'mut', e.g. 'mut s'
+   ·
+18 │         s_mut != s;
+   │                  ^ Invalid mutable borrow of immutable variable 's'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:9
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │         ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:14
+   │
+ 3 │     struct R {
+   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+21 │     fun t1(r: R) {
+   │               - The type '0x8675309::M::R' does not have the ability 'drop'
+22 │         r != r;
+   │              ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:26:9
+   │
+26 │         G0{} != G0{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:26:17
+   │
+26 │         G0{} != G0{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   │
+ 7 │     struct G1<phantom T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │         ^^^^
+   │         │
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   │
+27 │         G1{} != G1{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   │
+ 7 │     struct G1<phantom T: key> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+27 │         G1{} != G1{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   │
+27 │         G1{} != G1{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
+   │
+ 8 │     struct G2<phantom T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │         ^^^^
+   │         │
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
+   │
+28 │         G2{} != G2{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
+   │
+ 8 │     struct G2<phantom T> {}
+   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+28 │         G2{} != G2{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G2<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
+   │
+28 │         G2{} != G2{};
+   │                 ^^^^ Could not infer this type. Try adding an annotation
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/neq_invalid.move:32:9
+   │
+32 │         () != ();
+   │         ^^^^^^^^
+   │         │     │
+   │         │     Expected a single type, but found expression list type: '()'
+   │         Incompatible arguments to '!='
+
+error[E04005]: expected a single type
+   ┌─ tests/move_2024/typing/neq_invalid.move:33:9
+   │
+33 │         (0, 1) != (0, 1);
+   │         ^^^^^^^^^^^^^^^^
+   │         │         │
+   │         │         Expected a single type, but found expression list type: '(u64, u64)'
+   │         Incompatible arguments to '!='
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:34:19
+   │
+34 │         (1, 2, 3) != (0, 1);
+   │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+   │         │         │   
+   │         │         Incompatible arguments to '!='
+   │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/neq_invalid.move:35:16
+   │
+35 │         (0, 1) != (1, 2, 3);
+   │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
+   │         │      │   
+   │         │      Incompatible arguments to '!='
+   │         Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
@@ -1,198 +1,158 @@
-error[E01003]: invalid modifier
-  ┌─ tests/move_2024/typing/neq_invalid.move:2:5
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/typing/neq_invalid.move:9:17
   │
-2 │     struct S { u: u64 }
-  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-  │
-  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
-
-error[E01003]: invalid modifier
-  ┌─ tests/move_2024/typing/neq_invalid.move:3:5
-  │
-3 │     struct R {
-  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-  │
-  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
-
-error[E01003]: invalid modifier
-  ┌─ tests/move_2024/typing/neq_invalid.move:6:5
-  │
-6 │     struct G0<phantom T> has drop {}
-  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-  │
-  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
-
-error[E01003]: invalid modifier
-  ┌─ tests/move_2024/typing/neq_invalid.move:7:5
-  │
-7 │     struct G1<phantom T: key> {}
-  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-  │
-  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
-
-error[E01003]: invalid modifier
-  ┌─ tests/move_2024/typing/neq_invalid.move:8:5
-  │
-8 │     struct G2<phantom T> {}
-  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-  │
-  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+9 │         (0: u8) != (1: u128);
+  │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
+  │             │   │       
+  │             │   Incompatible arguments to '!='
+  │             Found: 'u8'. It is not compatible with the other type.
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/neq_invalid.move:13:17
+   ┌─ tests/move_2024/typing/neq_invalid.move:10:11
    │
-13 │         (0: u8) != (1: u128);
-   │             --  ^^     ---- Found: 'u128'. It is not compatible with the other type.
-   │             │   │       
-   │             │   Incompatible arguments to '!='
-   │             Found: 'u8'. It is not compatible with the other type.
-
-error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/neq_invalid.move:14:11
-   │
-14 │         0 != false;
+10 │         0 != false;
    │         - ^^ ----- Found: 'bool'. It is not compatible with the other type.
    │         │ │   
    │         │ Incompatible arguments to '!='
    │         Found: integer. It is not compatible with the other type.
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:22:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:18:9
    │
- 3 │     struct R {
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+ 3 │     public struct R { f: u64 }
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-21 │     fun t1(r: R) {
+17 │     fun t1(r: R) {
    │               - The type '0x8675309::M::R' does not have the ability 'drop'
-22 │         r != r;
+18 │         r != r;
    │         ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:22:14
+   ┌─ tests/move_2024/typing/neq_invalid.move:18:14
    │
- 3 │     struct R {
-   │            - To satisfy the constraint, the 'drop' ability would need to be added here
+ 3 │     public struct R { f: u64 }
+   │                   - To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-21 │     fun t1(r: R) {
+17 │     fun t1(r: R) {
    │               - The type '0x8675309::M::R' does not have the ability 'drop'
-22 │         r != r;
+18 │         r != r;
    │              ^ '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
 
-error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:26:9
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:9
    │
-26 │         G0{} != G0{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+ 4 │     public struct G0<phantom T> {}
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+22 │         G0{} != G0{};
+   │         ^^^^
+   │         │
+   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │         The type '0x8675309::M::G0<_>' does not have the ability 'drop'
 
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:26:17
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:9
    │
-26 │         G0{} != G0{};
+22 │         G0{} != G0{};
+   │         ^^^^ Could not infer this type. Try adding an annotation
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:17
+   │
+ 4 │     public struct G0<phantom T> {}
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+22 │         G0{} != G0{};
+   │                 ^^^^
+   │                 │
+   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
+   │                 The type '0x8675309::M::G0<_>' does not have the ability 'drop'
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/neq_invalid.move:22:17
+   │
+22 │         G0{} != G0{};
    │                 ^^^^ Could not infer this type. Try adding an annotation
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:23:9
    │
- 7 │     struct G1<phantom T: key> {}
-   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+ 5 │     public struct G1<phantom T: key> {}
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-27 │         G1{} != G1{};
+23 │         G1{} != G1{};
    │         ^^^^
    │         │
    │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x8675309::M::G1<_>' does not have the ability 'drop'
 
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:27:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:23:9
    │
-27 │         G1{} != G1{};
+23 │         G1{} != G1{};
    │         ^^^^ Could not infer this type. Try adding an annotation
 
 error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   ┌─ tests/move_2024/typing/neq_invalid.move:23:17
    │
- 7 │     struct G1<phantom T: key> {}
-   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
+ 5 │     public struct G1<phantom T: key> {}
+   │                   -- To satisfy the constraint, the 'drop' ability would need to be added here
    ·
-27 │         G1{} != G1{};
+23 │         G1{} != G1{};
    │                 ^^^^
    │                 │
    │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
 
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:27:17
+   ┌─ tests/move_2024/typing/neq_invalid.move:23:17
    │
-27 │         G1{} != G1{};
+23 │         G1{} != G1{};
    │                 ^^^^ Could not infer this type. Try adding an annotation
 
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
-   │
- 8 │     struct G2<phantom T> {}
-   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
-   ·
-28 │         G2{} != G2{};
-   │         ^^^^
-   │         │
-   │         '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │         The type '0x8675309::M::G2<_>' does not have the ability 'drop'
-
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:24:9
    │
-28 │         G2{} != G2{};
+24 │         G2{} != G2{};
    │         ^^^^ Could not infer this type. Try adding an annotation
 
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
-   │
- 8 │     struct G2<phantom T> {}
-   │            -- To satisfy the constraint, the 'drop' ability would need to be added here
-   ·
-28 │         G2{} != G2{};
-   │                 ^^^^
-   │                 │
-   │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
-   │                 The type '0x8675309::M::G2<_>' does not have the ability 'drop'
-
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/typing/neq_invalid.move:28:17
+   ┌─ tests/move_2024/typing/neq_invalid.move:24:17
    │
-28 │         G2{} != G2{};
+24 │         G2{} != G2{};
    │                 ^^^^ Could not infer this type. Try adding an annotation
 
 error[E04005]: expected a single type
-   ┌─ tests/move_2024/typing/neq_invalid.move:32:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:28:9
    │
-32 │         () != ();
+28 │         () != ();
    │         ^^^^^^^^
    │         │     │
    │         │     Expected a single type, but found expression list type: '()'
    │         Incompatible arguments to '!='
 
 error[E04005]: expected a single type
-   ┌─ tests/move_2024/typing/neq_invalid.move:33:9
+   ┌─ tests/move_2024/typing/neq_invalid.move:29:9
    │
-33 │         (0, 1) != (0, 1);
+29 │         (0, 1) != (0, 1);
    │         ^^^^^^^^^^^^^^^^
    │         │         │
    │         │         Expected a single type, but found expression list type: '(u64, u64)'
    │         Incompatible arguments to '!='
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/neq_invalid.move:34:19
+   ┌─ tests/move_2024/typing/neq_invalid.move:30:19
    │
-34 │         (1, 2, 3) != (0, 1);
+30 │         (1, 2, 3) != (0, 1);
    │         --------- ^^ ------ Found expression list of length 2: '({integer}, {integer})'. It is not compatible with the other type of length 3.
    │         │         │   
    │         │         Incompatible arguments to '!='
    │         Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/neq_invalid.move:35:16
+   ┌─ tests/move_2024/typing/neq_invalid.move:31:16
    │
-35 │         (0, 1) != (1, 2, 3);
+31 │         (0, 1) != (1, 2, 3);
    │         ------ ^^ --------- Found expression list of length 3: '({integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
    │         │      │   
    │         │      Incompatible arguments to '!='

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.exp
@@ -56,15 +56,6 @@ error[E04007]: incompatible types
    │         │ Incompatible arguments to '!='
    │         Found: integer. It is not compatible with the other type.
 
-error[E04024]: invalid usage of immutable variable
-   ┌─ tests/move_2024/typing/neq_invalid.move:18:18
-   │
-12 │     fun t0(s: S, s_ref: &S, s_mut: &mut S) {
-   │            - To use the variable mutably, it must be declared 'mut', e.g. 'mut s'
-   ·
-18 │         s_mut != s;
-   │                  ^ Invalid mutable borrow of immutable variable 's'
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_2024/typing/neq_invalid.move:22:9
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
@@ -1,0 +1,37 @@
+module 0x8675309::M {
+    struct S { u: u64 }
+    struct R {
+        f: u64
+    }
+    struct G0<phantom T> has drop {}
+    struct G1<phantom T: key> {}
+    struct G2<phantom T> {}
+
+
+
+    fun t0(s: S, s_ref: &S, s_mut: &mut S) {
+        (0: u8) != (1: u128);
+        0 != false;
+        &0 != 1;
+        1 != &0;
+        s != s_ref;
+        s_mut != s;
+    }
+
+    fun t1(r: R) {
+        r != r;
+    }
+
+    fun t3() {
+        G0{} != G0{};
+        G1{} != G1{};
+        G2{} != G2{};
+    }
+
+    fun t4() {
+        () != ();
+        (0, 1) != (0, 1);
+        (1, 2, 3) != (0, 1);
+        (0, 1) != (1, 2, 3);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/neq_invalid.move
@@ -1,13 +1,9 @@
 module 0x8675309::M {
-    struct S { u: u64 }
-    struct R {
-        f: u64
-    }
-    struct G0<phantom T> has drop {}
-    struct G1<phantom T: key> {}
-    struct G2<phantom T> {}
-
-
+    public struct S has drop { u: u64 }
+    public struct R { f: u64 }
+    public struct G0<phantom T> {}
+    public struct G1<phantom T: key> {}
+    public struct G2<phantom T> has drop {}
 
     fun t0(s: S, s_ref: &S, s_mut: &mut S) {
         (0: u8) != (1: u128);


### PR DESCRIPTION
## Description 

This considers refs during typechecking Eq/Neq binops, and does automatic referencing when possible to allow equality to work a bit easier.

Note this is now Move 2024 feature gated.

## Test Plan 

New tests, plus updated expected output for old ones.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
