### PR TITLE
A few fixes in the indexer/graphql README

### DIFF
--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -24,14 +24,14 @@ $ psql "postgres://$ME:$ME@localhost:5432/postgres" \
 
 ```sh
 $ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
-    -c "CREATE DATABASE sui_indexer_v2; -c 'ALTER SYSTEM SET max_connections = 500;"
+    -c "CREATE DATABASE sui_indexer_v2;" -c "ALTER SYSTEM SET max_connections = 500;"
 ```
 
 4. Finally, restart the `postgres` server so the max connections change takes effect.
 
 Mac
 ```sh
-brew services restart postgres
+brew services restart postgresql@15
 
 ```
 

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -5,7 +5,7 @@ Sui indexer is an off-fullnode service to serve data from Sui protocol, includin
 
 ## Steps to run locally
 ### Prerequisites
-- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgresql@version` and then add the following to your `~/.zshrc` or `~/.zprofile`, etc:
+- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgresql@15` and then add the following to your `~/.zshrc` or `~/.zprofile`, etc:
 ```sh
 export LDFLAGS="-L/opt/homebrew/opt/postgresql@15/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/postgresql@15/include"


### PR DESCRIPTION
## Description 

v14 doesn't actually work. So it's better to explicitly require 15.
There is also a mistake in the sql command.
The service name isn't correct either.

## Test Plan 

Run each command locally.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
