### PR TITLE
Indexer: prune partitions based on configured epochs to keep

### DIFF
--- a/crates/sui-indexer/migrations/2023-08-19-044020_events/up.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044020_events/up.sql
@@ -15,9 +15,9 @@ CREATE TABLE events
     timestamp_ms                BIGINT       NOT NULL,
     -- bcs of the Event contents (Event.contents)
     bcs                         BYTEA        NOT NULL,
-    PRIMARY KEY(tx_sequence_number, event_sequence_number)
-);
-
+    PRIMARY KEY(tx_sequence_number, event_sequence_number, checkpoint_sequence_number)
+) PARTITION BY RANGE (checkpoint_sequence_number);
+CREATE TABLE events_partition_0 PARTITION OF events FOR VALUES FROM (0) TO (MAXVALUE);
 CREATE INDEX events_package ON events (package, tx_sequence_number, event_sequence_number);
 CREATE INDEX events_package_module ON events (package, module, tx_sequence_number, event_sequence_number);
 CREATE INDEX events_event_type ON events (event_type text_pattern_ops, tx_sequence_number, event_sequence_number);

--- a/crates/sui-indexer/migrations/2023-08-19-044026_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2023-08-19-044026_transactions/up.sql
@@ -18,9 +18,8 @@ CREATE TABLE transactions (
     -- number of successful commands in this transaction, bound by number of command
     -- in a programmaable transaction.
     success_command_count       smallint     NOT NULL,
-    CONSTRAINT transactions_pkey PRIMARY KEY (tx_sequence_number, checkpoint_sequence_number)
+    PRIMARY KEY (tx_sequence_number, checkpoint_sequence_number)
 ) PARTITION BY RANGE (checkpoint_sequence_number);
-
 CREATE TABLE transactions_partition_0 PARTITION OF transactions FOR VALUES FROM (0) TO (MAXVALUE);
 CREATE INDEX transactions_transaction_digest ON transactions (transaction_digest);
 CREATE INDEX transactions_checkpoint_sequence_number ON transactions (checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
@@ -6,7 +6,7 @@ CREATE TABLE tx_senders (
     PRIMARY KEY(sender, tx_sequence_number, cp_sequence_number)
 ) PARTITION BY RANGE (cp_sequence_number);
 CREATE TABLE tx_senders_partition_0 PARTITION OF tx_senders FOR VALUES FROM (0) TO (MAXVALUE);
-CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number ASC, cp_sequence_number ASC);
+CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_recipients (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -16,7 +16,7 @@ CREATE TABLE tx_recipients (
     PRIMARY KEY(recipient, tx_sequence_number, cp_sequence_number)
 ) PARTITION BY RANGE (cp_sequence_number);
 CREATE TABLE tx_recipients_partition_0 PARTITION OF tx_recipients FOR VALUES FROM (0) TO (MAXVALUE);
-CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number ASC, cp_sequence_number ASC);
+CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number, cp_sequence_number);
 
 CREATE TABLE tx_input_objects (
     cp_sequence_number          BIGINT       NOT NULL,

--- a/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
+++ b/crates/sui-indexer/migrations/2023-10-06-204335_tx_indices/up.sql
@@ -4,7 +4,8 @@ CREATE TABLE tx_senders (
     -- SuiAddress in bytes.
     sender                      BYTEA        NOT NULL,
     PRIMARY KEY(sender, tx_sequence_number, cp_sequence_number)
-);
+) PARTITION BY RANGE (cp_sequence_number);
+CREATE TABLE tx_senders_partition_0 PARTITION OF tx_senders FOR VALUES FROM (0) TO (MAXVALUE);
 CREATE INDEX tx_senders_tx_sequence_number_index ON tx_senders (tx_sequence_number ASC, cp_sequence_number ASC);
 
 CREATE TABLE tx_recipients (
@@ -13,7 +14,8 @@ CREATE TABLE tx_recipients (
     -- SuiAddress in bytes.
     recipient                   BYTEA        NOT NULL,
     PRIMARY KEY(recipient, tx_sequence_number, cp_sequence_number)
-);
+) PARTITION BY RANGE (cp_sequence_number);
+CREATE TABLE tx_recipients_partition_0 PARTITION OF tx_recipients FOR VALUES FROM (0) TO (MAXVALUE);
 CREATE INDEX tx_recipients_tx_sequence_number_index ON tx_recipients (tx_sequence_number ASC, cp_sequence_number ASC);
 
 CREATE TABLE tx_input_objects (
@@ -22,7 +24,8 @@ CREATE TABLE tx_input_objects (
     -- Object ID in bytes. 
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
-);
+) PARTITION BY RANGE (cp_sequence_number);
+CREATE TABLE tx_input_objects_partition_0 PARTITION OF tx_input_objects FOR VALUES FROM (0) TO (MAXVALUE);
 
 CREATE TABLE tx_changed_objects (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -30,7 +33,8 @@ CREATE TABLE tx_changed_objects (
     -- Object Id in bytes.
     object_id                   BYTEA        NOT NULL,
     PRIMARY KEY(object_id, tx_sequence_number, cp_sequence_number)
-);
+) PARTITION BY RANGE (cp_sequence_number);
+CREATE TABLE tx_changed_objects_partition_0 PARTITION OF tx_changed_objects FOR VALUES FROM (0) TO (MAXVALUE);
 
 CREATE TABLE tx_calls (
     cp_sequence_number          BIGINT       NOT NULL,
@@ -41,7 +45,8 @@ CREATE TABLE tx_calls (
     -- 1. Using Primary Key as a unique index.
     -- 2. Diesel does not like tables with no primary key.
     PRIMARY KEY(package, tx_sequence_number, cp_sequence_number)
-);
+) PARTITION BY RANGE (cp_sequence_number);
+CREATE TABLE tx_calls_partition_0 PARTITION OF tx_calls FOR VALUES FROM (0) TO (MAXVALUE);
 CREATE INDEX tx_calls_module ON tx_calls (package, module, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_func ON tx_calls (package, module, func, tx_sequence_number, cp_sequence_number);
 CREATE INDEX tx_calls_tx_sequence_number ON tx_calls (tx_sequence_number, cp_sequence_number);

--- a/crates/sui-indexer/migrations/2023-11-29-193859_advance_partition/down.sql
+++ b/crates/sui-indexer/migrations/2023-11-29-193859_advance_partition/down.sql
@@ -1,1 +1,2 @@
 DROP PROCEDURE IF EXISTS advance_partition;
+DROP PROCEDURE IF EXISTS drop_partition;

--- a/crates/sui-indexer/migrations/2023-11-29-193859_advance_partition/up.sql
+++ b/crates/sui-indexer/migrations/2023-11-29-193859_advance_partition/up.sql
@@ -7,3 +7,11 @@ BEGIN
     EXECUTE format('CREATE TABLE IF NOT EXISTS %I_partition_%s PARTITION OF %I FOR VALUES FROM (%L) TO (MAXVALUE)', table_name, new_epoch, table_name, new_epoch_start_cp);
 END;
 $$;
+
+CREATE OR REPLACE PROCEDURE drop_partition(table_name TEXT, epoch BIGINT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    EXECUTE format('DROP TABLE IF EXISTS %I_partition_%s', table_name, epoch);
+END;
+$$;

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -165,7 +165,7 @@ where
             let packages = packages_per_checkpoint
                 .remove(checkpoint.checkpoint_summary.sequence_number())
                 .unwrap_or_default();
-            tasks.push(tokio::task::spawn(Self::index_one_checkpoint(
+            tasks.push(tokio::task::spawn(Self::index_checkpoint(
                 state_clone.clone(),
                 checkpoint.clone(),
                 metrics_clone.clone(),
@@ -297,7 +297,7 @@ where
         }))
     }
 
-    async fn index_one_checkpoint(
+    async fn index_checkpoint(
         state: Arc<S>,
         data: CheckpointData,
         metrics: Arc<IndexerMetrics>,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -96,7 +96,22 @@ diesel::table! {
 }
 
 diesel::table! {
-    events (tx_sequence_number, event_sequence_number) {
+    events (tx_sequence_number, event_sequence_number, checkpoint_sequence_number) {
+        tx_sequence_number -> Int8,
+        event_sequence_number -> Int8,
+        transaction_digest -> Bytea,
+        checkpoint_sequence_number -> Int8,
+        senders -> Array<Nullable<Bytea>>,
+        package -> Bytea,
+        module -> Text,
+        event_type -> Text,
+        timestamp_ms -> Int8,
+        bcs -> Bytea,
+    }
+}
+
+diesel::table! {
+    events_partition_0 (tx_sequence_number, event_sequence_number, checkpoint_sequence_number) {
         tx_sequence_number -> Int8,
         event_sequence_number -> Int8,
         transaction_digest -> Bytea,
@@ -262,7 +277,25 @@ diesel::table! {
 }
 
 diesel::table! {
+    tx_calls_partition_0 (package, tx_sequence_number, cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        tx_sequence_number -> Int8,
+        package -> Bytea,
+        module -> Text,
+        func -> Text,
+    }
+}
+
+diesel::table! {
     tx_changed_objects (object_id, tx_sequence_number, cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        tx_sequence_number -> Int8,
+        object_id -> Bytea,
+    }
+}
+
+diesel::table! {
+    tx_changed_objects_partition_0 (object_id, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         object_id -> Bytea,
@@ -289,6 +322,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    tx_input_objects_partition_0 (object_id, tx_sequence_number, cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        tx_sequence_number -> Int8,
+        object_id -> Bytea,
+    }
+}
+
+diesel::table! {
     tx_recipients (recipient, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
@@ -297,7 +338,23 @@ diesel::table! {
 }
 
 diesel::table! {
+    tx_recipients_partition_0 (recipient, tx_sequence_number, cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        tx_sequence_number -> Int8,
+        recipient -> Bytea,
+    }
+}
+
+diesel::table! {
     tx_senders (sender, tx_sequence_number, cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        tx_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    tx_senders_partition_0 (sender, tx_sequence_number, cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_sequence_number -> Int8,
         sender -> Bytea,
@@ -313,6 +370,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     epoch_peak_tps,
     epochs,
     events,
+    events_partition_0,
     move_call_metrics,
     move_calls,
     objects,
@@ -323,9 +381,14 @@ diesel::allow_tables_to_appear_in_same_query!(
     transactions,
     transactions_partition_0,
     tx_calls,
+    tx_calls_partition_0,
     tx_changed_objects,
+    tx_changed_objects_partition_0,
     tx_count_metrics,
     tx_input_objects,
+    tx_input_objects_partition_0,
     tx_recipients,
+    tx_recipients_partition_0,
     tx_senders,
+    tx_senders_partition_0,
 );

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -105,13 +105,19 @@ SET object_version = EXCLUDED.object_version,
 ";
 
 #[derive(Clone)]
+pub struct PgIndexerStoreConfig {
+    pub parallel_chunk_size: usize,
+    pub parallel_objects_chunk_size: usize,
+    pub epochs_to_keep: Option<u64>,
+}
+
+#[derive(Clone)]
 pub struct PgIndexerStore {
     blocking_cp: PgConnectionPool,
     module_cache: Arc<SyncModuleCache<IndexerStorePackageModuleResolver>>,
     metrics: IndexerMetrics,
-    parallel_chunk_size: usize,
-    parallel_objects_chunk_size: usize,
     partition_manager: PgPartitionManager,
+    config: PgIndexerStoreConfig,
 }
 
 impl PgIndexerStore {
@@ -127,16 +133,23 @@ impl PgIndexerStore {
             .unwrap_or_else(|_e| PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX.to_string())
             .parse::<usize>()
             .unwrap();
+        let epochs_to_keep = std::env::var("EPOCHS_TO_KEEP")
+            .map(|s| s.parse::<u64>().ok())
+            .unwrap_or_else(|_e| None);
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())
             .expect("Failed to initialize partition manager");
+        let config = PgIndexerStoreConfig {
+            parallel_chunk_size,
+            parallel_objects_chunk_size,
+            epochs_to_keep,
+        };
 
         Self {
             blocking_cp,
             module_cache,
             metrics,
-            parallel_chunk_size,
-            parallel_objects_chunk_size,
             partition_manager,
+            config,
         }
     }
 
@@ -764,12 +777,14 @@ impl PgIndexerStore {
                 let epoch_partition_data =
                     EpochPartitionData::compose_data(epoch_to_commit, last_epoch);
                 let table_partitions = self.partition_manager.get_table_partitions()?;
-                for (table, last_partition) in table_partitions {
+                for (table, (first_partition, last_partition)) in table_partitions {
                     let guard = self.metrics.advance_epoch_latency.start_timer();
-                    self.partition_manager.advance_table_epoch_partition(
+                    self.partition_manager.advance_and_prune_epoch_partition(
                         table.clone(),
+                        first_partition,
                         last_partition,
                         &epoch_partition_data,
+                        self.config.epochs_to_keep,
                     )?;
                     let elapsed = guard.stop_and_record();
                     info!(
@@ -887,7 +902,7 @@ impl IndexerStore for PgIndexerStore {
             .start_timer();
         let objects = make_final_list_of_objects_to_commit(object_changes);
         let len = objects.len();
-        let chunks = chunk!(objects, self.parallel_objects_chunk_size);
+        let chunks = chunk!(objects, self.config.parallel_objects_chunk_size);
         let futures = chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_objects_chunk(c)))
@@ -930,7 +945,7 @@ impl IndexerStore for PgIndexerStore {
             .start_timer();
 
         let len = objects.len();
-        let chunks = chunk!(objects, self.parallel_objects_chunk_size);
+        let chunks = chunk!(objects, self.config.parallel_objects_chunk_size);
         let futures = chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_objects_history_chunk(c)))
@@ -1000,7 +1015,7 @@ impl IndexerStore for PgIndexerStore {
             .start_timer();
         let len = transactions.len();
 
-        let chunks = chunk!(transactions, self.parallel_chunk_size);
+        let chunks = chunk!(transactions, self.config.parallel_chunk_size);
         let futures = chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_transactions_chunk(c)))
@@ -1030,7 +1045,7 @@ impl IndexerStore for PgIndexerStore {
             .metrics
             .checkpoint_db_commit_latency_events
             .start_timer();
-        let chunks = chunk!(events, self.parallel_chunk_size);
+        let chunks = chunk!(events, self.config.parallel_chunk_size);
         let futures = chunks
             .into_iter()
             .map(|c| self.spawn_blocking_task(move |this| this.persist_events_chunk(c)))
@@ -1080,7 +1095,7 @@ impl IndexerStore for PgIndexerStore {
             .metrics
             .checkpoint_db_commit_latency_tx_indices
             .start_timer();
-        let chunks = chunk!(indices, self.parallel_chunk_size);
+        let chunks = chunk!(indices, self.config.parallel_chunk_size);
 
         let futures = chunks
             .into_iter()

--- a/crates/sui-indexer/src/store/pg_partition_manager.rs
+++ b/crates/sui-indexer/src/store/pg_partition_manager.rs
@@ -92,7 +92,7 @@ impl PgPartitionManager {
         data: &EpochPartitionData,
     ) -> Result<(), IndexerError> {
         if data.next_epoch == 0 {
-            tracing::info!("Epoch 0 partition has been crate in migrations, skipped.");
+            tracing::info!("Epoch 0 partition has been created in the initial setup.");
             return Ok(());
         }
         if last_partition == data.last_epoch {


### PR DESCRIPTION
## Description 

title, also merged indexer store config for simplicity
stacked PR, will rebase when the stacked one is merged.

## Test Plan 

local run and make sure that partition advance and prune work as expected w/ and w/o setting epochs to keep
1. without setting it, indexer proceeds and does not prune
2. then I set EPOCHS_TO_KEEP=20, I saw

all older partitions was dropped at once
```
2024-03-13T16:24:14.834542Z  INFO commit_checkpoints{first=158236 last=158240}: sui_indexer::store::pg_partition_manager: Dropped epoch partition 0 for table tx_senders
2024-03-13T16:24:14.836281Z  INFO commit_checkpoints{first=158236 last=158240}: sui_indexer::store::pg_partition_manager: Dropped epoch partition 1 for table tx_senders
2024-03-13T16:24:14.837867Z  INFO commit_checkpoints{first=158236 last=158240}: sui_indexer::store::pg_partition_manager: Dropped epoch partition 2 for table tx_senders
2024-03-13T16:24:14.839214Z  INFO commit_checkpoints{first=158236 last=158240}: sui_indexer::store::pg_partition_manager: Dropped epoch partition 3 for table tx_senders
...
```
then each time indexer advances a new epoch, it will also drop an old one like below
```
2024-03-13T16:24:16.809498Z  INFO commit_checkpoints{first=159326 last=159330}: sui_indexer::store::pg_partition_manager: Dropped epoch partition 273 for table tx_input_objects
2024-03-13T16:24:16.809518Z  INFO commit_checkpoints{first=159326 last=159330}: sui_indexer::store::pg_indexer_store: Advanced epoch partition 292 for table tx_input_objects elapsed=0.003840167
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
