### PR TITLE
[move-2024] Change  default TOML to be 2024 beta

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -61,8 +61,7 @@ impl New {
             w,
             r#"[package]
 name = "{name}"
-
-# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/simple_new/args.exp
@@ -2,8 +2,7 @@ Command `new P1`:
 External Command `cat P1/Move.toml`:
 [package]
 name = "P1"
-
-# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
@@ -40,8 +39,7 @@ Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
 name = "P2"
-
-# edition = "2024.alpha" # To use the Move 2024 edition, currently in alpha
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 


### PR DESCRIPTION
## Description 

Change  default TOML to be 2024 beta

## Test Plan 

Local testing, plus other tests still work.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Changes the default `Move.toml` for `sui move new` and `move new` to use the Move 2024 beta release.