### PR TITLE
[gql][cherry pick]config changes

### DIFF
--- a/crates/sui-graphql-rpc/src/commands.rs
+++ b/crates/sui-graphql-rpc/src/commands.rs
@@ -13,11 +13,6 @@ use std::path::PathBuf;
     version
 )]
 pub enum Command {
-    GenerateConfig {
-        /// Path to output the YAML config, otherwise stdout.
-        #[clap(short, long)]
-        path: Option<PathBuf>,
-    },
     GenerateDocsExamples,
     GenerateSchema {
         /// Path to output GraphQL schema to, in SDL format.
@@ -28,11 +23,6 @@ pub enum Command {
         /// Path to output examples docs.
         #[clap(short, long)]
         file: Option<PathBuf>,
-    },
-    FromConfig {
-        /// Path to TOML file containing configuration for server.
-        #[clap(short, long)]
-        path: PathBuf,
     },
     StartServer {
         /// The title to display at the top of the page

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error as SuiGraphQLError, types::big_int::BigInt};
+use crate::types::big_int::BigInt;
 use async_graphql::*;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, path::PathBuf, time::Duration};
+use std::{collections::BTreeSet, time::Duration};
 use sui_json_rpc::name_service::NameServiceConfig;
 
 use crate::functional_group::FunctionalGroup;
@@ -43,10 +43,29 @@ pub(crate) const DEFAULT_SERVER_DB_POOL_SIZE: u32 = 3;
 pub(crate) const DEFAULT_SERVER_PROM_HOST: &str = "0.0.0.0";
 pub(crate) const DEFAULT_SERVER_PROM_PORT: u16 = 9184;
 
-/// Configuration on connections for the RPC, passed in as command-line arguments.
+/// The combination of all configurations for the GraphQL service.
+#[derive(Serialize, Clone, Deserialize, Debug, Default)]
+pub struct ServerConfig {
+    #[serde(default)]
+    pub service: ServiceConfig,
+    #[serde(default)]
+    pub connection: ConnectionConfig,
+    #[serde(default)]
+    pub internal_features: InternalFeatureConfig,
+    #[serde(default)]
+    pub tx_exec_full_node: TxExecFullNodeConfig,
+    #[serde(default)]
+    pub ide: Ide,
+}
+
+/// Configuration for connections for the RPC, passed in as command-line arguments. This configures
+/// specific connections between this service and other services, and might differ from instance to
+/// instance of the GraphQL service.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
 pub struct ConnectionConfig {
+    /// Port to bind the server to
     pub(crate) port: u16,
+    /// Host to bind the server to
     pub(crate) host: String,
     pub(crate) db_url: String,
     pub(crate) db_pool_size: u32,
@@ -54,7 +73,9 @@ pub struct ConnectionConfig {
     pub(crate) prom_port: u16,
 }
 
-/// Configuration on features supported by the RPC, passed in a TOML-based file.
+/// Configuration on features supported by the GraphQL service, passed in a TOML-based file. These
+/// configurations are shared across fleets of the service, i.e. all testnet services will have the
+/// same `ServiceConfig`.
 #[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServiceConfig {
@@ -66,6 +87,9 @@ pub struct ServiceConfig {
 
     #[serde(default)]
     pub(crate) experiments: Experiments,
+
+    #[serde(default)]
+    pub(crate) name_service: NameServiceConfig,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Copy)]
@@ -100,39 +124,11 @@ pub struct Limits {
 #[derive(Debug)]
 pub struct Version(pub &'static str);
 
-impl Limits {
-    /// Extract limits for the package resolver.
-    pub fn package_resolver_limits(&self) -> sui_package_resolver::Limits {
-        sui_package_resolver::Limits {
-            max_type_argument_depth: self.max_type_argument_depth as usize,
-            max_type_argument_width: self.max_type_argument_width as usize,
-            max_type_nodes: self.max_type_nodes as usize,
-            max_move_value_depth: self.max_move_value_depth as usize,
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Ide {
     #[serde(default)]
     pub(crate) ide_title: String,
-}
-
-impl Default for Ide {
-    fn default() -> Self {
-        Self {
-            ide_title: DEFAULT_IDE_TITLE.to_string(),
-        }
-    }
-}
-
-impl Ide {
-    pub fn new(ide_title: Option<String>) -> Self {
-        Self {
-            ide_title: ide_title.unwrap_or_else(|| DEFAULT_IDE_TITLE.to_string()),
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -144,67 +140,30 @@ pub struct Experiments {
     test_flag: bool,
 }
 
-impl ConnectionConfig {
-    pub fn new(
-        port: Option<u16>,
-        host: Option<String>,
-        db_url: Option<String>,
-        db_pool_size: Option<u32>,
-        prom_url: Option<String>,
-        prom_port: Option<u16>,
-    ) -> Self {
-        let default = Self::default();
-        Self {
-            port: port.unwrap_or(default.port),
-            host: host.unwrap_or(default.host),
-            db_url: db_url.unwrap_or(default.db_url),
-            db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
-            prom_url: prom_url.unwrap_or(default.prom_url),
-            prom_port: prom_port.unwrap_or(default.prom_port),
-        }
-    }
-
-    pub fn ci_integration_test_cfg() -> Self {
-        Self {
-            db_url: "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2".to_string(),
-            ..Default::default()
-        }
-    }
-
-    pub fn ci_integration_test_cfg_with_db_name(
-        db_name: String,
-        port: u16,
-        prom_port: u16,
-    ) -> Self {
-        Self {
-            db_url: format!("postgres://postgres:postgrespw@localhost:5432/{}", db_name),
-            port,
-            prom_port,
-            ..Default::default()
-        }
-    }
-
-    pub fn db_name(&self) -> String {
-        self.db_url.split('/').last().unwrap().to_string()
-    }
-
-    pub fn db_url(&self) -> String {
-        self.db_url.clone()
-    }
-
-    pub fn db_pool_size(&self) -> u32 {
-        self.db_pool_size
-    }
-
-    pub fn server_address(&self) -> String {
-        format!("{}:{}", self.host, self.port)
-    }
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
+pub struct InternalFeatureConfig {
+    #[serde(default)]
+    pub(crate) query_limits_checker: bool,
+    #[serde(default)]
+    pub(crate) feature_gate: bool,
+    #[serde(default)]
+    pub(crate) logger: bool,
+    #[serde(default)]
+    pub(crate) query_timeout: bool,
+    #[serde(default)]
+    pub(crate) metrics: bool,
+    #[serde(default)]
+    pub(crate) tracing: bool,
+    #[serde(default)]
+    pub(crate) apollo_tracing: bool,
+    #[serde(default)]
+    pub(crate) open_telemetry: bool,
 }
 
-impl ServiceConfig {
-    pub fn read(contents: &str) -> Result<Self, toml::de::Error> {
-        toml::de::from_str::<Self>(contents)
-    }
+#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq, Default)]
+pub struct TxExecFullNodeConfig {
+    #[serde(default)]
+    pub(crate) node_rpc_url: Option<String>,
 }
 
 /// The enabled features and service limits configured by the server.
@@ -297,6 +256,103 @@ impl ServiceConfig {
     }
 }
 
+impl TxExecFullNodeConfig {
+    pub fn new(node_rpc_url: Option<String>) -> Self {
+        Self { node_rpc_url }
+    }
+}
+
+impl ConnectionConfig {
+    pub fn new(
+        port: Option<u16>,
+        host: Option<String>,
+        db_url: Option<String>,
+        db_pool_size: Option<u32>,
+        prom_url: Option<String>,
+        prom_port: Option<u16>,
+    ) -> Self {
+        let default = Self::default();
+        Self {
+            port: port.unwrap_or(default.port),
+            host: host.unwrap_or(default.host),
+            db_url: db_url.unwrap_or(default.db_url),
+            db_pool_size: db_pool_size.unwrap_or(default.db_pool_size),
+            prom_url: prom_url.unwrap_or(default.prom_url),
+            prom_port: prom_port.unwrap_or(default.prom_port),
+        }
+    }
+
+    pub fn ci_integration_test_cfg() -> Self {
+        Self {
+            db_url: DEFAULT_SERVER_DB_URL.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn ci_integration_test_cfg_with_db_name(
+        db_name: String,
+        port: u16,
+        prom_port: u16,
+    ) -> Self {
+        Self {
+            db_url: format!("postgres://postgres:postgrespw@localhost:5432/{}", db_name),
+            port,
+            prom_port,
+            ..Default::default()
+        }
+    }
+
+    pub fn db_name(&self) -> String {
+        self.db_url.split('/').last().unwrap().to_string()
+    }
+
+    pub fn db_url(&self) -> String {
+        self.db_url.clone()
+    }
+
+    pub fn db_pool_size(&self) -> u32 {
+        self.db_pool_size
+    }
+
+    pub fn server_address(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+impl ServiceConfig {
+    pub fn read(contents: &str) -> Result<Self, toml::de::Error> {
+        toml::de::from_str::<Self>(contents)
+    }
+}
+
+impl Limits {
+    /// Extract limits for the package resolver.
+    pub fn package_resolver_limits(&self) -> sui_package_resolver::Limits {
+        sui_package_resolver::Limits {
+            max_type_argument_depth: self.max_type_argument_depth as usize,
+            max_type_argument_width: self.max_type_argument_width as usize,
+            max_type_nodes: self.max_type_nodes as usize,
+            max_move_value_depth: self.max_move_value_depth as usize,
+        }
+    }
+}
+
+impl Ide {
+    pub fn new(ide_title: Option<String>) -> Self {
+        Self {
+            ide_title: ide_title.unwrap_or_else(|| DEFAULT_IDE_TITLE.to_string()),
+        }
+    }
+}
+
+impl Default for Ide {
+    fn default() -> Self {
+        Self {
+            ide_title: DEFAULT_IDE_TITLE.to_string(),
+        }
+    }
+}
+
 impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
@@ -329,26 +385,6 @@ impl Default for Limits {
     }
 }
 
-#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq)]
-pub struct InternalFeatureConfig {
-    #[serde(default)]
-    pub(crate) query_limits_checker: bool,
-    #[serde(default)]
-    pub(crate) feature_gate: bool,
-    #[serde(default)]
-    pub(crate) logger: bool,
-    #[serde(default)]
-    pub(crate) query_timeout: bool,
-    #[serde(default)]
-    pub(crate) metrics: bool,
-    #[serde(default)]
-    pub(crate) tracing: bool,
-    #[serde(default)]
-    pub(crate) apollo_tracing: bool,
-    #[serde(default)]
-    pub(crate) open_telemetry: bool,
-}
-
 impl Default for InternalFeatureConfig {
     fn default() -> Self {
         Self {
@@ -361,64 +397,6 @@ impl Default for InternalFeatureConfig {
             apollo_tracing: false,
             open_telemetry: false,
         }
-    }
-}
-
-#[derive(Serialize, Clone, Deserialize, Debug, Eq, PartialEq, Default)]
-pub struct TxExecFullNodeConfig {
-    #[serde(default)]
-    pub(crate) node_rpc_url: Option<String>,
-}
-
-impl TxExecFullNodeConfig {
-    pub fn new(node_rpc_url: Option<String>) -> Self {
-        Self { node_rpc_url }
-    }
-}
-
-#[derive(Serialize, Clone, Deserialize, Debug, Default)]
-pub struct ServerConfig {
-    #[serde(default)]
-    pub service: ServiceConfig,
-    #[serde(default)]
-    pub connection: ConnectionConfig,
-    #[serde(default)]
-    pub internal_features: InternalFeatureConfig,
-    #[serde(default)]
-    pub name_service: NameServiceConfig,
-    #[serde(default)]
-    pub tx_exec_full_node: TxExecFullNodeConfig,
-    #[serde(default)]
-    pub ide: Ide,
-}
-
-impl ServerConfig {
-    pub fn from_yaml(path: &str) -> Result<Self, SuiGraphQLError> {
-        let contents = std::fs::read_to_string(path).map_err(|e| {
-            SuiGraphQLError::Internal(format!(
-                "Failed to read service cfg yaml file at {}, err: {}",
-                path, e
-            ))
-        })?;
-        serde_yaml::from_str::<Self>(&contents).map_err(|e| {
-            SuiGraphQLError::Internal(format!(
-                "Failed to deserialize service cfg from yaml: {}",
-                e
-            ))
-        })
-    }
-
-    pub fn to_yaml(&self) -> Result<String, SuiGraphQLError> {
-        serde_yaml::to_string(&self).map_err(|e| {
-            SuiGraphQLError::Internal(format!("Failed to create yaml from cfg: {}", e))
-        })
-    }
-
-    pub fn to_yaml_file(&self, path: PathBuf) -> Result<(), SuiGraphQLError> {
-        let config = self.to_yaml()?;
-        std::fs::write(path, config).map_err(|e| {
-            SuiGraphQLError::Internal(format!("Failed to create yaml from cfg: {}", e))
-        })
     }
 }
 
@@ -487,9 +465,8 @@ mod tests {
 
         use FunctionalGroup as G;
         let expect = ServiceConfig {
-            limits: Limits::default(),
             disabled_features: BTreeSet::from([G::Coins, G::NameService]),
-            experiments: Experiments::default(),
+            ..Default::default()
         };
 
         assert_eq!(actual, expect)
@@ -554,6 +531,7 @@ mod tests {
             },
             disabled_features: BTreeSet::from([FunctionalGroup::Analytics]),
             experiments: Experiments { test_flag: true },
+            ..Default::default()
         };
 
         assert_eq!(actual, expect);

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -10,10 +10,7 @@ use sui_graphql_rpc::config::{
     ConnectionConfig, Ide, ServerConfig, ServiceConfig, TxExecFullNodeConfig, Version,
 };
 use sui_graphql_rpc::server::builder::export_schema;
-use sui_graphql_rpc::server::graphiql_server::{
-    start_graphiql_server, start_graphiql_server_from_cfg_path,
-};
-use tracing::error;
+use sui_graphql_rpc::server::graphiql_server::start_graphiql_server;
 
 // WARNING!!!
 //
@@ -41,19 +38,6 @@ static VERSION: Version = Version(const_str::concat!(
 async fn main() {
     let cmd: Command = Command::parse();
     match cmd {
-        Command::GenerateConfig { path } => {
-            let cfg = ServerConfig::default();
-            if let Some(file) = path {
-                println!("Write config to file: {:?}", file);
-                cfg.to_yaml_file(file)
-                    .expect("Failed writing config to file");
-            } else {
-                println!(
-                    "{}",
-                    &cfg.to_yaml().expect("Failed serializing config to yaml")
-                );
-            }
-        }
         Command::GenerateDocsExamples => {
             let mut buf: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             // we are looking to put examples content in
@@ -114,16 +98,6 @@ async fn main() {
 
             start_graphiql_server(&server_config, &VERSION)
                 .await
-                .unwrap();
-        }
-        Command::FromConfig { path } => {
-            println!("Starting server...");
-            start_graphiql_server_from_cfg_path(path.to_str().unwrap(), &VERSION)
-                .await
-                .map_err(|x| {
-                    error!("Error: {:?}", x);
-                    x
-                })
                 .unwrap();
         }
     }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -225,16 +225,6 @@ impl ServerBuilder {
         })
     }
 
-    pub async fn from_yaml_config(
-        path: &str,
-        version: &Version,
-    ) -> Result<(Self, ServerConfig), Error> {
-        let config = ServerConfig::from_yaml(path)?;
-        Self::from_config(&config, version)
-            .await
-            .map(|builder| (builder, config))
-    }
-
     pub async fn from_config(config: &ServerConfig, version: &Version) -> Result<Self, Error> {
         // PROMETHEUS
         let prom_addr: SocketAddr = format!(
@@ -262,7 +252,7 @@ impl ServerBuilder {
         let state = AppState::new(config.connection.clone(), metrics.clone());
         let mut builder = ServerBuilder::new(state);
 
-        let name_service_config = config.name_service.clone();
+        let name_service_config = config.service.name_service.clone();
         let reader = PgManager::reader_with_config(
             config.connection.db_url.clone(),
             config.connection.db_pool_size,

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -29,15 +29,6 @@ pub async fn start_graphiql_server(
     .await
 }
 
-pub async fn start_graphiql_server_from_cfg_path(
-    server_config_path: &str,
-    version: &Version,
-) -> Result<(), Error> {
-    let (server_builder, config) =
-        ServerBuilder::from_yaml_config(server_config_path, version).await?;
-    start_graphiql_server_impl(server_builder, config.ide.ide_title).await
-}
-
 async fn start_graphiql_server_impl(
     server_builder: ServerBuilder,
     ide_title: String,

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -62,12 +62,12 @@ impl Domain {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub struct NameServiceConfig {
     pub package_address: SuiAddress,
     pub registry_id: ObjectID,
     pub reverse_registry_id: ObjectID,
-    domain_type_tag: TypeTag,
 }
 
 impl NameServiceConfig {
@@ -76,21 +76,20 @@ impl NameServiceConfig {
         registry_id: ObjectID,
         reverse_registry_id: ObjectID,
     ) -> Self {
-        let domain_type_tag = Domain::type_(package_address);
         Self {
             package_address,
             registry_id,
             reverse_registry_id,
-            domain_type_tag: TypeTag::Struct(Box::new(domain_type_tag)),
         }
     }
 
     pub fn record_field_id(&self, domain: &Domain) -> ObjectID {
+        let domain_type_tag = Domain::type_(self.package_address);
         let domain_bytes = bcs::to_bytes(domain).unwrap();
 
         sui_types::dynamic_field::derive_dynamic_field_id(
             self.registry_id,
-            &self.domain_type_tag,
+            &TypeTag::Struct(Box::new(domain_type_tag)),
             &domain_bytes,
         )
         .unwrap()


### PR DESCRIPTION
Today we have two entrypoints, `start-server` and `from-config`. The former is the standard way we launch the graphql service, by providing a `--config` path to a `.toml` file. The latter is a yaml-based entrypoint. Because we do not use this yaml config, this PR removes yaml-related code to simplify. Also refactors `config.rs` to this order:
1. consts and struct defs
2. impl async-graphql's Object macro
3. impl
4. impl Trait

Note that `NameServiceConfig` has a `domain_type_tag` field that is computed, so it probably won't play nicely with reading from a `.toml` file. I'll address this in a follow-up PR.

Existing

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
