### PR TITLE
[move-2024] Add Move 2024 migration to  `sui move` cli

### DIFF
--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -15,6 +15,7 @@ pub mod coverage;
 #[cfg(feature = "disassemble")]
 pub mod disassemble;
 pub mod manage_package;
+pub mod migrate;
 pub mod new;
 #[cfg(feature = "unit_test")]
 pub mod unit_test;
@@ -28,6 +29,7 @@ pub enum Command {
     #[cfg(feature = "disassemble")]
     Disassemble(disassemble::Disassemble),
     ManagePackage(manage_package::ManagePackage),
+    Migrate(migrate::Migrate),
     New(new::New),
     #[cfg(feature = "unit_test")]
     Test(unit_test::Test),
@@ -56,6 +58,7 @@ pub fn execute_move_command(
         #[cfg(feature = "disassemble")]
         Command::Disassemble(c) => c.execute(package_path, build_config),
         Command::ManagePackage(c) => c.execute(package_path, build_config),
+        Command::Migrate(c) => c.execute(package_path, build_config),
         Command::New(c) => c.execute(package_path),
 
         #[cfg(feature = "unit_test")]

--- a/crates/sui-move/src/migrate.rs
+++ b/crates/sui-move/src/migrate.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use move_package::BuildConfig as MoveBuildConfig;
 use move_cli::base::migrate;
+use move_package::BuildConfig as MoveBuildConfig;
 use std::path::PathBuf;
 
 #[derive(Parser)]

--- a/crates/sui-move/src/migrate.rs
+++ b/crates/sui-move/src/migrate.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use move_package::BuildConfig as MoveBuildConfig;
+use move_cli::base::migrate;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[group(id = "sui-move-migrate")]
+pub struct Migrate {
+    #[clap(flatten)]
+    pub migrate: migrate::Migrate,
+}
+
+impl Migrate {
+    pub fn execute(self, path: Option<PathBuf>, config: MoveBuildConfig) -> anyhow::Result<()> {
+        self.migrate.execute(path, config)
+    }
+}

--- a/external-crates/move/crates/move-cli/src/base/migrate.rs
+++ b/external-crates/move/crates/move-cli/src/base/migrate.rs
@@ -14,15 +14,6 @@ pub struct Migrate;
 impl Migrate {
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
-        if config.fetch_deps_only {
-            let mut config = config;
-            if config.test_mode {
-                config.dev_mode = true;
-            }
-            config.download_deps_for_package(&rerooted_path, &mut std::io::stdout())?;
-            return Ok(());
-        }
-
         config.migrate_package(
             &rerooted_path,
             &mut std::io::stdout(),


### PR DESCRIPTION
## Description 

What it says on the tin.

Also a small bit of cleanup for `fetch_deps_only` on migration mode, which shouldn't even be an option there,

## Test Plan 

Local testing, plus 👀 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Move migration will be available