### PR TITLE
[suiop][pagerduty] add priority to recent incidents listing

### DIFF
--- a/crates/suiop-cli/src/cli/incidents/pd.rs
+++ b/crates/suiop-cli/src/cli/incidents/pd.rs
@@ -143,8 +143,16 @@ pub async fn print_recent_incidents(long: bool, limit: usize, days: usize) -> Re
                 } else {
                     None
                 };
+            let priority = match incident["priority"]["name"].as_str() {
+                Some("P0") => "P0".red(),
+                Some("P1") => "P1".magenta(),
+                Some("P2") => "P2".truecolor(255, 165, 0),
+                Some("P3") => "P3".yellow(),
+                Some("P4") => "P4".white(),
+                _ => "  ".white(),
+            };
             println!(
-                "{}: ({}) {} ({})",
+                "{}: ({}) {} {} ({})",
                 incident["incident_number"]
                     .as_u64()
                     .expect("incident_number as_u64")
@@ -153,6 +161,7 @@ pub async fn print_recent_incidents(long: bool, limit: usize, days: usize) -> Re
                 resolved_at
                     .map(|v| (v.num_days().to_string() + "d").yellow())
                     .unwrap_or("".to_string().yellow()),
+                priority,
                 incident["title"].as_str().expect("title").green(),
                 incident["html_url"]
                     .as_str()


### PR DESCRIPTION
## Description 

Add priority to listing recent incidents

## Test Plan 

<img width="1406" alt="Screenshot 2024-03-12 at 2 00 44 PM" src="https://github.com/MystenLabs/sui/assets/11138157/4b669695-d96d-4169-a86e-83e7119dd30b">



---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
