### PR TITLE
[move] Add fine-grained calls to stacker across the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6730,6 +6730,7 @@ dependencies = [
  "move-core-types",
  "move-ir-to-bytecode",
  "move-ir-types",
+ "move-proc-macros",
  "move-symbol-pool",
  "once_cell",
  "pathdiff",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "move-core-types",
  "move-ir-to-bytecode",
  "move-ir-types",
+ "move-proc-macros",
  "move-stdlib",
  "move-symbol-pool",
  "once_cell",

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -33,6 +33,7 @@ move-ir-to-bytecode.workspace = true
 move-borrow-graph.workspace = true
 move-bytecode-source-map.workspace = true
 move-command-line-common.workspace = true
+move-proc-macros.workspace = true
 
 [dev-dependencies]
 move-stdlib.workspace = true

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     parser::ast::BinOp_,
     shared::{unique_map::UniqueMap, CompilationEnv},
 };
+use move_proc_macros::growing_stack;
 use state::{Value, *};
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
@@ -150,6 +151,7 @@ fn unused_mut_borrows(
 // Command
 //**************************************************************************************************
 
+#[growing_stack]
 fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
     use Command_ as C;
     match cmd_ {
@@ -221,6 +223,7 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue, value: Value) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, parent_e: &Exp) -> Values {
     use UnannotatedExp_ as E;
     let eloc = &parent_e.exp.loc;

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     shared::{unique_map::UniqueMap, CompilationEnv},
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use state::*;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -80,6 +81,7 @@ fn analyze(
     (final_invariants, liveness.states)
 }
 
+#[growing_stack]
 fn command(state: &mut LivenessState, sp!(_, cmd_): &Command) {
     use Command_ as C;
     match cmd_ {
@@ -116,6 +118,7 @@ fn lvalue(state: &mut LivenessState, sp!(_, l_): &LValue) {
     }
 }
 
+#[growing_stack]
 fn exp(state: &mut LivenessState, parent_e: &Exp) {
     use UnannotatedExp_ as E;
     match &parent_e.exp.value {
@@ -176,6 +179,8 @@ pub fn last_usage(
 }
 
 mod last_usage {
+    use move_proc_macros::growing_stack;
+
     use crate::{
         cfgir::liveness::state::LivenessState,
         diag,
@@ -238,6 +243,7 @@ mod last_usage {
         }
     }
 
+    #[growing_stack]
     fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
         use Command_ as C;
         match cmd_ {
@@ -296,6 +302,7 @@ mod last_usage {
         }
     }
 
+    #[growing_stack]
     fn exp(context: &mut Context, parent_e: &mut Exp) {
         use UnannotatedExp_ as E;
         match &mut parent_e.exp.value {

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     shared::{unique_map::UniqueMap, *},
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use state::*;
 use std::collections::BTreeMap;
@@ -207,6 +208,7 @@ fn unused_let_muts<T>(
 // Command
 //**************************************************************************************************
 
+#[growing_stack]
 fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
     use Command_ as C;
     match cmd_ {
@@ -343,6 +345,7 @@ fn lvalue(context: &mut Context, case: AssignCase, sp!(loc, l_): &LValue) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, parent_e: &Exp) {
     use UnannotatedExp_ as E;
     let eloc = &parent_e.exp.loc;

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -14,6 +14,7 @@ use crate::{
     shared::unique_map::UniqueMap,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use std::convert::TryFrom;
 
 /// returns true if anything changed
@@ -49,6 +50,7 @@ pub fn optimize(
 
 // Some(changed) to keep
 // None to remove the cmd
+#[growing_stack]
 fn optimize_cmd(
     consts: &UniqueMap<ConstantName, Value>,
     sp!(_, cmd_): &mut Command,
@@ -79,6 +81,7 @@ fn optimize_cmd(
     })
 }
 
+#[growing_stack]
 fn optimize_exp(consts: &UniqueMap<ConstantName, Value>, e: &mut Exp) -> bool {
     use UnannotatedExp_ as E;
     let optimize_exp = |e| optimize_exp(consts, e);

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -48,6 +48,8 @@ fn count(signature: &FunctionSignature, cfg: &MutForwardCFG) -> BTreeSet<Var> {
 }
 
 mod count {
+    use move_proc_macros::growing_stack;
+
     use crate::{
         hlir::ast::{FunctionSignature, *},
         parser::ast::{BinOp, UnaryOp},
@@ -109,6 +111,7 @@ mod count {
         }
     }
 
+    #[growing_stack]
     pub fn command(context: &mut Context, sp!(_, cmd_): &Command) {
         use Command_ as C;
         match cmd_ {
@@ -146,6 +149,7 @@ mod count {
         }
     }
 
+    #[growing_stack]
     fn exp(context: &mut Context, parent_e: &Exp) {
         use UnannotatedExp_ as E;
         match &parent_e.exp.value {
@@ -252,6 +256,7 @@ fn eliminate(cfg: &mut MutForwardCFG, ssa_temps: BTreeSet<Var>) {
 mod eliminate {
     use crate::hlir::ast::{self as H, *};
     use move_ir_types::location::*;
+    use move_proc_macros::growing_stack;
     use std::collections::{BTreeMap, BTreeSet};
 
     pub struct Context {
@@ -272,6 +277,7 @@ mod eliminate {
         }
     }
 
+    #[growing_stack]
     pub fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
         use Command_ as C;
         match cmd_ {
@@ -338,6 +344,7 @@ mod eliminate {
         }
     }
 
+    #[growing_stack]
     fn exp(context: &mut Context, parent_e: &mut Exp) {
         use UnannotatedExp_ as E;
         match &mut parent_e.exp.value {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/forwarding_jumps.rs
@@ -26,6 +26,8 @@
 // Label 2:
 //     ...
 
+use move_proc_macros::growing_stack;
+
 use crate::{
     cfgir::{
         ast::remap_labels,
@@ -123,6 +125,7 @@ fn optimize_forwarding_jumps(
     changed
 }
 
+#[growing_stack]
 fn optimize_cmd(sp!(_, cmd_): &mut Command, final_jumps: &BTreeMap<Label, Label>) -> bool {
     use Command_ as C;
     match cmd_ {

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/inline_blocks.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_proc_macros::growing_stack;
+
 use crate::{
     cfgir::{
         ast::remap_labels,
@@ -34,6 +36,7 @@ fn optimize_(start: Label, blocks: &mut BasicBlocks) -> bool {
     inline_single_target_blocks(&single_target_labels, start, blocks)
 }
 
+#[growing_stack]
 fn find_single_target_labels(start: Label, blocks: &BasicBlocks) -> BTreeSet<Label> {
     use Command_ as C;
     let mut counts = BTreeMap::new();

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/mod.rs
@@ -7,6 +7,7 @@ mod forwarding_jumps;
 mod inline_blocks;
 mod simplify_jumps;
 
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 
 use crate::{
@@ -40,6 +41,7 @@ const MOVE_2024_OPTIMIZATIONS: &[Optimization] = &[
     inline_blocks::optimize,
 ];
 
+#[growing_stack]
 pub fn optimize(
     env: &mut CompilationEnv,
     package: Option<Symbol>,

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/simplify_jumps.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_proc_macros::growing_stack;
+
 use crate::{
     cfgir::cfg::MutForwardCFG,
     expansion::ast::Mutability,
@@ -31,6 +33,7 @@ pub fn optimize(
     changed
 }
 
+#[growing_stack]
 fn optimize_cmd(sp!(_, cmd_): &mut Command) -> bool {
     use Command_ as C;
     use UnannotatedExp_ as E;

--- a/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/translate.rs
@@ -19,6 +19,7 @@ use crate::{
 use cfgir::ast::LoopInfo;
 use move_core_types::{account_address::AccountAddress as MoveAddress, runtime_value::MoveValue};
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use petgraph::{
     algo::{kosaraju_scc as petgraph_scc, toposort as petgraph_toposort},
@@ -664,6 +665,7 @@ fn function_body(
 
 type BlockList = Vec<(Label, BasicBlock)>;
 
+#[growing_stack]
 fn block(context: &mut Context, stmts: H::Block) -> BlockList {
     let (start_block, blocks) = block_(context, stmts);
     [(context.new_label(), start_block)]
@@ -672,6 +674,7 @@ fn block(context: &mut Context, stmts: H::Block) -> BlockList {
         .collect()
 }
 
+#[growing_stack]
 fn block_(context: &mut Context, stmts: H::Block) -> (BasicBlock, BlockList) {
     let mut current_block: BasicBlock = VecDeque::new();
     let mut blocks = Vec::new();
@@ -736,6 +739,7 @@ fn finalize_blocks(
     (out_label, out_blocks, block_info)
 }
 
+#[growing_stack]
 fn statement(
     context: &mut Context,
     sp!(sloc, stmt): H::Statement,

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -19,6 +19,7 @@ use crate::{
     shared::CompilationEnv,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 
 pub type AbsIntVisitorObj = Box<dyn AbstractInterpreterVisitor>;
 
@@ -336,6 +337,7 @@ pub trait SimpleAbsInt: Sized {
     ) -> Option<Vec<<Self::State as SimpleDomain>::Value>> {
         None
     }
+    #[growing_stack]
     fn exp(
         &self,
         context: &mut Self::ExecutionContext,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -26,6 +26,7 @@ use crate::{
 use move_command_line_common::parser::{parse_u16, parse_u256, parse_u32};
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
@@ -2804,6 +2805,7 @@ fn optional_types(context: &mut Context, pts_opt: Option<Vec<P::Type>>) -> Optio
 // Expressions
 //**************************************************************************************************
 
+#[growing_stack]
 fn sequence(context: &mut Context, loc: Loc, seq: P::Sequence) -> E::Sequence {
     let (puses, pitems, maybe_last_semicolon_loc, pfinal_item) = seq;
 
@@ -2831,6 +2833,7 @@ fn sequence(context: &mut Context, loc: Loc, seq: P::Sequence) -> E::Sequence {
     (use_funs, items)
 }
 
+#[growing_stack]
 fn sequence_item(context: &mut Context, sp!(loc, pitem_): P::SequenceItem) -> E::SequenceItem {
     use E::SequenceItem_ as ES;
     use P::SequenceItem_ as PS;
@@ -2873,6 +2876,7 @@ fn exps(context: &mut Context, pes: Vec<P::Exp>) -> Vec<E::Exp> {
         .collect()
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
     use E::Exp_ as EE;
     use P::Exp_ as PE;
@@ -3197,6 +3201,7 @@ fn move_or_copy_path_(context: &mut Context, case: PathCase, pe: Box<P::Exp>) ->
     })
 }
 
+#[growing_stack]
 fn exp_dotted(context: &mut Context, pdotted: Box<P::Exp>) -> Option<Box<E::ExpDotted>> {
     use E::ExpDotted_ as EE;
     use P::Exp_ as PE;

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -11,6 +11,7 @@ use crate::{
     typing::ast as T,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use std::{collections::VecDeque, iter::Peekable};
 
@@ -289,6 +290,7 @@ fn body(context: &mut Context, seq: &VecDeque<T::SequenceItem>) {
     }
 }
 
+#[growing_stack]
 fn tail(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
     use T::UnannotatedExp_ as E;
     let T::Exp {
@@ -379,6 +381,7 @@ fn tail_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option<
 // Value Position
 // -------------------------------------------------------------------------------------------------
 
+#[growing_stack]
 fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
     use T::UnannotatedExp_ as E;
 
@@ -530,6 +533,7 @@ fn value_block(context: &mut Context, seq: &VecDeque<T::SequenceItem>) -> Option
 // Statement Position
 // -------------------------------------------------------------------------------------------------
 
+#[growing_stack]
 fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
     use T::UnannotatedExp_ as E;
     let T::Exp {

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use std::{
@@ -662,6 +663,7 @@ fn body(
     }
 }
 
+#[growing_stack]
 fn tail(
     context: &mut Context,
     block: &mut Block,
@@ -851,6 +853,7 @@ fn tail_block(
 // Value Position
 // -------------------------------------------------------------------------------------------------
 
+#[growing_stack]
 fn value(
     context: &mut Context,
     block: &mut Block,
@@ -1485,6 +1488,7 @@ fn error_exp(loc: Loc) -> H::Exp {
 // Statement Position
 // -------------------------------------------------------------------------------------------------
 
+#[growing_stack]
 fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
     use H::{Command_ as C, Statement_ as S};
     use T::UnannotatedExp_ as E;

--- a/external-crates/move/crates/move-compiler/src/lib.rs
+++ b/external-crates/move/crates/move-compiler/src/lib.rs
@@ -10,14 +10,6 @@ extern crate move_ir_types;
 #[macro_use(symbol)]
 extern crate move_symbol_pool;
 
-pub const STACK_LIMIT: usize = 1_000_000_000;
-
-macro_rules! with_large_stack {
-    ($e:expr) => {
-        stacker::grow($crate::STACK_LIMIT, || $e)
-    };
-}
-
 pub mod cfgir;
 pub mod command_line;
 pub mod compiled_unit;

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -8,6 +8,7 @@ use crate::shared::{program_info::NamingProgramInfo, unique_map::UniqueMap, *};
 use crate::typing::core;
 use crate::{diag, ice};
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 
 //**************************************************************************************************
 // Entry
@@ -308,6 +309,7 @@ fn sequence(context: &mut Context, (uf, seq): &mut N::Sequence) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
     match e_ {
         N::Exp_::Value(_)
@@ -379,6 +381,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
     }
 }
 
+#[growing_stack]
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -21,6 +21,7 @@ use crate::{
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -1371,6 +1372,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
 // Exp
 //**************************************************************************************************
 
+#[growing_stack]
 fn sequence(context: &mut Context, (euse_funs, seq): E::Sequence) -> N::Sequence {
     context.new_local_scope();
     let nuse_funs = use_funs(context, euse_funs);
@@ -1379,6 +1381,7 @@ fn sequence(context: &mut Context, (euse_funs, seq): E::Sequence) -> N::Sequence
     (nuse_funs, nseq)
 }
 
+#[growing_stack]
 fn sequence_item(context: &mut Context, sp!(loc, ns_): E::SequenceItem) -> N::SequenceItem {
     use E::SequenceItem_ as ES;
     use N::SequenceItem_ as NS;
@@ -1419,6 +1422,7 @@ fn exps(context: &mut Context, es: Vec<E::Exp>) -> Vec<N::Exp> {
     es.into_iter().map(|e| *exp(context, Box::new(e))).collect()
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
     use E::Exp_ as EE;
     use N::Exp_ as NE;

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -6,10 +6,6 @@
 //      (<T> ",")* <T>?
 // Note that this allows an optional trailing comma.
 
-use move_command_line_common::files::FileHash;
-use move_ir_types::location::*;
-use move_symbol_pool::{symbol, Symbol};
-
 use crate::{
     diag,
     diagnostics::{Diagnostic, Diagnostics},
@@ -18,6 +14,11 @@ use crate::{
     shared::*,
     MatchedFileCommentMap,
 };
+
+use move_command_line_common::files::FileHash;
+use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
+use move_symbol_pool::{symbol, Symbol};
 
 struct Context<'env, 'lexer, 'input> {
     package_name: Option<Symbol>,
@@ -1116,6 +1117,7 @@ fn parse_sequence(context: &mut Context) -> Result<Sequence, Box<Diagnostic>> {
 //          | "return" <BlockLabel>? <Exp>?
 //          | "abort" "{" <Exp> "}"
 //          | "abort" <Exp>
+#[growing_stack]
 fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
     const VECTOR_IDENT: &str = "vector";
 
@@ -1701,6 +1703,7 @@ fn get_precedence(token: Tok) -> u32 {
 // This function takes the LHS of the expression as an argument, and it
 // continues parsing binary expressions as long as they have at least the
 // specified "min_prec" minimum precedence.
+#[growing_stack]
 fn parse_binop_exp(context: &mut Context, lhs: Exp, min_prec: u32) -> Result<Exp, Box<Diagnostic>> {
     let mut result = lhs;
     let mut next_tok_prec = get_precedence(context.tokens.peek());

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -24,6 +24,7 @@ use move_binary_format::file_format as F;
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::account_address::AccountAddress as MoveAddress;
 use move_ir_types::{ast as IR, location::*};
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -862,6 +863,7 @@ fn lvalue(context: &mut Context, code: &mut IR::BytecodeBlock, sp!(loc, l_): H::
 // Expressions
 //**************************************************************************************************
 
+#[growing_stack]
 fn exp(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
     use Value_ as V;
     use H::UnannotatedExp_ as E;

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -10,6 +10,7 @@ use crate::{
     typing::ast as T,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use petgraph::{algo::toposort as petgraph_toposort, graphmap::DiGraphMap};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -351,6 +352,7 @@ fn lvalue(context: &mut Context, sp!(loc, lv_): &T::LValue) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, e: &T::Exp) {
     use T::UnannotatedExp_ as E;
     match &e.exp.value {

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use move_core_types::u256::U256;
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 
 //**************************************************************************************************
 // Functions
@@ -135,12 +136,14 @@ fn unexpected_lambda_type(context: &mut Context, loc: Loc) {
 // Expressions
 //**************************************************************************************************
 
+#[growing_stack]
 fn sequence(context: &mut Context, (_, seq): &mut T::Sequence) {
     for item in seq {
         sequence_item(context, item)
     }
 }
 
+#[growing_stack]
 fn sequence_item(context: &mut Context, item: &mut T::SequenceItem) {
     use T::SequenceItem_ as S;
     match &mut item.value {
@@ -155,6 +158,7 @@ fn sequence_item(context: &mut Context, item: &mut T::SequenceItem) {
     }
 }
 
+#[growing_stack]
 pub fn exp(context: &mut Context, e: &mut T::Exp) {
     use T::UnannotatedExp_ as E;
     match &e.exp.value {

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -12,6 +12,7 @@ use crate::{
     typing::ast as T,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use move_symbol_pool::Symbol;
 use petgraph::{
     algo::{astar as petgraph_astar, tarjan_scc as petgraph_scc},
@@ -217,6 +218,7 @@ fn sequence_item(context: &mut Context, item: &T::SequenceItem) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, e: &T::Exp) {
     use T::UnannotatedExp_ as E;
     match &e.exp.value {

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 type LambdaMap = BTreeMap<Var_, (N::Lambda, Vec<Type>, Type)>;
@@ -425,6 +426,7 @@ fn recolor_use_funs_(ctx: &mut Recolor, use_fun_color: &mut Color) {
     }
 }
 
+#[growing_stack]
 fn recolor_seq(ctx: &mut Recolor, (use_funs, seq): &mut N::Sequence) {
     recolor_use_funs(ctx, use_funs);
     for sp!(_, item_) in seq {
@@ -461,6 +463,7 @@ fn recolor_lvalue(ctx: &mut Recolor, sp!(_, lvalue_): &mut N::LValue) {
     }
 }
 
+#[growing_stack]
 fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
     match e_ {
         N::Exp_::Value(_) | N::Exp_::Constant(_, _) => (),
@@ -635,6 +638,7 @@ fn block(context: &mut Context, b: &mut N::Block) {
     seq(context, &mut b.seq)
 }
 
+#[growing_stack]
 fn seq(context: &mut Context, (_use_funs, seq): &mut N::Sequence) {
     for sp!(_, item_) in seq {
         match item_ {
@@ -679,6 +683,7 @@ fn lvalue(context: &mut Context, sp!(_, lv_): &mut N::LValue) {
     }
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
     match e_ {
         N::Exp_::Value(_)

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -37,6 +37,7 @@ use crate::{
     FullyCompiledProgram,
 };
 use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 //**************************************************************************************************
@@ -393,6 +394,7 @@ mod check_valid_constant {
         },
     };
     use move_ir_types::location::*;
+    use move_proc_macros::growing_stack;
 
     pub(crate) fn signature<T: ToString, F: FnOnce() -> T>(
         context: &mut Context,
@@ -452,6 +454,7 @@ mod check_valid_constant {
         exp_(context, &e.exp)
     }
 
+    #[growing_stack]
     fn exp_(context: &mut Context, sp!(loc, e_): &T::UnannotatedExp) {
         use T::UnannotatedExp_ as E;
         const REFERENCE_CASE: &str = "References (and reference operations) are";
@@ -582,12 +585,14 @@ mod check_valid_constant {
         }
     }
 
+    #[growing_stack]
     fn sequence(context: &mut Context, (_, seq): &T::Sequence) {
         for item in seq {
             sequence_item(context, item)
         }
     }
 
+    #[growing_stack]
     fn sequence_item(context: &mut Context, sp!(loc, item_): &T::SequenceItem) {
         use T::SequenceItem_ as S;
         let error_case = match &item_ {
@@ -1168,6 +1173,7 @@ enum SeqCase {
     },
 }
 
+#[growing_stack]
 fn sequence(context: &mut Context, (use_funs, seq): N::Sequence) -> T::Sequence {
     use N::SequenceItem_ as NS;
     use T::SequenceItem_ as TS;
@@ -1236,6 +1242,7 @@ fn exp_vec(context: &mut Context, es: Vec<N::Exp>) -> Vec<T::Exp> {
     es.into_iter().map(|e| *exp(context, Box::new(e))).collect()
 }
 
+#[growing_stack]
 fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
     use N::Exp_ as NE;
     use T::UnannotatedExp_ as TE;
@@ -2219,6 +2226,7 @@ impl ExpDotted {
     }
 }
 
+#[growing_stack]
 fn process_exp_dotted(
     context: &mut Context,
     constraint_verb: Option<&str>,

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -8,6 +8,8 @@ use crate::parser::ast::{ConstantName, FunctionName};
 use crate::shared::{program_info::TypingProgramInfo, CompilationEnv};
 use crate::typing::ast as T;
 
+use move_proc_macros::growing_stack;
+
 pub type TypingVisitorObj = Box<dyn TypingVisitor>;
 
 pub trait TypingVisitor {
@@ -150,6 +152,7 @@ pub trait TypingVisitorContext {
         false
     }
 
+    #[growing_stack]
     fn visit_exp(&mut self, exp: &mut T::Exp) {
         use T::UnannotatedExp_ as E;
         if self.visit_exp_custom(exp) {

--- a/external-crates/move/crates/move-proc-macros/src/lib.rs
+++ b/external-crates/move/crates/move-proc-macros/src/lib.rs
@@ -3,7 +3,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DataEnum, DeriveInput};
+use syn::{parse_macro_input, Data, DataEnum, DeriveInput, ItemFn};
 
 /// This macro generates a function `order_to_variant_map` which returns a map
 /// of the position of each variant to the name of the variant.
@@ -80,4 +80,35 @@ pub fn test_variant_order(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     deriv.into()
+}
+
+/// This macro uses `stacker` to grow the stack of any function annotated with it. It does this by
+/// rewriting the function body to bump the stack pointer up by 1MB per call. The intent it to use
+/// this in the compiler to avoid stack overflows in many places that Rust was previously
+/// destroying the stack.
+///
+/// The `grow_stack` call takes two arguments, `RED_ZONE` and `STACK_SIZE`. It then checks to see
+/// if we're within `RED_ZONE` bytes of the end of the stack, and will allocate a new stack of at
+/// least `STACK_SIZE` bytes if so.
+
+const RED_ZONE: usize = 1024 * 1024; // 1MB
+const STACK_PER_CALL: usize = 1024 * 1024 * 8; // 8MB
+
+#[proc_macro_attribute]
+pub fn growing_stack(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(item as ItemFn);
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    } = input_fn;
+
+    let output = quote! {
+        #(#attrs)* #vis #sig {
+            stacker::maybe_grow(#RED_ZONE, #STACK_PER_CALL, || #block)
+        }
+    };
+
+    output.into()
 }

--- a/external-crates/move/crates/move-proc-macros/src/lib.rs
+++ b/external-crates/move/crates/move-proc-macros/src/lib.rs
@@ -82,6 +82,9 @@ pub fn test_variant_order(attr: TokenStream, item: TokenStream) -> TokenStream {
     deriv.into()
 }
 
+const RED_ZONE: usize = 1024 * 1024; // 1MB
+const STACK_PER_CALL: usize = 1024 * 1024 * 8; // 8MB
+
 /// This macro uses `stacker` to grow the stack of any function annotated with it. It does this by
 /// rewriting the function body to bump the stack pointer up by 1MB per call. The intent it to use
 /// this in the compiler to avoid stack overflows in many places that Rust was previously
@@ -90,10 +93,6 @@ pub fn test_variant_order(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// The `grow_stack` call takes two arguments, `RED_ZONE` and `STACK_SIZE`. It then checks to see
 /// if we're within `RED_ZONE` bytes of the end of the stack, and will allocate a new stack of at
 /// least `STACK_SIZE` bytes if so.
-
-const RED_ZONE: usize = 1024 * 1024; // 1MB
-const STACK_PER_CALL: usize = 1024 * 1024 * 8; // 8MB
-
 #[proc_macro_attribute]
 pub fn growing_stack(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(item as ItemFn);


### PR DESCRIPTION
## Description 

This replaces the previous stacker fix with an annotation proc macro that bumps the stack any time it's at risk of running out of room.

## Test Plan 

Everything still works as expected, plus windows tests (TBD).

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
