### PR TITLE
[gql][performance-tuning][2/n] Leverage `single_value()` for event look up by tx digest

### DIFF
--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -16,7 +16,7 @@ use crate::data::{self, QueryExecutor};
 use crate::{data::Db, error::Error};
 use async_graphql::connection::{Connection, CursorType, Edge};
 use async_graphql::*;
-use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
+use diesel::{BoolExpressionMethods, ExpressionMethods, NullableExpressionMethods, QueryDsl};
 use serde::{Deserialize, Serialize};
 use sui_indexer::models::{events::StoredEvent, transactions::StoredTransaction};
 use sui_indexer::schema::{events, transactions, tx_senders};
@@ -195,13 +195,14 @@ impl Event {
 
                         if let Some(digest) = &filter.transaction_digest {
                             query = query.filter(
-                                events::dsl::tx_sequence_number.eq_any(
+                                events::dsl::tx_sequence_number.nullable().eq(
                                     transactions::dsl::transactions
                                         .select(transactions::dsl::tx_sequence_number)
                                         .filter(
                                             transactions::dsl::transaction_digest
                                                 .eq(digest.to_vec()),
-                                        ),
+                                        )
+                                        .single_value(),
                                 ),
                             )
                         }

--- a/crates/sui-graphql-rpc/src/types/event.rs
+++ b/crates/sui-graphql-rpc/src/types/event.rs
@@ -194,6 +194,11 @@ impl Event {
                         }
 
                         if let Some(digest) = &filter.transaction_digest {
+                            // Since the event filter takes in a single tx_digest, we know that
+                            // there will only be one corresponding transaction. We can use
+                            // single_value() to tell the query planner that we expect only one
+                            // instead of a range of values, which will subsequently speed up query
+                            // execution time.
                             query = query.filter(
                                 events::dsl::tx_sequence_number.nullable().eq(
                                     transactions::dsl::transactions


### PR DESCRIPTION
## Description 

Since the event filter takes in a single `tx_digest`, we know that there will only be one corresponding transaction. We can use `single_value()` to tell the query planner that we expect only one instead of a range of values, which will subsequently speed up query execution time.

## Test Plan 

existing tests (will be picked up by benchmarking suite when I get to that)

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
