### PR TITLE
[move-2024] Add migration support for globally qualifying names

### DIFF
--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/args.exp
@@ -6,7 +6,7 @@ Please select one of the following editions:
 1) 2024.beta
 2) legacy
 
-Selection (default=1): Recorded edition in 'Move.toml'
+Selection (default=1): 
 
 Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
 Generated changes . . .
@@ -276,6 +276,7 @@ Updating "tests/test0.move" . . .
 Changes complete
 Wrote patchfile out to: ./migration.patch
 
+Recorded edition in 'Move.toml'
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical
 Files sources/mod1.move and migration_sources/mod1.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_names/args.exp
@@ -6,7 +6,7 @@ Please select one of the following editions:
 1) 2024.beta
 2) legacy
 
-Selection (default=1): Recorded edition in 'Move.toml'
+Selection (default=1): 
 
 Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
 Generated changes . . .
@@ -108,6 +108,7 @@ Updating "sources/mod_let_errors.move" . . .
 Changes complete
 Wrote patchfile out to: ./migration.patch
 
+Recorded edition in 'Move.toml'
 External Command `diff -r -s sources migration_sources`:
 Files sources/mod0.move and migration_sources/mod0.move are identical
 Files sources/mod_intermodule_errors.move and migration_sources/mod_intermodule_errors.move are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml
@@ -1,0 +1,13 @@
+
+# TOML FILE
+
+[package]
+name = "migration"
+
+# this is a comment
+[addresses]
+migration = "0x3"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/Move.toml.expected
@@ -1,0 +1,14 @@
+
+# TOML FILE
+
+[package]
+name = "migration"
+edition = "2024.beta"
+
+# this is a comment
+[addresses]
+migration = "0x3"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.exp
@@ -11,33 +11,37 @@ Selection (default=1):
 Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
 Generated changes . . .
 INCLUDING DEPENDENCY MoveStdlib
-BUILDING A
+BUILDING migration
 
 The following changes will be made.
 ============================================================
 
---- sources/mut_name.move
-+++ sources/mut_name.move
-@@ -3,1 +3,1 @@
--    fun dumpster_fire(mut x: u64, mut: u64): u64 {
-+    fun dumpster_fire(mut x: u64, `mut`: u64): u64 {
-@@ -5,1 +5,1 @@
--        let mut: u64 = mut + 2;
-+        let `mut`: u64 = `mut` + 2;
+--- sources/other.move
++++ sources/other.move
+@@ -4,1 +4,1 @@
+-    public fun t() { migration::migration::t() }
++    public fun t() { ::migration::migration::t() }
+--- tests/test0.move
++++ tests/test0.move
 @@ -6,1 +6,1 @@
--        mut + y + x
-+        `mut` + y + x
+-    #[expected_failure(abort_code = migration::validate::ErrorCode)]
++    #[expected_failure(abort_code = ::migration::validate::ErrorCode)]
 
 
 ============================================================
 Apply changes? (Y/n) 
-Updating "sources/mut_name.move" . . .
+Updating "sources/other.move" . . .
+Updating "tests/test0.move" . . .
 
 Changes complete
 Wrote patchfile out to: ./migration.patch
 
 Recorded edition in 'Move.toml'
 External Command `diff -r -s sources migration_sources`:
-Files sources/mut_name.move and migration_sources/mut_name.move are identical
+Files sources/migration.move and migration_sources/migration.move are identical
+Files sources/other.move and migration_sources/other.move are identical
+Files sources/validate.move and migration_sources/validate.move are identical
+External Command `diff -r -s tests migration_tests`:
+Files tests/test0.move and migration_tests/test0.move are identical
 External Command `diff -s Move.toml Move.toml.expected`:
 Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/args.txt
@@ -1,0 +1,4 @@
+migrate
+> diff -r -s sources migration_sources
+> diff -r -s tests migration_tests
+> diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/migration.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/migration.move
@@ -1,0 +1,5 @@
+module migration::migration {
+
+    public fun t() { abort migration::validate::make_error_code() }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/other.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/other.move
@@ -1,0 +1,5 @@
+module migration::other {
+    use migration::migration;
+
+    public fun t() { ::migration::migration::t() }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/validate.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_sources/validate.move
@@ -1,0 +1,7 @@
+module migration::validate {
+
+    const ErrorCode: u64= 0;
+
+    public fun make_error_code(): u64 { ErrorCode }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_tests/test0.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/migration_tests/test0.move
@@ -1,0 +1,10 @@
+#[test_only]
+module migration::migration_tests {
+    use migration::migration;
+
+    #[test]
+    #[expected_failure(abort_code = ::migration::validate::ErrorCode)]
+    fun test_t() {
+        migration::t()
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/migration.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/migration.move
@@ -1,0 +1,5 @@
+module migration::migration {
+
+    public fun t() { abort migration::validate::make_error_code() }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/other.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/other.move
@@ -1,0 +1,5 @@
+module migration::other {
+    use migration::migration;
+
+    public fun t() { migration::migration::t() }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/validate.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/sources/validate.move
@@ -1,0 +1,7 @@
+module migration::validate {
+
+    const ErrorCode: u64= 0;
+
+    public fun make_error_code(): u64 { ErrorCode }
+
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/tests/test0.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_paths/tests/test0.move
@@ -1,0 +1,10 @@
+#[test_only]
+module migration::migration_tests {
+    use migration::migration;
+
+    #[test]
+    #[expected_failure(abort_code = migration::validate::ErrorCode)]
+    fun test_t() {
+        migration::t()
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/Move.toml.expected
@@ -1,0 +1,13 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+
+# this is a comment
+[addresses]
+A = "0x1"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
@@ -14,6 +14,12 @@ INCLUDING DEPENDENCY MoveStdlib
 BUILDING A
 Unable to generate migration patch due to compilation errors.
 Please fix the errors in your current edition before attempting to migrate.
+error[E03006]: unexpected name in this position
+  ┌─ sources/mod1.move:5:9
+  │
+5 │         mod0::mod0::f();
+  │         ^^^^ Expected an address in this position, not a module
+
 error[E04007]: incompatible types
    ┌─ sources/mod.move:12:13
    │

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
@@ -6,7 +6,7 @@ Please select one of the following editions:
 1) 2024.beta
 2) legacy
 
-Selection (default=1): Recorded edition in 'Move.toml'
+Selection (default=1): 
 
 Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
 Generated changes . . .

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.exp
@@ -32,3 +32,5 @@ error[E04007]: incompatible types
    │             Given: '(A=0x1)::mod0::S'
 
 Error: Compilation error
+External Command `diff -s Move.toml Move.toml.expected`:
+Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/args.txt
@@ -1,1 +1,2 @@
 migrate
+> diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/sources/mod1.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_with_blocking_errors/sources/mod1.move
@@ -1,0 +1,9 @@
+module A::mod1 {
+    use A::mod0;
+
+    public fun t0(x: u64): u64 {
+        mod0::mod0::f();
+        x
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -347,6 +347,7 @@ codes!(
         NeedsPublic: { msg: "move 2024 migration: public struct", severity: NonblockingError },
         NeedsLetMut: { msg: "move 2024 migration: let mut", severity: NonblockingError },
         NeedsRestrictedIdentifier: { msg: "move 2024 migration: restricted identifier", severity: NonblockingError },
+        NeedsGlobalQualification: { msg: "move 2024 migration: global qualification", severity: NonblockingError },
     ]
 );
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -570,9 +570,10 @@ fn top_level_address_(
         // This should have been handled elsewhere in alias resolution for user-provided paths, and
         // should never occur in compiler-generated ones.
         P::LeadingNameAccess_::GlobalAddress(name) => {
-            context.env.add_diag(ice!(
-                (loc, "Found an address in top-level address position that uses a global name")
-            ));
+            context.env.add_diag(ice!((
+                loc,
+                "Found an address in top-level address position that uses a global name"
+            )));
             Address::NamedUnassigned(name)
         }
         P::LeadingNameAccess_::Name(name) => {
@@ -605,11 +606,12 @@ fn top_level_address_opt(context: &mut DefnContext, ln: P::LeadingNameAccess) ->
         // This should have been handled elsewhere in alias resolution for user-provided paths, and
         // should never occur in compiler-generated ones.
         P::LeadingNameAccess_::GlobalAddress(_) => {
-            context.env.add_diag(ice!(
-                (loc, "Found an address in top-level address position that uses a global name")
-            ));
+            context.env.add_diag(ice!((
+                loc,
+                "Found an address in top-level address position that uses a global name"
+            )));
             None
-        },
+        }
         P::LeadingNameAccess_::Name(name) => {
             let addr = named_address_mapping.get(&name.value).copied()?;
             Some(make_address(context, name, loc, addr))

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -567,10 +567,11 @@ fn top_level_address_(
             debug_assert!(name_res.is_ok());
             Address::anonymous(loc, bytes)
         }
+        // This should have been handled elsewhere in alias resolution for user-provided paths, and
+        // should never occur in compiler-generated ones.
         P::LeadingNameAccess_::GlobalAddress(name) => {
-            context.env.add_diag(diag!(
-                Syntax::InvalidAddress,
-                (loc, "Top-level addresses cannot start with '::'")
+            context.env.add_diag(ice!(
+                (loc, "Found an address in top-level address position that uses a global name")
             ));
             Address::NamedUnassigned(name)
         }
@@ -601,13 +602,14 @@ fn top_level_address_opt(context: &mut DefnContext, ln: P::LeadingNameAccess) ->
             debug_assert!(name_res.is_ok());
             Some(Address::anonymous(loc, bytes))
         }
-        P::LeadingNameAccess_::GlobalAddress(name) => {
-            context.env.add_diag(diag!(
-                Syntax::InvalidAddress,
-                (loc, "Top-level addresses cannot start with '::'")
+        // This should have been handled elsewhere in alias resolution for user-provided paths, and
+        // should never occur in compiler-generated ones.
+        P::LeadingNameAccess_::GlobalAddress(_) => {
+            context.env.add_diag(ice!(
+                (loc, "Found an address in top-level address position that uses a global name")
             ));
-            Some(Address::NamedUnassigned(name))
-        }
+            None
+        },
         P::LeadingNameAccess_::Name(name) => {
             let addr = named_address_mapping.get(&name.value).copied()?;
             Some(make_address(context, name, loc, addr))

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1700,11 +1700,11 @@ impl Move2024PathExpander {
                         if context.env.edition(context.current_package)
                             == Edition::E2024_MIGRATION =>
                     {
-                        context.env.add_diag(diag!(
-                            Migration::NeedsGlobalQualification,
-                            (root_name.loc, "Must globally qualify name")
-                        ));
                         if let Some(address) = top_level_address_opt(context, root_name) {
+                            context.env.add_diag(diag!(
+                                Migration::NeedsGlobalQualification,
+                                (root_name.loc, "Must globally qualify name")
+                            ));
                             let mident =
                                 sp(ident_loc, ModuleIdent_::new(address, ModuleName(next_name)));
                             ModuleAccess(loc, EN::ModuleAccess(mident, last_name))

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -1715,12 +1715,6 @@ impl Move2024PathExpander {
                             )
                         }
                     }
-                    // let result = if context.env.edition(context.current_package) == Edition::E2024_MIGRATION {
-                    //     if
-                    //     result
-                    // } else {
-                    //     return
-                    // }
                     result @ (ModuleIdent(_, _) | ModuleAccess(_, _)) => {
                         ResolutionFailure(Box::new(result), InvalidKind("an address".to_string()))
                     }

--- a/external-crates/move/crates/move-package/src/migration/mod.rs
+++ b/external-crates/move/crates/move-package/src/migration/mod.rs
@@ -87,17 +87,20 @@ impl<'a, W: Write, R: BufRead> MigrationContext<'a, W, R> {
 
         match edition {
             Edition::LEGACY => {
-                self.build_plan.record_package_edition(edition)?;
-                self.terminal.writeln(EDITION_RECORDED_MSG)?;
+                self.terminal.newline()?;
                 self.terminal.newline()?;
                 self.terminal.writeln(MIGRATION_RERUN)?;
                 self.terminal.newline()?;
-            }
-            Edition::E2024_BETA => {
                 self.build_plan.record_package_edition(edition)?;
                 self.terminal.writeln(EDITION_RECORDED_MSG)?;
                 self.terminal.newline()?;
+            }
+            Edition::E2024_BETA => {
+                self.terminal.newline()?;
+                self.terminal.newline()?;
                 self.perform_upgrade()?;
+                self.build_plan.record_package_edition(edition)?;
+                self.terminal.writeln(EDITION_RECORDED_MSG)?;
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
## Description 

In legacy move, we allowed three-place names to use an address in the first position, even if there was also a module in scope with that name. Move 2024's resolution rules now require `::` proceeding that name to do this. This updates migration to support.

Also, this moves writing the edition flag to the `Move.toml` file  _after_ successful migration, so that we aren't updating the it in the error case.

## Test Plan 

New tests plus more local testing against the sui framework code.
 
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
