### PR TITLE
[docs][sdk] Update links and lib ref

### DIFF
--- a/sdk/docs/pages/typescript/cryptography/keypairs.mdx
+++ b/sdk/docs/pages/typescript/cryptography/keypairs.mdx
@@ -12,7 +12,7 @@ The Sui TypeScript SDK supports three signing schemes:
 | ECDSA Secp256r1 | `Secp256r1Keypair` | `@mysten/sui.js/keypairs/secp256r1` |
 
 For information on these schemes, see the
-[Sui Wallet Specifications](https://docs.sui.io/testnet/learn/cryptography/sui-wallet-specs) topic.
+[Signatures](https://docs.sui.io/concepts/cryptography/transaction-auth/signatures) topic.
 
 To use, import the key pair class your project uses from the `@mysten/sui.js/keypairs` folder. For
 example, to use the Ed25519 scheme, import the `Ed25519Keypair` class from

--- a/sdk/docs/pages/typescript/cryptography/multisig.mdx
+++ b/sdk/docs/pages/typescript/cryptography/multisig.mdx
@@ -1,8 +1,8 @@
 # Multi-Signature Transactions
 
 The Sui TypeScript SDK provides a `MultiSigPublicKey` class to support
-[Multi-Signature](https://docs.sui.io/concepts/cryptography/transaction-auth/multisig) (MultiSig) transaction and
-personal message signing.
+[Multi-Signature](https://docs.sui.io/concepts/cryptography/transaction-auth/multisig) (MultiSig)
+transaction and personal message signing.
 
 This class implements the same interface as the `PublicKey` classes that [Keypairs](./keypairs) uses
 and you call the same methods to verify signatures for `PersonalMessages` and `TransactionBlocks`.

--- a/sdk/docs/pages/typescript/cryptography/multisig.mdx
+++ b/sdk/docs/pages/typescript/cryptography/multisig.mdx
@@ -1,7 +1,7 @@
 # Multi-Signature Transactions
 
 The Sui TypeScript SDK provides a `MultiSigPublicKey` class to support
-[Multi-Signature](https://docs.sui.io/learn/cryptography/sui-multisig) (MultiSig) transaction and
+[Multi-Signature](https://docs.sui.io/concepts/cryptography/transaction-auth/multisig) (MultiSig) transaction and
 personal message signing.
 
 This class implements the same interface as the `PublicKey` classes that [Keypairs](./keypairs) uses

--- a/sdk/docs/pages/typescript/hello-sui.mdx
+++ b/sdk/docs/pages/typescript/hello-sui.mdx
@@ -108,5 +108,5 @@ the faucet. You can check the total SUI for your address using the Sui Wallet or
 	the limit and must wait to successfully run it again.
 </Callout>
 
-You can also use the [Sui Client CLI](https://docs.sui.io/references/cli/client) to perform client calls
-on a Sui network.
+You can also use the [Sui Client CLI](https://docs.sui.io/references/cli/client) to perform client
+calls on a Sui network.

--- a/sdk/docs/pages/typescript/hello-sui.mdx
+++ b/sdk/docs/pages/typescript/hello-sui.mdx
@@ -10,8 +10,8 @@ projects.
 ## Before you begin
 
 You need an address on a Sui development network (Devnet, Testnet, local). If you don't already have
-an address, use the [Sui Client CLI](https://docs.sui.io/build/cli-client) or the
-[Sui Wallet browser extension](https://docs.mystenlabs.com/wallet) to create one.
+an address, use the [Sui Client CLI](https://docs.sui.io/references/cli/client) or the
+[Sui Wallet browser extension](https://docs.mystenlabs.com) to create one.
 
 You also need [Node.js](https://nodejs.org/en/download/current) and a package manager like
 [pnpm](https://pnpm.io/installation) to follow this example, so install them on your system if you
@@ -53,7 +53,7 @@ Create a new `index.js` file in the root of your project with the following code
 
 ```js
 import { getFullnodeUrl, SuiClient } from '@mysten/sui.js/client';
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui.js/faucet';
+import { getFaucetHost, requestSuiFromFaucetv1 } from '@mysten/sui.js/faucet';
 import { MIST_PER_SUI } from '@mysten/sui.js/utils';
 
 // replace <YOUR_SUI_ADDRESS> with your actual address, which is in the form 0x123...
@@ -72,7 +72,7 @@ const suiBefore = await suiClient.getBalance({
 	owner: MY_ADDRESS,
 });
 
-await requestSuiFromFaucetV0({
+await requestSuiFromFaucetv1({
 	// use getFaucetHost to make sure you're using correct faucet address
 	// you can also just use the address (see Sui TypeScript SDK Quick Start for values)
 	host: getFaucetHost('devnet'),
@@ -98,7 +98,7 @@ Save the file, then use Node.js to run it in your Console or Terminal:
 node index.js
 ```
 
-The code imports the `requestSuiFromFaucetV0` function from the SDK and calls it to mint SUI for the
+The code imports the `requestSuiFromFaucetv1` function from the SDK and calls it to mint SUI for the
 provided address. The code also imports `SuiClient` to create a new client on the Sui network that
 it uses to query the address and output the amount of SUI the address owns before and after using
 the faucet. You can check the total SUI for your address using the Sui Wallet or Sui Client CLI.
@@ -108,5 +108,5 @@ the faucet. You can check the total SUI for your address using the Sui Wallet or
 	the limit and must wait to successfully run it again.
 </Callout>
 
-You can also use the [Sui Client CLI](https://docs.sui.io/build/cli-client) to perform client calls
+You can also use the [Sui Client CLI](https://docs.sui.io/references/cli/client) to perform client calls
 on a Sui network.

--- a/sdk/docs/pages/typescript/install.mdx
+++ b/sdk/docs/pages/typescript/install.mdx
@@ -16,9 +16,9 @@ npm i @mysten/sui.js
 Projects developing against one of the on-chain Sui networks (Devnet, Testnet, Mainnet) should use
 the base SDK published in the NPM registry (previous section) because the code aligns with the
 relevant JSON-RPC. If your developing against a
-[local network](https://docs.sui.io/guides/developer/getting-started/local-network) built from the `main` branch of
-the Sui monorepo, however, you should use the `experimental`-tagged SDK package as it contains the
-latest features (or a local build detailed in the section that follows).
+[local network](https://docs.sui.io/guides/developer/getting-started/local-network) built from the
+`main` branch of the Sui monorepo, however, you should use the `experimental`-tagged SDK package as
+it contains the latest features (or a local build detailed in the section that follows).
 
 ```sh npm2yarn
 npm i @mysten/sui.js@experimental

--- a/sdk/docs/pages/typescript/install.mdx
+++ b/sdk/docs/pages/typescript/install.mdx
@@ -16,7 +16,7 @@ npm i @mysten/sui.js
 Projects developing against one of the on-chain Sui networks (Devnet, Testnet, Mainnet) should use
 the base SDK published in the NPM registry (previous section) because the code aligns with the
 relevant JSON-RPC. If your developing against a
-[local network](https://docs.sui.io/testnet/build/sui-local-network) built from the `main` branch of
+[local network](https://docs.sui.io/guides/developer/getting-started/local-network) built from the `main` branch of
 the Sui monorepo, however, you should use the `experimental`-tagged SDK package as it contains the
 latest features (or a local build detailed in the section that follows).
 

--- a/sdk/docs/pages/typescript/sui-client.mdx
+++ b/sdk/docs/pages/typescript/sui-client.mdx
@@ -36,7 +36,7 @@ during development. In a production application, however, you should use the
 
 For local development, you can run `cargo run --bin sui-test-validator` to spin up a local network
 with a local validator, a Full node, and a faucet server. Refer to
-[the Local Network guide](https://docs.sui.io/build/sui-local-network) for more information.
+[the Local Network guide](https://docs.sui.io/guides/developer/getting-started/local-network) for more information.
 
 ## Manually calling unsupported RPC methods
 
@@ -54,7 +54,7 @@ const committeeInfo = await client.call('suix_getCommitteeInfo', []);
 ```
 
 For a full list of available RPC methods, see the
-[RPC documentation](https://docs.sui.io/sui-jsonrpc).
+[RPC documentation](https://docs.sui.io/references/sui-api).
 
 ## Subscribing to events with SuiClient
 

--- a/sdk/docs/pages/typescript/sui-client.mdx
+++ b/sdk/docs/pages/typescript/sui-client.mdx
@@ -36,7 +36,8 @@ during development. In a production application, however, you should use the
 
 For local development, you can run `cargo run --bin sui-test-validator` to spin up a local network
 with a local validator, a Full node, and a faucet server. Refer to
-[the Local Network guide](https://docs.sui.io/guides/developer/getting-started/local-network) for more information.
+[the Local Network guide](https://docs.sui.io/guides/developer/getting-started/local-network) for
+more information.
 
 ## Manually calling unsupported RPC methods
 

--- a/sdk/docs/pages/typescript/transaction-building/gas.mdx
+++ b/sdk/docs/pages/typescript/transaction-building/gas.mdx
@@ -3,8 +3,7 @@
 With Programmable Transaction blocks, you can use the gas payment coin to construct coins with a set
 balance using `splitCoin`. This is useful for Sui payments, and avoids the need for up-front coin
 selection. You can use `txb.gas` to access the gas coin in a transaction block, and it is valid as
-input for any arguments, as long as it is used
-[by-reference](https://docs.sui.io/build/programming-with-objects/ch2-using-objects#pass-objects-by-reference).
+input for any arguments, as long as it is used [by-reference](https://docs.sui.io/guides/developer/sui-101/simulating-refs).
 Practically speaking, this means you can also add to the gas coin with `mergeCoins` and borrow it
 for Move functions with `moveCall`.
 

--- a/sdk/docs/pages/typescript/transaction-building/gas.mdx
+++ b/sdk/docs/pages/typescript/transaction-building/gas.mdx
@@ -3,9 +3,10 @@
 With Programmable Transaction blocks, you can use the gas payment coin to construct coins with a set
 balance using `splitCoin`. This is useful for Sui payments, and avoids the need for up-front coin
 selection. You can use `txb.gas` to access the gas coin in a transaction block, and it is valid as
-input for any arguments, as long as it is used [by-reference](https://docs.sui.io/guides/developer/sui-101/simulating-refs).
-Practically speaking, this means you can also add to the gas coin with `mergeCoins` and borrow it
-for Move functions with `moveCall`.
+input for any arguments, as long as it is used
+[by-reference](https://docs.sui.io/guides/developer/sui-101/simulating-refs). Practically speaking,
+this means you can also add to the gas coin with `mergeCoins` and borrow it for Move functions with
+`moveCall`.
 
 You can also transfer the gas coin using `transferObjects`, in the event that you want to transfer
 all of your coin balance to another address.


### PR DESCRIPTION
## Description 

Slack message pointed out requestSuiFromFaucetV0 s/b requestSuiFromFaucetV1 and there was a link without a redirect. Updated other links to docs.sui while here.

## Test Plan 

👀 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
