### PR TITLE
[pick #16783][GraphQL/DataLoader] Checkpoint DataLoader

### DIFF
--- a/crates/sui-graphql-rpc/src/types/available_range.rs
+++ b/crates/sui-graphql-rpc/src/types/available_range.rs
@@ -15,22 +15,14 @@ pub(crate) struct AvailableRange {
 #[Object]
 impl AvailableRange {
     async fn first(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(
-            ctx.data_unchecked(),
-            CheckpointId::by_seq_num(self.first),
-            Some(self.last),
-        )
-        .await
-        .extend()
+        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.first), Some(self.last))
+            .await
+            .extend()
     }
 
     async fn last(&self, ctx: &Context<'_>) -> Result<Option<Checkpoint>> {
-        Checkpoint::query(
-            ctx.data_unchecked(),
-            CheckpointId::by_seq_num(self.last),
-            Some(self.last),
-        )
-        .await
-        .extend()
+        Checkpoint::query(ctx, CheckpointId::by_seq_num(self.last), Some(self.last))
+            .await
+            .extend()
     }
 }

--- a/crates/sui-graphql-rpc/src/types/digest.rs
+++ b/crates/sui-graphql-rpc/src/types/digest.rs
@@ -9,7 +9,7 @@ use sui_types::digests::{ObjectDigest, TransactionDigest};
 
 pub(crate) const BASE58_DIGEST_LENGTH: usize = 32;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct Digest([u8; BASE58_DIGEST_LENGTH]);
 
 #[derive(thiserror::Error, Debug)]
@@ -22,8 +22,12 @@ pub(crate) enum Error {
 }
 
 impl Digest {
-    pub(crate) fn to_vec(&self) -> Vec<u8> {
+    pub(crate) fn to_vec(self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/epoch.rs
+++ b/crates/sui-graphql-rpc/src/types/epoch.rs
@@ -33,7 +33,7 @@ pub(crate) struct Epoch {
 /// DataLoader key for fetching an `Epoch` by its ID, optionally constrained by a consistency
 /// cursor.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub(crate) struct EpochKey {
+struct EpochKey {
     pub epoch_id: u64,
     pub checkpoint_viewed_at: Option<u64>,
 }
@@ -105,7 +105,7 @@ impl Epoch {
     async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<BigInt>> {
         let last = match self.stored.last_checkpoint_id {
             Some(last) => last as u64,
-            None => Checkpoint::query(ctx.data_unchecked(), CheckpointId::default(), None)
+            None => Checkpoint::query(ctx, CheckpointId::default(), None)
                 .await
                 .extend()?
                 .map_or(self.stored.first_checkpoint_id as u64, |c| {

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -236,7 +236,7 @@ impl Query {
         id: Option<CheckpointId>,
     ) -> Result<Option<Checkpoint>> {
         Checkpoint::query(
-            ctx.data_unchecked(),
+            ctx,
             id.unwrap_or_default(),
             /* checkpoint_viewed_at */ None,
         )

--- a/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs
@@ -388,15 +388,13 @@ impl TransactionBlockEffects {
         };
 
         Checkpoint::query(
-            ctx.data_unchecked(),
+            ctx,
             CheckpointId::by_seq_num(stored_tx.checkpoint_sequence_number as u64),
             Some(self.checkpoint_viewed_at),
         )
         .await
         .extend()
     }
-
-    // TODO: event_connection: EventConnection
 
     /// Base64 encoded bcs serialization of the on-chain transaction effects.
     async fn bcs(&self) -> Result<Base64> {


### PR DESCRIPTION
## Description

Implement two separate data loaders -- one for checkpoints by sequence number, and one for checkpoints by digest.

## Test Plan

Existing tests:

```
sui$ cargo nextest run -p sui-graphql-rpc
sui$ cargo nextest run -p sui-graphql-e2e-tests --features pg_integration
```

And test that the following queries runs much faster now:

```graphql
query {
  transactionBlocks(last: 50) {
    nodes {
      effects {
        checkpoint {
          digest
          sequenceNumber
        }
      }
    }
  }
}
```

```graphql
query {
  c00: checkpoint(id: { digest: "..." }) {
    sequenceNumber
  }
  c01: checkpoint(id: { digest: "..." }) {
    sequenceNumber
  }
  # ...
  c30: checkpoint(id: { digest: "..." }) {
    sequenceNumber
  }
}
```