### PR TITLE
[docs] PTB CLI guide and reference update

### DIFF
--- a/docs/content/guides/developer/app-examples/e2e-counter.mdx
+++ b/docs/content/guides/developer/app-examples/e2e-counter.mdx
@@ -12,10 +12,22 @@ If haven't followed Client App with Sui TypeScript SDK, run the following comman
 pnpm create @mysten/dapp --template react-client-dapp
 ```
 
+or 
+
+```bash
+yarn create @mysten/dapp --template react-client-dapp
+```
+
 To get a head start, you can automatically create this example using the following `template` value instead:
 
 ```bash
 pnpm create @mysten/dapp --template react-e2e-counter
+```
+
+or
+
+```bash
+yarn create @mysten/dapp --template react-e2e-counter
 ```
 
 ## Adding a Move module

--- a/docs/content/guides/developer/first-app.mdx
+++ b/docs/content/guides/developer/first-app.mdx
@@ -7,14 +7,50 @@ Before you can create your first dApp, you must have [Sui installed](./getting-s
 
 You use Move to write packages that live on chain, meaning they exist on the Sui network you publish them to. The instructions in this section walk you through writing a basic package, debugging and testing your code, and publishing. You need to follow these instructions in order to complete the exercise.
 
-You use the `move` Sui CLI command for some instructions. The Sui CLI installs with the binaries, so you have it on your system if you followed the install instructions. To verify you have it installed, run the following command in a terminal or console.
+You use the `move` Sui CLI command for some instructions. The Sui CLI installs with the binaries, so you have it on your system if you follow the install instructions. To verify you have it installed, run the following command in a terminal or console.
 
 ```shell
-sui --version
+$ sui --version
 ```
 
 If the console does not respond with a version number similar to the following, see the instructions to install Sui.
 
 ```shell
-sui 1.xx.x-abc123xyz
+$ sui 1.xx.x-abc123xyz
 ```
+
+## Connecting to a network
+
+After installing Sui, you can connect to a network. Sui has three public networks (Devnet, Testnet, Mainnet), and you can also run and connect to a local Sui network. For each network, you need an on-chain address specific to that network. The address is an object with a unique ID in the form `0x8bd4613c004aac53d06bb7ceb7f46832c9ae69bdc105dfc5fcac225d2061fcac`. In addition to that address, you need SUI to pay for the gas fees associated with your on-chain activity, like publishing packages and making Move calls to those packages. For all networks besides Mainnet, you can get free SUI coins for your account to facilitate package development. For the purposes of this example, connect to the Testnet network.
+
+### Connect to Testnet
+
+If you already have a network config set up, switch your active environment to Testnet. The following instruction is for the initial set up. 
+
+1. In your terminal or console, use the following command to begin the configuration:
+    ```shell
+    $ sui client
+    ```
+1. At the prompt, type <kbd>y</kbd> and press <kbd>Enter</kbd> to connect to a Sui Full node server.
+1. At the following prompt, type the address of the Testnet server (`https://fullnode.testnet.sui.io:443`) and press <kbd>Enter</kbd>.
+1. At the following prompt, type `testnet` to give the network an alias and press <kbd>Enter</kbd>. You can use the alias in subsequent commands instead of typing the complete URL.
+1. At the following prompt, type `0` and press <kbd>Enter</kbd>. The selection creates an address in the `ed25519` signing scheme.
+1. The response provides an alias for your address, the actual address ID, and a secret recovery phrase. Be sure to save this information for later reference. Because this is on the Testnet network, the security of this information is not as important as if it were on Mainnet.
+1. In your terminal or console, use the following command to get SUI for your account.
+    ```shell
+    $ sui client faucet
+    ```
+1. You can confirm that you received SUI by using the following command. There may be a delay in receiving coins depending on the activity of the network.
+    ```shell
+    $ sui client gas
+    ```
+You are now connected to the Sui Testnet network and should have an account with available SUI.  
+
+
+## Related links
+
+- [Write a Move Package](./first-app/write-package.mdx): Continue this example by creating the necessary Move code for your package.
+- [Connect to a Sui Network](./getting-started/connect.mdx): Connect to an available Sui network.
+- [Connect to a Local Network](./getting-started/local-network.mdx): Start and connect to a local Sui network.
+- [Get Sui Address](./getting-started/get-address.mdx): Get an address for the current Sui network.
+- [Get SUI Tokens](./getting-started/get-coins.mdx): Get SUI for the active address on Devnet, Testnet, or a local network.

--- a/docs/content/guides/developer/first-app/build-test.mdx
+++ b/docs/content/guides/developer/first-app/build-test.mdx
@@ -8,13 +8,13 @@ If you followed [Write a Move Package](./write-package.mdx), you have a basic mo
 
 Make sure your terminal or console is in the directory that contains your package (`my_first_package` if you're following along). Use the following command to build your package:
 
-```bash
-sui move build
+```shell
+$ sui move build
 ```
 
 A successful build returns a response similar to the following:
 
-```bash
+```shell
 UPDATING GIT DEPENDENCY https://github.com/MystenLabs/sui.git
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
@@ -27,17 +27,17 @@ Now that you have designed your asset and its accessor functions, it's time to t
 
 ## Testing a package {#testing-a-package}
 
-Sui includes support for the Move testing framework that enables you to write unit tests that analyze Move code much like test frameworks for other languages (for example, the built-in Rust testing framework or the JUnit framework for Java).
+Sui includes support for the Move testing framework. Using the framework, you can write unit tests that analyze Move code much like test frameworks for other languages, such as the built-in Rust testing framework or the JUnit framework for Java.
 
 An individual Move unit test is encapsulated in a public function that has no parameters, no return values, and has the `#[test]` annotation. The testing framework executes such functions when you call the `sui move test` command from the package root (`my_move_package` directory as per the current running example):
 
-```bash
-sui move test
+```shell
+$ sui move test
 ```
 
 If you execute this command for the package created in [Write a Package](./write-package.mdx), you see the following output. Unsurprisingly, the test result has an `OK` status because there are no tests written yet to fail.
 
-```bash
+```shell
 BUILDING Sui
 BUILDING MoveStdlib
 BUILDING my_first_package
@@ -48,22 +48,22 @@ Test result: OK. Total tests: 0; passed: 0; failed: 0
 To actually test your code, you need to add test functions. Start with adding a basic test function to the `my_module.move` file, inside the module definition:
 
 ```move
-    #[test]
-    public fun test_sword_create() {
+#[test]
+public fun test_sword_create() {
 
-        // Create a dummy TxContext for testing
-        let ctx = tx_context::dummy();
+    // Create a dummy TxContext for testing
+    let ctx = tx_context::dummy();
 
-        // Create a sword
-        let sword = Sword {
-            id: object::new(&mut ctx),
-            magic: 42,
-            strength: 7,
-        };
+    // Create a sword
+    let sword = Sword {
+        id: object::new(&mut ctx),
+        magic: 42,
+        strength: 7,
+    };
 
-        // Check if accessor functions return correct values
-        assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
-    }
+    // Check if accessor functions return correct values
+    assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
+}
 ```
 
 As the code shows, the unit test function (`test_sword_create()`) creates a dummy instance of the `TxContext` struct and assigns it to `ctx`. The function then creates a sword object using `ctx` to create a unique identifier and assigns `42` to the `magic` parameter and `7` to `strength`. Finally, the test calls the `magic` and `strength` accessor functions to verify that they return correct values.
@@ -72,13 +72,13 @@ The function passes the dummy context, `ctx`, to the `object::new` function as a
 
 Now that you have a test function, run the test command again:
 
-```bash
-sui move test
+```shell
+$ sui move test
 ```
 
 After running the `test` command, however, you get a compilation error instead of a test result:
 
-```bash
+```shell
 error[E06001]: unused value without 'drop'
    ┌─ ./sources/my_module.move:60:65
    │
@@ -104,13 +104,13 @@ The `Sword` struct represents a game asset that digitally mimics a real-world it
 
 One of the solutions (as suggested in the error message), is to add the `drop` ability to the definition of the `Sword` struct, which would allow instances of this struct to disappear (be dropped). The ability to drop a valuable asset is not a desirable asset property in this case, so another solution is needed. Another way to solve this problem is to transfer ownership of the `sword`.
 
-To get the test to work, add the following line to the beginning of the testing function to import the Transfer module:
+To get the test to work, add the following line to the beginning of the testing function to import the `Transfer` module:
 
 ```move
 use sui::transfer;
 ```
 
-With the Transfer module imported, add the following lines to the end of the test function (after the `!assert` call) to transfer ownership of the `sword` to a freshly created dummy address:
+With the `Transfer` module imported, add the following lines to the end of the test function (after the `!assert` call) to transfer ownership of the `sword` to a freshly created dummy address:
 
 ```move
 // Create a dummy address and transfer the sword
@@ -120,7 +120,7 @@ transfer::transfer(sword, dummy_address);
 
 Run the test command again. Now the output shows a single successful test has run:
 
-```
+```shell
 BUILDING MoveStdlib
 BUILDING Sui
 BUILDING my_first_package
@@ -137,46 +137,50 @@ Use a filter string to run only a matching subset of the unit tests. With a filt
 
 Example:
 
-```bash
-sui move test sword
+```shell
+$ sui move test sword
 ```
 
 The previous command runs all tests whose name contains `sword`.
 
 You can discover more testing options through:
-```bash
-sui move test -h
+
+```shell
+$ sui move test -h
 ```
 
 ## Sui-specific testing
 
-The previous testing example is largely pure Move and isn't specific to Sui beyond using some Sui packages, such as `sui::tx_context` and `sui::transfer`. While this style of testing is already useful for writing Move code for Sui, you might also want to test additional Sui-specific features. In particular, a Move call in Sui is encapsulated in a Sui transaction, and you might want to test interactions between different transactions within a single test (for example, one transaction creating an object and the other one transferring it).
+The previous testing example uses Move but isn't specific to Sui beyond using some Sui packages, such as `sui::tx_context` and `sui::transfer`. While this style of testing is already useful for writing Move code for Sui, you might also want to test additional Sui-specific features. In particular, a Move call in Sui is encapsulated in a Sui transaction, and you might want to test interactions between different transactions within a single test (for example, one transaction creating an object and the other one transferring it).
+
 Sui-specific testing is supported through the `test_scenario` module that provides Sui-related testing functionality otherwise unavailable in pure Move and its testing framework.
 
 The `test_scenario` module provides a scenario that emulates a series of Sui transactions, each with a potentially different user executing them. A test using this module typically starts the first transaction using the `test_scenario::begin` function. This function takes an address of the user executing the transaction as its argument and returns an instance of the `Scenario` struct representing a scenario.
 
 An instance of the `Scenario` struct contains a per-address object pool emulating Sui object storage, with helper functions provided to manipulate objects in the pool. After the first transaction finishes, subsequent test transactions start with the `test_scenario::next_tx` function. This function takes an instance of the `Scenario` struct representing the current scenario and an address of a user as arguments.
+
 Update your `my_module.move` file to include entry functions callable from Sui that implement `sword` creation and transfer. With these in place, you can then add a multi-transaction test that uses the `test_scenario` module to test these new capabilities. Put these functions after the accessors (Part 5 in comments).
 
 ```move
-    public fun sword_create(magic: u64, strength: u64, recipient: address, ctx: &mut TxContext) {
-        use sui::transfer;
+public fun sword_create(magic: u64, strength: u64, recipient: address, ctx: &mut TxContext) {
 
-        // create a sword
-        let sword = Sword {
-            id: object::new(ctx),
-            magic: magic,
-            strength: strength,
-        };
-        // transfer the sword
-        transfer::transfer(sword, recipient);
-    }
+    // create a sword
+    let sword = Sword {
+        id: object::new(ctx),
+        magic: magic,
+        strength: strength,
+    };
+    // transfer the sword
+    transfer::transfer(sword, recipient);
 
-    public fun sword_transfer(sword: Sword, recipient: address, _ctx: &mut TxContext) {
-        use sui::transfer;
-        // transfer the sword
-        transfer::transfer(sword, recipient);
-    }
+}
+
+public fun sword_transfer(sword: Sword, recipient: address, _ctx: &mut TxContext) {
+
+    // transfer the sword
+    transfer::public_transfer(sword, recipient);
+    
+}
 ```
 
 The code of the new functions uses struct creation and Sui-internal modules (`TxContext` and `Transfer`) in a way similar to what you have seen in the previous sections. The important part is for the entry functions to have correct signatures.
@@ -246,7 +250,7 @@ In the pure Move testing function, the function transfers the `sword` object to 
 
 Run the test command again to see two successful tests for our module:
 
-```bash
+```shell
 BUILDING Sui
 BUILDING MoveStdlib
 BUILDING my_first_package
@@ -256,4 +260,100 @@ Running Move unit tests
 Test result: OK. Total tests: 2; passed: 2; failed: 0
 ```
 
-Now that you have built a tested package, the next topic walks you through publishing your package to a Sui network.
+### Module initializers
+
+Each module in a package can include a special initializer function that runs at publication time. The goal of an initializer function is to pre-initialize module-specific data (for example, to create singleton objects). The initializer function must have the following properties for it to execute at publication:
+
+- Function name must be `init`
+- The parameter list must end with either a `&mut TxContext` or a `&TxContext` type
+- No return values
+- Private visibility
+- Optionally, the parameter list starts by accepting the module's one-time witness by value
+
+For example, the following `init` functions are all valid:
+
+- `fun init(ctx: &TxContext)`
+- `fun init(ctx: &mut TxContext)`
+- `fun init(otw: EXAMPLE, ctx: &TxContext)`
+- `fun init(otw: EXAMPLE, ctx: &mut TxContext)`
+
+While the `sui move` command does not support publishing explicitly, you can still test module initializers using the testing framework by dedicating the first transaction to executing the initializer function.
+
+The `init` function for the module in the running example creates a `Forge` object.
+
+```move
+    /// Module initializer to be executed when this module is published
+    fun init(ctx: &mut TxContext) {
+        let admin = Forge {
+            id: object::new(ctx),
+            swords_created: 0,
+        };
+
+        // transfer the forge object to the module/package publisher
+        transfer::transfer(admin, tx_context::sender(ctx));
+    }
+```
+
+The tests you have so far call the `init` function, but the initializer function itself isn't tested to ensure it properly creates a `Forge` object. To test this functionality, add a `new_sword` function to take the forge as a parameter and to update the number of created swords at the end of the function. If this were an actual module, you'd replace the `create_sword` function with `new_sword`. To keep the existing tests from failing, however, the example uses both functions.
+
+```move
+    /// Constructor for creating swords
+    public fun new_sword(
+        forge: &mut Forge,
+        magic: u64,
+        strength: u64,
+        ctx: &mut TxContext,
+    ): Sword {
+        forge.swords_created = forge.swords_created + 1;
+        Sword {
+            id: object::new(ctx),
+            magic: magic,
+            strength: strength,
+        }
+    }
+```
+
+Now, create a function to test the module initialization:
+
+```move
+#[test_only] use sui::test_scenario as ts;
+
+#[test_only] const ADMIN: address = @0xAD;
+
+#[test]
+public fun test_module_init() {
+    let ts = ts::begin(@0x0);
+
+    // first transaction to emulate module initialization.
+    {
+        ts::next_tx(&mut ts, ADMIN);
+        init(ts::ctx(&mut ts));
+    };
+
+    // second transaction to check if the forge has been created
+    // and has initial value of zero swords created
+    {
+        ts::next_tx(&mut ts, ADMIN);
+
+        // extract the Forge object
+        let forge: Forge = ts::take_from_sender(&mut ts);
+
+        // verify number of created swords
+        assert!(swords_created(&forge) == 0, 1);
+
+        // return the Forge object to the object pool
+        ts::return_to_sender(&mut ts, forge);
+    };
+
+    ts::end(ts);
+}
+```
+
+As the new test function shows, the first transaction (explicitly) calls the initializer. The next transaction checks if the `Forge` object has been created and properly initialized.
+
+You can refer to the source code for the package (with all the tests and functions properly adjusted) in the [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move) module in the `sui/examples` directory.
+
+## Related links
+
+- [Publish a Package](./publish.mdx): Continue the example by publishing your package to the Sui network.
+- [Package Upgrades](../../../concepts/sui-move-concepts/packages.mdx): Upgrading packages published on the Sui network. 

--- a/docs/content/guides/developer/first-app/client-tssdk.mdx
+++ b/docs/content/guides/developer/first-app/client-tssdk.mdx
@@ -2,12 +2,18 @@
 title: Client App with Sui TypeScript SDK
 ---
 
-This exercise walks you through setting up dApp Kit in a React App, allowing you to connect to wallets, and query data from Sui RPC nodes to display in your app. If you want to get a fully functional app up and running quickly, run the following command in a terminal or console to scaffold a new app with all steps in this exercise already implemented:
+This exercise diverges from the example built in the previous topics in this section. Rather than adding a frontend to the running example, the instruction walks you through setting up dApp Kit in a React App, allowing you to connect to wallets, and query data from Sui RPC nodes to display in your app. You can use it to create your own frontend for the example used previously, but if you want to get a fully functional app up and running quickly, run the following command in a terminal or console to scaffold a new app with all steps in this exercise already implemented:
 
 {@include: ../../../snippets/info-pnpm-required.mdx}
 
 ```bash
 pnpm create @mysten/dapp --template react-client-dapp
+```
+
+or 
+
+```bash
+yarn create @mysten/dapp --template react-client-dapp
 ```
 
 ## What is the Sui TypeScript SDK?
@@ -208,7 +214,7 @@ You now have a dApp connected to wallets and can query data from RPC nodes.
 
 ## Related links
 
-The next step from here is to start interacting with Move modules, constructing transaction blocks, and making Move calls. This exercise continues in the end to end example.
+The next step from here is to start interacting with Move modules, constructing transaction blocks, and making Move calls. This exercise continues in the Counter end-to-end example.
 
 - [End-to-End Example](../app-examples/e2e-counter.mdx): Continue this exercise by creating an app.
 - [Sui 101](../sui-101.mdx): Learn the basics of the Sui network and how to interact with on-chain objects using Move.

--- a/docs/content/guides/developer/first-app/debug.mdx
+++ b/docs/content/guides/developer/first-app/debug.mdx
@@ -1,8 +1,9 @@
 ---
 title: Debugging
+description: Move does not have a native debugger. You can, however, use the std::debug module to monitor variable values while your code executes.
 ---
 
-At the moment, there isn't a debugger for Move. To aid with debugging, however, you can use the `std::debug` module to print out arbitrary values. To do so, first import the debug module in your source file:
+Move does not currently have a native debugger. You can use the `std::debug` module, however, to print arbitrary values to the console. Monitoring variable values in this manner can provide insight into the logic of your modules. To do so, first import the debug module in your source file:
 
 ```move
 use std::debug;
@@ -27,3 +28,85 @@ debug::print_stack_trace();
 ```
 
 Alternatively, any call to abort or assertion failure also prints the stacktrace at the point of failure.
+
+## Using debug in my_module
+
+To see the module in action, update your `my_module` code to include debug calls. Specifically, update the `new_sword` function so that you print the value of `forge` before and after updating `swords_created`. Also, include a `print_stack_trace` so that the function looks like the following:
+
+```move
+public fun new_sword(
+    forge: &mut Forge,
+    magic: u64,
+    strength: u64,
+    ctx: &mut TxContext,
+): Sword {
+    debug::print(forge);
+    forge.swords_created = forge.swords_created + 1;
+    debug::print(forge);
+    debug::print_stack_trace();
+    Sword {
+        id: object::new(ctx),
+        magic: magic,
+        strength: strength,
+    }
+}
+```
+
+To see the results, run the module's tests.
+
+```shell
+$ sui move test
+```
+
+The response prints out the expected results as the test calls the `new_sword` function.
+
+```shell
+INCLUDING DEPENDENCY Sui
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING my_first_package
+Running Move unit tests
+[ PASS    ] 0x0::my_module::test_module_init
+[debug] 0x0::my_module::Forge {
+  id: 0x2::object::UID {
+    id: 0x2::object::ID {
+      bytes: @<OBJECT-ID>
+    }
+  },
+  swords_created: 0
+}
+[debug] 0x0::my_module::Forge {
+  id: 0x2::object::UID {
+    id: 0x2::object::ID {
+      bytes: @<OBJECT-ID>
+    }
+  },
+  swords_created: 1
+}
+Call Stack:
+    [0] 0000000000000000000000000000000000000000000000000000000000000000::my_module::test_sword_transactions
+
+        Code:
+            [19] LdU64(7)
+            [20] MutBorrowLoc(3)
+            [21] Call(14)
+          > [22] Call(4)
+            [23] LdConst(1)
+            [24] CallGeneric(2)
+            [25] ImmBorrowLoc(3)
+
+        Locals:
+            [0] -
+            [1] { { { <OBJECT-ID-WITHOUT-0x> } }, 1 }
+            [2] -
+            [3] { 2, { 00000000000000000000000000000000000000000000000000000000000000ad, [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0, 0, 0 } }
+
+
+Operand Stack:
+
+[ PASS    ] 0x0::my_module::test_sword_transactions
+Test result: OK. Total tests: 2; passed: 2; failed: 0
+```
+
+## Related links
+
+- [Publish a Package](./publish.mdx): Publish the example to the Sui network.

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -98,7 +98,11 @@ If you try to run tests on the whole package at this point, you encounter compil
 `new_sword` function signature change. The changes required for the tests to run again is an exercise left for you. If you need help, you can refer to the source code for the package (with all the tests properly adjusted) in [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move).
 
 ### Publish the package
-Once you have the package ready, you can publish it to the Sui network. To do so, use the `sui client publish` command of the Sui Client CLI. You will need to set a gas budget by using the `--gas-budget` flag. The gas budget is the maximum amount of gas you are willing to spend on the transaction. In testnet and devnet, a high budget would allow the transaction to be executed by the network.
+Once you have the package ready, you can publish it to the Sui network. To do so, use 
+```
+sui client publish
+```
+You will need to set a gas budget by using the `--gas-budget` flag. The gas budget is the maximum amount of gas you are willing to spend on the transaction. In testnet and devnet, a high budget would allow the transaction to be executed by the network.
 
 You can then check the status of the package using the `sui client objects` command. You can also view the status of the package using the [Sui Explorer](https://suiexplorer.com) or any other Sui blockchain explorer tools.
 
@@ -160,18 +164,18 @@ Now that the package is published, you can interact with it by calling functions
 
 For example, you can create a new `Sword` object defined in the package by calling the `new_sword` function in the `my_module` package, and then transfer the `Sword` object to any address:
 
-```shell
+```bash
 $ sui client ptb \
-	--assign forge @0xFORGEID \
+	--assign forge @0xFORGE_ID \
 	--assign to_address @0xADDRESS \
 	--move-call 0xPACKAGEID::my_module::new_sword forge 3 3 \
 	--assign sword \
 	--transfer-objects to_address "[sword]" \
 	--gas-budget 20000000
 ```
-Make sure to replace `0xFORGEID`, `0xADDRESS`, and `0xPACKAGEID` with the actual `objectId` of the `Forge` object, the address of the recipient, and the `objectId` of the package, respectively. The above command makes use of the Sui Client PTB CLI. You can learn more about it [here](../../../references/cli/ptb.mdx).
+Make sure to replace `0xFORGE_ID`, `0xADDRESS`, and `0xPACKAGEID` with the actual `objectId` of the `Forge` object, the address of the recipient, and the `objectId` of the package, respectively. The above command makes use of the Sui Client PTB CLI. You can learn more about it [here](../../../references/cli/ptb.mdx).
 
-Once the transaction is executed, you can check the status of the `Sword` object using the `sui client objects` command or the blockchain explorer of your choice:
+Once the transaction is executed, you can check the status of the `Sword` object using the `sui client objects` command or the blockchain explorer of your choice. You should see a total of 4 objects now:
 ```
 ╭───────────────────────────────────────────────────────────────────────────────────────╮
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -173,9 +173,10 @@ $ sui client ptb \
 	--transfer-objects to_address "[sword]" \
 	--gas-budget 20000000
 ```
+{@include: ../../../references/cli/address-prefix.mdx}
 Make sure to replace `0xFORGE_ID`, `0xADDRESS`, and `0xPACKAGEID` with the actual `objectId` of the `Forge` object, the address of the recipient, and the `objectId` of the package, respectively. The above command makes use of the Sui Client PTB CLI. You can learn more about it [here](../../../references/cli/ptb.mdx).
 
-Once the transaction is executed, you can check the status of the `Sword` object using the `sui client objects` command or the blockchain explorer of your choice. You should see a total of 4 objects now:
+Once the transaction is executed, you can check the status of the `Sword` object by using the `sui client objects` command or the blockchain explorer of your choice. You should see a total of 4 objects now:
 ```
 ╭───────────────────────────────────────────────────────────────────────────────────────╮
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -4,107 +4,68 @@ title: Publish a Package
 
 Before you can call functions in a Move package (beyond an emulated Sui execution scenario), that package must be available on the Sui network. When you publish a package, you are actually creating an immutable Sui object on the network that anyone can access.
 
-To publish your package to the Sui network, you can use the `sui client publish` command of the Sui Client CLI. After the package becomes available on the network, you can then use the `sui client call` command to access the functions available in the package.
+To publish your package to the Sui network, use the `publish` CLI command in the root of your package. Use the `--gas-budget` flag to set a value for the maximum amount of gas the transaction can cost. If the cost of the transaction is more than the budget you set, the transaction fails and your package doesn't publish.  
 
-### Module initializers
-
-Each module in a package can include a special initializer function that runs at publication time. The goal of an initializer function is to pre-initialize module-specific data (for example, to create singleton objects). The initializer function must have the following properties for it to execute at publication:
-
-- Function name must be `init`
-- The parameter list must end with either a `&mut TxContext` or a `&TxContext` type
-- No return values
-- Private visibility
-- Optionally, the parameter list starts by accepting the module's one-time witness by value
-
-For example, the following `init` functions are all valid:
-
-- `fun init(ctx: &TxContext)`
-- `fun init(ctx: &mut TxContext)`
-- `fun init(otw: EXAMPLE, ctx: &TxContext)`
-- `fun init(otw: EXAMPLE, ctx: &mut TxContext)`
-
-While the `sui move` command does not support publishing explicitly, you can still test module initializers using the testing framework by dedicating the first transaction to executing the initializer function.
-
-Continuing the fantasy game example, the `init` function should create a `Forge` object.
-
-```move
-    /// Module initializer to be executed when this module is published
-    fun init(ctx: &mut TxContext) {
-        let admin = Forge {
-            id: object::new(ctx),
-            swords_created: 0,
-        };
-
-        // transfer the forge object to the module/package publisher
-        transfer::transfer(admin, tx_context::sender(ctx));
-    }
+```shell
+$ sui client publish --gas-budget 5000000
 ```
 
-The tests you have so far call the `init` function, but the initializer function itself isn't tested to ensure it properly creates a `Forge` object. To test this functionality, modify the `sword_create` function to take the forge as a parameter and to update the number of
-created swords at the end of the function:
+If the publish transaction is successful, your terminal or console responds with the details of the publish transaction separated into sections, including transaction data, transaction effects, transaction block events, object changes, and balance changes. 
 
-```move
-    /// Constructor for creating swords
-    public fun new_sword(
-        forge: &mut Forge,
-        magic: u64,
-        strength: u64,
-        ctx: &mut TxContext,
-    ): Sword {
-        forge.swords_created = forge.swords_created + 1;
-        // ...
-    }
+In the **Object Changes** table, you can find the information about the package you just published in the **Published Objects** section. Your response has the actual `PackageID` that identifies the package (instead of `<PACKAGE-ID>`) in the form `0x123...ABC`.  
+
+```shell
+╭─────────────────────────────────────────────────────────────────────╮
+│ Object Changes                                                      │
+├─────────────────────────────────────────────────────────────────────┤
+│ Created Objects:                                                    │
+│  ...                                                                │
+|                                                                     |
+│ Mutated Objects:                                                    │
+│  ...                                                                │
+|                                                                     |
+│ Published Objects:                                                  │
+│  ┌──                                                                │
+│  │ PackageID: <PACKAGE-ID>                                          │
+│  │ Version: 1                                                       │
+│  │ Digest: <DIGEST-HASH>                                            │
+│  │ Modules: my_module                                               │
+│  └──                                                                │
+╰─────────────────────────────────────────────────────────────────────╯
 ```
 
-Now, create a function to test the module initialization:
+Your currently active address now has three objects (or more, if you had objects prior to this example). Assuming you are using a new address, running the `sui objects` command reveals what those objects are.
 
-```move
-    #[test_only] use sui::test_scenario as ts;
+```
+$ sui client objects
 
-    #[test_only] const ADMIN: address = @0xAD;
-
-    #[test]
-    public fun test_module_init() {
-        let ts = ts::begin(@0x0);
-
-        // first transaction to emulate module initialization.
-        {
-            ts::next_tx(&mut ts, ADMIN);
-            init(ts::ctx(&mut ts));
-        };
-
-        // second transaction to check if the forge has been created
-        // and has initial value of zero swords created
-        {
-            ts::next_tx(&mut ts, ADMIN);
-
-            // extract the Forge object
-            let forge: Forge = ts::take_from_sender(&mut ts);
-
-            // verify number of created swords
-            assert!(swords_created(&forge) == 0, 1);
-
-            // return the Forge object to the object pool
-            ts::return_to_sender(&mut ts, forge);
-        };
-
-        ts::end(ts);
-    }
+╭───────────────────────────────────────────────────────────────────────────────────────╮
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
+│ │ objectType │  <PACKAGE-ID>::my_module::Forge                                      │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
+│ │ objectType │  0x0000..0002::coin::Coin                                            │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
+│ │ objectType │  0x0000..0002::package::UpgradeCap                                   │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+╰───────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-As the new test function shows, the first transaction (explicitly) calls the initializer. The next transaction checks if the `Forge` object has been created and properly initialized.
+The `objectId` field is the unique identifier of each object. 
 
-If you try to run tests on the whole package at this point, you encounter compilation errors in the existing tests because of the
-`new_sword` function signature change. The changes required for the tests to run again is an exercise left for you. If you need help, you can refer to the source code for the package (with all the tests properly adjusted) in [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move).
-
-### Publish the package
-Once you have the package ready, you can publish it to the Sui network. To do so, use 
-```
-sui client publish
-```
-You will need to set a gas budget by using the `--gas-budget` flag. The gas budget is the maximum amount of gas you are willing to spend on the transaction. In testnet and devnet, a high budget would allow the transaction to be executed by the network.
-
-You can then check the status of the package using the `sui client objects` command. You can also view the status of the package using the [Sui Explorer](https://suiexplorer.com) or any other Sui blockchain explorer tools.
+- `Coin` object: You received the Coin object from the Testnet faucet. It's value is slightly less than when you received it because of the cost of gas for the publish transaction. 
+- `Forge` object: Recall that the `init` function runs when the package gets published. The `init` function for this example package creates a `Forge` object and transfers it to the publisher (you).
+- `UpgradeCap` object: Each package you publish results in the receipt of an `UpgradeCap` object. You use this object to upgrade the package later or to burn it so the package cannot be upgraded.
 
 ```mermaid
 flowchart TB
@@ -117,36 +78,10 @@ flowchart TB
     end
 ```
 
-```
-$ sui client objects
-
-╭───────────────────────────────────────────────────────────────────────────────────────╮
-│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0x48dc0998f450a86a63f9a59a03b60a87baa61ae5b552ecb8cfb9524b4109aa15  │ │
-│ │ version    │  10                                                                  │ │
-│ │ digest     │  fuEysv0wzTTNP13kgMFhP6V7GG43mbKcvjnw4jlg14w=                        │ │
-│ │ objectType │  0xe4dc..88cd::my_module::Forge                                      │ │
-│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
-│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0x9e3cab3f784819e0125168b7f8e9a2977bd59c3b0bff42a22cb0993f3e4e7a35  │ │
-│ │ version    │  10                                                                  │ │
-│ │ digest     │  2byd+RLeh48n6rxo8bAeILNWS6VjaEzapcn5sdg1VmM=                        │ │
-│ │ objectType │  0x0000..0002::coin::Coin                                            │ │
-│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
-│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0xe3db38c2e8529bc5fdcb67c1a03d8717c58b7b68e2816111e4ad8d2556bc0c53  │ │
-│ │ version    │  10                                                                  │ │
-│ │ digest     │  NVY9pLVpoFFmvAP4sxkIATVRwfcBff+ysXHdaiZx+Ec=                        │ │
-│ │ objectType │  0x0000..0002::package::UpgradeCap                                   │ │
-│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
-╰───────────────────────────────────────────────────────────────────────────────────────╯
-```
-Note that the `objectId` field is the unique identifier of each object. You can use this identifier to call functions in the package. We now have 3 objects under our address:
-- The `Coin` object as a result of calling faucet in testnet or devnet
-- The `Forge` object as a result of the `init` function in the package
-- The `UpgradeCap` object as a result of publishing the package. You can learn more about it [here](../../../concepts/sui-move-concepts/packages/upgrade.mdx).
-
 ### Interact with the package
+
+Now that the package is on chain, you can call its functions to interact with the package. You can use the `sui move call` command to make individual calls to package functions, or you can construct more advanced blocks of transactions using the `sui client ptb` command. The `ptb` part of the command stands for [programmable transaction blocks](../../../concepts/transactions/prog-txn-blocks.mdx). In basic terms, PTBs allow you to group commands together in a single transaction for more efficient and cost-effective network activity.
+
 ```mermaid
 flowchart TB
     my_module["my_module::new_sword(&Forge, strength, magic)"]
@@ -160,50 +95,65 @@ flowchart TB
     
     Sui_client --"PTB"--> my_module
 ```
-Now that the package is published, you can interact with it by calling functions in the package. You can use the `sui client ptb` command of the Sui Client PTB CLI to call functions in the package. PTB stands for Programmable Transaction Blocks. You can learn more about it [here](../../../concepts/transactions/prog-txn-blocks.mdx). Transactions are what clients use to make changes to the Sui blockchain. A programmable transaction block is a collection of transactions that are executed together.
 
 For example, you can create a new `Sword` object defined in the package by calling the `new_sword` function in the `my_module` package, and then transfer the `Sword` object to any address:
 
 ```bash
 $ sui client ptb \
-	--assign forge @0xFORGE_ID \
-	--assign to_address @0xADDRESS \
-	--move-call 0xPACKAGEID::my_module::new_sword forge 3 3 \
+	--assign forge @<FORGE-ID> \
+	--assign to_address @<TO-ADDRESS> \
+	--move-call <PACKAGE-ID>::my_module::new_sword forge 3 3 \
 	--assign sword \
 	--transfer-objects to_address "[sword]" \
 	--gas-budget 20000000
 ```
-{@include: ../../../references/cli/address-prefix.mdx}
-Make sure to replace `0xFORGE_ID`, `0xADDRESS`, and `0xPACKAGEID` with the actual `objectId` of the `Forge` object, the address of the recipient, and the `objectId` of the package, respectively. The above command makes use of the Sui Client PTB CLI. You can learn more about it [here](../../../references/cli/ptb.mdx).
 
-Once the transaction is executed, you can check the status of the `Sword` object by using the `sui client objects` command or the blockchain explorer of your choice. You should see a total of 4 objects now:
+:::info 
+
+{@include: ../../../snippets/address-prefix.mdx}
+
+:::
+
+Make sure to replace `<FORGE-ID>`, `<TO-ADDRESS>`, and `<PACKAGE-ID>` with the actual `objectId` of the `Forge` object, the address of the recipient (your address in this case), and the `packageID` of the package, respectively. 
+
+After the transaction executes, you can check the status of the `Sword` object by using the `sui client objects` command again. Provided you used your address as the `<TO-ADDRESS>`, you should now see a total of four objects:
+
 ```
 ╭───────────────────────────────────────────────────────────────────────────────────────╮
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0x48dc0998f450a86a63f9a59a03b60a87baa61ae5b552ecb8cfb9524b4109aa15  │ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
 │ │ version    │  11                                                                  │ │
-│ │ digest     │  /R0NMICp49ab3nQ8tgb5RlZ6O7SeyQVHKiBcr8Y6QeY=                        │ │
-│ │ objectType │  0xe4dc..88cd::my_module::Forge                                      │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
+│ │ objectType │  <PACKAGE-ID>::my_module::Forge                                      │ │
 │ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0x9e3cab3f784819e0125168b7f8e9a2977bd59c3b0bff42a22cb0993f3e4e7a35  │ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
 │ │ version    │  11                                                                  │ │
-│ │ digest     │  2OvUOhqwlHsOE9Vn40Hzf0HQQTPTp/edWp4V3Ch43Pg=                        │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
 │ │ objectType │  0x0000..0002::coin::Coin                                            │ │
 │ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0xe0f15011cb6796a7e016c63344067cb93dabe69ff84162b2967ed99b826c4c1d  │ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
 │ │ version    │  11                                                                  │ │
-│ │ digest     │  yCzz7CLjJJOlqGINDB4Cpe8y3u0NvsU1A+RGaEdZnO8=                        │ │
-│ │ objectType │  0xe4dc..88cd::my_module::Sword                                      │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
+│ │ objectType │  <PACKAGE-ID>::my_module::Sword                                      │ │
 │ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
 │ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
-│ │ objectId   │  0xe3db38c2e8529bc5fdcb67c1a03d8717c58b7b68e2816111e4ad8d2556bc0c53  │ │
+│ │ objectId   │  <OBJECT-ID>                                                         │ │
 │ │ version    │  10                                                                  │ │
-│ │ digest     │  NVY9pLVpoFFmvAP4sxkIATVRwfcBff+ysXHdaiZx+Ec=                        │ │
+│ │ digest     │  <DIGEST-HASH>                                                       │ │
 │ │ objectType │  0x0000..0002::package::UpgradeCap                                   │ │
 │ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
 ╰───────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-Congratulations! You have successfully published a package to the Sui network and modified the blockchain state by using a Programmable Transaction Block! You can find more dApp examples in the [App Examples](../app-examples.mdx) page.
+Congratulations! You have successfully published a package to the Sui network and modified the blockchain state by using a programmable transaction block. 
+
+## Related links
+
+- [Debugging](./debug.mdx): Print values to aid in logic debugging.
+- [Package Upgrades](../../../concepts/sui-move-concepts/packages.mdx): Upgrading packages published on the Sui network.
+- [Publish a Move Package](../../../references/cli/client.mdx#publish-a-move-package): More details about using the CLI to publish a package.
+- [Programmable Transaction Blocks](../../../concepts/transactions/prog-txn-blocks.mdx): PTBs are collections of transactions that are executed together.
+- [Sui Client PTB CLI](../../../references/cli/ptb.mdx): The `client ptb` command allows you to specify the transactions for execution in a programmable transaction block directly from your CLI or through bash scripts.
+- [App Examples](../app-examples.mdx): End-to-end examples that include smart contract logic and frontend code.

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -96,3 +96,109 @@ As the new test function shows, the first transaction (explicitly) calls the ini
 
 If you try to run tests on the whole package at this point, you encounter compilation errors in the existing tests because of the
 `new_sword` function signature change. The changes required for the tests to run again is an exercise left for you. If you need help, you can refer to the source code for the package (with all the tests properly adjusted) in [first_package](https://github.com/MystenLabs/sui/tree/main/examples/move/first_package/sources/example.move).
+
+### Publish the package
+Once you have the package ready, you can publish it to the Sui network. To do so, use the `sui client publish` command of the Sui Client CLI. You will need to set a gas budget by using the `--gas-budget` flag. The gas budget is the maximum amount of gas you are willing to spend on the transaction. In testnet and devnet, a high budget would allow the transaction to be executed by the network.
+
+You can then check the status of the package using the `sui client objects` command. You can also view the status of the package using the [Sui Explorer](https://suiexplorer.com) or any other Sui blockchain explorer tools.
+
+```mermaid
+flowchart TB
+
+    subgraph Sui Blockchain
+        direction TB
+        address --> Forge
+	address --> UpgradeCap
+	address --> Coin
+    end
+```
+
+```
+$ sui client objects
+
+╭───────────────────────────────────────────────────────────────────────────────────────╮
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0x48dc0998f450a86a63f9a59a03b60a87baa61ae5b552ecb8cfb9524b4109aa15  │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  fuEysv0wzTTNP13kgMFhP6V7GG43mbKcvjnw4jlg14w=                        │ │
+│ │ objectType │  0xe4dc..88cd::my_module::Forge                                      │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0x9e3cab3f784819e0125168b7f8e9a2977bd59c3b0bff42a22cb0993f3e4e7a35  │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  2byd+RLeh48n6rxo8bAeILNWS6VjaEzapcn5sdg1VmM=                        │ │
+│ │ objectType │  0x0000..0002::coin::Coin                                            │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0xe3db38c2e8529bc5fdcb67c1a03d8717c58b7b68e2816111e4ad8d2556bc0c53  │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  NVY9pLVpoFFmvAP4sxkIATVRwfcBff+ysXHdaiZx+Ec=                        │ │
+│ │ objectType │  0x0000..0002::package::UpgradeCap                                   │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+╰───────────────────────────────────────────────────────────────────────────────────────╯
+```
+Note that the `objectId` field is the unique identifier of each object. You can use this identifier to call functions in the package. We now have 3 objects under our address:
+- The `Coin` object as a result of calling faucet in testnet or devnet
+- The `Forge` object as a result of the `init` function in the package
+- The `UpgradeCap` object as a result of publishing the package. You can learn more about it [here](../../../concepts/sui-move-concepts/packages/upgrade.mdx).
+
+### Interact with the package
+```mermaid
+flowchart TB
+    my_module["my_module::new_sword(&Forge, strength, magic)"]
+    
+    Sui_client["Sui client"]
+
+    subgraph Sui Blockchain
+	my_module
+	my_module --Sword--> address
+    end
+    
+    Sui_client --"PTB"--> my_module
+```
+Now that the package is published, you can interact with it by calling functions in the package. You can use the `sui client ptb` command of the Sui Client PTB CLI to call functions in the package. PTB stands for Programmable Transaction Blocks. You can learn more about it [here](../../../concepts/transactions/prog-txn-blocks.mdx). Transactions are what clients use to make changes to the Sui blockchain. A programmable transaction block is a collection of transactions that are executed together.
+
+For example, you can create a new `Sword` object defined in the package by calling the `new_sword` function in the `my_module` package, and then transfer the `Sword` object to any address:
+
+```shell
+$ sui client ptb \
+	--assign forge @0xFORGEID \
+	--assign to_address @0xADDRESS \
+	--move-call 0xPACKAGEID::my_module::new_sword forge 3 3 \
+	--assign sword \
+	--transfer-objects to_address "[sword]" \
+	--gas-budget 20000000
+```
+Make sure to replace `0xFORGEID`, `0xADDRESS`, and `0xPACKAGEID` with the actual `objectId` of the `Forge` object, the address of the recipient, and the `objectId` of the package, respectively. The above command makes use of the Sui Client PTB CLI. You can learn more about it [here](../../../references/cli/ptb.mdx).
+
+Once the transaction is executed, you can check the status of the `Sword` object using the `sui client objects` command or the blockchain explorer of your choice:
+```
+╭───────────────────────────────────────────────────────────────────────────────────────╮
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0x48dc0998f450a86a63f9a59a03b60a87baa61ae5b552ecb8cfb9524b4109aa15  │ │
+│ │ version    │  11                                                                  │ │
+│ │ digest     │  /R0NMICp49ab3nQ8tgb5RlZ6O7SeyQVHKiBcr8Y6QeY=                        │ │
+│ │ objectType │  0xe4dc..88cd::my_module::Forge                                      │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0x9e3cab3f784819e0125168b7f8e9a2977bd59c3b0bff42a22cb0993f3e4e7a35  │ │
+│ │ version    │  11                                                                  │ │
+│ │ digest     │  2OvUOhqwlHsOE9Vn40Hzf0HQQTPTp/edWp4V3Ch43Pg=                        │ │
+│ │ objectType │  0x0000..0002::coin::Coin                                            │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0xe0f15011cb6796a7e016c63344067cb93dabe69ff84162b2967ed99b826c4c1d  │ │
+│ │ version    │  11                                                                  │ │
+│ │ digest     │  yCzz7CLjJJOlqGINDB4Cpe8y3u0NvsU1A+RGaEdZnO8=                        │ │
+│ │ objectType │  0xe4dc..88cd::my_module::Sword                                      │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+│ ╭────────────┬──────────────────────────────────────────────────────────────────────╮ │
+│ │ objectId   │  0xe3db38c2e8529bc5fdcb67c1a03d8717c58b7b68e2816111e4ad8d2556bc0c53  │ │
+│ │ version    │  10                                                                  │ │
+│ │ digest     │  NVY9pLVpoFFmvAP4sxkIATVRwfcBff+ysXHdaiZx+Ec=                        │ │
+│ │ objectType │  0x0000..0002::package::UpgradeCap                                   │ │
+│ ╰────────────┴──────────────────────────────────────────────────────────────────────╯ │
+╰───────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+Congratulations! You have successfully published a package to the Sui network and modified the blockchain state by using a Programmable Transaction Block! You can find more dApp examples in the [App Examples](../app-examples.mdx) page.

--- a/docs/content/guides/developer/first-app/write-package.mdx
+++ b/docs/content/guides/developer/first-app/write-package.mdx
@@ -3,37 +3,68 @@ title: Write a Move Package
 description: The first step in getting a package on chain is to write the Move code that defines the logic of your package. The structure of a Move package is similar to those in Rust.
 ---
 
-Before you can build a Move package and run its code, you must first [install Sui binaries](../getting-started/sui-install.mdx) for your operating system.
-
-### Create the package
-
 To begin, open a terminal or console at the location you plan to store your package. Use the `sui move new` command to create an empty Move package with the name `my_first_package`:
 
-``` shell
-sui move new my_first_package
+```shell
+$ sui move new my_first_package
 ```
 
-Running the previous command creates a directory with the name you provide (`my_first_package`). The command populates the new directory with a skeleton Move project that consists of a `sources` directory and a `Move.toml` manifest file. Open the manifest with a text editor to review its contents:
+Running the previous command creates a directory with the name you provide (`my_first_package` in this case). The command populates the new directory with a skeleton Move project that consists of a `sources` directory and a `Move.toml` manifest file. Open the manifest with a text editor to review its contents:
 
-```shell
-cat my_first_package/Move.toml
+```move title="my_first_package/Move.toml"
 [package]
 name = "my_first_package"
-version = "0.0.1"
+
+# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+# license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
+# authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
 
+# For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
+# Revision can be a branch, a tag, and a commit hash.
+# MyRemotePackage = { git = "https://some.remote/host.git", subdir = "remote/path", rev = "main" }
+
+# For local dependencies use `local = path`. Path is relative to the package root
+# Local = { local = "../path/to" }
+
+# To resolve a version conflict and force a specific version for dependency
+# override use `override = true`
+# Override = { local = "../conflicting/version", override = true }
+
 [addresses]
 my_first_package = "0x0"
+
+# Named addresses will be accessible in Move as `@name`. They're also exported:
+# for example, `std = "0x1"` is exported by the Standard Library.
+# alice = "0xA11CE"
+
+[dev-dependencies]
+# The dev-dependencies section allows overriding dependencies for `--test` and
+# `--dev` modes. You can introduce test-only dependencies here.
+# Local = { local = "../path/to/dev-build" }
+
+[dev-addresses]
+# The dev-addresses section allows overwriting named addresses for the `--test`
+# and `--dev` modes.
+# alice = "0xB0B"
 ```
+
+The manifest file contents include available sections of the manifest and comments that provide additional information. In Move, you prepend the hash mark (`#`) to a line to denote a comment.
+
+- **[package]:** Contains metadata for the package. By default, the `sui move new` command populates only the `name` value of the metadata. In this case, the example passes `my_first_package` to the command, which becomes the name of the package. You can delete the first `#` of subsequent lines of the `[package]` section to provide values for the other available metadata fields. 
+- **[dependencies]:** Lists the other packages that your package depends on to run. By default, the `sui move new` command lists the `Sui` package on GitHub (Testnet version) as the lone dependency.  
+- **[addresses]:** Declares named addresses that your package uses. By default, the section includes the package you create with the `sui move new` command and an address of `0x0`. The publish process replaces the `0x0` address with an actual on-chain address.
+- **[dev-dependencies]:** Includes only comments that describe the section.
+- **[dev-addresses]:** Includes only comments that describe the section.
 
 ### Defining the package
 
 You have a package now but it doesn't do anything. To make your package useful, you must add logic contained in `.move` source files that define *modules*. Use a text editor or the command line to create your first package source file named `my_module.move` in the `sources` directory of the package:
 
 ``` shell
-touch my_first_package/sources/my_module.move
+$ touch my_first_package/sources/my_module.move
 ```
 
 Populate the `my_module.move` file with the following code:
@@ -90,14 +121,17 @@ module my_first_package::my_module {
 
 The comments in the preceding code highlight different parts of a typical Move source file.
 
-* **Part 1: Imports** - Code reuse is a necessity in modern programming. Move supports this concept with imports that allow your module to use types and functions declared in other modules. In this example, the module imports from `object`, `transfer`, and `tx_context` modules. These modules are available to the package because the `Move.toml` file defines the Sui dependency (along with the `sui` named address) where they are defined.
+- **Part 1: Imports** - Code reuse is a necessity in modern programming. Move supports this concept with imports that allow your module to use types and functions declared in other modules. In this example, the module imports from `object`, `transfer`, and `tx_context` modules. These modules are available to the package because the `Move.toml` file defines the Sui dependency (along with the `sui` named address) where they are defined.
 
-* **Part 2: Struct declarations** - Structs define types that a module can create or destroy. Struct definitions can include abilities provided with the `has` keyword. The structs in this example, for instance, have the `key` ability, which indicates that these structs are Sui objects that you can transfer between addresses. The `store` ability on the structs provide the ability to appear in other struct fields and be transferred freely.
+- **Part 2: Struct declarations** - Structs define types that a module can create or destroy. Struct definitions can include abilities provided with the `has` keyword. The structs in this example, for instance, have the `key` ability, which indicates that these structs are Sui objects that you can transfer between addresses. The `store` ability on the structs provides the ability to appear in other struct fields and be transferred freely.
 
-* **Part 3: Module initializer** - A special function that is invoked exactly once when the module publishes.
+- **Part 3: Module initializer** - A special function that is invoked exactly once when the module publishes.
 
-* **Part 4: Accessor functions** - These functions allow the fields of the module's structs to be read from other modules.
+- **Part 4: Accessor functions** - These functions allow the fields of the module's structs to be read from other modules.
 
 After you save the file, you have a complete Move package.
 
-In the next topic, you learn to build and test your package to get it ready for publishing.
+## Related links
+
+- [Build and Test Packages](./build-test.mdx): Continue this example to build and test your package to get it ready for publishing.
+- [Sui Move CLI](../../../references/cli/move.mdx): Available Move commands the CLI provides.  

--- a/docs/content/references/cli/address-prefix.mdx
+++ b/docs/content/references/cli/address-prefix.mdx
@@ -1,0 +1,5 @@
+:::info
+You can pass literal addresses and objects IDs by prefixing them with '@'. This is needed to distinguish a hexadecimal value from an address in some situations. 
+
+For addresses that are in your local wallet, you can use their alias instead (passing them without '@', e.g., --transfer-objects my_alias).
+:::

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -3,14 +3,14 @@ title: Sui Client PTB CLI
 description: The Sui Client PTB CLI enables a user to construct a PTB and execute it from the command line or a file.
 ---
 
-The `client ptb` command allows users to specify the transactions to be executed in a Programmable Transaction Block directly from your CLI or through bash scripts.
+The `client ptb` command allows you to specify the transactions for execution in a programmable transaction block (PTB) directly from your CLI or through bash scripts.
 
 ## Commands
 
 The following list itemizes all the available args for the `sui client ptb` command. Use the `--help` for a long help version that includes some examples on how to use this command.
 
 ```
-Build, preview, and execute programmable transaction blocks. Depending on your shell, you might have to use quotes around arrays or other passed values. Use --help to see examples for how to use the core functionality of this command.
+Build, preview, and execute PTBs. Depending on your shell, you might have to use quotes around arrays or other passed values. Use --help to see examples for how to use the core functionality of this command.
 
 Usage: sui client ptb [OPTIONS]
 
@@ -39,24 +39,30 @@ The main philosophy behind the CLI PTB support is to enable a user to build and 
 Besides using existing [traditional PTB](/concepts/transactions/prog-txn-blocks/) related concepts, we introduce a few new and important concepts for this command. 
 
 :::warning
-Note that all the following examples were tested using a `bash` shell environment and your experience may vary depending on how your shell interprets the input values (e.g., zsh requires to pass values in brackets by adding quotes around it: "[]"; bash accepts them without quotes).
+
+All the following examples were tested using a `bash` shell environment and your experience may vary depending on how your shell interprets the input values (e.g., zsh requires to pass values in brackets by adding quotes around it: "[]"; bash accepts them without quotes).
+
 :::
 
 ### Addresses and Object IDs
-{@include: ./address-prefix.mdx}
+
+{@include: ../../snippets/address-prefix.mdx}
 
 Here are some examples for `transfer-objects` and `gas-coin`:
+
 ```bash
 sui client ptb --transfer-objects @0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331 --gas-coin @0x00002819ee07a66e53800495ccf5eeade8a02054a2e0827546c70e4b226f0495
 ```
 
-
 ### Assign
-The `--assign` argument is used to bind values to variables. There are two ways you can use it:
-* assign a value to a variable
-* assign a variable to the result of the previous command
 
-Let's look at the first case where we assign a value to a variable. We want to check if some variable's value is none. We call the `0x1::option::is_none` function from the Move standard library, and pass in the variable name like this: 
+Use the `--assign` argument to bind values to variables. There are two ways you can use it:
+
+- assign a value to a variable
+- assign a variable to the result of the previous command
+
+Let's look at the first case where you assign a value to a variable. You want to check if some variable's value is `none`. Call the `0x1::option::is_none` function from the Move standard library, and pass in the variable name: 
+
 ```bash
 sui client ptb \
 --assign my_variable none \
@@ -65,10 +71,12 @@ sui client ptb \
 ```
 
 :::tip
+
 CLI PTB uses name resolution for common packages like `sui`, `std`, `deepbook`, so you can use them directly instead of their addresses: `0x2`, `0x1`, or `0xdee9`.
+
 :::
 
-In the second case, if a previous command outputs some result, it can be bound to a variable in order to be accessed later. Let's see an example where we want a new coin with 1000 MIST, which we can achieve by using the `split-coins` command. Once we do that, we want to transfer the new coin to another address. Without the `--assign` argument, we would not be able to instruct the CLI to transfer that new coin object as we would not have a way to refer to it.
+In the second case, if a previous command outputs some result, you can bound it to a variable for later access. Let's see an example where you want a new coin with 1000 MIST, which you can achieve by using the `split-coins` command. After you do that, you want to transfer the new coin to another address. Without the `--assign` argument, you couldn't instruct the CLI to transfer that new coin object as you would not have a way to refer to it.
 
 ```bash
 sui client ptb \
@@ -79,11 +87,9 @@ sui client ptb \
 ```
 
 :::tip
-Variable names cannot be `address`, `bool`, `vector`, `some`, `none`, `gas`, `u8`, `u16`, `u32`, `u64`, `u128`, or `u256`.
-:::
 
-:::tip
 If you build a complex PTB, use the `--preview` flag to display the PTB transaction list instead of executing it.
+
 :::
 
 ## Examples
@@ -91,11 +97,14 @@ If you build a complex PTB, use the `--preview` flag to display the PTB transact
 The following examples demonstrate how to use the `client ptb` command.
 
 :::tip
-When a PTB is executed, the output contains all the relevant information (tx data, gas cost, effects, object changes, etc.). Use `--summary` to get a short summary when you do not need all the data. For complex PTBs, you can use `--preview` to display the PTB transaction list instead of executing it.
+
+When a PTB is executed, the output contains all the relevant information (transaction data, gas cost, effects, object changes, and so on). Use `--summary` to get a short summary when you do not need all the data. For complex PTBs, you can use `--preview` to display the PTB transaction list instead of executing it.
+
 :::
 
 ### Move call
-When needing to execute a move call, use the `--move-call` transaction to call a specific function from a package. The CLI PTB supports name resolution for common packages like `sui`, `std`, `deepbook`, so you can use both `0x1::option::is_none` as well as `std::option::is_none` for passing the function name.
+
+When needing to execute a Move call, use the `--move-call` transaction to call a specific function from a package. The CLI PTB supports name resolution for common packages like `sui`, `std`, `deepbook`, so you can use both `0x1::option::is_none` as well as `std::option::is_none` for passing the function name.
 
 ```bash
 --assign A none
@@ -103,13 +112,15 @@ When needing to execute a move call, use the `--move-call` transaction to call a
 ```
 
 To call a specific function from a specific package
+
 ```bash
 --move-call @0xPACKAGE_ADDR::MODULE::FUNCTION "<TYPE>" FUNC_ARG1 FUNC_ARG2 ...
 ```
 
 
 ### Publish
-Publishing a package is one of the most important commands that users need when working with Sui. While the CLI has a standalone `publish` command, PTBs also supports publishing and upgrading packages. One main difference is that with `sui client ptb`, you would need to explicitly transfer the upgrade cap object that is returned when creating a package, or destroy it with a call to [`make_immutable`](/concepts/sui-move-concepts/packages.mdx). Here is an example on how to publish a Move project on chain using the `sui client ptb` command. It makes a call to the `sui::tx_context::sender` to acquire the sender and assigns the result of that call to the `sender` variable, and then calls the publish command. The result of `publish` is bounded to `upgrade_cap` variable, and then this object is transferred to the sender. 
+
+Publishing a package is one of the most important commands you need when working with Sui. While the CLI has a standalone `publish` command, PTBs also support publishing and upgrading packages. One main difference is that with `sui client ptb`, you must explicitly transfer the `UpgradeCap` object that is returned when creating a package, or destroy it with a call to [`make_immutable`](/concepts/sui-move-concepts/packages.mdx). Here is an example on how to publish a Move project on chain using the `sui client ptb` command. It makes a call to the `sui::tx_context::sender` to acquire the sender and assigns the result of that call to the `sender` variable, and then calls the publish command. The result of `publish` is bounded to `upgrade_cap` variable, and then this object is transferred to the sender. 
 
 ```bash
 --move-call sui::tx_context::sender
@@ -122,7 +133,7 @@ Publishing a package is one of the most important commands that users need when 
 
 ### Split, destroy, and merge coins
 
-The following example showcases how to split a gas coin into multiple coins, make a move call to destroy one or more of the new coins, and finally merge the coins that were not destroyed back into the gas coin. It also showcases how to use framework name resolution (e.g., `sui::coin` instead of `0x2::coin`) and how to refer to different values in an array using the `.` syntax.
+The following example showcases how to split a gas coin into multiple coins, make a move call to destroy one or more of the new coins, and finally merge the coins that were not destroyed back into the gas coin. It also showcases how to use framework name resolution (for example, `sui::coin` instead of `0x2::coin`) and how to refer to different values in an array using the `.` syntax.
 
 ```bash
 # Split off from gas
@@ -155,11 +166,27 @@ This example creates three new coins from gas and transfers them to a different 
 ```
 
 :::info
+
 You can also pass an alias (without the '@') instead of an address.
+
 :::
 
 ## Reserved words
-Variable names cannot be `address`, `bool`, `vector`, `some`, `none`, `gas`, `u8`, `u16`, `u32`, `u64`, `u128`, or `u256`.
+
+You cannot use the following words for variable names:
+
+- `address`
+- `bool`
+- `vector`
+- `some`
+- `none`
+- `gas`
+- `u8`
+- `u16`
+- `u32`
+- `u64`
+- `u128`
+- `u256` 
 
 ## JSON output
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -100,7 +100,12 @@ When needing to execute a move call, use the `--move-call` transaction to call a
 
 ```bash
 --assign A none
---move-call std::option::is_none<u64> A
+--move-call std::option::is_none "<u64>" A
+```
+
+To call a specific function from a specific package
+```bash
+--move-call @0xPACKAGE_ADDR::MODULE_NAME::FUNCTION_NAME "FUNC_ARG1" "FUNC_ARG2"
 ```
 
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -43,14 +43,13 @@ Note that all the following examples were tested using a `bash` shell environmen
 :::
 
 ### Addresses and Object IDs
-You can pass literal addresses and objects IDs by prefixing them with '@'. This is needed to distinguish a hexadecimal value from an address in some situations. Here are some examples for `transfer-objects` and `gas-coin`:
+{@include: ./address-prefix.mdx}
+
+Here are some examples for `transfer-objects` and `gas-coin`:
 ```bash
 sui client ptb --transfer-objects @0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331 --gas-coin @0x00002819ee07a66e53800495ccf5eeade8a02054a2e0827546c70e4b226f0495
 ```
 
-:::tip
-For addresses that are in your local wallet, you can use their alias instead (passing them without '@', e.g., --transfer-objects my_alias).
-:::
 
 ### Assign
 The `--assign` argument is used to bind values to variables. There are two ways you can use it:
@@ -105,7 +104,7 @@ When needing to execute a move call, use the `--move-call` transaction to call a
 
 To call a specific function from a specific package
 ```bash
---move-call @0xPACKAGE_ADDR::MODULE_NAME::FUNCTION_NAME "FUNC_ARG1" "FUNC_ARG2"
+--move-call @0xPACKAGE_ADDR::MODULE::FUNCTION "<TYPE>" FUNC_ARG1 FUNC_ARG2 ...
 ```
 
 

--- a/docs/content/sidebars/concepts.js
+++ b/docs/content/sidebars/concepts.js
@@ -86,7 +86,7 @@ const concepts = [
 					'concepts/sui-move-concepts/one-time-witness',
 					{
 						type: 'category',
-						label: 'Packages',
+						label: 'Package Upgrades',
 						link: {
 							type: 'doc',
 							id: 'concepts/sui-move-concepts/packages',

--- a/docs/content/snippets/address-prefix.mdx
+++ b/docs/content/snippets/address-prefix.mdx
@@ -1,5 +1,3 @@
-:::info
 You can pass literal addresses and objects IDs by prefixing them with '@'. This is needed to distinguish a hexadecimal value from an address in some situations. 
 
-For addresses that are in your local wallet, you can use their alias instead (passing them without '@', e.g., --transfer-objects my_alias).
-:::
+For addresses that are in your local wallet, you can use their alias instead (passing them without '@', for example, --transfer-objects my_alias).

--- a/docs/content/snippets/info-pnpm-required.mdx
+++ b/docs/content/snippets/info-pnpm-required.mdx
@@ -1,5 +1,5 @@
 :::info
 
-You must use the pnpm package manager to create Sui project scaffolds. Follow the [pnpm install](https://pnpm.io/installation) instructions, if needed.
+You must use the pnpm or yarn package managers to create Sui project scaffolds. Follow the [pnpm install](https://pnpm.io/installation) or [yarn install](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) instructions, if needed.
 
 :::


### PR DESCRIPTION
## Description 

- Completed the publish package guide and added another execution step that interacts with the package using PTB.
- Added a small example of calling a move package in the PTB CLI reference section
- Refactored the tip section for address prefix `@` in CLI so the fragment can be reused across doc site

## Test Plan 

Visual inspection

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
