### PR TITLE
[Consensus] use consensus_ as metric prefix

### DIFF
--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -112,7 +112,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             .find(|(_, a)| &a.protocol_key == self.keypair.public())
             .expect("Own authority should be among the consensus authorities!");
 
-        let registry = Registry::new_custom(Some("mysticeti_".to_string()), None).unwrap();
+        let registry = Registry::new_custom(Some("consensus".to_string()), None).unwrap();
 
         // TODO: that should be replaced by a metered channel. We can discuss if unbounded approach
         // is the one we want to go with.


### PR DESCRIPTION
## Description 

This is more consistent with the code structure, and avoids the double "_".

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
