### PR TITLE
indexer: dynamically adjust index batch size to avoid oom

### DIFF
--- a/crates/sui-indexer/src/db.rs
+++ b/crates/sui-indexer/src/db.rs
@@ -23,8 +23,8 @@ pub struct PgConnectionPoolConfig {
 
 impl PgConnectionPoolConfig {
     const DEFAULT_POOL_SIZE: u32 = 100;
-    const DEFAULT_CONNECTION_TIMEOUT: u64 = 3600;
-    const DEFAULT_STATEMENT_TIMEOUT: u64 = 3600;
+    const DEFAULT_CONNECTION_TIMEOUT: u64 = 30;
+    const DEFAULT_STATEMENT_TIMEOUT: u64 = 30;
 
     fn connection_config(&self) -> PgConnectionConfig {
         PgConnectionConfig {

--- a/crates/sui-indexer/src/db.rs
+++ b/crates/sui-indexer/src/db.rs
@@ -23,8 +23,8 @@ pub struct PgConnectionPoolConfig {
 
 impl PgConnectionPoolConfig {
     const DEFAULT_POOL_SIZE: u32 = 100;
-    const DEFAULT_CONNECTION_TIMEOUT: u64 = 30;
-    const DEFAULT_STATEMENT_TIMEOUT: u64 = 30;
+    const DEFAULT_CONNECTION_TIMEOUT: u64 = 3600;
+    const DEFAULT_STATEMENT_TIMEOUT: u64 = 3600;
 
     fn connection_config(&self) -> PgConnectionConfig {
         PgConnectionConfig {

--- a/crates/sui-indexer/src/framework/builder.rs
+++ b/crates/sui-indexer/src/framework/builder.rs
@@ -53,7 +53,7 @@ impl IndexerBuilder {
         self
     }
 
-    pub async fn run(self) {
+    pub async fn run(self, metrics: IndexerMetrics) {
         let (downloaded_checkpoint_data_sender, downloaded_checkpoint_data_receiver) =
             mysten_metrics::metered_channel::channel(
                 self.checkpoint_buffer_size,
@@ -81,6 +81,7 @@ impl IndexerBuilder {
                 downloaded_checkpoint_data_receiver,
             ),
             self.handlers,
+            metrics,
         )
         .await;
     }

--- a/crates/sui-indexer/src/framework/builder.rs
+++ b/crates/sui-indexer/src/framework/builder.rs
@@ -53,7 +53,7 @@ impl IndexerBuilder {
         self
     }
 
-    pub async fn run(self, metrics: IndexerMetrics) {
+    pub async fn run(self) {
         let (downloaded_checkpoint_data_sender, downloaded_checkpoint_data_receiver) =
             mysten_metrics::metered_channel::channel(
                 self.checkpoint_buffer_size,
@@ -81,7 +81,7 @@ impl IndexerBuilder {
                 downloaded_checkpoint_data_receiver,
             ),
             self.handlers,
-            metrics,
+            self.metrics.clone(),
         )
         .await;
     }

--- a/crates/sui-indexer/src/framework/runner.rs
+++ b/crates/sui-indexer/src/framework/runner.rs
@@ -1,29 +1,55 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_rest_api::CheckpointData;
+use crate::metrics::IndexerMetrics;
 
+use super::fetcher::CheckpointDownloadData;
 use super::interface::Handler;
 
-pub async fn run<S>(stream: S, mut handlers: Vec<Box<dyn Handler>>)
+// Limit indexing parallelism on big checkpoints to avoid OOM,
+// by limiting the total size of batch checkpoints to ~50MB.
+// On testnet, most checkpoints are < 200KB, some can go up to 50MB.
+const CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT: usize = 50000000;
+const CHECKPOINT_PROCESSING_BATCH_SIZE: usize = 100;
+
+pub async fn run<S>(stream: S, mut handlers: Vec<Box<dyn Handler>>, metrics: IndexerMetrics)
 where
-    S: futures::Stream<Item = CheckpointData> + std::marker::Unpin,
+    S: futures::Stream<Item = CheckpointDownloadData> + std::marker::Unpin,
 {
     use futures::StreamExt;
 
     let batch_size = std::env::var("CHECKPOINT_PROCESSING_BATCH_SIZE")
-        .unwrap_or(25.to_string())
+        .unwrap_or(CHECKPOINT_PROCESSING_BATCH_SIZE.to_string())
         .parse::<usize>()
         .unwrap();
     tracing::info!("Indexer runner is starting with {batch_size}");
     let mut chunks: futures::stream::ReadyChunks<S> = stream.ready_chunks(batch_size);
     while let Some(checkpoints) = chunks.next().await {
         //TODO create tracing spans for processing
-        futures::future::join_all(
-            handlers
-                .iter_mut()
-                .map(|handler| async { handler.process_checkpoints(&checkpoints).await.unwrap() }),
-        )
-        .await;
+        let mut cp_batch = vec![];
+        let mut cp_batch_total_size = 0;
+        for checkpoint in checkpoints.iter() {
+            cp_batch_total_size += checkpoint.size;
+            cp_batch.push(checkpoint.data.clone());
+            if cp_batch_total_size >= CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT {
+                futures::future::join_all(handlers.iter_mut().map(|handler| async {
+                    handler.process_checkpoints(&cp_batch).await.unwrap()
+                }))
+                .await;
+
+                metrics.indexing_batch_size.set(cp_batch_total_size as i64);
+                cp_batch = vec![];
+                cp_batch_total_size = 0;
+            }
+        }
+        if !cp_batch.is_empty() {
+            futures::future::join_all(
+                handlers
+                    .iter_mut()
+                    .map(|handler| async { handler.process_checkpoints(&cp_batch).await.unwrap() }),
+            )
+            .await;
+            metrics.indexing_batch_size.set(cp_batch_total_size as i64);
+        }
     }
 }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -56,7 +56,7 @@ use super::CheckpointDataToCommit;
 use super::EpochToCommit;
 use super::TransactionObjectChangesToCommit;
 
-const CHECKPOINT_QUEUE_SIZE: usize = 1000;
+const CHECKPOINT_QUEUE_SIZE: usize = 100;
 
 pub async fn new_handlers<S>(
     state: S,

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -17,6 +17,8 @@ use crate::types::IndexerResult;
 
 use super::{CheckpointDataToCommit, EpochToCommit};
 
+const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
+
 pub async fn start_tx_checkpoint_commit_task<S>(
     state: S,
     metrics: IndexerMetrics,
@@ -29,7 +31,7 @@ pub async fn start_tx_checkpoint_commit_task<S>(
 
     info!("Indexer checkpoint commit task started...");
     let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
-        .unwrap_or(5.to_string())
+        .unwrap_or(CHECKPOINT_COMMIT_BATCH_SIZE.to_string())
         .parse::<usize>()
         .unwrap();
     info!("Using checkpoint commit batch size {checkpoint_commit_batch_size}");

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -19,7 +19,7 @@ use crate::metrics::IndexerMetrics;
 use crate::store::IndexerStore;
 use crate::IndexerConfig;
 
-const DOWNLOAD_QUEUE_SIZE: usize = 1000;
+const DOWNLOAD_QUEUE_SIZE: usize = 200;
 
 pub struct Indexer;
 

--- a/crates/sui-indexer/src/indexer.rs
+++ b/crates/sui-indexer/src/indexer.rs
@@ -79,12 +79,13 @@ impl Indexer {
         );
         spawn_monitored_task!(objects_snapshot_processor.start());
 
-        let checkpoint_handler = new_handlers(store, metrics).await?;
+        let checkpoint_handler = new_handlers(store, metrics.clone()).await?;
         crate::framework::runner::run(
             mysten_metrics::metered_channel::ReceiverStream::new(
                 downloaded_checkpoint_data_receiver,
             ),
             vec![Box::new(checkpoint_handler)],
+            metrics,
         )
         .await;
 

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -101,6 +101,7 @@ pub struct IndexerMetrics {
     pub fullnode_transaction_download_latency: Histogram,
     pub fullnode_object_download_latency: Histogram,
     pub checkpoint_index_latency: Histogram,
+    pub indexing_batch_size: IntGauge,
     pub indexing_tx_object_changes_latency: Histogram,
     pub indexing_objects_latency: Histogram,
     pub indexing_get_object_in_mem_hit: IntCounter,
@@ -283,6 +284,11 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            indexing_batch_size: register_int_gauge_with_registry!(
+                "indexing_batch_size",
+                "Size of the indexing batch",
+                registry,
+            ).unwrap(),
             indexing_tx_object_changes_latency: register_histogram_with_registry!(
                 "indexing_tx_object_changes_latency",
                 "Time spent in indexing object changes for a transaction",

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -69,11 +69,11 @@ macro_rules! chunk {
 // is now less relevant. We should do experiments and remove it if it's true.
 const PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX: usize = 1000;
 // The amount of rows to update in one DB transcation
-const PG_COMMIT_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
+const PG_COMMIT_PARALLEL_CHUNK_SIZE: usize = 100;
 // The amount of rows to update in one DB transcation, for objects particularly
 // Having this number too high may cause many db deadlocks because of
 // optimistic locking.
-const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX: usize = 500;
+const PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE: usize = 500;
 
 // with rn = 1, we only select the latest version of each object,
 // so that we don't have to update the same object multiple times.
@@ -120,11 +120,11 @@ impl PgIndexerStore {
             SyncModuleCache::new(IndexerStorePackageModuleResolver::new(blocking_cp.clone())),
         );
         let parallel_chunk_size = std::env::var("PG_COMMIT_PARALLEL_CHUNK_SIZE")
-            .unwrap_or_else(|_e| PG_COMMIT_PARALLEL_CHUNK_SIZE_PER_DB_TX.to_string())
+            .unwrap_or_else(|_e| PG_COMMIT_PARALLEL_CHUNK_SIZE.to_string())
             .parse::<usize>()
             .unwrap();
         let parallel_objects_chunk_size = std::env::var("PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE")
-            .unwrap_or_else(|_e| PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE_PER_DB_TX.to_string())
+            .unwrap_or_else(|_e| PG_COMMIT_OBJECTS_PARALLEL_CHUNK_SIZE.to_string())
             .parse::<usize>()
             .unwrap();
         let partition_manager = PgPartitionManager::new(blocking_cp.clone())


### PR DESCRIPTION
## Description 

the checkpoint size varies a lot and as a result, it's challenging to find a static batch size for indexing;
from the experiment, batch size of 10 would still sometimes go OOM, thus this PR introduces a dynamic way of adjusting the batch size based on the downloaded checkpoint data size.

## Test Plan 

experiment on rpc-benchmark.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
