### PR TITLE
[bridge][solidity] add mockUSDT, fix supportedTokens in deploy script and print addresses

### DIFF
--- a/bridge/evm/script/deploy_bridge.s.sol
+++ b/bridge/evm/script/deploy_bridge.s.sol
@@ -34,13 +34,16 @@ contract DeployBridge is Script {
             // deploy mock tokens
             MockWBTC wBTC = new MockWBTC();
             MockUSDC USDC = new MockUSDC();
+            MockUSDT USDT = new MockUSDT();
 
             // update config with mock addresses
             config.supportedTokens = new address[](4);
-            config.supportedTokens[0] = address(0);
-            config.supportedTokens[1] = address(wBTC);
-            config.supportedTokens[2] = config.WETH;
-            config.supportedTokens[3] = address(USDC);
+            // In BridgeConfig.sol `supportedTokens is shifted by one
+            // and the first token is SUI.
+            config.supportedTokens[0] = address(wBTC);
+            config.supportedTokens[1] = config.WETH;
+            config.supportedTokens[2] = address(USDC);
+            config.supportedTokens[3] = address(USDT);
         }
 
         // convert supported chains from uint256 to uint8[]
@@ -112,6 +115,18 @@ contract DeployBridge is Script {
         // transfer limiter ownership to bridge
         BridgeLimiter instance = BridgeLimiter(limiter);
         instance.transferOwnership(suiBridge);
+
+        // print deployed addresses for post deployment setup
+        console.log("[Deployed] BridgeConfig:", address(bridgeConfig));
+        console.log("[Deployed] SuiBridge:", suiBridge);
+        console.log("[Deployed] BridgeLimiter:", limiter);
+        console.log("[Deployed] BridgeCommittee:", bridgeCommittee);
+        console.log("[Deployed] BridgeVault:", address(vault));
+        console.log("[Deployed] BTC:", bridgeConfig.getTokenAddress(1));
+        console.log("[Deployed] ETH:", bridgeConfig.getTokenAddress(2));
+        console.log("[Deployed] USDC:", bridgeConfig.getTokenAddress(3));
+        console.log("[Deployed] USDT:", bridgeConfig.getTokenAddress(4));
+
         vm.stopBroadcast();
     }
 

--- a/bridge/evm/test/mocks/MockTokens.sol
+++ b/bridge/evm/test/mocks/MockTokens.sol
@@ -57,6 +57,25 @@ contract MockSmallUSDC is ERC20 {
     function testMock() public {}
 }
 
+contract MockUSDT is ERC20 {
+    constructor() ERC20("Tether", "USDT") {}
+
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function burn(address form, uint256 amount) public virtual {
+        _burn(form, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return 6;
+    }
+
+    function testMock() public {}
+}
+
+
 contract WETH {
     string public name = "Wrapped Ether";
     string public symbol = "WETH";


### PR DESCRIPTION
## Description 

as title.
(I don't quite like how we handle `supportedTokens` in config, it's quite error-prone)
The reason to print addresses is like in post deployment processing it's easier to grab the addresses from output than anything else.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
