### PR TITLE
Made 'for' a Move 2024 keyword

### DIFF
--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/loop.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/loop.move
@@ -4,7 +4,7 @@
 
 module 0x42::m {
 
-    macro fun for($start: u64, $stop: u64, $body: |u64|) {
+    macro fun `for`($start: u64, $stop: u64, $body: |u64|) {
         let mut i = $start;
         let stop = $stop;
         while (i < stop) {
@@ -25,7 +25,7 @@ module 0x42::m {
 
     entry fun t0() {
         let mut count = 0;
-        0x42::m::for!(0, 10, |x| count = count + x*x);
+        0x42::m::`for`!(0, 10, |x| count = count + x*x);
         assert!(count == 285, 0);
 
         let es = vector[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/loop_nested.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/loop_nested.move
@@ -4,7 +4,7 @@
 
 module 0x42::m {
 
-    macro fun for($start: u64, $stop: u64, $body: |u64|) {
+    macro fun `for`($start: u64, $stop: u64, $body: |u64|) {
         let mut i = $start;
         let stop = $stop;
         while (i < stop) {
@@ -15,13 +15,13 @@ module 0x42::m {
 
     macro fun new<$T>($len: u64, $f: |u64| -> $T): vector<$T> {
         let mut v = vector[];
-        for!(0, $len, |i| v.push_back($f(i)));
+        `for`!(0, $len, |i| v.push_back($f(i)));
         v
     }
 
     macro fun for_each<$T>($v: &vector<$T>, $body: |&$T|) {
         let v = $v;
-        for!(0, v.length(), |i| $body(v.borrow(i)))
+        `for`!(0, v.length(), |i| $body(v.borrow(i)))
     }
 
     macro fun fold<$T, $U>(

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -91,6 +91,7 @@ pub enum Tok {
     Match,
     BlockLabel,
     MinusGreater,
+    For,
 }
 
 impl fmt::Display for Tok {
@@ -172,6 +173,7 @@ impl fmt::Display for Tok {
             Match => "match",
             BlockLabel => "'[Identifier]",
             MinusGreater => "->",
+            For => "for",
         };
         fmt::Display::fmt(s, formatter)
     }
@@ -883,6 +885,7 @@ fn get_name_token(edition: Edition, name: &str) -> Tok {
             "enum" => Tok::Enum,
             "type" => Tok::Type,
             "match" => Tok::Match,
+            "for" => Tok::For,
             _ => Tok::Identifier,
         },
         _ => Tok::Identifier,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/for_keyword.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/for_keyword.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/parser/for_keyword.move:2:9
+  │
+2 │     fun for(_: u64): bool { false }
+  │         ^^^
+  │         │
+  │         Unexpected 'for'
+  │         Expected an identifier
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/for_keyword.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/for_keyword.move
@@ -1,0 +1,3 @@
+module a::m {
+    fun for(_: u64): bool { false }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_have_unique_scopes_nested.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_have_unique_scopes_nested.move
@@ -1,6 +1,6 @@
 module a::m {
     // macros have their own unique scopes
-    macro fun for($start: u64, $stop: u64, $body: |u64|) {
+    macro fun `for`($start: u64, $stop: u64, $body: |u64|) {
         let mut i = $start;
         let stop = $stop;
         while (i < stop) {
@@ -22,7 +22,7 @@ module a::m {
     macro fun new<$T>($len: u64, $f: |u64| -> $T): vector<$T> {
         let len = $len;
         let mut v = vector[];
-        for!(0, len, |i| v.push_back($f(i)));
+        `for`!(0, len, |i| v.push_back($f(i)));
         v
     }
 


### PR DESCRIPTION
## Description 

- `for` is now a keyword in Move 2024 

## Test Plan 

- new tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Move 2024 now reserves `for` as a keyword 