### PR TITLE
indexer fix: user input instead of fast-path opts

### DIFF
--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -41,12 +41,10 @@ impl WriteApiServer for WriteApi {
         options: Option<SuiTransactionBlockResponseOptions>,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
-        let fast_path_options = SuiTransactionBlockResponseOptions::full_content();
         let sui_transaction_response = self
             .fullnode
-            .execute_transaction_block(tx_bytes, signatures, Some(fast_path_options), request_type)
+            .execute_transaction_block(tx_bytes, signatures, options.clone(), request_type)
             .await?;
-
         Ok(SuiTransactionBlockResponseWithOptions {
             response: sui_transaction_response,
             options: options.unwrap_or_default(),


### PR DESCRIPTION
## Description 

the fast-path opts were needed when we wanted read-after-write consistency, but it's no longer needed and could cause error as described in https://mysten-labs.slack.com/archives/C0578KFD9D2/p1710944999356049

## Test Plan 

local indexer server and run

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
