### PR TITLE
[move-compiler] Update `FilesSourcesText` to Arc the source

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -22,6 +22,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::ExitStatus,
+    sync::Arc,
 };
 // if windows
 #[cfg(target_family = "windows")]
@@ -170,7 +171,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
                 .map(|fname| {
                     let contents = fs::read_to_string(Path::new(fname.as_str())).unwrap();
                     let fhash = FileHash::new(&contents);
-                    (fhash, (*fname, contents))
+                    (fhash, (*fname, Arc::from(contents)))
                 })
                 .collect::<HashMap<_, _>>()
         })

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -30,6 +30,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fs,
     path::Path,
+    sync::Arc,
 };
 
 pub mod on_disk_state_view;
@@ -144,7 +145,7 @@ pub(crate) fn explain_publish_error(
         file_hash,
         (
             FileName::from(unit.source_path.to_string_lossy()),
-            file_contents,
+            Arc::from(file_contents),
         ),
     );
 

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -349,6 +349,10 @@ impl Compiler {
             .iter_mut()
             .for_each(|(_, (path, _))| *path = relativize_path(&vfs_root, *path));
 
+        for (fhash, (fname, contents)) in source_text.iter() {
+            compilation_env.add_source_file(*fhash, *fname, contents.clone())
+        }
+
         let res: Result<_, (Pass, Diagnostics)> =
             SteppedCompiler::new_at_parser(compilation_env, pre_compiled_lib, pprog)
                 .run::<TARGET>()

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -19,7 +19,10 @@ use anyhow::anyhow;
 use comments::*;
 use move_command_line_common::files::{find_move_filenames_vfs, FileHash};
 use move_symbol_pool::Symbol;
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 use vfs::VfsPath;
 
 /// Parses program's targets and dependencies, both of which are read from different virtual file
@@ -149,21 +152,20 @@ fn parse_file(
     path.open_file()?.read_to_string(&mut source_buffer)?;
     let file_hash = FileHash::new(&source_buffer);
     let fname = Symbol::from(path.as_str());
-    let buffer = match verify_string(file_hash, &source_buffer) {
-        Err(ds) => {
+    let source_str = Arc::from(source_buffer);
+    if let Err(ds) = verify_string(file_hash, &source_str) {
             compilation_env.add_diags(ds);
-            files.insert(file_hash, (fname, source_buffer));
+        files.insert(file_hash, (fname, source_str));
             return Ok((vec![], MatchedFileCommentMap::new(), file_hash));
         }
-        Ok(()) => &source_buffer,
-    };
-    let (defs, comments) = match parse_file_string(compilation_env, file_hash, buffer, package) {
+    let (defs, comments) = match parse_file_string(compilation_env, file_hash, &source_str, package)
+    {
         Ok(defs_and_comments) => defs_and_comments,
         Err(ds) => {
             compilation_env.add_diags(ds);
             (vec![], MatchedFileCommentMap::new())
         }
     };
-    files.insert(file_hash, (fname, source_buffer));
+    files.insert(file_hash, (fname, source_str));
     Ok((defs, comments, file_hash))
 }

--- a/external-crates/move/crates/move-unit-test/src/test_reporter.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_reporter.rs
@@ -20,7 +20,7 @@ use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     io::{Result, Write},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -205,7 +205,7 @@ impl TestFailure {
 
     fn get_line_number(
         loc: &Loc,
-        files: &SimpleFiles<Symbol, &str>,
+        files: &SimpleFiles<Symbol, Arc<str>>,
         file_mapping: &HashMap<FileHash, usize>,
     ) -> String {
         Self::get_line_number_internal(loc, files, file_mapping)
@@ -214,7 +214,7 @@ impl TestFailure {
 
     fn get_line_number_internal(
         loc: &Loc,
-        files: &SimpleFiles<Symbol, &str>,
+        files: &SimpleFiles<Symbol, Arc<str>>,
         file_mapping: &HashMap<FileHash, usize>,
     ) -> std::result::Result<String, codespan_reporting::files::Error> {
         let id = file_mapping
@@ -239,7 +239,7 @@ impl TestFailure {
             let mut files = SimpleFiles::new();
             let mut file_mapping = HashMap::new();
             for (fhash, (fname, source)) in &test_plan.files {
-                let id = files.add(*fname, source.as_str());
+                let id = files.add(*fname, source.clone());
                 file_mapping.insert(*fhash, id);
             }
 


### PR DESCRIPTION
## Description 

Arc the strings for file sources inside of `FilesSourcesText` and add a `MappedFiles` struct to manage the file mappings (to be extended and added to over time -- there's places for simplification with this, but that can be done in separate PRs/gradually).

## Test Plan 

Made sure existing tests all pass + #16659 uses this (this was split off from that).

