### PR TITLE
[Consensus 2.0] fix potential liveness issue

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -275,15 +275,15 @@ impl Core {
         // Unnecessary to verify own blocks.
         let verified_block = VerifiedBlock::new_verified(signed_block, serialized);
 
-        // Add to the threshold clock and pending ancestors
-        self.threshold_clock.add_block(verified_block.reference());
-
         // Accept the block into BlockManager and DagState.
         let (accepted_blocks, missing) = self
             .block_manager
             .try_accept_blocks(vec![verified_block.clone()]);
         assert_eq!(accepted_blocks.len(), 1);
         assert!(missing.is_empty());
+
+        // Internally accept the block to move the threshold clock etc
+        self.add_accepted_blocks(vec![verified_block.clone()]);
 
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
         self.dag_state.write().flush();


### PR DESCRIPTION
## Description 

This PR is fixing the issue of not emitting a new round signal when a new quorum is reached after proposing for a round. This could potentially create a liveness issue under network faults and marginal quorum availability as the leader timeout component would never get signalled about the new round to trigger a new round advancement.

The PR is re-using the `add_accepted_blocks` method to handle this

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
