### PR TITLE
[gql][cherry pick] suins subdomains

### DIFF
--- a/crates/sui-graphql-rpc/src/error.rs
+++ b/crates/sui-graphql-rpc/src/error.rs
@@ -4,7 +4,7 @@
 use async_graphql::{ErrorExtensionValues, ErrorExtensions, Pos, Response, ServerError};
 use async_graphql_axum::GraphQLResponse;
 use sui_indexer::errors::IndexerError;
-use sui_json_rpc::name_service::DomainParseError;
+use sui_json_rpc::name_service::NameServiceError;
 
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
@@ -66,7 +66,7 @@ pub enum Error {
     #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
     ProtocolVersionUnsupported(u64, u64),
     #[error(transparent)]
-    DomainParse(#[from] DomainParseError),
+    NameService(#[from] NameServiceError),
     #[error("'first' and 'last' must not be used together")]
     CursorNoFirstLast,
     #[error("Connection's page size of {0} exceeds max of {1}")]
@@ -81,7 +81,7 @@ pub enum Error {
 impl ErrorExtensions for Error {
     fn extend(&self) -> async_graphql::Error {
         async_graphql::Error::new(format!("{}", self)).extend_with(|_err, e| match self {
-            Error::DomainParse(_)
+            Error::NameService(_)
             | Error::CursorNoFirstLast
             | Error::PageTooLarge(_, _)
             | Error::ProtocolVersionUnsupported(_, _)

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -230,6 +230,23 @@ impl Checkpoint {
         }))
     }
 
+    /// Look up a `Checkpoint` in the database and retrieve its `timestamp_ms` field. This method
+    /// takes a connection, so that it can be used within a transaction.
+    pub(crate) fn query_timestamp(
+        conn: &mut Conn,
+        seq_num: u64,
+    ) -> Result<u64, diesel::result::Error> {
+        use checkpoints::dsl;
+
+        let stored: i64 = conn.first(move || {
+            dsl::checkpoints
+                .select(dsl::timestamp_ms)
+                .filter(dsl::sequence_number.eq(seq_num as i64))
+        })?;
+
+        Ok(stored as u64)
+    }
+
     pub(crate) async fn query_latest_checkpoint_sequence_number(db: &Db) -> Result<u64, Error> {
         db.execute(move |conn| Checkpoint::latest_checkpoint_sequence_number(conn))
             .await

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -404,10 +404,14 @@ impl OwnerImpl {
 
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
         Ok(
-            NameService::reverse_resolve_to_name(ctx, self.address, self.checkpoint_viewed_at)
-                .await
-                .extend()?
-                .map(|d| d.to_string()),
+            SuinsRegistration::reverse_resolve_to_name(
+                ctx,
+                self.address,
+                self.checkpoint_viewed_at,
+            )
+            .await
+            .extend()?
+            .map(|d| d.to_string()),
         )
     }
 

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -403,14 +403,12 @@ impl OwnerImpl {
     }
 
     pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        Ok(SuinsRegistration::reverse_resolve_to_name(
-            ctx.data_unchecked::<Db>(),
-            ctx.data_unchecked::<NameServiceConfig>(),
-            self.address,
+        Ok(
+            NameService::reverse_resolve_to_name(ctx, self.address, self.checkpoint_viewed_at)
+                .await
+                .extend()?
+                .map(|d| d.to_string()),
         )
-        .await
-        .extend()?
-        .map(|d| d.to_string()))
     }
 
     pub(crate) async fn suins_registrations(

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -368,14 +368,16 @@ impl Query {
         domain: Domain,
     ) -> Result<Option<Address>> {
         Ok(
-            NameService::resolve_to_record(ctx, &domain, /* checkpoint_viewed_at */ None)
-                .await
-                .extend()?
-                .and_then(|r| r.target_address)
-                .map(|a| Address {
-                    address: a.into(),
-                    checkpoint_viewed_at: None,
-                }),
+            SuinsRegistration::resolve_to_record(
+                ctx, &domain, /* checkpoint_viewed_at */ None,
+            )
+            .await
+            .extend()?
+            .and_then(|r| r.target_address)
+            .map(|a| Address {
+                address: a.into(),
+                checkpoint_viewed_at: None,
+            }),
         )
     }
 

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -7,7 +7,6 @@ use async_graphql::{connection::Connection, *};
 use fastcrypto::encoding::{Base64, Encoding};
 use move_core_types::account_address::AccountAddress;
 use serde::de::DeserializeOwned;
-use sui_json_rpc::name_service::NameServiceConfig;
 use sui_json_rpc_types::DevInspectArgs;
 use sui_sdk::SuiClient;
 use sui_types::transaction::{TransactionData, TransactionKind};
@@ -36,7 +35,7 @@ use super::{
     type_filter::ExactTypeFilter,
 };
 use crate::{
-    config::ServiceConfig, context_data::db_data_provider::PgManager, data::Db, error::Error,
+    config::ServiceConfig, context_data::db_data_provider::PgManager, error::Error,
     mutation::Mutation,
 };
 
@@ -368,18 +367,16 @@ impl Query {
         ctx: &Context<'_>,
         domain: Domain,
     ) -> Result<Option<Address>> {
-        Ok(SuinsRegistration::resolve_to_record(
-            ctx.data_unchecked::<Db>(),
-            ctx.data_unchecked::<NameServiceConfig>(),
-            &domain,
+        Ok(
+            NameService::resolve_to_record(ctx, &domain, /* checkpoint_viewed_at */ None)
+                .await
+                .extend()?
+                .and_then(|r| r.target_address)
+                .map(|a| Address {
+                    address: a.into(),
+                    checkpoint_viewed_at: None,
+                }),
         )
-        .await
-        .extend()?
-        .and_then(|r| r.target_address)
-        .map(|a| Address {
-            address: a.into(),
-            checkpoint_viewed_at: None,
-        }))
     }
 
     /// The coin metadata associated with the given coin type.

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -30,7 +30,7 @@ use crate::{
 use async_graphql::{connection::Connection, *};
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
-use sui_indexer::models::objects::StoredHistoryObject;
+use sui_indexer::models_v2::objects::StoredHistoryObject;
 use sui_json_rpc::name_service::{
     Domain as NativeDomain, NameRecord, NameServiceConfig, NameServiceError,
 };

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -7,6 +7,7 @@ use super::{
     balance::{self, Balance},
     base64::Base64,
     big_int::BigInt,
+    checkpoint::Checkpoint,
     coin::Coin,
     cursor::Page,
     display::DisplayEntry,
@@ -21,11 +22,18 @@ use super::{
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
     type_filter::ExactTypeFilter,
 };
-use crate::{data::Db, error::Error};
+use crate::{
+    consistency::{build_objects_query, consistent_range, View},
+    data::{Db, DbConnection, QueryExecutor},
+    error::Error,
+};
 use async_graphql::{connection::Connection, *};
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
-use sui_json_rpc::name_service::{Domain as NativeDomain, NameRecord, NameServiceConfig};
+use sui_indexer::models::objects::StoredHistoryObject;
+use sui_json_rpc::name_service::{
+    Domain as NativeDomain, NameRecord, NameServiceConfig, NameServiceError,
+};
 use sui_types::{base_types::SuiAddress as NativeSuiAddress, dynamic_field::Field, id::UID};
 
 const MOD_REGISTRATION: &IdentStr = ident_str!("suins_registration");
@@ -51,6 +59,19 @@ pub(crate) struct SuinsRegistration {
 
     /// The deserialized representation of the Move object's contents.
     pub native: NativeSuinsRegistration,
+}
+
+/// Represents the results of a query for a domain's `NameRecord` and its parent's `NameRecord`. The
+/// `expiration_timestamp_ms` on the name records are compared to the checkpoint's timestamp to
+/// check that the domain is not expired.
+pub(crate) struct DomainExpiration {
+    /// The domain's `NameRecord`.
+    pub name_record: Option<NameRecord>,
+    /// The parent's `NameRecord`, populated only if the domain is a subdomain.
+    pub parent_name_record: Option<NameRecord>,
+    /// The timestamp of the checkpoint at which the query was made. This is used to check if the
+    /// `expiration_timestamp_ms` on the name records are expired.
+    pub checkpoint_timestamp_ms: u64,
 }
 
 pub(crate) enum SuinsRegistrationDowncastError {
@@ -306,37 +327,82 @@ impl SuinsRegistration {
 impl SuinsRegistration {
     /// Lookup the SuiNS NameRecord for the given `domain` name. `config` specifies where to find
     /// the domain name registry, and its type.
+    ///
+    /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this was queried
+    /// for, or `None` if the data was requested at the latest checkpoint.
+    ///
+    /// The `NameRecord` is returned only if it has not expired as of the `checkpoint_viewed_at` or
+    /// latest checkpoint's timestamp.
+    ///
+    /// For leaf domains, the `NameRecord` is returned only if its parent is valid and not expired.
     pub(crate) async fn resolve_to_record(
-        db: &Db,
-        config: &NameServiceConfig,
+        ctx: &Context<'_>,
         domain: &Domain,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<NameRecord>, Error> {
-        let record_id = config.record_field_id(&domain.0);
-
-        let Some(object) = MoveObject::query(db, record_id.into(), ObjectLookupKey::Latest).await?
+        // Query for the domain's NameRecord and parent NameRecord if applicable. The checkpoint's
+        // timestamp is also fetched. These values are used to determine if the domain is expired.
+        let Some(domain_expiration) =
+            Self::query_domain_expiration(ctx, domain, checkpoint_viewed_at).await?
         else {
             return Ok(None);
         };
 
-        let field: Field<NativeDomain, NameRecord> = object
-            .native
-            .to_rust()
-            .ok_or_else(|| Error::Internal("Malformed Suins NameRecord".to_string()))?;
+        // Get the name_record from the query. If we didn't find it, we return as it means that the
+        // requested name is not registered.
+        let Some(name_record) = domain_expiration.name_record else {
+            return Ok(None);
+        };
 
-        Ok(Some(field.value))
+        // If name record is SLD, or Node subdomain, we can check the expiration and return the
+        // record if not expired.
+        if !name_record.is_leaf_record() {
+            return if !name_record.is_node_expired(domain_expiration.checkpoint_timestamp_ms) {
+                Ok(Some(name_record))
+            } else {
+                Err(Error::NameService(NameServiceError::NameExpired))
+            };
+        }
+
+        // If we cannot find the parent, then the name is expired.
+        let Some(parent_name_record) = domain_expiration.parent_name_record else {
+            return Err(Error::NameService(NameServiceError::NameExpired));
+        };
+
+        // If the parent is valid for this leaf, and not expired, then we can return the name
+        // record. Otherwise, the name is expired.
+        if parent_name_record.is_valid_leaf_parent(&name_record)
+            && !parent_name_record.is_node_expired(domain_expiration.checkpoint_timestamp_ms)
+        {
+            Ok(Some(name_record))
+        } else {
+            Err(Error::NameService(NameServiceError::NameExpired))
+        }
     }
 
     /// Lookup the SuiNS Domain for the given `address`. `config` specifies where to find the domain
     /// name registry, and its type.
+    ///
+    /// `checkpoint_viewed_at` represents the checkpoint sequence number at which this was queried
+    /// for, or `None` if the data was requested at the latest checkpoint.
     pub(crate) async fn reverse_resolve_to_name(
-        db: &Db,
-        config: &NameServiceConfig,
+        ctx: &Context<'_>,
         address: SuiAddress,
+        checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<NativeDomain>, Error> {
+        let config = ctx.data_unchecked::<NameServiceConfig>();
+
         let reverse_record_id = config.reverse_record_field_id(address.as_slice());
 
-        let Some(object) =
-            MoveObject::query(db, reverse_record_id.into(), ObjectLookupKey::Latest).await?
+        let Some(object) = MoveObject::query(
+            ctx.data_unchecked(),
+            reverse_record_id.into(),
+            match checkpoint_viewed_at {
+                Some(checkpoint_viewed_at) => ObjectLookupKey::LatestAt(checkpoint_viewed_at),
+                None => ObjectLookupKey::Latest,
+            },
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -346,7 +412,110 @@ impl SuinsRegistration {
             .to_rust()
             .ok_or_else(|| Error::Internal("Malformed Suins Domain".to_string()))?;
 
-        Ok(Some(field.value))
+        let domain = Domain(field.value);
+
+        // We attempt to resolve the domain to a record, and if it fails, we return None. That way
+        // we can validate that the name has not expired and is still valid.
+        let Some(_) = Self::resolve_to_record(ctx, &domain, checkpoint_viewed_at).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(domain.0))
+    }
+
+    /// Query for a domain's NameRecord, its parent's NameRecord if supplied, and the timestamp of
+    /// the checkpoint bound.
+    async fn query_domain_expiration(
+        ctx: &Context<'_>,
+        domain: &Domain,
+        checkpoint_viewed_at: Option<u64>,
+    ) -> Result<Option<DomainExpiration>, Error> {
+        let config = ctx.data_unchecked::<NameServiceConfig>();
+        let db: &crate::data::pg::PgExecutor = ctx.data_unchecked::<Db>();
+        // Construct the list of `object_id`s to look up. The first element is the domain's
+        // `NameRecord`. If the domain is a subdomain, there will be a second element for the
+        // parent's `NameRecord`.
+        let mut object_ids = vec![SuiAddress::from(config.record_field_id(&domain.0))];
+        if domain.0.is_subdomain() {
+            object_ids.push(SuiAddress::from(config.record_field_id(&domain.0.parent())));
+        }
+
+        // Create a page with a bound of `object_ids` length to fetch the relevant `NameRecord`s.
+        let page: Page<object::Cursor> = Page::from_params(
+            ctx.data_unchecked(),
+            Some(object_ids.len() as u64),
+            None,
+            None,
+            None,
+        )
+        .map_err(|_| {
+            Error::Internal("Page size of 2 is incompatible with configured limits".to_string())
+        })?;
+
+        // prepare the filter for the query.
+        let filter = ObjectFilter {
+            object_ids: Some(object_ids.clone()),
+            ..Default::default()
+        };
+
+        let response = db
+            .execute_repeatable(move |conn| {
+                let Some((lhs, rhs)) = consistent_range(conn, checkpoint_viewed_at)? else {
+                    return Ok::<_, diesel::result::Error>(None);
+                };
+
+                let timestamp_ms = Checkpoint::query_timestamp(conn, rhs)?;
+
+                let sql = build_objects_query(
+                    View::Consistent,
+                    lhs as i64,
+                    rhs as i64,
+                    &page,
+                    move |query| filter.apply(query),
+                    move |newer| newer,
+                );
+
+                let objects: Vec<StoredHistoryObject> =
+                    conn.results(move || sql.clone().into_boxed())?;
+
+                Ok(Some((timestamp_ms, objects)))
+            })
+            .await?;
+
+        let Some((checkpoint_timestamp_ms, results)) = response else {
+            return Err(Error::Client(
+                "Requested data is outside the available range".to_string(),
+            ));
+        };
+
+        let mut domain_expiration = DomainExpiration {
+            parent_name_record: None,
+            name_record: None,
+            checkpoint_timestamp_ms,
+        };
+
+        // Max size of results is 2. We loop through them, convert to objects, and then parse
+        // name_record. We then assign it to the correct field on `domain_expiration` based on the
+        // address.
+        for result in results {
+            let object = Object::try_from_stored_history_object(result, None)?;
+            let move_object = MoveObject::try_from(&object).map_err(|_| {
+                Error::Internal(format!(
+                    "Expected {0} to be a NameRecord, but it's not a Move Object.",
+                    object.address
+                ))
+            })?;
+
+            let record = NameRecord::try_from(move_object.native)?;
+
+            if object.address == object_ids[0] {
+                domain_expiration.name_record = Some(record);
+            } else if Some(&object.address) == object_ids.get(1) {
+                domain_expiration.parent_name_record = Some(record);
+            }
+        }
+
+        Ok(Some(domain_expiration))
     }
 
     /// Query the database for a `page` of SuiNS registrations. The page uses the same cursor type

--- a/crates/sui-indexer/src/apis/indexer_api_v2.rs
+++ b/crates/sui-indexer/src/apis/indexer_api_v2.rs
@@ -291,12 +291,10 @@ impl IndexerApiServer for IndexerApiV2 {
     }
 
     async fn resolve_name_service_address(&self, name: String) -> RpcResult<Option<SuiAddress>> {
-        let domain = name.parse::<Domain>().map_err(|e| {
-            IndexerError::InvalidArgumentError(format!(
-                "Failed to parse NameService Domain with error: {:?}",
-                e
-            ))
-        })?;
+        // TODO(manos): Implement new logic.
+        let domain = name
+            .parse::<Domain>()
+            .map_err(IndexerError::NameServiceError)?;
 
         let record_id = self.name_service_config.record_field_id(&domain);
 
@@ -305,14 +303,8 @@ impl IndexerApiServer for IndexerApiV2 {
             None => return Ok(None),
         };
 
-        let record = field_record_object
-            .to_rust::<Field<Domain, NameRecord>>()
-            .ok_or_else(|| {
-                IndexerError::PersistentStorageDataCorruptionError(format!(
-                    "Malformed Object {record_id}"
-                ))
-            })?
-            .value;
+        let record = NameRecord::try_from(field_record_object)
+            .map_err(|e| IndexerError::PersistentStorageDataCorruptionError(e.to_string()))?;
 
         Ok(record.target_address)
     }

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -4,6 +4,7 @@
 use fastcrypto::error::FastCryptoError;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::error::CallError;
+use sui_json_rpc::name_service::NameServiceError;
 use thiserror::Error;
 
 use sui_types::base_types::ObjectIDParseError;
@@ -125,6 +126,9 @@ pub enum IndexerError {
 
     #[error("Indexer failed to send item to channel with error: `{0}`")]
     MpscChannelError(String),
+
+    #[error(transparent)]
+    NameServiceError(#[from] NameServiceError),
 }
 
 pub trait Context<T> {

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+use sui_json_rpc::name_service;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    collection_types::VecMap,
+};
+
+#[test]
+fn test_parent_extraction() {
+    let mut name = name_service::Domain::from_str("leaf.node.test.sui").unwrap();
+
+    assert_eq!(name.parent().to_string(), "node.test.sui");
+
+    name = name_service::Domain::from_str("node.test.sui").unwrap();
+
+    assert_eq!(name.parent().to_string(), "test.sui");
+}
+
+#[test]
+fn test_expirations() {
+    let system_time: u64 = 100;
+
+    let mut name = name_service::NameRecord {
+        nft_id: sui_types::id::ID::new(ObjectID::random()),
+        data: VecMap { contents: vec![] },
+        target_address: Some(SuiAddress::random_for_testing_only()),
+        expiration_timestamp_ms: system_time + 10,
+    };
+
+    assert!(!name.is_node_expired(system_time));
+
+    name.expiration_timestamp_ms = system_time - 10;
+
+    assert!(name.is_node_expired(system_time));
+}

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
-use sui_json_rpc::name_service;
+use sui_json_rpc::name_service::{self, Domain};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     collection_types::VecMap,
@@ -10,11 +10,11 @@ use sui_types::{
 
 #[test]
 fn test_parent_extraction() {
-    let mut name = name_service::Domain::from_str("leaf.node.test.sui").unwrap();
+    let mut name = Domain::from_str("leaf.node.test.sui").unwrap();
 
     assert_eq!(name.parent().to_string(), "node.test.sui");
 
-    name = name_service::Domain::from_str("node.test.sui").unwrap();
+    name = Domain::from_str("node.test.sui").unwrap();
 
     assert_eq!(name.parent().to_string(), "test.sui");
 }
@@ -35,4 +35,60 @@ fn test_expirations() {
     name.expiration_timestamp_ms = system_time - 10;
 
     assert!(name.is_node_expired(system_time));
+}
+
+#[test]
+fn test_name_service_outputs() {
+    assert_eq!("@test".parse::<Domain>().unwrap().to_string(), "test.sui");
+    assert_eq!(
+        "test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.sui"
+    );
+    assert_eq!(
+        "test@sld".parse::<Domain>().unwrap().to_string(),
+        "test.sld.sui"
+    );
+    assert_eq!(
+        "test.test@example".parse::<Domain>().unwrap().to_string(),
+        "test.test.example.sui"
+    );
+    assert_eq!(
+        "sui@sui".parse::<Domain>().unwrap().to_string(),
+        "sui.sui.sui"
+    );
+
+    assert_eq!("@sui".parse::<Domain>().unwrap().to_string(), "sui.sui");
+
+    assert_eq!(
+        "test*test@test".parse::<Domain>().unwrap().to_string(),
+        "test.test.test.sui"
+    );
+    assert_eq!(
+        "test.test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.test.sui"
+    );
+    assert_eq!(
+        "test.test.test.sui".parse::<Domain>().unwrap().to_string(),
+        "test.test.test.sui"
+    );
+}
+
+#[test]
+fn test_different_wildcard() {
+    assert_eq!("test.sui".parse::<Domain>(), "test*sui".parse::<Domain>(),);
+
+    assert_eq!("@test".parse::<Domain>(), "test*sui".parse::<Domain>(),);
+}
+
+#[test]
+fn test_invalid_inputs() {
+    assert!("*".parse::<Domain>().is_err());
+    assert!(".".parse::<Domain>().is_err());
+    assert!("@".parse::<Domain>().is_err());
+    assert!("@inner.sui".parse::<Domain>().is_err());
+    assert!("@inner*sui".parse::<Domain>().is_err());
+    assert!("test@".parse::<Domain>().is_err());
+    assert!("sui".parse::<Domain>().is_err());
+    assert!("test.test@example.sui".parse::<Domain>().is_err());
+    assert!("test@test@example".parse::<Domain>().is_err());
 }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use tokio::task::JoinError;
 
 use crate::authority_state::StateReadError;
+use crate::name_service::NameServiceError;
 
 pub type RpcInterimResult<T = ()> = Result<T, Error>;
 
@@ -64,6 +65,9 @@ pub enum Error {
 
     #[error("Unsupported Feature: {0}")]
     UnsupportedFeature(String),
+
+    #[error("transparent")]
+    NameServiceError(#[from] NameServiceError),
 }
 
 impl From<SuiError> for Error {
@@ -91,6 +95,17 @@ impl From<Error> for RpcError {
                 | SuiObjectResponseError::DynamicFieldNotFound { .. }
                 | SuiObjectResponseError::Deleted { .. }
                 | SuiObjectResponseError::DisplayError { .. } => {
+                    RpcError::Call(CallError::InvalidParams(err.into()))
+                }
+                _ => RpcError::Call(CallError::Failed(err.into())),
+            },
+            Error::NameServiceError(err) => match err {
+                NameServiceError::ExceedsMaxLength { .. }
+                | NameServiceError::InvalidHyphens { .. }
+                | NameServiceError::InvalidLength { .. }
+                | NameServiceError::InvalidUnderscore { .. }
+                | NameServiceError::LabelsEmpty { .. }
+                | NameServiceError::InvalidSeparator { .. } => {
                     RpcError::Call(CallError::InvalidParams(err.into()))
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -10,7 +10,9 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::VecMap;
-use sui_types::id::ID;
+use sui_types::dynamic_field::Field;
+use sui_types::id::{ID, UID};
+use sui_types::object::Object;
 use sui_types::TypeTag;
 
 const NAME_SERVICE_DOMAIN_MODULE: &IdentStr = ident_str!("domain");
@@ -23,6 +25,7 @@ const NAME_SERVICE_DEFAULT_REVERSE_REGISTRY: &str =
     "0x2fd099e17a292d2bc541df474f9fafa595653848cbabb2d7a4656ec786a1969f";
 const _NAME_SERVICE_OBJECT_ADDRESS: &str =
     "0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871";
+const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Registry {
@@ -60,10 +63,31 @@ impl Domain {
             type_params: vec![],
         }
     }
+
+    /// Derive the parent domain for a given domain
+    /// SAFETY: This is a safe operation because we only allow a
+    /// domain's label vector size to be >= 2 (see `Domain::from_str`)
+    pub fn parent(&self) -> Domain {
+        Domain {
+            labels: self.labels[0..(self.labels.len() - 1)].to_vec(),
+        }
+    }
+
+    pub fn is_subdomain(&self) -> bool {
+        self.depth() >= 3
+    }
+
+    /// Returns the depth for a name.
+    /// Depth is defined by the amount of labels in a domain, including TLD.
+    /// E.g. `test.example.sui` -> `3`
+    ///
+    /// SAFETY: We can safely cast to a u8 as the max depth is 235.
+    pub fn depth(&self) -> u8 {
+        self.labels.len() as u8
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "kebab-case")]
 pub struct NameServiceConfig {
     pub package_address: SuiAddress,
     pub registry_id: ObjectID,
@@ -115,29 +139,15 @@ impl Default for NameServiceConfig {
     }
 }
 
-#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub enum DomainParseError {
-    #[error("String length: {0} exceeds maximum allowed length: {1}")]
-    ExceedsMaxLength(usize, usize),
-    #[error("String length: {0} outside of valid range: [{1}, {2}]")]
-    InvalidLength(usize, usize, usize),
-    #[error("Hyphens are not allowed as the first or last character")]
-    InvalidHyphens,
-    #[error("Only lowercase letters, numbers, and hyphens are allowed")]
-    InvalidUnderscore,
-    #[error("Domain must contain at least one label")]
-    LabelsEmpty,
-}
-
 impl FromStr for Domain {
-    type Err = DomainParseError;
+    type Err = NameServiceError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         /// The maximum length of a full domain
         const MAX_DOMAIN_LENGTH: usize = 200;
 
         if s.len() > MAX_DOMAIN_LENGTH {
-            return Err(DomainParseError::ExceedsMaxLength(
+            return Err(NameServiceError::ExceedsMaxLength(
                 s.len(),
                 MAX_DOMAIN_LENGTH,
             ));
@@ -149,8 +159,8 @@ impl FromStr for Domain {
             .map(validate_label)
             .collect::<Result<Vec<_>, Self::Err>>()?;
 
-        if labels.is_empty() {
-            return Err(DomainParseError::LabelsEmpty);
+        if labels.len() < 2 {
+            return Err(NameServiceError::LabelsEmpty);
         }
 
         let labels = labels.into_iter().map(ToOwned::to_owned).collect();
@@ -159,14 +169,14 @@ impl FromStr for Domain {
     }
 }
 
-fn validate_label(label: &str) -> Result<&str, DomainParseError> {
+fn validate_label(label: &str) -> Result<&str, NameServiceError> {
     const MIN_LABEL_LENGTH: usize = 1;
     const MAX_LABEL_LENGTH: usize = 63;
     let bytes = label.as_bytes();
     let len = bytes.len();
 
     if !(MIN_LABEL_LENGTH..=MAX_LABEL_LENGTH).contains(&len) {
-        return Err(DomainParseError::InvalidLength(
+        return Err(NameServiceError::InvalidLength(
             len,
             MIN_LABEL_LENGTH,
             MAX_LABEL_LENGTH,
@@ -183,8 +193,8 @@ fn validate_label(label: &str) -> Result<&str, DomainParseError> {
 
         if !is_valid_character {
             match character {
-                b'-' => return Err(DomainParseError::InvalidHyphens),
-                _ => return Err(DomainParseError::InvalidUnderscore),
+                b'-' => return Err(NameServiceError::InvalidHyphens),
+                _ => return Err(NameServiceError::InvalidUnderscore),
             }
         };
     }
@@ -222,4 +232,72 @@ pub struct NameRecord {
     pub target_address: Option<SuiAddress>,
     /// Additional data which may be stored in a record
     pub data: VecMap<String, String>,
+}
+
+impl NameRecord {
+    /// Leaf records expire when their parent expires.
+    /// The `expiration_timestamp_ms` is set to `0` (on-chain) to indicate this.
+    pub fn is_leaf_record(&self) -> bool {
+        self.expiration_timestamp_ms == LEAF_EXPIRATION_TIMESTAMP
+    }
+
+    /// WARNING: This only applies for `leaf` records
+    pub fn is_valid_leaf_parent(&self, child: &NameRecord) -> bool {
+        self.nft_id == child.nft_id
+    }
+
+    /// Checks if a `node` name record has expired.
+    /// Expects the latest checkpoint's timestamp.
+    pub fn is_node_expired(&self, checkpoint_timestamp_ms: u64) -> bool {
+        self.expiration_timestamp_ms < checkpoint_timestamp_ms
+    }
+}
+
+impl TryFrom<Object> for NameRecord {
+    type Error = NameServiceError;
+
+    fn try_from(object: Object) -> Result<Self, NameServiceError> {
+        object
+            .to_rust::<Field<Domain, Self>>()
+            .map(|record| record.value)
+            .ok_or_else(|| NameServiceError::MalformedObject(object.id()))
+    }
+}
+
+#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum NameServiceError {
+    #[error("Name Service: String length: {0} exceeds maximum allowed length: {1}")]
+    ExceedsMaxLength(usize, usize),
+    #[error("Name Service: String length: {0} outside of valid range: [{1}, {2}]")]
+    InvalidLength(usize, usize, usize),
+    #[error("Name Service: Hyphens are not allowed as the first or last character")]
+    InvalidHyphens,
+    #[error("Name Service: Only lowercase letters, numbers, and hyphens are allowed")]
+    InvalidUnderscore,
+    #[error("Name Service: Domain must contain at least one label")]
+    LabelsEmpty,
+    #[error("Name Service: Domain must include only one separator")]
+    InvalidSeparator,
+
+    #[error("Name Service: Name has expired.")]
+    NameExpired,
+    #[error("Name Service: Malformed object for {0}")]
+    MalformedObject(ObjectID),
+}
+
+/// A SuinsRegistration object to manage an SLD
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SuinsRegistration {
+    pub id: UID,
+    pub domain: Domain,
+    pub domain_name: String,
+    pub expiration_timestamp_ms: u64,
+    pub image_url: String,
+}
+
+/// A SubDomainRegistration object to manage a subdomain.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SubDomainRegistration {
+    pub id: UID,
+    pub nft: SuinsRegistration,
 }

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -91,6 +91,7 @@ impl Domain {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub struct NameServiceConfig {
     pub package_address: SuiAddress,
     pub registry_id: ObjectID,

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -26,6 +26,9 @@ const NAME_SERVICE_DEFAULT_REVERSE_REGISTRY: &str =
 const _NAME_SERVICE_OBJECT_ADDRESS: &str =
     "0x6e0ddefc0ad98889c04bab9639e512c21766c5e6366f89e696956d9be6952871";
 const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
+const DEFAULT_TLD: &str = "sui";
+const ACCEPTED_SEPARATORS: [char; 2] = ['.', '*'];
+const SUI_NEW_FORMAT_SEPARATOR: char = '@';
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Registry {
@@ -152,21 +155,75 @@ impl FromStr for Domain {
                 MAX_DOMAIN_LENGTH,
             ));
         }
+        let separator = separator(s)?;
 
-        let labels = s
-            .split('.')
+        let formatted_string = convert_from_new_format(s, &separator)?;
+
+        let labels = formatted_string
+            .split(separator)
             .rev()
             .map(validate_label)
             .collect::<Result<Vec<_>, Self::Err>>()?;
 
+        // A valid domain in our system has at least a TLD and an SLD (len == 2).
         if labels.len() < 2 {
             return Err(NameServiceError::LabelsEmpty);
         }
 
         let labels = labels.into_iter().map(ToOwned::to_owned).collect();
-
         Ok(Domain { labels })
     }
+}
+
+/// Parses a separator from the domain string input.
+/// E.g.  `example.sui` -> `.` | example*sui -> `@` | `example*sui` -> `*`
+fn separator(s: &str) -> Result<char, NameServiceError> {
+    let mut domain_separator: Option<char> = None;
+
+    for separator in ACCEPTED_SEPARATORS.iter() {
+        if s.contains(*separator) {
+            if domain_separator.is_some() {
+                return Err(NameServiceError::InvalidSeparator);
+            }
+
+            domain_separator = Some(*separator);
+        }
+    }
+
+    match domain_separator {
+        Some(separator) => Ok(separator),
+        None => Ok(ACCEPTED_SEPARATORS[0]),
+    }
+}
+
+/// Converts @label ending to label{separator}sui ending.
+///
+/// E.g. `@example` -> `example.sui` | `test@example` -> `test.example.sui`
+fn convert_from_new_format(s: &str, separator: &char) -> Result<String, NameServiceError> {
+    let mut splits = s.split(SUI_NEW_FORMAT_SEPARATOR);
+
+    let Some(before) = splits.next() else {
+        return Err(NameServiceError::InvalidSeparator);
+    };
+
+    let Some(after) = splits.next() else {
+        return Ok(before.to_string());
+    };
+
+    if splits.next().is_some() || after.contains(*separator) || after.is_empty() {
+        return Err(NameServiceError::InvalidSeparator);
+    }
+
+    let mut parts = vec![];
+
+    if !before.is_empty() {
+        parts.push(before);
+    }
+
+    parts.push(after);
+    parts.push(DEFAULT_TLD);
+
+    Ok(parts.join(&separator.to_string()))
 }
 
 fn validate_label(label: &str) -> Result<&str, NameServiceError> {

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::VecMap;
 use sui_types::dynamic_field::Field;
 use sui_types::id::{ID, UID};
-use sui_types::object::Object;
+use sui_types::object::{MoveObject, Object};
 use sui_types::TypeTag;
 
 const NAME_SERVICE_DOMAIN_MODULE: &IdentStr = ident_str!("domain");
@@ -257,6 +257,17 @@ impl TryFrom<Object> for NameRecord {
     type Error = NameServiceError;
 
     fn try_from(object: Object) -> Result<Self, NameServiceError> {
+        object
+            .to_rust::<Field<Domain, Self>>()
+            .map(|record| record.value)
+            .ok_or_else(|| NameServiceError::MalformedObject(object.id()))
+    }
+}
+
+impl TryFrom<MoveObject> for NameRecord {
+    type Error = NameServiceError;
+
+    fn try_from(object: MoveObject) -> Result<Self, NameServiceError> {
         object
             .to_rust::<Field<Domain, Self>>()
             .map(|record| record.value)


### PR DESCRIPTION
Cherry-picks 
1. #15576 
2. #16319 
3. #15466 
in that order to support expiration checks, subdomains, and alternative formats to the existing dot format.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

---------

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
