### PR TITLE
[pick #16650][GraphQL/DataLoader] Epochs

### DIFF
--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -16,6 +16,7 @@ use sui_indexer::indexer_reader::IndexerReader;
 
 use tracing::error;
 
+#[derive(Clone)]
 pub(crate) struct PgExecutor {
     pub inner: IndexerReader,
     pub limits: Limits,

--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -61,7 +61,7 @@ pub(crate) fn graphql_error_at_pos(
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -24,6 +24,7 @@ use crate::{
     server::version::{check_version_middleware, set_version_middleware},
     types::query::{Query, SuiGraphQLSchema},
 };
+use async_graphql::dataloader::DataLoader;
 use async_graphql::extensions::ApolloTracing;
 use async_graphql::extensions::Tracing;
 use async_graphql::EmptySubscription;
@@ -296,6 +297,7 @@ impl ServerBuilder {
 
         builder = builder
             .context_data(config.service.clone())
+            .context_data(DataLoader::new(db.clone(), tokio::spawn))
             .context_data(db)
             .context_data(pg_conn_pool)
             .context_data(Resolver::new_with_limits(

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -117,7 +117,7 @@ impl Checkpoint {
     /// The epoch this checkpoint is part of.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.stored.epoch as u64),
             self.checkpoint_viewed_at,
         )

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
 use crate::context_data::db_data_provider::{convert_to_validators, PgManager};
 use crate::data::{Db, DbConnection, QueryExecutor};
 use crate::error::Error;
@@ -14,6 +16,7 @@ use super::system_state_summary::SystemStateSummary;
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::validator_set::ValidatorSet;
 use async_graphql::connection::Connection;
+use async_graphql::dataloader::{DataLoader, Loader};
 use async_graphql::*;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
 use fastcrypto::encoding::{Base58, Encoding};
@@ -21,8 +24,17 @@ use sui_indexer::models_v2::epoch::QueryableEpochInfo;
 use sui_indexer::schema_v2::epochs;
 use sui_types::messages_checkpoint::CheckpointCommitment as EpochCommitment;
 
+#[derive(Clone)]
 pub(crate) struct Epoch {
     pub stored: QueryableEpochInfo,
+    pub checkpoint_viewed_at: Option<u64>,
+}
+
+/// DataLoader key for fetching an `Epoch` by its ID, optionally constrained by a consistency
+/// cursor.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+pub(crate) struct EpochKey {
+    pub epoch_id: u64,
     pub checkpoint_viewed_at: Option<u64>,
 }
 
@@ -259,13 +271,31 @@ impl Epoch {
     /// Look up an `Epoch` in the database, optionally filtered by its Epoch ID. If no ID is
     /// supplied, defaults to fetching the latest epoch.
     pub(crate) async fn query(
-        db: &Db,
+        ctx: &Context<'_>,
         filter: Option<u64>,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Option<Self>, Error> {
+        if let Some(epoch_id) = filter {
+            let dl: &DataLoader<Db> = ctx.data_unchecked();
+            dl.load_one(EpochKey {
+                epoch_id,
+                checkpoint_viewed_at,
+            })
+            .await
+        } else {
+            Self::query_latest_at(ctx.data_unchecked(), checkpoint_viewed_at).await
+        }
+    }
+
+    /// Look up the latest `Epoch` from the database, optionally filtered by a consistency cursor
+    /// (querying for a consistency cursor in the past looks for the latest epoch as of that
+    /// cursor).
+    pub(crate) async fn query_latest_at(
+        db: &Db,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<Self>, Error> {
         use epochs::dsl;
 
-        let id = filter.map(|id| id as i64);
         let (stored, checkpoint_viewed_at): (Option<QueryableEpochInfo>, u64) = db
             .execute_repeatable(move |conn| {
                 let checkpoint_viewed_at = match checkpoint_viewed_at {
@@ -287,10 +317,6 @@ impl Epoch {
                             .filter(dsl::first_checkpoint_id.le(checkpoint_viewed_at as i64))
                             .order_by(dsl::first_checkpoint_id.desc());
 
-                        if let Some(id) = id {
-                            query = query.filter(dsl::epoch.eq(id));
-                        }
-
                         query
                     })
                     .optional()?;
@@ -304,5 +330,54 @@ impl Epoch {
             stored,
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
         }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<EpochKey> for Db {
+    type Value = Epoch;
+    type Error = Error;
+
+    async fn load(&self, keys: &[EpochKey]) -> Result<HashMap<EpochKey, Epoch>, Error> {
+        use epochs::dsl;
+
+        let epoch_ids: BTreeSet<_> = keys.iter().map(|key| key.epoch_id as i64).collect();
+        let epochs: Vec<QueryableEpochInfo> = self
+            .execute_repeatable(move |conn| {
+                conn.results(move || {
+                    dsl::epochs
+                        .select(QueryableEpochInfo::as_select())
+                        .filter(dsl::epoch.eq_any(epoch_ids.iter().cloned()))
+                })
+            })
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to fetch epochs: {e}")))?;
+
+        let epoch_id_to_stored: BTreeMap<_, _> = epochs
+            .into_iter()
+            .map(|stored| (stored.epoch as u64, stored))
+            .collect();
+
+        Ok(keys
+            .iter()
+            .filter_map(|key| {
+                let stored = epoch_id_to_stored.get(&key.epoch_id).cloned()?;
+                let epoch = Epoch {
+                    stored,
+                    checkpoint_viewed_at: key.checkpoint_viewed_at,
+                };
+
+                // We filter by checkpoint viewed at in memory because it should be quite rare that
+                // this query actually filters something (only in edge cases), and not trying to
+                // encode it in the SQL query makes the query much simpler and therefore easier for
+                // the DB to plan.
+                let start = epoch.stored.first_checkpoint_id as u64;
+                if matches!(key.checkpoint_viewed_at, Some(cp) if cp < start) {
+                    None
+                } else {
+                    Some((*key, epoch))
+                }
+            })
+            .collect())
     }
 }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -226,7 +226,7 @@ impl Query {
 
     /// Fetch epoch information by ID (defaults to the latest epoch).
     async fn epoch(&self, ctx: &Context<'_>, id: Option<u64>) -> Result<Option<Epoch>> {
-        Epoch::query(ctx.data_unchecked(), id, None).await.extend()
+        Epoch::query(ctx, id, None).await.extend()
     }
 
     /// Fetch checkpoint information by sequence number or digest (defaults to the latest available

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -305,7 +305,7 @@ impl StakedSui {
     /// The epoch at which this stake became active.
     async fn activated_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.activation_epoch()),
             self.super_.super_.checkpoint_viewed_at,
         )
@@ -316,7 +316,7 @@ impl StakedSui {
     /// The epoch at which this object was requested to join a stake pool.
     async fn requested_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.request_epoch()),
             self.super_.super_.checkpoint_viewed_at,
         )

--- a/crates/sui-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block.rs
@@ -199,13 +199,9 @@ impl TransactionBlock {
             return Ok(None);
         };
 
-        Epoch::query(
-            ctx.data_unchecked(),
-            Some(*id),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(*id), Some(self.checkpoint_viewed_at))
+            .await
+            .extend()
     }
 
     /// Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -372,7 +372,7 @@ impl TransactionBlockEffects {
     /// The epoch this transaction was finalized in.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native().executed_epoch()),
             Some(self.checkpoint_viewed_at),
         )

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -41,7 +41,7 @@ impl AuthenticatorStateUpdateTransaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.epoch),
             Some(self.checkpoint_viewed_at),
         )
@@ -131,7 +131,7 @@ impl ActiveJwk {
     /// The most recent epoch in which the JWK was validated.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.epoch),
             Some(self.checkpoint_viewed_at),
         )

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -34,13 +34,9 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
-        Epoch::query(
-            ctx.data_unchecked(),
-            Some(self.epoch),
-            Some(self.checkpoint_viewed_at),
-        )
-        .await
-        .extend()
+        Epoch::query(ctx, Some(self.epoch), Some(self.checkpoint_viewed_at))
+            .await
+            .extend()
     }
 
     /// Consensus round of the commit.

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -126,7 +126,7 @@ impl ChangeEpochTransaction {
     /// The next (to become) epoch.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.epoch),
             Some(self.checkpoint_viewed_at),
         )
@@ -224,7 +224,7 @@ impl AuthenticatorStateExpireTransaction {
     /// Expire JWKs that have a lower epoch than this.
     async fn min_epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.min_epoch),
             Some(self.checkpoint_viewed_at),
         )

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/randomness_state_update.rs
@@ -18,7 +18,7 @@ impl RandomnessStateUpdateTransaction {
     /// Epoch of the randomness state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(
-            ctx.data_unchecked(),
+            ctx,
             Some(self.native.epoch),
             Some(self.checkpoint_viewed_at),
         )

--- a/crates/sui-indexer/src/models_v2/epoch.rs
+++ b/crates/sui-indexer/src/models_v2/epoch.rs
@@ -33,7 +33,7 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
 }
 
-#[derive(Queryable, Selectable)]
+#[derive(Queryable, Selectable, Clone)]
 #[diesel(table_name = epochs)]
 pub struct QueryableEpochInfo {
     pub epoch: i64,


### PR DESCRIPTION
## Description

Initial plumbing to use `Db` as the source for a `DataLoader` and an implementation of `DataLoader` for `Epoch` to exercise it.

## Test Plan

This is a behaviour preserving refactor, so we use the existing tests:

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```

@wlmyng also manually tested a query that would previously have done multiple sequential Epoch reads, and found a 10x speed-up (3s to 300ms) in local testing.