### PR TITLE
Simplify notify_checkpoint interface not to take a PendingCheckpoint

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2485,7 +2485,6 @@ impl AuthorityPerEpochStore {
             self.get_reconfig_state_read_lock_guard().should_accept_tx()
         };
         let make_checkpoint = should_accept_tx || final_round;
-        let mut created_pending_checkpoints = Vec::new();
         if make_checkpoint {
             // Filter out roots of any deferred tx.
             for deferred in deferred_tx_roots {
@@ -2507,9 +2506,7 @@ impl AuthorityPerEpochStore {
                     checkpoint_height,
                 },
             });
-
             self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
-            created_pending_checkpoints.push(pending_checkpoint);
 
             // Generate pending checkpoint for user tx with randomness.
             if let Some(randomness_round) = randomness_round {
@@ -2526,9 +2523,7 @@ impl AuthorityPerEpochStore {
                         checkpoint_height: checkpoint_height + 1,
                     },
                 });
-
                 self.write_pending_checkpoint(&mut batch, &pending_checkpoint)?;
-                created_pending_checkpoints.push(pending_checkpoint);
             }
         }
 
@@ -2536,8 +2531,12 @@ impl AuthorityPerEpochStore {
 
         // Only after batch is written, notify checkpoint service to start building any new
         // pending checkpoints.
-        for pending_checkpoint in created_pending_checkpoints {
-            checkpoint_service.notify_checkpoint(&pending_checkpoint)?;
+        if make_checkpoint {
+            debug!(
+                ?commit_round,
+                "Notifying checkpoint service about new pending checkpoint(s)",
+            );
+            checkpoint_service.notify_checkpoint()?;
         }
 
         // Once commit processing is recorded, kick off randomness generation.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1764,7 +1764,7 @@ pub trait CheckpointServiceNotify {
         info: &CheckpointSignatureMessage,
     ) -> SuiResult;
 
-    fn notify_checkpoint(&self, checkpoint: &PendingCheckpointV2) -> SuiResult;
+    fn notify_checkpoint(&self) -> SuiResult;
 }
 
 /// This is a service used to communicate with other pieces of sui(for ex. authority)
@@ -1850,7 +1850,7 @@ impl CheckpointService {
         let mut batch = epoch_store.db_batch_for_test();
         epoch_store.write_pending_checkpoint(&mut batch, &checkpoint)?;
         batch.write()?;
-        self.notify_checkpoint(&checkpoint)?;
+        self.notify_checkpoint()?;
         Ok(())
     }
 }
@@ -1898,11 +1898,7 @@ impl CheckpointServiceNotify for CheckpointService {
         Ok(())
     }
 
-    fn notify_checkpoint(&self, checkpoint: &PendingCheckpointV2) -> SuiResult {
-        debug!(
-            checkpoint_commit_height = checkpoint.height(),
-            "Notifying builder about checkpoint",
-        );
+    fn notify_checkpoint(&self) -> SuiResult {
         self.notify_builder.notify_one();
         Ok(())
     }
@@ -1919,7 +1915,7 @@ impl CheckpointServiceNotify for CheckpointServiceNoop {
         Ok(())
     }
 
-    fn notify_checkpoint(&self, _: &PendingCheckpointV2) -> SuiResult {
+    fn notify_checkpoint(&self) -> SuiResult {
         Ok(())
     }
 }


### PR DESCRIPTION
Argument was only used for logging, but its existence makes it seem like it would be used for the notification.