### PR TITLE
[graphql] Add build sha as a header

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -76,13 +76,13 @@ task 15 'run-graphql'. lines 66-71:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-sui-rpc-version": "2024.2.0-unknown",
+    "x-sui-rpc-version": "2024.2.0-testing-no-sha",
     "access-control-allow-origin": "*",
     "vary": "origin",
     "vary": "access-control-request-method",
     "vary": "access-control-request-headers",
 }
-Service version: 2024.2.0-unknown
+Service version: 2024.2.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -76,13 +76,13 @@ task 15 'run-graphql'. lines 66-71:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-sui-rpc-version": "2024.2.0",
+    "x-sui-rpc-version": "2024.2.0-unknown",
     "access-control-allow-origin": "*",
     "vary": "origin",
     "vary": "access-control-request-method",
     "vary": "access-control-request-headers",
 }
-Service version: 2024.2.0
+Service version: 2024.2.0-unknown
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -135,8 +135,9 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
-/// The Version of the service. major.minor combination represents the major release.
-/// The patch represents a fix in that release.
+/// The Version of the service. `year.month` represents the major release.
+/// New `patch` versions represent backwards compatible fixes for their major release.
+/// The `full` version is `year.month.patch-sha`.
 #[derive(Copy, Clone, Debug)]
 pub struct Version {
     /// The year of this release.
@@ -176,11 +177,7 @@ impl Version {
 
 impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}.{}.{}-{}",
-            self.year, self.month, self.patch, self.sha
-        )
+        write!(f, "{}", self.full)
     }
 }
 

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -135,26 +135,41 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
+/// The Version of the service. major.minor combination represents the major release.
+/// The patch represents a fix in that release.
 #[derive(Copy, Clone, Debug)]
 pub struct Version {
-    /// The major version is set as the year
-    pub major: &'static str,
-    /// The minor version is set as the quarter when this release happened
-    pub minor: &'static str,
-    /// The patch is just an integer that is incremented with each release
-    /// in that quarter
+    /// The year of this release.
+    pub year: &'static str,
+    /// The month of this release.
+    pub month: &'static str,
+    /// The patch is a positive number incremented for every compatible release on top of the major.month release.
     pub patch: &'static str,
-    /// The commit sha for this release
+    /// The commit sha for this release.
     pub sha: &'static str,
+    /// The full version string.
+    /// Note that this extra field is used only for the uptime_metric function which requries a
+    /// &'static str.
+    pub full: &'static str,
 }
 
 impl Version {
+    /// Use for testing when you need the Version obj and a year.month &str
     pub fn for_testing() -> Self {
         Self {
-            major: env!("CARGO_PKG_VERSION_MAJOR"),
-            minor: env!("CARGO_PKG_VERSION_MINOR"),
+            year: env!("CARGO_PKG_VERSION_MAJOR"),
+            month: env!("CARGO_PKG_VERSION_MINOR"),
             patch: env!("CARGO_PKG_VERSION_PATCH"),
             sha: "unknown",
+            // note that this full field is needed for metrics but not for testing
+            full: const_str::concat!(
+                env!("CARGO_PKG_VERSION_MAJOR"),
+                ".",
+                env!("CARGO_PKG_VERSION_MINOR"),
+                ".",
+                env!("CARGO_PKG_VERSION_PATCH"),
+                "-unknown"
+            ),
         }
     }
 }
@@ -164,7 +179,7 @@ impl Display for Version {
         write!(
             f,
             "{}.{}.{}-{}",
-            self.major, self.minor, self.patch, self.sha
+            self.year, self.month, self.patch, self.sha
         )
     }
 }

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -6,7 +6,7 @@ use crate::types::big_int::BigInt;
 use async_graphql::*;
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, time::Duration};
+use std::{collections::BTreeSet, fmt::Display, time::Duration};
 use sui_json_rpc::name_service::NameServiceConfig;
 
 // TODO: calculate proper cost limits
@@ -135,8 +135,39 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
-#[derive(Debug)]
-pub struct Version(pub &'static str);
+#[derive(Copy, Clone, Debug)]
+pub struct Version {
+    /// The major version is set as the year
+    pub major: &'static str,
+    /// The minor version is set as the quarter when this release happened
+    pub minor: &'static str,
+    /// The patch is just an integer that is incremented with each release
+    /// in that quarter
+    pub patch: &'static str,
+    /// The commit sha for this release
+    pub sha: &'static str,
+}
+
+impl Version {
+    pub fn for_testing() -> Self {
+        Self {
+            major: env!("CARGO_PKG_VERSION_MAJOR"),
+            minor: env!("CARGO_PKG_VERSION_MINOR"),
+            patch: env!("CARGO_PKG_VERSION_PATCH"),
+            sha: "unknown",
+        }
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}.{}.{}-{}",
+            self.major, self.minor, self.patch, self.sha
+        )
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -161,7 +161,7 @@ impl Version {
             year: env!("CARGO_PKG_VERSION_MAJOR"),
             month: env!("CARGO_PKG_VERSION_MINOR"),
             patch: env!("CARGO_PKG_VERSION_PATCH"),
-            sha: "unknown",
+            sha: "testing-no-sha",
             // note that this full field is needed for metrics but not for testing
             full: const_str::concat!(
                 env!("CARGO_PKG_VERSION_MAJOR"),
@@ -169,7 +169,7 @@ impl Version {
                 env!("CARGO_PKG_VERSION_MINOR"),
                 ".",
                 env!("CARGO_PKG_VERSION_PATCH"),
-                "-unknown"
+                "-testing-no-sha"
             ),
         }
     }

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -36,13 +36,11 @@ static VERSION: Version = Version {
     patch: env!("CARGO_PKG_VERSION_PATCH"),
     sha: GIT_REVISION,
     full: const_str::concat!(
-        concat!(
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            ".",
-            env!("CARGO_PKG_VERSION_MINOR"),
-            ".",
-            env!("CARGO_PKG_VERSION_PATCH")
-        ),
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        ".",
+        env!("CARGO_PKG_VERSION_MINOR"),
+        ".",
+        env!("CARGO_PKG_VERSION_PATCH"),
         "-",
         GIT_REVISION
     ),

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -23,18 +23,19 @@ const GIT_REVISION: &str = {
         revision
     } else {
         git_version::git_version!(
-            args = ["--always", "--abbrev=12", "--dirty", "--exclude", "*"],
+            args = ["--always", "--abbrev=40", "--dirty", "--exclude", "*"],
             fallback = "DIRTY"
         )
     }
 };
 
 // VERSION mimics what other sui binaries use for the same const
-static VERSION: Version = Version(const_str::concat!(
-    env!("CARGO_PKG_VERSION"),
-    "-",
-    GIT_REVISION
-));
+static VERSION: Version = Version {
+    major: env!("CARGO_PKG_VERSION_MAJOR"),
+    minor: env!("CARGO_PKG_VERSION_MINOR"),
+    patch: env!("CARGO_PKG_VERSION_PATCH"),
+    sha: GIT_REVISION,
+};
 
 #[tokio::main]
 async fn main() {

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -31,10 +31,21 @@ const GIT_REVISION: &str = {
 
 // VERSION mimics what other sui binaries use for the same const
 static VERSION: Version = Version {
-    major: env!("CARGO_PKG_VERSION_MAJOR"),
-    minor: env!("CARGO_PKG_VERSION_MINOR"),
+    year: env!("CARGO_PKG_VERSION_MAJOR"),
+    month: env!("CARGO_PKG_VERSION_MINOR"),
     patch: env!("CARGO_PKG_VERSION_PATCH"),
     sha: GIT_REVISION,
+    full: const_str::concat!(
+        concat!(
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            ".",
+            env!("CARGO_PKG_VERSION_MINOR"),
+            ".",
+            env!("CARGO_PKG_VERSION_PATCH")
+        ),
+        "-",
+        GIT_REVISION
+    ),
 };
 
 #[tokio::main]

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -171,7 +171,7 @@ impl FromRef<AppState> for Metrics {
 
 impl FromRef<AppState> for Version {
     fn from_ref(app_state: &AppState) -> Version {
-        app_state.version.clone()
+        app_state.version
     }
 }
 
@@ -367,7 +367,7 @@ impl ServerBuilder {
             config.service.clone(),
             metrics.clone(),
             cancellation_token,
-            version.clone(),
+            *version,
         );
         let mut builder = ServerBuilder::new(state);
 

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -169,11 +169,11 @@ impl FromRef<AppState> for Metrics {
     }
 }
 
-impl FromRef<AppState> for Version {
-    fn from_ref(app_state: &AppState) -> Version {
-        app_state.version
-    }
-}
+// impl FromRef<AppState> for Version {
+//     fn from_ref(app_state: &AppState) -> Version {
+//         app_state.version
+//     }
+// }
 
 impl ServerBuilder {
     pub fn new(state: AppState) -> Self {
@@ -355,7 +355,7 @@ impl ServerBuilder {
         registry
             .register(mysten_metrics::uptime_metric(
                 "graphql",
-                Box::leak(Box::new(version.clone().to_string())),
+                version.full,
                 "unknown",
             ))
             .unwrap();

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -169,12 +169,6 @@ impl FromRef<AppState> for Metrics {
     }
 }
 
-// impl FromRef<AppState> for Version {
-//     fn from_ref(app_state: &AppState) -> Version {
-//         app_state.version
-//     }
-// }
-
 impl ServerBuilder {
     pub fn new(state: AppState) -> Self {
         Self {

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -140,7 +140,7 @@ pub(crate) struct AppState {
 pub(crate) struct CheckpointWatermark(pub Arc<AtomicU64>);
 
 impl AppState {
-    fn new(
+    pub(crate) fn new(
         connection: ConnectionConfig,
         service: ServiceConfig,
         metrics: Metrics,
@@ -632,7 +632,7 @@ pub mod tests {
 
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-
+        let version = Version::for_testing();
         let metrics = metrics();
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
@@ -643,6 +643,7 @@ pub mod tests {
             service_config.clone(),
             metrics.clone(),
             cancellation_token.clone(),
+            version,
         );
         ServerBuilder::new(state)
             .context_data(db)

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -23,7 +23,7 @@ pub async fn start_graphiql_server(
     cancellation_token: CancellationToken,
 ) -> Result<(), Error> {
     info!("Starting server with config: {:?}", server_config);
-    info!("Server version: {:?}", version);
+    info!("Server version: {}", version);
     start_graphiql_server_impl(
         ServerBuilder::from_config(server_config, version, cancellation_token).await?,
         server_config.ide.ide_title.clone(),

--- a/crates/sui-graphql-rpc/src/server/version.rs
+++ b/crates/sui-graphql-rpc/src/server/version.rs
@@ -147,7 +147,6 @@ mod tests {
     use super::*;
     use crate::{
         config::{ConnectionConfig, ServiceConfig, Version},
-        consistency::CheckpointViewedAt,
         metrics::Metrics,
         server::builder::AppState,
     };

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -185,7 +185,7 @@ pub async fn start_graphql_server_with_fn_rpc(
 
     // Starts graphql server
     tokio::spawn(async move {
-        start_graphiql_server(&server_config, &Version("test"), cancellation_token)
+        start_graphiql_server(&server_config, &Version::for_testing(), cancellation_token)
             .await
             .unwrap();
     })

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -61,7 +61,8 @@ describe('GraphQL SuiClient compatibility', () => {
 	test('getRpcApiVersion', async () => {
 		const version = await graphQLClient!.getRpcApiVersion();
 
-		expect(version?.match(/^\d+.\d+.\d+-[a-z0-9]{40}$/)).not.toBeNull();
+		// unknown is used for testing scenarios where we do not know the SHA
+		expect(version?.match(/^\d+.\d+.\d+-(unknown|[a-z0-9]{40})$/)).not.toBeNull();
 	});
 
 	test('getCoins', async () => {

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -61,7 +61,7 @@ describe('GraphQL SuiClient compatibility', () => {
 	test('getRpcApiVersion', async () => {
 		const version = await graphQLClient!.getRpcApiVersion();
 
-		expect(version?.match(/^\d+.\d+.\d+$/)).not.toBeNull();
+		expect(version?.match(/^\d+.\d+.\d+-[a-z0-9]{40}$/)).not.toBeNull();
 	});
 
 	test('getCoins', async () => {

--- a/sdk/graphql-transport/test/compatability.test.ts
+++ b/sdk/graphql-transport/test/compatability.test.ts
@@ -61,8 +61,8 @@ describe('GraphQL SuiClient compatibility', () => {
 	test('getRpcApiVersion', async () => {
 		const version = await graphQLClient!.getRpcApiVersion();
 
-		// unknown is used for testing scenarios where we do not know the SHA
-		expect(version?.match(/^\d+.\d+.\d+-(unknown|[a-z0-9]{40})$/)).not.toBeNull();
+		// testing-no-sha is used for testing scenarios where we do not know the SHA
+		expect(version?.match(/^\d+.\d+.\d+-(testing-no-sha|[a-z0-9]{40})$/)).not.toBeNull();
 	});
 
 	test('getCoins', async () => {


### PR DESCRIPTION
## Description 

Add the build sha into the existing version header.

## Test Plan 

👀 

```bash
🚀 sui-graphql-rpc % curl -i -X POST http://127.0.0.1:8000 --data '{"query": "query {chainIdentifier}"}'
HTTP/1.1 200 OK
content-type: application/json
content-length: 39
x-sui-rpc-version: 2024.2.0-17a173450a86f16b06b5818f21397b808adb2d8c
access-control-allow-origin: *
vary: origin
vary: access-control-request-method
vary: access-control-request-headers
date: Thu, 21 Mar 2024 01:43:28 GMT
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
