### PR TITLE
[Consensus] start service with unspecified IP

### DIFF
--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -1,9 +1,18 @@
 name: Mysticeti
 
 on:
+  # Allow triggering the workflow manually.
   workflow_dispatch:
+    inputs:
+      sui_repo_ref:
+        description: "Branch / commit to test"
+        type: string
+        required: true
+        default: main
+
+  # Triggers the workflow every day at 05:00 UTC.
   schedule:
-    - cron: '0 5 * * *' # everyday 05:00
+    - cron: '0 5 * * *'
 
 env:
   # Enable Mysticeti in tests.
@@ -52,6 +61,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
@@ -121,7 +132,7 @@ jobs:
           swap-size-gb: 256
       - name: cargo simtest
         run: |
-          scripts/simtest/cargo-simtest simtest
+          scripts/simtest/cargo-simtest simtest --no-fail-fast
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -178,7 +178,9 @@ where
             synchronizer: synchronizer.clone(),
             dag_state,
         });
-        network_manager.install_service(network_keypair, network_service);
+        network_manager
+            .install_service(network_keypair, network_service)
+            .await;
 
         Self {
             context,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -59,7 +59,7 @@ where
     fn client(&self) -> Arc<Self::Client>;
 
     /// Installs network service.
-    fn install_service(&self, network_keypair: NetworkKeyPair, service: Arc<S>);
+    async fn install_service(&self, network_keypair: NetworkKeyPair, service: Arc<S>);
 
     /// Stops the network service.
     async fn stop(&self);

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -18,18 +18,6 @@ enum TestStore {
 }
 
 impl TestStore {
-    fn new_rocksdb_store() -> Self {
-        let temp_dir = TempDir::new().unwrap();
-        TestStore::RocksDB((
-            RocksDBStore::new(temp_dir.path().to_str().unwrap()),
-            temp_dir,
-        ))
-    }
-
-    fn new_mem_store() -> Self {
-        TestStore::Mem(MemStore::new())
-    }
-
     fn store(&self) -> &dyn Store {
         match self {
             TestStore::RocksDB((store, _)) => store,
@@ -38,10 +26,22 @@ impl TestStore {
     }
 }
 
+fn new_rocksdb_teststore() -> TestStore {
+    let temp_dir = TempDir::new().unwrap();
+    TestStore::RocksDB((
+        RocksDBStore::new(temp_dir.path().to_str().unwrap()),
+        temp_dir,
+    ))
+}
+
+fn new_mem_teststore() -> TestStore {
+    TestStore::Mem(MemStore::new())
+}
+
 #[rstest]
 #[tokio::test]
 async fn read_and_contain_blocks(
-    #[values(TestStore::new_rocksdb_store(), TestStore::new_mem_store())] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
 
@@ -106,7 +106,7 @@ async fn read_and_contain_blocks(
 #[rstest]
 #[tokio::test]
 async fn scan_blocks(
-    #[values(TestStore::new_rocksdb_store(), TestStore::new_mem_store())] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
 
@@ -189,7 +189,7 @@ async fn scan_blocks(
 #[rstest]
 #[tokio::test]
 async fn read_and_scan_commits(
-    #[values(TestStore::new_rocksdb_store(), TestStore::new_mem_store())] test_store: TestStore,
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
 

--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -4,7 +4,7 @@
 use eyre::{eyre, Result};
 use std::{
     borrow::Cow,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
 pub use ::multiaddr::Error;
@@ -106,9 +106,24 @@ impl Multiaddr {
         let mut new_address = ::multiaddr::Multiaddr::empty();
         for component in &self.0 {
             match component {
-                multiaddr::Protocol::Ip4(_) => new_address.push(multiaddr::Protocol::Ip4(
-                    std::net::Ipv4Addr::new(0, 0, 0, 0),
-                )),
+                multiaddr::Protocol::Ip4(_) => {
+                    new_address.push(multiaddr::Protocol::Ip4(Ipv4Addr::UNSPECIFIED))
+                }
+                c => new_address.push(c),
+            }
+        }
+        Self(new_address)
+    }
+
+    /// Set the ip address to `127.0.0.1`. For instance, it converts the following address
+    /// `/ip4/155.138.174.208/tcp/1500/http` into `/ip4/127.0.0.1/tcp/1500/http`.
+    pub fn localhost_ip_multi_address(&self) -> Self {
+        let mut new_address = ::multiaddr::Multiaddr::empty();
+        for component in &self.0 {
+            match component {
+                multiaddr::Protocol::Ip4(_) => {
+                    new_address.push(multiaddr::Protocol::Ip4(Ipv4Addr::LOCALHOST))
+                }
                 c => new_address.push(c),
             }
         }

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -72,7 +72,7 @@ use tokio::{
     sync::{broadcast, mpsc, watch},
     task::{AbortHandle, JoinSet},
 };
-use tracing::{debug, error, info, instrument, trace};
+use tracing::{debug, info, instrument, trace, warn};
 
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/sui.StateSync.rs"));
@@ -1144,12 +1144,12 @@ async fn sync_checkpoint_contents_from_archive<S>(
                     )
                     .await
                 {
-                    error!("State sync from archive failed with error: {:?}", err);
+                    warn!("State sync from archive failed with error: {:?}", err);
                 } else {
                     info!("State sync from archive is complete. Checkpoints downloaded = {:?}, Txns downloaded = {:?}", checkpoint_counter.load(Ordering::Relaxed), txn_counter.load(Ordering::Relaxed));
                 }
             } else {
-                error!("Failed to find an archive reader to complete the state sync request");
+                warn!("Failed to find an archive reader to complete the state sync request");
             }
         }
         tokio::time::sleep(Duration::from_secs(5)).await;

--- a/crates/telemetry-subscribers/tests/reload.rs
+++ b/crates/telemetry-subscribers/tests/reload.rs
@@ -9,6 +9,11 @@ use tracing::{debug, info};
 
 #[test]
 fn reload() {
+    if std::env::var("RUST_LOG").is_ok() {
+        println!("RUST_LOG is set, this test may fail to capture logs. Skipping ...");
+        return;
+    }
+
     let log_file_prefix = "out.log";
     let mut config = TelemetryConfig::new();
     config.log_file = Some(log_file_prefix.to_owned());

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -267,9 +267,11 @@ impl TestCluster {
             .fullnode_handle
             .sui_node
             .with(|node| node.subscribe_to_epoch_change());
-        timeout(timeout_dur, async move {
+        let mut state = Option::None;
+        timeout(timeout_dur, async {
             while let Ok(system_state) = epoch_rx.recv().await {
                 info!("received epoch {}", system_state.epoch());
+                state = Some(system_state.clone());
                 match target_epoch {
                     Some(target_epoch) if system_state.epoch() >= target_epoch => {
                         return system_state;
@@ -284,6 +286,9 @@ impl TestCluster {
         })
         .await
         .unwrap_or_else(|_| {
+            if let Some(state) = state {
+                panic!("Timed out waiting for cluster to reach epoch {target_epoch:?}. Current epoch: {}", state.epoch());
+            }
             panic!("Timed out waiting for cluster to target epoch {target_epoch:?}")
         })
     }


### PR DESCRIPTION
## Description 

Receive the network service IP from the host, instead of specifying it when starting the service. Among other reasons, this helps with binding to the same IP and port after stopping the service in sim tests.

Also,
- Allow the Mysticeti workflow to run from a branch or commit.
- Use `warn` for not finding archive reader.
- Avoid spurious lint issues when running simtest.

## Test Plan 

CI
https://github.com/MystenLabs/sui/actions/runs/8276357969/job/22644782845

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
