### PR TITLE
fix: add some sleep before zklogin test

### DIFF
--- a/sdk/typescript/test/e2e/multisig.test.ts
+++ b/sdk/typescript/test/e2e/multisig.test.ts
@@ -9,33 +9,33 @@ import { MultiSigPublicKey } from '../../src/multisig/publickey';
 import { TransactionBlock } from '../../src/transactions';
 import { getZkLoginSignature } from '../../src/zklogin';
 import { toZkLoginPublicIdentifier } from '../../src/zklogin/publickey';
-import { DEFAULT_RECIPIENT, TestToolbox, setupWithFundedAddress } from './utils/setup';
+import { DEFAULT_RECIPIENT, setupWithFundedAddress, TestToolbox } from './utils/setup';
 
 describe('MultiSig with zklogin signature', () => {
 	let toolbox: TestToolbox;
 
 	beforeAll(async () => {
-		// Make sure the epoch is at least 1 so the JWK objects can be found when verifying zklogin signature. 
+		// Make sure the epoch is at least 1 so the JWK objects can be found when verifying zklogin signature.
 		const startTime = Date.now();
 		const timeout = 20000; // 20 seconds timeout
 		let epochInfo;
-	
+
 		let retires = 50;
 		while (retires !== 0) {
 			epochInfo = await toolbox.client.getCurrentEpoch();
 			if (BigInt(epochInfo.epoch) > 1) {
 				break;
 			}
-	
+
 			if (Date.now() - startTime > timeout) {
 				throw new Error('Timeout waiting for epoch 1');
 			}
-	
+
 			// Wait for a short interval before checking again
 			await new Promise((resolve) => setTimeout(resolve, 200)); // Sleep for 200ms
 			retires -= 1;
 		}
-	
+
 		expect(BigInt(epochInfo!.epoch)).toBeGreaterThan(1);
 	});
 

--- a/sdk/typescript/test/e2e/multisig.test.ts
+++ b/sdk/typescript/test/e2e/multisig.test.ts
@@ -2,16 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromB64 } from '@mysten/bcs';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { Ed25519Keypair } from '../../src/keypairs/ed25519';
 import { MultiSigPublicKey } from '../../src/multisig/publickey';
 import { TransactionBlock } from '../../src/transactions';
 import { getZkLoginSignature } from '../../src/zklogin';
 import { toZkLoginPublicIdentifier } from '../../src/zklogin/publickey';
-import { DEFAULT_RECIPIENT, setupWithFundedAddress } from './utils/setup';
+import { DEFAULT_RECIPIENT, TestToolbox, setupWithFundedAddress } from './utils/setup';
 
 describe('MultiSig with zklogin signature', () => {
+	let toolbox: TestToolbox;
+
+	beforeAll(async () => {
+		// Make sure the epoch is at least 1 so the JWK objects can be found when verifying zklogin signature. 
+		const startTime = Date.now();
+		const timeout = 20000; // 20 seconds timeout
+		let epochInfo;
+	
+		let retires = 50;
+		while (retires !== 0) {
+			epochInfo = await toolbox.client.getCurrentEpoch();
+			if (BigInt(epochInfo.epoch) > 1) {
+				break;
+			}
+	
+			if (Date.now() - startTime > timeout) {
+				throw new Error('Timeout waiting for epoch 1');
+			}
+	
+			// Wait for a short interval before checking again
+			await new Promise((resolve) => setTimeout(resolve, 200)); // Sleep for 200ms
+			retires -= 1;
+		}
+	
+		expect(BigInt(epochInfo!.epoch)).toBeGreaterThan(1);
+	});
+
 	it('Execute tx with multisig with 1 sig and 1 zkLogin sig combined', async () => {
 		// set up default zklogin public identifier consistent with default zklogin proof.
 		let pkZklogin = toZkLoginPublicIdentifier(


### PR DESCRIPTION
## Description 

ocassionally this test fails in localnet before JWK object is created, this adds a wait time to make sure epoch reaches 1 to run the zklogin tx. 
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
