### PR TITLE
[Consensus] fix additional test failures for Sui with Mysticeti

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -14,20 +14,35 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Parameters {
     /// Time to wait for parent round leader before sealing a block.
+    /// Default: 250ms
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
+    /// Minimum delay between rounds, to avoid generating too many rounds when latency is low.
+    /// This is especially necessary for tests running locally.
+    /// This should be set low enough, for example ~50ms, to avoid reducing round rate in
+    /// realistic and distributed configurations.
+    /// Default: 50ms
+    #[serde(default = "Parameters::default_min_round_delay")]
+    pub min_round_delay: Duration,
+
     /// Maximum forward time drift (how far in future) allowed for received blocks.
+    /// Default: 500ms
     #[serde(default = "Parameters::default_max_forward_time_drift")]
     pub max_forward_time_drift: Duration,
 
-    /// The database path. The path should be provided in order for the node to be able to boot
+    /// The database path.
+    /// Required.
     pub db_path: Option<PathBuf>,
 }
 
 impl Parameters {
     pub fn default_leader_timeout() -> Duration {
         Duration::from_millis(250)
+    }
+
+    pub fn default_min_round_delay() -> Duration {
+        Duration::from_millis(50)
     }
 
     pub fn default_max_forward_time_drift() -> Duration {
@@ -49,6 +64,7 @@ impl Default for Parameters {
     fn default() -> Self {
         Self {
             leader_timeout: Parameters::default_leader_timeout(),
+            min_round_delay: Parameters::default_min_round_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
             db_path: None,
         }

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -10,24 +10,22 @@ use serde::{Deserialize, Serialize};
 /// All fields should tolerate inconsistencies among authorities, without affecting safety of the
 /// protocol. Otherwise, they need to be part of Sui protocol config or epoch state on-chain.
 ///
-/// NOTE: default values should make sense, so most operators should not need to specify any field.
+/// NOTE: fields with default values are specified in the serde default functions. Most operators
+/// should not need to specify any field, except db_path.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Parameters {
     /// Time to wait for parent round leader before sealing a block.
-    /// Default: 250ms
     #[serde(default = "Parameters::default_leader_timeout")]
     pub leader_timeout: Duration,
 
     /// Minimum delay between rounds, to avoid generating too many rounds when latency is low.
     /// This is especially necessary for tests running locally.
-    /// This should be set low enough, for example ~50ms, to avoid reducing round rate in
-    /// realistic and distributed configurations.
-    /// Default: 50ms
+    /// If setting a non-default value, it should be set low enough (<50ms) to avoid reducing
+    /// round rate and increasing latency in realistic and distributed configurations.
     #[serde(default = "Parameters::default_min_round_delay")]
     pub min_round_delay: Duration,
 
     /// Maximum forward time drift (how far in future) allowed for received blocks.
-    /// Default: 500ms
     #[serde(default = "Parameters::default_max_forward_time_drift")]
     pub max_forward_time_drift: Duration,
 

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -5,6 +5,9 @@ expression: parameters
 leader_timeout:
   secs: 0
   nanos: 250000000
+min_round_delay:
+  secs: 0
+  nanos: 50000000
 max_forward_time_drift:
   secs: 0
   nanos: 500000000

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -22,7 +22,7 @@ opentelemetry_api = { version = "0.20.0", optional = true }
 opentelemetry-otlp = { version = "0.13.0", features = ["grpc-tonic"], optional = true }
 tracing-opentelemetry = { version = "0.21.0", optional = true }
 opentelemetry-proto = { version = "0.3", optional = true }
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 futures.workspace = true
 clap.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
## Description 

- Fix the test timeout errors by adding a minimum delay between rounds. Otherwise with small p2p latencies in tests, consensus has high round rate, uses significant CPU and slows down tests.
- Fix `test_coin_deny_list_creation` by only allow overriding consensus protocol when protocol config is >= 36. But in future Mysticeti will need to be able to run at earlier protocol versions, because Narwhal may get removed completely. An alternative is to remove these tests for specific earlier protocol versions.

## Test Plan 

CI
Local tests with `CONSENSUS=mysticeti`

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
