### PR TITLE
docker: add back old sui-node image and add a deterministic canary

### DIFF
--- a/docker/deterministic-canary/Dockerfile
+++ b/docker/deterministic-canary/Dockerfile
@@ -1,0 +1,83 @@
+ARG PROFILE=release
+# ARG BUILD_DATE
+# ARG GIT_REVISION
+ARG RUST_VERSION=1.76.0
+
+FROM scratch AS base
+
+FROM stagex/rust:${RUST_VERSION} AS rust
+FROM base AS fetch
+
+COPY --from=stagex/busybox . /
+COPY --from=stagex/musl . /
+COPY --from=rust . /
+
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/libunwind . /
+COPY --from=stagex/openssl . /
+COPY --from=stagex/zlib . /
+
+# NOTE: Necessary for `cargo fetch`, but CA trust is not relied upon
+COPY --from=stagex/ca-certificates . /
+
+# HACK: gcc puts things in /usr/lib64 
+COPY --from=stagex/gcc /usr/lib64/* /usr/lib/
+
+RUN cargo new canary
+
+WORKDIR canary
+
+RUN cargo fetch
+
+FROM fetch AS build
+
+# Rust build deps
+
+COPY --from=stagex/binutils . /
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/make . /
+COPY --from=stagex/musl . /
+
+# Sui build deps
+
+COPY --from=stagex/clang . /
+COPY --from=stagex/linux-headers . /
+
+ARG PROFILE
+# ARG GIT_REVISION
+
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS='-C target-feature=-crt-static -C codegen-units=1'
+# ENV GIT_REVISION=${GIT_REVISION}
+ENV PROFILE=${PROFILE}
+
+RUN --network=none cargo build --frozen --profile ${PROFILE}
+
+FROM scratch AS install
+
+COPY --from=stagex/busybox . /
+
+COPY --from=stagex/busybox . /rootfs
+COPY --from=stagex/libunwind . /rootfs
+COPY --from=stagex/gcc . /rootfs
+COPY --from=stagex/musl . /rootfs
+
+# HACK: In the current release of stagex, gcc puts things in /usr/lib64,
+# but we expect them in /usr/lib
+COPY --from=stagex/gcc /usr/lib64/* /rootfs/usr/lib/
+
+RUN mkdir -p /rootfs/usr/local/bin
+COPY --from=build canary/target/release/canary /rootfs/usr/local/bin/canary
+
+RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
+
+FROM scratch AS package
+
+# ARG GIT_REVISION
+
+# LABEL build-date=${BUILD_DATE}
+# LABEL git-revision=${GIT_REVISION}
+
+COPY --from=install /rootfs /

--- a/docker/deterministic-canary/build.sh
+++ b/docker/deterministic-canary/build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OCI_OUTPUT="$REPO_ROOT/build/oci"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+PROFILE="release"
+PLATFORM="linux/amd64"
+
+echo
+echo "Building minimal deterministic repro"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo "output directory: \t$OCI_OUTPUT"
+echo
+
+export DOCKER_BUILDKIT=1
+export SOURCE_DATE_EPOCH=1
+
+	# --build-arg GIT_REVISION="$GIT_REVISION" \
+	# --build-arg BUILD_DATE="$BUILD_DATE" \
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg PROFILE="$PROFILE" \
+	--platform "$PLATFORM" \
+	--output type=oci,rewrite-timestamp=true,force-compression=true,tar=false,dest=$OCI_OUTPUT/canary,name=canary \
+	"$@"

--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -1,0 +1,91 @@
+ARG PROFILE=release
+ARG BUILD_DATE
+ARG GIT_REVISION
+ARG RUST_VERSION=1.76.0
+
+FROM scratch AS base
+
+FROM stagex/rust:${RUST_VERSION} AS rust
+FROM base AS fetch
+
+COPY --from=stagex/busybox . /
+COPY --from=stagex/musl . /
+COPY --from=rust . /
+
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/libunwind . /
+COPY --from=stagex/openssl . /
+COPY --from=stagex/zlib . /
+
+# NOTE: Necessary for `cargo fetch`, but CA trust is not relied upon
+COPY --from=stagex/ca-certificates . /
+
+# HACK: gcc puts things in /usr/lib64 
+COPY --from=stagex/gcc /usr/lib64/* /usr/lib/
+
+COPY . /sui
+
+WORKDIR sui
+
+RUN cargo fetch
+
+FROM fetch AS build
+
+# Rust build deps
+
+COPY --from=stagex/binutils . /
+COPY --from=stagex/gcc . /
+COPY --from=stagex/llvm . /
+COPY --from=stagex/make . /
+COPY --from=stagex/musl . /
+
+# Sui build deps
+
+COPY --from=stagex/clang . /
+COPY --from=stagex/linux-headers . /
+
+ARG PROFILE
+ARG GIT_REVISION
+
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS='-C target-feature=-crt-static -C codegen-units=1'
+ENV GIT_REVISION=${GIT_REVISION}
+ENV PROFILE=${PROFILE}
+
+RUN --network=none cargo build --frozen --profile ${PROFILE} --bin sui-node
+
+FROM scratch AS install
+
+COPY --from=stagex/busybox . /
+
+COPY --from=stagex/busybox . /rootfs
+COPY --from=stagex/libunwind . /rootfs
+COPY --from=stagex/gcc . /rootfs
+COPY --from=stagex/musl . /rootfs
+
+# HACK: In the current release of stagex, gcc puts things in /usr/lib64,
+# but we expect them in /usr/lib
+COPY --from=stagex/gcc /usr/lib64/* /rootfs/usr/lib/
+
+# support current + legacy paths
+RUN mkdir -p /rootfs/opt/sui/bin
+RUN mkdir -p /rootfs/usr/local/bin
+COPY --from=build sui/target/release/sui-node /rootfs/opt/sui/bin/sui-node
+
+
+
+RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
+
+FROM scratch AS package
+
+ARG PROFILE
+ARG GIT_REVISION
+
+LABEL build-date=${BUILD_DATE}
+LABEL git-revision=${GIT_REVISION}
+
+COPY --from=install /rootfs /
+
+RUN ln -s /opt/sui/bin/sui-node /usr/local/bin/sui-node
+

--- a/docker/sui-node-deterministic/build.sh
+++ b/docker/sui-node-deterministic/build.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OCI_OUTPUT="$REPO_ROOT/build/oci"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+# option to build using debug symbols
+if [ "$1" = "--debug-symbols" ]; then
+	PROFILE="bench"
+	echo "Building with full debug info enabled ... WARNING: binary size might significantly increase"
+	shift
+else
+	PROFILE="release"
+fi
+
+echo
+echo "Building sui-node docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo "output directory: \t$OCI_OUTPUT"
+echo
+
+export DOCKER_BUILDKIT=1
+export SOURCE_DATE_EPOCH=1
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	--build-arg PROFILE="$PROFILE" \
+  --output type=oci,rewrite-timestamp=true,force-compression=true,tar=false,dest=$OCI_OUTPUT/sui-node,name=sui-node \
+	"$@"

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -1,91 +1,36 @@
+# Build application
+#
+# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
+# and build the application.
+FROM rust:1.75-bullseye AS builder
 ARG PROFILE=release
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+WORKDIR "$WORKDIR/sui"
+RUN apt-get update && apt-get install -y cmake clang
+
+COPY Cargo.toml Cargo.lock ./
+COPY consensus consensus
+COPY crates crates
+COPY sui-execution sui-execution
+COPY narwhal narwhal
+COPY external-crates external-crates
+
+RUN cargo build --profile ${PROFILE} --bin sui-node
+
+# Production Image
+FROM debian:bullseye-slim AS runtime
+# Use jemalloc as memory allocator
+RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
+ARG PROFILE=release
+WORKDIR "$WORKDIR/sui"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /sui/target/release/sui-node /opt/sui/bin/sui-node
+# Support legacy usages of /usr/local/bin/sui-node
+COPY --from=builder /sui/target/release/sui-node /usr/local/bin
+
 ARG BUILD_DATE
 ARG GIT_REVISION
-ARG RUST_VERSION=1.76.0
-
-FROM scratch AS base
-
-FROM stagex/rust:${RUST_VERSION} AS rust
-FROM base AS fetch
-
-COPY --from=stagex/busybox . /
-COPY --from=stagex/musl . /
-COPY --from=rust . /
-
-COPY --from=stagex/gcc . /
-COPY --from=stagex/llvm . /
-COPY --from=stagex/libunwind . /
-COPY --from=stagex/openssl . /
-COPY --from=stagex/zlib . /
-
-# NOTE: Necessary for `cargo fetch`, but CA trust is not relied upon
-COPY --from=stagex/ca-certificates . /
-
-# HACK: gcc puts things in /usr/lib64 
-COPY --from=stagex/gcc /usr/lib64/* /usr/lib/
-
-COPY . /sui
-
-WORKDIR sui
-
-RUN cargo fetch
-
-FROM fetch AS build
-
-# Rust build deps
-
-COPY --from=stagex/binutils . /
-COPY --from=stagex/gcc . /
-COPY --from=stagex/llvm . /
-COPY --from=stagex/make . /
-COPY --from=stagex/musl . /
-
-# Sui build deps
-
-COPY --from=stagex/clang . /
-COPY --from=stagex/linux-headers . /
-
-ARG PROFILE
-ARG GIT_REVISION
-
-ENV RUST_BACKTRACE=1
-ENV RUSTFLAGS='-C target-feature=-crt-static -C codegen-units=1'
-ENV GIT_REVISION=${GIT_REVISION}
-ENV PROFILE=${PROFILE}
-
-RUN --network=none cargo build --frozen --profile ${PROFILE} --bin sui-node
-
-FROM scratch AS install
-
-COPY --from=stagex/busybox . /
-
-COPY --from=stagex/busybox . /rootfs
-COPY --from=stagex/libunwind . /rootfs
-COPY --from=stagex/gcc . /rootfs
-COPY --from=stagex/musl . /rootfs
-
-# HACK: In the current release of stagex, gcc puts things in /usr/lib64,
-# but we expect them in /usr/lib
-COPY --from=stagex/gcc /usr/lib64/* /rootfs/usr/lib/
-
-# support current + legacy paths
-RUN mkdir -p /rootfs/opt/sui/bin
-RUN mkdir -p /rootfs/usr/local/bin
-COPY --from=build sui/target/release/sui-node /rootfs/opt/sui/bin/sui-node
-
-
-
-RUN --network=none find /rootfs -exec touch -hcd "@0" "{}" +
-
-FROM scratch AS package
-
-ARG PROFILE
-ARG GIT_REVISION
-
-LABEL build-date=${BUILD_DATE}
-LABEL git-revision=${GIT_REVISION}
-
-COPY --from=install /rootfs /
-
-RUN ln -s /opt/sui/bin/sui-node /usr/local/bin/sui-node
-
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -7,7 +7,6 @@ set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-OCI_OUTPUT="$REPO_ROOT/build/oci"
 DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
@@ -27,15 +26,10 @@ echo "Dockerfile: \t$DOCKERFILE"
 echo "docker context: $REPO_ROOT"
 echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
-echo "output directory: \t$OCI_OUTPUT"
 echo
-
-export DOCKER_BUILDKIT=1
-export SOURCE_DATE_EPOCH=1
 
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg PROFILE="$PROFILE" \
-  --output type=oci,rewrite-timestamp=true,force-compression=true,tar=false,dest=$OCI_OUTPUT/sui-node,name=sui-node \
 	"$@"


### PR DESCRIPTION
## Description 

output from the canary build
```
 => exporting manifest sha256:2ec436df682191538225be5c30465d3aae75c31f392ac7f84ade5908095c5e7f                                                                                                                                                        
 => => exporting config sha256:02e10b7996825007a153055ac8e441c471a0a73b860c729a32e5229ea9e530e6   

{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:2ec436df682191538225be5c30465d3aae75c31f392ac7f84ade5908095c5e7f","size":481,"annotations":{"org.opencontainers.image.created":"1970-01-01T00:00:01Z","org.opencontainers.image.ref.name":"docker.io/library/canary:latest"},"platform":{"architecture":"amd64","os":"linux"}}]}

```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
