### PR TITLE
Fix race in pending checkpoint notification

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2485,6 +2485,7 @@ impl AuthorityPerEpochStore {
             self.get_reconfig_state_read_lock_guard().should_accept_tx()
         };
         let make_checkpoint = should_accept_tx || final_round;
+        let mut created_pending_checkpoints = Vec::new();
         if make_checkpoint {
             // Filter out roots of any deferred tx.
             for deferred in deferred_tx_roots {
@@ -2508,7 +2509,7 @@ impl AuthorityPerEpochStore {
             });
 
             self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
-            checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
+            created_pending_checkpoints.push(pending_checkpoint);
 
             // Generate pending checkpoint for user tx with randomness.
             if let Some(randomness_round) = randomness_round {
@@ -2527,11 +2528,17 @@ impl AuthorityPerEpochStore {
                 });
 
                 self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
-                checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
+                created_pending_checkpoints.push(pending_checkpoint);
             }
         }
 
         batch.write()?;
+
+        // Only after batch is written, notify checkpoint service to start building any new
+        // pending checkpoints.
+        for pending_checkpoint in created_pending_checkpoints {
+            checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
+        }
 
         // Once commit processing is recorded, kick off randomness generation.
         if let Some(randomness_round) = randomness_round {


### PR DESCRIPTION
## Description 

Previously we notified checkpoint service of new pending checkpoints before the batch containing it was written.