### PR TITLE
[Consensus 2.0] acknowledge transaction on submission

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -14,6 +14,7 @@ use tokio::sync::{broadcast, watch};
 use tracing::warn;
 
 use crate::stake_aggregator::{QuorumThreshold, StakeAggregator};
+use crate::transaction::TransactionGuard;
 use crate::{
     block::{
         timestamp_utc_ms, Block, BlockAPI, BlockRef, BlockTimestampMs, BlockV1, Round, SignedBlock,
@@ -289,6 +290,11 @@ impl Core {
 
         // Update internal state.
         self.last_proposed_block = verified_block.clone();
+
+        // Now acknowledge the transactions for their inclusion to block
+        transaction_guards
+            .into_iter()
+            .for_each(TransactionGuard::acknowledge);
 
         tracing::info!("Created block {}", verified_block);
 

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -8,6 +8,7 @@ use mysten_metrics::metered_channel::channel_with_total;
 use sui_protocol_config::ProtocolConfig;
 use tap::tap::TapFallible;
 use thiserror::Error;
+use tokio::sync::oneshot;
 use tracing::error;
 
 use crate::block::Transaction;
@@ -18,19 +19,27 @@ const MAX_PENDING_TRANSACTIONS: usize = 2_000;
 
 const MAX_CONSUMED_TRANSACTIONS_PER_REQUEST: u64 = 5_000;
 
+/// The guard acts as an acknowledgment mechanism for the inclusion of the transaction to a block.
+/// When the guard is dropped then the transaction has been acknowledged.
+pub(crate) struct TransactionGuard {
+    pub transaction: Transaction,
+    // implicitly dropping the sender acknowledges the transaction
+    _included_in_block_ack: oneshot::Sender<()>,
+}
+
 /// The TransactionConsumer is responsible for fetching the next transactions to be included for the block proposals.
 /// The transactions are submitted to a channel which is shared between the TransactionConsumer and the TransactionClient
 /// and are pulled every time the `next` method is called.
 pub(crate) struct TransactionConsumer {
-    tx_receiver: metered_channel::Receiver<Transaction>,
+    tx_receiver: metered_channel::Receiver<TransactionGuard>,
     max_consumed_bytes_per_request: u64,
     max_consumed_transactions_per_request: u64,
-    pending_transaction: Option<Transaction>,
+    pending_transaction: Option<TransactionGuard>,
 }
 
 impl TransactionConsumer {
     pub(crate) fn new(
-        tx_receiver: metered_channel::Receiver<Transaction>,
+        tx_receiver: metered_channel::Receiver<TransactionGuard>,
         context: Arc<Context>,
         max_consumed_transactions_per_request: Option<u64>,
     ) -> Self {
@@ -47,26 +56,26 @@ impl TransactionConsumer {
 
     // Attempts to fetch the next transactions that have been submitted for sequence. Also a `max_consumed_bytes_per_request` parameter
     // is given in order to ensure up to `max_consumed_bytes_per_request` bytes of transactions are retrieved.
-    pub(crate) fn next(&mut self) -> Vec<Transaction> {
+    pub(crate) fn next(&mut self) -> Vec<TransactionGuard> {
         let mut transactions = Vec::new();
         let mut total_size: usize = 0;
 
-        if let Some(transaction) = self.pending_transaction.take() {
+        if let Some(t) = self.pending_transaction.take() {
             // Here we assume that a transaction can always fit in `max_fetched_bytes_per_request`
-            total_size += transaction.data().len();
-            transactions.push(transaction);
+            total_size += t.transaction.data().len();
+            transactions.push(t);
         }
 
-        while let Ok(transaction) = self.tx_receiver.try_recv() {
-            total_size += transaction.data().len();
+        while let Ok(t) = self.tx_receiver.try_recv() {
+            total_size += t.transaction.data().len();
 
             // If we went over the max size with this transaction, just cache it for the next pull.
             if total_size as u64 > self.max_consumed_bytes_per_request {
-                self.pending_transaction = Some(transaction);
+                self.pending_transaction = Some(t);
                 break;
             }
 
-            transactions.push(transaction);
+            transactions.push(t);
 
             if transactions.len() as u64 >= self.max_consumed_transactions_per_request {
                 break;
@@ -78,7 +87,7 @@ impl TransactionConsumer {
 
 #[derive(Clone)]
 pub struct TransactionClient {
-    sender: metered_channel::Sender<Transaction>,
+    sender: metered_channel::Sender<TransactionGuard>,
     max_transaction_size: u64,
 }
 
@@ -92,7 +101,9 @@ pub enum ClientError {
 }
 
 impl TransactionClient {
-    pub(crate) fn new(context: Arc<Context>) -> (Self, metered_channel::Receiver<Transaction>) {
+    pub(crate) fn new(
+        context: Arc<Context>,
+    ) -> (Self, metered_channel::Receiver<TransactionGuard>) {
         let (sender, receiver) = channel_with_total(
             MAX_PENDING_TRANSACTIONS,
             &context.metrics.channel_metrics.tx_transactions_submit,
@@ -110,20 +121,40 @@ impl TransactionClient {
         )
     }
 
-    // Submits a transaction to be sequenced. The transaction length gets evaluated and rejected from consensus if too big.
-    // That shouldn't be the common case as sizes should be aligned between consensus and client.
+    /// Submits a transaction to be sequenced. The method returns when the transaction has been successfully
+    /// included to the next proposed block.
     pub async fn submit(&self, transaction: Vec<u8>) -> Result<(), ClientError> {
+        let included_in_block = self.submit_no_wait(transaction).await?;
+        included_in_block.await.ok();
+        Ok(())
+    }
+
+    /// Submits a transaction to be sequenced. The transaction length gets evaluated and rejected from consensus if too big.
+    /// That shouldn't be the common case as sizes should be aligned between consensus and client. The method returns
+    /// a receiver to wait on until the transactions has been included in the next block to get proposed. The consumer should
+    /// not care about the receiver result and just wait on it to consider as inclusion acknowledgement.
+    pub(crate) async fn submit_no_wait(
+        &self,
+        transaction: Vec<u8>,
+    ) -> Result<oneshot::Receiver<()>, ClientError> {
+        let (included_in_block_ack_send, included_in_block_ack_receive) = oneshot::channel();
         if transaction.len() as u64 > self.max_transaction_size {
             return Err(ClientError::OversizedTransaction(
                 transaction.len() as u64,
                 self.max_transaction_size,
             ));
         }
+
+        let t = TransactionGuard {
+            transaction: Transaction::new(transaction),
+            _included_in_block_ack: included_in_block_ack_send,
+        };
         self.sender
-            .send(Transaction::new(transaction))
+            .send(t)
             .await
             .tap_err(|e| error!("Submit transaction failed with {:?}", e))
-            .map_err(|e| ClientError::SubmitError(e.to_string()))
+            .map_err(|e| ClientError::SubmitError(e.to_string()))?;
+        Ok(included_in_block_ack_receive)
     }
 }
 
@@ -161,10 +192,14 @@ impl TransactionVerifier for NoopTransactionVerifier {
 mod tests {
     use crate::context::Context;
     use crate::transaction::{TransactionClient, TransactionConsumer};
+    use futures::stream::FuturesUnordered;
+    use futures::StreamExt;
     use std::sync::Arc;
+    use std::time::Duration;
     use sui_protocol_config::ProtocolConfig;
+    use tokio::time::timeout;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_submit_and_consume() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_consensus_max_transaction_size_bytes(2_000); // 2KB
@@ -176,23 +211,40 @@ mod tests {
         let (client, tx_receiver) = TransactionClient::new(context.clone());
         let mut consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
 
-        // submit some transactions
+        // submit asynchronously the transactions and keep the waiters
+        let mut included_in_block_waiters = FuturesUnordered::new();
         for i in 0..3 {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
-            client
-                .submit(transaction)
+            let w = client
+                .submit_no_wait(transaction)
                 .await
-                .expect("Shouldn't submit successfully transaction")
+                .expect("Shouldn't submit successfully transaction");
+            included_in_block_waiters.push(w);
         }
 
         // now pull the transactions from the consumer
         let transactions = consumer.next();
         assert_eq!(transactions.len(), 3);
 
-        for (i, transaction) in transactions.iter().enumerate() {
-            let t: String = bcs::from_bytes(transaction.data()).unwrap();
+        for (i, t) in transactions.iter().enumerate() {
+            let t: String = bcs::from_bytes(t.transaction.data()).unwrap();
             assert_eq!(format!("transaction {i}").to_string(), t);
+        }
+
+        assert!(
+            timeout(Duration::from_secs(1), included_in_block_waiters.next())
+                .await
+                .is_err(),
+            "We should expect to timeout as none of the transactions have been acknowledged yet"
+        );
+
+        // Now acknowledge the inclusion of transactions by just dropping the guards
+        drop(transactions);
+
+        // Now make sure that all the waiters have returned
+        while let Some(result) = included_in_block_waiters.next().await {
+            assert!(result.is_err());
         }
 
         // try to pull again transactions, result should be empty
@@ -215,10 +267,10 @@ mod tests {
         for i in 0..10 {
             let transaction =
                 bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
-            client
-                .submit(transaction)
+            let _w = client
+                .submit_no_wait(transaction)
                 .await
-                .expect("Shouldn't submit successfully transaction")
+                .expect("Shouldn't submit successfully transaction");
         }
 
         // now pull the transactions from the consumer
@@ -227,7 +279,10 @@ mod tests {
         assert_eq!(transactions.len(), 7);
 
         // ensure their total size is less than `max_bytes_to_fetch`
-        let total_size: u64 = transactions.iter().map(|t| t.data().len() as u64).sum();
+        let total_size: u64 = transactions
+            .iter()
+            .map(|t| t.transaction.data().len() as u64)
+            .sum();
         assert!(
             total_size
                 <= context
@@ -245,7 +300,10 @@ mod tests {
         assert_eq!(transactions.len(), 3);
 
         // ensure their total size is less than `max_bytes_to_fetch`
-        let total_size: u64 = transactions.iter().map(|t| t.data().len() as u64).sum();
+        let total_size: u64 = transactions
+            .iter()
+            .map(|t| t.transaction.data().len() as u64)
+            .sum();
         assert!(
             total_size
                 <= context
@@ -261,8 +319,8 @@ mod tests {
         // try to pull again transactions, result should be empty
         assert!(consumer.next().is_empty());
 
-        for (i, transaction) in all_transactions.iter().enumerate() {
-            let t: String = bcs::from_bytes(transaction.data()).unwrap();
+        for (i, t) in all_transactions.iter().enumerate() {
+            let t: String = bcs::from_bytes(t.transaction.data()).unwrap();
             assert_eq!(format!("transaction {i}").to_string(), t);
         }
     }


### PR DESCRIPTION
## Description 

The PR is modifying the transaction submission of the transaction client to return only when the transaction has been successfully included to the next block proposal. The `TransactionGuard` struct has been added which is implicitly acknowledging the transaction inclusion once dropped.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
