### PR TITLE
[move-2024] Add move 2024 beta edition

### DIFF
--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.alpha"
+edition = "2024.beta"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.alpha
+1) 2024.beta
 2) legacy
 
 Selection (default=1): Recorded edition in 'Move.toml'

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
@@ -2,4 +2,4 @@ Command `build`:
 Error: Error parsing '[package]' section of manifest
 
 Caused by:
-    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha"
+    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.alpha
+1) 2024.beta
 2) legacy
 
 Selection (default=1): Recorded edition in 'Move.toml'

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{diag, diagnostics::Diagnostic, shared::CompilationEnv};
+use crate::{diag, diagnostics::Diagnostic, shared::{CompilationEnv, format_oxford_list}};
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
@@ -74,18 +74,14 @@ pub fn check_feature_or_error(
 
 pub fn create_feature_error(edition: Edition, feature: FeatureGate, loc: Loc) -> Diagnostic {
     assert!(!edition.supports(feature));
-    let valid_editions = valid_editions_for_feature(feature)
-        .into_iter()
-        .map(|e| e.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
+    let valid_editions = format_oxford_list!("and", "'{}'", valid_editions_for_feature(feature));
     let mut diag = diag!(
         Editions::FeatureTooNew,
         (
             loc,
             format!(
                 "{} not supported by current edition '{edition}', \
-                only '{valid_editions}' support this feature",
+                only {valid_editions} support this feature",
                 feature.error_prefix(),
             )
         )
@@ -110,6 +106,10 @@ static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
 const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
+    FeatureGate::MacroFuns,
+];
+
+const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::NestedUse,
     FeatureGate::PublicPackage,
     FeatureGate::PostFixAbilities,
@@ -120,7 +120,6 @@ const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
     FeatureGate::Move2024Keywords,
     FeatureGate::BlockLabels,
     FeatureGate::Move2024Paths,
-    FeatureGate::MacroFuns,
     FeatureGate::Move2024Optimizations,
     FeatureGate::SyntaxMethods,
     FeatureGate::AutoborrowEq,
@@ -137,6 +136,10 @@ impl Edition {
         edition: symbol!("2024"),
         release: Some(symbol!("alpha")),
     };
+    pub const E2024_BETA: Self = Self {
+        edition: symbol!("2024"),
+        release: Some(symbol!("beta")),
+    };
     pub const E2024_MIGRATION: Self = Self {
         edition: symbol!("2024"),
         release: Some(symbol!("migration")),
@@ -144,8 +147,8 @@ impl Edition {
 
     const SEP: &'static str = ".";
 
-    pub const ALL: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_MIGRATION];
-    pub const VALID: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA];
+    pub const ALL: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA, Self::E2024_MIGRATION];
+    pub const VALID: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA];
 
     pub fn supports(&self, feature: FeatureGate) -> bool {
         SUPPORTED_FEATURES.get(self).unwrap().contains(&feature)
@@ -155,8 +158,9 @@ impl Edition {
     fn prev(&self) -> Option<Self> {
         match *self {
             Self::LEGACY => None,
-            Self::E2024_ALPHA => Some(Self::LEGACY),
-            Self::E2024_MIGRATION => Some(Self::E2024_ALPHA),
+            Self::E2024_ALPHA => Some(Self::E2024_BETA),
+            Self::E2024_BETA => Some(Self::LEGACY),
+            Self::E2024_MIGRATION => Some(Self::E2024_BETA),
             _ => self.unknown_edition_panic(),
         }
     }
@@ -169,6 +173,11 @@ impl Edition {
             Self::E2024_ALPHA => {
                 let mut features = self.prev().unwrap().features();
                 features.extend(E2024_ALPHA_FEATURES);
+                features
+            }
+            Self::E2024_BETA => {
+                let mut features = self.prev().unwrap().features();
+                features.extend(E2024_BETA_FEATURES);
                 features
             }
             Self::E2024_MIGRATION => {
@@ -187,11 +196,7 @@ impl Edition {
     fn unknown_edition_error(&self) -> anyhow::Error {
         anyhow::anyhow!(
             "Unsupported edition \"{self}\". Current supported editions include: {}",
-            Self::VALID
-                .iter()
-                .map(|e| format!("\"{}\"", e))
-                .collect::<Vec<_>>()
-                .join(", ")
+            format_oxford_list!("and", "\"{}\"", Self::VALID)
         )
     }
 }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -905,3 +905,38 @@ impl IndexedPhysicalPackagePath {
         })
     }
 }
+
+//**************************************************************************************************
+// Format a comma list correctly for error reporting and other messages.
+//**************************************************************************************************
+
+macro_rules! format_oxford_list {
+    ($sep:expr, $format_str:expr, $e:expr) => {{
+        let entries = $e;
+        match entries.len() {
+            0 => String::new(),
+            1 => format!($format_str, entries[0]),
+            2 => format!(
+                "{} {} {}",
+                format!($format_str, entries[0]),
+                $sep,
+                format!($format_str, entries[1])
+            ),
+            _ => {
+                let entries = entries
+                    .iter()
+                    .map(|entry| format!($format_str, entry))
+                    .collect::<Vec<_>>();
+                if let Some((last, init)) = entries.split_last() {
+                    let mut result = init.join(", ");
+                    result.push_str(&format!(", {} {}", $sep, last));
+                    result
+                } else {
+                    String::new()
+                }
+            }
+        }
+    }};
+}
+
+pub(crate) use format_oxford_list;

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.exp
@@ -14,7 +14,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/expansion/invalid_unpack_assign_mdot_no_struct.move:4:9
   │
 4 │         Self::f() = 0;
-  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/dot_call.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/dot_call.move:4:5
   │
 4 │     public use fun imm as S.f;
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:13:9
    │
 13 │         use fun mut as S.g;
-   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:14:9
    │
 14 │         s.imm();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -26,7 +26,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:15:9
    │
 15 │         s.f();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -34,7 +34,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:16:9
    │
 16 │         s.mut();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -42,7 +42,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:17:9
    │
 17 │         s.g();
-   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -50,7 +50,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/feature_gate/dot_call.move:18:9
    │
 18 │         s.val();
-   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/feature_gate/public_package.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/feature_gate/public_package.move:2:5
   │
 2 │     public(package) fun foo(): u64 { 0 }
-  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/named_blocks_invalid.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/named_blocks_invalid.move:3:9
   │
 3 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -22,7 +22,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -36,7 +36,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -44,7 +44,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -64,7 +64,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -72,7 +72,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -92,7 +92,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -100,7 +100,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -120,7 +120,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -128,7 +128,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -142,7 +142,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:53:9
    │
 53 │         'name: {
-   │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -156,7 +156,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:60:14
    │
 60 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -176,7 +176,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:67:14
    │
 67 │         loop 'outer2: {
-   │              ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -184,7 +184,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:68:18
    │
 68 │             loop 'inner2: {
-   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -204,7 +204,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:76:22
    │
 76 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -212,7 +212,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:77:26
    │
 77 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -232,7 +232,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:85:14
    │
 85 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -240,7 +240,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/named_blocks_invalid.move:86:18
    │
 86 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/syntax_annotations_unsupported.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:6:7
   │
 6 │     #[syntax(index)]
-  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:10:7
    │
 10 │     #[syntax(index)]
-   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │       ^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -27,7 +27,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:21:7
    │
 21 │     #[syntax(for)]
-   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │       ^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -35,7 +35,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:25:7
    │
 25 │     #[syntax(assign)]
-   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │       ^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -43,7 +43,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/naming/syntax_annotations_unsupported.move:29:7
    │
 29 │     #[syntax(nonsense)]
-   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │       ^^^^^^^^^^^^^^^^ 'syntax' methods are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_infix_and_postfix.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_infix_and_postfix.move:5:34
   │
 5 │     struct Foo has copy, drop {} has store;
-  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                                  ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_commas.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_commas.move:5:19
   │
 5 │     struct Foo {} has store copy;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_no_semi.move:5:19
   │
 5 │     struct Foo {} has
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_abilities_with_semi.move:5:19
   │
 5 │     struct Foo {} has;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_no_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_no_semi.move:5:19
   │
 5 │     struct Foo {} has store
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifier_postfix_with_semi.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifier_postfix_with_semi.move:4:19
   │
 4 │     struct Foo {} has store;
-  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                   ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/ability_modifies_infix_no_abilities_postfix.move:4:28
   │
 4 │     struct Foo has copy {} has;
-  │                            ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                            ^^^ Postfix abilities are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/copy_move_path.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:12:9
    │
 12 │         copy x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/copy_move_path.move:13:9
    │
 13 │         move x.y.z;
-   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │         ^^^^ Move 2024 paths are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_conflicting_visibility.exp
@@ -10,7 +10,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:2:20
   │
 2 │     public(friend) public(package) fun t0() {}
-  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                    ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -51,7 +51,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/function_conflicting_visibility.move:4:12
   │
 4 │     public public(package) fun t2() {}
-  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │            ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -117,7 +117,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/function_conflicting_visibility.move:10:21
    │
 10 │     public(package) public(package) fun s1() {}
-   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                     ^^^^^^^^^^^^^^^ 'public(package)' is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_2.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_2.move:4:9
   │
 4 │         'name {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/named_blocks_invalid_3.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/named_blocks_invalid_3.move:4:9
   │
 4 │         'name: {
-  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -16,7 +16,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:11:14
    │
 11 │         loop 'name: {
-   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -30,7 +30,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:17:14
    │
 17 │         loop 'outer: {
-   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -38,7 +38,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:18:18
    │
 18 │             loop 'inner: {
-   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -58,7 +58,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:26:22
    │
 26 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -66,7 +66,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:27:26
    │
 27 │             while (cond) 'inner: {
-   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                          ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -86,7 +86,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:35:22
    │
 35 │         while (cond) 'outer: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -94,7 +94,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:36:22
    │
 36 │             let _x = 'inner: {
-   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                      ^^^^^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -114,7 +114,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:45:14
    │
 45 │         loop 'l: {
-   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │              ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -122,7 +122,7 @@ error[E13001]: feature is not supported in specified edition
    ┌─ tests/move_check/parser/named_blocks_invalid_3.move:46:18
    │
 46 │             loop 'l: {
-   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' support this feature
+   │                  ^^ Block labels are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
    │
    = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_declaration.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_declaration.move:4:15
   │
 4 │     struct Foo(u64)
-  │               ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │               ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_fields_keyword_field.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:5
   │
 4 │     public struct Foo(fun)
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 
@@ -18,7 +18,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_fields_keyword_field.move:4:22
   │
 4 │     public struct Foo(fun)
-  │                      ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                      ^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_pack.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_pack.move:7:17
   │
 7 │         let _ = Foo(0);
-  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │                 ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/positional_struct_unpack.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/positional_struct_unpack.move:7:9
   │
 7 │         Foo(_) = x;
-  │         ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^^ Positional fields are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
@@ -12,6 +12,6 @@ error[E00002]: DEPRECATED. unexpected spec item
 3 │       let _ = x[1];
   │               ^^^^ Specification blocks are deprecated and are no longer used
   │
-  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha'
+  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024.beta'
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/struct_public.exp
@@ -2,7 +2,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/struct_public.move:3:5
   │
 3 │     public struct Foo {}
-  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │     ^^^^^^ Struct visibility modifiers are not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/use_with_modifiers_exp.exp
@@ -11,7 +11,7 @@ error[E13001]: feature is not supported in specified edition
   ┌─ tests/move_check/parser/use_with_modifiers_exp.move:3:9
   │
 3 │         public use fun bar as X.baz;
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' support this feature
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method syntax is not supported by current edition 'legacy', only '2024.alpha' and '2024.beta' support this feature
   │
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
 

--- a/external-crates/move/crates/move-package/src/migration/mod.rs
+++ b/external-crates/move/crates/move-package/src/migration/mod.rs
@@ -20,7 +20,7 @@ pub const EDITION_SELECT_PROMPT: &str = "Please select one of the following edit
 
 pub static EDITION_OPTIONS: Lazy<BTreeMap<String, Edition>> = Lazy::new(|| {
     let mut map = BTreeMap::new();
-    map.insert("1".to_string(), Edition::E2024_ALPHA);
+    map.insert("1".to_string(), Edition::E2024_BETA);
     map.insert("2".to_string(), Edition::LEGACY);
     map
 });
@@ -93,7 +93,7 @@ impl<'a, W: Write, R: BufRead> MigrationContext<'a, W, R> {
                 self.terminal.writeln(MIGRATION_RERUN)?;
                 self.terminal.newline()?;
             }
-            Edition::E2024_ALPHA => {
+            Edition::E2024_BETA => {
                 self.build_plan.record_package_edition(edition)?;
                 self.terminal.writeln(EDITION_RECORDED_MSG)?;
                 self.terminal.newline()?;

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024". Current supported editions include: "legacy", "2024.alpha"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.resolved
@@ -1,1 +1,71 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.beta". Current supported editions include: "legacy", "2024.alpha"
+ResolvedGraph {
+    graph: DependencyGraph {
+        root_path: "tests/test_sources/parsing_edition_2024_beta",
+        root_package_id: "name",
+        root_package_name: "name",
+        package_graph: {
+            "name": [],
+        },
+        package_table: {},
+        always_deps: {
+            "name",
+        },
+        manifest_digest: "D3668DB427EF41C488DF5C8A65136CCF7E3615263A60C104B20998FEFD2B92AE",
+        deps_digest: "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+    },
+    build_options: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        lock_file: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        default_flavor: None,
+        default_edition: None,
+        deps_as_root: false,
+        silence_warnings: false,
+        warnings_are_errors: false,
+        additional_named_addresses: {},
+        no_lint: false,
+    },
+    package_table: {
+        "name": Package {
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "name",
+                    authors: [
+                        "some author",
+                    ],
+                    license: Some(
+                        "\"license\"",
+                    ),
+                    edition: Some(
+                        Edition {
+                            edition: "2024",
+                            release: Some(
+                                "beta",
+                            ),
+                        },
+                    ),
+                    flavor: None,
+                    custom_properties: {},
+                },
+                addresses: None,
+                dev_address_assignments: None,
+                build: None,
+                dependencies: {},
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            renaming: {},
+            resolved_table: {},
+            source_digest: "ELIDED_FOR_TEST",
+        },
+    },
+}

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move.resolved
@@ -1,1 +1,1 @@
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", and "2024.beta"

--- a/external-crates/move/crates/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/crates/move-symbol-pool/src/lib.rs
@@ -91,6 +91,7 @@ static_symbols!(
     "%macro",
     "lint",
     "migration",
+    "beta",
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

This establishes Move 2024 Beta (less macros) as an edition in the compiler and updates tests appropriately.

## Test Plan 

Updated tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
