### PR TITLE
[suiop][service-platform] fix top-level cargo file and add name to project cargo file

### DIFF
--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -81,10 +81,13 @@ fn add_member_to_workspace(path: &Path) -> Result<()> {
         .as_array_mut()
         .unwrap()
         .push_formatted(toml_edit::Value::String(toml_edit::Formatted::new(
-            path.file_name()
-                .expect("getting the project name from the given path")
+            Path::new("crates/")
+                .join(
+                    path.file_name()
+                        .expect("getting the project name from the given path"),
+                )
                 .to_str()
-                .unwrap()
+                .expect("converting the path to a str")
                 .to_string(),
         )));
     fs::write(workspace_toml_path, toml.to_string())
@@ -111,12 +114,14 @@ fn create_rust_service(path: &Path) -> Result<()> {
     let cargo_toml = PROJECT_DIR.get_file(cargo_toml_path).unwrap();
     let main_rs = PROJECT_DIR.get_file("src/main.rs").unwrap();
     let main_body = main_rs.contents();
-    let cargo_body = cargo_toml.contents();
+    let cargo_body = std::str::from_utf8(cargo_toml.contents())?;
+    let mut toml_content = cargo_body.parse::<toml_edit::Document>()?;
+    toml_content["package"]["name"] = toml_edit::value(path.file_name().unwrap().to_str().unwrap());
     create_dir_all(path.join("src"))?;
     let mut main_file = File::create(path.join("src/main.rs"))?;
     main_file.write_all(main_body)?;
     let mut cargo_file = File::create(path.join("Cargo.toml"))?;
-    cargo_file.write_all(cargo_body)?;
+    cargo_file.write_all(toml_content.to_string().as_bytes())?;
 
     // add the project as a member of the cargo workspace
     if is_sui_service {


### PR DESCRIPTION
## Description 
Make a single invocation of `suiop service init` produce a working crate within the sui repo.

- include `crates/` in the top-level reference so the workspace still works
- rename boilerplate cargo toml project to the new directory name

## Test Plan 
```
» cargo run -- s i --path ../test-svc
   Compiling suiop-cli v0.1.9 (/Users/jkjensen/mysten/sui/crates/suiop-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 7.14s                                                                                                                                                                     
     Running `/Users/jkjensen/mysten/sui/target/debug/suiop s i --path ../test-svc`
2024-03-11T17:19:52.224787Z  INFO suioplib::cli::service::init: creating rust service in ../test-svc
» cd ../test-svc 
» cargo run
   Compiling test-svc v0.0.1 (/Users/jkjensen/mysten/sui/crates/test-svc)
    Finished dev [unoptimized + debuginfo] target(s) in 4.36s
     Running `/Users/jkjensen/mysten/sui/target/debug/test-svc`
```
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
