### PR TITLE
[CI] do not run multiple iterations for the determinism test

### DIFF
--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -75,7 +75,7 @@ jobs:
       # Run simulator tests
       - name: Run simtest
         run: |
-            tsh -i ${{ steps.auth.outputs.identity-file }} --ttl 120 ssh ubuntu@simtest-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && RUSTUP_MAX_RETRIES=10 CARGO_TERM_COLOR=always CARGO_INCREMENTAL=0 CARGO_NET_RETRY=10 RUST_BACKTRACE=short RUST_LOG=off NUM_CPUS=24 MSIM_TEST_NUM=${{ env.TEST_NUM }} ./scripts/simtest/simtest-run.sh"
+          tsh -i ${{ steps.auth.outputs.identity-file }} --ttl 120 ssh ubuntu@simtest-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && RUSTUP_MAX_RETRIES=10 CARGO_TERM_COLOR=always CARGO_INCREMENTAL=0 CARGO_NET_RETRY=10 RUST_BACKTRACE=short RUST_LOG=off NUM_CPUS=24 TEST_NUM=${{ env.TEST_NUM }} ./scripts/simtest/simtest-run.sh"
   
   notify:
     name: Notify

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -33,13 +33,14 @@ SIMTEST_LOGS_DIR=~/simtest_logs
 LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"
 LOG_FILE="$LOG_DIR/log"
 
-# By default run 30 iterations for each test. But allow overrides.
-${MSIM_TEST_NUM:=30}
+# By default run 1 iteration for each test, if not specified.
+: ${TEST_NUM:=1}
 
 # This command runs many different tests, so it already uses all CPUs fairly efficiently, and
 # don't need to be done inside of the for loop below.
 # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
 MSIM_TEST_SEED="$SEED" \
+MSIM_TEST_NUM=${TEST_NUM} \
 MSIM_WATCHDOG_TIMEOUT_MS=60000 \
 scripts/simtest/cargo-simtest simtest \
   --color always \
@@ -76,6 +77,7 @@ wait
 LOG_FILE="$LOG_DIR/determinism-log"
 
 MSIM_TEST_SEED="$SEED" \
+MSIM_TEST_NUM=1 \
 MSIM_WATCHDOG_TIMEOUT_MS=60000 \
 MSIM_TEST_CHECK_DETERMINISM=1
 scripts/simtest/cargo-simtest simtest \

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -36,6 +36,12 @@ LOG_FILE="$LOG_DIR/log"
 # By default run 1 iteration for each test, if not specified.
 : ${TEST_NUM:=1}
 
+echo ""
+echo "================================================"
+echo "Running e2e simtests with $TEST_NUM iterations"
+echo "================================================"
+date
+
 # This command runs many different tests, so it already uses all CPUs fairly efficiently, and
 # don't need to be done inside of the for loop below.
 # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
@@ -50,6 +56,12 @@ scripts/simtest/cargo-simtest simtest \
   --package sui-e2e-tests \
   --profile simtestnightly \
   -E "$TEST_FILTER" 2>&1 | tee "$LOG_FILE"
+
+echo ""
+echo "============================================="
+echo "Running $NUM_CPUS stress simtests in parallel"
+echo "============================================="
+date
 
 for SUB_SEED in `seq 1 $NUM_CPUS`; do
   SEED="$SUB_SEED$DATE"
@@ -73,8 +85,15 @@ done
 # wait for all the jobs to end
 wait
 
+echo ""
+echo "==========================="
+echo "Running determinism simtest"
+echo "==========================="
+date
+
 # Check for determinism in stress simtests
 LOG_FILE="$LOG_DIR/determinism-log"
+echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
@@ -87,7 +106,12 @@ scripts/simtest/cargo-simtest simtest \
   --profile simtestnightly \
   -E "$TEST_FILTER" 2>&1 | tee "$LOG_FILE"
 
+echo ""
+echo "============================================="
 echo "All tests completed, checking for failures..."
+echo "============================================="
+date
+
 grep -qHn FAIL "$LOG_DIR"/*
 
 # if grep found no failures exit now


### PR DESCRIPTION
## Description 

A small followup to #16707, emit more info from the script and only run the determinism test (last step) once.

## Test Plan 

https://github.com/MystenLabs/sui/actions/runs/8311292117

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
