### PR TITLE
[move/docgen] Fix docgen for dependencies

### DIFF
--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/address.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/address.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::address`
 
+Provides a way to get address length since it's a
+platform-specific parameter.
 
 
 -  [Function `length`](#0x1_address_length)
@@ -16,6 +18,8 @@
 
 ## Function `length`
 
+Should be converted to a native function.
+Current implementation only works for Sui.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/address.md#0x1_address_length">length</a>(): u64

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/ascii.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::ascii`
 
+The <code>ASCII</code> module defines basic string and char newtypes in Move that verify
+that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 
 
 -  [Struct `String`](#0x1_ascii_String)
@@ -31,6 +33,11 @@
 
 ## Struct `String`
 
+The <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> struct holds a vector of bytes that all represent
+valid ASCII characters. Note that these ASCII characters may not all
+be printable. To determine if a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> contains only "printable"
+characters you should use the <code>all_characters_printable</code> predicate
+defined in this module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -58,6 +65,7 @@
 
 ## Struct `Char`
 
+An ASCII character.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a> <b>has</b> <b>copy</b>, drop, store
@@ -88,6 +96,7 @@
 
 <a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
 
+An invalid ASCII character was encountered when creating an ASCII string.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
@@ -99,6 +108,7 @@
 
 ## Function `char`
 
+Convert a <code>byte</code> into a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> that is checked to make sure it is valid ASCII.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>
@@ -124,6 +134,8 @@
 
 ## Function `string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Aborts if
+<code>bytes</code> contains non-ASCII characters.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -153,6 +165,9 @@
 
 ## Function `try_string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Returns
+<code>Some(&lt;ascii_string&gt;)</code> if the <code>bytes</code> contains all valid ASCII
+characters. Otherwise returns <code>None</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_try_string">try_string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>&gt;
@@ -184,6 +199,8 @@
 
 ## Function `all_characters_printable`
 
+Returns <code><b>true</b></code> if all characters in <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> are printable characters
+Returns <code><b>false</b></code> otherwise. Not all <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>s are printable strings.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_all_characters_printable">all_characters_printable</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
@@ -287,6 +304,7 @@
 
 ## Function `as_bytes`
 
+Get the inner bytes of the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> as a reference
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -311,6 +329,7 @@
 
 ## Function `into_bytes`
 
+Unpack the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> to get its backing bytes
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -336,6 +355,7 @@
 
 ## Function `byte`
 
+Unpack the <code>char</code> into its underlying byte.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_byte">byte</a>(char: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
@@ -361,6 +381,7 @@
 
 ## Function `is_valid_char`
 
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
@@ -385,6 +406,7 @@
 
 ## Function `is_printable_char`
 
+Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/bcs.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/bcs.md
@@ -3,6 +3,10 @@
 
 # Module `0x1::bcs`
 
+Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+Serialization). BCS is the binary encoding for Move resources and other non-module values
+published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+details on BCS.
 
 
 -  [Function `to_bytes`](#0x1_bcs_to_bytes)
@@ -16,6 +20,7 @@
 
 ## Function `to_bytes`
 
+Return the binary representation of <code>v</code> in BCS (Binary Canonical Serialization) format
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/bcs.md#0x1_bcs_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/option.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/option.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::option`
 
+This module defines the Option type and its methods to represent and handle an optional value.
 
 
 -  [Struct `Option`](#0x1_option_Option)
@@ -35,6 +36,8 @@
 
 ## Struct `Option`
 
+Abstraction of a value that may or may not be present. Implemented with a vector of size
+zero or one because Move bytecode does not have ADTs.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt; <b>has</b> <b>copy</b>, drop, store
@@ -65,6 +68,8 @@
 
 <a name="0x1_option_EOPTION_IS_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
@@ -74,6 +79,8 @@
 
 <a name="0x1_option_EOPTION_NOT_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
@@ -85,6 +92,7 @@
 
 ## Function `none`
 
+Return an empty <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_none">none</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -109,6 +117,7 @@
 
 ## Function `some`
 
+Return an <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> containing <code>e</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_some">some</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -133,6 +142,7 @@
 
 ## Function `is_none`
 
+Return true if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -157,6 +167,7 @@
 
 ## Function `is_some`
 
+Return true if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -181,6 +192,8 @@
 
 ## Function `contains`
 
+Return true if the value in <code>t</code> is equal to <code>e_ref</code>
+Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
@@ -205,6 +218,8 @@
 
 ## Function `borrow`
 
+Return an immutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
@@ -230,6 +245,8 @@
 
 ## Function `borrow_with_default`
 
+Return a reference to the value inside <code>t</code> if it holds one
+Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
@@ -256,6 +273,8 @@
 
 ## Function `get_with_default`
 
+Return the value inside <code>t</code> if it holds one
+Return <code>default</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -285,6 +304,8 @@
 
 ## Function `fill`
 
+Convert the none option <code>t</code> to a some option by adding <code>e</code>.
+Aborts if <code>t</code> already holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
@@ -311,6 +332,8 @@
 
 ## Function `extract`
 
+Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -336,6 +359,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
@@ -361,6 +386,8 @@
 
 ## Function `swap`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
@@ -389,6 +416,9 @@
 
 ## Function `swap_or_fill`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value;
+or if there is no old value, fill it with <code>e</code>.
+Different from swap(), swap_or_fill() allows for <code>t</code> not holding a value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -417,6 +447,7 @@
 
 ## Function `destroy_with_default`
 
+Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -443,6 +474,8 @@
 
 ## Function `destroy_some`
 
+Unpack <code>t</code> and return its contents
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -471,6 +504,8 @@
 
 ## Function `destroy_none`
 
+Unpack <code>t</code>
+Aborts if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
@@ -497,6 +532,8 @@
 
 ## Function `to_vec`
 
+Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
+and an empty vector otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/string.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/string.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::string`
 
+The <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
 
 
 -  [Struct `String`](#0x1_string_String)
@@ -36,6 +37,7 @@
 
 ## Struct `String`
 
+A <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -66,6 +68,7 @@
 
 <a name="0x1_string_EINVALID_INDEX"></a>
 
+Index out of range.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
@@ -75,6 +78,7 @@
 
 <a name="0x1_string_EINVALID_UTF8"></a>
 
+An invalid UTF8 encoding.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
@@ -86,6 +90,7 @@
 
 ## Function `utf8`
 
+Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -111,6 +116,7 @@
 
 ## Function `from_ascii`
 
+Convert an ASCII string to a UTF8 string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_from_ascii">from_ascii</a>(s: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -135,6 +141,8 @@
 
 ## Function `to_ascii`
 
+Convert an UTF8 string to an ASCII string.
+Aborts if <code>s</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_to_ascii">to_ascii</a>(s: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -160,6 +168,7 @@
 
 ## Function `try_utf8`
 
+Tries to create a new string from a sequence of bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_try_utf8">try_utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>&gt;
@@ -188,6 +197,7 @@
 
 ## Function `bytes`
 
+Returns a reference to the underlying byte vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -212,6 +222,7 @@
 
 ## Function `is_empty`
 
+Checks whether this string is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): bool
@@ -236,6 +247,7 @@
 
 ## Function `length`
 
+Returns the length of this string, in bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64
@@ -260,6 +272,7 @@
 
 ## Function `append`
 
+Appends a string.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -284,6 +297,7 @@
 
 ## Function `append_utf8`
 
+Appends bytes which must be in valid utf8 format.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
@@ -308,6 +322,8 @@
 
 ## Function `insert`
 
+Insert the other string at the byte index in given string. The index must be at a valid utf8 char
+boundary.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -339,6 +355,9 @@
 
 ## Function `sub_string`
 
+Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
+of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+guaranteeing that the result is valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -369,6 +388,7 @@
 
 ## Function `index_of`
 
+Computes the index of the first occurrence of a string. Returns <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_index_of">index_of</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/type_name.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::type_name`
 
+Functionality for converting Move types into values. Use with care!
 
 
 -  [Struct `TypeName`](#0x1_type_name_TypeName)
@@ -42,7 +43,13 @@
 <code>name: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a></code>
 </dt>
 <dd>
-
+ String representation of the type. All types are represented
+ using their source syntax:
+ "u8", "u64", "bool", "address", "vector", and so on for primitive types.
+ Struct types are represented as fully qualified type names; e.g.
+ <code>00000000000000000000000000000001::string::String</code> or
+ <code>0000000000000000000000000000000a::module_name1::type_name1&lt;0000000000000000000000000000000a::module_name2::type_name2&lt;u64&gt;&gt;</code>
+ Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
 </dd>
 </dl>
 
@@ -56,6 +63,7 @@
 
 <a name="0x1_type_name_ASCII_C"></a>
 
+ASCII Character code for the <code>c</code> (lowercase c) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_C">ASCII_C</a>: u8 = 99;
@@ -65,6 +73,7 @@
 
 <a name="0x1_type_name_ASCII_COLON"></a>
 
+ASCII Character code for the <code>:</code> (colon) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_COLON">ASCII_COLON</a>: u8 = 58;
@@ -74,6 +83,7 @@
 
 <a name="0x1_type_name_ASCII_E"></a>
 
+ASCII Character code for the <code>e</code> (lowercase e) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_E">ASCII_E</a>: u8 = 101;
@@ -83,6 +93,7 @@
 
 <a name="0x1_type_name_ASCII_O"></a>
 
+ASCII Character code for the <code>o</code> (lowercase o) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_O">ASCII_O</a>: u8 = 111;
@@ -92,6 +103,7 @@
 
 <a name="0x1_type_name_ASCII_R"></a>
 
+ASCII Character code for the <code>r</code> (lowercase r) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_R">ASCII_R</a>: u8 = 114;
@@ -101,6 +113,7 @@
 
 <a name="0x1_type_name_ASCII_T"></a>
 
+ASCII Character code for the <code>t</code> (lowercase t) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_T">ASCII_T</a>: u8 = 116;
@@ -110,6 +123,7 @@
 
 <a name="0x1_type_name_ASCII_V"></a>
 
+ASCII Character code for the <code>v</code> (lowercase v) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_V">ASCII_V</a>: u8 = 118;
@@ -119,6 +133,7 @@
 
 <a name="0x1_type_name_ENonModuleType"></a>
 
+The type is not from a package/module. It is a primitive type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ENonModuleType">ENonModuleType</a>: u64 = 0;
@@ -130,6 +145,10 @@
 
 ## Function `get`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are defining IDs (the ID of the package in
+storage that first introduced the type).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -152,6 +171,11 @@
 
 ## Function `get_with_original_ids`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are original IDs (the ID of the first version of
+the package, even if the type in question was introduced in a
+later upgrade).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -174,6 +198,8 @@
 
 ## Function `is_primitive`
 
+Returns true iff the TypeName represents a primitive type, i.e. one of
+u8, u16, u32, u64, u128, u256, bool, address, vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_is_primitive">is_primitive</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): bool
@@ -214,6 +240,7 @@
 
 ## Function `borrow_string`
 
+Get the String representation of <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_borrow_string">borrow_string</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -238,6 +265,8 @@
 
 ## Function `get_address`
 
+Get Address string (Base16 encoded), first part of the TypeName.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_address">get_address</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -279,6 +308,8 @@
 
 ## Function `get_module`
 
+Get name of the module.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_module">get_module</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -320,6 +351,7 @@
 
 ## Function `into_string`
 
+Convert <code>self</code> into its inner String
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_into_string">into_string</a>(self: <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>

--- a/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/vector.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/move-stdlib/vector.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::vector`
 
+A variable-sized container that can hold any type. Indexing is 0-based, and
+vectors are growable. This module has many native functions.
 
 
 -  [Constants](#@Constants_0)
@@ -36,6 +38,7 @@
 
 <a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
 
+The index into the vector is out of bounds
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
@@ -47,6 +50,7 @@
 
 ## Function `empty`
 
+Create an empty vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -69,6 +73,7 @@
 
 ## Function `length`
 
+Return the length of the vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64
@@ -91,6 +96,8 @@
 
 ## Function `borrow`
 
+Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element
@@ -113,6 +120,7 @@
 
 ## Function `push_back`
 
+Add element <code>e</code> to the end of the vector <code>v</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element)
@@ -135,6 +143,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
@@ -157,6 +167,8 @@
 
 ## Function `pop_back`
 
+Pop an element from the end of vector <code>v</code>.
+Aborts if <code>v</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element
@@ -179,6 +191,8 @@
 
 ## Function `destroy_empty`
 
+Destroy the vector <code>v</code>.
+Aborts if <code>v</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -201,6 +215,8 @@
 
 ## Function `swap`
 
+Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
+Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64)
@@ -223,6 +239,7 @@
 
 ## Function `singleton`
 
+Return an vector of size one containing element <code>e</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -249,6 +266,7 @@
 
 ## Function `reverse`
 
+Reverses the order of the elements in the vector <code>v</code> in place.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -282,6 +300,7 @@
 
 ## Function `append`
 
+Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -308,6 +327,7 @@
 
 ## Function `is_empty`
 
+Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool
@@ -332,6 +352,8 @@
 
 ## Function `contains`
 
+Return true if <code>e</code> is in the vector <code>v</code>.
+Otherwise, returns false.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool
@@ -362,6 +384,8 @@
 
 ## Function `index_of`
 
+Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
+Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64)
@@ -392,6 +416,9 @@
 
 ## Function `remove`
 
+Remove the <code>i</code>th element of the vector <code>v</code>, shifting all subsequent elements.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
@@ -422,6 +449,11 @@
 
 ## Function `insert`
 
+Insert <code>e</code> at position <code>i</code> in the vector <code>v</code>.
+If <code>i</code> is in bounds, this shifts the old <code>v[i]</code> and all subsequent elements to the right.
+If <code>i == <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>, this adds <code>e</code> to the end of the vector.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i &gt; <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64)
@@ -454,6 +486,9 @@
 
 ## Function `swap_remove`
 
+Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the vector.
+This is O(1), but does not preserve ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/address.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/address.md
@@ -33,6 +33,7 @@
 
 <a name="0x2_address_EAddressParseError"></a>
 
+Error from <code>from_bytes</code> when it is supplied too many or too few bytes.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a>: u64 = 0;
@@ -42,6 +43,7 @@
 
 <a name="0x2_address_LENGTH"></a>
 
+The length of an address, in bytes
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_LENGTH">LENGTH</a>: u64 = 32;
@@ -62,6 +64,8 @@
 
 ## Function `to_u256`
 
+Convert <code>a</code> into a u256 by interpreting <code>a</code> as the bytes of a big-endian integer
+(e.g., <code><a href="../../dependencies/sui-framework/address.md#0x2_address_to_u256">to_u256</a>(0x1) == 1</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_u256">to_u256</a>(a: <b>address</b>): u256
@@ -84,6 +88,8 @@
 
 ## Function `from_u256`
 
+Convert <code>n</code> into an address by encoding it as a big-endian integer (e.g., <code><a href="../../dependencies/sui-framework/address.md#0x2_address_from_u256">from_u256</a>(1) = @0x1</code>)
+Aborts if <code>n</code> > <code>MAX_ADDRESS</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_u256">from_u256</a>(n: u256): <b>address</b>
@@ -106,6 +112,8 @@
 
 ## Function `from_bytes`
 
+Convert <code>bytes</code> into an address.
+Aborts with <code><a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a></code> if the length of <code>bytes</code> is not 32
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_bytes">from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
@@ -128,6 +136,7 @@
 
 ## Function `to_bytes`
 
+Convert <code>a</code> into BCS-encoded bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_bytes">to_bytes</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -152,6 +161,7 @@
 
 ## Function `to_ascii_string`
 
+Convert <code>a</code> to a hex-encoded ASCII string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_ascii_string">to_ascii_string</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -176,6 +186,7 @@
 
 ## Function `to_string`
 
+Convert <code>a</code> to a hex-encoded ASCII string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_string">to_string</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -200,6 +211,12 @@
 
 ## Function `from_ascii_bytes`
 
+Converts an ASCII string to an address, taking the numerical value for each character. The
+string must be Base16 encoded, and thus exactly 64 characters long.
+For example, the string "00000000000000000000000000000000000000000000000000000000DEADB33F"
+will be converted to the address @0xDEADB33F.
+Aborts with <code><a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a></code> if the length of <code>s</code> is not 64,
+or if an invalid character is encountered.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_ascii_bytes">from_ascii_bytes</a>(bytes: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
@@ -260,6 +277,7 @@
 
 ## Function `length`
 
+Length of a Sui address in bytes
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_length">length</a>(): u64
@@ -284,6 +302,7 @@
 
 ## Function `max`
 
+Largest possible address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_max">max</a>(): u256

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/authenticator_state.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/authenticator_state.md
@@ -41,6 +41,9 @@
 
 ## Resource `AuthenticatorState`
 
+Singleton shared object which stores the global authenticator state.
+The actual state is stored in a dynamic field of type AuthenticatorStateInner to support
+future versions of the authenticator state.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">AuthenticatorState</a> <b>has</b> key
@@ -96,7 +99,7 @@
 <code>active_jwks: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;</code>
 </dt>
 <dd>
-
+ List of currently active JWKs.
 </dd>
 </dl>
 
@@ -107,6 +110,7 @@
 
 ## Struct `JWK`
 
+Must match the JWK struct in fastcrypto-zkp
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_JWK">JWK</a> <b>has</b> <b>copy</b>, drop, store
@@ -152,6 +156,7 @@
 
 ## Struct `JwkId`
 
+Must match the JwkId struct in fastcrypto-zkp
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_JwkId">JwkId</a> <b>has</b> <b>copy</b>, drop, store
@@ -227,6 +232,7 @@
 
 <a name="0x2_authenticator_state_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -426,6 +432,9 @@
 
 ## Function `create`
 
+Create and share the AuthenticatorState object. This function is call exactly once, when
+the authenticator state object is first created.
+Can only be called by genesis or change_epoch transactions.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_create">create</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -563,6 +572,10 @@
 
 ## Function `update_authenticator_state`
 
+Record a new set of active_jwks. Called when executing the AuthenticatorStateUpdate system
+transaction. The new input vector must be sorted and must not contain duplicates.
+If a new JWK is already present, but with a previous epoch, then the epoch is updated to
+indicate that the JWK has been validated in the current epoch and should not be expired.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_update_authenticator_state">update_authenticator_state</a>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">authenticator_state::AuthenticatorState</a>, new_active_jwks: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -768,6 +781,8 @@
 
 ## Function `get_active_jwks`
 
+Get the current active_jwks. Called when the node starts up in order to load the current
+JWK state from the chain.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_get_active_jwks">get_active_jwks</a>(self: &<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">authenticator_state::AuthenticatorState</a>, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/bag.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/bag.md
@@ -3,6 +3,26 @@
 
 # Module `0x2::bag`
 
+A bag is a heterogeneous map-like collection. The collection is similar to <code>sui::table</code> in that
+its keys and values are not stored within the <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> value, but instead are stored using Sui's
+object system. The <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> struct acts only as a handle into the object system to retrieve those
+keys and values.
+Note that this means that <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let bag1 = bag::new();
+let bag2 = bag::new();
+bag::add(&mut bag1, 0, false);
+bag::add(&mut bag1, 1, true);
+bag::add(&mut bag2, 0, false);
+bag::add(&mut bag2, 1, true);
+// bag1 does not equal bag2, despite having the same entries
+assert!(&bag1 != &bag2, 0);
+```
+At it's core, <code>sui::bag</code> is a wrapper around <code>UID</code> that allows for access to
+<code>sui::dynamic_field</code> while preventing accidentally stranding field values. A <code>UID</code> can be
+deleted, even if it has dynamic fields associated with it, but a bag, on the other hand, must be
+empty to be destroyed.
 
 
 -  [Resource `Bag`](#0x2_bag_Bag)
@@ -46,13 +66,13 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ the ID of this bag
 </dd>
 <dt>
 <code>size: u64</code>
 </dt>
 <dd>
-
+ the number of key-value pairs in the bag
 </dd>
 </dl>
 
@@ -77,6 +97,7 @@
 
 ## Function `new`
 
+Creates a new, empty bag
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>
@@ -104,6 +125,9 @@
 
 ## Function `add`
 
+Adds a key-value pair to the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the bag already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K, v: V)
@@ -129,6 +153,11 @@
 
 ## Function `borrow`
 
+Immutable borrows the value associated with the key in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &V
@@ -153,6 +182,11 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the value associated with the key in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &<b>mut</b> V
@@ -177,6 +211,11 @@
 
 ## Function `remove`
 
+Mutably borrows the key-value pair in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): V
@@ -203,6 +242,7 @@
 
 ## Function `contains`
 
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
@@ -227,6 +267,8 @@
 
 ## Function `contains_with_type`
 
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
+with an assigned value of type <code>V</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
@@ -251,6 +293,7 @@
 
 ## Function `length`
 
+Returns the size of the bag, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_length">length</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): u64
@@ -275,6 +318,7 @@
 
 ## Function `is_empty`
 
+Returns true iff the bag is empty (if <code>length</code> returns <code>0</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_is_empty">is_empty</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): bool
@@ -299,6 +343,8 @@
 
 ## Function `destroy_empty`
 
+Destroys an empty bag
+Aborts with <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_destroy_empty">destroy_empty</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/balance.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/balance.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::balance`
 
+A storable handler for Balances in general. Is used in the <code>Coin</code>
+module to allow balance operations and can be used to implement
+custom coins with <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> and <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>s.
 
 
 -  [Struct `Supply`](#0x2_balance_Supply)
@@ -32,6 +35,8 @@
 
 ## Struct `Supply`
 
+A Supply of T. Used for minting and burning.
+Wrapped into a <code>TreasuryCap</code> in the <code>Coin</code> module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt; <b>has</b> store
@@ -59,6 +64,8 @@
 
 ## Struct `Balance`
 
+Storable balance - an inner struct of a Coin type.
+Can be used to store coins which don't need the key ability.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; <b>has</b> store
@@ -89,6 +96,7 @@
 
 <a name="0x2_balance_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENotSystemAddress">ENotSystemAddress</a>: u64 = 3;
@@ -98,6 +106,7 @@
 
 <a name="0x2_balance_ENonZero"></a>
 
+For when trying to destroy a non-zero balance.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENonZero">ENonZero</a>: u64 = 0;
@@ -107,6 +116,7 @@
 
 <a name="0x2_balance_ENotEnough"></a>
 
+For when trying to withdraw more than there is.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENotEnough">ENotEnough</a>: u64 = 2;
@@ -116,6 +126,7 @@
 
 <a name="0x2_balance_EOverflow"></a>
 
+For when an overflow is happening on Supply operations.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_EOverflow">EOverflow</a>: u64 = 1;
@@ -127,6 +138,7 @@
 
 ## Function `value`
 
+Get the amount stored in a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_value">value</a>&lt;T&gt;(self: &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -151,6 +163,7 @@
 
 ## Function `supply_value`
 
+Get the <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_supply_value">supply_value</a>&lt;T&gt;(supply: &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64
@@ -175,6 +188,7 @@
 
 ## Function `create_supply`
 
+Create a new supply for type T.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_create_supply">create_supply</a>&lt;T: drop&gt;(_: T): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -199,6 +213,7 @@
 
 ## Function `increase_supply`
 
+Increase supply by <code>value</code> and create a new <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;</code> with this value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_increase_supply">increase_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -225,6 +240,7 @@
 
 ## Function `decrease_supply`
 
+Burn a Balance<T> and decrease Supply<T>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -252,6 +268,7 @@
 
 ## Function `zero`
 
+Create a zero <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> for type <code>T</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_zero">zero</a>&lt;T&gt;(): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -276,6 +293,7 @@
 
 ## Function `join`
 
+Join two balances together.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -302,6 +320,7 @@
 
 ## Function `split`
 
+Split a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> and take a sub balance from it.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -328,6 +347,7 @@
 
 ## Function `withdraw_all`
 
+Withdraw all balance. After this the remaining balance must be 0.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_withdraw_all">withdraw_all</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -353,6 +373,7 @@
 
 ## Function `destroy_zero`
 
+Destroy a zero <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
@@ -378,6 +399,9 @@
 
 ## Function `create_staking_rewards`
 
+CAUTION: this function creates a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> without increasing the supply.
+It should only be called by the epoch change system txn to create staking rewards,
+and nowhere else.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -403,6 +427,9 @@
 
 ## Function `destroy_storage_rebates`
 
+CAUTION: this function destroys a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> without decreasing the supply.
+It should only be called by the epoch change system txn to destroy storage rebates,
+and nowhere else.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -428,6 +455,7 @@
 
 ## Function `destroy_supply`
 
+Destroy a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> preventing any further minting and burning.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/clock.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/clock.md
@@ -3,6 +3,8 @@
 
 # Module `0x2::clock`
 
+APIs for accessing time from move calls, via the <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code>: a unique
+shared object that is created at 0x6 during genesis.
 
 
 -  [Resource `Clock`](#0x2_clock_Clock)
@@ -23,6 +25,14 @@
 
 ## Resource `Clock`
 
+Singleton shared object that exposes time to Move calls.  This
+object is found at address 0x6, and can only be read (accessed
+via an immutable reference) by entry functions.
+
+Entry Functions that attempt to accept <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code> by mutable
+reference or value will fail to verify, and honest validators
+will not sign or execute transactions that use <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code> as an
+input parameter, unless it is passed by immutable reference.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a> <b>has</b> key
@@ -45,7 +55,10 @@
 <code>timestamp_ms: u64</code>
 </dt>
 <dd>
-
+ The clock's timestamp, which is set automatically by a
+ system transaction every time consensus commits a
+ schedule, or by <code>sui::clock::increment_for_testing</code> during
+ testing.
 </dd>
 </dl>
 
@@ -59,6 +72,7 @@
 
 <a name="0x2_clock_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -70,6 +84,8 @@
 
 ## Function `timestamp_ms`
 
+The <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a></code>'s current timestamp as a running total of
+milliseconds since an arbitrary point in the past.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_timestamp_ms">timestamp_ms</a>(<a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>): u64
@@ -94,6 +110,8 @@
 
 ## Function `create`
 
+Create and share the singleton Clock -- this function is
+called exactly once, during genesis.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_create">create</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/coin.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/coin.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::coin`
 
+Defines the <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> type - platform wide representation of fungible
+tokens and coins. <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> can be described as a secure wrapper around
+<code>Balance</code> type.
 
 
 -  [Resource `Coin`](#0x2_coin_Coin)
@@ -68,6 +71,7 @@
 
 ## Resource `Coin`
 
+A coin of type <code>T</code> worth <code>value</code>. Transferable and storable
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; <b>has</b> store, key
@@ -101,6 +105,8 @@
 
 ## Resource `CoinMetadata`
 
+Each Coin type T created through <code>create_currency</code> function will have a
+unique instance of CoinMetadata<T> that stores the metadata for this coin type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt; <b>has</b> store, key
@@ -123,31 +129,34 @@
 <code>decimals: u8</code>
 </dt>
 <dd>
-
+ Number of decimal places the coin uses.
+ A coin with <code>value </code> N and <code>decimals</code> D should be shown as N / 10^D
+ E.g., a coin with <code>value</code> 7002 and decimals 3 should be displayed as 7.002
+ This is metadata for display usage only.
 </dd>
 <dt>
 <code>name: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
-
+ Name for the token
 </dd>
 <dt>
 <code>symbol: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a></code>
 </dt>
 <dd>
-
+ Symbol for the token
 </dd>
 <dt>
 <code>description: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
-
+ Description of the token
 </dd>
 <dt>
 <code>icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;</code>
 </dt>
 <dd>
-
+ URL for the token logo
 </dd>
 </dl>
 
@@ -158,6 +167,8 @@
 
 ## Resource `RegulatedCoinMetadata`
 
+Similar to CoinMetadata, but created only for regulated coins that use the DenyList.
+This object is always immutable.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; <b>has</b> key
@@ -180,13 +191,13 @@
 <code>coin_metadata_object: <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a></code>
 </dt>
 <dd>
-
+ The ID of the coin's CoinMetadata object.
 </dd>
 <dt>
 <code>deny_cap_object: <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a></code>
 </dt>
 <dd>
-
+ The ID of the coin's DenyCap object.
 </dd>
 </dl>
 
@@ -197,6 +208,8 @@
 
 ## Resource `TreasuryCap`
 
+Capability allowing the bearer to mint and burn
+coins of type <code>T</code>. Transferable
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt; <b>has</b> store, key
@@ -230,6 +243,8 @@
 
 ## Resource `DenyCap`
 
+Capability allowing the bearer to freeze addresses, preventing those addresses from
+interacting with the coin as an input to a transaction.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">DenyCap</a>&lt;T&gt; <b>has</b> store, key
@@ -287,6 +302,7 @@
 
 <a name="0x2_coin_ENotEnough"></a>
 
+Trying to split a coin more times than its balance allows.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_ENotEnough">ENotEnough</a>: u64 = 2;
@@ -296,6 +312,7 @@
 
 <a name="0x2_coin_DENY_LIST_COIN_INDEX"></a>
 
+The index into the deny list vector for the <code>sui::coin::Coin</code> type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>: u64 = 0;
@@ -305,6 +322,7 @@
 
 <a name="0x2_coin_EBadWitness"></a>
 
+A type passed to create_supply is not a one-time witness.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_EBadWitness">EBadWitness</a>: u64 = 0;
@@ -314,6 +332,7 @@
 
 <a name="0x2_coin_EInvalidArg"></a>
 
+Invalid arguments are passed to a function.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_EInvalidArg">EInvalidArg</a>: u64 = 1;
@@ -325,6 +344,7 @@
 
 ## Function `total_supply`
 
+Return the total number of <code>T</code>'s in circulation.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_total_supply">total_supply</a>&lt;T&gt;(cap: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): u64
@@ -349,6 +369,10 @@
 
 ## Function `treasury_into_supply`
 
+Unwrap <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> getting the <code>Supply</code>.
+
+Operation is irreversible. Supply cannot be converted into a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> due
+to different security guarantees (TreasuryCap can be created only once for a type)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_treasury_into_supply">treasury_into_supply</a>&lt;T&gt;(treasury: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -375,6 +399,7 @@
 
 ## Function `supply_immut`
 
+Get immutable reference to the treasury's <code>Supply</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_supply_immut">supply_immut</a>&lt;T&gt;(treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -399,6 +424,7 @@
 
 ## Function `supply_mut`
 
+Get mutable reference to the treasury's <code>Supply</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_supply_mut">supply_mut</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -423,6 +449,7 @@
 
 ## Function `value`
 
+Public getter for the coin's value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_value">value</a>&lt;T&gt;(self: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
@@ -447,6 +474,7 @@
 
 ## Function `balance`
 
+Get immutable reference to the balance of a coin.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -471,6 +499,7 @@
 
 ## Function `balance_mut`
 
+Get a mutable reference to the balance of a coin.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -495,6 +524,7 @@
 
 ## Function `from_balance`
 
+Wrap a balance into a Coin to make it transferable.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -519,6 +549,7 @@
 
 ## Function `into_balance`
 
+Destruct a Coin wrapper and keep the balance.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -545,6 +576,8 @@
 
 ## Function `take`
 
+Take a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> worth of <code>value</code> from <code>Balance</code>.
+Aborts if <code>value &gt; <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>.value</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_take">take</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -574,6 +607,7 @@
 
 ## Function `put`
 
+Put a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;</code> to the <code>Balance&lt;T&gt;</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_put">put</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -598,6 +632,8 @@
 
 ## Function `join`
 
+Consume the coin <code>c</code> and add its value to <code>self</code>.
+Aborts if <code>c.value + self.value &gt; U64_MAX</code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -624,6 +660,8 @@
 
 ## Function `split`
 
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -650,6 +688,8 @@
 
 ## Function `divide_into_n`
 
+Split coin <code>self</code> into <code>n - 1</code> coins with equal balances. The remainder is left in
+<code>self</code>. Return newly created coins.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_divide_into_n">divide_into_n</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;
@@ -686,6 +726,8 @@
 
 ## Function `zero`
 
+Make any Coin with a zero value. Useful for placeholding
+bids/payments or preemptively making empty balances.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -710,6 +752,7 @@
 
 ## Function `destroy_zero`
 
+Destroy a coin with value zero
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_destroy_zero">destroy_zero</a>&lt;T&gt;(c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -736,6 +779,9 @@
 
 ## Function `create_currency`
 
+Create a new currency type <code>T</code> as and return the <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> for
+<code>T</code> to the caller. Can only be called with a <code>one-time-witness</code>
+type, ensuring that there's only one <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> per <code>T</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_create_currency">create_currency</a>&lt;T: drop&gt;(witness: T, decimals: u8, symbol: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, name: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, description: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
@@ -784,6 +830,9 @@
 
 ## Function `create_regulated_currency`
 
+This creates a new currency, via <code>create_currency</code>, but with an extra capability that
+allows for specific addresses to have their coins frozen. Those addresses cannot interact
+with the coin as input objects.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_create_regulated_currency">create_regulated_currency</a>&lt;T: drop&gt;(witness: T, decimals: u8, symbol: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, name: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, description: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
@@ -833,6 +882,8 @@
 
 ## Function `mint`
 
+Create a coin worth <code>value</code> and increase the total supply
+in <code>cap</code> accordingly.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint">mint</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -862,6 +913,9 @@
 
 ## Function `mint_balance`
 
+Mint some amount of T as a <code>Balance</code> and increase the total
+supply in <code>cap</code> accordingly.
+Aborts if <code>value</code> + <code>cap.total_supply</code> >= U64_MAX
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint_balance">mint_balance</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -888,6 +942,8 @@
 
 ## Function `burn`
 
+Destroy the coin <code>c</code> and decrease the total supply in <code>cap</code>
+accordingly.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
@@ -914,6 +970,8 @@
 
 ## Function `deny_list_add`
 
+Adds the given address to the deny list, preventing it
+from interacting with the specified coin type as an input to a transaction.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_add">deny_list_add</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -950,6 +1008,8 @@
 
 ## Function `deny_list_remove`
 
+Removes an address from the deny list.
+Aborts with <code>ENotFrozen</code> if the address is not already in the list.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_remove">deny_list_remove</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -986,6 +1046,8 @@
 
 ## Function `deny_list_contains`
 
+Returns true iff the given address is denied for the given coin type. It will
+return false if given a non-coin type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(freezer: &<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, addr: <b>address</b>): bool
@@ -1022,6 +1084,7 @@
 
 ## Function `mint_and_transfer`
 
+Mint <code>amount</code> of <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code>recipient</code>. Invokes <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint">mint</a>()</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -1048,6 +1111,7 @@
 
 ## Function `update_name`
 
+Update name of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, name: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -1074,6 +1138,7 @@
 
 ## Function `update_symbol`
 
+Update the symbol of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, symbol: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
@@ -1100,6 +1165,7 @@
 
 ## Function `update_description`
 
+Update the description of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, description: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -1126,6 +1192,7 @@
 
 ## Function `update_icon_url`
 
+Update the url of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/deny_list.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/deny_list.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::deny_list`
 
+Defines the <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a></code> type. The <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a></code> shared object is used to restrict access to
+instances of certain core types from being used as inputs by specified addresses in the deny
+list.
 
 
 -  [Resource `DenyList`](#0x2_deny_list_DenyList)
@@ -32,6 +35,7 @@
 
 ## Resource `DenyList`
 
+A shared object that stores the addresses that are blocked for a given core type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a> <b>has</b> key
@@ -54,7 +58,7 @@
 <code>lists: <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
 </dt>
 <dd>
-
+ The individual deny lists.
 </dd>
 </dl>
 
@@ -65,6 +69,7 @@
 
 ## Resource `PerTypeList`
 
+Stores the addresses that are denied for a given core type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_PerTypeList">PerTypeList</a> <b>has</b> store, key
@@ -87,13 +92,16 @@
 <code>denied_count: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;<b>address</b>, u64&gt;</code>
 </dt>
 <dd>
-
+ Number of object types that have been banned for a given address.
+ Used to quickly skip checks for most addresses.
 </dd>
 <dt>
 <code>denied_addresses: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;</code>
 </dt>
 <dd>
-
+ Set of addresses that are banned for a given type.
+ For example with <code>sui::coin::Coin</code>: If addresses A and B are banned from using
+ "0...0123::my_coin::MY_COIN", this will be "0...0123::my_coin::MY_COIN" -> {A, B}.
 </dd>
 </dl>
 
@@ -107,6 +115,7 @@
 
 <a name="0x2_deny_list_ENotSystemAddress"></a>
 
+Trying to create a deny list object when not called by the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -116,6 +125,7 @@
 
 <a name="0x2_deny_list_COIN_INDEX"></a>
 
+The index into the deny list vector for the <code>sui::coin::Coin</code> type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_COIN_INDEX">COIN_INDEX</a>: u64 = 0;
@@ -125,6 +135,7 @@
 
 <a name="0x2_deny_list_ENotDenied"></a>
 
+The specified address to be removed is not already in the deny list.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotDenied">ENotDenied</a>: u64 = 1;
@@ -136,6 +147,10 @@
 
 ## Function `add`
 
+Adds the given address to the deny list of the specified type, preventing it
+from interacting with instances of that type as an input to a transaction. For coins,
+the type specified is the type of the coin, not the coin type itself. For example,
+"00...0123::my_coin::MY_COIN" would be the type, not "00...02::coin::Coin".
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_add">add</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>)
@@ -205,6 +220,8 @@
 
 ## Function `remove`
 
+Removes a previously denied address from the list.
+Aborts with <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotDenied">ENotDenied</a></code> if the address is not on the list.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_remove">remove</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>)
@@ -269,6 +286,7 @@
 
 ## Function `contains`
 
+Returns true iff the given address is denied for the given type.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_contains">contains</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>): bool
@@ -334,6 +352,8 @@
 
 ## Function `create`
 
+Creation of the deny list object is restricted to the system address
+via a system transaction.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_create">create</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/dynamic_field.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/dynamic_field.md
@@ -3,6 +3,12 @@
 
 # Module `0x2::dynamic_field`
 
+In addition to the fields declared in its type definition, a Sui object can have dynamic fields
+that can be added after the object has been constructed. Unlike ordinary field names
+(which are always statically declared identifiers) a dynamic field name can be any value with
+the <code><b>copy</b></code>, <code>drop</code>, and <code>store</code> abilities, e.g. an integer, a boolean, or a string.
+This gives Sui programmers the flexibility to extend objects on-the-fly, and it also serves as a
+building block for core collection types
 
 
 -  [Resource `Field`](#0x2_dynamic_field_Field)
@@ -35,6 +41,7 @@
 
 ## Resource `Field`
 
+Internal object used for storing the field and value
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt; <b>has</b> key
@@ -51,19 +58,20 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ Determined by the hash of the object ID, the field name value and it's type,
+ i.e. hash(parent.id || name || Name)
 </dd>
 <dt>
 <code>name: Name</code>
 </dt>
 <dd>
-
+ The value for the name of this field
 </dd>
 <dt>
 <code>value: Value</code>
 </dt>
 <dd>
-
+ The value bound to this field
 </dd>
 </dl>
 
@@ -77,6 +85,7 @@
 
 <a name="0x2_dynamic_field_EBCSSerializationFailure"></a>
 
+Failed to serialize the field's name
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a>: u64 = 3;
@@ -86,6 +95,7 @@
 
 <a name="0x2_dynamic_field_ESharedObjectOperationNotSupported"></a>
 
+The object added as a dynamic field was previously a shared object
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_ESharedObjectOperationNotSupported">ESharedObjectOperationNotSupported</a>: u64 = 4;
@@ -95,6 +105,7 @@
 
 <a name="0x2_dynamic_field_EFieldAlreadyExists"></a>
 
+The object already has a dynamic field with this name (with the value and type specified)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>: u64 = 0;
@@ -104,6 +115,8 @@
 
 <a name="0x2_dynamic_field_EFieldDoesNotExist"></a>
 
+Cannot load dynamic field.
+The object does not have a dynamic field with this name (with the value and type specified)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a>: u64 = 1;
@@ -113,6 +126,7 @@
 
 <a name="0x2_dynamic_field_EFieldTypeMismatch"></a>
 
+The object has a field with that name, but the value type does not match
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a>: u64 = 2;
@@ -124,6 +138,8 @@
 
 ## Function `add`
 
+Adds a dynamic field to the object <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a></code> if the object already has that field with that name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
@@ -161,6 +177,10 @@
 
 ## Function `borrow`
 
+Immutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
@@ -191,6 +211,10 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
@@ -221,6 +245,11 @@
 
 ## Function `remove`
 
+Removes the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code> and returns the
+bound value.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): Value
@@ -252,6 +281,8 @@
 
 ## Function `exists_`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> but without specifying the <code>Value</code> type
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -281,6 +312,7 @@
 
 ## Function `remove_if_exists`
 
+Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if it exists or none otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;
@@ -312,6 +344,8 @@
 
 ## Function `exists_with_type`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -401,6 +435,7 @@
 
 ## Function `hash_type_and_key`
 
+May abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: <b>address</b>, k: K): <b>address</b>
@@ -445,6 +480,10 @@
 
 ## Function `borrow_child_object`
 
+throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match,
+and may also abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>
+we need two versions to return a reference or a mutable reference
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, id: <b>address</b>): &Child
@@ -489,6 +528,9 @@
 
 ## Function `remove_child_object`
 
+throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match,
+and may also abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/dynamic_object_field.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/dynamic_object_field.md
@@ -3,6 +3,10 @@
 
 # Module `0x2::dynamic_object_field`
 
+Similar to <code>sui::dynamic_field</code>, this module allows for the access of dynamic fields. But
+unlike, <code>sui::dynamic_field</code> the values bound to these dynamic fields _must_ be objects
+themselves. This allows for the objects to still exist within in storage, which may be important
+for external tools. The difference is otherwise not observable from within Move.
 
 
 -  [Struct `Wrapper`](#0x2_dynamic_object_field_Wrapper)
@@ -53,6 +57,8 @@
 
 ## Function `add`
 
+Adds a dynamic object field to the object <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code>EFieldAlreadyExists</code> if the object already has that field with that name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
@@ -86,6 +92,10 @@
 
 ## Function `borrow`
 
+Immutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
@@ -115,6 +125,10 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
@@ -144,6 +158,11 @@
 
 ## Function `remove`
 
+Removes the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code> and returns
+the bound object.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): Value
@@ -175,6 +194,8 @@
 
 ## Function `exists_`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic object field with the name specified by
+<code>name: Name</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -203,6 +224,8 @@
 
 ## Function `exists_with_type`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -233,6 +256,8 @@
 
 ## Function `id`
 
+Returns the ID of the object associated with the dynamic object field
+Returns none otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/event.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/event.md
@@ -3,6 +3,31 @@
 
 # Module `0x2::event`
 
+Events module. Defines the <code>sui::event::emit</code> function which
+creates and sends a custom MoveEvent as a part of the effects
+certificate of the transaction.
+
+Every MoveEvent has the following properties:
+- sender
+- type signature (<code>T</code>)
+- event data (the value of <code>T</code>)
+- timestamp (local to a node)
+- transaction digest
+
+Example:
+```
+module my::marketplace {
+use sui::event;
+/* ... */
+struct ItemPurchased has copy, drop {
+item_id: ID, buyer: address
+}
+entry fun buy(/* .... */) {
+/* ... */
+event::emit(ItemPurchased { item_id: ..., buyer: .... })
+}
+}
+```
 
 
 -  [Function `emit`](#0x2_event_emit)
@@ -16,6 +41,13 @@
 
 ## Function `emit`
 
+Emit a custom Move event, sending the data offchain.
+
+Used for creating custom indexes and tracking onchain
+activity in a way that suits a specific application the most.
+
+The type <code>T</code> is the main way to index the event, and can contain
+phantom parameters, eg <code><a href="../../dependencies/sui-framework/event.md#0x2_event_emit">emit</a>(MyEvent&lt;<b>phantom</b> T&gt;)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/event.md#0x2_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(<a href="../../dependencies/sui-framework/event.md#0x2_event">event</a>: T)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/hex.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/hex.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::hex`
 
+HEX (Base16) encoding utility.
 
 
 -  [Constants](#@Constants_0)
@@ -41,6 +42,7 @@
 
 <a name="0x2_hex_HEX"></a>
 
+Vector of Base16 values from <code>00</code> to <code>FF</code>
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_HEX">HEX</a>: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; = [ByteArray([48, 48]), ByteArray([48, 49]), ByteArray([48, 50]), ByteArray([48, 51]), ByteArray([48, 52]), ByteArray([48, 53]), ByteArray([48, 54]), ByteArray([48, 55]), ByteArray([48, 56]), ByteArray([48, 57]), ByteArray([48, 97]), ByteArray([48, 98]), ByteArray([48, 99]), ByteArray([48, 100]), ByteArray([48, 101]), ByteArray([48, 102]), ByteArray([49, 48]), ByteArray([49, 49]), ByteArray([49, 50]), ByteArray([49, 51]), ByteArray([49, 52]), ByteArray([49, 53]), ByteArray([49, 54]), ByteArray([49, 55]), ByteArray([49, 56]), ByteArray([49, 57]), ByteArray([49, 97]), ByteArray([49, 98]), ByteArray([49, 99]), ByteArray([49, 100]), ByteArray([49, 101]), ByteArray([49, 102]), ByteArray([50, 48]), ByteArray([50, 49]), ByteArray([50, 50]), ByteArray([50, 51]), ByteArray([50, 52]), ByteArray([50, 53]), ByteArray([50, 54]), ByteArray([50, 55]), ByteArray([50, 56]), ByteArray([50, 57]), ByteArray([50, 97]), ByteArray([50, 98]), ByteArray([50, 99]), ByteArray([50, 100]), ByteArray([50, 101]), ByteArray([50, 102]), ByteArray([51, 48]), ByteArray([51, 49]), ByteArray([51, 50]), ByteArray([51, 51]), ByteArray([51, 52]), ByteArray([51, 53]), ByteArray([51, 54]), ByteArray([51, 55]), ByteArray([51, 56]), ByteArray([51, 57]), ByteArray([51, 97]), ByteArray([51, 98]), ByteArray([51, 99]), ByteArray([51, 100]), ByteArray([51, 101]), ByteArray([51, 102]), ByteArray([52, 48]), ByteArray([52, 49]), ByteArray([52, 50]), ByteArray([52, 51]), ByteArray([52, 52]), ByteArray([52, 53]), ByteArray([52, 54]), ByteArray([52, 55]), ByteArray([52, 56]), ByteArray([52, 57]), ByteArray([52, 97]), ByteArray([52, 98]), ByteArray([52, 99]), ByteArray([52, 100]), ByteArray([52, 101]), ByteArray([52, 102]), ByteArray([53, 48]), ByteArray([53, 49]), ByteArray([53, 50]), ByteArray([53, 51]), ByteArray([53, 52]), ByteArray([53, 53]), ByteArray([53, 54]), ByteArray([53, 55]), ByteArray([53, 56]), ByteArray([53, 57]), ByteArray([53, 97]), ByteArray([53, 98]), ByteArray([53, 99]), ByteArray([53, 100]), ByteArray([53, 101]), ByteArray([53, 102]), ByteArray([54, 48]), ByteArray([54, 49]), ByteArray([54, 50]), ByteArray([54, 51]), ByteArray([54, 52]), ByteArray([54, 53]), ByteArray([54, 54]), ByteArray([54, 55]), ByteArray([54, 56]), ByteArray([54, 57]), ByteArray([54, 97]), ByteArray([54, 98]), ByteArray([54, 99]), ByteArray([54, 100]), ByteArray([54, 101]), ByteArray([54, 102]), ByteArray([55, 48]), ByteArray([55, 49]), ByteArray([55, 50]), ByteArray([55, 51]), ByteArray([55, 52]), ByteArray([55, 53]), ByteArray([55, 54]), ByteArray([55, 55]), ByteArray([55, 56]), ByteArray([55, 57]), ByteArray([55, 97]), ByteArray([55, 98]), ByteArray([55, 99]), ByteArray([55, 100]), ByteArray([55, 101]), ByteArray([55, 102]), ByteArray([56, 48]), ByteArray([56, 49]), ByteArray([56, 50]), ByteArray([56, 51]), ByteArray([56, 52]), ByteArray([56, 53]), ByteArray([56, 54]), ByteArray([56, 55]), ByteArray([56, 56]), ByteArray([56, 57]), ByteArray([56, 97]), ByteArray([56, 98]), ByteArray([56, 99]), ByteArray([56, 100]), ByteArray([56, 101]), ByteArray([56, 102]), ByteArray([57, 48]), ByteArray([57, 49]), ByteArray([57, 50]), ByteArray([57, 51]), ByteArray([57, 52]), ByteArray([57, 53]), ByteArray([57, 54]), ByteArray([57, 55]), ByteArray([57, 56]), ByteArray([57, 57]), ByteArray([57, 97]), ByteArray([57, 98]), ByteArray([57, 99]), ByteArray([57, 100]), ByteArray([57, 101]), ByteArray([57, 102]), ByteArray([97, 48]), ByteArray([97, 49]), ByteArray([97, 50]), ByteArray([97, 51]), ByteArray([97, 52]), ByteArray([97, 53]), ByteArray([97, 54]), ByteArray([97, 55]), ByteArray([97, 56]), ByteArray([97, 57]), ByteArray([97, 97]), ByteArray([97, 98]), ByteArray([97, 99]), ByteArray([97, 100]), ByteArray([97, 101]), ByteArray([97, 102]), ByteArray([98, 48]), ByteArray([98, 49]), ByteArray([98, 50]), ByteArray([98, 51]), ByteArray([98, 52]), ByteArray([98, 53]), ByteArray([98, 54]), ByteArray([98, 55]), ByteArray([98, 56]), ByteArray([98, 57]), ByteArray([98, 97]), ByteArray([98, 98]), ByteArray([98, 99]), ByteArray([98, 100]), ByteArray([98, 101]), ByteArray([98, 102]), ByteArray([99, 48]), ByteArray([99, 49]), ByteArray([99, 50]), ByteArray([99, 51]), ByteArray([99, 52]), ByteArray([99, 53]), ByteArray([99, 54]), ByteArray([99, 55]), ByteArray([99, 56]), ByteArray([99, 57]), ByteArray([99, 97]), ByteArray([99, 98]), ByteArray([99, 99]), ByteArray([99, 100]), ByteArray([99, 101]), ByteArray([99, 102]), ByteArray([100, 48]), ByteArray([100, 49]), ByteArray([100, 50]), ByteArray([100, 51]), ByteArray([100, 52]), ByteArray([100, 53]), ByteArray([100, 54]), ByteArray([100, 55]), ByteArray([100, 56]), ByteArray([100, 57]), ByteArray([100, 97]), ByteArray([100, 98]), ByteArray([100, 99]), ByteArray([100, 100]), ByteArray([100, 101]), ByteArray([100, 102]), ByteArray([101, 48]), ByteArray([101, 49]), ByteArray([101, 50]), ByteArray([101, 51]), ByteArray([101, 52]), ByteArray([101, 53]), ByteArray([101, 54]), ByteArray([101, 55]), ByteArray([101, 56]), ByteArray([101, 57]), ByteArray([101, 97]), ByteArray([101, 98]), ByteArray([101, 99]), ByteArray([101, 100]), ByteArray([101, 101]), ByteArray([101, 102]), ByteArray([102, 48]), ByteArray([102, 49]), ByteArray([102, 50]), ByteArray([102, 51]), ByteArray([102, 52]), ByteArray([102, 53]), ByteArray([102, 54]), ByteArray([102, 55]), ByteArray([102, 56]), ByteArray([102, 57]), ByteArray([102, 97]), ByteArray([102, 98]), ByteArray([102, 99]), ByteArray([102, 100]), ByteArray([102, 101]), ByteArray([102, 102])];
@@ -52,6 +54,7 @@
 
 ## Function `encode`
 
+Encode <code>bytes</code> in lowercase hex
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_encode">encode</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -85,6 +88,12 @@
 
 ## Function `decode`
 
+Decode hex into <code>bytes</code>
+Takes a hex string (no 0x prefix) (e.g. b"0f3a")
+Returns vector of <code>bytes</code> that represents the hex string (e.g. x"0f3a")
+Hex string can be case insensitive (e.g. b"0F3A" and b"0f3a" both return x"0f3a")
+Aborts if the hex string does not have an even number of characters (as each hex character is 2 characters long)
+Aborts if the hex string contains non-valid hex characters (valid characters are 0 - 9, a - f, A - F)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_decode">decode</a>(<a href="../../dependencies/sui-framework/hex.md#0x2_hex">hex</a>: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/linked_table.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/linked_table.md
@@ -3,6 +3,8 @@
 
 # Module `0x2::linked_table`
 
+Similar to <code>sui::table</code> but the values are linked together, allowing for ordered insertion and
+removal
 
 
 -  [Resource `LinkedTable`](#0x2_linked_table_LinkedTable)
@@ -55,25 +57,25 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ the ID of this table
 </dd>
 <dt>
 <code>size: u64</code>
 </dt>
 <dd>
-
+ the number of key-value pairs in the table
 </dd>
 <dt>
 <code>head: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;</code>
 </dt>
 <dd>
-
+ the front of the table, i.e. the key of the first entry
 </dd>
 <dt>
 <code>tail: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;</code>
 </dt>
 <dd>
-
+ the back of the table, i.e. the key of the last entry
 </dd>
 </dl>
 
@@ -100,19 +102,19 @@
 <code>prev: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;</code>
 </dt>
 <dd>
-
+ the previous key
 </dd>
 <dt>
 <code>next: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;</code>
 </dt>
 <dd>
-
+ the next key
 </dd>
 <dt>
 <code>value: V</code>
 </dt>
 <dd>
-
+ the value being stored
 </dd>
 </dl>
 
@@ -146,6 +148,7 @@
 
 ## Function `new`
 
+Creates a new, empty table
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;
@@ -175,6 +178,7 @@
 
 ## Function `front`
 
+Returns the key for the first element in the table, or None if the table is empty
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_front">front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;
@@ -199,6 +203,7 @@
 
 ## Function `back`
 
+Returns the key for the last element in the table, or None if the table is empty
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_back">back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;
@@ -223,6 +228,10 @@
 
 ## Function `push_front`
 
+Inserts a key-value pair at the front of the table, i.e. the newly inserted pair will be
+the first element in the table
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_push_front">push_front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
@@ -262,6 +271,10 @@
 
 ## Function `push_back`
 
+Inserts a key-value pair at the back of the table, i.e. the newly inserted pair will be
+the last element in the table
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_push_back">push_back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
@@ -301,6 +314,9 @@
 
 ## Function `borrow`
 
+Immutable borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &V
@@ -325,6 +341,9 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
@@ -352,6 +371,10 @@
 
 ## Function `prev`
 
+Borrows the key for the previous entry of the specified key <code>k: K</code> in the table
+<code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_prev">prev</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;
@@ -376,6 +399,10 @@
 
 ## Function `next`
 
+Borrows the key for the next entry of the specified key <code>k: K</code> in the table
+<code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_next">next</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;K&gt;
@@ -400,6 +427,10 @@
 
 ## Function `remove`
 
+Removes the key-value pair in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+This splices the element out of the ordering.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>. Note: this is also what happens when the table is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): V
@@ -434,6 +465,8 @@
 
 ## Function `pop_front`
 
+Removes the front of the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code><a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
@@ -460,6 +493,8 @@
 
 ## Function `pop_back`
 
+Removes the back of the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code><a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
@@ -486,6 +521,8 @@
 
 ## Function `contains`
 
+Returns true iff there is a value associated with the key <code>k: K</code> in table
+<code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): bool
@@ -510,6 +547,7 @@
 
 ## Function `length`
 
+Returns the size of the table, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): u64
@@ -534,6 +572,7 @@
 
 ## Function `is_empty`
 
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;): bool
@@ -558,6 +597,8 @@
 
 ## Function `destroy_empty`
 
+Destroys an empty table
+Aborts with <code><a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;)
@@ -584,6 +625,8 @@
 
 ## Function `drop`
 
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_drop">drop</a>&lt;K: <b>copy</b>, drop, store, V: drop, store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/linked_table.md#0x2_linked_table_LinkedTable">linked_table::LinkedTable</a>&lt;K, V&gt;)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/math.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/math.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::math`
 
+Basic math for nicer programmability
 
 
 -  [Function `max`](#0x2_math_max)
@@ -22,6 +23,7 @@
 
 ## Function `max`
 
+Return the larger of <code>x</code> and <code>y</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_max">max</a>(x: u64, y: u64): u64
@@ -50,6 +52,7 @@
 
 ## Function `min`
 
+Return the smaller of <code>x</code> and <code>y</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <b>min</b>(x: u64, y: u64): u64
@@ -78,6 +81,7 @@
 
 ## Function `diff`
 
+Return the absolute value of x - y
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_diff">diff</a>(x: u64, y: u64): u64
@@ -106,6 +110,7 @@
 
 ## Function `pow`
 
+Return the value of a base raised to a power
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_pow">pow</a>(base: u64, exponent: u8): u64
@@ -141,6 +146,31 @@
 
 ## Function `sqrt`
 
+Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt(9) => 3
+math::sqrt(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt(8) => 2;
+math::sqrt(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt(10000)).
+
+
+math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_sqrt">sqrt</a>(x: u64): u64
@@ -179,6 +209,31 @@
 
 ## Function `sqrt_u128`
 
+Similar to math::sqrt, but for u128 numbers. Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt_u128(9) => 3
+math::sqrt_u128(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt_u128(8) => 2;
+math::sqrt_u128(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt_u128(10000)).
+
+
+math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_sqrt_u128">sqrt_u128</a>(x: u128): u128
@@ -217,6 +272,7 @@
 
 ## Function `divide_and_round_up`
 
+Calculate x / y, but round up the result.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_divide_and_round_up">divide_and_round_up</a>(x: u64, y: u64): u64

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/object.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/object.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::object`
 
+Sui object identifiers
 
 
 -  [Struct `ID`](#0x2_object_ID)
@@ -44,6 +45,12 @@
 
 ## Struct `ID`
 
+An object ID. This is used to reference Sui Objects.
+This is *not* guaranteed to be globally unique--anyone can create an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> or
+from an object, and ID's can be freely copied and dropped.
+Here, the values are not globally unique because there can be multiple values of type <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
+with the same underlying bytes. For example, <code><a href="../../dependencies/sui-framework/object.md#0x2_object_id">object::id</a>(&obj)</code> can be called as many times
+as you want for a given <code>obj</code>, and each <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> value will be identical.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a> <b>has</b> <b>copy</b>, drop, store
@@ -71,6 +78,12 @@
 
 ## Struct `UID`
 
+Globally unique IDs that define an object's ID in storage. Any Sui Object, that is a struct
+with the <code>key</code> ability, must have <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> as its first field.
+These are globally unique in the sense that no two values of type <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> are ever equal, in
+other words for any two values <code>id1: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> and <code>id2: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>, <code>id1</code> != <code>id2</code>.
+This is a privileged type that can only be derived from a <code>TxContext</code>.
+<code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> doesn't have the <code>drop</code> ability, so deleting a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> requires a call to <code>delete</code>.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a> <b>has</b> store
@@ -101,6 +114,7 @@
 
 <a name="0x2_object_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -110,6 +124,7 @@
 
 <a name="0x2_object_SUI_AUTHENTICATOR_STATE_ID"></a>
 
+The hardcoded ID for the singleton AuthenticatorState Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_AUTHENTICATOR_STATE_ID">SUI_AUTHENTICATOR_STATE_ID</a>: <b>address</b> = 7;
@@ -119,6 +134,7 @@
 
 <a name="0x2_object_SUI_CLOCK_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton Clock Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_CLOCK_OBJECT_ID">SUI_CLOCK_OBJECT_ID</a>: <b>address</b> = 6;
@@ -128,6 +144,7 @@
 
 <a name="0x2_object_SUI_DENY_LIST_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton DenyList.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_DENY_LIST_OBJECT_ID">SUI_DENY_LIST_OBJECT_ID</a>: <b>address</b> = 403;
@@ -137,6 +154,7 @@
 
 <a name="0x2_object_SUI_RANDOM_ID"></a>
 
+The hardcoded ID for the singleton Random Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_RANDOM_ID">SUI_RANDOM_ID</a>: <b>address</b> = 8;
@@ -146,6 +164,7 @@
 
 <a name="0x2_object_SUI_SYSTEM_STATE_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton Sui System State Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_SYSTEM_STATE_OBJECT_ID">SUI_SYSTEM_STATE_OBJECT_ID</a>: <b>address</b> = 5;
@@ -157,6 +176,7 @@
 
 ## Function `id_to_bytes`
 
+Get the raw bytes of a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_to_bytes">id_to_bytes</a>(id: &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -181,6 +201,7 @@
 
 ## Function `id_to_address`
 
+Get the inner bytes of <code>id</code> as an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_to_address">id_to_address</a>(id: &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>): <b>address</b>
@@ -205,6 +226,7 @@
 
 ## Function `id_from_bytes`
 
+Make an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from raw bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_from_bytes">id_from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -229,6 +251,7 @@
 
 ## Function `id_from_address`
 
+Make an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_from_address">id_from_address</a>(bytes: <b>address</b>): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -253,6 +276,8 @@
 
 ## Function `sui_system_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>SuiSystemState</code> object.
+This should only be called once from <code>sui_system</code>.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_sui_system_state">sui_system_state</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -280,6 +305,8 @@
 
 ## Function `clock`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>Clock</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -306,6 +333,8 @@
 
 ## Function `authenticator_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>AuthenticatorState</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state">authenticator_state</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state">authenticator_state</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -332,6 +361,8 @@
 
 ## Function `randomness_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>Random</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/random.md#0x2_random">random</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_randomness_state">randomness_state</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -358,6 +389,8 @@
 
 ## Function `sui_deny_list_object_id`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>DenyList</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -384,6 +417,7 @@
 
 ## Function `uid_as_inner`
 
+Get the inner <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>uid</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_as_inner">uid_as_inner</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -408,6 +442,7 @@
 
 ## Function `uid_to_inner`
 
+Get the raw bytes of a <code>uid</code>'s inner <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_inner">uid_to_inner</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -432,6 +467,7 @@
 
 ## Function `uid_to_bytes`
 
+Get the raw bytes of a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_bytes">uid_to_bytes</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -456,6 +492,7 @@
 
 ## Function `uid_to_address`
 
+Get the inner bytes of <code>id</code> as an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_address">uid_to_address</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <b>address</b>
@@ -480,6 +517,8 @@
 
 ## Function `new`
 
+Create a new object. Returns the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> that must be stored in a Sui object.
+This is the only way to create <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>s.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -506,6 +545,7 @@
 
 ## Function `delete`
 
+Delete the object and it's <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>. This is the only way to eliminate a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_delete">delete</a>(id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>)
@@ -531,6 +571,7 @@
 
 ## Function `id`
 
+Get the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id">id</a>&lt;T: key&gt;(obj: &T): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -555,6 +596,7 @@
 
 ## Function `borrow_id`
 
+Borrow the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_borrow_id">borrow_id</a>&lt;T: key&gt;(obj: &T): &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -579,6 +621,7 @@
 
 ## Function `id_bytes`
 
+Get the raw bytes for the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_bytes">id_bytes</a>&lt;T: key&gt;(obj: &T): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -603,6 +646,7 @@
 
 ## Function `id_address`
 
+Get the inner bytes for the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_address">id_address</a>&lt;T: key&gt;(obj: &T): <b>address</b>
@@ -627,6 +671,11 @@
 
 ## Function `borrow_uid`
 
+Get the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for <code>obj</code>.
+Safe because Sui has an extra bytecode verifier pass that forces every struct with
+the <code>key</code> ability to have a distinguished <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> field.
+Cannot be made public as the access to <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for a given object must be privileged, and
+restrictable in the object's module.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_borrow_uid">borrow_uid</a>&lt;T: key&gt;(obj: &T): &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -649,6 +698,7 @@
 
 ## Function `new_uid_from_hash`
 
+Generate a new UID specifically used for creating a UID from a hash
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/random.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/random.md
@@ -27,6 +27,8 @@
 
 ## Resource `Random`
 
+Singleton shared object which stores the global randomness state.
+The actual state is stored in a versioned inner field.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_Random">Random</a> <b>has</b> key
@@ -146,6 +148,9 @@
 
 ## Function `create`
 
+Create and share the Random object. This function is called exactly once, when
+the Random object is first created.
+Can only be called by genesis or change_epoch transactions.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_create">create</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -249,6 +254,8 @@
 
 ## Function `update_randomness_state`
 
+Record new randomness. Called when executing the RandomnessStateUpdate system
+transaction.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_update_randomness_state">update_randomness_state</a>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_Random">random::Random</a>, new_round: u64, new_bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/sui.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/sui.md
@@ -3,6 +3,8 @@
 
 # Module `0x2::sui`
 
+Coin<SUI> is the token used to pay for gas in Sui.
+It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 
 
 -  [Struct `SUI`](#0x2_sui_SUI)
@@ -25,6 +27,7 @@
 
 ## Struct `SUI`
 
+Name of the coin
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">SUI</a> <b>has</b> drop
@@ -55,6 +58,7 @@
 
 <a name="0x2_sui_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_ENotSystemAddress">ENotSystemAddress</a>: u64 = 1;
@@ -73,6 +77,8 @@
 
 <a name="0x2_sui_MIST_PER_SUI"></a>
 
+The amount of Mist per Sui token based on the the fact that mist is
+10^-9 of a Sui token
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_MIST_PER_SUI">MIST_PER_SUI</a>: u64 = 1000000000;
@@ -82,6 +88,7 @@
 
 <a name="0x2_sui_TOTAL_SUPPLY_MIST"></a>
 
+The total supply of Sui denominated in Mist (10 Billion * 10^9)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>: u64 = 10000000000000000000;
@@ -91,6 +98,7 @@
 
 <a name="0x2_sui_TOTAL_SUPPLY_SUI"></a>
 
+The total supply of Sui denominated in whole Sui tokens (10 Billion)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_TOTAL_SUPPLY_SUI">TOTAL_SUPPLY_SUI</a>: u64 = 10000000000;
@@ -102,6 +110,8 @@
 
 ## Function `new`
 
+Register the <code><a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">SUI</a></code> Coin to acquire its <code>Supply</code>.
+This should be called only once during genesis creation.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/table.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/table.md
@@ -3,6 +3,21 @@
 
 # Module `0x2::table`
 
+A table is a map-like collection. But unlike a traditional collection, it's keys and values are
+not stored within the <code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> value, but instead are stored using Sui's object system. The
+<code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> struct acts only as a handle into the object system to retrieve those keys and values.
+Note that this means that <code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let table1 = table::new<u64, bool>();
+let table2 = table::new<u64, bool>();
+table::add(&mut table1, 0, false);
+table::add(&mut table1, 1, true);
+table::add(&mut table2, 0, false);
+table::add(&mut table2, 1, true);
+// table1 does not equal table2, despite having the same entries
+assert!(&table1 != &table2, 0);
+```
 
 
 -  [Resource `Table`](#0x2_table_Table)
@@ -46,13 +61,13 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ the ID of this table
 </dd>
 <dt>
 <code>size: u64</code>
 </dt>
 <dd>
-
+ the number of key-value pairs in the table
 </dd>
 </dl>
 
@@ -77,6 +92,7 @@
 
 ## Function `new`
 
+Creates a new, empty table
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;
@@ -104,6 +120,9 @@
 
 ## Function `add`
 
+Adds a key-value pair to the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K, v: V)
@@ -129,6 +148,9 @@
 
 ## Function `borrow`
 
+Immutable borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &V
@@ -153,6 +175,9 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
@@ -177,6 +202,9 @@
 
 ## Function `remove`
 
+Removes the key-value pair in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): V
@@ -203,6 +231,7 @@
 
 ## Function `contains`
 
+Returns true iff there is a value associated with the key <code>k: K</code> in table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): bool
@@ -227,6 +256,7 @@
 
 ## Function `length`
 
+Returns the size of the table, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): u64
@@ -251,6 +281,7 @@
 
 ## Function `is_empty`
 
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): bool
@@ -275,6 +306,8 @@
 
 ## Function `destroy_empty`
 
+Destroys an empty table
+Aborts with <code><a href="../../dependencies/sui-framework/table.md#0x2_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
@@ -301,6 +334,8 @@
 
 ## Function `drop`
 
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b>, drop, store, V: drop, store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/transfer.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/transfer.md
@@ -31,6 +31,13 @@
 
 ## Struct `Receiving`
 
+This represents the ability to <code>receive</code> an object of type <code>T</code>.
+This type is ephemeral per-transaction and cannot be stored on-chain.
+This does not represent the obligation to receive the object that it
+references, but simply the ability to receive the object with object ID
+<code>id</code> at version <code>version</code> if you can prove mutable access to the parent
+object during the transaction.
+Internals of this struct are opaque outside this module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a>&lt;T: key&gt; <b>has</b> drop
@@ -67,6 +74,7 @@
 
 <a name="0x2_transfer_EBCSSerializationFailure"></a>
 
+Serialization of the object failed.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EBCSSerializationFailure">EBCSSerializationFailure</a>: u64 = 1;
@@ -76,6 +84,7 @@
 
 <a name="0x2_transfer_EReceivingObjectTypeMismatch"></a>
 
+The object being received is not of the expected type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EReceivingObjectTypeMismatch">EReceivingObjectTypeMismatch</a>: u64 = 2;
@@ -85,6 +94,8 @@
 
 <a name="0x2_transfer_ESharedNonNewObject"></a>
 
+Shared an object that was previously created. Shared objects must currently
+be constructed in the transaction they are created.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a>: u64 = 0;
@@ -94,6 +105,7 @@
 
 <a name="0x2_transfer_ESharedObjectOperationNotSupported"></a>
 
+Shared object operations such as wrapping, freezing, and converting to owned are not allowed.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedObjectOperationNotSupported">ESharedObjectOperationNotSupported</a>: u64 = 4;
@@ -103,6 +115,8 @@
 
 <a name="0x2_transfer_EUnableToReceiveObject"></a>
 
+Represents both the case where the object does not exist and the case where the object is not
+able to be accessed through the parent that is passed-in.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EUnableToReceiveObject">EUnableToReceiveObject</a>: u64 = 3;
@@ -114,6 +128,13 @@
 
 ## Function `transfer`
 
+Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer">transfer</a></code> is invoked. Use
+<code>public_transfer</code> to transfer an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
@@ -138,6 +159,11 @@
 
 ## Function `public_transfer`
 
+Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
+The object must have <code>store</code> to be transferred outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_transfer">public_transfer</a>&lt;T: store, key&gt;(obj: T, recipient: <b>address</b>)
@@ -162,6 +188,11 @@
 
 ## Function `freeze_object`
 
+Freeze <code>obj</code>. After freezing <code>obj</code> becomes immutable and can no longer be transferred or
+mutated.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>freeze_object</code> is invoked. Use
+<code>public_freeze_object</code> to freeze an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_freeze_object">freeze_object</a>&lt;T: key&gt;(obj: T)
@@ -186,6 +217,9 @@
 
 ## Function `public_freeze_object`
 
+Freeze <code>obj</code>. After freezing <code>obj</code> becomes immutable and can no longer be transferred or
+mutated.
+The object must have <code>store</code> to be frozen outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_freeze_object">public_freeze_object</a>&lt;T: store, key&gt;(obj: T)
@@ -210,6 +244,13 @@
 
 ## Function `share_object`
 
+Turn the given object into a mutable shared object that everyone can access and mutate.
+This is irreversible, i.e. once an object is shared, it will stay shared forever.
+Aborts with <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a></code> of the object being shared was not created in this
+transaction. This restriction may be relaxed in the future.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>share_object</code> is invoked. Use
+<code>public_share_object</code> to share an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_share_object">share_object</a>&lt;T: key&gt;(obj: T)
@@ -234,6 +275,11 @@
 
 ## Function `public_share_object`
 
+Turn the given object into a mutable shared object that everyone can access and mutate.
+This is irreversible, i.e. once an object is shared, it will stay shared forever.
+Aborts with <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a></code> of the object being shared was not created in this
+transaction. This restriction may be relaxed in the future.
+The object must have <code>store</code> to be shared outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_share_object">public_share_object</a>&lt;T: store, key&gt;(obj: T)
@@ -258,6 +304,12 @@
 
 ## Function `receive`
 
+Given mutable (i.e., locked) access to the <code>parent</code> and a <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument
+referencing an object of type <code>T</code> owned by <code>parent</code> use the <code>to_receive</code>
+argument to receive and return the referenced owned object of type <code>T</code>.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>receive</code> is invoked. Use
+<code>public_receive</code> to receivne an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_receive">receive</a>&lt;T: key&gt;(parent: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, to_receive: <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): T
@@ -286,6 +338,10 @@
 
 ## Function `public_receive`
 
+Given mutable (i.e., locked) access to the <code>parent</code> and a <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument
+referencing an object of type <code>T</code> owned by <code>parent</code> use the <code>to_receive</code>
+argument to receive and return the referenced owned object of type <code>T</code>.
+The object must have <code>store</code> to be received outside of its defining module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_receive">public_receive</a>&lt;T: store, key&gt;(parent: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, to_receive: <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): T
@@ -314,6 +370,7 @@
 
 ## Function `receiving_object_id`
 
+Return the object ID that the given <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument references.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_receiving_object_id">receiving_object_id</a>&lt;T: key&gt;(receiving: &<a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/tx_context.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/tx_context.md
@@ -23,6 +23,9 @@
 
 ## Struct `TxContext`
 
+Information about the transaction currently being executed.
+This cannot be constructed by a transaction--it is a privileged object created by
+the VM and passed in to the entrypoint of the transaction as <code>&<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">TxContext</a></code>.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">TxContext</a> <b>has</b> drop
@@ -39,31 +42,32 @@
 <code>sender: <b>address</b></code>
 </dt>
 <dd>
-
+ The address of the user that signed the current transaction
 </dd>
 <dt>
 <code>tx_hash: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
-
+ Hash of the current transaction
 </dd>
 <dt>
 <code>epoch: u64</code>
 </dt>
 <dd>
-
+ The current epoch number
 </dd>
 <dt>
 <code>epoch_timestamp_ms: u64</code>
 </dt>
 <dd>
-
+ Timestamp that the epoch started at
 </dd>
 <dt>
 <code>ids_created: u64</code>
 </dt>
 <dd>
-
+ Counter recording the number of fresh id's created while executing
+ this transaction. Always 0 at the start of a transaction
 </dd>
 </dl>
 
@@ -74,6 +78,8 @@
 
 ## Function `sender`
 
+Return the address of the user that signed the current
+transaction
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
@@ -98,6 +104,8 @@
 
 ## Function `digest`
 
+Return the transaction digest (hash of transaction inputs).
+Please do not use as a source of randomness.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_digest">digest</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -122,6 +130,7 @@
 
 ## Function `epoch`
 
+Return the current epoch
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_epoch">epoch</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -146,6 +155,7 @@
 
 ## Function `epoch_timestamp_ms`
 
+Return the epoch start time as a unix timestamp in milliseconds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_epoch_timestamp_ms">epoch_timestamp_ms</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -170,6 +180,9 @@
 
 ## Function `fresh_object_address`
 
+Create an <code><b>address</b></code> that has not been used. As it is an object address, it will never
+occur as the address for a user.
+In other words, the generated address is a globally unique object ID.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_fresh_object_address">fresh_object_address</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
@@ -197,6 +210,8 @@
 
 ## Function `ids_created`
 
+Return the number of id's created by the current transaction.
+Hidden for now, but may expose later
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_ids_created">ids_created</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -221,6 +236,7 @@
 
 ## Function `derive_id`
 
+Native function for deriving an ID via hash(tx_hash || ids_created)
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_derive_id">derive_id</a>(tx_hash: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ids_created: u64): <b>address</b>

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/types.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/types.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::types`
 
+Sui types helpers and utilities
 
 
 -  [Function `is_one_time_witness`](#0x2_types_is_one_time_witness)
@@ -16,6 +17,8 @@
 
 ## Function `is_one_time_witness`
 
+Tests if the argument type is a one-time witness, that is a type with only one instantiation
+across the entire code base.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/types.md#0x2_types_is_one_time_witness">is_one_time_witness</a>&lt;T: drop&gt;(_: &T): bool

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/url.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/url.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::url`
 
+URL: standard Uniform Resource Locator string
 
 
 -  [Struct `Url`](#0x2_url_Url)
@@ -21,6 +22,7 @@
 
 ## Struct `Url`
 
+Standard Uniform Resource Locator (URL) string.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a> <b>has</b> <b>copy</b>, drop, store
@@ -48,6 +50,7 @@
 
 ## Function `new_unsafe`
 
+Create a <code><a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a></code>, with no validation
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_new_unsafe">new_unsafe</a>(<a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>
@@ -72,6 +75,8 @@
 
 ## Function `new_unsafe_from_bytes`
 
+Create a <code><a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a></code> with no validation from bytes
+Note: this will abort if <code>bytes</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_new_unsafe_from_bytes">new_unsafe_from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>
@@ -97,6 +102,7 @@
 
 ## Function `inner_url`
 
+Get inner URL
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_inner_url">inner_url</a>(self: &<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -121,6 +127,7 @@
 
 ## Function `update`
 
+Update the inner URL
 
 
 <pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>, <a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/vec_set.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/vec_set.md
@@ -30,6 +30,11 @@
 
 ## Struct `VecSet`
 
+A set data structure backed by a vector. The set is guaranteed not to
+contain duplicate keys. All operations are O(N) in the size of the set
+- the intention of this data structure is only to provide the convenience
+of programming against a set API. Sets that need sorted iteration rather
+than insertion order iteration should be handwritten.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K: <b>copy</b>, drop&gt; <b>has</b> <b>copy</b>, drop, store
@@ -60,6 +65,7 @@
 
 <a name="0x2_vec_set_EKeyAlreadyExists"></a>
 
+This key already exists in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_EKeyAlreadyExists">EKeyAlreadyExists</a>: u64 = 0;
@@ -69,6 +75,7 @@
 
 <a name="0x2_vec_set_EKeyDoesNotExist"></a>
 
+This key does not exist in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
@@ -80,6 +87,7 @@
 
 ## Function `empty`
 
+Create an empty <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_empty">empty</a>&lt;K: <b>copy</b>, drop&gt;(): <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
@@ -104,6 +112,7 @@
 
 ## Function `singleton`
 
+Create a singleton <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> that only contains one element.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_singleton">singleton</a>&lt;K: <b>copy</b>, drop&gt;(key: K): <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
@@ -128,6 +137,8 @@
 
 ## Function `insert`
 
+Insert a <code>key</code> into self.
+Aborts if <code>key</code> is already present in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_insert">insert</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: K)
@@ -153,6 +164,7 @@
 
 ## Function `remove`
 
+Remove the entry <code>key</code> from self. Aborts if <code>key</code> is not present in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_remove">remove</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K)
@@ -178,6 +190,7 @@
 
 ## Function `contains`
 
+Return true if <code>self</code> contains an entry for <code>key</code>, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_contains">contains</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): bool
@@ -202,6 +215,7 @@
 
 ## Function `size`
 
+Return the number of entries in <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_size">size</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): u64
@@ -226,6 +240,7 @@
 
 ## Function `is_empty`
 
+Return true if <code>self</code> has 0 elements, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): bool
@@ -250,6 +265,8 @@
 
 ## Function `into_keys`
 
+Unpack <code>self</code> into vectors of keys.
+The output keys are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b>, drop&gt;(self: <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;
@@ -275,6 +292,9 @@
 
 ## Function `keys`
 
+Borrow the <code>contents</code> of the <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> to access content by index
+without unpacking. The contents are stored in insertion order,
+*not* sorted.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_keys">keys</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;
@@ -299,6 +319,8 @@
 
 ## Function `get_idx_opt`
 
+Find the index of <code>key</code> in <code>self</code>. Return <code>None</code> if <code>key</code> is not in <code>self</code>.
+Note that keys are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
@@ -331,6 +353,8 @@
 
 ## Function `get_idx`
 
+Find the index of <code>key</code> in <code>self</code>. Aborts if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_get_idx">get_idx</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): u64

--- a/crates/sui-framework/docs/deepbook/dependencies/sui-framework/versioned.md
+++ b/crates/sui-framework/docs/deepbook/dependencies/sui-framework/versioned.md
@@ -28,6 +28,12 @@
 
 ## Resource `Versioned`
 
+A wrapper type that supports versioning of the inner type.
+The inner type is a dynamic field of the Versioned object, and is keyed using version.
+User of this type could load the inner object using corresponding type based on the version.
+You can also upgrade the inner object to a new type version.
+If you want to support lazy upgrade of the inner type, one caveat is that all APIs would have
+to use mutable reference even if it's a read-only API.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">Versioned</a> <b>has</b> store, key
@@ -61,6 +67,8 @@
 
 ## Struct `VersionChangeCap`
 
+Represents a hot potato object generated when we take out the dynamic field.
+This is to make sure that we always put a new value back.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">VersionChangeCap</a>
@@ -97,6 +105,7 @@
 
 <a name="0x2_versioned_EInvalidUpgrade"></a>
 
+Failed to upgrade the inner object due to invalid capability or new version.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_EInvalidUpgrade">EInvalidUpgrade</a>: u64 = 0;
@@ -108,6 +117,7 @@
 
 ## Function `create`
 
+Create a new Versioned object that contains a initial value of type <code>T</code> with an initial version.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_create">create</a>&lt;T: store&gt;(init_version: u64, init_value: T, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>
@@ -137,6 +147,7 @@
 
 ## Function `version`
 
+Get the current version of the inner type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_version">version</a>(self: &<a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): u64
@@ -161,6 +172,8 @@
 
 ## Function `load_value`
 
+Load the inner value based on the current version. Caller specifies an expected type T.
+If the type mismatch, the load will fail.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_load_value">load_value</a>&lt;T: store&gt;(self: &<a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): &T
@@ -185,6 +198,7 @@
 
 ## Function `load_value_mut`
 
+Similar to load_value, but return a mutable reference.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_load_value_mut">load_value_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): &<b>mut</b> T
@@ -209,6 +223,8 @@
 
 ## Function `remove_value_for_upgrade`
 
+Take the inner object out for upgrade. To ensure we always upgrade properly, a capability object is returned
+and must be used when we upgrade.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_remove_value_for_upgrade">remove_value_for_upgrade</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): (T, <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">versioned::VersionChangeCap</a>)
@@ -239,6 +255,8 @@
 
 ## Function `upgrade`
 
+Upgrade the inner object with a new version and new value. Must use the capability returned
+by calling remove_value_for_upgrade.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_upgrade">upgrade</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>, new_version: u64, new_value: T, cap: <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">versioned::VersionChangeCap</a>)
@@ -267,6 +285,7 @@
 
 ## Function `destroy`
 
+Destroy this Versioned container, and return the inner object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_destroy">destroy</a>&lt;T: store&gt;(self: <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): T

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/address.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/address.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::address`
 
+Provides a way to get address length since it's a
+platform-specific parameter.
 
 
 -  [Function `length`](#0x1_address_length)
@@ -16,6 +18,8 @@
 
 ## Function `length`
 
+Should be converted to a native function.
+Current implementation only works for Sui.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/address.md#0x1_address_length">length</a>(): u64

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/ascii.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::ascii`
 
+The <code>ASCII</code> module defines basic string and char newtypes in Move that verify
+that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 
 
 -  [Struct `String`](#0x1_ascii_String)
@@ -31,6 +33,11 @@
 
 ## Struct `String`
 
+The <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> struct holds a vector of bytes that all represent
+valid ASCII characters. Note that these ASCII characters may not all
+be printable. To determine if a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> contains only "printable"
+characters you should use the <code>all_characters_printable</code> predicate
+defined in this module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -58,6 +65,7 @@
 
 ## Struct `Char`
 
+An ASCII character.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a> <b>has</b> <b>copy</b>, drop, store
@@ -88,6 +96,7 @@
 
 <a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
 
+An invalid ASCII character was encountered when creating an ASCII string.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
@@ -99,6 +108,7 @@
 
 ## Function `char`
 
+Convert a <code>byte</code> into a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> that is checked to make sure it is valid ASCII.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>
@@ -124,6 +134,8 @@
 
 ## Function `string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Aborts if
+<code>bytes</code> contains non-ASCII characters.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -153,6 +165,9 @@
 
 ## Function `try_string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Returns
+<code>Some(&lt;ascii_string&gt;)</code> if the <code>bytes</code> contains all valid ASCII
+characters. Otherwise returns <code>None</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_try_string">try_string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>&gt;
@@ -184,6 +199,8 @@
 
 ## Function `all_characters_printable`
 
+Returns <code><b>true</b></code> if all characters in <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> are printable characters
+Returns <code><b>false</b></code> otherwise. Not all <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>s are printable strings.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_all_characters_printable">all_characters_printable</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
@@ -287,6 +304,7 @@
 
 ## Function `as_bytes`
 
+Get the inner bytes of the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> as a reference
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -311,6 +329,7 @@
 
 ## Function `into_bytes`
 
+Unpack the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> to get its backing bytes
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -336,6 +355,7 @@
 
 ## Function `byte`
 
+Unpack the <code>char</code> into its underlying byte.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_byte">byte</a>(char: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
@@ -361,6 +381,7 @@
 
 ## Function `is_valid_char`
 
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
@@ -385,6 +406,7 @@
 
 ## Function `is_printable_char`
 
+Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/bcs.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/bcs.md
@@ -3,6 +3,10 @@
 
 # Module `0x1::bcs`
 
+Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+Serialization). BCS is the binary encoding for Move resources and other non-module values
+published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+details on BCS.
 
 
 -  [Function `to_bytes`](#0x1_bcs_to_bytes)
@@ -16,6 +20,7 @@
 
 ## Function `to_bytes`
 
+Return the binary representation of <code>v</code> in BCS (Binary Canonical Serialization) format
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/bcs.md#0x1_bcs_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/option.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/option.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::option`
 
+This module defines the Option type and its methods to represent and handle an optional value.
 
 
 -  [Struct `Option`](#0x1_option_Option)
@@ -35,6 +36,8 @@
 
 ## Struct `Option`
 
+Abstraction of a value that may or may not be present. Implemented with a vector of size
+zero or one because Move bytecode does not have ADTs.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt; <b>has</b> <b>copy</b>, drop, store
@@ -65,6 +68,8 @@
 
 <a name="0x1_option_EOPTION_IS_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
@@ -74,6 +79,8 @@
 
 <a name="0x1_option_EOPTION_NOT_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
@@ -85,6 +92,7 @@
 
 ## Function `none`
 
+Return an empty <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_none">none</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -109,6 +117,7 @@
 
 ## Function `some`
 
+Return an <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> containing <code>e</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_some">some</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -133,6 +142,7 @@
 
 ## Function `is_none`
 
+Return true if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -157,6 +167,7 @@
 
 ## Function `is_some`
 
+Return true if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -181,6 +192,8 @@
 
 ## Function `contains`
 
+Return true if the value in <code>t</code> is equal to <code>e_ref</code>
+Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
@@ -205,6 +218,8 @@
 
 ## Function `borrow`
 
+Return an immutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../borrow.md#0x2_borrow">borrow</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
@@ -230,6 +245,8 @@
 
 ## Function `borrow_with_default`
 
+Return a reference to the value inside <code>t</code> if it holds one
+Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
@@ -256,6 +273,8 @@
 
 ## Function `get_with_default`
 
+Return the value inside <code>t</code> if it holds one
+Return <code>default</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -285,6 +304,8 @@
 
 ## Function `fill`
 
+Convert the none option <code>t</code> to a some option by adding <code>e</code>.
+Aborts if <code>t</code> already holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
@@ -311,6 +332,8 @@
 
 ## Function `extract`
 
+Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -336,6 +359,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
@@ -361,6 +386,8 @@
 
 ## Function `swap`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
@@ -389,6 +416,9 @@
 
 ## Function `swap_or_fill`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value;
+or if there is no old value, fill it with <code>e</code>.
+Different from swap(), swap_or_fill() allows for <code>t</code> not holding a value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -417,6 +447,7 @@
 
 ## Function `destroy_with_default`
 
+Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -443,6 +474,8 @@
 
 ## Function `destroy_some`
 
+Unpack <code>t</code> and return its contents
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -471,6 +504,8 @@
 
 ## Function `destroy_none`
 
+Unpack <code>t</code>
+Aborts if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
@@ -497,6 +532,8 @@
 
 ## Function `to_vec`
 
+Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
+and an empty vector otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/string.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/string.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::string`
 
+The <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
 
 
 -  [Struct `String`](#0x1_string_String)
@@ -36,6 +37,7 @@
 
 ## Struct `String`
 
+A <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -66,6 +68,7 @@
 
 <a name="0x1_string_EINVALID_INDEX"></a>
 
+Index out of range.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
@@ -75,6 +78,7 @@
 
 <a name="0x1_string_EINVALID_UTF8"></a>
 
+An invalid UTF8 encoding.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
@@ -86,6 +90,7 @@
 
 ## Function `utf8`
 
+Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -111,6 +116,7 @@
 
 ## Function `from_ascii`
 
+Convert an ASCII string to a UTF8 string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_from_ascii">from_ascii</a>(s: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -135,6 +141,8 @@
 
 ## Function `to_ascii`
 
+Convert an UTF8 string to an ASCII string.
+Aborts if <code>s</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_to_ascii">to_ascii</a>(s: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -160,6 +168,7 @@
 
 ## Function `try_utf8`
 
+Tries to create a new string from a sequence of bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_try_utf8">try_utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>&gt;
@@ -188,6 +197,7 @@
 
 ## Function `bytes`
 
+Returns a reference to the underlying byte vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -212,6 +222,7 @@
 
 ## Function `is_empty`
 
+Checks whether this string is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): bool
@@ -236,6 +247,7 @@
 
 ## Function `length`
 
+Returns the length of this string, in bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64
@@ -260,6 +272,7 @@
 
 ## Function `append`
 
+Appends a string.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -284,6 +297,7 @@
 
 ## Function `append_utf8`
 
+Appends bytes which must be in valid utf8 format.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
@@ -308,6 +322,8 @@
 
 ## Function `insert`
 
+Insert the other string at the byte index in given string. The index must be at a valid utf8 char
+boundary.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -339,6 +355,9 @@
 
 ## Function `sub_string`
 
+Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
+of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+guaranteeing that the result is valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -369,6 +388,7 @@
 
 ## Function `index_of`
 
+Computes the index of the first occurrence of a string. Returns <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_index_of">index_of</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/type_name.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::type_name`
 
+Functionality for converting Move types into values. Use with care!
 
 
 -  [Struct `TypeName`](#0x1_type_name_TypeName)
@@ -42,7 +43,13 @@
 <code>name: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a></code>
 </dt>
 <dd>
-
+ String representation of the type. All types are represented
+ using their source syntax:
+ "u8", "u64", "bool", "address", "vector", and so on for primitive types.
+ Struct types are represented as fully qualified type names; e.g.
+ <code>00000000000000000000000000000001::string::String</code> or
+ <code>0000000000000000000000000000000a::module_name1::type_name1&lt;0000000000000000000000000000000a::module_name2::type_name2&lt;u64&gt;&gt;</code>
+ Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
 </dd>
 </dl>
 
@@ -56,6 +63,7 @@
 
 <a name="0x1_type_name_ASCII_C"></a>
 
+ASCII Character code for the <code>c</code> (lowercase c) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_C">ASCII_C</a>: u8 = 99;
@@ -65,6 +73,7 @@
 
 <a name="0x1_type_name_ASCII_COLON"></a>
 
+ASCII Character code for the <code>:</code> (colon) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_COLON">ASCII_COLON</a>: u8 = 58;
@@ -74,6 +83,7 @@
 
 <a name="0x1_type_name_ASCII_E"></a>
 
+ASCII Character code for the <code>e</code> (lowercase e) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_E">ASCII_E</a>: u8 = 101;
@@ -83,6 +93,7 @@
 
 <a name="0x1_type_name_ASCII_O"></a>
 
+ASCII Character code for the <code>o</code> (lowercase o) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_O">ASCII_O</a>: u8 = 111;
@@ -92,6 +103,7 @@
 
 <a name="0x1_type_name_ASCII_R"></a>
 
+ASCII Character code for the <code>r</code> (lowercase r) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_R">ASCII_R</a>: u8 = 114;
@@ -101,6 +113,7 @@
 
 <a name="0x1_type_name_ASCII_T"></a>
 
+ASCII Character code for the <code>t</code> (lowercase t) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_T">ASCII_T</a>: u8 = 116;
@@ -110,6 +123,7 @@
 
 <a name="0x1_type_name_ASCII_V"></a>
 
+ASCII Character code for the <code>v</code> (lowercase v) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_V">ASCII_V</a>: u8 = 118;
@@ -119,6 +133,7 @@
 
 <a name="0x1_type_name_ENonModuleType"></a>
 
+The type is not from a package/module. It is a primitive type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ENonModuleType">ENonModuleType</a>: u64 = 0;
@@ -130,6 +145,10 @@
 
 ## Function `get`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are defining IDs (the ID of the package in
+storage that first introduced the type).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -152,6 +171,11 @@
 
 ## Function `get_with_original_ids`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are original IDs (the ID of the first version of
+the package, even if the type in question was introduced in a
+later upgrade).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -174,6 +198,8 @@
 
 ## Function `is_primitive`
 
+Returns true iff the TypeName represents a primitive type, i.e. one of
+u8, u16, u32, u64, u128, u256, bool, address, vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_is_primitive">is_primitive</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): bool
@@ -214,6 +240,7 @@
 
 ## Function `borrow_string`
 
+Get the String representation of <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_borrow_string">borrow_string</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -238,6 +265,8 @@
 
 ## Function `get_address`
 
+Get Address string (Base16 encoded), first part of the TypeName.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_address">get_address</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -279,6 +308,8 @@
 
 ## Function `get_module`
 
+Get name of the module.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_module">get_module</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -320,6 +351,7 @@
 
 ## Function `into_string`
 
+Convert <code>self</code> into its inner String
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_into_string">into_string</a>(self: <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>

--- a/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/vector.md
+++ b/crates/sui-framework/docs/sui-framework/dependencies/move-stdlib/vector.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::vector`
 
+A variable-sized container that can hold any type. Indexing is 0-based, and
+vectors are growable. This module has many native functions.
 
 
 -  [Constants](#@Constants_0)
@@ -36,6 +38,7 @@
 
 <a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
 
+The index into the vector is out of bounds
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
@@ -47,6 +50,7 @@
 
 ## Function `empty`
 
+Create an empty vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -69,6 +73,7 @@
 
 ## Function `length`
 
+Return the length of the vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64
@@ -91,6 +96,8 @@
 
 ## Function `borrow`
 
+Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../borrow.md#0x2_borrow">borrow</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element
@@ -113,6 +120,7 @@
 
 ## Function `push_back`
 
+Add element <code>e</code> to the end of the vector <code>v</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element)
@@ -135,6 +143,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
@@ -157,6 +167,8 @@
 
 ## Function `pop_back`
 
+Pop an element from the end of vector <code>v</code>.
+Aborts if <code>v</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element
@@ -179,6 +191,8 @@
 
 ## Function `destroy_empty`
 
+Destroy the vector <code>v</code>.
+Aborts if <code>v</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -201,6 +215,8 @@
 
 ## Function `swap`
 
+Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
+Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64)
@@ -223,6 +239,7 @@
 
 ## Function `singleton`
 
+Return an vector of size one containing element <code>e</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -249,6 +266,7 @@
 
 ## Function `reverse`
 
+Reverses the order of the elements in the vector <code>v</code> in place.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -282,6 +300,7 @@
 
 ## Function `append`
 
+Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -308,6 +327,7 @@
 
 ## Function `is_empty`
 
+Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool
@@ -332,6 +352,8 @@
 
 ## Function `contains`
 
+Return true if <code>e</code> is in the vector <code>v</code>.
+Otherwise, returns false.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool
@@ -362,6 +384,8 @@
 
 ## Function `index_of`
 
+Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
+Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64)
@@ -392,6 +416,9 @@
 
 ## Function `remove`
 
+Remove the <code>i</code>th element of the vector <code>v</code>, shifting all subsequent elements.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
@@ -422,6 +449,11 @@
 
 ## Function `insert`
 
+Insert <code>e</code> at position <code>i</code> in the vector <code>v</code>.
+If <code>i</code> is in bounds, this shifts the old <code>v[i]</code> and all subsequent elements to the right.
+If <code>i == <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>, this adds <code>e</code> to the end of the vector.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i &gt; <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64)
@@ -454,6 +486,9 @@
 
 ## Function `swap_remove`
 
+Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the vector.
+This is O(1), but does not preserve ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/address.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/address.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::address`
 
+Provides a way to get address length since it's a
+platform-specific parameter.
 
 
 -  [Function `length`](#0x1_address_length)
@@ -16,6 +18,8 @@
 
 ## Function `length`
 
+Should be converted to a native function.
+Current implementation only works for Sui.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/address.md#0x1_address_length">length</a>(): u64

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/ascii.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/ascii.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::ascii`
 
+The <code>ASCII</code> module defines basic string and char newtypes in Move that verify
+that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 
 
 -  [Struct `String`](#0x1_ascii_String)
@@ -31,6 +33,11 @@
 
 ## Struct `String`
 
+The <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> struct holds a vector of bytes that all represent
+valid ASCII characters. Note that these ASCII characters may not all
+be printable. To determine if a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code> contains only "printable"
+characters you should use the <code>all_characters_printable</code> predicate
+defined in this module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -58,6 +65,7 @@
 
 ## Struct `Char`
 
+An ASCII character.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a> <b>has</b> <b>copy</b>, drop, store
@@ -88,6 +96,7 @@
 
 <a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
 
+An invalid ASCII character was encountered when creating an ASCII string.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
@@ -99,6 +108,7 @@
 
 ## Function `char`
 
+Convert a <code>byte</code> into a <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">Char</a></code> that is checked to make sure it is valid ASCII.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>
@@ -124,6 +134,8 @@
 
 ## Function `string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Aborts if
+<code>bytes</code> contains non-ASCII characters.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -153,6 +165,9 @@
 
 ## Function `try_string`
 
+Convert a vector of bytes <code>bytes</code> into an <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>. Returns
+<code>Some(&lt;ascii_string&gt;)</code> if the <code>bytes</code> contains all valid ASCII
+characters. Otherwise returns <code>None</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_try_string">try_string</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>&gt;
@@ -184,6 +199,8 @@
 
 ## Function `all_characters_printable`
 
+Returns <code><b>true</b></code> if all characters in <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> are printable characters
+Returns <code><b>false</b></code> otherwise. Not all <code><a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">String</a></code>s are printable strings.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_all_characters_printable">all_characters_printable</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): bool
@@ -287,6 +304,7 @@
 
 ## Function `as_bytes`
 
+Get the inner bytes of the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> as a reference
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -311,6 +329,7 @@
 
 ## Function `into_bytes`
 
+Unpack the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> to get its backing bytes
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_into_bytes">into_bytes</a>(<a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -336,6 +355,7 @@
 
 ## Function `byte`
 
+Unpack the <code>char</code> into its underlying byte.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_byte">byte</a>(char: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
@@ -361,6 +381,7 @@
 
 ## Function `is_valid_char`
 
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
@@ -385,6 +406,7 @@
 
 ## Function `is_printable_char`
 
+Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/bcs.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/bcs.md
@@ -3,6 +3,10 @@
 
 # Module `0x1::bcs`
 
+Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+Serialization). BCS is the binary encoding for Move resources and other non-module values
+published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+details on BCS.
 
 
 -  [Function `to_bytes`](#0x1_bcs_to_bytes)
@@ -16,6 +20,7 @@
 
 ## Function `to_bytes`
 
+Return the binary representation of <code>v</code> in BCS (Binary Canonical Serialization) format
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/bcs.md#0x1_bcs_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/option.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/option.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::option`
 
+This module defines the Option type and its methods to represent and handle an optional value.
 
 
 -  [Struct `Option`](#0x1_option_Option)
@@ -35,6 +36,8 @@
 
 ## Struct `Option`
 
+Abstraction of a value that may or may not be present. Implemented with a vector of size
+zero or one because Move bytecode does not have ADTs.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a>&lt;Element&gt; <b>has</b> <b>copy</b>, drop, store
@@ -65,6 +68,8 @@
 
 <a name="0x1_option_EOPTION_IS_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
@@ -74,6 +79,8 @@
 
 <a name="0x1_option_EOPTION_NOT_SET"></a>
 
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
+The <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
@@ -85,6 +92,7 @@
 
 ## Function `none`
 
+Return an empty <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_none">none</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -109,6 +117,7 @@
 
 ## Function `some`
 
+Return an <code><a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">Option</a></code> containing <code>e</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_some">some</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -133,6 +142,7 @@
 
 ## Function `is_none`
 
+Return true if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -157,6 +167,7 @@
 
 ## Function `is_some`
 
+Return true if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
@@ -181,6 +192,8 @@
 
 ## Function `contains`
 
+Return true if the value in <code>t</code> is equal to <code>e_ref</code>
+Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
@@ -205,6 +218,8 @@
 
 ## Function `borrow`
 
+Return an immutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
@@ -230,6 +245,8 @@
 
 ## Function `borrow_with_default`
 
+Return a reference to the value inside <code>t</code> if it holds one
+Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
@@ -256,6 +273,8 @@
 
 ## Function `get_with_default`
 
+Return the value inside <code>t</code> if it holds one
+Return <code>default</code> if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -285,6 +304,8 @@
 
 ## Function `fill`
 
+Convert the none option <code>t</code> to a some option by adding <code>e</code>.
+Aborts if <code>t</code> already holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
@@ -311,6 +332,8 @@
 
 ## Function `extract`
 
+Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -336,6 +359,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the value inside <code>t</code>
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
@@ -361,6 +386,8 @@
 
 ## Function `swap`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
@@ -389,6 +416,9 @@
 
 ## Function `swap_or_fill`
 
+Swap the old value inside <code>t</code> with <code>e</code> and return the old value;
+or if there is no old value, fill it with <code>e</code>.
+Different from swap(), swap_or_fill() allows for <code>t</code> not holding a value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
@@ -417,6 +447,7 @@
 
 ## Function `destroy_with_default`
 
+Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
@@ -443,6 +474,8 @@
 
 ## Function `destroy_some`
 
+Unpack <code>t</code> and return its contents
+Aborts if <code>t</code> does not hold a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
@@ -471,6 +504,8 @@
 
 ## Function `destroy_none`
 
+Unpack <code>t</code>
+Aborts if <code>t</code> holds a value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
@@ -497,6 +532,8 @@
 
 ## Function `to_vec`
 
+Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
+and an empty vector otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/string.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/string.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::string`
 
+The <code><a href="../../dependencies/move-stdlib/string.md#0x1_string">string</a></code> module defines the <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
 
 
 -  [Struct `String`](#0x1_string_String)
@@ -36,6 +37,7 @@
 
 ## Struct `String`
 
+A <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
@@ -66,6 +68,7 @@
 
 <a name="0x1_string_EINVALID_INDEX"></a>
 
+Index out of range.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
@@ -75,6 +78,7 @@
 
 <a name="0x1_string_EINVALID_UTF8"></a>
 
+An invalid UTF8 encoding.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
@@ -86,6 +90,7 @@
 
 ## Function `utf8`
 
+Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_utf8">utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -111,6 +116,7 @@
 
 ## Function `from_ascii`
 
+Convert an ASCII string to a UTF8 string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_from_ascii">from_ascii</a>(s: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -135,6 +141,8 @@
 
 ## Function `to_ascii`
 
+Convert an UTF8 string to an ASCII string.
+Aborts if <code>s</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_to_ascii">to_ascii</a>(s: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -160,6 +168,7 @@
 
 ## Function `try_utf8`
 
+Tries to create a new string from a sequence of bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_try_utf8">try_utf8</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>&gt;
@@ -188,6 +197,7 @@
 
 ## Function `bytes`
 
+Returns a reference to the underlying byte vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_bytes">bytes</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -212,6 +222,7 @@
 
 ## Function `is_empty`
 
+Checks whether this string is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): bool
@@ -236,6 +247,7 @@
 
 ## Function `length`
 
+Returns the length of this string, in bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64
@@ -260,6 +272,7 @@
 
 ## Function `append`
 
+Appends a string.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -284,6 +297,7 @@
 
 ## Function `append_utf8`
 
+Appends bytes which must be in valid utf8 format.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
@@ -308,6 +322,8 @@
 
 ## Function `insert`
 
+Insert the other string at the byte index in given string. The index must be at a valid utf8 char
+boundary.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -339,6 +355,9 @@
 
 ## Function `sub_string`
 
+Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
+of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+guaranteeing that the result is valid utf8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -369,6 +388,7 @@
 
 ## Function `index_of`
 
+Computes the index of the first occurrence of a string. Returns <code><a href="../../dependencies/move-stdlib/string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/string.md#0x1_string_index_of">index_of</a>(s: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>, r: &<a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>): u64

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/type_name.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/type_name.md
@@ -3,6 +3,7 @@
 
 # Module `0x1::type_name`
 
+Functionality for converting Move types into values. Use with care!
 
 
 -  [Struct `TypeName`](#0x1_type_name_TypeName)
@@ -42,7 +43,13 @@
 <code>name: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a></code>
 </dt>
 <dd>
-
+ String representation of the type. All types are represented
+ using their source syntax:
+ "u8", "u64", "bool", "address", "vector", and so on for primitive types.
+ Struct types are represented as fully qualified type names; e.g.
+ <code>00000000000000000000000000000001::string::String</code> or
+ <code>0000000000000000000000000000000a::module_name1::type_name1&lt;0000000000000000000000000000000a::module_name2::type_name2&lt;u64&gt;&gt;</code>
+ Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
 </dd>
 </dl>
 
@@ -56,6 +63,7 @@
 
 <a name="0x1_type_name_ASCII_C"></a>
 
+ASCII Character code for the <code>c</code> (lowercase c) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_C">ASCII_C</a>: u8 = 99;
@@ -65,6 +73,7 @@
 
 <a name="0x1_type_name_ASCII_COLON"></a>
 
+ASCII Character code for the <code>:</code> (colon) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_COLON">ASCII_COLON</a>: u8 = 58;
@@ -74,6 +83,7 @@
 
 <a name="0x1_type_name_ASCII_E"></a>
 
+ASCII Character code for the <code>e</code> (lowercase e) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_E">ASCII_E</a>: u8 = 101;
@@ -83,6 +93,7 @@
 
 <a name="0x1_type_name_ASCII_O"></a>
 
+ASCII Character code for the <code>o</code> (lowercase o) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_O">ASCII_O</a>: u8 = 111;
@@ -92,6 +103,7 @@
 
 <a name="0x1_type_name_ASCII_R"></a>
 
+ASCII Character code for the <code>r</code> (lowercase r) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_R">ASCII_R</a>: u8 = 114;
@@ -101,6 +113,7 @@
 
 <a name="0x1_type_name_ASCII_T"></a>
 
+ASCII Character code for the <code>t</code> (lowercase t) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_T">ASCII_T</a>: u8 = 116;
@@ -110,6 +123,7 @@
 
 <a name="0x1_type_name_ASCII_V"></a>
 
+ASCII Character code for the <code>v</code> (lowercase v) symbol.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ASCII_V">ASCII_V</a>: u8 = 118;
@@ -119,6 +133,7 @@
 
 <a name="0x1_type_name_ENonModuleType"></a>
 
+The type is not from a package/module. It is a primitive type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_ENonModuleType">ENonModuleType</a>: u64 = 0;
@@ -130,6 +145,10 @@
 
 ## Function `get`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are defining IDs (the ID of the package in
+storage that first introduced the type).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -152,6 +171,11 @@
 
 ## Function `get_with_original_ids`
 
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are original IDs (the ID of the first version of
+the package, even if the type in question was introduced in a
+later upgrade).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -174,6 +198,8 @@
 
 ## Function `is_primitive`
 
+Returns true iff the TypeName represents a primitive type, i.e. one of
+u8, u16, u32, u64, u128, u256, bool, address, vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_is_primitive">is_primitive</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): bool
@@ -214,6 +240,7 @@
 
 ## Function `borrow_string`
 
+Get the String representation of <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_borrow_string">borrow_string</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): &<a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -238,6 +265,8 @@
 
 ## Function `get_address`
 
+Get Address string (Base16 encoded), first part of the TypeName.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_address">get_address</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -279,6 +308,8 @@
 
 ## Function `get_module`
 
+Get name of the module.
+Aborts if given a primitive type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_get_module">get_module</a>(self: &<a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -320,6 +351,7 @@
 
 ## Function `into_string`
 
+Convert <code>self</code> into its inner String
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_into_string">into_string</a>(self: <a href="../../dependencies/move-stdlib/type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>

--- a/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/vector.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/move-stdlib/vector.md
@@ -3,6 +3,8 @@
 
 # Module `0x1::vector`
 
+A variable-sized container that can hold any type. Indexing is 0-based, and
+vectors are growable. This module has many native functions.
 
 
 -  [Constants](#@Constants_0)
@@ -36,6 +38,7 @@
 
 <a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
 
+The index into the vector is out of bounds
 
 
 <pre><code><b>const</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
@@ -47,6 +50,7 @@
 
 ## Function `empty`
 
+Create an empty vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -69,6 +73,7 @@
 
 ## Function `length`
 
+Return the length of the vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64
@@ -91,6 +96,8 @@
 
 ## Function `borrow`
 
+Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element
@@ -113,6 +120,7 @@
 
 ## Function `push_back`
 
+Add element <code>e</code> to the end of the vector <code>v</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element)
@@ -135,6 +143,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
@@ -157,6 +167,8 @@
 
 ## Function `pop_back`
 
+Pop an element from the end of vector <code>v</code>.
+Aborts if <code>v</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element
@@ -179,6 +191,8 @@
 
 ## Function `destroy_empty`
 
+Destroy the vector <code>v</code>.
+Aborts if <code>v</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -201,6 +215,8 @@
 
 ## Function `swap`
 
+Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
+Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64)
@@ -223,6 +239,7 @@
 
 ## Function `singleton`
 
+Return an vector of size one containing element <code>e</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -249,6 +266,7 @@
 
 ## Function `reverse`
 
+Reverses the order of the elements in the vector <code>v</code> in place.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -282,6 +300,7 @@
 
 ## Function `append`
 
+Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
@@ -308,6 +327,7 @@
 
 ## Function `is_empty`
 
+Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool
@@ -332,6 +352,8 @@
 
 ## Function `contains`
 
+Return true if <code>e</code> is in the vector <code>v</code>.
+Otherwise, returns false.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool
@@ -362,6 +384,8 @@
 
 ## Function `index_of`
 
+Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
+Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64)
@@ -392,6 +416,9 @@
 
 ## Function `remove`
 
+Remove the <code>i</code>th element of the vector <code>v</code>, shifting all subsequent elements.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
@@ -422,6 +449,11 @@
 
 ## Function `insert`
 
+Insert <code>e</code> at position <code>i</code> in the vector <code>v</code>.
+If <code>i</code> is in bounds, this shifts the old <code>v[i]</code> and all subsequent elements to the right.
+If <code>i == <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>, this adds <code>e</code> to the end of the vector.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i &gt; <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64)
@@ -454,6 +486,9 @@
 
 ## Function `swap_remove`
 
+Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the vector.
+This is O(1), but does not preserve ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/address.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/address.md
@@ -33,6 +33,7 @@
 
 <a name="0x2_address_EAddressParseError"></a>
 
+Error from <code>from_bytes</code> when it is supplied too many or too few bytes.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a>: u64 = 0;
@@ -42,6 +43,7 @@
 
 <a name="0x2_address_LENGTH"></a>
 
+The length of an address, in bytes
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_LENGTH">LENGTH</a>: u64 = 32;
@@ -62,6 +64,8 @@
 
 ## Function `to_u256`
 
+Convert <code>a</code> into a u256 by interpreting <code>a</code> as the bytes of a big-endian integer
+(e.g., <code><a href="../../dependencies/sui-framework/address.md#0x2_address_to_u256">to_u256</a>(0x1) == 1</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_u256">to_u256</a>(a: <b>address</b>): u256
@@ -84,6 +88,8 @@
 
 ## Function `from_u256`
 
+Convert <code>n</code> into an address by encoding it as a big-endian integer (e.g., <code><a href="../../dependencies/sui-framework/address.md#0x2_address_from_u256">from_u256</a>(1) = @0x1</code>)
+Aborts if <code>n</code> > <code>MAX_ADDRESS</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_u256">from_u256</a>(n: u256): <b>address</b>
@@ -106,6 +112,8 @@
 
 ## Function `from_bytes`
 
+Convert <code>bytes</code> into an address.
+Aborts with <code><a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a></code> if the length of <code>bytes</code> is not 32
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_bytes">from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
@@ -128,6 +136,7 @@
 
 ## Function `to_bytes`
 
+Convert <code>a</code> into BCS-encoded bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_bytes">to_bytes</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -152,6 +161,7 @@
 
 ## Function `to_ascii_string`
 
+Convert <code>a</code> to a hex-encoded ASCII string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_ascii_string">to_ascii_string</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -176,6 +186,7 @@
 
 ## Function `to_string`
 
+Convert <code>a</code> to a hex-encoded ASCII string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_to_string">to_string</a>(a: <b>address</b>): <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>
@@ -200,6 +211,12 @@
 
 ## Function `from_ascii_bytes`
 
+Converts an ASCII string to an address, taking the numerical value for each character. The
+string must be Base16 encoded, and thus exactly 64 characters long.
+For example, the string "00000000000000000000000000000000000000000000000000000000DEADB33F"
+will be converted to the address @0xDEADB33F.
+Aborts with <code><a href="../../dependencies/sui-framework/address.md#0x2_address_EAddressParseError">EAddressParseError</a></code> if the length of <code>s</code> is not 64,
+or if an invalid character is encountered.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_from_ascii_bytes">from_ascii_bytes</a>(bytes: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
@@ -260,6 +277,7 @@
 
 ## Function `length`
 
+Length of a Sui address in bytes
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_length">length</a>(): u64
@@ -284,6 +302,7 @@
 
 ## Function `max`
 
+Largest possible address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/address.md#0x2_address_max">max</a>(): u256

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/authenticator_state.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/authenticator_state.md
@@ -41,6 +41,9 @@
 
 ## Resource `AuthenticatorState`
 
+Singleton shared object which stores the global authenticator state.
+The actual state is stored in a dynamic field of type AuthenticatorStateInner to support
+future versions of the authenticator state.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">AuthenticatorState</a> <b>has</b> key
@@ -96,7 +99,7 @@
 <code>active_jwks: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;</code>
 </dt>
 <dd>
-
+ List of currently active JWKs.
 </dd>
 </dl>
 
@@ -107,6 +110,7 @@
 
 ## Struct `JWK`
 
+Must match the JWK struct in fastcrypto-zkp
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_JWK">JWK</a> <b>has</b> <b>copy</b>, drop, store
@@ -152,6 +156,7 @@
 
 ## Struct `JwkId`
 
+Must match the JwkId struct in fastcrypto-zkp
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_JwkId">JwkId</a> <b>has</b> <b>copy</b>, drop, store
@@ -227,6 +232,7 @@
 
 <a name="0x2_authenticator_state_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -426,6 +432,9 @@
 
 ## Function `create`
 
+Create and share the AuthenticatorState object. This function is call exactly once, when
+the authenticator state object is first created.
+Can only be called by genesis or change_epoch transactions.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_create">create</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -563,6 +572,10 @@
 
 ## Function `update_authenticator_state`
 
+Record a new set of active_jwks. Called when executing the AuthenticatorStateUpdate system
+transaction. The new input vector must be sorted and must not contain duplicates.
+If a new JWK is already present, but with a previous epoch, then the epoch is updated to
+indicate that the JWK has been validated in the current epoch and should not be expired.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_update_authenticator_state">update_authenticator_state</a>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">authenticator_state::AuthenticatorState</a>, new_active_jwks: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -768,6 +781,8 @@
 
 ## Function `get_active_jwks`
 
+Get the current active_jwks. Called when the node starts up in order to load the current
+JWK state from the chain.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_get_active_jwks">get_active_jwks</a>(self: &<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_AuthenticatorState">authenticator_state::AuthenticatorState</a>, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state_ActiveJwk">authenticator_state::ActiveJwk</a>&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/bag.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/bag.md
@@ -3,6 +3,26 @@
 
 # Module `0x2::bag`
 
+A bag is a heterogeneous map-like collection. The collection is similar to <code>sui::table</code> in that
+its keys and values are not stored within the <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> value, but instead are stored using Sui's
+object system. The <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> struct acts only as a handle into the object system to retrieve those
+keys and values.
+Note that this means that <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let bag1 = bag::new();
+let bag2 = bag::new();
+bag::add(&mut bag1, 0, false);
+bag::add(&mut bag1, 1, true);
+bag::add(&mut bag2, 0, false);
+bag::add(&mut bag2, 1, true);
+// bag1 does not equal bag2, despite having the same entries
+assert!(&bag1 != &bag2, 0);
+```
+At it's core, <code>sui::bag</code> is a wrapper around <code>UID</code> that allows for access to
+<code>sui::dynamic_field</code> while preventing accidentally stranding field values. A <code>UID</code> can be
+deleted, even if it has dynamic fields associated with it, but a bag, on the other hand, must be
+empty to be destroyed.
 
 
 -  [Resource `Bag`](#0x2_bag_Bag)
@@ -46,13 +66,13 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ the ID of this bag
 </dd>
 <dt>
 <code>size: u64</code>
 </dt>
 <dd>
-
+ the number of key-value pairs in the bag
 </dd>
 </dl>
 
@@ -77,6 +97,7 @@
 
 ## Function `new`
 
+Creates a new, empty bag
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>
@@ -104,6 +125,9 @@
 
 ## Function `add`
 
+Adds a key-value pair to the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the bag already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K, v: V)
@@ -129,6 +153,11 @@
 
 ## Function `borrow`
 
+Immutable borrows the value associated with the key in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &V
@@ -153,6 +182,11 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the value associated with the key in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): &<b>mut</b> V
@@ -177,6 +211,11 @@
 
 ## Function `remove`
 
+Mutably borrows the key-value pair in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the bag does not have an entry with
+that key <code>k: K</code>.
+Aborts with <code>sui::dynamic_field::EFieldTypeMismatch</code> if the bag has an entry for the key, but
+the value does not have the specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): V
@@ -203,6 +242,7 @@
 
 ## Function `contains`
 
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
@@ -227,6 +267,8 @@
 
 ## Function `contains_with_type`
 
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">Bag</a></code>
+with an assigned value of type <code>V</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, k: K): bool
@@ -251,6 +293,7 @@
 
 ## Function `length`
 
+Returns the size of the bag, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_length">length</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): u64
@@ -275,6 +318,7 @@
 
 ## Function `is_empty`
 
+Returns true iff the bag is empty (if <code>length</code> returns <code>0</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_is_empty">is_empty</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: &<a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): bool
@@ -299,6 +343,8 @@
 
 ## Function `destroy_empty`
 
+Destroys an empty bag
+Aborts with <code><a href="../../dependencies/sui-framework/bag.md#0x2_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/bag.md#0x2_bag_destroy_empty">destroy_empty</a>(<a href="../../dependencies/sui-framework/bag.md#0x2_bag">bag</a>: <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/balance.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/balance.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::balance`
 
+A storable handler for Balances in general. Is used in the <code>Coin</code>
+module to allow balance operations and can be used to implement
+custom coins with <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> and <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>s.
 
 
 -  [Struct `Supply`](#0x2_balance_Supply)
@@ -32,6 +35,8 @@
 
 ## Struct `Supply`
 
+A Supply of T. Used for minting and burning.
+Wrapped into a <code>TreasuryCap</code> in the <code>Coin</code> module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a>&lt;T&gt; <b>has</b> store
@@ -59,6 +64,8 @@
 
 ## Struct `Balance`
 
+Storable balance - an inner struct of a Coin type.
+Can be used to store coins which don't need the key ability.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; <b>has</b> store
@@ -89,6 +96,7 @@
 
 <a name="0x2_balance_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENotSystemAddress">ENotSystemAddress</a>: u64 = 3;
@@ -98,6 +106,7 @@
 
 <a name="0x2_balance_ENonZero"></a>
 
+For when trying to destroy a non-zero balance.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENonZero">ENonZero</a>: u64 = 0;
@@ -107,6 +116,7 @@
 
 <a name="0x2_balance_ENotEnough"></a>
 
+For when trying to withdraw more than there is.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_ENotEnough">ENotEnough</a>: u64 = 2;
@@ -116,6 +126,7 @@
 
 <a name="0x2_balance_EOverflow"></a>
 
+For when an overflow is happening on Supply operations.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_EOverflow">EOverflow</a>: u64 = 1;
@@ -127,6 +138,7 @@
 
 ## Function `value`
 
+Get the amount stored in a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_value">value</a>&lt;T&gt;(self: &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -151,6 +163,7 @@
 
 ## Function `supply_value`
 
+Get the <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_supply_value">supply_value</a>&lt;T&gt;(supply: &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64
@@ -175,6 +188,7 @@
 
 ## Function `create_supply`
 
+Create a new supply for type T.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_create_supply">create_supply</a>&lt;T: drop&gt;(_: T): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -199,6 +213,7 @@
 
 ## Function `increase_supply`
 
+Increase supply by <code>value</code> and create a new <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;</code> with this value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_increase_supply">increase_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -225,6 +240,7 @@
 
 ## Function `decrease_supply`
 
+Burn a Balance<T> and decrease Supply<T>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -252,6 +268,7 @@
 
 ## Function `zero`
 
+Create a zero <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> for type <code>T</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_zero">zero</a>&lt;T&gt;(): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -276,6 +293,7 @@
 
 ## Function `join`
 
+Join two balances together.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): u64
@@ -302,6 +320,7 @@
 
 ## Function `split`
 
+Split a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> and take a sub balance from it.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -328,6 +347,7 @@
 
 ## Function `withdraw_all`
 
+Withdraw all balance. After this the remaining balance must be 0.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_withdraw_all">withdraw_all</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -353,6 +373,7 @@
 
 ## Function `destroy_zero`
 
+Destroy a zero <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
@@ -378,6 +399,9 @@
 
 ## Function `create_staking_rewards`
 
+CAUTION: this function creates a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> without increasing the supply.
+It should only be called by the epoch change system txn to create staking rewards,
+and nowhere else.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -403,6 +427,9 @@
 
 ## Function `destroy_storage_rebates`
 
+CAUTION: this function destroys a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">Balance</a></code> without decreasing the supply.
+It should only be called by the epoch change system txn to destroy storage rebates,
+and nowhere else.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -428,6 +455,7 @@
 
 ## Function `destroy_supply`
 
+Destroy a <code><a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">Supply</a></code> preventing any further minting and burning.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;): u64

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/clock.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/clock.md
@@ -3,6 +3,8 @@
 
 # Module `0x2::clock`
 
+APIs for accessing time from move calls, via the <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code>: a unique
+shared object that is created at 0x6 during genesis.
 
 
 -  [Resource `Clock`](#0x2_clock_Clock)
@@ -23,6 +25,14 @@
 
 ## Resource `Clock`
 
+Singleton shared object that exposes time to Move calls.  This
+object is found at address 0x6, and can only be read (accessed
+via an immutable reference) by entry functions.
+
+Entry Functions that attempt to accept <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code> by mutable
+reference or value will fail to verify, and honest validators
+will not sign or execute transactions that use <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a></code> as an
+input parameter, unless it is passed by immutable reference.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">Clock</a> <b>has</b> key
@@ -45,7 +55,10 @@
 <code>timestamp_ms: u64</code>
 </dt>
 <dd>
-
+ The clock's timestamp, which is set automatically by a
+ system transaction every time consensus commits a
+ schedule, or by <code>sui::clock::increment_for_testing</code> during
+ testing.
 </dd>
 </dl>
 
@@ -59,6 +72,7 @@
 
 <a name="0x2_clock_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -70,6 +84,8 @@
 
 ## Function `timestamp_ms`
 
+The <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a></code>'s current timestamp as a running total of
+milliseconds since an arbitrary point in the past.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_timestamp_ms">timestamp_ms</a>(<a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../../dependencies/sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>): u64
@@ -94,6 +110,8 @@
 
 ## Function `create`
 
+Create and share the singleton Clock -- this function is
+called exactly once, during genesis.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock_create">create</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/coin.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/coin.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::coin`
 
+Defines the <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> type - platform wide representation of fungible
+tokens and coins. <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> can be described as a secure wrapper around
+<code>Balance</code> type.
 
 
 -  [Resource `Coin`](#0x2_coin_Coin)
@@ -68,6 +71,7 @@
 
 ## Resource `Coin`
 
+A coin of type <code>T</code> worth <code>value</code>. Transferable and storable
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt; <b>has</b> store, key
@@ -101,6 +105,8 @@
 
 ## Resource `CoinMetadata`
 
+Each Coin type T created through <code>create_currency</code> function will have a
+unique instance of CoinMetadata<T> that stores the metadata for this coin type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt; <b>has</b> store, key
@@ -123,31 +129,34 @@
 <code>decimals: u8</code>
 </dt>
 <dd>
-
+ Number of decimal places the coin uses.
+ A coin with <code>value </code> N and <code>decimals</code> D should be shown as N / 10^D
+ E.g., a coin with <code>value</code> 7002 and decimals 3 should be displayed as 7.002
+ This is metadata for display usage only.
 </dd>
 <dt>
 <code>name: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
-
+ Name for the token
 </dd>
 <dt>
 <code>symbol: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a></code>
 </dt>
 <dd>
-
+ Symbol for the token
 </dd>
 <dt>
 <code>description: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
-
+ Description of the token
 </dd>
 <dt>
 <code>icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;</code>
 </dt>
 <dd>
-
+ URL for the token logo
 </dd>
 </dl>
 
@@ -158,6 +167,8 @@
 
 ## Resource `RegulatedCoinMetadata`
 
+Similar to CoinMetadata, but created only for regulated coins that use the DenyList.
+This object is always immutable.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; <b>has</b> key
@@ -180,13 +191,13 @@
 <code>coin_metadata_object: <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a></code>
 </dt>
 <dd>
-
+ The ID of the coin's CoinMetadata object.
 </dd>
 <dt>
 <code>deny_cap_object: <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a></code>
 </dt>
 <dd>
-
+ The ID of the coin's DenyCap object.
 </dd>
 </dl>
 
@@ -197,6 +208,8 @@
 
 ## Resource `TreasuryCap`
 
+Capability allowing the bearer to mint and burn
+coins of type <code>T</code>. Transferable
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt; <b>has</b> store, key
@@ -230,6 +243,8 @@
 
 ## Resource `DenyCap`
 
+Capability allowing the bearer to freeze addresses, preventing those addresses from
+interacting with the coin as an input to a transaction.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">DenyCap</a>&lt;T&gt; <b>has</b> store, key
@@ -287,6 +302,7 @@
 
 <a name="0x2_coin_ENotEnough"></a>
 
+Trying to split a coin more times than its balance allows.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_ENotEnough">ENotEnough</a>: u64 = 2;
@@ -296,6 +312,7 @@
 
 <a name="0x2_coin_DENY_LIST_COIN_INDEX"></a>
 
+The index into the deny list vector for the <code>sui::coin::Coin</code> type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>: u64 = 0;
@@ -305,6 +322,7 @@
 
 <a name="0x2_coin_EBadWitness"></a>
 
+A type passed to create_supply is not a one-time witness.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_EBadWitness">EBadWitness</a>: u64 = 0;
@@ -314,6 +332,7 @@
 
 <a name="0x2_coin_EInvalidArg"></a>
 
+Invalid arguments are passed to a function.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_EInvalidArg">EInvalidArg</a>: u64 = 1;
@@ -325,6 +344,7 @@
 
 ## Function `total_supply`
 
+Return the total number of <code>T</code>'s in circulation.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_total_supply">total_supply</a>&lt;T&gt;(cap: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): u64
@@ -349,6 +369,10 @@
 
 ## Function `treasury_into_supply`
 
+Unwrap <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> getting the <code>Supply</code>.
+
+Operation is irreversible. Supply cannot be converted into a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> due
+to different security guarantees (TreasuryCap can be created only once for a type)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_treasury_into_supply">treasury_into_supply</a>&lt;T&gt;(treasury: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -375,6 +399,7 @@
 
 ## Function `supply_immut`
 
+Get immutable reference to the treasury's <code>Supply</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_supply_immut">supply_immut</a>&lt;T&gt;(treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -399,6 +424,7 @@
 
 ## Function `supply_mut`
 
+Get mutable reference to the treasury's <code>Supply</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_supply_mut">supply_mut</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
@@ -423,6 +449,7 @@
 
 ## Function `value`
 
+Public getter for the coin's value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_value">value</a>&lt;T&gt;(self: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
@@ -447,6 +474,7 @@
 
 ## Function `balance`
 
+Get immutable reference to the balance of a coin.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -471,6 +499,7 @@
 
 ## Function `balance_mut`
 
+Get a mutable reference to the balance of a coin.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -495,6 +524,7 @@
 
 ## Function `from_balance`
 
+Wrap a balance into a Coin to make it transferable.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -519,6 +549,7 @@
 
 ## Function `into_balance`
 
+Destruct a Coin wrapper and keep the balance.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -545,6 +576,8 @@
 
 ## Function `take`
 
+Take a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> worth of <code>value</code> from <code>Balance</code>.
+Aborts if <code>value &gt; <a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>.value</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_take">take</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -574,6 +607,7 @@
 
 ## Function `put`
 
+Put a <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a>&lt;T&gt;</code> to the <code>Balance&lt;T&gt;</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_put">put</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/balance.md#0x2_balance">balance</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -598,6 +632,8 @@
 
 ## Function `join`
 
+Consume the coin <code>c</code> and add its value to <code>self</code>.
+Aborts if <code>c.value + self.value &gt; U64_MAX</code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -624,6 +660,8 @@
 
 ## Function `split`
 
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -650,6 +688,8 @@
 
 ## Function `divide_into_n`
 
+Split coin <code>self</code> into <code>n - 1</code> coins with equal balances. The remainder is left in
+<code>self</code>. Return newly created coins.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_divide_into_n">divide_into_n</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;
@@ -686,6 +726,8 @@
 
 ## Function `zero`
 
+Make any Coin with a zero value. Useful for placeholding
+bids/payments or preemptively making empty balances.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -710,6 +752,7 @@
 
 ## Function `destroy_zero`
 
+Destroy a coin with value zero
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_destroy_zero">destroy_zero</a>&lt;T&gt;(c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -736,6 +779,9 @@
 
 ## Function `create_currency`
 
+Create a new currency type <code>T</code> as and return the <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> for
+<code>T</code> to the caller. Can only be called with a <code>one-time-witness</code>
+type, ensuring that there's only one <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">TreasuryCap</a></code> per <code>T</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_create_currency">create_currency</a>&lt;T: drop&gt;(witness: T, decimals: u8, symbol: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, name: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, description: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
@@ -784,6 +830,9 @@
 
 ## Function `create_regulated_currency`
 
+This creates a new currency, via <code>create_currency</code>, but with an extra capability that
+allows for specific addresses to have their coins frozen. Those addresses cannot interact
+with the coin as input objects.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_create_regulated_currency">create_regulated_currency</a>&lt;T: drop&gt;(witness: T, decimals: u8, symbol: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, name: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, description: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, icon_url: <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
@@ -833,6 +882,8 @@
 
 ## Function `mint`
 
+Create a coin worth <code>value</code> and increase the total supply
+in <code>cap</code> accordingly.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint">mint</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
@@ -862,6 +913,9 @@
 
 ## Function `mint_balance`
 
+Mint some amount of T as a <code>Balance</code> and increase the total
+supply in <code>cap</code> accordingly.
+Aborts if <code>value</code> + <code>cap.total_supply</code> >= U64_MAX
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint_balance">mint_balance</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, value: u64): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
@@ -888,6 +942,8 @@
 
 ## Function `burn`
 
+Destroy the coin <code>c</code> and decrease the total supply in <code>cap</code>
+accordingly.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;): u64
@@ -914,6 +970,8 @@
 
 ## Function `deny_list_add`
 
+Adds the given address to the deny list, preventing it
+from interacting with the specified coin type as an input to a transaction.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_add">deny_list_add</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -950,6 +1008,8 @@
 
 ## Function `deny_list_remove`
 
+Removes an address from the deny list.
+Aborts with <code>ENotFrozen</code> if the address is not already in the list.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_remove">deny_list_remove</a>&lt;T&gt;(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_DenyCap">coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -986,6 +1046,8 @@
 
 ## Function `deny_list_contains`
 
+Returns true iff the given address is denied for the given coin type. It will
+return false if given a non-coin type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(freezer: &<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, addr: <b>address</b>): bool
@@ -1022,6 +1084,7 @@
 
 ## Function `mint_and_transfer`
 
+Mint <code>amount</code> of <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">Coin</a></code> and send it to <code>recipient</code>. Invokes <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint">mint</a>()</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_mint_and_transfer">mint_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -1048,6 +1111,7 @@
 
 ## Function `update_name`
 
+Update name of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_name">update_name</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, name: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -1074,6 +1138,7 @@
 
 ## Function `update_symbol`
 
+Update the symbol of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_symbol">update_symbol</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, symbol: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)
@@ -1100,6 +1165,7 @@
 
 ## Function `update_description`
 
+Update the description of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_description">update_description</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, description: <a href="../../dependencies/move-stdlib/string.md#0x1_string_String">string::String</a>)
@@ -1126,6 +1192,7 @@
 
 ## Function `update_icon_url`
 
+Update the url of the coin in <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">CoinMetadata</a></code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="../../dependencies/sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/deny_list.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/deny_list.md
@@ -3,6 +3,9 @@
 
 # Module `0x2::deny_list`
 
+Defines the <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a></code> type. The <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a></code> shared object is used to restrict access to
+instances of certain core types from being used as inputs by specified addresses in the deny
+list.
 
 
 -  [Resource `DenyList`](#0x2_deny_list_DenyList)
@@ -32,6 +35,7 @@
 
 ## Resource `DenyList`
 
+A shared object that stores the addresses that are blocked for a given core type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">DenyList</a> <b>has</b> key
@@ -54,7 +58,7 @@
 <code>lists: <a href="../../dependencies/sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
 </dt>
 <dd>
-
+ The individual deny lists.
 </dd>
 </dl>
 
@@ -65,6 +69,7 @@
 
 ## Resource `PerTypeList`
 
+Stores the addresses that are denied for a given core type.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_PerTypeList">PerTypeList</a> <b>has</b> store, key
@@ -87,13 +92,16 @@
 <code>denied_count: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;<b>address</b>, u64&gt;</code>
 </dt>
 <dd>
-
+ Number of object types that have been banned for a given address.
+ Used to quickly skip checks for most addresses.
 </dd>
 <dt>
 <code>denied_addresses: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;</code>
 </dt>
 <dd>
-
+ Set of addresses that are banned for a given type.
+ For example with <code>sui::coin::Coin</code>: If addresses A and B are banned from using
+ "0...0123::my_coin::MY_COIN", this will be "0...0123::my_coin::MY_COIN" -> {A, B}.
 </dd>
 </dl>
 
@@ -107,6 +115,7 @@
 
 <a name="0x2_deny_list_ENotSystemAddress"></a>
 
+Trying to create a deny list object when not called by the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -116,6 +125,7 @@
 
 <a name="0x2_deny_list_COIN_INDEX"></a>
 
+The index into the deny list vector for the <code>sui::coin::Coin</code> type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_COIN_INDEX">COIN_INDEX</a>: u64 = 0;
@@ -125,6 +135,7 @@
 
 <a name="0x2_deny_list_ENotDenied"></a>
 
+The specified address to be removed is not already in the deny list.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotDenied">ENotDenied</a>: u64 = 1;
@@ -136,6 +147,10 @@
 
 ## Function `add`
 
+Adds the given address to the deny list of the specified type, preventing it
+from interacting with instances of that type as an input to a transaction. For coins,
+the type specified is the type of the coin, not the coin type itself. For example,
+"00...0123::my_coin::MY_COIN" would be the type, not "00...02::coin::Coin".
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_add">add</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>)
@@ -205,6 +220,8 @@
 
 ## Function `remove`
 
+Removes a previously denied address from the list.
+Aborts with <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_ENotDenied">ENotDenied</a></code> if the address is not on the list.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_remove">remove</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>)
@@ -269,6 +286,7 @@
 
 ## Function `contains`
 
+Returns true iff the given address is denied for the given type.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_contains">contains</a>(<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a>: &<a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_DenyList">deny_list::DenyList</a>, per_type_index: u64, type: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, addr: <b>address</b>): bool
@@ -334,6 +352,8 @@
 
 ## Function `create`
 
+Creation of the deny list object is restricted to the system address
+via a system transaction.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list_create">create</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/dynamic_field.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/dynamic_field.md
@@ -3,6 +3,12 @@
 
 # Module `0x2::dynamic_field`
 
+In addition to the fields declared in its type definition, a Sui object can have dynamic fields
+that can be added after the object has been constructed. Unlike ordinary field names
+(which are always statically declared identifiers) a dynamic field name can be any value with
+the <code><b>copy</b></code>, <code>drop</code>, and <code>store</code> abilities, e.g. an integer, a boolean, or a string.
+This gives Sui programmers the flexibility to extend objects on-the-fly, and it also serves as a
+building block for core collection types
 
 
 -  [Resource `Field`](#0x2_dynamic_field_Field)
@@ -35,6 +41,7 @@
 
 ## Resource `Field`
 
+Internal object used for storing the field and value
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_Field">Field</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt; <b>has</b> key
@@ -51,19 +58,20 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ Determined by the hash of the object ID, the field name value and it's type,
+ i.e. hash(parent.id || name || Name)
 </dd>
 <dt>
 <code>name: Name</code>
 </dt>
 <dd>
-
+ The value for the name of this field
 </dd>
 <dt>
 <code>value: Value</code>
 </dt>
 <dd>
-
+ The value bound to this field
 </dd>
 </dl>
 
@@ -77,6 +85,7 @@
 
 <a name="0x2_dynamic_field_EBCSSerializationFailure"></a>
 
+Failed to serialize the field's name
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a>: u64 = 3;
@@ -86,6 +95,7 @@
 
 <a name="0x2_dynamic_field_ESharedObjectOperationNotSupported"></a>
 
+The object added as a dynamic field was previously a shared object
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_ESharedObjectOperationNotSupported">ESharedObjectOperationNotSupported</a>: u64 = 4;
@@ -95,6 +105,7 @@
 
 <a name="0x2_dynamic_field_EFieldAlreadyExists"></a>
 
+The object already has a dynamic field with this name (with the value and type specified)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>: u64 = 0;
@@ -104,6 +115,8 @@
 
 <a name="0x2_dynamic_field_EFieldDoesNotExist"></a>
 
+Cannot load dynamic field.
+The object does not have a dynamic field with this name (with the value and type specified)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a>: u64 = 1;
@@ -113,6 +126,7 @@
 
 <a name="0x2_dynamic_field_EFieldTypeMismatch"></a>
 
+The object has a field with that name, but the value type does not match
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a>: u64 = 2;
@@ -124,6 +138,8 @@
 
 ## Function `add`
 
+Adds a dynamic field to the object <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a></code> if the object already has that field with that name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
@@ -161,6 +177,10 @@
 
 ## Function `borrow`
 
+Immutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
@@ -191,6 +211,10 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
@@ -221,6 +245,11 @@
 
 ## Function `remove`
 
+Removes the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code> and returns the
+bound value.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
+Aborts with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): Value
@@ -252,6 +281,8 @@
 
 ## Function `exists_`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> but without specifying the <code>Value</code> type
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -281,6 +312,7 @@
 
 ## Function `remove_if_exists`
 
+Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if it exists or none otherwise.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;Value&gt;
@@ -312,6 +344,8 @@
 
 ## Function `exists_with_type`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -401,6 +435,7 @@
 
 ## Function `hash_type_and_key`
 
+May abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: <b>address</b>, k: K): <b>address</b>
@@ -445,6 +480,10 @@
 
 ## Function `borrow_child_object`
 
+throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match,
+and may also abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>
+we need two versions to return a reference or a mutable reference
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, id: <b>address</b>): &Child
@@ -489,6 +528,9 @@
 
 ## Function `remove_child_object`
 
+throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if a child does not exist with that ID
+or throws <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the type does not match,
+and may also abort with <code><a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_field.md#0x2_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/dynamic_object_field.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/dynamic_object_field.md
@@ -3,6 +3,10 @@
 
 # Module `0x2::dynamic_object_field`
 
+Similar to <code>sui::dynamic_field</code>, this module allows for the access of dynamic fields. But
+unlike, <code>sui::dynamic_field</code> the values bound to these dynamic fields _must_ be objects
+themselves. This allows for the objects to still exist within in storage, which may be important
+for external tools. The difference is otherwise not observable from within Move.
 
 
 -  [Struct `Wrapper`](#0x2_dynamic_object_field_Wrapper)
@@ -53,6 +57,8 @@
 
 ## Function `add`
 
+Adds a dynamic object field to the object <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Aborts with <code>EFieldAlreadyExists</code> if the object already has that field with that name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name, value: Value)
@@ -86,6 +92,10 @@
 
 ## Function `borrow`
 
+Immutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &Value
@@ -115,6 +125,10 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): &<b>mut</b> Value
@@ -144,6 +158,11 @@
 
 ## Function `remove`
 
+Removes the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code> and returns
+the bound object.
+Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): Value
@@ -175,6 +194,8 @@
 
 ## Function `exists_`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic object field with the name specified by
+<code>name: Name</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -203,6 +224,8 @@
 
 ## Function `exists_with_type`
 
+Returns true if and only if the <code><a href="../../dependencies/sui-framework/object.md#0x2_object">object</a></code> has a dynamic field with the name specified by
+<code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store, key&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): bool
@@ -233,6 +256,8 @@
 
 ## Function `id`
 
+Returns the ID of the object associated with the dynamic object field
+Returns none otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/dynamic_object_field.md#0x2_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../../dependencies/sui-framework/object.md#0x2_object">object</a>: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, name: Name): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/event.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/event.md
@@ -3,6 +3,31 @@
 
 # Module `0x2::event`
 
+Events module. Defines the <code>sui::event::emit</code> function which
+creates and sends a custom MoveEvent as a part of the effects
+certificate of the transaction.
+
+Every MoveEvent has the following properties:
+- sender
+- type signature (<code>T</code>)
+- event data (the value of <code>T</code>)
+- timestamp (local to a node)
+- transaction digest
+
+Example:
+```
+module my::marketplace {
+use sui::event;
+/* ... */
+struct ItemPurchased has copy, drop {
+item_id: ID, buyer: address
+}
+entry fun buy(/* .... */) {
+/* ... */
+event::emit(ItemPurchased { item_id: ..., buyer: .... })
+}
+}
+```
 
 
 -  [Function `emit`](#0x2_event_emit)
@@ -16,6 +41,13 @@
 
 ## Function `emit`
 
+Emit a custom Move event, sending the data offchain.
+
+Used for creating custom indexes and tracking onchain
+activity in a way that suits a specific application the most.
+
+The type <code>T</code> is the main way to index the event, and can contain
+phantom parameters, eg <code><a href="../../dependencies/sui-framework/event.md#0x2_event_emit">emit</a>(MyEvent&lt;<b>phantom</b> T&gt;)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/event.md#0x2_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(<a href="../../dependencies/sui-framework/event.md#0x2_event">event</a>: T)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/hex.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/hex.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::hex`
 
+HEX (Base16) encoding utility.
 
 
 -  [Constants](#@Constants_0)
@@ -41,6 +42,7 @@
 
 <a name="0x2_hex_HEX"></a>
 
+Vector of Base16 values from <code>00</code> to <code>FF</code>
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_HEX">HEX</a>: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; = [ByteArray([48, 48]), ByteArray([48, 49]), ByteArray([48, 50]), ByteArray([48, 51]), ByteArray([48, 52]), ByteArray([48, 53]), ByteArray([48, 54]), ByteArray([48, 55]), ByteArray([48, 56]), ByteArray([48, 57]), ByteArray([48, 97]), ByteArray([48, 98]), ByteArray([48, 99]), ByteArray([48, 100]), ByteArray([48, 101]), ByteArray([48, 102]), ByteArray([49, 48]), ByteArray([49, 49]), ByteArray([49, 50]), ByteArray([49, 51]), ByteArray([49, 52]), ByteArray([49, 53]), ByteArray([49, 54]), ByteArray([49, 55]), ByteArray([49, 56]), ByteArray([49, 57]), ByteArray([49, 97]), ByteArray([49, 98]), ByteArray([49, 99]), ByteArray([49, 100]), ByteArray([49, 101]), ByteArray([49, 102]), ByteArray([50, 48]), ByteArray([50, 49]), ByteArray([50, 50]), ByteArray([50, 51]), ByteArray([50, 52]), ByteArray([50, 53]), ByteArray([50, 54]), ByteArray([50, 55]), ByteArray([50, 56]), ByteArray([50, 57]), ByteArray([50, 97]), ByteArray([50, 98]), ByteArray([50, 99]), ByteArray([50, 100]), ByteArray([50, 101]), ByteArray([50, 102]), ByteArray([51, 48]), ByteArray([51, 49]), ByteArray([51, 50]), ByteArray([51, 51]), ByteArray([51, 52]), ByteArray([51, 53]), ByteArray([51, 54]), ByteArray([51, 55]), ByteArray([51, 56]), ByteArray([51, 57]), ByteArray([51, 97]), ByteArray([51, 98]), ByteArray([51, 99]), ByteArray([51, 100]), ByteArray([51, 101]), ByteArray([51, 102]), ByteArray([52, 48]), ByteArray([52, 49]), ByteArray([52, 50]), ByteArray([52, 51]), ByteArray([52, 52]), ByteArray([52, 53]), ByteArray([52, 54]), ByteArray([52, 55]), ByteArray([52, 56]), ByteArray([52, 57]), ByteArray([52, 97]), ByteArray([52, 98]), ByteArray([52, 99]), ByteArray([52, 100]), ByteArray([52, 101]), ByteArray([52, 102]), ByteArray([53, 48]), ByteArray([53, 49]), ByteArray([53, 50]), ByteArray([53, 51]), ByteArray([53, 52]), ByteArray([53, 53]), ByteArray([53, 54]), ByteArray([53, 55]), ByteArray([53, 56]), ByteArray([53, 57]), ByteArray([53, 97]), ByteArray([53, 98]), ByteArray([53, 99]), ByteArray([53, 100]), ByteArray([53, 101]), ByteArray([53, 102]), ByteArray([54, 48]), ByteArray([54, 49]), ByteArray([54, 50]), ByteArray([54, 51]), ByteArray([54, 52]), ByteArray([54, 53]), ByteArray([54, 54]), ByteArray([54, 55]), ByteArray([54, 56]), ByteArray([54, 57]), ByteArray([54, 97]), ByteArray([54, 98]), ByteArray([54, 99]), ByteArray([54, 100]), ByteArray([54, 101]), ByteArray([54, 102]), ByteArray([55, 48]), ByteArray([55, 49]), ByteArray([55, 50]), ByteArray([55, 51]), ByteArray([55, 52]), ByteArray([55, 53]), ByteArray([55, 54]), ByteArray([55, 55]), ByteArray([55, 56]), ByteArray([55, 57]), ByteArray([55, 97]), ByteArray([55, 98]), ByteArray([55, 99]), ByteArray([55, 100]), ByteArray([55, 101]), ByteArray([55, 102]), ByteArray([56, 48]), ByteArray([56, 49]), ByteArray([56, 50]), ByteArray([56, 51]), ByteArray([56, 52]), ByteArray([56, 53]), ByteArray([56, 54]), ByteArray([56, 55]), ByteArray([56, 56]), ByteArray([56, 57]), ByteArray([56, 97]), ByteArray([56, 98]), ByteArray([56, 99]), ByteArray([56, 100]), ByteArray([56, 101]), ByteArray([56, 102]), ByteArray([57, 48]), ByteArray([57, 49]), ByteArray([57, 50]), ByteArray([57, 51]), ByteArray([57, 52]), ByteArray([57, 53]), ByteArray([57, 54]), ByteArray([57, 55]), ByteArray([57, 56]), ByteArray([57, 57]), ByteArray([57, 97]), ByteArray([57, 98]), ByteArray([57, 99]), ByteArray([57, 100]), ByteArray([57, 101]), ByteArray([57, 102]), ByteArray([97, 48]), ByteArray([97, 49]), ByteArray([97, 50]), ByteArray([97, 51]), ByteArray([97, 52]), ByteArray([97, 53]), ByteArray([97, 54]), ByteArray([97, 55]), ByteArray([97, 56]), ByteArray([97, 57]), ByteArray([97, 97]), ByteArray([97, 98]), ByteArray([97, 99]), ByteArray([97, 100]), ByteArray([97, 101]), ByteArray([97, 102]), ByteArray([98, 48]), ByteArray([98, 49]), ByteArray([98, 50]), ByteArray([98, 51]), ByteArray([98, 52]), ByteArray([98, 53]), ByteArray([98, 54]), ByteArray([98, 55]), ByteArray([98, 56]), ByteArray([98, 57]), ByteArray([98, 97]), ByteArray([98, 98]), ByteArray([98, 99]), ByteArray([98, 100]), ByteArray([98, 101]), ByteArray([98, 102]), ByteArray([99, 48]), ByteArray([99, 49]), ByteArray([99, 50]), ByteArray([99, 51]), ByteArray([99, 52]), ByteArray([99, 53]), ByteArray([99, 54]), ByteArray([99, 55]), ByteArray([99, 56]), ByteArray([99, 57]), ByteArray([99, 97]), ByteArray([99, 98]), ByteArray([99, 99]), ByteArray([99, 100]), ByteArray([99, 101]), ByteArray([99, 102]), ByteArray([100, 48]), ByteArray([100, 49]), ByteArray([100, 50]), ByteArray([100, 51]), ByteArray([100, 52]), ByteArray([100, 53]), ByteArray([100, 54]), ByteArray([100, 55]), ByteArray([100, 56]), ByteArray([100, 57]), ByteArray([100, 97]), ByteArray([100, 98]), ByteArray([100, 99]), ByteArray([100, 100]), ByteArray([100, 101]), ByteArray([100, 102]), ByteArray([101, 48]), ByteArray([101, 49]), ByteArray([101, 50]), ByteArray([101, 51]), ByteArray([101, 52]), ByteArray([101, 53]), ByteArray([101, 54]), ByteArray([101, 55]), ByteArray([101, 56]), ByteArray([101, 57]), ByteArray([101, 97]), ByteArray([101, 98]), ByteArray([101, 99]), ByteArray([101, 100]), ByteArray([101, 101]), ByteArray([101, 102]), ByteArray([102, 48]), ByteArray([102, 49]), ByteArray([102, 50]), ByteArray([102, 51]), ByteArray([102, 52]), ByteArray([102, 53]), ByteArray([102, 54]), ByteArray([102, 55]), ByteArray([102, 56]), ByteArray([102, 57]), ByteArray([102, 97]), ByteArray([102, 98]), ByteArray([102, 99]), ByteArray([102, 100]), ByteArray([102, 101]), ByteArray([102, 102])];
@@ -52,6 +54,7 @@
 
 ## Function `encode`
 
+Encode <code>bytes</code> in lowercase hex
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_encode">encode</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -85,6 +88,12 @@
 
 ## Function `decode`
 
+Decode hex into <code>bytes</code>
+Takes a hex string (no 0x prefix) (e.g. b"0f3a")
+Returns vector of <code>bytes</code> that represents the hex string (e.g. x"0f3a")
+Hex string can be case insensitive (e.g. b"0F3A" and b"0f3a" both return x"0f3a")
+Aborts if the hex string does not have an even number of characters (as each hex character is 2 characters long)
+Aborts if the hex string contains non-valid hex characters (valid characters are 0 - 9, a - f, A - F)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/hex.md#0x2_hex_decode">decode</a>(<a href="../../dependencies/sui-framework/hex.md#0x2_hex">hex</a>: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/math.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/math.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::math`
 
+Basic math for nicer programmability
 
 
 -  [Function `max`](#0x2_math_max)
@@ -22,6 +23,7 @@
 
 ## Function `max`
 
+Return the larger of <code>x</code> and <code>y</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_max">max</a>(x: u64, y: u64): u64
@@ -50,6 +52,7 @@
 
 ## Function `min`
 
+Return the smaller of <code>x</code> and <code>y</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <b>min</b>(x: u64, y: u64): u64
@@ -78,6 +81,7 @@
 
 ## Function `diff`
 
+Return the absolute value of x - y
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_diff">diff</a>(x: u64, y: u64): u64
@@ -106,6 +110,7 @@
 
 ## Function `pow`
 
+Return the value of a base raised to a power
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_pow">pow</a>(base: u64, exponent: u8): u64
@@ -141,6 +146,31 @@
 
 ## Function `sqrt`
 
+Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt(9) => 3
+math::sqrt(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt(8) => 2;
+math::sqrt(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt(10000)).
+
+
+math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_sqrt">sqrt</a>(x: u64): u64
@@ -179,6 +209,31 @@
 
 ## Function `sqrt_u128`
 
+Similar to math::sqrt, but for u128 numbers. Get a nearest lower integer Square Root for <code>x</code>. Given that this
+function can only operate with integers, it is impossible
+to get perfect (or precise) integer square root for some numbers.
+
+Example:
+```
+math::sqrt_u128(9) => 3
+math::sqrt_u128(8) => 2 // the nearest lower square root is 4;
+```
+
+In integer math, one of the possible ways to get results with more
+precision is to use higher values or temporarily multiply the
+value by some bigger number. Ideally if this is a square of 10 or 100.
+
+Example:
+```
+math::sqrt_u128(8) => 2;
+math::sqrt_u128(8 * 10000) => 282;
+// now we can use this value as if it was 2.82;
+// but to get the actual result, this value needs
+// to be divided by 100 (because sqrt_u128(10000)).
+
+
+math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
+```
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_sqrt_u128">sqrt_u128</a>(x: u128): u128
@@ -217,6 +272,7 @@
 
 ## Function `divide_and_round_up`
 
+Calculate x / y, but round up the result.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/math.md#0x2_math_divide_and_round_up">divide_and_round_up</a>(x: u64, y: u64): u64

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/object.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/object.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::object`
 
+Sui object identifiers
 
 
 -  [Struct `ID`](#0x2_object_ID)
@@ -44,6 +45,12 @@
 
 ## Struct `ID`
 
+An object ID. This is used to reference Sui Objects.
+This is *not* guaranteed to be globally unique--anyone can create an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> or
+from an object, and ID's can be freely copied and dropped.
+Here, the values are not globally unique because there can be multiple values of type <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
+with the same underlying bytes. For example, <code><a href="../../dependencies/sui-framework/object.md#0x2_object_id">object::id</a>(&obj)</code> can be called as many times
+as you want for a given <code>obj</code>, and each <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> value will be identical.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a> <b>has</b> <b>copy</b>, drop, store
@@ -71,6 +78,12 @@
 
 ## Struct `UID`
 
+Globally unique IDs that define an object's ID in storage. Any Sui Object, that is a struct
+with the <code>key</code> ability, must have <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> as its first field.
+These are globally unique in the sense that no two values of type <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> are ever equal, in
+other words for any two values <code>id1: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> and <code>id2: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>, <code>id1</code> != <code>id2</code>.
+This is a privileged type that can only be derived from a <code>TxContext</code>.
+<code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> doesn't have the <code>drop</code> ability, so deleting a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> requires a call to <code>delete</code>.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a> <b>has</b> store
@@ -101,6 +114,7 @@
 
 <a name="0x2_object_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
@@ -110,6 +124,7 @@
 
 <a name="0x2_object_SUI_AUTHENTICATOR_STATE_ID"></a>
 
+The hardcoded ID for the singleton AuthenticatorState Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_AUTHENTICATOR_STATE_ID">SUI_AUTHENTICATOR_STATE_ID</a>: <b>address</b> = 7;
@@ -119,6 +134,7 @@
 
 <a name="0x2_object_SUI_CLOCK_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton Clock Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_CLOCK_OBJECT_ID">SUI_CLOCK_OBJECT_ID</a>: <b>address</b> = 6;
@@ -128,6 +144,7 @@
 
 <a name="0x2_object_SUI_DENY_LIST_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton DenyList.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_DENY_LIST_OBJECT_ID">SUI_DENY_LIST_OBJECT_ID</a>: <b>address</b> = 403;
@@ -137,6 +154,7 @@
 
 <a name="0x2_object_SUI_RANDOM_ID"></a>
 
+The hardcoded ID for the singleton Random Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_RANDOM_ID">SUI_RANDOM_ID</a>: <b>address</b> = 8;
@@ -146,6 +164,7 @@
 
 <a name="0x2_object_SUI_SYSTEM_STATE_OBJECT_ID"></a>
 
+The hardcoded ID for the singleton Sui System State Object.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_SUI_SYSTEM_STATE_OBJECT_ID">SUI_SYSTEM_STATE_OBJECT_ID</a>: <b>address</b> = 5;
@@ -157,6 +176,7 @@
 
 ## Function `id_to_bytes`
 
+Get the raw bytes of a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_to_bytes">id_to_bytes</a>(id: &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -181,6 +201,7 @@
 
 ## Function `id_to_address`
 
+Get the inner bytes of <code>id</code> as an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_to_address">id_to_address</a>(id: &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>): <b>address</b>
@@ -205,6 +226,7 @@
 
 ## Function `id_from_bytes`
 
+Make an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from raw bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_from_bytes">id_from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -229,6 +251,7 @@
 
 ## Function `id_from_address`
 
+Make an <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> from an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_from_address">id_from_address</a>(bytes: <b>address</b>): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -253,6 +276,8 @@
 
 ## Function `sui_system_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>SuiSystemState</code> object.
+This should only be called once from <code><a href="../../sui_system.md#0x3_sui_system">sui_system</a></code>.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_sui_system_state">sui_system_state</a>(ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -280,6 +305,8 @@
 
 ## Function `clock`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>Clock</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/clock.md#0x2_clock">clock</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -306,6 +333,8 @@
 
 ## Function `authenticator_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>AuthenticatorState</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state">authenticator_state</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/authenticator_state.md#0x2_authenticator_state">authenticator_state</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -332,6 +361,8 @@
 
 ## Function `randomness_state`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>Random</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/random.md#0x2_random">random</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_randomness_state">randomness_state</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -358,6 +389,8 @@
 
 ## Function `sui_deny_list_object_id`
 
+Create the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for the singleton <code>DenyList</code> object.
+This should only be called once from <code><a href="../../dependencies/sui-framework/deny_list.md#0x2_deny_list">deny_list</a></code>.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -384,6 +417,7 @@
 
 ## Function `uid_as_inner`
 
+Get the inner <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>uid</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_as_inner">uid_as_inner</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -408,6 +442,7 @@
 
 ## Function `uid_to_inner`
 
+Get the raw bytes of a <code>uid</code>'s inner <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_inner">uid_to_inner</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -432,6 +467,7 @@
 
 ## Function `uid_to_bytes`
 
+Get the raw bytes of a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_bytes">uid_to_bytes</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -456,6 +492,7 @@
 
 ## Function `uid_to_address`
 
+Get the inner bytes of <code>id</code> as an address.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_uid_to_address">uid_to_address</a>(uid: &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>): <b>address</b>
@@ -480,6 +517,8 @@
 
 ## Function `new`
 
+Create a new object. Returns the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> that must be stored in a Sui object.
+This is the only way to create <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>s.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -506,6 +545,7 @@
 
 ## Function `delete`
 
+Delete the object and it's <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>. This is the only way to eliminate a <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_delete">delete</a>(id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>)
@@ -531,6 +571,7 @@
 
 ## Function `id`
 
+Get the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id">id</a>&lt;T: key&gt;(obj: &T): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -555,6 +596,7 @@
 
 ## Function `borrow_id`
 
+Borrow the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_borrow_id">borrow_id</a>&lt;T: key&gt;(obj: &T): &<a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>
@@ -579,6 +621,7 @@
 
 ## Function `id_bytes`
 
+Get the raw bytes for the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_bytes">id_bytes</a>&lt;T: key&gt;(obj: &T): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -603,6 +646,7 @@
 
 ## Function `id_address`
 
+Get the inner bytes for the underlying <code><a href="../../dependencies/sui-framework/object.md#0x2_object_ID">ID</a></code> of <code>obj</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_id_address">id_address</a>&lt;T: key&gt;(obj: &T): <b>address</b>
@@ -627,6 +671,11 @@
 
 ## Function `borrow_uid`
 
+Get the <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for <code>obj</code>.
+Safe because Sui has an extra bytecode verifier pass that forces every struct with
+the <code>key</code> ability to have a distinguished <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> field.
+Cannot be made public as the access to <code><a href="../../dependencies/sui-framework/object.md#0x2_object_UID">UID</a></code> for a given object must be privileged, and
+restrictable in the object's module.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_borrow_uid">borrow_uid</a>&lt;T: key&gt;(obj: &T): &<a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>
@@ -649,6 +698,7 @@
 
 ## Function `new_uid_from_hash`
 
+Generate a new UID specifically used for creating a UID from a hash
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/pay.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/pay.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::pay`
 
+This module provides handy functionality for wallets and <code>sui::Coin</code> management.
 
 
 -  [Constants](#@Constants_0)
@@ -30,6 +31,7 @@
 
 <a name="0x2_pay_ENoCoins"></a>
 
+For when empty vector is supplied into join function.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_ENoCoins">ENoCoins</a>: u64 = 0;
@@ -41,6 +43,7 @@
 
 ## Function `keep`
 
+Transfer <code>c</code> to the sender of the current transaction
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_keep">keep</a>&lt;T&gt;(c: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -65,6 +68,8 @@
 
 ## Function `split`
 
+Split coin <code>self</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left is <code>self</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -91,6 +96,8 @@
 
 ## Function `split_vec`
 
+Split coin <code>self</code> into multiple coins, each with balance specified
+in <code>split_amounts</code>. Remaining balance is left in <code>self</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_split_vec">split_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, split_amounts: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -121,6 +128,8 @@
 
 ## Function `split_and_transfer`
 
+Send <code>amount</code> units of <code>c</code> to <code>recipient</code>
+Aborts with <code>EVALUE</code> if <code>amount</code> is greater than or equal to <code>amount</code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_split_and_transfer">split_and_transfer</a>&lt;T&gt;(c: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, amount: u64, recipient: <b>address</b>, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -147,6 +156,8 @@
 
 ## Function `divide_and_keep`
 
+Divide coin <code>self</code> into <code>n - 1</code> coins with equal balances. If the balance is
+not evenly divisible by <code>n</code>, the remainder is left in <code>self</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, n: u64, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -179,6 +190,7 @@
 
 ## Function `join`
 
+Join <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a></code> into <code>self</code>. Re-exports <code><a href="../../dependencies/sui-framework/coin.md#0x2_coin_join">coin::join</a></code> function.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, <a href="../../dependencies/sui-framework/coin.md#0x2_coin">coin</a>: <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;)
@@ -203,6 +215,7 @@
 
 ## Function `join_vec`
 
+Join everything in <code>coins</code> with <code>self</code>
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, coins: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;)
@@ -234,6 +247,7 @@
 
 ## Function `join_vec_and_transfer`
 
+Join a vector of <code>Coin</code> into a single object and transfer it to <code>receiver</code>.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="../../dependencies/sui-framework/pay.md#0x2_pay_join_vec_and_transfer">join_vec_and_transfer</a>&lt;T&gt;(coins: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, receiver: <b>address</b>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/priority_queue.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/priority_queue.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::priority_queue`
 
+Priority queue implemented using a max heap.
 
 
 -  [Struct `PriorityQueue`](#0x2_priority_queue_PriorityQueue)
@@ -27,6 +28,11 @@
 
 ## Struct `PriorityQueue`
 
+Struct representing a priority queue. The <code>entries</code> vector represents a max
+heap structure, where entries[0] is the root, entries[1] and entries[2] are the
+left child and right child of the root, etc. More generally, the children of
+entries[i] are at at i * 2 + 1 and i * 2 + 2. The max heap should have the invariant
+that the parent node's priority is always higher than its child nodes' priorities.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">PriorityQueue</a>&lt;T: drop&gt; <b>has</b> drop, store
@@ -90,6 +96,7 @@
 
 <a name="0x2_priority_queue_EPopFromEmptyHeap"></a>
 
+For when heap is empty and there's no data to pop.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_EPopFromEmptyHeap">EPopFromEmptyHeap</a>: u64 = 0;
@@ -101,6 +108,7 @@
 
 ## Function `new`
 
+Create a new priority queue from the input entry vectors.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_new">new</a>&lt;T: drop&gt;(entries: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;): <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;
@@ -132,6 +140,7 @@
 
 ## Function `pop_max`
 
+Pop the entry with the highest priority value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_pop_max">pop_max</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;): (u64, T)
@@ -163,6 +172,7 @@
 
 ## Function `insert`
 
+Insert a new entry into the queue.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_insert">insert</a>&lt;T: drop&gt;(pq: &<b>mut</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_PriorityQueue">priority_queue::PriorityQueue</a>&lt;T&gt;, priority: u64, value: T)
@@ -281,6 +291,11 @@
 
 ## Function `max_heapify_recursive`
 
+Max heapify the subtree whose root is at index <code>i</code>. That means after this function
+finishes, the subtree should have the property that the parent node has higher priority
+than both child nodes.
+This function assumes that all the other nodes in the subtree (nodes other than the root)
+do satisfy the max heap property.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_max_heapify_recursive">max_heapify_recursive</a>&lt;T: drop&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../../dependencies/sui-framework/priority_queue.md#0x2_priority_queue_Entry">priority_queue::Entry</a>&lt;T&gt;&gt;, len: u64, i: u64)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/random.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/random.md
@@ -27,6 +27,8 @@
 
 ## Resource `Random`
 
+Singleton shared object which stores the global randomness state.
+The actual state is stored in a versioned inner field.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_Random">Random</a> <b>has</b> key
@@ -146,6 +148,9 @@
 
 ## Function `create`
 
+Create and share the Random object. This function is called exactly once, when
+the Random object is first created.
+Can only be called by genesis or change_epoch transactions.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_create">create</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
@@ -249,6 +254,8 @@
 
 ## Function `update_randomness_state`
 
+Record new randomness. Called when executing the RandomnessStateUpdate system
+transaction.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_update_randomness_state">update_randomness_state</a>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/random.md#0x2_random_Random">random::Random</a>, new_round: u64, new_bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ctx: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/sui.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/sui.md
@@ -3,6 +3,8 @@
 
 # Module `0x2::sui`
 
+Coin<SUI> is the token used to pay for gas in Sui.
+It has 9 decimals, and the smallest unit (10^-9) is called "mist".
 
 
 -  [Struct `SUI`](#0x2_sui_SUI)
@@ -25,6 +27,7 @@
 
 ## Struct `SUI`
 
+Name of the coin
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">SUI</a> <b>has</b> drop
@@ -55,6 +58,7 @@
 
 <a name="0x2_sui_ENotSystemAddress"></a>
 
+Sender is not @0x0 the system address.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_ENotSystemAddress">ENotSystemAddress</a>: u64 = 1;
@@ -73,6 +77,8 @@
 
 <a name="0x2_sui_MIST_PER_SUI"></a>
 
+The amount of Mist per Sui token based on the the fact that mist is
+10^-9 of a Sui token
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_MIST_PER_SUI">MIST_PER_SUI</a>: u64 = 1000000000;
@@ -82,6 +88,7 @@
 
 <a name="0x2_sui_TOTAL_SUPPLY_MIST"></a>
 
+The total supply of Sui denominated in Mist (10 Billion * 10^9)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>: u64 = 10000000000000000000;
@@ -91,6 +98,7 @@
 
 <a name="0x2_sui_TOTAL_SUPPLY_SUI"></a>
 
+The total supply of Sui denominated in whole Sui tokens (10 Billion)
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_TOTAL_SUPPLY_SUI">TOTAL_SUPPLY_SUI</a>: u64 = 10000000000;
@@ -102,6 +110,8 @@
 
 ## Function `new`
 
+Register the <code><a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">SUI</a></code> Coin to acquire its <code>Supply</code>.
+This should be called only once during genesis creation.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../dependencies/sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/table.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/table.md
@@ -3,6 +3,21 @@
 
 # Module `0x2::table`
 
+A table is a map-like collection. But unlike a traditional collection, it's keys and values are
+not stored within the <code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> value, but instead are stored using Sui's object system. The
+<code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> struct acts only as a handle into the object system to retrieve those keys and values.
+Note that this means that <code><a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a></code> values with exactly the same key-value mapping will not be
+equal, with <code>==</code>, at runtime. For example
+```
+let table1 = table::new<u64, bool>();
+let table2 = table::new<u64, bool>();
+table::add(&mut table1, 0, false);
+table::add(&mut table1, 1, true);
+table::add(&mut table2, 0, false);
+table::add(&mut table2, 1, true);
+// table1 does not equal table2, despite having the same entries
+assert!(&table1 != &table2, 0);
+```
 
 
 -  [Resource `Table`](#0x2_table_Table)
@@ -46,13 +61,13 @@
 <code>id: <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ the ID of this table
 </dd>
 <dt>
 <code>size: u64</code>
 </dt>
 <dd>
-
+ the number of key-value pairs in the table
 </dd>
 </dl>
 
@@ -77,6 +92,7 @@
 
 ## Function `new`
 
+Creates a new, empty table
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_new">new</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;
@@ -104,6 +120,9 @@
 
 ## Function `add`
 
+Adds a key-value pair to the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
+Aborts with <code>sui::dynamic_field::EFieldAlreadyExists</code> if the table already has an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K, v: V)
@@ -129,6 +148,9 @@
 
 ## Function `borrow`
 
+Immutable borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &V
@@ -153,6 +175,9 @@
 
 ## Function `borrow_mut`
 
+Mutably borrows the value associated with the key in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
@@ -177,6 +202,9 @@
 
 ## Function `remove`
 
+Removes the key-value pair in the table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code> and returns the value.
+Aborts with <code>sui::dynamic_field::EFieldDoesNotExist</code> if the table does not have an entry with
+that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<b>mut</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): V
@@ -203,6 +231,7 @@
 
 ## Function `contains`
 
+Returns true iff there is a value associated with the key <code>k: K</code> in table <code><a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">Table</a>&lt;K, V&gt;</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;, k: K): bool
@@ -227,6 +256,7 @@
 
 ## Function `length`
 
+Returns the size of the table, the number of key-value pairs
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): u64
@@ -251,6 +281,7 @@
 
 ## Function `is_empty`
 
+Returns true iff the table is empty (if <code>length</code> returns <code>0</code>)
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: &<a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;): bool
@@ -275,6 +306,8 @@
 
 ## Function `destroy_empty`
 
+Destroys an empty table
+Aborts with <code><a href="../../dependencies/sui-framework/table.md#0x2_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)
@@ -301,6 +334,8 @@
 
 ## Function `drop`
 
+Drop a possibly non-empty table.
+Usable only if the value type <code>V</code> has the <code>drop</code> ability
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table.md#0x2_table_drop">drop</a>&lt;K: <b>copy</b>, drop, store, V: drop, store&gt;(<a href="../../dependencies/sui-framework/table.md#0x2_table">table</a>: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;K, V&gt;)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/table_vec.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/table_vec.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::table_vec`
 
+A basic scalable vector library implemented using <code>Table</code>.
 
 
 -  [Struct `TableVec`](#0x2_table_vec_TableVec)
@@ -47,7 +48,7 @@
 <code>contents: <a href="../../dependencies/sui-framework/table.md#0x2_table_Table">table::Table</a>&lt;u64, Element&gt;</code>
 </dt>
 <dd>
-
+ The contents of the table vector.
 </dd>
 </dl>
 
@@ -81,6 +82,7 @@
 
 ## Function `empty`
 
+Create an empty TableVec.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_empty">empty</a>&lt;Element: store&gt;(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;
@@ -107,6 +109,7 @@
 
 ## Function `singleton`
 
+Return a TableVec of size one containing element <code>e</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_singleton">singleton</a>&lt;Element: store&gt;(e: Element, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;
@@ -133,6 +136,7 @@
 
 ## Function `length`
 
+Return the length of the TableVec.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_length">length</a>&lt;Element: store&gt;(t: &<a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): u64
@@ -157,6 +161,7 @@
 
 ## Function `is_empty`
 
+Return if the TableVec is empty or not.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_is_empty">is_empty</a>&lt;Element: store&gt;(t: &<a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): bool
@@ -181,6 +186,8 @@
 
 ## Function `borrow`
 
+Acquire an immutable reference to the <code>i</code>th element of the TableVec <code>t</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64): &Element
@@ -206,6 +213,7 @@
 
 ## Function `push_back`
 
+Add element <code>e</code> to the end of the TableVec <code>t</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_push_back">push_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, e: Element)
@@ -231,6 +239,8 @@
 
 ## Function `borrow_mut`
 
+Return a mutable reference to the <code>i</code>th element in the TableVec <code>t</code>.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_borrow_mut">borrow_mut</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
@@ -256,6 +266,8 @@
 
 ## Function `pop_back`
 
+Pop an element from the end of TableVec <code>t</code>.
+Aborts if <code>t</code> is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_pop_back">pop_back</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;): Element
@@ -282,6 +294,8 @@
 
 ## Function `destroy_empty`
 
+Destroy the TableVec <code>t</code>.
+Aborts if <code>t</code> is not empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_destroy_empty">destroy_empty</a>&lt;Element: store&gt;(t: <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;)
@@ -308,6 +322,8 @@
 
 ## Function `drop`
 
+Drop a possibly non-empty TableVec <code>t</code>.
+Usable only if the value type <code>Element</code> has the <code>drop</code> ability
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_drop">drop</a>&lt;Element: drop, store&gt;(t: <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;)
@@ -333,6 +349,8 @@
 
 ## Function `swap`
 
+Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the TableVec <code>t</code>.
+Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_swap">swap</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64, j: u64)
@@ -363,6 +381,9 @@
 
 ## Function `swap_remove`
 
+Swap the <code>i</code>th element of the TableVec <code>t</code> with the last element and then pop the TableVec.
+This is O(1), but does not preserve ordering of elements in the TableVec.
+Aborts if <code>i</code> is out of bounds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_swap_remove">swap_remove</a>&lt;Element: store&gt;(t: &<b>mut</b> <a href="../../dependencies/sui-framework/table_vec.md#0x2_table_vec_TableVec">table_vec::TableVec</a>&lt;Element&gt;, i: u64): Element

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/transfer.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/transfer.md
@@ -31,6 +31,13 @@
 
 ## Struct `Receiving`
 
+This represents the ability to <code>receive</code> an object of type <code>T</code>.
+This type is ephemeral per-transaction and cannot be stored on-chain.
+This does not represent the obligation to receive the object that it
+references, but simply the ability to receive the object with object ID
+<code>id</code> at version <code>version</code> if you can prove mutable access to the parent
+object during the transaction.
+Internals of this struct are opaque outside this module.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a>&lt;T: key&gt; <b>has</b> drop
@@ -67,6 +74,7 @@
 
 <a name="0x2_transfer_EBCSSerializationFailure"></a>
 
+Serialization of the object failed.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EBCSSerializationFailure">EBCSSerializationFailure</a>: u64 = 1;
@@ -76,6 +84,7 @@
 
 <a name="0x2_transfer_EReceivingObjectTypeMismatch"></a>
 
+The object being received is not of the expected type.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EReceivingObjectTypeMismatch">EReceivingObjectTypeMismatch</a>: u64 = 2;
@@ -85,6 +94,8 @@
 
 <a name="0x2_transfer_ESharedNonNewObject"></a>
 
+Shared an object that was previously created. Shared objects must currently
+be constructed in the transaction they are created.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a>: u64 = 0;
@@ -94,6 +105,7 @@
 
 <a name="0x2_transfer_ESharedObjectOperationNotSupported"></a>
 
+Shared object operations such as wrapping, freezing, and converting to owned are not allowed.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedObjectOperationNotSupported">ESharedObjectOperationNotSupported</a>: u64 = 4;
@@ -103,6 +115,8 @@
 
 <a name="0x2_transfer_EUnableToReceiveObject"></a>
 
+Represents both the case where the object does not exist and the case where the object is not
+able to be accessed through the parent that is passed-in.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_EUnableToReceiveObject">EUnableToReceiveObject</a>: u64 = 3;
@@ -114,6 +128,13 @@
 
 ## Function `transfer`
 
+Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer">transfer</a></code> is invoked. Use
+<code>public_transfer</code> to transfer an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
@@ -138,6 +159,11 @@
 
 ## Function `public_transfer`
 
+Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
+The object must have <code>store</code> to be transferred outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_transfer">public_transfer</a>&lt;T: store, key&gt;(obj: T, recipient: <b>address</b>)
@@ -162,6 +188,11 @@
 
 ## Function `freeze_object`
 
+Freeze <code>obj</code>. After freezing <code>obj</code> becomes immutable and can no longer be transferred or
+mutated.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>freeze_object</code> is invoked. Use
+<code>public_freeze_object</code> to freeze an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_freeze_object">freeze_object</a>&lt;T: key&gt;(obj: T)
@@ -186,6 +217,9 @@
 
 ## Function `public_freeze_object`
 
+Freeze <code>obj</code>. After freezing <code>obj</code> becomes immutable and can no longer be transferred or
+mutated.
+The object must have <code>store</code> to be frozen outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_freeze_object">public_freeze_object</a>&lt;T: store, key&gt;(obj: T)
@@ -210,6 +244,13 @@
 
 ## Function `share_object`
 
+Turn the given object into a mutable shared object that everyone can access and mutate.
+This is irreversible, i.e. once an object is shared, it will stay shared forever.
+Aborts with <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a></code> of the object being shared was not created in this
+transaction. This restriction may be relaxed in the future.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>share_object</code> is invoked. Use
+<code>public_share_object</code> to share an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_share_object">share_object</a>&lt;T: key&gt;(obj: T)
@@ -234,6 +275,11 @@
 
 ## Function `public_share_object`
 
+Turn the given object into a mutable shared object that everyone can access and mutate.
+This is irreversible, i.e. once an object is shared, it will stay shared forever.
+Aborts with <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_ESharedNonNewObject">ESharedNonNewObject</a></code> of the object being shared was not created in this
+transaction. This restriction may be relaxed in the future.
+The object must have <code>store</code> to be shared outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_share_object">public_share_object</a>&lt;T: store, key&gt;(obj: T)
@@ -258,6 +304,12 @@
 
 ## Function `receive`
 
+Given mutable (i.e., locked) access to the <code>parent</code> and a <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument
+referencing an object of type <code>T</code> owned by <code>parent</code> use the <code>to_receive</code>
+argument to receive and return the referenced owned object of type <code>T</code>.
+This function has custom rules performed by the Sui Move bytecode verifier that ensures
+that <code>T</code> is an object defined in the module where <code>receive</code> is invoked. Use
+<code>public_receive</code> to receivne an object with <code>store</code> outside of its module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_receive">receive</a>&lt;T: key&gt;(parent: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, to_receive: <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): T
@@ -286,6 +338,10 @@
 
 ## Function `public_receive`
 
+Given mutable (i.e., locked) access to the <code>parent</code> and a <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument
+referencing an object of type <code>T</code> owned by <code>parent</code> use the <code>to_receive</code>
+argument to receive and return the referenced owned object of type <code>T</code>.
+The object must have <code>store</code> to be received outside of its defining module.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_public_receive">public_receive</a>&lt;T: store, key&gt;(parent: &<b>mut</b> <a href="../../dependencies/sui-framework/object.md#0x2_object_UID">object::UID</a>, to_receive: <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): T
@@ -314,6 +370,7 @@
 
 ## Function `receiving_object_id`
 
+Return the object ID that the given <code><a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">Receiving</a></code> argument references.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_receiving_object_id">receiving_object_id</a>&lt;T: key&gt;(receiving: &<a href="../../dependencies/sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;T&gt;): <a href="../../dependencies/sui-framework/object.md#0x2_object_ID">object::ID</a>

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/tx_context.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/tx_context.md
@@ -23,6 +23,9 @@
 
 ## Struct `TxContext`
 
+Information about the transaction currently being executed.
+This cannot be constructed by a transaction--it is a privileged object created by
+the VM and passed in to the entrypoint of the transaction as <code>&<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">TxContext</a></code>.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">TxContext</a> <b>has</b> drop
@@ -39,31 +42,32 @@
 <code>sender: <b>address</b></code>
 </dt>
 <dd>
-
+ The address of the user that signed the current transaction
 </dd>
 <dt>
 <code>tx_hash: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
-
+ Hash of the current transaction
 </dd>
 <dt>
 <code>epoch: u64</code>
 </dt>
 <dd>
-
+ The current epoch number
 </dd>
 <dt>
 <code>epoch_timestamp_ms: u64</code>
 </dt>
 <dd>
-
+ Timestamp that the epoch started at
 </dd>
 <dt>
 <code>ids_created: u64</code>
 </dt>
 <dd>
-
+ Counter recording the number of fresh id's created while executing
+ this transaction. Always 0 at the start of a transaction
 </dd>
 </dl>
 
@@ -74,6 +78,8 @@
 
 ## Function `sender`
 
+Return the address of the user that signed the current
+transaction
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_sender">sender</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
@@ -98,6 +104,8 @@
 
 ## Function `digest`
 
+Return the transaction digest (hash of transaction inputs).
+Please do not use as a source of randomness.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_digest">digest</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -122,6 +130,7 @@
 
 ## Function `epoch`
 
+Return the current epoch
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_epoch">epoch</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -146,6 +155,7 @@
 
 ## Function `epoch_timestamp_ms`
 
+Return the epoch start time as a unix timestamp in milliseconds.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_epoch_timestamp_ms">epoch_timestamp_ms</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -170,6 +180,9 @@
 
 ## Function `fresh_object_address`
 
+Create an <code><b>address</b></code> that has not been used. As it is an object address, it will never
+occur as the address for a user.
+In other words, the generated address is a globally unique object ID.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_fresh_object_address">fresh_object_address</a>(ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
@@ -197,6 +210,8 @@
 
 ## Function `ids_created`
 
+Return the number of id's created by the current transaction.
+Hidden for now, but may expose later
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_ids_created">ids_created</a>(self: &<a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): u64
@@ -221,6 +236,7 @@
 
 ## Function `derive_id`
 
+Native function for deriving an ID via hash(tx_hash || ids_created)
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_derive_id">derive_id</a>(tx_hash: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ids_created: u64): <b>address</b>

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/types.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/types.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::types`
 
+Sui types helpers and utilities
 
 
 -  [Function `is_one_time_witness`](#0x2_types_is_one_time_witness)
@@ -16,6 +17,8 @@
 
 ## Function `is_one_time_witness`
 
+Tests if the argument type is a one-time witness, that is a type with only one instantiation
+across the entire code base.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/types.md#0x2_types_is_one_time_witness">is_one_time_witness</a>&lt;T: drop&gt;(_: &T): bool

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/url.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/url.md
@@ -3,6 +3,7 @@
 
 # Module `0x2::url`
 
+URL: standard Uniform Resource Locator string
 
 
 -  [Struct `Url`](#0x2_url_Url)
@@ -21,6 +22,7 @@
 
 ## Struct `Url`
 
+Standard Uniform Resource Locator (URL) string.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a> <b>has</b> <b>copy</b>, drop, store
@@ -48,6 +50,7 @@
 
 ## Function `new_unsafe`
 
+Create a <code><a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a></code>, with no validation
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_new_unsafe">new_unsafe</a>(<a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>): <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>
@@ -72,6 +75,8 @@
 
 ## Function `new_unsafe_from_bytes`
 
+Create a <code><a href="../../dependencies/sui-framework/url.md#0x2_url_Url">Url</a></code> with no validation from bytes
+Note: this will abort if <code>bytes</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_new_unsafe_from_bytes">new_unsafe_from_bytes</a>(bytes: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>
@@ -97,6 +102,7 @@
 
 ## Function `inner_url`
 
+Get inner URL
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_inner_url">inner_url</a>(self: &<a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>): <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>
@@ -121,6 +127,7 @@
 
 ## Function `update`
 
+Update the inner URL
 
 
 <pre><code><b>public</b> <b>fun</b> <b>update</b>(self: &<b>mut</b> <a href="../../dependencies/sui-framework/url.md#0x2_url_Url">url::Url</a>, <a href="../../dependencies/sui-framework/url.md#0x2_url">url</a>: <a href="../../dependencies/move-stdlib/ascii.md#0x1_ascii_String">ascii::String</a>)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/vec_map.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/vec_map.md
@@ -38,6 +38,12 @@
 
 ## Struct `VecMap`
 
+A map data structure backed by a vector. The map is guaranteed not to contain duplicate keys, but entries
+are *not* sorted by key--entries are included in insertion order.
+All operations are O(N) in the size of the map--the intention of this data structure is only to provide
+the convenience of programming against a map API.
+Large maps should use handwritten parent/child relationships instead.
+Maps that need sorted iteration rather than insertion order iteration should also be handwritten.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a>&lt;K: <b>copy</b>, V&gt; <b>has</b> <b>copy</b>, drop, store
@@ -65,6 +71,7 @@
 
 ## Struct `Entry`
 
+An entry in the map
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_Entry">Entry</a>&lt;K: <b>copy</b>, V&gt; <b>has</b> <b>copy</b>, drop, store
@@ -101,6 +108,7 @@
 
 <a name="0x2_vec_map_EKeyAlreadyExists"></a>
 
+This key already exists in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_EKeyAlreadyExists">EKeyAlreadyExists</a>: u64 = 0;
@@ -110,6 +118,7 @@
 
 <a name="0x2_vec_map_EKeyDoesNotExist"></a>
 
+This key does not exist in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
@@ -119,6 +128,7 @@
 
 <a name="0x2_vec_map_EIndexOutOfBounds"></a>
 
+Trying to access an element of the map at an invalid index
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_EIndexOutOfBounds">EIndexOutOfBounds</a>: u64 = 3;
@@ -128,6 +138,7 @@
 
 <a name="0x2_vec_map_EMapEmpty"></a>
 
+Trying to pop from a map that is empty
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_EMapEmpty">EMapEmpty</a>: u64 = 4;
@@ -137,6 +148,7 @@
 
 <a name="0x2_vec_map_EMapNotEmpty"></a>
 
+Trying to destroy a map that is not empty
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_EMapNotEmpty">EMapNotEmpty</a>: u64 = 2;
@@ -148,6 +160,7 @@
 
 ## Function `empty`
 
+Create an empty <code><a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">VecMap</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_empty">empty</a>&lt;K: <b>copy</b>, V&gt;(): <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;
@@ -172,6 +185,8 @@
 
 ## Function `insert`
 
+Insert the entry <code>key</code> |-> <code>value</code> into <code>self</code>.
+Aborts if <code>key</code> is already bound in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_insert">insert</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: K, value: V)
@@ -197,6 +212,7 @@
 
 ## Function `remove`
 
+Remove the entry <code>key</code> |-> <code>value</code> from self. Aborts if <code>key</code> is not bound in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_remove">remove</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): (K, V)
@@ -223,6 +239,7 @@
 
 ## Function `pop`
 
+Pop the most recently inserted entry from the map. Aborts if the map is empty.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_pop">pop</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): (K, V)
@@ -249,6 +266,8 @@
 
 ## Function `get_mut`
 
+Get a mutable reference to the value bound to <code>key</code> in <code>self</code>.
+Aborts if <code>key</code> is not bound in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get_mut">get_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): &<b>mut</b> V
@@ -275,6 +294,8 @@
 
 ## Function `get`
 
+Get a reference to the value bound to <code>key</code> in <code>self</code>.
+Aborts if <code>key</code> is not bound in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get">get</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): &V
@@ -301,6 +322,9 @@
 
 ## Function `try_get`
 
+Safely try borrow a value bound to <code>key</code> in <code>self</code>.
+Return Some(V) if the value exists, None otherwise.
+Only works for a "copyable" value as references cannot be stored in <code><a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_try_get">try_get</a>&lt;K: <b>copy</b>, V: <b>copy</b>&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;V&gt;
@@ -329,6 +353,7 @@
 
 ## Function `contains`
 
+Return true if <code>self</code> contains an entry for <code>key</code>, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_contains">contains</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): bool
@@ -353,6 +378,7 @@
 
 ## Function `size`
 
+Return the number of entries in <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_size">size</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): u64
@@ -377,6 +403,7 @@
 
 ## Function `is_empty`
 
+Return true if <code>self</code> has 0 elements, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_is_empty">is_empty</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): bool
@@ -401,6 +428,7 @@
 
 ## Function `destroy_empty`
 
+Destroy an empty map. Aborts if <code>self</code> is not empty
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;)
@@ -427,6 +455,8 @@
 
 ## Function `into_keys_values`
 
+Unpack <code>self</code> into vectors of its keys and values.
+The output keys and values are stored in insertion order, *not* sorted by key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_into_keys_values">into_keys_values</a>&lt;K: <b>copy</b>, V&gt;(self: <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): (<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;V&gt;)
@@ -465,6 +495,8 @@
 
 ## Function `keys`
 
+Returns a list of keys in the map.
+Do not assume any particular ordering.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_keys">keys</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;
@@ -497,6 +529,8 @@
 
 ## Function `get_idx_opt`
 
+Find the index of <code>key</code> in <code>self</code>. Return <code>None</code> if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted by key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
@@ -529,6 +563,8 @@
 
 ## Function `get_idx`
 
+Find the index of <code>key</code> in <code>self</code>. Aborts if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted by key.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get_idx">get_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, key: &K): u64
@@ -555,6 +591,9 @@
 
 ## Function `get_entry_by_idx`
 
+Return a reference to the <code>idx</code>th entry of <code>self</code>. This gives direct access into the backing array of the map--use with caution.
+Note that map entries are stored in insertion order, *not* sorted by key.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_size">size</a>(self)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get_entry_by_idx">get_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &V)
@@ -581,6 +620,9 @@
 
 ## Function `get_entry_by_idx_mut`
 
+Return a mutable reference to the <code>idx</code>th entry of <code>self</code>. This gives direct access into the backing array of the map--use with caution.
+Note that map entries are stored in insertion order, *not* sorted by key.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_size">size</a>(self)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_get_entry_by_idx_mut">get_entry_by_idx_mut</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (&K, &<b>mut</b> V)
@@ -607,6 +649,8 @@
 
 ## Function `remove_entry_by_idx`
 
+Remove the entry at index <code>idx</code> from self.
+Aborts if <code>idx</code> is greater than or equal to <code><a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_size">size</a>(self)</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_remove_entry_by_idx">remove_entry_by_idx</a>&lt;K: <b>copy</b>, V&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;K, V&gt;, idx: u64): (K, V)

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/vec_set.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/vec_set.md
@@ -30,6 +30,11 @@
 
 ## Struct `VecSet`
 
+A set data structure backed by a vector. The set is guaranteed not to
+contain duplicate keys. All operations are O(N) in the size of the set
+- the intention of this data structure is only to provide the convenience
+of programming against a set API. Sets that need sorted iteration rather
+than insertion order iteration should be handwritten.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K: <b>copy</b>, drop&gt; <b>has</b> <b>copy</b>, drop, store
@@ -60,6 +65,7 @@
 
 <a name="0x2_vec_set_EKeyAlreadyExists"></a>
 
+This key already exists in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_EKeyAlreadyExists">EKeyAlreadyExists</a>: u64 = 0;
@@ -69,6 +75,7 @@
 
 <a name="0x2_vec_set_EKeyDoesNotExist"></a>
 
+This key does not exist in the map
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_EKeyDoesNotExist">EKeyDoesNotExist</a>: u64 = 1;
@@ -80,6 +87,7 @@
 
 ## Function `empty`
 
+Create an empty <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_empty">empty</a>&lt;K: <b>copy</b>, drop&gt;(): <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
@@ -104,6 +112,7 @@
 
 ## Function `singleton`
 
+Create a singleton <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> that only contains one element.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_singleton">singleton</a>&lt;K: <b>copy</b>, drop&gt;(key: K): <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;
@@ -128,6 +137,8 @@
 
 ## Function `insert`
 
+Insert a <code>key</code> into self.
+Aborts if <code>key</code> is already present in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_insert">insert</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: K)
@@ -153,6 +164,7 @@
 
 ## Function `remove`
 
+Remove the entry <code>key</code> from self. Aborts if <code>key</code> is not present in <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_remove">remove</a>&lt;K: <b>copy</b>, drop&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K)
@@ -178,6 +190,7 @@
 
 ## Function `contains`
 
+Return true if <code>self</code> contains an entry for <code>key</code>, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_contains">contains</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): bool
@@ -202,6 +215,7 @@
 
 ## Function `size`
 
+Return the number of entries in <code>self</code>
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_size">size</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): u64
@@ -226,6 +240,7 @@
 
 ## Function `is_empty`
 
+Return true if <code>self</code> has 0 elements, false otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): bool
@@ -250,6 +265,8 @@
 
 ## Function `into_keys`
 
+Unpack <code>self</code> into vectors of keys.
+The output keys are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b>, drop&gt;(self: <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;
@@ -275,6 +292,9 @@
 
 ## Function `keys`
 
+Borrow the <code>contents</code> of the <code><a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> to access content by index
+without unpacking. The contents are stored in insertion order,
+*not* sorted.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_keys">keys</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;K&gt;
@@ -299,6 +319,8 @@
 
 ## Function `get_idx_opt`
 
+Find the index of <code>key</code> in <code>self</code>. Return <code>None</code> if <code>key</code> is not in <code>self</code>.
+Note that keys are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_get_idx_opt">get_idx_opt</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): <a href="../../dependencies/move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
@@ -331,6 +353,8 @@
 
 ## Function `get_idx`
 
+Find the index of <code>key</code> in <code>self</code>. Aborts if <code>key</code> is not in <code>self</code>.
+Note that map entries are stored in insertion order, *not* sorted.
 
 
 <pre><code><b>fun</b> <a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_get_idx">get_idx</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="../../dependencies/sui-framework/vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;, key: &K): u64

--- a/crates/sui-framework/docs/sui-system/dependencies/sui-framework/versioned.md
+++ b/crates/sui-framework/docs/sui-system/dependencies/sui-framework/versioned.md
@@ -28,6 +28,12 @@
 
 ## Resource `Versioned`
 
+A wrapper type that supports versioning of the inner type.
+The inner type is a dynamic field of the Versioned object, and is keyed using version.
+User of this type could load the inner object using corresponding type based on the version.
+You can also upgrade the inner object to a new type version.
+If you want to support lazy upgrade of the inner type, one caveat is that all APIs would have
+to use mutable reference even if it's a read-only API.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">Versioned</a> <b>has</b> store, key
@@ -61,6 +67,8 @@
 
 ## Struct `VersionChangeCap`
 
+Represents a hot potato object generated when we take out the dynamic field.
+This is to make sure that we always put a new value back.
 
 
 <pre><code><b>struct</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">VersionChangeCap</a>
@@ -97,6 +105,7 @@
 
 <a name="0x2_versioned_EInvalidUpgrade"></a>
 
+Failed to upgrade the inner object due to invalid capability or new version.
 
 
 <pre><code><b>const</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_EInvalidUpgrade">EInvalidUpgrade</a>: u64 = 0;
@@ -108,6 +117,7 @@
 
 ## Function `create`
 
+Create a new Versioned object that contains a initial value of type <code>T</code> with an initial version.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_create">create</a>&lt;T: store&gt;(init_version: u64, init_value: T, ctx: &<b>mut</b> <a href="../../dependencies/sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>
@@ -137,6 +147,7 @@
 
 ## Function `version`
 
+Get the current version of the inner type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_version">version</a>(self: &<a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): u64
@@ -161,6 +172,8 @@
 
 ## Function `load_value`
 
+Load the inner value based on the current version. Caller specifies an expected type T.
+If the type mismatch, the load will fail.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_load_value">load_value</a>&lt;T: store&gt;(self: &<a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): &T
@@ -185,6 +198,7 @@
 
 ## Function `load_value_mut`
 
+Similar to load_value, but return a mutable reference.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_load_value_mut">load_value_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): &<b>mut</b> T
@@ -209,6 +223,8 @@
 
 ## Function `remove_value_for_upgrade`
 
+Take the inner object out for upgrade. To ensure we always upgrade properly, a capability object is returned
+and must be used when we upgrade.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_remove_value_for_upgrade">remove_value_for_upgrade</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): (T, <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">versioned::VersionChangeCap</a>)
@@ -239,6 +255,8 @@
 
 ## Function `upgrade`
 
+Upgrade the inner object with a new version and new value. Must use the capability returned
+by calling remove_value_for_upgrade.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_upgrade">upgrade</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>, new_version: u64, new_value: T, cap: <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_VersionChangeCap">versioned::VersionChangeCap</a>)
@@ -267,6 +285,7 @@
 
 ## Function `destroy`
 
+Destroy this Versioned container, and return the inner object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_destroy">destroy</a>&lt;T: store&gt;(self: <a href="../../dependencies/sui-framework/versioned.md#0x2_versioned_Versioned">versioned::Versioned</a>): T

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -85,12 +85,14 @@ pub(crate) fn parse_program(
         named_address_map,
     } in deps
     {
-        let (defs, _, _) = parse_file(&path, compilation_env, &mut files, package)?;
+        let (defs, dep_comment_map, fhash) =
+            parse_file(&path, compilation_env, &mut files, package)?;
         lib_definitions.extend(defs.into_iter().map(|def| PackageDefinition {
             package,
             named_address_map,
             def,
         }));
+        source_comments.insert(fhash, dep_comment_map);
     }
 
     let pprog = parser::ast::Program {


### PR DESCRIPTION
## Description 

Fix parsing so that docgen can output doc comments for dependency packages. 

Bottom commit is the actual change, top commit is all of the regenerated docs. 

## Test Plan 

CI

