### PR TITLE
Print module name when unexpected reference is found

### DIFF
--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -1681,7 +1681,7 @@ impl<'env> ModuleEnv<'env> {
         let module_env = self
             .env
             .find_module(&module_name)
-            .expect("unexpected reference to module not found in global env");
+            .expect(&format!("unexpected reference to module: {:#?} not found in global env", module_name));
         module_env.into_function(FunId::new(self.env.symbol_pool.make(view.name().as_str())))
     }
 


### PR DESCRIPTION
With this patch
```
thread 'main' panicked at 'unexpected reference to module: ModuleName(16, Symbol(3)) not found in global env', language/move-model/src/model.rs:2115:14
```