### PR TITLE
Allow `sui client call` command to set gas price

### DIFF
--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -167,6 +167,7 @@ impl TestCaseImpl for CoinIndexTest {
                 args,
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -251,6 +252,7 @@ impl TestCaseImpl for CoinIndexTest {
                 ],
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -316,6 +318,7 @@ impl TestCaseImpl for CoinIndexTest {
                 args,
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -355,6 +358,7 @@ impl TestCaseImpl for CoinIndexTest {
                 ],
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -386,6 +390,7 @@ impl TestCaseImpl for CoinIndexTest {
                 ],
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -455,6 +460,7 @@ impl TestCaseImpl for CoinIndexTest {
                 ],
                 None,
                 rgp * 2_000_000,
+                None,
             )
             .await
             .unwrap();
@@ -701,6 +707,7 @@ async fn add_to_envelope(
             ],
             None,
             rgp * 2_000_000,
+            None,
         )
         .await
         .unwrap();

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -263,6 +263,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                     rpc_arguments,
                     gas,
                     *gas_budget,
+                    None,
                 )
                 .await?,
         )?)

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -89,6 +89,7 @@ impl TicTacToe {
                 ],
                 None, // The node will pick a gas object belong to the signer if not provided.
                 1000,
+                None,
             )
             .await?;
 
@@ -188,6 +189,7 @@ impl TicTacToe {
                     ],
                     None,
                     1000,
+                    None,
                 )
                 .await?;
 

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -259,6 +259,7 @@ impl TransactionBuilder {
         call_args: Vec<SuiJsonValue>,
         gas: Option<ObjectID>,
         gas_budget: u64,
+        gas_price: Option<u64>,
     ) -> anyhow::Result<TransactionData> {
         let mut builder = ProgrammableTransactionBuilder::new();
         self.single_move_call(
@@ -279,7 +280,11 @@ impl TransactionBuilder {
                 _ => None,
             })
             .collect();
-        let gas_price = self.0.get_reference_gas_price().await?;
+        let gas_price = if let Some(gas_price) = gas_price {
+            gas_price
+        } else {
+            self.0.get_reference_gas_price().await?
+        };
         let gas = self
             .select_gas(signer, gas, gas_budget, input_objects, gas_price)
             .await?;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -183,8 +183,8 @@ pub enum SuiClientCommands {
         #[clap(long)]
         gas_budget: u64,
 
-        /// Optional gas price for this call
-        #[clap(long)]
+        /// Optional gas price for this call. Currently use only for testing and not in production enviroments.
+        #[clap(hide = true)]
         gas_price: Option<u64>,
 
         /// Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -183,6 +183,10 @@ pub enum SuiClientCommands {
         #[clap(long)]
         gas_budget: u64,
 
+        /// Optional gas price for this call
+        #[clap(long)]
+        gas_price: Option<u64>,
+
         /// Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data
         /// (TransactionData) using base64 encoding, and print out the string <TX_BYTES>. The string can
         /// be used to execute transaction with `sui client execute-signed-tx --tx-bytes <TX_BYTES>`.
@@ -1128,12 +1132,14 @@ impl SuiClientCommands {
                 type_args,
                 gas,
                 gas_budget,
+                gas_price,
                 args,
                 serialize_unsigned_transaction,
                 serialize_signed_transaction,
             } => {
                 let tx_data = construct_move_call_transaction(
-                    package, &module, &function, type_args, gas, gas_budget, args, context,
+                    package, &module, &function, type_args, gas, gas_budget, gas_price, args,
+                    context,
                 )
                 .await?;
                 serialize_or_execute!(
@@ -2068,6 +2074,7 @@ async fn construct_move_call_transaction(
     type_args: Vec<TypeTag>,
     gas: Option<ObjectID>,
     gas_budget: u64,
+    gas_price: Option<u64>,
     args: Vec<SuiJsonValue>,
     context: &mut WalletContext,
 ) -> Result<TransactionData, anyhow::Error> {
@@ -2088,7 +2095,7 @@ async fn construct_move_call_transaction(
     client
         .transaction_builder()
         .move_call(
-            sender, package, module, function, type_args, args, gas, gas_budget,
+            sender, package, module, function, type_args, args, gas, gas_budget, gas_price,
         )
         .await
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -683,6 +683,8 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
 
     assert!(resp.is_err());
 
+    // Try a transfer with explicitly set gas price.
+    // It should fail due to that gas price is below RGP.
     let args = vec![
         SuiJsonValue::new(json!(created_obj))?,
         SuiJsonValue::new(json!(address2))?,

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -259,6 +259,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -606,6 +607,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args,
         gas: None,
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        gas_price: None,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
     }
@@ -645,6 +647,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        gas_price: None,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
     }
@@ -671,6 +674,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        gas_price: None,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
     }
@@ -678,6 +682,30 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     .await;
 
     assert!(resp.is_err());
+
+    let args = vec![
+        SuiJsonValue::new(json!(created_obj))?,
+        SuiJsonValue::new(json!(address2))?,
+    ];
+
+    let resp = SuiClientCommands::Call {
+        package,
+        module: "object_basics".to_string(),
+        function: "transfer".to_string(),
+        type_args: vec![],
+        args: args.to_vec(),
+        gas: Some(gas),
+        gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        gas_price: Some(1),
+        serialize_unsigned_transaction: false,
+        serialize_signed_transaction: false,
+    }
+    .execute(context)
+    .await;
+
+    assert!(resp.is_err());
+    let err_string = format!("{} ", resp.err().unwrap());
+    assert!(err_string.contains("Gas price 1 under reference gas price"));
 
     // FIXME: uncomment once we figure out what is going on with `resolve_and_type_check`
     // let err_string = format!("{} ", resp.err().unwrap());
@@ -699,6 +727,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        gas_price: None,
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
     }
@@ -845,6 +874,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -867,6 +897,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![SuiJsonValue::from_str(&shared_id.to_string()).unwrap()],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -952,6 +983,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -990,6 +1022,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![
             SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
             SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),
@@ -1078,6 +1111,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -1116,6 +1150,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![
             SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
             SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),
@@ -1204,6 +1239,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![],
         serialize_unsigned_transaction: false,
         serialize_signed_transaction: false,
@@ -1242,6 +1278,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         type_args: vec![],
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        gas_price: None,
         args: vec![
             SuiJsonValue::from_str(&parent.object_id.to_string()).unwrap(),
             SuiJsonValue::from_str(&child.object_id.to_string()).unwrap(),


### PR DESCRIPTION
## Description 

This PR only adds the `gas_price` option in the `sui client call` command.

I can add this option to other `sui client` command if there is a need for it.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
