### PR TITLE
[RunWithRange] Work toward graceful shutdown

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1513,6 +1513,7 @@ impl SuiNode {
                 .await;
 
             if stop_condition == StopReason::RunWithRangeCondition {
+                SuiNode::shutdown(&self).await;
                 self.shutdown_channel_tx
                     .send(run_with_range)
                     .expect("RunWithRangeCondition met but failed to send shutdown message");
@@ -1694,6 +1695,12 @@ impl SuiNode {
             }
 
             info!("Reconfiguration finished");
+        }
+    }
+
+    async fn shutdown(&self) {
+        if let Some(validator_components) = &*self.validator_components.lock().await {
+            validator_components.consensus_manager.shutdown().await;
         }
     }
 


### PR DESCRIPTION
## Description 

So far this is the only thing I've identified that needs to be shutdown manually (due to being an async shutdown) rather than being handled by `Drop`. If there are others, please point them out

## Test Plan 

Existing `RunWithRange` simtests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
