### PR TITLE
[pick #16755][GraphQL/E2E] Fix protocol version to 39

### DIFF
--- a/crates/sui-graphql-e2e-tests/README.md
+++ b/crates/sui-graphql-e2e-tests/README.md
@@ -4,7 +4,7 @@ runner.
 # Local Set-up
 
 These tests require a running instance of the `postgres` service, with a
-database set-up.  The instructions below assume that `postgres` has been
+database set-up. The instructions below assume that `postgres` has been
 installed using `brew`:
 
 1. See the instructions in the Sui Indexer [README](../sui-indexer/README.md)
@@ -20,18 +20,20 @@ $ psql "postgres://$ME:$ME@localhost:5432/postgres" \
     -c "CREATE ROLE postgres WITH SUPERUSER LOGIN PASSWORD 'postgrespw';"
 ```
 
-3. Then, create the database that the tests expect, using the `postgres` user and increase the max connections since many tests might run in parallel.
+3. Then, create the database that the tests expect, using the `postgres` user
+   and increase the max connections since many tests might run in parallel.
 
 ```sh
 $ psql "postgres://postgres:postgrespw@localhost:5432/postgres" \
-    -c "CREATE DATABASE sui_indexer_v2; -c 'ALTER SYSTEM SET max_connections = 500;"
+    -c "CREATE DATABASE sui_indexer_v2;" -c "ALTER SYSTEM SET max_connections = 500;"
 ```
 
-4. Finally, restart the `postgres` server so the max connections change takes effect.
+4. Finally, restart the `postgres` server so the max connections change takes
+   effect.
 
 Mac
 ```sh
-brew services restart postgres
+brew services restart postgresql@15
 
 ```
 
@@ -42,8 +44,21 @@ Linux
 
 # Running Locally
 
-When running the tests locally, they must be run with the `pg_integration` feature enabled:
+When running the tests locally, they must be run with the `pg_integration`
+feature enabled:
 
 ```sh
 $ cargo nextest run --features pg_integration
 ```
+
+# Snapshot Stability
+
+Tests are pinned to an existing protocol version that has already been used on a
+production network. The protocol version controls the protocol config and also
+the version of the framework that gets used by tests. By using a version that
+has already been used in a production setting, we are guaranteeing that it will
+not be changed by later modifications to the protocol or framework (this would
+be a bug).
+
+When adding a new test, **remember to set the `--protocol-version`** for that
+test to ensure stability.

--- a/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
+++ b/crates/sui-graphql-e2e-tests/tests/available_range/available_range.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator
+//# init --protocol-version 39 --simulator
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/checkpoint_connection_pagination.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --simulator
 
 // Test cursor connection pagination logic
 // The implementation privileges `after`, `before`, `first`, and `last` in that order.

--- a/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/coin_metadata.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses test=0x0 --accounts A --simulator
 
 //# publish --sender A
 module test::fake {

--- a/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/dynamic_fields.move
@@ -8,7 +8,7 @@
 // This test also demonstrates why we need separate dynamicField and dynamicObjectField APIs.
 // It is possible for a dynamic field and a dynamic object field to share the same name lookup.
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::m {

--- a/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/owned_objects.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 A=0x42 --simulator
+//# init --protocol-version 39 --addresses Test=0x0 A=0x42 --simulator
 
 // Tests objects on address, object, and owner.
 //

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
+//# init --protocol-version 39 --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/balances.move
@@ -14,7 +14,7 @@
 // snapshot@[0, 4), first two transaction blocks are out of available range.
 // snapshot@[0, 6), all transaction blocks are out of available range.
 
-//# init --addresses P0=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A B --simulator
 
 //# publish --sender A
 module P0::fake {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/checkpoints/transaction_blocks.move
@@ -8,7 +8,7 @@
 // 2          | 3
 // 3          | 2
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/coins.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/coins.move
@@ -7,7 +7,7 @@
 // coin2@A | coin2@B | coin2@B | coin2@B | coin2@B | coin2@B
 // coin3@A | coin3@A | coin3@A | coin3@A | coin3@A | coin3@A
 
-//# init --addresses P0=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A B --simulator
 
 //# publish --sender A
 module P0::fake {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_df.move
@@ -9,7 +9,7 @@
 // 5       | removed df1, df2, df3
 // 6       | mutated parent
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/deleted_dof.move
@@ -9,7 +9,7 @@
 // 5              |               | deleted child
 // 6              |               | mutated parent
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer.move
@@ -14,7 +14,7 @@
 // 3              | 3             | added child to parent
 // 4              | 4             | reclaimed child from parent
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dof_add_reclaim_transfer_reclaim_add.move
@@ -13,7 +13,7 @@
 // 4              | 6             | reclaim child from another parent
 // 7              | 7             | add child to original parent
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/dynamic_fields.move
@@ -7,7 +7,7 @@
 // chkpt3: add df4, 5, 6 parent @ version 5, child @ version 4
 // chkpt4: remove df1, df2, df3 parent @ version 6, child @ version 4
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_df.move
@@ -9,7 +9,7 @@
 // 5       | mutated df1
 // 6       | mutated parent again
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/dynamic_fields/mutated_dof.move
@@ -10,7 +10,7 @@
 // 5              | 6             | mutated child
 // 7              | 7             | add child back to parent
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
@@ -8,7 +8,7 @@
 // 2     | 2
 // An additional checkpoint is created at the end.
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# create-checkpoint
 

--- a/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
@@ -17,7 +17,7 @@
 // 11 | epoch          |        11 |     2
 // 12 | epoch          |        12 |     3
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/object_at_version.move
@@ -14,7 +14,7 @@
 // checkpoint 4. The object would only be visible at version 6 from objects_snapshot, and at version
 // 7 from objects_history.
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 
 // cp | object_id | owner

--- a/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/objects_pagination_single.move
@@ -5,7 +5,7 @@
 // one object as a cursor to view the other object that gets mutated per checkpoint. The ordering is
 // consistent even if the cursor object is mutated.
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/performance/many_objects.move
@@ -7,7 +7,7 @@
 // criteria are then invalidated by a newer version of the matched object. We set `last: 1` but
 // transfer the last 3 objects because we increase the limit by 2 behind the scenes.
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/staked_sui.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C
+//# init --protocol-version 39 --simulator --accounts C
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/consistency/tx_address_objects.move
@@ -12,7 +12,7 @@
 // 2  | (3, 3, 3)
 // 3  | (4, 4, 4, 4)
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/datetime/datetime.move
+++ b/crates/sui-graphql-e2e-tests/tests/datetime/datetime.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator
+//# init --protocol-version 39 --simulator
 
 //# create-checkpoint
 

--- a/crates/sui-graphql-e2e-tests/tests/epoch/epoch.move
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/epoch.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C
+//# init --protocol-version 39 --simulator --accounts C
 
 
 // TODO: Short term hack to get around indexer epoch issue

--- a/crates/sui-graphql-e2e-tests/tests/epoch/system_state.move
+++ b/crates/sui-graphql-e2e-tests/tests/epoch/system_state.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C --custom-validator-account 
+//# init --protocol-version 39 --simulator --accounts C --custom-validator-account 
 
 // Run a few transactions and check that the system state storage fund is correctly reported
 // for historical epochs

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/event_connection.move
@@ -9,7 +9,7 @@
 // Verifies correct event when filtered for Test::M1::EventB
 // Verifies error when filtered on sender, package, module and event type with generics and <
 
-//# init --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/nested_emit_event.move
@@ -5,7 +5,7 @@
 // The emitting module is where the entrypoint function is defined -
 // in other words, the function called by a programmable transaction block.
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/event_connection/pagination.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/limits/directives.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/directives.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# run-graphql
 

--- a/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
+++ b/crates/sui-graphql-e2e-tests/tests/limits/output_node_estimation.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses A=0x42 --simulator
+//# init --protocol-version 39 --addresses A=0x42 --simulator
 
 //# run-graphql --show-usage
 # pageInfo does not inherit connection's weights

--- a/crates/sui-graphql-e2e-tests/tests/objects/coin.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/coin.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A --simulator
 
 //# publish --sender A
 module P0::fake {

--- a/crates/sui-graphql-e2e-tests/tests/objects/data.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/data.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A --simulator
 
 //# publish
 module P0::m {

--- a/crates/sui-graphql-e2e-tests/tests/objects/display.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/display.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish --sender A
 module Test::boars {

--- a/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/filter_by_type.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C
+//# init --protocol-version 39 --simulator --accounts C
 
 // TODO: Short term hack to get around indexer epoch issue
 //# create-checkpoint

--- a/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/pagination.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 A=0x42 --simulator
+//# init --protocol-version 39 --addresses Test=0x0 A=0x42 --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/public_transfer.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A --simulator
 
 //# publish
 module P0::m {

--- a/crates/sui-graphql-e2e-tests/tests/objects/received.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/received.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --simulator
 
 //# run-graphql
 {

--- a/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/objects/staked_sui.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C
+//# init --protocol-version 39 --simulator --accounts C
 
 //# run-graphql
 { # Initial query yields only the validator's stake

--- a/crates/sui-graphql-e2e-tests/tests/owner/downcasts.move
+++ b/crates/sui-graphql-e2e-tests/tests/owner/downcasts.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --accounts A --simulator
 
 // Split off a gas coin, so we have an object to query
 //# programmable --sender A --inputs 1000 @A

--- a/crates/sui-graphql-e2e-tests/tests/packages/friends.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/friends.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 P1=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator
 
 //# publish --upgradeable --sender A
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/functions.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/functions.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 P1=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator
 
 //# run-graphql
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/modules.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/modules.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses pkg=0x0 --simulator
+//# init --protocol-version 39 --addresses pkg=0x0 --simulator
 
 //# publish
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/structs.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/structs.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 P1=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator
 
 //# run-graphql
 

--- a/crates/sui-graphql-e2e-tests/tests/packages/types.move
+++ b/crates/sui-graphql-e2e-tests/tests/packages/types.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --simulator
 
 //# run-graphql
 # Happy path -- valid type, get everything

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator --accounts C O P Q R S
+//# init --protocol-version 39 --simulator --accounts C O P Q R S
 
 //# programmable --sender C --inputs @C 1000 2000 3000 4000 5000
 //> SplitCoins(Gas, [Input(1), Input(2), Input(3), Input(4), Input(5)]);

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/dependencies.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/events.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses Test=0x0 --accounts A --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
+++ b/crates/sui-graphql-e2e-tests/tests/transaction_block_effects/object_changes.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
+//# init --protocol-version 39 --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
 
 //# publish
 module Test::M1 {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/errors.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --simulator
 
 //# publish
 

--- a/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/programmable.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 P1=0x0 --accounts A --simulator
+//# init --protocol-version 39 --addresses P0=0x0 P1=0x0 --accounts A --simulator
 
 //# publish --upgradeable --sender A
 module P0::m {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/random.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/random.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator
+//# init --protocol-version 39 --simulator
 
 //# create-checkpoint
 

--- a/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/shared.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses P0=0x0 --simulator
+//# init --protocol-version 39 --addresses P0=0x0 --simulator
 
 //# publish
 module P0::m {

--- a/crates/sui-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/sui-graphql-e2e-tests/tests/transactions/system.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --simulator
+//# init --protocol-version 39 --simulator
 
 // Tests for representations of all the various system transactions
 

--- a/crates/sui-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/sui-graphql-e2e-tests/tests/validator/validator.move
@@ -3,7 +3,7 @@
 
 // Test the change of APY with heavy transactions
 
-//# init --simulator --accounts A --addresses P0=0x0
+//# init --protocol-version 39 --simulator --accounts A --addresses P0=0x0
 
 //# advance-epoch
 


### PR DESCRIPTION
## Description
Make sure all existing E2E tests used a fixed protocol version (I picked 39), so that when there are changes to a future protocol version, they won't cause all the digests/addresses etc in these tests to change.

Also updated the `update_all_snapshots` script to not update these snapshots (should no longer be required) and therefore removed the dependency on `psql`.

Added a section to the E2E test README to remind people to set a protocol version. I opted for an approach where we set a protocol version for each test rather than setting it once for all tests because:

- The logic that controls which protocol version to use is embedded within the sui-specific init logic, but the entrypoint we use in the test runner is from the Move transactional test codebase (which is not aware of protocol versions, etc).
- We may want to set different protocol versions for different tests, in general, and so setting a blanket override or a hidden different default (other than the latest protocol version) seems liable to confuse people.

## Test Plan
Created a change to the framework (and a protocol version bump) on top of this change and ran the tests -- they still passed, with no need to change snapshots.