### PR TITLE
[docs] ptb transfer object ordering were swapped

### DIFF
--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -98,13 +98,13 @@ flowchart TB
 
 For example, you can create a new `Sword` object defined in the package by calling the `new_sword` function in the `my_module` package, and then transfer the `Sword` object to any address:
 
-```bash
+```shell
 $ sui client ptb \
 	--assign forge @<FORGE-ID> \
 	--assign to_address @<TO-ADDRESS> \
 	--move-call <PACKAGE-ID>::my_module::new_sword forge 3 3 \
 	--assign sword \
-	--transfer-objects to_address "[sword]" \
+	--transfer-objects "[sword]" to_address \
 	--gas-budget 20000000
 ```
 


### PR DESCRIPTION
## Description 

Example code swapped the ordering of `to_address` and the parameters as a result of https://github.com/MystenLabs/sui/pull/16566 

## Test Plan 

Visual inspection

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
