### PR TITLE
[graphql][cherry-pick] Fix metrics issue with elapsed time not being correct (#16782)

### DIFF
--- a/crates/sui-graphql-rpc/src/data/pg.rs
+++ b/crates/sui-graphql-rpc/src/data/pg.rs
@@ -58,9 +58,8 @@ impl QueryExecutor for PgExecutor {
             .inner
             .run_query_async(move |conn| txn(&mut PgConnection { max_cost, conn }))
             .await;
-        let elapsed = instant.elapsed();
         self.metrics
-            .observe_db_data(elapsed.as_secs(), result.is_ok());
+            .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
             error!("DB query error: {e:?}");
         }
@@ -81,9 +80,8 @@ impl QueryExecutor for PgExecutor {
             .inner
             .run_query_repeatable_async(move |conn| txn(&mut PgConnection { max_cost, conn }))
             .await;
-        let elapsed = instant.elapsed();
         self.metrics
-            .observe_db_data(elapsed.as_secs(), result.is_ok());
+            .observe_db_data(instant.elapsed(), result.is_ok());
         if let Err(e) = &result {
             error!("DB query error: {e:?}");
         }

--- a/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
+++ b/crates/sui-graphql-rpc/src/extensions/query_limits_checker.rs
@@ -189,8 +189,6 @@ impl Extension for QueryLimitsChecker {
             )?;
             max_depth_seen = max_depth_seen.max(running_costs.depth);
         }
-        let elapsed = instant.elapsed().as_millis() as u64;
-
         if ctx.data_opt::<ShowUsage>().is_some() {
             *self.validation_result.lock().await = Some(ValidationRes {
                 input_nodes: running_costs.input_nodes,
@@ -201,7 +199,7 @@ impl Extension for QueryLimitsChecker {
                 num_fragments: doc.fragments.len() as u32,
             });
         }
-        metrics.query_validation_latency(elapsed);
+        metrics.query_validation_latency(instant.elapsed());
         metrics
             .request_metrics
             .input_nodes

--- a/crates/sui-graphql-rpc/src/metrics.rs
+++ b/crates/sui-graphql-rpc/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_graphql::{PathSegment, ServerError};
 use prometheus::{
@@ -95,25 +95,27 @@ impl Metrics {
     }
 
     /// Updates the DB related metrics (latency, error, success)
-    pub(crate) fn observe_db_data(&self, time: u64, succeeded: bool) {
+    pub(crate) fn observe_db_data(&self, time: Duration, succeeded: bool) {
         let label = if succeeded { "success" } else { "error" };
         self.db_metrics.db_fetches.with_label_values(&[label]).inc();
         self.db_metrics
             .db_fetch_latency
             .with_label_values(&[label])
-            .observe(time as f64);
+            .observe(time.as_secs_f64());
     }
 
     /// The total time needed for handling the query
-    pub(crate) fn query_latency(&self, time: u64) {
-        self.request_metrics.query_latency.observe(time as f64);
+    pub(crate) fn query_latency(&self, time: Duration) {
+        self.request_metrics
+            .query_latency
+            .observe(time.as_secs_f64());
     }
 
     /// The time needed for validating the query
-    pub(crate) fn query_validation_latency(&self, time: u64) {
+    pub(crate) fn query_validation_latency(&self, time: Duration) {
         self.request_metrics
             .query_validation_latency
-            .observe(time as f64);
+            .observe(time.as_secs_f64());
     }
 
     /// Increment the total number of queries by one

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -403,8 +403,7 @@ impl ResponseHandler for MetricsCallbackHandler {
 
 impl Drop for MetricsCallbackHandler {
     fn drop(&mut self) {
-        let elapsed = self.start.elapsed().as_millis() as u64;
-        self.metrics.query_latency(elapsed);
+        self.metrics.query_latency(self.start.elapsed());
         self.metrics.request_metrics.inflight_requests.dec();
     }
 }


### PR DESCRIPTION
## Description 

Fix metrics issue with elapsed time not being correctly converted to seconds. It is now standardized everywhere that any elapsed argument should be of type `Duration`, and on that variable we call `as_secs_f64()` to pass it to the prometheus metric. This should fix the problem with the latency metric in our dashboards.

## Test Plan 

👀 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
