### PR TITLE
[wallet-standard] add isSuiChain utility

### DIFF
--- a/.changeset/giant-tomatoes-worry.md
+++ b/.changeset/giant-tomatoes-worry.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-standard': minor
+---
+
+Add isSuiChain utility which is useful for type-safe wallet interfaces in dApps

--- a/.changeset/giant-tomatoes-worry.md
+++ b/.changeset/giant-tomatoes-worry.md
@@ -2,4 +2,4 @@
 '@mysten/wallet-standard': minor
 ---
 
-Add isSuiChain utility which is useful for type-safe wallet interfaces in dApps
+Add isSuiChain utility which is useful for type-safe dApp interfaces in wallets

--- a/sdk/wallet-standard/src/chains.ts
+++ b/sdk/wallet-standard/src/chains.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { IdentifierString } from '@wallet-standard/core';
+
 /** Sui Devnet */
 export const SUI_DEVNET_CHAIN = 'sui:devnet';
 
@@ -25,3 +27,11 @@ export type SuiChain =
 	| typeof SUI_TESTNET_CHAIN
 	| typeof SUI_LOCALNET_CHAIN
 	| typeof SUI_MAINNET_CHAIN;
+
+/**
+ * Utility that returns whether or not a chain identifier is a valid Sui chain.
+ * @param chain a chain identifier in the form of `${string}:{$string}`
+ */
+export function isSuiChain(chain: IdentifierString): chain is SuiChain {
+	return SUI_CHAINS.includes(chain as SuiChain);
+}


### PR DESCRIPTION
## Description 

This PR adds a new type-guard util called `isSuiChain` which is useful for implementing dApp interfaces in wallets (see example below). The Solana wallet-standard has an equivalent utility for this as well, and it seems to be used commonly in open source wallet implementations.

<img width="841" alt="image" src="https://github.com/MystenLabs/sui/assets/7453188/2f54e316-06ad-4547-8086-950fb983d787">

## Test Plan 
- Manual testing

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
