### PR TITLE
update fullnode spec to use mysten + external ssfns instead of mysten-only

### DIFF
--- a/docs/content/guides/operator/sui-full-node.mdx
+++ b/docs/content/guides/operator/sui-full-node.mdx
@@ -126,27 +126,27 @@ Open a terminal or console to the `sui` directory you downloaded in the previous
 
     ```shell
     p2p-config:
-        seed-peers:
-            - address: /dns/icn-00.mainnet.sui.io/udp/8084
-            peer-id: 303f1f35afc9a6f82f8d21724f44e1245f4d8eca0806713a07c525dadda95a66
-            - address: /dns/icn-01.mainnet.sui.io/udp/8084
-            peer-id: cb7ce193cf7a41e9cc2f99e65dd1487b6314a57c74be42cc8c9225b203301812
-            - address: /dns/mel-00.mainnet.sui.io/udp/8084
-            peer-id: d32b55bdf1737ec415df8c88b3bf91e194b59ee3127e3f38ea46fd88ba2e7849
-            - address: /dns/mel-01.mainnet.sui.io/udp/8084
-            peer-id: bbf3be337fc16614a1953da83db729abfdc40596e197f36fe408574f7c9b780e
-            - address: /dns/ewr-00.mainnet.sui.io/udp/8084
-            peer-id: c7bf6cb93ca8fdda655c47ebb85ace28e6931464564332bf63e27e90199c50ee
-            - address: /dns/ewr-01.mainnet.sui.io/udp/8084
-            peer-id: 3227f8a05f0faa1a197c075d31135a366a1c6f3d4872cb8af66c14dea3e0eb66
-            - address: /dns/sjc-00.mainnet.sui.io/udp/8084
-            peer-id: 6f0b25087cd6b2fd2e4329bcf308ac95a37c49277dd7286b72470c124809db5b
-            - address: /dns/sjc-01.mainnet.sui.io/udp/8084
-            peer-id: af1d5d8468b3612ac2b6ff3ca91e99a71390dbe5b83dea9f6ae2da708d689227
-            - address: /dns/lhr-00.mainnet.sui.io/udp/8084
-            peer-id: c619a5e0f8f36eac45118c1f8bda28f0f508e2839042781f1d4a9818043f732c
-            - address: /dns/lhr-01.mainnet.sui.io/udp/8084
-            peer-id: 53dcedf250f73b1ec83250614498947db00d17c0181020fcdb7b6db12afbc175
+      seed-peers:
+        - address: /dns/mel-00.mainnet.sui.io/udp/8084
+          peer-id: d32b55bdf1737ec415df8c88b3bf91e194b59ee3127e3f38ea46fd88ba2e7849
+        - address: /dns/ewr-00.mainnet.sui.io/udp/8084
+          peer-id: c7bf6cb93ca8fdda655c47ebb85ace28e6931464564332bf63e27e90199c50ee
+        - address: /dns/ewr-01.mainnet.sui.io/udp/8084
+          peer-id: 3227f8a05f0faa1a197c075d31135a366a1c6f3d4872cb8af66c14dea3e0eb66
+        - address: /dns/lhr-00.mainnet.sui.io/udp/8084
+          peer-id: c619a5e0f8f36eac45118c1f8bda28f0f508e2839042781f1d4a9818043f732c
+        - address: /dns/sui-mainnet-ssfn-1.nodeinfra.com/udp/8084
+          peer-id: 0c52ca8d2b9f51be4a50eb44ace863c05aadc940a7bd15d4d3f498deb81d7fc6
+        - address: /dns/sui-mainnet-ssfn-2.nodeinfra.com/udp/8084
+          peer-id: 1dbc28c105aa7eb9d1d3ac07ae663ea638d91f2b99c076a52bbded296bd3ed5c
+        - address: /dns/sui-mainnet-ssfn-ashburn-na.overclock.run/udp/8084
+          peer-id: 5ff8461ab527a8f241767b268c7aaf24d0312c7b923913dd3c11ee67ef181e45
+        - address: /dns/sui-mainnet-ssfn-dallas-na.overclock.run/udp/8084
+          peer-id: e1a4f40d66f1c89559a195352ba9ff84aec28abab1d3aa1c491901a252acefa6
+        - address: /dns/ssn01.mainnet.sui.rpcpool.com/udp/8084
+          peer-id: fadb7ccb0b7fc99223419176e707f5122fef4ea686eb8e80d1778588bf5a0bcd
+        - address: /dns/ssn02.mainnet.sui.rpcpool.com/udp/8084
+          peer-id: 13783584a90025b87d4604f1991252221e5fd88cab40001642f4b00111ae9b7e
     ```
 
     </TabItem>
@@ -154,17 +154,21 @@ Open a terminal or console to the `sui` directory you downloaded in the previous
 
     ```shell
     p2p-config:
-        seed-peers:
-            - address: /dns/nrt-tnt-ssfn-00.testnet.sui.io/udp/8084
-            peer-id: 23a1f7cd901b6277cbedaa986b3fc183f171d800cabba863d48f698f518967e1
-            - address: /dns/ewr-tnt-ssfn-00.testnet.sui.io/udp/8084
-            peer-id: df8a8d128051c249e224f95fcc463f518a0ebed8986bbdcc11ed751181fecd38
-            - address: /dns/lax-tnt-ssfn-00.testnet.sui.io/udp/8084
-            peer-id: f9a72a0a6c17eed09c27898eab389add704777c03e135846da2428f516a0c11d
-            - address: /dns/lhr-tnt-ssfn-00.testnet.sui.io/udp/8084
-            peer-id: 9393d6056bb9c9d8475a3cf3525c747257f17c6a698a7062cbbd1875bc6ef71e
-            - address: /dns/mel-tnt-ssfn-00.testnet.sui.io/udp/8084
-            peer-id: c88742f46e66a11cb8c84aca488065661401ef66f726cb9afeb8a5786d83456e
+      seed-peers:
+        - address: /dns/yto-tnt-ssfn-01.testnet.sui.io/udp/8084
+          peer-id: 2ed53564d5581ded9b6773970ac2f1c84d39f9edf01308ff5a1ffe09b1add7b3
+        - address: /dns/yto-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: 6563732e5ab33b4ae09c73a98fd37499b71b8f03c27b5cc51acc26934974aff2
+        - address: /dns/nrt-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: 23a1f7cd901b6277cbedaa986b3fc183f171d800cabba863d48f698f518967e1
+        - address: /dns/ewr-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: df8a8d128051c249e224f95fcc463f518a0ebed8986bbdcc11ed751181fecd38
+        - address: /dns/lax-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: f9a72a0a6c17eed09c27898eab389add704777c03e135846da2428f516a0c11d
+        - address: /dns/lhr-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: 9393d6056bb9c9d8475a3cf3525c747257f17c6a698a7062cbbd1875bc6ef71e
+        - address: /dns/mel-tnt-ssfn-00.testnet.sui.io/udp/8084
+          peer-id: c88742f46e66a11cb8c84aca488065661401ef66f726cb9afeb8a5786d83456e
     ```
 
     </TabItem>


### PR DESCRIPTION
## Description 

Update our docs with the list of new 3rd party ssfns

## Test Plan 

Going to test each ssfn independently

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
