### PR TITLE
[GraphQL/Timeout] Disambiguate extension factory and extension

### DIFF
--- a/crates/sui-graphql-rpc/src/extensions/timeout.rs
+++ b/crates/sui-graphql-rpc/src/extensions/timeout.rs
@@ -16,21 +16,24 @@ use uuid::Uuid;
 
 use crate::{config::ServiceConfig, error::code};
 
+/// Extension factory for creating new `Timeout` instances, per query.
+pub(crate) struct Timeout;
+
 #[derive(Debug, Default)]
-pub(crate) struct Timeout {
+struct TimeoutExt {
     pub query: Mutex<Option<String>>,
 }
 
 impl ExtensionFactory for Timeout {
     fn create(&self) -> Arc<dyn Extension> {
-        Arc::new(Timeout {
+        Arc::new(TimeoutExt {
             query: Mutex::new(None),
         })
     }
 }
 
 #[async_trait::async_trait]
-impl Extension for Timeout {
+impl Extension for TimeoutExt {
     async fn parse_query(
         &self,
         ctx: &ExtensionContext<'_>,

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -309,7 +309,7 @@ impl ServerBuilder {
             builder = builder.extension(QueryLimitsChecker::default());
         }
         if config.internal_features.query_timeout {
-            builder = builder.extension(Timeout::default());
+            builder = builder.extension(Timeout);
         }
         if config.internal_features.tracing {
             builder = builder.extension(Tracing);
@@ -546,7 +546,7 @@ pub mod tests {
                 .context_data(cfg)
                 .context_data(query_id())
                 .context_data(ip_address())
-                .extension(Timeout::default())
+                .extension(Timeout)
                 .extension(TimedExecuteExt {
                     min_req_delay: delay,
                 })


### PR DESCRIPTION
## Description

There is only one extension factory per server instance, but a new instance of the extension is created once per query. Using the same type for both of these is confusing.

## Test Plan

```
sui$ cargo build -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```