### PR TITLE
Add shared object version manager

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -193,6 +193,7 @@ pub mod authority_store_pruner;
 pub mod authority_store_tables;
 pub mod authority_store_types;
 pub mod epoch_start_configuration;
+pub mod shared_object_version_manager;
 pub mod test_authority_builder;
 
 pub(crate) mod authority_notify_read;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -18,7 +18,6 @@ use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::future::Future;
-use std::iter;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_config::node::ExpensiveSafetyCheckConfig;
@@ -34,11 +33,10 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::InputKey;
 use sui_types::transaction::{
-    AuthenticatorStateUpdate, CertifiedTransaction, InputObjectKind, SenderSignedData,
-    SharedInputObject, Transaction, TransactionDataAPI, TransactionKey, TransactionKind,
-    VerifiedCertificate, VerifiedSignedTransaction, VerifiedTransaction,
+    AuthenticatorStateUpdate, CertifiedTransaction, InputObjectKind, SenderSignedData, Transaction,
+    TransactionDataAPI, TransactionKey, TransactionKind, VerifiedCertificate,
+    VerifiedSignedTransaction, VerifiedTransaction,
 };
-use sui_types::SUI_RANDOMNESS_STATE_OBJECT_ID;
 use tokio::sync::OnceCell;
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::rocks::{read_size_from_env, ReadWriteOptions};
@@ -57,6 +55,9 @@ use crate::checkpoints::{
     PendingCheckpoint, PendingCheckpointInfo, PendingCheckpointV2, PendingCheckpointV2Contents,
 };
 
+use crate::authority::shared_object_version_manager::{
+    AssignedTxAndVersions, ConsensusSharedObjVerAssignment, SharedObjVerManager,
+};
 use crate::consensus_handler::{
     SequencedConsensusTransaction, SequencedConsensusTransactionKey,
     SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
@@ -80,7 +81,7 @@ use sui_execution::{self, Executor};
 use sui_macros::fail_point;
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_storage::mutex_table::{MutexGuard, MutexTable};
-use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::effects::TransactionEffects;
 use sui_types::executable_transaction::{
     TrustedExecutableTransaction, VerifiedExecutableTransaction,
 };
@@ -92,9 +93,7 @@ use sui_types::messages_consensus::{
     check_total_jwk_size, AuthorityCapabilities, ConsensusTransaction, ConsensusTransactionKey,
     ConsensusTransactionKind,
 };
-use sui_types::storage::{
-    transaction_input_object_keys, transaction_receiving_object_keys, GetSharedLocks, ObjectKey,
-};
+use sui_types::storage::GetSharedLocks;
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartSystemStateTrait,
 };
@@ -1411,7 +1410,7 @@ impl AuthorityPerEpochStore {
     // Because all paths that assign shared locks for a shared object transaction call this
     // function, it is impossible for parent_sync to be updated before this function completes
     // successfully for each affected object id.
-    async fn get_or_init_next_object_versions(
+    pub(crate) async fn get_or_init_next_object_versions(
         &self,
         objects_to_init: &[(ObjectID, SequenceNumber)],
         cache_reader: &dyn ExecutionCacheRead,
@@ -1483,27 +1482,20 @@ impl AuthorityPerEpochStore {
 
     async fn set_assigned_shared_object_versions(
         &self,
-        tx_key: &TransactionKey,
-        init_shared_versions: &[(ObjectID, SequenceNumber)],
-        assigned_versions: &Vec<(ObjectID, SequenceNumber)>,
-        cache_reader: &dyn ExecutionCacheRead,
+        versions: AssignedTxAndVersions,
+        db_batch: &mut DBBatch,
     ) -> SuiResult {
-        debug!(
-            ?tx_key,
-            ?assigned_versions,
-            "set_assigned_shared_object_versions"
-        );
+        debug!("set_assigned_shared_object_versions: {:?}", versions);
 
-        self.get_or_init_next_object_versions(init_shared_versions, cache_reader)
-            .await?;
         if self.randomness_state_enabled() {
-            self.tables()?
-                .assigned_shared_object_versions_v2
-                .insert(tx_key, assigned_versions)?;
+            db_batch.insert_batch(&self.tables()?.assigned_shared_object_versions_v2, versions)?;
         } else {
-            self.tables()?
-                .assigned_shared_object_versions
-                .insert(tx_key.unwrap_digest(), assigned_versions)?;
+            db_batch.insert_batch(
+                &self.tables()?.assigned_shared_object_versions,
+                versions
+                    .iter()
+                    .map(|(key, versions)| (key.unwrap_digest(), versions)),
+            )?;
         }
         Ok(())
     }
@@ -1597,6 +1589,7 @@ impl AuthorityPerEpochStore {
     /// Lock a sequence number for the shared objects of the input transaction based on the effects
     /// of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who catch up by state sync.
+    // TODO: We should be able to pass in a vector of certs/effects and lock them all at once.
     #[instrument(level = "trace", skip_all)]
     pub async fn acquire_shared_locks_from_effects(
         &self,
@@ -1604,22 +1597,17 @@ impl AuthorityPerEpochStore {
         effects: &TransactionEffects,
         cache_reader: &dyn ExecutionCacheRead,
     ) -> SuiResult {
-        let init_shared_versions: Vec<_> = certificate
-            .shared_input_objects()
-            .map(SharedInputObject::into_id_and_version)
-            .collect();
-        let assigned_versions: Vec<_> = effects
-            .input_shared_objects()
-            .into_iter()
-            .map(|iso| iso.id_and_version())
-            .collect();
-        self.set_assigned_shared_object_versions(
-            &certificate.key(),
-            &init_shared_versions,
-            &assigned_versions,
+        let versions = SharedObjVerManager::assign_versions_from_effects(
+            &[(certificate, effects)],
+            self,
             cache_reader,
         )
-        .await
+        .await?;
+        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
+        self.set_assigned_shared_object_versions(versions, &mut db_batch)
+            .await?;
+        db_batch.write()?;
+        Ok(())
     }
 
     /// When submitting a certificate caller **must** provide a ReconfigState lock guard
@@ -2006,92 +1994,6 @@ impl AuthorityPerEpochStore {
     pub fn jwk_active_in_current_epoch(&self, jwk_id: &JwkId, jwk: &JWK) -> bool {
         let jwk_aggregator = self.jwk_aggregator.lock();
         jwk_aggregator.has_quorum_for_key(&(jwk_id.clone(), jwk.clone()))
-    }
-
-    /// Locks a sequence number for the shared objects of the input transaction. Also updates the
-    /// last consensus index, consensus_message_processed and pending_certificates tables.
-    /// This function must only be called from the consensus task (i.e. from handle_consensus_transaction).
-    ///
-    /// Caller is responsible to call consensus_message_processed before this method
-    pub async fn record_shared_object_cert_from_consensus(
-        &self,
-        batch: &mut DBBatch,
-        shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
-        certificate: &VerifiedExecutableTransaction,
-    ) -> Result<(), SuiError> {
-        // Make an iterator to save the certificate.
-        let transaction_digest = *certificate.digest();
-
-        // Make an iterator to update the locks of the transaction's shared objects.
-        let shared_input_objects: Vec<_> = certificate.shared_input_objects().collect();
-
-        let mut input_object_keys = transaction_input_object_keys(certificate)?;
-        let mut assigned_versions = Vec::with_capacity(shared_input_objects.len());
-        let mut is_mutable_input = Vec::with_capacity(shared_input_objects.len());
-        // Record receiving object versions towards the shared version computation.
-        let receiving_object_keys = transaction_receiving_object_keys(certificate);
-        input_object_keys.extend(receiving_object_keys);
-
-        for (SharedInputObject { id, mutable, .. }, version) in shared_input_objects
-            .iter()
-            .map(|obj| (obj, *shared_input_next_versions.get(&obj.id()).unwrap()))
-        {
-            assigned_versions.push((*id, version));
-            input_object_keys.push(ObjectKey(*id, version));
-            is_mutable_input.push(*mutable);
-        }
-
-        let next_version =
-            SequenceNumber::lamport_increment(input_object_keys.iter().map(|obj| obj.1));
-
-        // Update the next version for the shared objects.
-        assigned_versions
-            .iter()
-            .zip(is_mutable_input.into_iter())
-            .filter_map(|((id, _), mutable)| {
-                if mutable {
-                    Some((*id, next_version))
-                } else {
-                    None
-                }
-            })
-            .for_each(|(id, version)| {
-                shared_input_next_versions.insert(id, version);
-            });
-
-        trace!(tx_digest = ?transaction_digest,
-               ?assigned_versions, ?next_version,
-               "locking shared objects");
-
-        self.finish_assign_shared_object_versions(batch, certificate, assigned_versions)
-    }
-
-    fn finish_assign_shared_object_versions(
-        &self,
-        write_batch: &mut DBBatch,
-        certificate: &VerifiedExecutableTransaction,
-        assigned_versions: Vec<(ObjectID, SequenceNumber)>,
-    ) -> SuiResult {
-        let tx_key = certificate.key();
-
-        debug!(
-            ?tx_key,
-            ?assigned_versions,
-            "finish_assign_shared_object_versions"
-        );
-        if self.randomness_state_enabled() {
-            write_batch.insert_batch(
-                &self.tables()?.assigned_shared_object_versions_v2,
-                iter::once((tx_key, assigned_versions)),
-            )?;
-        } else {
-            write_batch.insert_batch(
-                &self.tables()?.assigned_shared_object_versions,
-                iter::once((tx_key.unwrap_digest(), assigned_versions.clone())),
-            )?;
-        }
-
-        Ok(())
     }
 
     /// Record when finished processing a transaction from consensus.
@@ -2644,6 +2546,32 @@ impl AuthorityPerEpochStore {
         Ok(transactions_to_schedule)
     }
 
+    async fn process_consensus_transaction_shared_object_versions(
+        &self,
+        cache_reader: &dyn ExecutionCacheRead,
+        transactions: &[VerifiedExecutableTransaction],
+        randomness_round: Option<RandomnessRound>,
+        db_batch: &mut DBBatch,
+    ) -> SuiResult {
+        let ConsensusSharedObjVerAssignment {
+            shared_input_next_versions,
+            assigned_versions,
+        } = SharedObjVerManager::assign_versions_from_consensus(
+            self,
+            cache_reader,
+            transactions,
+            randomness_round,
+        )
+        .await?;
+        self.set_assigned_shared_object_versions(assigned_versions, db_batch)
+            .await?;
+        db_batch.insert_batch(
+            &self.tables()?.next_shared_object_versions,
+            shared_input_next_versions,
+        )?;
+        Ok(())
+    }
+
     #[cfg(any(test, feature = "test-utils"))]
     fn get_highest_pending_checkpoint_height(&self) -> CheckpointHeight {
         if self.randomness_state_enabled() {
@@ -2731,72 +2659,22 @@ impl AuthorityPerEpochStore {
         Option<RandomnessRound>, // round number for generated randomness
         bool,                    // true if final round
     )> {
-        if generate_randomness {
+        let randomness_round = if generate_randomness {
             // invariant checks
-            assert!(randomness_manager.is_some());
             assert!(dkg_closed);
-        }
+            Some(
+                randomness_manager
+                    .as_mut()
+                    .expect("randomness manager should exist if randomness is enabled")
+                    .reserve_next_randomness(batch)?,
+            )
+        } else {
+            None
+        };
 
         let mut verified_certificates = Vec::with_capacity(transactions.len());
         let mut notifications = Vec::with_capacity(transactions.len());
         let mut deferred_tx_roots = Vec::with_capacity(transactions.len());
-
-        let mut reserved_randomness_round = None;
-
-        // get the current next versions for each shared object in transactions
-        let mut shared_input_next_versions = {
-            let unique_shared_input_objects = {
-                let mut shared_input_objects: Vec<_> = transactions
-                    .iter()
-                    .filter_map(|tx| tx.0.as_shared_object_txn())
-                    .flat_map(|tx| {
-                        tx.transaction_data()
-                            .shared_input_objects()
-                            .into_iter()
-                            .map(|so| so.into_id_and_version())
-                    })
-                    .collect();
-
-                if generate_randomness {
-                    shared_input_objects.push((
-                        SUI_RANDOMNESS_STATE_OBJECT_ID,
-                        self.epoch_start_config().randomness_obj_initial_shared_version().expect("randomness_obj_initial_shared_version should exist if randomness is enabled")
-                    ));
-                }
-
-                shared_input_objects.sort();
-                shared_input_objects.dedup();
-                shared_input_objects
-            };
-
-            let mut shared_input_next_versions = self
-                .get_or_init_next_object_versions(&unique_shared_input_objects, cache_reader)
-                .await?;
-
-            // If we're generating randomness, update the randomness state object version.
-            if generate_randomness {
-                let round = randomness_manager
-                    .as_mut()
-                    .expect("randomness manager should exist if randomness is enabled")
-                    .reserve_next_randomness(batch)?;
-                reserved_randomness_round = Some(round);
-
-                let version = shared_input_next_versions
-                    .get_mut(&SUI_RANDOMNESS_STATE_OBJECT_ID)
-                    .expect("added randomness state object to lookup above");
-                debug!("assigning shared object versions for randomness: epoch {}, round {round:?} -> version {version:?}", self.epoch());
-                batch.insert_batch(
-                    &self.tables()?.assigned_shared_object_versions_v2,
-                    iter::once((
-                        TransactionKey::RandomnessRound(self.epoch(), round),
-                        vec![(SUI_RANDOMNESS_STATE_OBJECT_ID, *version)],
-                    )),
-                )?;
-                version.increment();
-            }
-
-            shared_input_next_versions
-        };
 
         let mut deferred_txns: BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>> =
             BTreeMap::new();
@@ -2808,7 +2686,6 @@ impl AuthorityPerEpochStore {
             match self
                 .process_consensus_transaction(
                     batch,
-                    &mut shared_input_next_versions,
                     tx,
                     checkpoint_service,
                     commit_round,
@@ -2864,10 +2741,13 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        batch.insert_batch(
-            &self.tables()?.next_shared_object_versions,
-            shared_input_next_versions.into_iter(),
-        )?;
+        self.process_consensus_transaction_shared_object_versions(
+            cache_reader,
+            &verified_certificates,
+            randomness_round,
+            batch,
+        )
+        .await?;
 
         let (lock, final_round) = self.process_end_of_publish_transactions_and_reconfig(
             batch,
@@ -2880,7 +2760,7 @@ impl AuthorityPerEpochStore {
             notifications,
             deferred_tx_roots,
             lock,
-            reserved_randomness_round,
+            randomness_round,
             final_round,
         ))
     }
@@ -2989,7 +2869,6 @@ impl AuthorityPerEpochStore {
     async fn process_consensus_transaction<C: CheckpointServiceNotify>(
         &self,
         batch: &mut DBBatch,
-        shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
         transaction: &VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
         commit_round: Round,
@@ -3072,15 +2951,6 @@ impl AuthorityPerEpochStore {
                         certificate.digest(),
                     );
                     return Ok(ConsensusCertificateResult::Ignored);
-                }
-
-                if certificate.contains_shared_object() {
-                    self.record_shared_object_cert_from_consensus(
-                        batch,
-                        shared_input_next_versions,
-                        &certificate,
-                    )
-                    .await?;
                 }
 
                 Ok(ConsensusCertificateResult::SuiTransaction(certificate))
@@ -3235,12 +3105,6 @@ impl AuthorityPerEpochStore {
 
                 // If needed we can support owned object system transactions as well...
                 assert!(system_transaction.contains_shared_object());
-                self.record_shared_object_cert_from_consensus(
-                    batch,
-                    shared_input_next_versions,
-                    system_transaction,
-                )
-                .await?;
 
                 Ok(ConsensusCertificateResult::SuiTransaction(
                     system_transaction.clone(),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2660,7 +2660,6 @@ impl AuthorityPerEpochStore {
         bool,                    // true if final round
     )> {
         let randomness_round = if generate_randomness {
-            // invariant checks
             assert!(dkg_closed);
             Some(
                 randomness_manager

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -54,7 +54,7 @@ impl SharedObjVerManager {
             // If we're generating randomness, update the randomness state object version.
             let version = shared_input_next_versions
                 .get_mut(&SUI_RANDOMNESS_STATE_OBJECT_ID)
-                .expect("added randomness state object to lookup above");
+                .expect("randomness state object must have been added in get_or_init_versions()");
             debug!("assigning shared object versions for randomness: epoch {}, round {round:?} -> version {version:?}", epoch_store.epoch());
             assigned_versions.push((
                 TransactionKey::RandomnessRound(epoch_store.epoch(), round),

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
+use crate::authority::AuthorityPerEpochStore;
+use crate::execution_cache::ExecutionCacheRead;
+use std::collections::HashMap;
+use sui_types::crypto::RandomnessRound;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::storage::{
+    transaction_input_object_keys, transaction_receiving_object_keys, ObjectKey,
+};
+use sui_types::transaction::{
+    SenderSignedData, SharedInputObject, TransactionDataAPI, TransactionKey,
+};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    error::SuiResult,
+    SUI_RANDOMNESS_STATE_OBJECT_ID,
+};
+use tracing::{debug, trace};
+
+pub struct SharedObjVerManager {}
+
+pub type AssignedTxAndVersions = Vec<(TransactionKey, Vec<(ObjectID, SequenceNumber)>)>;
+
+#[must_use]
+#[derive(Default)]
+pub struct ConsensusSharedObjVerAssignment {
+    pub shared_input_next_versions: HashMap<ObjectID, SequenceNumber>,
+    pub assigned_versions: AssignedTxAndVersions,
+}
+
+impl SharedObjVerManager {
+    pub async fn assign_versions_from_consensus(
+        epoch_store: &AuthorityPerEpochStore,
+        cache_reader: &dyn ExecutionCacheRead,
+        certificates: &[VerifiedExecutableTransaction],
+        randomness_round: Option<RandomnessRound>,
+    ) -> SuiResult<ConsensusSharedObjVerAssignment> {
+        let mut shared_input_next_versions = get_or_init_versions(
+            certificates.iter().map(|cert| cert.data()),
+            epoch_store,
+            cache_reader,
+            randomness_round.is_some(),
+        )
+        .await?;
+        let mut assigned_versions = Vec::new();
+        // We must update randomness object version first before processing any transaction,
+        // so that all reads are using the next version.
+        // TODO: Add a test that actually check this, i.e. if we change the order, some test should fail.
+        if let Some(round) = randomness_round {
+            // If we're generating randomness, update the randomness state object version.
+            let version = shared_input_next_versions
+                .get_mut(&SUI_RANDOMNESS_STATE_OBJECT_ID)
+                .expect("added randomness state object to lookup above");
+            debug!("assigning shared object versions for randomness: epoch {}, round {round:?} -> version {version:?}", epoch_store.epoch());
+            assigned_versions.push((
+                TransactionKey::RandomnessRound(epoch_store.epoch(), round),
+                vec![(SUI_RANDOMNESS_STATE_OBJECT_ID, *version)],
+            ));
+            version.increment();
+        }
+        for cert in certificates {
+            if !cert.contains_shared_object() {
+                continue;
+            }
+            let cert_assigned_versions =
+                assign_versions_for_certificate(cert, &mut shared_input_next_versions);
+            assigned_versions.push((cert.key(), cert_assigned_versions));
+        }
+
+        Ok(ConsensusSharedObjVerAssignment {
+            shared_input_next_versions,
+            assigned_versions,
+        })
+    }
+
+    pub async fn assign_versions_from_effects(
+        certs_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
+        epoch_store: &AuthorityPerEpochStore,
+        cache_reader: &dyn ExecutionCacheRead,
+    ) -> SuiResult<AssignedTxAndVersions> {
+        // We don't care about the results since we can use effects to assign versions.
+        // But we must call it to make sure whenever a shared object is touched the first time
+        // during an epoch, either through consensus or through checkpoint executor,
+        // its next version must be initialized. This is because we initialize the next version
+        // of a shared object in an epoch by reading the current version from the object store.
+        // This must be done before we mutate it the first time, otherwise we would be initializing
+        // it with the wrong version.
+        let _ = get_or_init_versions(
+            certs_and_effects.iter().map(|(cert, _)| cert.data()),
+            epoch_store,
+            cache_reader,
+            false,
+        )
+        .await?;
+        let mut assigned_versions = Vec::new();
+        for (cert, effects) in certs_and_effects {
+            let cert_assigned_versions: Vec<_> = effects
+                .input_shared_objects()
+                .into_iter()
+                .map(|iso| iso.id_and_version())
+                .collect();
+            let tx_key = cert.key();
+            trace!(
+                ?tx_key,
+                ?cert_assigned_versions,
+                "locking shared objects from effects"
+            );
+            assigned_versions.push((tx_key, cert_assigned_versions));
+        }
+        Ok(assigned_versions)
+    }
+}
+
+async fn get_or_init_versions(
+    transactions: impl Iterator<Item = &SenderSignedData>,
+    epoch_store: &AuthorityPerEpochStore,
+    cache_reader: &dyn ExecutionCacheRead,
+    generate_randomness: bool,
+) -> SuiResult<HashMap<ObjectID, SequenceNumber>> {
+    let mut shared_input_objects: Vec<_> = transactions
+        .flat_map(|tx| {
+            tx.transaction_data()
+                .shared_input_objects()
+                .into_iter()
+                .map(|so| so.into_id_and_version())
+        })
+        .collect();
+
+    if generate_randomness {
+        shared_input_objects.push((
+            SUI_RANDOMNESS_STATE_OBJECT_ID,
+            epoch_store
+                .epoch_start_config()
+                .randomness_obj_initial_shared_version()
+                .expect(
+                    "randomness_obj_initial_shared_version should exist if randomness is enabled",
+                ),
+        ));
+    }
+
+    shared_input_objects.sort();
+    shared_input_objects.dedup();
+
+    epoch_store
+        .get_or_init_next_object_versions(&shared_input_objects, cache_reader)
+        .await
+}
+
+fn assign_versions_for_certificate(
+    cert: &VerifiedExecutableTransaction,
+    shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
+) -> Vec<(ObjectID, SequenceNumber)> {
+    let tx_digest = cert.digest();
+
+    // Make an iterator to update the locks of the transaction's shared objects.
+    let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
+
+    let mut input_object_keys =
+        transaction_input_object_keys(cert).expect("Transaction input should have been verified");
+    let mut assigned_versions = Vec::with_capacity(shared_input_objects.len());
+    let mut is_mutable_input = Vec::with_capacity(shared_input_objects.len());
+    // Record receiving object versions towards the shared version computation.
+    let receiving_object_keys = transaction_receiving_object_keys(cert);
+    input_object_keys.extend(receiving_object_keys);
+
+    for (SharedInputObject { id, mutable, .. }, version) in shared_input_objects
+        .iter()
+        .map(|obj| (obj, *shared_input_next_versions.get(&obj.id()).unwrap()))
+    {
+        assigned_versions.push((*id, version));
+        input_object_keys.push(ObjectKey(*id, version));
+        is_mutable_input.push(*mutable);
+    }
+
+    let next_version = SequenceNumber::lamport_increment(input_object_keys.iter().map(|obj| obj.1));
+
+    // Update the next version for the shared objects.
+    assigned_versions
+        .iter()
+        .zip(is_mutable_input)
+        .filter_map(|((id, _), mutable)| {
+            if mutable {
+                Some((*id, next_version))
+            } else {
+                None
+            }
+        })
+        .for_each(|(id, version)| {
+            shared_input_next_versions.insert(id, version);
+        });
+
+    trace!(
+        ?tx_digest,
+        ?assigned_versions,
+        ?next_version,
+        "locking shared objects"
+    );
+
+    assigned_versions
+}


### PR DESCRIPTION
## Description 

This PR moves all the shared object version calculation logic out to a separate file.
Previously we would accumulate shared object version assignment one by one as we process each transaction.
This PR changes it such that we simply process all of them in the end when we have the list of verified transactions.
This has a few benefits:
1. It simplifies the consensus transaction processing
2. Makes it easier to reason about the version assignment logic
3. Allows better code sharing (this will be needed in the benchmark)
4. A side benefit is that we could also batch assign version for a vector of effects from checkpoint_executor

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
