### PR TITLE
[Consensus 2.0] fix mysticeti committee member ordering

### DIFF
--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -216,20 +216,30 @@ impl<T> IndexMut<AuthorityIndex> for Vec<T> {
 #[cfg(test)]
 mod tests {
     use crate::{local_committee_and_keys, Stake};
+    use std::collections::BTreeMap;
 
     #[test]
     fn committee_basic() {
         // GIVEN
         let epoch = 100;
         let num_of_authorities = 9;
-        let authority_stakes = (1..=9).map(|s| s as Stake).collect();
-        let (committee, _) = local_committee_and_keys(epoch, authority_stakes);
+        let authority_stakes = (1..=9).map(|s| s as Stake).collect::<Vec<_>>();
+        let (committee, _) = local_committee_and_keys(epoch, authority_stakes.clone());
 
         // THEN make sure the output Committee fields are populated correctly.
+        // the committee authorities are ordered by their public key, so stakes will not be in same order.
         assert_eq!(committee.size(), num_of_authorities);
+
+        let mut authorities_by_stake = BTreeMap::new();
         for (i, authority) in committee.authorities() {
-            assert_eq!((i.value() + 1) as Stake, authority.stake);
+            authorities_by_stake.insert(authority.stake, i);
         }
+
+        assert_eq!(authorities_by_stake.len(), committee.size());
+        assert_eq!(
+            authorities_by_stake.keys().cloned().collect::<Vec<_>>(),
+            authority_stakes
+        );
 
         // AND ensure thresholds are calculated correctly.
         assert_eq!(committee.total_stake(), 45);

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -36,13 +36,18 @@ pub struct Committee {
 }
 
 impl Committee {
-    pub fn new(epoch: Epoch, authorities: Vec<Authority>) -> Self {
+    pub fn new(epoch: Epoch, mut authorities: Vec<Authority>) -> Self {
         assert!(!authorities.is_empty(), "Committee cannot be empty!");
         assert!(
             authorities.len() < u32::MAX as usize,
             "Too many authorities ({})!",
             authorities.len()
         );
+
+        // sort the authorities by their protocol (public) key in ascending order - critical to be
+        // aligned with the SUI committee.
+        authorities.sort_by(|a1, a2| a1.protocol_key.cmp(&a2.protocol_key));
+
         let total_stake = authorities.iter().map(|a| a.stake).sum();
         assert_ne!(total_stake, 0, "Total stake cannot be zero!");
         let quorum_threshold = 2 * total_stake / 3 + 1;

--- a/consensus/config/tests/snapshots/committee_test__committee.snap
+++ b/consensus/config/tests/snapshots/committee_test__committee.snap
@@ -7,36 +7,21 @@ total_stake: 55
 quorum_threshold: 37
 validity_threshold: 19
 authorities:
-  - stake: 1
-    address: ""
-    hostname: test_host
-    network_key: lscBzpFcgepvETNDWHp61B+teyauHrk6kb5XBszDufg=
-    protocol_key: tembhBjGw+XVGXywAYDja1R67d8pSKGhYypbgeRUJmTTdzfNnr/LHJ3U0bZY49ChGXw6mKwBVJV4KP3na8YFaef9wQuHKgwjvhJT3FnimCPyBwIz4cFasq1d3As4/yeP
   - stake: 2
     address: ""
     hostname: test_host
     network_key: VnXFtZxaTby9AquydHFr9dy8+GlVoPcsm8icljGTbWQ=
     protocol_key: hLIJiig6cqajwuIlnxjL+bxhZxCgEWUGdN9VyJSqMAvuN6tDm7qTcBplvDICmgSlGJwHZ5IzyOH6N+Wj1Fa1odxsM86eLf9g+MjzT/h869sqV9EpyXtpYbufPYCW0fkT
-  - stake: 3
+  - stake: 9
     address: ""
     hostname: test_host
-    network_key: +yTI/ZSBZa9CmHP/Qhjtf2bgTR0lC+9NUP8BgQq0OPw=
-    protocol_key: kci5lWPW4LlAr1jLSyEkGtYeSfstp3daJ0pChi5zo4KaDOOQd7IbnRPyP/zMqkfTE9MIyymjSkhnI72/Wogbqedrc5lhIp+C2wtbv79mdC8SrbHb2Y/LHvYD7w1mOJFM
-  - stake: 4
-    address: ""
-    hostname: test_host
-    network_key: TLb93AG1NlYtf9dVMnS6LJE5aRfqt2LsSBJeuoa3wHk=
-    protocol_key: onGDFBk46p2hpQFq3QJbyAVD0G05FOxRaJQH3LacRTRRfdXWLtewyUi1Z0MMX4H3CpoldjqoGeMbESvqgTZeKt6HE3d8pn6TApMzf632WI3DfUGUUMBM7ciCivNaKTBS
+    network_key: YxoEz+3fDnLfrOkpqVkRxfj/HqlqsoQqt9bzSLjxJEc=
+    protocol_key: iIEIwu3rHEXU1fy+2VNUKjqV2tFLcu35a5Uo+qO99rQ63nywUvOsiDxrUvzOpJYoDZ/Xa4PnzgkhFTiGVi/Qt6ASIBhu/66jjxhDs6Pt7h1CtRFnD3zWRkgYinIzmxuQ
   - stake: 5
     address: ""
     hostname: test_host
     network_key: 7DYZ4De7EKRhhH0GBMTKlBqUeXnFMgkzLKjekMAuesw=
     protocol_key: iM3E2wCApVtOKv1I/jSpNXO1kPRCnHo0c6H/qgyxvJngmgW1KYnWtycts8drNLIUGLtinT83V8D3Xnc3whUAqiKYrJ5vu2knQXqFBCmgrqo7N0xZ0T/uuKVWjoNqyHHl
-  - stake: 6
-    address: ""
-    hostname: test_host
-    network_key: B2I7VErvTa/POXtLemf+iDEt/966mNqq3F+DdHcvi8U=
-    protocol_key: pEiGWt/9mL2YXfHkYntXWy7OzGdS1psbJQ2D5Xp5FS7XZWYQzh7+zz/bkOfgWCRaFoV8bbsmb7eVwuMvOTnPvCSamtyUQ3pc+SKVTsXtRbwRNvWtXjTVHGQQSXE5R1kp
   - stake: 7
     address: ""
     hostname: test_host
@@ -47,14 +32,29 @@ authorities:
     hostname: test_host
     network_key: +0ebVcUY7X8QIafWGbUmzlhy/Vc2LtNRqqLzk4NgLoU=
     protocol_key: jDvXpT0oTY7w9BWERszWiLBu9Aajj9WbbPkfmE9M+ijxGCooLK14P1lsqOZ67XMoAIfh8Z5t/hNanV5fH+3PtJT6o8APO5pCoTcLi5SoScRSQKMCevHqHAizI57wG4cl
-  - stake: 9
+  - stake: 3
     address: ""
     hostname: test_host
-    network_key: YxoEz+3fDnLfrOkpqVkRxfj/HqlqsoQqt9bzSLjxJEc=
-    protocol_key: iIEIwu3rHEXU1fy+2VNUKjqV2tFLcu35a5Uo+qO99rQ63nywUvOsiDxrUvzOpJYoDZ/Xa4PnzgkhFTiGVi/Qt6ASIBhu/66jjxhDs6Pt7h1CtRFnD3zWRkgYinIzmxuQ
+    network_key: +yTI/ZSBZa9CmHP/Qhjtf2bgTR0lC+9NUP8BgQq0OPw=
+    protocol_key: kci5lWPW4LlAr1jLSyEkGtYeSfstp3daJ0pChi5zo4KaDOOQd7IbnRPyP/zMqkfTE9MIyymjSkhnI72/Wogbqedrc5lhIp+C2wtbv79mdC8SrbHb2Y/LHvYD7w1mOJFM
   - stake: 10
     address: ""
     hostname: test_host
     network_key: lT6jnl+ZiC2MhDfooUetAJFDd6cRQy1Lq9KKjKqOevo=
     protocol_key: lxvqS7Rm/l8gmFj6Q3CJ3Qv994gzsM/hSt5YoBrE8v4UmfoyuvQ0JQ9gw2qNbMuiDwvkCAxotLiCa0yjKjZe5Kk8QS37dGZw5akNHQ2SHkc+CK7bccWVkdfRnF4iQal5
+  - stake: 4
+    address: ""
+    hostname: test_host
+    network_key: TLb93AG1NlYtf9dVMnS6LJE5aRfqt2LsSBJeuoa3wHk=
+    protocol_key: onGDFBk46p2hpQFq3QJbyAVD0G05FOxRaJQH3LacRTRRfdXWLtewyUi1Z0MMX4H3CpoldjqoGeMbESvqgTZeKt6HE3d8pn6TApMzf632WI3DfUGUUMBM7ciCivNaKTBS
+  - stake: 6
+    address: ""
+    hostname: test_host
+    network_key: B2I7VErvTa/POXtLemf+iDEt/966mNqq3F+DdHcvi8U=
+    protocol_key: pEiGWt/9mL2YXfHkYntXWy7OzGdS1psbJQ2D5Xp5FS7XZWYQzh7+zz/bkOfgWCRaFoV8bbsmb7eVwuMvOTnPvCSamtyUQ3pc+SKVTsXtRbwRNvWtXjTVHGQQSXE5R1kp
+  - stake: 1
+    address: ""
+    hostname: test_host
+    network_key: lscBzpFcgepvETNDWHp61B+teyauHrk6kb5XBszDufg=
+    protocol_key: tembhBjGw+XVGXywAYDja1R67d8pSKGhYypbgeRUJmTTdzfNnr/LHJ3U0bZY49ChGXw6mKwBVJV4KP3na8YFaef9wQuHKgwjvhJT3FnimCPyBwIz4cFasq1d3As4/yeP
 

--- a/consensus/config/tests/snapshots/committee_test__committee.snap
+++ b/consensus/config/tests/snapshots/committee_test__committee.snap
@@ -7,21 +7,36 @@ total_stake: 55
 quorum_threshold: 37
 validity_threshold: 19
 authorities:
+  - stake: 1
+    address: ""
+    hostname: test_host
+    network_key: lscBzpFcgepvETNDWHp61B+teyauHrk6kb5XBszDufg=
+    protocol_key: tembhBjGw+XVGXywAYDja1R67d8pSKGhYypbgeRUJmTTdzfNnr/LHJ3U0bZY49ChGXw6mKwBVJV4KP3na8YFaef9wQuHKgwjvhJT3FnimCPyBwIz4cFasq1d3As4/yeP
   - stake: 2
     address: ""
     hostname: test_host
     network_key: VnXFtZxaTby9AquydHFr9dy8+GlVoPcsm8icljGTbWQ=
     protocol_key: hLIJiig6cqajwuIlnxjL+bxhZxCgEWUGdN9VyJSqMAvuN6tDm7qTcBplvDICmgSlGJwHZ5IzyOH6N+Wj1Fa1odxsM86eLf9g+MjzT/h869sqV9EpyXtpYbufPYCW0fkT
-  - stake: 9
+  - stake: 3
     address: ""
     hostname: test_host
-    network_key: YxoEz+3fDnLfrOkpqVkRxfj/HqlqsoQqt9bzSLjxJEc=
-    protocol_key: iIEIwu3rHEXU1fy+2VNUKjqV2tFLcu35a5Uo+qO99rQ63nywUvOsiDxrUvzOpJYoDZ/Xa4PnzgkhFTiGVi/Qt6ASIBhu/66jjxhDs6Pt7h1CtRFnD3zWRkgYinIzmxuQ
+    network_key: +yTI/ZSBZa9CmHP/Qhjtf2bgTR0lC+9NUP8BgQq0OPw=
+    protocol_key: kci5lWPW4LlAr1jLSyEkGtYeSfstp3daJ0pChi5zo4KaDOOQd7IbnRPyP/zMqkfTE9MIyymjSkhnI72/Wogbqedrc5lhIp+C2wtbv79mdC8SrbHb2Y/LHvYD7w1mOJFM
+  - stake: 4
+    address: ""
+    hostname: test_host
+    network_key: TLb93AG1NlYtf9dVMnS6LJE5aRfqt2LsSBJeuoa3wHk=
+    protocol_key: onGDFBk46p2hpQFq3QJbyAVD0G05FOxRaJQH3LacRTRRfdXWLtewyUi1Z0MMX4H3CpoldjqoGeMbESvqgTZeKt6HE3d8pn6TApMzf632WI3DfUGUUMBM7ciCivNaKTBS
   - stake: 5
     address: ""
     hostname: test_host
     network_key: 7DYZ4De7EKRhhH0GBMTKlBqUeXnFMgkzLKjekMAuesw=
     protocol_key: iM3E2wCApVtOKv1I/jSpNXO1kPRCnHo0c6H/qgyxvJngmgW1KYnWtycts8drNLIUGLtinT83V8D3Xnc3whUAqiKYrJ5vu2knQXqFBCmgrqo7N0xZ0T/uuKVWjoNqyHHl
+  - stake: 6
+    address: ""
+    hostname: test_host
+    network_key: B2I7VErvTa/POXtLemf+iDEt/966mNqq3F+DdHcvi8U=
+    protocol_key: pEiGWt/9mL2YXfHkYntXWy7OzGdS1psbJQ2D5Xp5FS7XZWYQzh7+zz/bkOfgWCRaFoV8bbsmb7eVwuMvOTnPvCSamtyUQ3pc+SKVTsXtRbwRNvWtXjTVHGQQSXE5R1kp
   - stake: 7
     address: ""
     hostname: test_host
@@ -32,29 +47,14 @@ authorities:
     hostname: test_host
     network_key: +0ebVcUY7X8QIafWGbUmzlhy/Vc2LtNRqqLzk4NgLoU=
     protocol_key: jDvXpT0oTY7w9BWERszWiLBu9Aajj9WbbPkfmE9M+ijxGCooLK14P1lsqOZ67XMoAIfh8Z5t/hNanV5fH+3PtJT6o8APO5pCoTcLi5SoScRSQKMCevHqHAizI57wG4cl
-  - stake: 3
+  - stake: 9
     address: ""
     hostname: test_host
-    network_key: +yTI/ZSBZa9CmHP/Qhjtf2bgTR0lC+9NUP8BgQq0OPw=
-    protocol_key: kci5lWPW4LlAr1jLSyEkGtYeSfstp3daJ0pChi5zo4KaDOOQd7IbnRPyP/zMqkfTE9MIyymjSkhnI72/Wogbqedrc5lhIp+C2wtbv79mdC8SrbHb2Y/LHvYD7w1mOJFM
+    network_key: YxoEz+3fDnLfrOkpqVkRxfj/HqlqsoQqt9bzSLjxJEc=
+    protocol_key: iIEIwu3rHEXU1fy+2VNUKjqV2tFLcu35a5Uo+qO99rQ63nywUvOsiDxrUvzOpJYoDZ/Xa4PnzgkhFTiGVi/Qt6ASIBhu/66jjxhDs6Pt7h1CtRFnD3zWRkgYinIzmxuQ
   - stake: 10
     address: ""
     hostname: test_host
     network_key: lT6jnl+ZiC2MhDfooUetAJFDd6cRQy1Lq9KKjKqOevo=
     protocol_key: lxvqS7Rm/l8gmFj6Q3CJ3Qv994gzsM/hSt5YoBrE8v4UmfoyuvQ0JQ9gw2qNbMuiDwvkCAxotLiCa0yjKjZe5Kk8QS37dGZw5akNHQ2SHkc+CK7bccWVkdfRnF4iQal5
-  - stake: 4
-    address: ""
-    hostname: test_host
-    network_key: TLb93AG1NlYtf9dVMnS6LJE5aRfqt2LsSBJeuoa3wHk=
-    protocol_key: onGDFBk46p2hpQFq3QJbyAVD0G05FOxRaJQH3LacRTRRfdXWLtewyUi1Z0MMX4H3CpoldjqoGeMbESvqgTZeKt6HE3d8pn6TApMzf632WI3DfUGUUMBM7ciCivNaKTBS
-  - stake: 6
-    address: ""
-    hostname: test_host
-    network_key: B2I7VErvTa/POXtLemf+iDEt/966mNqq3F+DdHcvi8U=
-    protocol_key: pEiGWt/9mL2YXfHkYntXWy7OzGdS1psbJQ2D5Xp5FS7XZWYQzh7+zz/bkOfgWCRaFoV8bbsmb7eVwuMvOTnPvCSamtyUQ3pc+SKVTsXtRbwRNvWtXjTVHGQQSXE5R1kp
-  - stake: 1
-    address: ""
-    hostname: test_host
-    network_key: lscBzpFcgepvETNDWHp61B+teyauHrk6kb5XBszDufg=
-    protocol_key: tembhBjGw+XVGXywAYDja1R67d8pSKGhYypbgeRUJmTTdzfNnr/LHJ3U0bZY49ChGXw6mKwBVJV4KP3na8YFaef9wQuHKgwjvhJT3FnimCPyBwIz4cFasq1d3As4/yeP
 

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -110,10 +110,10 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         let name: AuthorityName = self.keypair.public().into();
 
+        let sui_committee = system_state.get_sui_committee();
         let authority_index: AuthorityIndex = committee
             .to_authority_index(
-                epoch_store
-                    .committee()
+                sui_committee
                     .authority_index(&name)
                     .expect("Should have valid index for own authority") as usize,
             )

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -298,3 +298,87 @@ impl EpochStartValidatorInfoV1 {
         (&self.protocol_pubkey).into()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::base_types::SuiAddress;
+    use crate::committee::CommitteeTrait;
+    use crate::crypto::{get_key_pair, AuthorityKeyPair};
+    use crate::sui_system_state::epoch_start_sui_system_state::{
+        EpochStartSystemStateTrait, EpochStartSystemStateV1, EpochStartValidatorInfoV1,
+    };
+    use fastcrypto::traits::KeyPair;
+    use mysten_network::Multiaddr;
+    use narwhal_crypto::NetworkKeyPair;
+    use rand::thread_rng;
+    use sui_protocol_config::ProtocolVersion;
+
+    #[test]
+    fn test_sui_and_mysticeti_committee_are_same() {
+        // GIVEN
+        let mut active_validators = vec![];
+
+        for i in 0..10 {
+            let (sui_address, protocol_key): (SuiAddress, AuthorityKeyPair) = get_key_pair();
+            let narwhal_network_key = NetworkKeyPair::generate(&mut thread_rng());
+
+            active_validators.push(EpochStartValidatorInfoV1 {
+                sui_address,
+                protocol_pubkey: protocol_key.public().clone(),
+                narwhal_network_pubkey: narwhal_network_key.public().clone(),
+                narwhal_worker_pubkey: narwhal_network_key.public().clone(),
+                sui_net_address: Multiaddr::empty(),
+                p2p_address: Multiaddr::empty(),
+                narwhal_primary_address: Multiaddr::empty(),
+                narwhal_worker_address: Multiaddr::empty(),
+                voting_power: 1_000,
+                hostname: format!("host-{i}").to_string(),
+            })
+        }
+
+        let state = EpochStartSystemStateV1 {
+            epoch: 10,
+            protocol_version: ProtocolVersion::MAX.as_u64(),
+            reference_gas_price: 0,
+            safe_mode: false,
+            epoch_start_timestamp_ms: 0,
+            epoch_duration_ms: 0,
+            active_validators,
+        };
+
+        // WHEN
+        let sui_committee = state.get_sui_committee();
+        let mysticeti_committee = state.get_mysticeti_committee();
+
+        // THEN
+        // assert the validators details
+        assert_eq!(sui_committee.num_members(), 4);
+        assert_eq!(sui_committee.num_members(), mysticeti_committee.size());
+        assert_eq!(
+            sui_committee.validity_threshold(),
+            mysticeti_committee.validity_threshold()
+        );
+        assert_eq!(
+            sui_committee.quorum_threshold(),
+            mysticeti_committee.quorum_threshold()
+        );
+        assert_eq!(state.epoch, mysticeti_committee.epoch());
+
+        for (authority_index, mysticeti_authority) in mysticeti_committee.authorities() {
+            let sui_authority_name = sui_committee
+                .authority_by_index(authority_index.value() as u32)
+                .unwrap();
+
+            assert_eq!(
+                mysticeti_authority.protocol_key.pubkey.to_bytes(),
+                sui_authority_name.0,
+                "Mysten & SUI committee member of same index correspond to different public key"
+            );
+            assert_eq!(
+                mysticeti_authority.stake,
+                sui_committee.weight(sui_authority_name),
+                "Mysten & SUI committee member stake differs"
+            );
+        }
+    }
+}

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -198,6 +198,10 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             });
         }
 
+        // Sort the authorities by their protocol (public) key in ascending order. That's the sorting
+        // SUI committee follows and we
+        authorities.sort_by(|a1, a2| a1.protocol_key.cmp(&a2.protocol_key));
+
         ConsensusCommittee::new(self.epoch as consensus_config::Epoch, authorities)
     }
 
@@ -352,7 +356,7 @@ mod test {
 
         // THEN
         // assert the validators details
-        assert_eq!(sui_committee.num_members(), 4);
+        assert_eq!(sui_committee.num_members(), 10);
         assert_eq!(sui_committee.num_members(), mysticeti_committee.size());
         assert_eq!(
             sui_committee.validity_threshold(),


### PR DESCRIPTION
## Description 

Committee members should be ordered in the same order as the SUI committee (protocol public key order ascending).

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
