### PR TITLE
[bridge 62/n] make `bridge_client_gas_object` optional, add tests for starting bridge node

### DIFF
--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -94,6 +94,10 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 256
+      - name: Install Foundry
+        run: |
+          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup'; } | bash
+          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
       - name: cargo test
         run: |
           cargo nextest run --profile ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,6 +111,10 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 256
+      - name: Install Foundry
+        run: |
+          curl -L https://foundry.paradigm.xyz | { cat; echo '$FOUNDRY_BIN_DIR/foundryup'; } | bash
+          echo "$HOME/.config/.foundry/bin" >> $GITHUB_PATH
       - name: cargo test
         run: |
           cargo nextest run --profile ci

--- a/crates/sui-bridge/build.rs
+++ b/crates/sui-bridge/build.rs
@@ -23,8 +23,13 @@ fn main() -> Result<(), ExitStatus> {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false);
-    if !forge_installed {
-        eprintln!("Installing forge");
+    let anvil_installed = Command::new("which")
+        .arg("anvil")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    if !forge_installed || !anvil_installed {
+        eprintln!("Installing forge and/or anvil");
         // Also print the path where foundryup is installed
         let install_cmd = "curl -L https://foundry.paradigm.xyz | { cat; echo 'echo foundryup-path=\"$FOUNDRY_BIN_DIR/foundryup\"'; } | bash";
 
@@ -32,7 +37,7 @@ fn main() -> Result<(), ExitStatus> {
             .arg("-c")
             .arg(install_cmd)
             .output()
-            .expect("Failed to install Forge");
+            .expect("Failed to fetch foundryup");
 
         // extract foundryup path
         let output_str = String::from_utf8_lossy(&output.stdout);
@@ -44,7 +49,7 @@ fn main() -> Result<(), ExitStatus> {
             }
         }
         if foundryup_path.is_none() {
-            eprintln!("Error installing forge: expect a foundry path in output");
+            eprintln!("Error installing forge/anvil: expect a foundry path in output");
             exit(1);
         }
         let foundryup_path = foundryup_path.unwrap();

--- a/crates/sui-bridge/src/lib.rs
+++ b/crates/sui-bridge/src/lib.rs
@@ -21,6 +21,7 @@ pub mod sui_syncer;
 pub mod sui_transaction_builder;
 pub mod tools;
 pub mod types;
+pub mod utils;
 
 #[cfg(test)]
 pub(crate) mod eth_mock_provider;

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -81,6 +81,7 @@ async fn start_client_components(
         } else if let Some(cursor) = cursor {
             sui_modules_to_watch.insert(module.clone(), cursor);
         } else {
+            // TODO: for sui the query can start from genesis
             return Err(anyhow::anyhow!(
                 "No cursor found for sui bridge module {} in storage or config override",
                 module
@@ -113,6 +114,7 @@ async fn start_client_components(
             // +1: The stored value is the last block that was processed, so we start from the next block.
             eth_contracts_to_watch.insert(*contract, cursor + 1);
         } else {
+            // TODO: can we not rely on this when node starts for the first time?
             return Err(anyhow::anyhow!(
                 "No cursor found for eth contract {} in storage or config override",
                 contract
@@ -161,4 +163,235 @@ async fn start_client_components(
 
     all_handles.extend(orchestrator.run(bridge_action_executor));
     Ok(all_handles)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::process::Child;
+
+    use super::*;
+    use crate::BRIDGE_ENABLE_PROTOCOL_VERSION;
+    use crate::{config::BridgeNodeConfig, server::APPLICATION_JSON};
+    use fastcrypto::secp256k1::Secp256k1KeyPair;
+    use sui_config::local_ip_utils::get_available_port;
+    use sui_types::base_types::SuiAddress;
+    use sui_types::crypto::get_key_pair;
+    use sui_types::crypto::EncodeDecodeBase64;
+    use sui_types::crypto::KeypairTraits;
+    use sui_types::crypto::SuiKeyPair;
+    use sui_types::digests::TransactionDigest;
+    use sui_types::event::EventID;
+    use test_cluster::TestClusterBuilder;
+
+    const DUMMY_ETH_ADDRESS: &str = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984";
+
+    #[tokio::test]
+    async fn test_starting_bridge_node() {
+        telemetry_subscribers::init_for_testing();
+        let (test_cluster, anvil_port, _child) = setup().await;
+
+        // prepare node config (server only)
+        let tmp_dir = std::env::temp_dir();
+        let authority_key_path = "test_starting_bridge_node_bridge_authority_key";
+        let server_listen_port = get_available_port("127.0.0.1");
+        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
+        let base64_encoded = kp.encode_base64();
+        std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
+
+        let config = BridgeNodeConfig {
+            server_listen_port,
+            metrics_port: get_available_port("127.0.0.1"),
+            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            approved_governance_actions: vec![],
+            run_client: false,
+            bridge_client_key_path_base64_sui_key: None,
+            bridge_client_gas_object: None,
+            sui_bridge_modules: None,
+            db_path: None,
+            eth_bridge_contracts_start_block_override: None,
+            sui_bridge_modules_last_processed_event_id_override: None,
+        };
+        // Spawn bridge node in memory
+        tokio::spawn(async move {
+            run_bridge_node(config).await.unwrap();
+        });
+
+        let server_url = format!("http://127.0.0.1:{}", server_listen_port);
+        // Now we expect to see the server to be up and running.
+        wait_for_server_to_be_up(server_url, 3).await;
+    }
+
+    #[tokio::test]
+    async fn test_starting_bridge_node_with_client() {
+        telemetry_subscribers::init_for_testing();
+        let (test_cluster, anvil_port, _child) = setup().await;
+
+        // prepare node config (server + client)
+        let tmp_dir = std::env::temp_dir();
+        let db_path = tmp_dir.join("test_starting_bridge_node_with_client_db");
+        let authority_key_path = "test_starting_bridge_node_with_client_bridge_authority_key";
+        let server_listen_port = get_available_port("127.0.0.1");
+
+        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
+        let base64_encoded = kp.encode_base64();
+        std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
+
+        let client_sui_address = SuiAddress::from(kp.public());
+        // send some gas to this address
+        test_cluster
+            .transfer_sui_must_exceeed(client_sui_address, 1000000000)
+            .await;
+
+        let config = BridgeNodeConfig {
+            server_listen_port,
+            metrics_port: get_available_port("127.0.0.1"),
+            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            approved_governance_actions: vec![],
+            run_client: true,
+            bridge_client_key_path_base64_sui_key: None,
+            bridge_client_gas_object: None,
+            sui_bridge_modules: Some(vec!["bridge".into()]),
+            db_path: Some(db_path),
+            eth_bridge_contracts_start_block_override: Some(BTreeMap::from_iter(vec![(
+                DUMMY_ETH_ADDRESS.into(),
+                0,
+            )])),
+            sui_bridge_modules_last_processed_event_id_override: Some(BTreeMap::from_iter(vec![(
+                "bridge".into(),
+                EventID {
+                    tx_digest: TransactionDigest::random(),
+                    event_seq: 0,
+                },
+            )])),
+        };
+        // Spawn bridge node in memory
+        let config_clone = config.clone();
+        tokio::spawn(async move {
+            run_bridge_node(config_clone).await.unwrap();
+        });
+
+        let server_url = format!("http://127.0.0.1:{}", server_listen_port);
+        // Now we expect to see the server to be up and running.
+        // client components are spawned earlier than server, so as long as the server is up,
+        // we know the client components are already running.
+        wait_for_server_to_be_up(server_url, 3).await;
+    }
+
+    #[tokio::test]
+    async fn test_starting_bridge_node_with_client_and_separate_client_key() {
+        telemetry_subscribers::init_for_testing();
+        let (test_cluster, anvil_port, _child) = setup().await;
+
+        // prepare node config (server + client)
+        let tmp_dir = std::env::temp_dir();
+        let db_path =
+            tmp_dir.join("test_starting_bridge_node_with_client_and_separate_client_key_db");
+        let authority_key_path =
+            "test_starting_bridge_node_with_client_and_separate_client_key_bridge_authority_key";
+        let server_listen_port = get_available_port("127.0.0.1");
+
+        // prepare bridge authority key
+        let kp = test_cluster.bridge_authority_keys.as_ref().unwrap()[0].copy();
+        let base64_encoded = kp.encode_base64();
+        std::fs::write(tmp_dir.join(authority_key_path), base64_encoded).unwrap();
+
+        // prepare bridge client key
+        let (_, kp): (_, Secp256k1KeyPair) = get_key_pair();
+        let kp = SuiKeyPair::from(kp);
+        let client_key_path =
+            "test_starting_bridge_node_with_client_and_separate_client_key_bridge_client_key";
+        std::fs::write(tmp_dir.join(client_key_path), kp.encode_base64()).unwrap();
+        let client_sui_address = SuiAddress::from(&kp.public());
+
+        // send some gas to this address
+        let gas_obj = test_cluster
+            .transfer_sui_must_exceeed(client_sui_address, 1000000000)
+            .await;
+
+        let config = BridgeNodeConfig {
+            server_listen_port,
+            metrics_port: get_available_port("127.0.0.1"),
+            bridge_authority_key_path_base64_raw: tmp_dir.join(authority_key_path),
+            sui_rpc_url: test_cluster.fullnode_handle.rpc_url,
+            eth_rpc_url: format!("http://127.0.0.1:{}", anvil_port),
+            eth_addresses: vec![DUMMY_ETH_ADDRESS.into()],
+            approved_governance_actions: vec![],
+            run_client: true,
+            bridge_client_key_path_base64_sui_key: Some(tmp_dir.join(client_key_path)),
+            bridge_client_gas_object: Some(gas_obj),
+            sui_bridge_modules: Some(vec!["bridge".into()]),
+            db_path: Some(db_path),
+            eth_bridge_contracts_start_block_override: Some(BTreeMap::from_iter(vec![(
+                DUMMY_ETH_ADDRESS.into(),
+                0,
+            )])),
+            sui_bridge_modules_last_processed_event_id_override: Some(BTreeMap::from_iter(vec![(
+                "bridge".into(),
+                EventID {
+                    tx_digest: TransactionDigest::random(),
+                    event_seq: 0,
+                },
+            )])),
+        };
+        // Spawn bridge node in memory
+        let config_clone = config.clone();
+        tokio::spawn(async move {
+            run_bridge_node(config_clone).await.unwrap();
+        });
+
+        let server_url = format!("http://127.0.0.1:{}", server_listen_port);
+        // Now we expect to see the server to be up and running.
+        // client components are spawned earlier than server, so as long as the server is up,
+        // we know the client components are already running.
+        wait_for_server_to_be_up(server_url, 3).await;
+    }
+
+    async fn setup() -> (test_cluster::TestCluster, u16, Child) {
+        let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
+            .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+            .with_epoch_duration_ms(10000)
+            .build_with_bridge()
+            .await;
+
+        test_cluster
+            .wait_for_next_epoch_and_assert_bridge_committee_initialized()
+            .await;
+
+        // Start eth node with anvil
+        let anvil_port = get_available_port("127.0.0.1");
+        let eth_node_process = std::process::Command::new("anvil")
+            .arg("--port")
+            .arg(anvil_port.to_string())
+            .spawn()
+            .expect("Failed to start anvil");
+
+        (test_cluster, anvil_port, eth_node_process)
+    }
+
+    async fn wait_for_server_to_be_up(server_url: String, timeout_sec: u64) {
+        let now = std::time::Instant::now();
+        // Now we expect to see the server to be up and running, the max time to wait is 3 seconds.
+        loop {
+            if let Ok(true) = reqwest::Client::new()
+                .get(server_url.clone())
+                .header(reqwest::header::ACCEPT, APPLICATION_JSON)
+                .send()
+                .await
+                .map(|res| res.status().is_success())
+            {
+                break;
+            }
+            if now.elapsed().as_secs() > timeout_sec {
+                panic!("Server is not up and running after 3 seconds");
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
 }

--- a/crates/sui-bridge/src/tools/cli.rs
+++ b/crates/sui-bridge/src/tools/cli.rs
@@ -1,33 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
 use clap::*;
-use fastcrypto::ed25519::Ed25519KeyPair;
-use fastcrypto::secp256k1::Secp256k1KeyPair;
-use fastcrypto::traits::EncodeDecodeBase64;
 use shared_crypto::intent::Intent;
 use shared_crypto::intent::IntentMessage;
-use std::path::PathBuf;
 use std::sync::Arc;
 use sui_bridge::client::bridge_authority_aggregator::BridgeAuthorityAggregator;
-use sui_bridge::config::BridgeNodeConfig;
-use sui_bridge::crypto::BridgeAuthorityKeyPair;
-use sui_bridge::crypto::BridgeAuthorityPublicKeyBytes;
 use sui_bridge::eth_transaction_builder::build_eth_transaction;
 use sui_bridge::sui_client::SuiClient;
 use sui_bridge::sui_transaction_builder::build_sui_transaction;
 use sui_bridge::tools::{
     make_action, select_contract_address, Args, BridgeCliConfig, BridgeValidatorCommand,
 };
+use sui_bridge::utils::{
+    generate_bridge_authority_key_and_write_to_file, generate_bridge_client_key_and_write_to_file,
+    generate_bridge_node_config_and_write_to_file,
+};
 use sui_config::Config;
 use sui_sdk::SuiClient as SuiSdkClient;
-use sui_types::base_types::ObjectID;
-use sui_types::base_types::SuiAddress;
 use sui_types::bridge::BridgeChainId;
-use sui_types::crypto::get_key_pair;
 use sui_types::crypto::Signature;
-use sui_types::crypto::SuiKeyPair;
 use sui_types::transaction::Transaction;
 
 #[tokio::main]
@@ -163,77 +155,4 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Generate Bridge Authority key (Secp256k1KeyPair) and write to a file as base64 encoded `privkey`.
-fn generate_bridge_authority_key_and_write_to_file(path: &PathBuf) -> Result<(), anyhow::Error> {
-    let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
-    let eth_address = BridgeAuthorityPublicKeyBytes::from(&kp.public).to_eth_address();
-    println!(
-        "Corresponding Ethereum address by this ecdsa key: {:?}",
-        eth_address
-    );
-    let sui_address = SuiAddress::from(&kp.public);
-    println!(
-        "Corresponding Sui address by this ecdsa key: {:?}",
-        sui_address
-    );
-    let base64_encoded = kp.encode_base64();
-    std::fs::write(path, base64_encoded)
-        .map_err(|err| anyhow!("Failed to write encoded key to path: {:?}", err))
-}
-
-/// Generate Bridge Client key (Secp256k1KeyPair or Ed25519KeyPair) and write to a file as base64 encoded `flag || privkey`.
-fn generate_bridge_client_key_and_write_to_file(
-    path: &PathBuf,
-    use_ecdsa: bool,
-) -> Result<(), anyhow::Error> {
-    let kp = if use_ecdsa {
-        let (_, kp): (_, Secp256k1KeyPair) = get_key_pair();
-        let eth_address = BridgeAuthorityPublicKeyBytes::from(&kp.public).to_eth_address();
-        println!(
-            "Corresponding Ethereum address by this ecdsa key: {:?}",
-            eth_address
-        );
-        SuiKeyPair::from(kp)
-    } else {
-        let (_, kp): (_, Ed25519KeyPair) = get_key_pair();
-        SuiKeyPair::from(kp)
-    };
-    let sui_address = SuiAddress::from(&kp.public());
-    println!("Corresponding Sui address by this key: {:?}", sui_address);
-
-    let contents = kp.encode_base64();
-    std::fs::write(path, contents)
-        .map_err(|err| anyhow!("Failed to write encoded key to path: {:?}", err))
-}
-
-/// Generate Bridge Node Config template and write to a file.
-fn generate_bridge_node_config_and_write_to_file(
-    path: &PathBuf,
-    run_client: bool,
-) -> Result<(), anyhow::Error> {
-    let mut config = BridgeNodeConfig {
-        server_listen_port: 9191,
-        metrics_port: 9184,
-        bridge_authority_key_path_base64_raw: PathBuf::from("/path/to/your/bridge_authority_key"),
-        sui_rpc_url: "your_sui_rpc_url".to_string(),
-        eth_rpc_url: "your_eth_rpc_url".to_string(),
-        eth_addresses: vec!["bridge_eth_proxy_address".into()],
-        approved_governance_actions: vec![],
-        run_client,
-        bridge_client_key_path_base64_sui_key: None,
-        bridge_client_gas_object: None,
-        sui_bridge_modules: Some(vec!["modules_to_watch".into()]),
-        db_path: None,
-        eth_bridge_contracts_start_block_override: None,
-        sui_bridge_modules_last_processed_event_id_override: None,
-    };
-    if run_client {
-        config.bridge_client_key_path_base64_sui_key =
-            Some(PathBuf::from("/path/to/your/bridge_client_key"));
-        config.bridge_client_gas_object = Some(ObjectID::ZERO);
-        config.db_path = Some(PathBuf::from("/path/to/your/client_db"));
-    }
-    config.save(path)
 }

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::BridgeNodeConfig;
+use crate::crypto::BridgeAuthorityKeyPair;
+use crate::crypto::BridgeAuthorityPublicKeyBytes;
+use anyhow::anyhow;
+use fastcrypto::ed25519::Ed25519KeyPair;
+use fastcrypto::secp256k1::Secp256k1KeyPair;
+use fastcrypto::traits::EncodeDecodeBase64;
+use std::path::PathBuf;
+use sui_config::Config;
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::get_key_pair;
+use sui_types::crypto::SuiKeyPair;
+
+/// Generate Bridge Authority key (Secp256k1KeyPair) and write to a file as base64 encoded `privkey`.
+pub fn generate_bridge_authority_key_and_write_to_file(
+    path: &PathBuf,
+) -> Result<(), anyhow::Error> {
+    let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
+    let eth_address = BridgeAuthorityPublicKeyBytes::from(&kp.public).to_eth_address();
+    println!(
+        "Corresponding Ethereum address by this ecdsa key: {:?}",
+        eth_address
+    );
+    let sui_address = SuiAddress::from(&kp.public);
+    println!(
+        "Corresponding Sui address by this ecdsa key: {:?}",
+        sui_address
+    );
+    let base64_encoded = kp.encode_base64();
+    std::fs::write(path, base64_encoded)
+        .map_err(|err| anyhow!("Failed to write encoded key to path: {:?}", err))
+}
+
+/// Generate Bridge Client key (Secp256k1KeyPair or Ed25519KeyPair) and write to a file as base64 encoded `flag || privkey`.
+pub fn generate_bridge_client_key_and_write_to_file(
+    path: &PathBuf,
+    use_ecdsa: bool,
+) -> Result<(), anyhow::Error> {
+    let kp = if use_ecdsa {
+        let (_, kp): (_, Secp256k1KeyPair) = get_key_pair();
+        let eth_address = BridgeAuthorityPublicKeyBytes::from(&kp.public).to_eth_address();
+        println!(
+            "Corresponding Ethereum address by this ecdsa key: {:?}",
+            eth_address
+        );
+        SuiKeyPair::from(kp)
+    } else {
+        let (_, kp): (_, Ed25519KeyPair) = get_key_pair();
+        SuiKeyPair::from(kp)
+    };
+    let sui_address = SuiAddress::from(&kp.public());
+    println!("Corresponding Sui address by this key: {:?}", sui_address);
+
+    let contents = kp.encode_base64();
+    std::fs::write(path, contents)
+        .map_err(|err| anyhow!("Failed to write encoded key to path: {:?}", err))
+}
+
+/// Generate Bridge Node Config template and write to a file.
+pub fn generate_bridge_node_config_and_write_to_file(
+    path: &PathBuf,
+    run_client: bool,
+) -> Result<(), anyhow::Error> {
+    let mut config = BridgeNodeConfig {
+        server_listen_port: 9191,
+        metrics_port: 9184,
+        bridge_authority_key_path_base64_raw: PathBuf::from("/path/to/your/bridge_authority_key"),
+        sui_rpc_url: "your_sui_rpc_url".to_string(),
+        eth_rpc_url: "your_eth_rpc_url".to_string(),
+        eth_addresses: vec!["bridge_eth_proxy_address".into()],
+        approved_governance_actions: vec![],
+        run_client,
+        bridge_client_key_path_base64_sui_key: None,
+        bridge_client_gas_object: None,
+        sui_bridge_modules: Some(vec!["modules_to_watch".into()]),
+        db_path: None,
+        eth_bridge_contracts_start_block_override: None,
+        sui_bridge_modules_last_processed_event_id_override: None,
+    };
+    if run_client {
+        config.bridge_client_key_path_base64_sui_key =
+            Some(PathBuf::from("/path/to/your/bridge_client_key"));
+        config.db_path = Some(PathBuf::from("/path/to/your/client_db"));
+    }
+    config.save(path)
+}

--- a/crates/sui-e2e-tests/tests/bridge_tests.rs
+++ b/crates/sui-e2e-tests/tests/bridge_tests.rs
@@ -76,24 +76,9 @@ async fn test_committee_registration() {
         bridge.committee().member_registrations.contents.len()
     );
 
-    // wait for next epoch
-    test_cluster.wait_for_epoch(None).await;
-
-    let bridge = get_bridge(
-        test_cluster
-            .fullnode_handle
-            .sui_node
-            .state()
-            .get_object_store(),
-    )
-    .unwrap();
-
-    // Committee should be initiated
-    assert!(bridge.committee().member_registrations.contents.is_empty());
-    assert_eq!(
-        test_cluster.swarm.active_validators().count(),
-        bridge.committee().members.contents.len()
-    );
+    test_cluster
+        .wait_for_next_epoch_and_assert_bridge_committee_initialized()
+        .await;
 }
 
 #[tokio::test]

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -43,8 +43,10 @@ use sui_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConf
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ConciseableName;
 use sui_types::base_types::{AuthorityName, ObjectID, ObjectRef, SuiAddress};
+use sui_types::bridge::get_bridge;
 use sui_types::bridge::get_bridge_obj_initial_shared_version;
 use sui_types::bridge::BridgeSummary;
+use sui_types::bridge::BridgeTrait;
 use sui_types::committee::CommitteeTrait;
 use sui_types::committee::{Committee, EpochId};
 use sui_types::crypto::get_key_pair;
@@ -484,6 +486,20 @@ impl TestCluster {
         }
     }
 
+    pub async fn wait_for_next_epoch_and_assert_bridge_committee_initialized(&self) {
+        // wait for next epoch
+        self.wait_for_epoch(None).await;
+
+        let bridge = get_bridge(self.fullnode_handle.sui_node.state().get_object_store()).unwrap();
+
+        // Committee should be initiated
+        assert!(bridge.committee().member_registrations.contents.is_empty());
+        assert_eq!(
+            self.swarm.active_validators().count(),
+            bridge.committee().members.contents.len()
+        );
+    }
+
     pub async fn wait_for_authenticator_state_update(&self) {
         timeout(
             Duration::from_secs(60),
@@ -677,6 +693,22 @@ impl TestCluster {
             .await
             .unwrap()
             .unwrap()
+    }
+
+    pub async fn transfer_sui_must_exceeed(&self, receiver: SuiAddress, amount: u64) -> ObjectID {
+        let sender = self.get_address_0();
+        let tx = self
+            .test_transaction_builder_with_sender(sender)
+            .await
+            .transfer_sui(Some(amount), receiver)
+            .build();
+        let effects = self
+            .sign_and_execute_transaction(&tx)
+            .await
+            .effects
+            .unwrap();
+        assert_eq!(&SuiExecutionStatus::Success, effects.status());
+        effects.created().first().unwrap().object_id()
     }
 
     #[cfg(msim)]
@@ -1034,18 +1066,9 @@ impl TestClusterBuilder {
         for node in test_cluster.swarm.active_validators() {
             let validator_address = node.config.sui_address();
             // 1, send some gas to validator
-            let sender = test_cluster.get_address_0();
-            let tx = test_cluster
-                .test_transaction_builder_with_sender(sender)
-                .await
-                .transfer_sui(Some(1000000000), validator_address)
-                .build();
-            let response = test_cluster.sign_and_execute_transaction(&tx).await;
-            assert_eq!(
-                &SuiExecutionStatus::Success,
-                response.effects.unwrap().status()
-            );
-
+            test_cluster
+                .transfer_sui_must_exceeed(validator_address, 1000000000)
+                .await;
             // 2, create committee registration tx
             let coins = test_cluster
                 .sui_client()


### PR DESCRIPTION
## Description 

This PR does two things:
1. make `bridge_client_gas_object` in BridgeConfig optional. If no gas object is provided, then we look for any gas object owned by the client address.
2. add tests for starting bridge node.
3. move key generation helper functions to `crates/sui-bridge/src/utils.rs`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
