### PR TITLE
Allow skip protocol upgrade

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -428,34 +428,33 @@ mod test {
                 test_cluster.wait_for_all_nodes_upgrade_to(version).await;
                 info!("All nodes are at protocol version: {version}");
                 // Let all nodes run for a few epochs at this version.
-                tokio::time::sleep(Duration::from_secs(50)).await;
+                tokio::time::sleep(Duration::from_secs(30)).await;
                 if version == max_ver {
-                    let stake_subsidy_start_epoch = test_cluster
-                        .sui_client()
-                        .governance_api()
-                        .get_latest_sui_system_state()
-                        .await
-                        .unwrap()
-                        .stake_subsidy_start_epoch;
-                    assert_eq!(stake_subsidy_start_epoch, 20);
                     break;
                 }
                 let next_version = version + 1;
                 let new_framework = sui_framework_snapshot::load_bytecode_snapshot(next_version);
-                let new_framework_ref: Vec<_> = match &new_framework {
-                    Ok(f) => f.iter().collect(),
+                let new_framework_ref = match &new_framework {
+                    Ok(f) => Some(f.iter().collect::<Vec<_>>()),
                     Err(_) => {
-                        // The only time where we could not load an existing snapshot is when
-                        // it's the next version to be pushed out, and hence we don't have a
-                        // snapshot yet. This must be the current max version.
-                        assert_eq!(next_version, max_ver);
-                        BuiltInFramework::iter_system_packages().collect()
+                        if next_version == max_ver {
+                            Some(BuiltInFramework::iter_system_packages().collect::<Vec<_>>())
+                        } else {
+                            // Often we want to be able to create multiple protocol config versions
+                            // on main that none have shipped to any production network. In this case,
+                            // some of the protocol versions may not have a framework snapshot.
+                            None
+                        }
                     }
                 };
-                for package in new_framework_ref {
-                    framework_injection::set_override(*package.id(), package.modules().clone());
+                if let Some(new_framework_ref) = new_framework_ref {
+                    for package in new_framework_ref {
+                        framework_injection::set_override(*package.id(), package.modules().clone());
+                    }
+                    info!("Framework injected for next_version {next_version}");
+                } else {
+                    info!("No framework snapshot to inject for next_version {next_version}");
                 }
-                info!("Framework injected for next_version {next_version}");
                 test_cluster
                     .update_validator_supported_versions(
                         SupportedProtocolVersions::new_for_testing(starting_version, next_version),
@@ -466,8 +465,8 @@ mod test {
             finished_clone.store(true, Ordering::SeqCst);
         });
 
-        test_simulated_load(test_init_data_clone, 120).await;
-        for _ in 0..120 {
+        test_simulated_load(test_init_data_clone, 150).await;
+        for _ in 0..150 {
             if finished.load(Ordering::Relaxed) {
                 break;
             }


### PR DESCRIPTION
## Description 

The protocol config upgrade compatibility test doesn't allow skipping versions on main.
This makes it difficult to move forward when we want to plan ahead.
This PR fixes that by simply not injecting framework if a snapshot for a version is not found.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
