### PR TITLE
[move-2024] index syntax write-up

### DIFF
--- a/external-crates/move/documentation/book/src/SUMMARY.md
+++ b/external-crates/move/documentation/book/src/SUMMARY.md
@@ -31,6 +31,10 @@
 - [Packages](packages.md)
 - [Unit Tests](unit-testing.md)
 
+## Advanced Concepts
+
+- [Index Syntax Methods](index-syntax.md)
+
 ## Reference
 
 - [Coding Conventions](coding-conventions.md)

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -9,7 +9,7 @@ easing usage across the language.
 
 ## Overview and Summary
 
-Consider a matrix type that uses a vector of vectors to represent its values. We can write a small
+Consider a `Matrix` type that uses a vector of vectors to represent its values. We can write a small
 library using `index` syntax annotations on its `borrow` functions as follows:
 
 ```

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -174,7 +174,7 @@ public fun borrow<Element>(v: &vector<Element>, i: u64): &Element {
 #### Mutable Accessor
 
 The mutable index syntax method is the dual of the immutable one, allowing for both read and write
-operations. It takes a mutable reference of the subject type and returns an mutable reference to
+operations. It takes a mutable reference of the subject type and returns a mutable reference to
 the element type. The `borrow_mut` function defined in `std::vector` is an example of this:
 
 ```move

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -1,9 +1,11 @@
 # Index Syntax
 
-Index syntax in Move defines a family of operations that allow users to write custom index accessors
-for their datatypes. These definitions allow programmers to use index syntax, such as accessing
-a matrix element as `m[i,j]`, all based on user definitions. These definitions are bespoke per-type
-and available implicitly for any programmer using the type, easing usage across the language.
+Syntax attributes establish a way to allow programmers to define operations for syntax-like usage in
+Move. Our first syntax method, `index`, allows programmers to define a group of operations that
+may be used as custom index accessors for their datatypes. These definitions allow programmers to
+use index syntax, such as accessing a matrix element as `m[i,j]`, all based on user definitions.
+These definitions are bespoke per-type and available implicitly for any programmer using the type,
+easing usage across the language.
 
 ## Overview and Summary
 

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -85,7 +85,7 @@ let m_0_0 = &mut mat[0, 0];
     // translates to matrix::borrow_mut(&mut mat, 0, 0)
 ``
 
-Index expressions may also be intermixed with field accesses:
+Index expressions might also be intermixed with field accesses:
 
 ```move
 public struct V { v: vector<u64> }

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -98,11 +98,11 @@ fun borrow_first(input: &Vs): &u64 {
 }
 ```
 
-### Index functions take flexible arguments
+### Index Functions Take Flexible Arguments
 
 Note that, aside from the definition and type limitations described in the rest of this chapter,
-there are no restrictions on the values that may be passed as index parameters, allowing for
-intricate programmatic behavior when using index syntax. For example, a data structure might wish to
+there are no restrictions on the values that can be passed as index parameters, allowing for
+intricate programmatic behavior when using index syntax. For example, a data structure might 
 take a default value if the index is out of bounds:
 
 ```
@@ -141,7 +141,7 @@ adhere to the following rules:
 1. The `#[syntax(index)]` attribute is added to the designated functions defined in the same module
    as the subject type.
 2. The designated functions have `public` visibility.
-3. The functions take a reference type as its "subject" type (its first argument) and returns a
+3. The functions take a reference type as its subject type (its first argument) and returns a
    matching references type (`mut` if the subject was `mut`).
 4. Each type has only a single mutable and single immutable definition.
 5. Immutable and mutable versions have type agreement:
@@ -150,7 +150,7 @@ adhere to the following rules:
     - Type parameters, if present, have identical constraints between both versions.
     - All parameters beyond the subject type are identical.
 
-These are described in greater detail, with additional examples, below.
+The following content and additional examples describe these rules in greater detail.
 
 ### Declaration
 
@@ -160,7 +160,7 @@ compiler that the function is an index accessor for the specified type.
 
 #### Immutable Accessor
 
-The immutable index syntax method is defined for read-only accesses. It takes an immutable reference
+The immutable index syntax method is defined for read-only access. It takes an immutable reference
 of the subject type and returns an immutable reference to the element type. The `borrow` function
 defined in `std::vector` is an example of this:
 
@@ -292,7 +292,7 @@ public fun borrow_mut<T, U>(s: &mut Matrix<U>, i: u64, j: u32):  &mut U { ... }
     // ERROR! `j` is a different type
 ```
 
-Again, the gaol here is to make the usage across the immutable and mutable versions consistent. This
+Again, the goal here is to make the usage across the immutable and mutable versions consistent. This
 allows index syntax methods to work without changing out the behavior or constraints based on
 mutable versus immutable usage, ultimately ensuring a consistent interface to program against.
 

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -69,7 +69,7 @@ let mat = matrix::make_matrix(...);
 let m_0_0 = mat[0, 0];
 ```
 
-During compilation, the compiler will translate these into the appropriate function invocations
+During compilation, the compiler translates these into the appropriate function invocations
 based on the position and mutable usage of the expression:
 
 ```move

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -143,10 +143,10 @@ your definitions adhere to the following rules:
 1. The `#[syntax(index)]` attribute is added to the designated functions defined in the same module
    as the subject type.
 1. The designated functions have `public` visibility.
-3. The functions take a reference type as its subject type (its first argument) and returns a
+1. The functions take a reference type as its subject type (its first argument) and returns a
    matching references type (`mut` if the subject was `mut`).
-4. Each type has only a single mutable and single immutable definition.
-5. Immutable and mutable versions have type agreement:
+1. Each type has only a single mutable and single immutable definition.
+1. Immutable and mutable versions have type agreement:
     - The subject types match, differing only in mutability.
     - The return types match the mutability of their subject types.
     - Type parameters, if present, have identical constraints between both versions.

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -67,7 +67,7 @@ adhere to the following rules:
 2. The designated functions have `public` visibility.
 3. The functions take a reference type as its "subject" type (its first argument) and returns a
    matching references type (`mut` if the subject was `mut`).
-4. Each type has only a single mutable and single immuable definition.
+4. Each type has only a single mutable and single immutable definition.
 5. Immutable and mutable versions have type agreement:
     - The subject types match, differing only in mutability.
     - The return types match the mutability of their subject types.
@@ -97,8 +97,8 @@ public fun borrow<Element>(v: &vector<Element>, i: u64): &Element {
 
 ### Mutable Accessor
 
-The mutable index syntax method is the dual of the immuttable one, allowing for both read and write
-opreations. It takes a mutable reference of the subject type and returns an mutable reference to
+The mutable index syntax method is the dual of the immutable one, allowing for both read and write
+operations. It takes a mutable reference of the subject type and returns an mutable reference to
 the element type. The `borrow_mut` function defined in `std::vector` is an example of this:
 
 ```move

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -1,16 +1,18 @@
 # Index Syntax
 
-Syntax attributes establish a way to allow programmers to define operations for syntax-like usage in
-Move. Our first syntax method, `index`, allows programmers to define a group of operations that
-can be used as custom index accessors for their datatypes. These definitions allow programmers to
-use index syntax, such as accessing a matrix element as `m[i,j]`, all based on user definitions.
-These definitions are bespoke per-type and available implicitly for any programmer using the type,
-easing usage across the language.
+Move provides syntax attributes to allow you to define operations that look and feel like native
+move code, lowering these operations into your user-provided definitions.
+
+Our first syntax method, `index`, allows you to define a group of operations that can be used as
+custom index accessors for your datatypes, such as accessing a matrix element as `m[i,j]`, by
+annotating functions that should be used for these index operations. Moreover, these definitions are
+bespoke per-type and available implicitly for any programmer using your type.
 
 ## Overview and Summary
 
-Consider a `Matrix` type that uses a vector of vectors to represent its values. We can write a small
-library using `index` syntax annotations on its `borrow` functions as follows:
+To start, consider a `Matrix` type that uses a vector of vectors to represent its values. You can
+write a small library using `index` syntax annotations on the `borrow` and `borrow_mut` functions as
+follows:
 
 ```
 module matrix {
@@ -61,8 +63,8 @@ while (i < 3) {
 
 ## Usage
 
-As the example indicates, if a datatype defines an index syntax function, it may be used by
-invoking index syntax on a value of that type:
+As the example indicates, if you define a datatype and an asoociated an index syntax method, anyone
+may invoke that method by writin invoking index syntax on a value of that type:
 
 ```move
 let mat = matrix::make_matrix(...);
@@ -85,7 +87,7 @@ let m_0_0 = &mut mat[0, 0];
     // translates to matrix::borrow_mut(&mut mat, 0, 0)
 ``
 
-Index expressions might also be intermixed with field accesses:
+You can also intermix index expressions with field accesses:
 
 ```move
 public struct V { v: vector<u64> }
@@ -101,9 +103,9 @@ fun borrow_first(input: &Vs): &u64 {
 ### Index Functions Take Flexible Arguments
 
 Note that, aside from the definition and type limitations described in the rest of this chapter,
-there are no restrictions on the values that can be passed as index parameters, allowing for
-intricate programmatic behavior when using index syntax. For example, a data structure might 
-take a default value if the index is out of bounds:
+Move places no restrictions on the values your index syntax method takes as parameters. This allows
+you to implement intricate programmatic behavior when defining index syntax, such as a data
+structure that take a default value if the index is out of bounds:
 
 ```
 #[syntax(index)]
@@ -121,7 +123,7 @@ public fun borrow_or_set<Key: copy, Value: drop>(
 }
 ```
 
-Indexing into `MTable` would then require the user provide a default value:
+Now, when you index into `MTable`, you must also provide a default value:
 
 ```
 let string_key: String = ...;
@@ -129,14 +131,14 @@ let mut table: MTable<String, u64> = m_table::make_table();
 let entry: &mut u64 = &mut table[string_key, 0];
 ```
 
-This sort of extensible power allows developers to write precise index interfaces for their types,
+This sort of extensible power allows you to write precise index interfaces for your types,
 concretely enforcing bespoke behavior.
 
 
 ## Defining Index Syntax Functions
 
-This powerful syntax form allows for all user-defined datatypes to behave in this way, assuming they
-adhere to the following rules:
+This powerful syntax form allows all of your user-defined datatypes to behave in this way, assuming
+your definitions adhere to the following rules:
 
 1. The `#[syntax(index)]` attribute is added to the designated functions defined in the same module
    as the subject type.
@@ -206,7 +208,7 @@ public fun borrow_matrix<T>(s: &Matrix<T>, i: u64, j: u64): &T { ... }
     // for its immutable index syntax method
 ```
 
-This ensures that the user can always tell which method is being invoked, without the need to
+This ensures that you can always tell which method is being invoked, without the need to
 inspect type instantiation.
 
 ### Type Constraints
@@ -214,7 +216,7 @@ inspect type instantiation.
 By default, an index syntax method has the following type constraints:
 
 **Its subject type (first argument) must be a reference to a single type defined in the same module
-as the marked function.** This means that we cannot define index syntax methods for tuples,
+as the marked function.** This means that you cannot define index syntax methods for tuples,
 type parameters, or values:
 
 ```move

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -1,0 +1,219 @@
+# Index Syntax
+
+Index syntax in Move defines a family of operations that allow users to write custom index accessors
+for their datatypes. These definitions allow programmers to use index syntax, such as accessing
+a matrix element as `m[i,j]`, all based on user definitions. These definitions are bespoke per-type
+and available implicitly for any programmer using the type, easing usage across the language.
+
+## Overview and Summary
+
+Consider a matrix type that uses a vector of vectors to represent its values. We can write a small
+library using `index` syntax annotations on its `borrow` functions as follows:
+
+```
+module matrix {
+
+    public struct Matrix<T> { v: vector<vector<T>> }
+
+    #[syntax(index)]
+    public fun borrow<T>(s: &Matrix<T>, i: u64, j: u64):  &T {
+        borrow(borrow(s.v, i), j)
+    }
+
+    #[syntax(index)]
+    public fun borrow_mut<T>(s: &mut Matrix<T>, i: u64, j: u64):  &mut T {
+        borrow_mut(borrow_mut(s.v, i), j)
+    }
+
+    public fun make_matrix<T>(v: vector<vector<T>>):  Matrix<T> {
+        Matrix { v }
+    }
+
+}
+```
+
+Now anyone using this Matrix type has access to index syntax for it:
+
+```
+let v0 = vector<u64>[1, 0, 0];
+let v1 = vector<u64>[0, 1, 0];
+let v2 = vector<u64>[0, 0, 1];
+let v = vector<vector<u64>>[v0, v1, v2];
+let mut m = matrix::make_matrix(v);
+
+let mut i = 0;
+while (i < 3) {
+    let mut j = 0;
+    while (j < 3) {
+        if (i == j) {
+            assert!(m[i, j] == 1, i);
+        } else {
+            assert!(m[i, j] == 0, i + 10);
+        };
+        *(&mut m[i,j]) = 2;
+        j = j + 1;
+    };
+    i = i + 1;
+}
+```
+
+This powerful syntax form allows for all user-defined datatypes to behave in this way, assuming they
+adhere to the following rules:
+
+1. The `#[syntax(index)]` attribute is added to the designated functions defined in the same module
+   as the subject type.
+2. The designated functions have `public` visibility.
+3. The functions take a reference type as its "subject" type (its first argument) and returns a
+   matching references type (`mut` if the subject was `mut`).
+4. Each type has only a single mutable and single immuable definition.
+5. Immutable and mutable versions have type agreement:
+    - The subject types match, differing only in mutability.
+    - The return types match the mutability of their subject types.
+    - Type parameters, if present, have identical constraints between both versions.
+    - All parameters beyond the subject type are identical.
+
+These are described in greater detail, with additional examples, below.
+
+## Declaration
+
+To declare an index syntax method, you add the `#[syntax(index)]` attribute above the relevant
+function definition in the same module as the subject type's definition. This signals to the
+compiler that the function is an index accessor for the specified type.
+
+### Immutable Accessor
+
+The immutable index syntax method is defined for read-only accesses. It takes an immutable reference
+of the subject type and returns an immutable reference to the element type. The `borrow` function
+defined in `std::vector` is an example of this:
+
+```move
+#[syntax(index)]
+public fun borrow<Element>(v: &vector<Element>, i: u64): &Element {
+    // implementation
+}
+```
+
+### Mutable Accessor
+
+The mutable index syntax method is the dual of the immuttable one, allowing for both read and write
+opreations. It takes a mutable reference of the subject type and returns an mutable reference to
+the element type. The `borrow_mut` function defined in `std::vector` is an example of this:
+
+```move
+#[syntax(index)]
+public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element {
+    // implementation
+}
+```
+
+### Visibility
+
+To ensure that indexing functions are available anywhere the type is used, all index syntax methods
+must have public visibility. This ensures ergonomic usage of indexing across modules and packages in
+Move.
+
+### No Duplicates
+
+In addition to the above requirements, we restrict each subject base type to defining a single
+index syntax method for immutable references and a single index syntax method for mutable
+references. For example, you may not define a specialized version for a polymorphic type:
+
+```move
+#[syntax(index)]
+public fun borrow_matrix_u64(s: &Matrix<u64>, i: u64, j: u64): &u64 { ... }
+
+#[syntax(index)]
+public fun borrow_matrix<T>(s: &Matrix<T>, i: u64, j: u64): &T { ... }
+    // ERROR! Matrix already has a definition
+    // for its immutable index syntax method
+```
+
+This ensures that the user can always tell which method is being invoked, without the need to
+inspect type instantiation.
+
+## Type Constraints
+
+By default, an index syntax method has the following type constraints:
+
+**Its subject type (first argument) must be a reference to a single type defined in the same module
+as the marked function.** This means that we cannot define index syntax methods for tuples,
+type parameters, or values:
+
+```move
+#[syntax(index)]
+public fun borrow_fst(x: &(u64, u64), ...): &u64 { ... }
+    // ERROR because the subject type is a tuple
+
+#[syntax(index)]
+public fun borrow_tyarg<T>(x: &T, ...): &T { ... }
+    // ERROR because the subject type is a type parameter
+
+#[syntax(index)]
+public fun borrow_value(x: Matrix<u64>, ...): &u64 { ... }
+    // ERROR because x is not a reference
+```
+
+**The subject type must match mutability with the return type.** This restriction allows users to
+clarify the expected behavior when they borrow an indexed expression as `&vec[i]` versus `&mut
+vec[i]`. The Move compiler uses the mutability marker to determine which borrow form to call to
+produce a reference of the appropriate mutability. As a result, we disallow index syntax methods
+whose subject and return mutability differ:
+
+```move
+#[syntax(index)]
+public fun borrow_imm(x: &mut Matrix<u64>, ...): &u64 { ... }
+    // ERROR! incompatible mutability
+
+```
+
+## Type Compatibility
+
+When defining an immutable and mutable index syntax method pair, they are subject to a number of
+compatibility constraints:
+
+1. They must take the same number of type parameters, those type parameters must have the same
+   constraints.
+5. Type parameters must be used the same _by position_, not name.
+2. Their subject types must match exactly except for the mutability.
+3. Their return types must match exactly except for the mutability.
+4. All other parameter types must match exactly.
+These constraints are to ensure that index syntax behaves identically
+regardless of being in a mutable or immutable position.
+
+To illustrate some of these errors, recall the Matrix definition above:
+
+```move
+#[syntax(index)]
+public fun borrow<T>(s: &Matrix<T>, i: u64, j: u64):  &T {
+    borrow(borrow(s.v, i), j)
+}
+```
+
+All of the following are type-incompatible definitions of the mutable version:
+
+```move
+#[syntax(index)]
+public fun borrow_mut<T: drop>(s: &mut Matrix<T>, i: u64, j: u64):  &mut T { ... }
+    // ERROR! `T` has `drop` here, but no in the immutable version
+
+#[syntax(index)]
+public fun borrow_mut(s: &mut Matrix<u64>, i: u64, j: u64):  &mut u64 { ... }
+    // ERROR! This takes a different number of type parameters
+
+#[syntax(index)]
+public fun borrow_mut<T, U>(s: &mut Matrix<U>, i: u64, j: u64):  &mut U { ... }
+    // ERROR! This takes a different number of type parameters
+
+#[syntax(index)]
+public fun borrow_mut<T, U>(s: &mut Matrix<U>, i_j: (u64, u64)):  &mut U { ... }
+    // ERROR! This takes a different number of arguments
+
+#[syntax(index)]
+public fun borrow_mut<T, U>(s: &mut Matrix<U>, i: u64, j: u32):  &mut U { ... }
+    // ERROR! `j` is a different type
+```
+
+Again, the gaol here is to make the usage across the immutable and mutable versions consistent. This
+allows index syntax methods to work without changing the behavior or constraints out based on
+mutable versus immutable usage, ultimately ensuring a consistent interface to program against.
+

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -34,7 +34,7 @@ module matrix {
 }
 ```
 
-Now anyone using this Matrix type has access to index syntax for it:
+Now anyone using this `Matrix` type has access to index syntax for it:
 
 ```
 let v0 = vector<u64>[1, 0, 0];

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -63,8 +63,8 @@ while (i < 3) {
 
 ## Usage
 
-As the example indicates, if you define a datatype and an asoociated an index syntax method, anyone
-may invoke that method by writin invoking index syntax on a value of that type:
+As the example indicates, if you define a datatype and an associated index syntax method, anyone
+can invoke that method by writing index syntax on a value of that type:
 
 ```move
 let mat = matrix::make_matrix(...);
@@ -105,7 +105,7 @@ fun borrow_first(input: &Vs): &u64 {
 Note that, aside from the definition and type limitations described in the rest of this chapter,
 Move places no restrictions on the values your index syntax method takes as parameters. This allows
 you to implement intricate programmatic behavior when defining index syntax, such as a data
-structure that take a default value if the index is out of bounds:
+structure that takes a default value if the index is out of bounds:
 
 ```
 #[syntax(index)]
@@ -142,7 +142,7 @@ your definitions adhere to the following rules:
 
 1. The `#[syntax(index)]` attribute is added to the designated functions defined in the same module
    as the subject type.
-2. The designated functions have `public` visibility.
+1. The designated functions have `public` visibility.
 3. The functions take a reference type as its subject type (its first argument) and returns a
    matching references type (`mut` if the subject was `mut`).
 4. Each type has only a single mutable and single immutable definition.
@@ -156,7 +156,7 @@ The following content and additional examples describe these rules in greater de
 
 ### Declaration
 
-To declare an index syntax method, you add the `#[syntax(index)]` attribute above the relevant
+To declare an index syntax method, add the `#[syntax(index)]` attribute above the relevant
 function definition in the same module as the subject type's definition. This signals to the
 compiler that the function is an index accessor for the specified type.
 
@@ -233,8 +233,8 @@ public fun borrow_value(x: Matrix<u64>, ...): &u64 { ... }
     // ERROR because x is not a reference
 ```
 
-**The subject type must match mutability with the return type.** This restriction allows users to
-clarify the expected behavior when they borrow an indexed expression as `&vec[i]` versus `&mut
+**The subject type must match mutability with the return type.** This restriction allows you to
+clarify the expected behavior when borrowing an indexed expression as `&vec[i]` versus `&mut
 vec[i]`. The Move compiler uses the mutability marker to determine which borrow form to call to
 produce a reference of the appropriate mutability. As a result, we disallow index syntax methods
 whose subject and return mutability differ:

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -251,10 +251,11 @@ compatibility constraints:
 
 1. They must take the same number of type parameters, those type parameters must have the same
    constraints.
-5. Type parameters must be used the same _by position_, not name.
-2. Their subject types must match exactly except for the mutability.
-3. Their return types must match exactly except for the mutability.
-4. All other parameter types must match exactly.
+1. Type parameters must be used the same _by position_, not name.
+1. Their subject types must match exactly except for the mutability.
+1. Their return types must match exactly except for the mutability.
+1. All other parameter types must match exactly.
+
 These constraints are to ensure that index syntax behaves identically
 regardless of being in a mutable or immutable position.
 

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -2,7 +2,7 @@
 
 Syntax attributes establish a way to allow programmers to define operations for syntax-like usage in
 Move. Our first syntax method, `index`, allows programmers to define a group of operations that
-may be used as custom index accessors for their datatypes. These definitions allow programmers to
+can be used as custom index accessors for their datatypes. These definitions allow programmers to
 use index syntax, such as accessing a matrix element as `m[i,j]`, all based on user definitions.
 These definitions are bespoke per-type and available implicitly for any programmer using the type,
 easing usage across the language.

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -292,6 +292,6 @@ public fun borrow_mut<T, U>(s: &mut Matrix<U>, i: u64, j: u32):  &mut U { ... }
 ```
 
 Again, the gaol here is to make the usage across the immutable and mutable versions consistent. This
-allows index syntax methods to work without changing the behavior or constraints out based on
+allows index syntax methods to work without changing out the behavior or constraints based on
 mutable versus immutable usage, ultimately ensuring a consistent interface to program against.
 

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -258,7 +258,7 @@ compatibility constraints:
 These constraints are to ensure that index syntax behaves identically
 regardless of being in a mutable or immutable position.
 
-To illustrate some of these errors, recall the Matrix definition above:
+To illustrate some of these errors, recall the previous `Matrix` definition:
 
 ```move
 #[syntax(index)]

--- a/external-crates/move/documentation/book/src/index-syntax.md
+++ b/external-crates/move/documentation/book/src/index-syntax.md
@@ -194,7 +194,7 @@ Move.
 
 In addition to the above requirements, we restrict each subject base type to defining a single
 index syntax method for immutable references and a single index syntax method for mutable
-references. For example, you may not define a specialized version for a polymorphic type:
+references. For example, you cannot define a specialized version for a polymorphic type:
 
 ```move
 #[syntax(index)]


### PR DESCRIPTION
## Description 

Add a write-up for index syntax methods for Move 2024 book

## Test Plan 

👁️ 🔴 👁️  

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
