### PR TITLE
Remove unneeded flag enable_randomness_ptb_restrictions (#16715)

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1377,7 +1377,6 @@
                 "enable_group_ops_native_functions": false,
                 "enable_jwk_consensus_updates": false,
                 "enable_poseidon": false,
-                "enable_randomness_ptb_restrictions": false,
                 "end_of_epoch_transaction_supported": false,
                 "hardened_otw_check": false,
                 "include_consensus_digest_in_prologue": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -112,7 +112,7 @@ const MAX_PROTOCOL_VERSION: u64 = 40;
 // Version 38: Introduce limits for binary tables size.
 // Version 39: Allow skipped epochs for randomness updates.
 //             Extra version to fix `test_upgrade_compatibility` simtest.
-// Version 40: Reject PTBs that contain invalid commands after one that uses Random.
+// Version 40:
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -387,10 +387,6 @@ struct FeatureFlags {
     // Reject functions with mutable Random.
     #[serde(skip_serializing_if = "is_false")]
     reject_mutable_random_on_entry_functions: bool,
-
-    // Limit PTBs that contain invalid commands after one that uses Random.
-    #[serde(skip_serializing_if = "is_false")]
-    enable_randomness_ptb_restrictions: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1175,10 +1171,6 @@ impl ProtocolConfig {
 
     pub fn reject_mutable_random_on_entry_functions(&self) -> bool {
         self.feature_flags.reject_mutable_random_on_entry_functions
-    }
-
-    pub fn enable_randomness_ptb_restrictions(&self) -> bool {
-        self.feature_flags.enable_randomness_ptb_restrictions
     }
 }
 
@@ -1966,12 +1958,9 @@ impl ProtocolConfig {
                     cfg.execution_version = Some(3);
                 }
                 39 => {
-                    // It is important that we keep this protocol version brank due to an issue with random.move.
+                    // It is important that we keep this protocol version blank due to an issue with random.move.
                 }
-                40 => {
-                    // TODO: We don't actually need this.
-                    cfg.feature_flags.enable_randomness_ptb_restrictions = true;
-                }
+                40 => {}
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_40.snap
@@ -40,7 +40,6 @@ feature_flags:
   allow_receiving_object_id: true
   enable_coin_deny_list: true
   reject_mutable_random_on_entry_functions: true
-  enable_randomness_ptb_restrictions: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_40.snap
@@ -42,7 +42,6 @@ feature_flags:
   allow_receiving_object_id: true
   enable_coin_deny_list: true
   reject_mutable_random_on_entry_functions: true
-  enable_randomness_ptb_restrictions: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_40.snap
@@ -45,7 +45,6 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  enable_randomness_ptb_restrictions: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -984,25 +984,22 @@ impl ProgrammableTransaction {
         }
 
         // A command that uses Random can only be followed by TransferObjects or MergeCoins.
-        if config.enable_randomness_ptb_restrictions() {
-            // Check if there is a random object in the input objects
-            if let Some(random_index) = inputs.iter().position(|obj| {
-                matches!(obj, CallArg::Object(ObjectArg::SharedObject { id, .. }) if *id == SUI_RANDOMNESS_STATE_OBJECT_ID)
-            }) {
-                let mut used_random_object = false;
-                let random_index = random_index.try_into().unwrap();
-                for command in commands {
-                    if !used_random_object {
-                        used_random_object = command.is_input_arg_used(random_index);
-                    } else {
-                        fp_ensure!(
-                            matches!(
-                                command,
-                                Command::TransferObjects(_, _) | Command::MergeCoins(_, _)
-                            ),
-                            UserInputError::PostRandomCommandRestrictions
-                        );
-                    }
+        if let Some(random_index) = inputs.iter().position(|obj| {
+            matches!(obj, CallArg::Object(ObjectArg::SharedObject { id, .. }) if *id == SUI_RANDOMNESS_STATE_OBJECT_ID)
+        }) {
+            let mut used_random_object = false;
+            let random_index = random_index.try_into().unwrap();
+            for command in commands {
+                if !used_random_object {
+                    used_random_object = command.is_input_arg_used(random_index);
+                } else {
+                    fp_ensure!(
+                        matches!(
+                            command,
+                            Command::TransferObjects(_, _) | Command::MergeCoins(_, _)
+                        ),
+                        UserInputError::PostRandomCommandRestrictions
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Description 

`enable_randomness_ptb_restrictions` is not needed since Random does not yet exist on testnet/mainnet.

(`git cherry-pick 1c60177dcbf876850575c9581f477af7111a6e9d` that removed the unneeded flag in main)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

