### PR TITLE
[docker]: migrate to debian and install system ca certs

### DIFF
--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -88,7 +88,9 @@ LABEL git-revision=${GIT_REVISION}
 RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 
-COPY --from=install /rootfs /
+RUN mkdir -p /opt/sui/bin
+RUN mkdir -p /usr/local/bin
+COPY --from=build sui/target/release/sui-node /opt/sui/bin/sui-node
 
 RUN ln -s /opt/sui/bin/sui-node /usr/local/bin/sui-node
 

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -77,13 +77,16 @@ COPY --from=build sui/target/release/sui-node /rootfs/opt/sui/bin/sui-node
 
 RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
 
-FROM scratch AS package
+FROM debian:bullseye-slim AS package
 
 ARG PROFILE
 ARG GIT_REVISION
 
 LABEL build-date=${BUILD_DATE}
 LABEL git-revision=${GIT_REVISION}
+
+RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 
 COPY --from=install /rootfs /
 


### PR DESCRIPTION
Due to changes from:
https://github.com/MystenLabs/sui/pull/16522

Reported Issue + Panic from Missing CA Certs.

Might be irrelevant due to:https://github.com/MystenLabs/sui/pull/16669

Should resolve: https://github.com/MystenLabs/sui/issues/16586




## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
