### PR TITLE
[move-2024] Add support for migrating keywords

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/Move.toml
+++ b/crates/sui-framework/packages/move-stdlib/Move.toml
@@ -2,6 +2,7 @@
 name = "MoveStdlib"
 version = "1.5.0"
 published-at = "0x1"
+edition = "2024.beta"
 
 [addresses]
 std = "0x1"

--- a/crates/sui-framework/packages/move-stdlib/Move.toml
+++ b/crates/sui-framework/packages/move-stdlib/Move.toml
@@ -2,7 +2,6 @@
 name = "MoveStdlib"
 version = "1.5.0"
 published-at = "0x1"
-edition = "2024.beta"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml
@@ -1,0 +1,13 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
@@ -3,7 +3,7 @@
 
 [package]
 name = "A"
-edition = "2024.alpha"
+edition = "2024.beta"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/Move.toml.expected
@@ -1,0 +1,14 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+edition = "2024.alpha"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
@@ -3,7 +3,7 @@ Package toml does not specify an edition. As of 2024, Move requires all packages
 
 Please select one of the following editions:
 
-1) 2024.alpha
+1) 2024.beta
 2) legacy
 
 Selection (default=1): Recorded edition in 'Move.toml'

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
@@ -1,0 +1,131 @@
+Command `migrate`:
+Package toml does not specify an edition. As of 2024, Move requires all packages to define a language edition.
+
+Please select one of the following editions:
+
+1) 2024.alpha
+2) legacy
+
+Selection (default=1): Recorded edition in 'Move.toml'
+
+Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
+Generated changes . . .
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING A
+
+The following changes will be made.
+============================================================
+
+--- sources/mod0.move
++++ sources/mod0.move
+@@ -3,1 +3,1 @@
+-    struct S { n: u64 }
++    public struct S { n: u64 }
+@@ -5,1 +5,1 @@
+-    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
++    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+@@ -6,1 +6,1 @@
+-        if (type == match) {
++        if (`type` == `match`) {
+@@ -7,1 +7,1 @@
+-            type
++            `type`
+@@ -8,1 +8,1 @@
+-        } else if (mut) {
++        } else if (`mut`) {
+@@ -9,1 +9,1 @@
+-            match
++            `match`
+@@ -11,1 +11,1 @@
+-            enum.n
++            `enum`.n
+--- sources/mod_intermodule_errors.move
++++ sources/mod_intermodule_errors.move
+@@ -3,1 +3,1 @@
+-    struct S { n: u64 }
++    public struct S { n: u64 }
+@@ -5,1 +5,1 @@
+-    public fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
++    public fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+@@ -6,1 +6,1 @@
+-        if (type == match) {
++        if (`type` == `match`) {
+@@ -7,1 +7,1 @@
+-            type
++            `type`
+@@ -8,1 +8,1 @@
+-        } else if (mut) {
++        } else if (`mut`) {
+@@ -9,1 +9,1 @@
+-            match
++            `match`
+@@ -11,1 +11,1 @@
+-            enum.n
++            `enum`.n
+--- sources/mod_let.move
++++ sources/mod_let.move
+@@ -3,1 +3,1 @@
+-    struct S has drop { n: u64 }
++    public struct S has drop { n: u64 }
+@@ -5,1 +5,1 @@
+-    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
++    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+@@ -6,1 +6,1 @@
+-        let type = 0;
++        let `type` = 0;
+@@ -7,1 +7,1 @@
+-        let enum = 1;
++        let `enum` = 1;
+@@ -8,1 +8,1 @@
+-        let mut = 2;
++        let `mut` = 2;
+@@ -9,1 +9,1 @@
+-        let match = 3;
++        let `match` = 3;
+@@ -10,1 +10,1 @@
+-        type + enum + mut + match
++        `type` + `enum` + `mut` + `match`
+--- sources/mod_let_errors.move
++++ sources/mod_let_errors.move
+@@ -3,1 +3,1 @@
+-    struct S { n: u64 }
++    public struct S { n: u64 }
+@@ -5,1 +5,1 @@
+-    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
++    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+@@ -6,1 +6,1 @@
+-        let type = 0;
++        let `type` = 0;
+@@ -7,1 +7,1 @@
+-        let enum = 1;
++        let `enum` = 1;
+@@ -8,1 +8,1 @@
+-        let mut = 2;
++        let `mut` = 2;
+@@ -9,1 +9,1 @@
+-        let match = 3;
++        let `match` = 3;
+@@ -10,1 +10,1 @@
+-        type + enum + mut + match
++        `type` + `enum` + `mut` + `match`
+
+
+============================================================
+Apply changes? (Y/n) 
+Updating "sources/mod0.move" . . .
+Updating "sources/mod_intermodule_errors.move" . . .
+Updating "sources/mod_let.move" . . .
+Updating "sources/mod_let_errors.move" . . .
+
+Changes complete
+Wrote patchfile out to: ./migration.patch
+
+External Command `diff -r -s sources migration_sources`:
+Files sources/mod0.move and migration_sources/mod0.move are identical
+Files sources/mod_intermodule_errors.move and migration_sources/mod_intermodule_errors.move are identical
+Files sources/mod_let.move and migration_sources/mod_let.move are identical
+Files sources/mod_let_errors.move and migration_sources/mod_let_errors.move are identical
+External Command `diff -r -s tests migration_tests`:
+diff: tests: No such file or directory
+External Command `diff -s Move.toml Move.toml.expected`:
+Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
@@ -125,7 +125,5 @@ Files sources/mod0.move and migration_sources/mod0.move are identical
 Files sources/mod_intermodule_errors.move and migration_sources/mod_intermodule_errors.move are identical
 Files sources/mod_let.move and migration_sources/mod_let.move are identical
 Files sources/mod_let_errors.move and migration_sources/mod_let_errors.move are identical
-External Command `diff -r -s tests migration_tests`:
-diff: tests: No such file or directory
 External Command `diff -s Move.toml Move.toml.expected`:
 Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.txt
@@ -1,0 +1,4 @@
+migrate
+> diff -r -s sources migration_sources
+> diff -r -s tests migration_tests
+> diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.txt
@@ -1,4 +1,3 @@
 migrate
 > diff -r -s sources migration_sources
-> diff -r -s tests migration_tests
 > diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod0.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod0.move
@@ -1,0 +1,15 @@
+module A::mod0 {
+
+    public struct S { n: u64 }
+
+    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+        if (`type` == `match`) {
+            `type`
+        } else if (`mut`) {
+            `match`
+        } else {
+            `enum`.n
+        }
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_intermodule_errors.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_intermodule_errors.move
@@ -1,0 +1,24 @@
+module A::mod1 {
+
+    public struct S { n: u64 }
+
+    public fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+        if (`type` == `match`) {
+            `type`
+        } else if (`mut`) {
+            `match`
+        } else {
+            `enum`.n
+        }
+    }
+
+}
+
+module A::mod2 {
+
+    use A::mod1::t0;
+    use A::mod1::S;
+
+    public fun t1(t: u64, e: S, m: bool, m2: u64): u64 { t0(t, e, m, m2) }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_let.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_let.move
@@ -1,0 +1,13 @@
+module A::mod_let {
+
+    public struct S has drop { n: u64 }
+
+    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+        let `type` = 0;
+        let `enum` = 1;
+        let `mut` = 2;
+        let `match` = 3;
+        `type` + `enum` + `mut` + `match`
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_let_errors.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/migration_sources/mod_let_errors.move
@@ -1,0 +1,13 @@
+module A::mod_let_errors {
+
+    public struct S { n: u64 }
+
+    fun t0(`type`: u64, `enum`: S, `mut`: bool, `match`: u64): u64 {
+        let `type` = 0;
+        let `enum` = 1;
+        let `mut` = 2;
+        let `match` = 3;
+        `type` + `enum` + `mut` + `match`
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod0.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod0.move
@@ -1,0 +1,15 @@
+module A::mod0 {
+
+    struct S { n: u64 }
+
+    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
+        if (type == match) {
+            type
+        } else if (mut) {
+            match
+        } else {
+            enum.n
+        }
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_intermodule_errors.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_intermodule_errors.move
@@ -1,0 +1,24 @@
+module A::mod1 {
+
+    struct S { n: u64 }
+
+    public fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
+        if (type == match) {
+            type
+        } else if (mut) {
+            match
+        } else {
+            enum.n
+        }
+    }
+
+}
+
+module A::mod2 {
+
+    use A::mod1::t0;
+    use A::mod1::S;
+
+    public fun t1(t: u64, e: S, m: bool, m2: u64): u64 { t0(t, e, m, m2) }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_let.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_let.move
@@ -1,0 +1,13 @@
+module A::mod_let {
+
+    struct S has drop { n: u64 }
+
+    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
+        let type = 0;
+        let enum = 1;
+        let mut = 2;
+        let match = 3;
+        type + enum + mut + match
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_let_errors.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/sources/mod_let_errors.move
@@ -1,0 +1,13 @@
+module A::mod_let_errors {
+
+    struct S { n: u64 }
+
+    fun t0(type: u64, enum: S, mut: bool, match: u64): u64 {
+        let type = 0;
+        let enum = 1;
+        let mut = 2;
+        let match = 3;
+        type + enum + mut + match
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml
@@ -1,0 +1,13 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/Move.toml.expected
@@ -1,0 +1,14 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+edition = "2024.beta"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.exp
@@ -1,0 +1,42 @@
+Command `migrate`:
+Package toml does not specify an edition. As of 2024, Move requires all packages to define a language edition.
+
+Please select one of the following editions:
+
+1) 2024.beta
+2) legacy
+
+Selection (default=1): Recorded edition in 'Move.toml'
+
+Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
+Generated changes . . .
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING A
+
+The following changes will be made.
+============================================================
+
+--- sources/mut_name.move
++++ sources/mut_name.move
+@@ -3,1 +3,1 @@
+-    fun dumpster_fire(mut x: u64, mut: u64): u64 {
++    fun dumpster_fire(mut x: u64, `mut`: u64): u64 {
+@@ -5,1 +5,1 @@
+-        let mut: u64 = mut + 2;
++        let `mut`: u64 = `mut` + 2;
+@@ -6,1 +6,1 @@
+-        mut + y + x
++        `mut` + y + x
+
+
+============================================================
+Apply changes? (Y/n) 
+Updating "sources/mut_name.move" . . .
+
+Changes complete
+Wrote patchfile out to: ./migration.patch
+
+External Command `diff -r -s sources migration_sources`:
+Files sources/mut_name.move and migration_sources/mut_name.move are identical
+External Command `diff -s Move.toml Move.toml.expected`:
+Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/args.txt
@@ -1,0 +1,3 @@
+migrate
+> diff -r -s sources migration_sources
+> diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/migration_sources/mut_name.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/migration_sources/mut_name.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    fun dumpster_fire(mut x: u64, `mut`: u64): u64 {
+        let mut y: u64 = 10;
+        let `mut`: u64 = `mut` + 2;
+        `mut` + y + x
+    }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/sources/mut_name.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names_mut_allowed/sources/mut_name.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    fun dumpster_fire(mut x: u64, mut: u64): u64 {
+        let mut y: u64 = 10;
+        let mut: u64 = mut + 2;
+        mut + y + x
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -346,6 +346,7 @@ codes!(
     Migration: [
         NeedsPublic: { msg: "move 2024 migration: public struct", severity: NonblockingError },
         NeedsLetMut: { msg: "move 2024 migration: let mut", severity: NonblockingError },
+        NeedsRestrictedIdentifier: { msg: "move 2024 migration: restricted identifier", severity: NonblockingError },
     ]
 );
 

--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -9,7 +9,11 @@ use std::{
     str::FromStr,
 };
 
-use crate::{diag, diagnostics::Diagnostic, shared::{CompilationEnv, format_oxford_list}};
+use crate::{
+    diag,
+    diagnostics::Diagnostic,
+    shared::{format_oxford_list, CompilationEnv},
+};
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
@@ -105,9 +109,7 @@ pub fn valid_editions_for_feature(feature: FeatureGate) -> Vec<Edition> {
 static SUPPORTED_FEATURES: Lazy<BTreeMap<Edition, BTreeSet<FeatureGate>>> =
     Lazy::new(|| BTreeMap::from_iter(Edition::ALL.iter().map(|e| (*e, e.features()))));
 
-const E2024_ALPHA_FEATURES: &[FeatureGate] = &[
-    FeatureGate::MacroFuns,
-];
+const E2024_ALPHA_FEATURES: &[FeatureGate] = &[FeatureGate::MacroFuns];
 
 const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::NestedUse,
@@ -147,7 +149,12 @@ impl Edition {
 
     const SEP: &'static str = ".";
 
-    pub const ALL: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA, Self::E2024_MIGRATION];
+    pub const ALL: &'static [Self] = &[
+        Self::LEGACY,
+        Self::E2024_ALPHA,
+        Self::E2024_BETA,
+        Self::E2024_MIGRATION,
+    ];
     pub const VALID: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA];
 
     pub fn supports(&self, feature: FeatureGate) -> bool {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -3608,8 +3608,8 @@ fn check_valid_function_parameter_name(context: &mut Context, is_macro: Option<L
         context.env().add_diag(diag);
     } else if !is_valid_local_variable_name(v.value()) {
         let msg = format!(
-            "Invalid parameter name '{}'. Local variable names must start with 'a'..'z' or \
-                 '_'",
+            "Invalid parameter name '{}'. Local variable names must start with 'a'..'z', '_', \
+            or be a valid name quoted with backticks (`name`)",
             v,
         );
         context
@@ -3622,8 +3622,8 @@ fn check_valid_function_parameter_name(context: &mut Context, is_macro: Option<L
 fn check_valid_local_name(context: &mut Context, v: &Var) {
     if !is_valid_local_variable_name(v.value()) {
         let msg = format!(
-            "Invalid local variable name '{}'. Local variable names must start with 'a'..'z' or \
-             '_'",
+            "Invalid local name '{}'. Local variable names must start with 'a'..'z', '_', \
+            or be a valid name quoted with backticks (`name`)",
             v,
         );
         context

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -690,7 +690,6 @@ impl Var {
 
     pub fn is_valid_name(s: Symbol) -> bool {
         s.starts_with('_')
-            || (s.starts_with('`') && s.ends_with('`'))
             || s.starts_with(|c: char| c.is_ascii_lowercase())
             || Self::is_syntax_identifier_name(s)
     }

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -690,6 +690,7 @@ impl Var {
 
     pub fn is_valid_name(s: Symbol) -> bool {
         s.starts_with('_')
+            || (s.starts_with('`') && s.ends_with('`'))
             || s.starts_with(|c: char| c.is_ascii_lowercase())
             || Self::is_syntax_identifier_name(s)
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -798,7 +798,7 @@ fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagno
 // and returns None otherwise.
 //     MutOpt = "mut"?
 fn parse_mut_opt(context: &mut Context) -> Result<Option<Loc>, Box<Diagnostic>> {
-    // In migration mode, 'mu'` is assumed to be an identifier that needsd escaping.
+    // In migration mode, 'mut' is assumed to be an identifier that needsd escaping.
     if context.env.edition(context.package_name) == Edition::E2024_MIGRATION {
         Ok(None)
     } else if context.tokens.peek() == Tok::Mut {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -356,6 +356,16 @@ fn parse_identifier(context: &mut Context) -> Result<Name, Box<Diagnostic>> {
             let peeled = &content[1..content.len() - 1];
             peeled.into()
         }
+        // carve-out for migration with new keywords
+        tok @ (Tok::Mut | Tok::Match | Tok::Enum | Tok::Type)
+            if context.env.edition(context.package_name) == Edition::E2024_MIGRATION =>
+        {
+            context.env.add_diag(diag!(
+                Migration::NeedsRestrictedIdentifier,
+                (context.tokens.current_token_loc(), format!("{}", tok))
+            ));
+            context.tokens.content().into()
+        }
         _ => {
             return Err(unexpected_token_error(context.tokens, "an identifier"));
         }
@@ -440,6 +450,19 @@ fn parse_leading_name_access_<'a, F: FnOnce() -> &'a str>(
         Tok::NumValue => {
             let sp!(loc, addr) = parse_address_bytes(context)?;
             Ok(sp(loc, LeadingNameAccess_::AnonymousAddress(addr)))
+        }
+        // carve-out for migration with new keywords
+        Tok::Mut | Tok::Match | Tok::Enum | Tok::Type
+            if context.env.edition(context.package_name) == Edition::E2024_MIGRATION =>
+        {
+            if global_name {
+                Err(unexpected_token_error(context.tokens, item_description()))
+            } else {
+                let loc = current_token_loc(context.tokens);
+                let n = parse_identifier(context)?;
+                let name = LeadingNameAccess_::Name(n);
+                Ok(sp(loc, name))
+            }
         }
         _ => Err(unexpected_token_error(context.tokens, item_description())),
     }
@@ -771,6 +794,27 @@ fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagno
 // Fields and Bindings
 //**************************************************************************************************
 
+// Parse an optional "mut" modifier token. Consumes and returns the location of the token if present
+// and returns None otherwise.
+//     MutOpt = "mut"?
+fn parse_mut_opt(context: &mut Context) -> Result<Option<Loc>, Box<Diagnostic>> {
+    // In migration mode, 'mu'` is assumed to be an identifier that needsd escaping.
+    if context.env.edition(context.package_name) == Edition::E2024_MIGRATION {
+        Ok(None)
+    } else if context.tokens.peek() == Tok::Mut {
+        let start_loc = context.tokens.start_loc();
+        context.tokens.advance()?;
+        let end_loc = context.tokens.previous_end_loc();
+        Ok(Some(make_loc(
+            context.tokens.file_hash(),
+            start_loc,
+            end_loc,
+        )))
+    } else {
+        Ok(None)
+    }
+}
+
 // Parse a field name optionally followed by a colon and an expression argument:
 //      ExpField = <Field> <":" <Exp>>?
 fn parse_exp_field(context: &mut Context) -> Result<(Field, Exp), Box<Diagnostic>> {
@@ -794,23 +838,16 @@ fn parse_exp_field(context: &mut Context) -> Result<(Field, Exp), Box<Diagnostic
 // If the binding is not specified, the default is to use a variable
 // with the same name as the field.
 fn parse_bind_field(context: &mut Context) -> Result<(Field, Bind), Box<Diagnostic>> {
-    if context.tokens.peek() == Tok::Mut {
-        let start_loc = context.tokens.start_loc();
-        context.tokens.advance()?;
-        let end_loc = context.tokens.previous_end_loc();
-        let mut_loc = make_loc(context.tokens.file_hash(), start_loc, end_loc);
-        let f = parse_field(context)?;
-        let arg = sp(f.loc(), Bind_::Var(Some(mut_loc), Var(f.0)));
-        Ok((f, arg))
+    let mut_ = parse_mut_opt(context)?;
+    let f = parse_field(context)?;
+    let arg = if mut_.is_some() {
+        sp(f.loc(), Bind_::Var(mut_, Var(f.0)))
+    } else if match_token(context.tokens, Tok::Colon)? {
+        parse_bind(context)?
     } else {
-        let f = parse_field(context)?;
-        let arg = if match_token(context.tokens, Tok::Colon)? {
-            parse_bind(context)?
-        } else {
-            sp(f.loc(), Bind_::Var(None, Var(f.0)))
-        };
-        Ok((f, arg))
-    }
+        sp(f.loc(), Bind_::Var(None, Var(f.0)))
+    };
+    Ok((f, arg))
 }
 
 // Parse a binding:
@@ -823,19 +860,15 @@ fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
     if matches!(
         context.tokens.peek(),
         Tok::Identifier | Tok::RestrictedIdentifier | Tok::Mut
+        // carve-out for migration with new keywords
+        | Tok::Match | Tok::Enum | Tok::Type
     ) {
         let next_tok = context.tokens.lookahead()?;
         if !matches!(
             next_tok,
             Tok::LBrace | Tok::Less | Tok::ColonColon | Tok::LParen
         ) {
-            let mut_ = if context.tokens.peek() == Tok::Mut {
-                context.tokens.advance()?;
-                let end_loc = context.tokens.previous_end_loc();
-                Some(make_loc(context.tokens.file_hash(), start_loc, end_loc))
-            } else {
-                None
-            };
+            let mut_ = parse_mut_opt(context)?;
             let v = Bind_::Var(mut_, parse_var(context)?);
             let end_loc = context.tokens.previous_end_loc();
             return Ok(spanned(context.tokens.file_hash(), start_loc, end_loc, v));
@@ -1178,6 +1211,12 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
             }
         }
         Tok::Identifier | Tok::RestrictedIdentifier | Tok::SyntaxIdentifier => {
+            parse_name_exp(context)?
+        }
+        // carve-out for migration with new keywords
+        Tok::Mut | Tok::Match | Tok::Enum | Tok::Type
+            if context.env.edition(context.package_name) == Edition::E2024_MIGRATION =>
+        {
             parse_name_exp(context)?
         }
 
@@ -2442,14 +2481,7 @@ fn parse_function_decl(
 // Parse a function parameter:
 //      Parameter = "mut"? <Var> ":" <Type>
 fn parse_parameter(context: &mut Context) -> Result<(Mutability, Var, Type), Box<Diagnostic>> {
-    let mut_ = if context.tokens.peek() == Tok::Mut {
-        let start_loc = context.tokens.start_loc();
-        context.tokens.advance()?;
-        let end_loc = context.tokens.previous_end_loc();
-        Some(make_loc(context.tokens.file_hash(), start_loc, end_loc))
-    } else {
-        None
-    };
+    let mut_ = parse_mut_opt(context)?;
     let v = parse_var(context)?;
     consume_token(context.tokens, Tok::Colon)?;
     let t = parse_type(context)?;

--- a/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_local_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/expansion/invalid_local_name.exp
@@ -2,7 +2,7 @@ error[E02010]: invalid name
   ┌─ tests/move_check/expansion/invalid_local_name.move:4:11
   │
 4 │     fun t(No: u64) {
-  │           ^^ Invalid parameter name 'No'. Local variable names must start with 'a'..'z' or '_'
+  │           ^^ Invalid parameter name 'No'. Local variable names must start with 'a'..'z', '_', or be a valid name quoted with backticks (`name`)
 
 error[E03005]: unbound unscoped name
   ┌─ tests/move_check/expansion/invalid_local_name.move:5:9
@@ -14,13 +14,13 @@ error[E02010]: invalid name
   ┌─ tests/move_check/expansion/invalid_local_name.move:9:13
   │
 9 │         let No;
-  │             ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' or '_'
+  │             ^^ Invalid local name 'No'. Local variable names must start with 'a'..'z', '_', or be a valid name quoted with backticks (`name`)
 
 error[E02010]: invalid name
    ┌─ tests/move_check/expansion/invalid_local_name.move:14:13
    │
 14 │         let No = 100;
-   │             ^^ Invalid local variable name 'No'. Local variable names must start with 'a'..'z' or '_'
+   │             ^^ Invalid local name 'No'. Local variable names must start with 'a'..'z', '_', or be a valid name quoted with backticks (`name`)
 
 error[E03005]: unbound unscoped name
    ┌─ tests/move_check/expansion/invalid_local_name.move:15:13


### PR DESCRIPTION
## Description 

This sets up a (mildly hacky) solution to migrate newly-reserved keywords when they appear in existing code by maing them restricted identifiers (e.g., "type" -> "`type`").

## Test Plan 

New test case for migration, plus attempting to run it against the sui framework locally which does similar things.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
