### PR TITLE
[NameService][GraphQL] Adds support to @ (at) format output.

### DIFF
--- a/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
+++ b/crates/sui-graphql-rpc/schema/current_progress_schema.graphql
@@ -89,7 +89,7 @@ type Address implements IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
 	manage the associated domain.
@@ -473,7 +473,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -632,7 +632,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -817,6 +817,11 @@ type DisplayEntry {
 	An error string describing why the template could not be rendered.
 	"""
 	error: String
+}
+
+enum DomainFormat {
+	AT
+	DOT
 }
 
 type DryRunEffect {
@@ -1430,7 +1435,7 @@ interface IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object or address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated domain.
 	"""
@@ -1764,7 +1769,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -1944,7 +1949,7 @@ type MovePackage implements IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this package. These grant the owner the capability to
 	manage the associated domain.
@@ -2275,7 +2280,7 @@ type Object implements IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -2620,7 +2625,7 @@ type Owner implements IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object or address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object or address. These grant the owner the
 	capability to manage the associated domain.
@@ -3242,7 +3247,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -3444,7 +3449,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.

--- a/crates/sui-graphql-rpc/src/types/address.rs
+++ b/crates/sui-graphql-rpc/src/types/address.rs
@@ -10,7 +10,7 @@ use super::{
     owner::OwnerImpl,
     stake::StakedSui,
     sui_address::SuiAddress,
-    suins_registration::SuinsRegistration,
+    suins_registration::{DomainFormat, SuinsRegistration},
     transaction_block::{self, TransactionBlock, TransactionBlockFilter},
     type_filter::ExactTypeFilter,
 };
@@ -111,8 +111,12 @@ impl Address {
     }
 
     /// The domain explicitly configured as the default domain pointing to this address.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl::from(self).default_suins_name(ctx).await
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
+        OwnerImpl::from(self).default_suins_name(ctx, format).await
     }
 
     /// The SuinsRegistration NFTs owned by this address. These grant the owner the capability to

--- a/crates/sui-graphql-rpc/src/types/coin.rs
+++ b/crates/sui-graphql-rpc/src/types/coin.rs
@@ -19,7 +19,7 @@ use super::object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectS
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use async_graphql::*;
@@ -124,9 +124,13 @@ impl Coin {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
         OwnerImpl::from(&self.super_.super_)
-            .default_suins_name(ctx)
+            .default_suins_name(ctx, format)
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -13,7 +13,7 @@ use super::object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectS
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use crate::data::Db;
@@ -114,9 +114,13 @@ impl CoinMetadata {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
         OwnerImpl::from(&self.super_.super_)
-            .default_suins_name(ctx)
+            .default_suins_name(ctx, format)
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -15,7 +15,7 @@ use super::object::{self, ObjectFilter, ObjectImpl, ObjectLookupKey, ObjectOwner
 use super::owner::OwnerImpl;
 use super::stake::StakedSuiDowncastError;
 use super::sui_address::SuiAddress;
-use super::suins_registration::{SuinsRegistration, SuinsRegistrationDowncastError, DomainFormat};
+use super::suins_registration::{DomainFormat, SuinsRegistration, SuinsRegistrationDowncastError};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use super::{coin::Coin, object::Object};

--- a/crates/sui-graphql-rpc/src/types/move_object.rs
+++ b/crates/sui-graphql-rpc/src/types/move_object.rs
@@ -15,7 +15,7 @@ use super::object::{self, ObjectFilter, ObjectImpl, ObjectLookupKey, ObjectOwner
 use super::owner::OwnerImpl;
 use super::stake::StakedSuiDowncastError;
 use super::sui_address::SuiAddress;
-use super::suins_registration::{SuinsRegistration, SuinsRegistrationDowncastError};
+use super::suins_registration::{SuinsRegistration, SuinsRegistrationDowncastError, DomainFormat};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use super::{coin::Coin, object::Object};
@@ -193,8 +193,14 @@ impl MoveObject {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl::from(&self.super_).default_suins_name(ctx).await
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
+        OwnerImpl::from(&self.super_)
+            .default_suins_name(ctx, format)
+            .await
     }
 
     /// The SuinsRegistration NFTs owned by this object. These grant the owner the capability to

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -14,7 +14,7 @@ use super::object::{
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{SuinsRegistration, DomainFormat};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use crate::consistency::ConsistentNamedCursor;
@@ -164,8 +164,14 @@ impl MovePackage {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl::from(&self.super_).default_suins_name(ctx).await
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
+        OwnerImpl::from(&self.super_)
+            .default_suins_name(ctx, format)
+            .await
     }
 
     /// The SuinsRegistration NFTs owned by this package. These grant the owner the capability to

--- a/crates/sui-graphql-rpc/src/types/move_package.rs
+++ b/crates/sui-graphql-rpc/src/types/move_package.rs
@@ -14,7 +14,7 @@ use super::object::{
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
 use super::sui_address::SuiAddress;
-use super::suins_registration::{SuinsRegistration, DomainFormat};
+use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use crate::consistency::ConsistentNamedCursor;

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -17,7 +17,7 @@ use super::move_object::MoveObject;
 use super::move_package::MovePackage;
 use super::owner::OwnerImpl;
 use super::stake::StakedSui;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block;
 use super::transaction_block::TransactionBlockFilter;
 use super::type_filter::{ExactTypeFilter, TypeFilter};
@@ -345,8 +345,12 @@ impl Object {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl::from(self).default_suins_name(ctx).await
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
+        OwnerImpl::from(self).default_suins_name(ctx, format).await
     }
 
     /// The SuinsRegistration NFTs owned by this object. These grant the owner the capability to

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -9,8 +9,7 @@ use super::dynamic_field::DynamicFieldName;
 use super::move_package::MovePackage;
 use super::object::ObjectLookupKey;
 use super::stake::StakedSui;
-use super::suins_registration::NameService;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{DomainFormat, NameService, SuinsRegistration};
 use crate::data::Db;
 use crate::types::balance::{self, Balance};
 use crate::types::coin::Coin;
@@ -97,6 +96,7 @@ pub(crate) struct OwnerImpl {
     ),
     field(
         name = "default_suins_name",
+        arg(name = "format", ty = "Option<DomainFormat>"),
         ty = "Option<String>",
         desc = "The domain explicitly configured as the default domain pointing to this object or \
                 address."
@@ -204,8 +204,12 @@ impl Owner {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object or address.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
-        OwnerImpl::from(self).default_suins_name(ctx).await
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
+        OwnerImpl::from(self).default_suins_name(ctx, format).await
     }
 
     /// The SuinsRegistration NFTs owned by this object or address. These grant the owner the
@@ -403,12 +407,16 @@ impl OwnerImpl {
         .extend()
     }
 
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
         Ok(
             NameService::reverse_resolve_to_name(ctx, self.address, self.checkpoint_viewed_at)
                 .await
                 .extend()?
-                .map(|d| d.to_string()),
+                .map(|d| d.format(format.unwrap_or(DomainFormat::Dot).into())),
         )
     }
 

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -14,7 +14,7 @@ use super::move_object::MoveObjectImpl;
 use super::move_value::MoveValue;
 use super::object::{Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus};
 use super::owner::OwnerImpl;
-use super::suins_registration::{SuinsRegistration, DomainFormat};
+use super::suins_registration::{DomainFormat, SuinsRegistration};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use super::{

--- a/crates/sui-graphql-rpc/src/types/stake.rs
+++ b/crates/sui-graphql-rpc/src/types/stake.rs
@@ -14,7 +14,7 @@ use super::move_object::MoveObjectImpl;
 use super::move_value::MoveValue;
 use super::object::{Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus};
 use super::owner::OwnerImpl;
-use super::suins_registration::SuinsRegistration;
+use super::suins_registration::{SuinsRegistration, DomainFormat};
 use super::transaction_block::{self, TransactionBlock, TransactionBlockFilter};
 use super::type_filter::ExactTypeFilter;
 use super::{
@@ -133,9 +133,13 @@ impl StakedSui {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
         OwnerImpl::from(&self.super_.super_)
-            .default_suins_name(ctx)
+            .default_suins_name(ctx, format)
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -47,6 +47,13 @@ pub(crate) struct NameService;
 #[derive(Debug)]
 pub(crate) struct Domain(NativeDomain);
 
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+#[graphql(remote = "sui_json_rpc::name_service::DomainFormat")]
+pub enum DomainFormat {
+    At,
+    Dot
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct NativeSuinsRegistration {
     pub id: UID,
@@ -162,9 +169,13 @@ impl SuinsRegistration {
     }
 
     /// The domain explicitly configured as the default domain pointing to this object.
-    pub(crate) async fn default_suins_name(&self, ctx: &Context<'_>) -> Result<Option<String>> {
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+        format: Option<DomainFormat>,
+    ) -> Result<Option<String>> {
         OwnerImpl::from(&self.super_.super_)
-            .default_suins_name(ctx)
+            .default_suins_name(ctx, format)
             .await
     }
 

--- a/crates/sui-graphql-rpc/src/types/suins_registration.rs
+++ b/crates/sui-graphql-rpc/src/types/suins_registration.rs
@@ -51,7 +51,7 @@ pub(crate) struct Domain(NativeDomain);
 #[graphql(remote = "sui_json_rpc::name_service::DomainFormat")]
 pub enum DomainFormat {
     At,
-    Dot
+    Dot,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -93,7 +93,7 @@ type Address implements IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this address. These grant the owner the capability to
 	manage the associated domain.
@@ -477,7 +477,7 @@ type Coin implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -636,7 +636,7 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -821,6 +821,11 @@ type DisplayEntry {
 	An error string describing why the template could not be rendered.
 	"""
 	error: String
+}
+
+enum DomainFormat {
+	AT
+	DOT
 }
 
 type DryRunEffect {
@@ -1434,7 +1439,7 @@ interface IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object or address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated domain.
 	"""
@@ -1768,7 +1773,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -1948,7 +1953,7 @@ type MovePackage implements IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this package. These grant the owner the capability to
 	manage the associated domain.
@@ -2279,7 +2284,7 @@ type Object implements IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -2624,7 +2629,7 @@ type Owner implements IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object or address.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object or address. These grant the owner the
 	capability to manage the associated domain.
@@ -3246,7 +3251,7 @@ type StakedSui implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -3448,7 +3453,7 @@ type SuinsRegistration implements IMoveObject & IObject & IOwner {
 	"""
 	The domain explicitly configured as the default domain pointing to this object.
 	"""
-	defaultSuinsName: String
+	defaultSuinsName(format: DomainFormat): String
 	"""
 	The SuinsRegistration NFTs owned by this object. These grant the owner the capability to
 	manage the associated domain.
@@ -4174,4 +4179,3 @@ schema {
 	query: Query
 	mutation: Mutation
 }
-

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -96,18 +96,18 @@ fn test_invalid_inputs() {
 #[test]
 fn output_tests() {
     let mut domain = "test.sui".parse::<Domain>().unwrap();
-    assert!(domain.format('.', false) == "test.sui");
-    assert!(domain.format('.', true) == "@test");
+    assert!(domain.format(name_service::DomainFormat::Dot) == "test.sui");
+    assert!(domain.format(name_service::DomainFormat::At) == "@test");
 
     domain = "test.test.sui".parse::<Domain>().unwrap();
-    assert!(domain.format('.', false) == "test.test.sui");
-    assert!(domain.format('.', true) == "test@test");
+    assert!(domain.format(name_service::DomainFormat::Dot) == "test.test.sui");
+    assert!(domain.format(name_service::DomainFormat::At) == "test@test");
 
     domain = "test.test.test.sui".parse::<Domain>().unwrap();
-    assert!(domain.format('.', false) == "test.test.test.sui");
-    assert!(domain.format('.', true) == "test.test@test");
+    assert!(domain.format(name_service::DomainFormat::Dot) == "test.test.test.sui");
+    assert!(domain.format(name_service::DomainFormat::At) == "test.test@test");
 
     domain = "test.test.test.test.sui".parse::<Domain>().unwrap();
-    assert!(domain.format('.', false) == "test.test.test.test.sui");
-    assert!(domain.format('.', true) == "test.test.test@test");
+    assert!(domain.format(name_service::DomainFormat::Dot) == "test.test.test.test.sui");
+    assert!(domain.format(name_service::DomainFormat::At) == "test.test.test@test");
 }

--- a/crates/sui-json-rpc-tests/tests/name_service_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/name_service_tests.rs
@@ -92,3 +92,22 @@ fn test_invalid_inputs() {
     assert!("test.test@example.sui".parse::<Domain>().is_err());
     assert!("test@test@example".parse::<Domain>().is_err());
 }
+
+#[test]
+fn output_tests() {
+    let mut domain = "test.sui".parse::<Domain>().unwrap();
+    assert!(domain.format('.', false) == "test.sui");
+    assert!(domain.format('.', true) == "@test");
+
+    domain = "test.test.sui".parse::<Domain>().unwrap();
+    assert!(domain.format('.', false) == "test.test.sui");
+    assert!(domain.format('.', true) == "test@test");
+
+    domain = "test.test.test.sui".parse::<Domain>().unwrap();
+    assert!(domain.format('.', false) == "test.test.test.sui");
+    assert!(domain.format('.', true) == "test.test@test");
+
+    domain = "test.test.test.test.sui".parse::<Domain>().unwrap();
+    assert!(domain.format('.', false) == "test.test.test.test.sui");
+    assert!(domain.format('.', true) == "test.test.test@test");
+}

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -107,14 +107,15 @@ impl Domain {
         labels.reverse();
 
         if format == DomainFormat::Dot {
-            return labels.join(&sep);
+            return labels.join(sep);
         };
 
         // SAFETY: This is a safe operation because we only allow a
         // domain's label vector size to be >= 2 (see `Domain::from_str`)
         let _tld = labels.pop();
         let sld = labels.pop().unwrap();
-        return format!("{}{}{}", labels.join(&sep), SUI_NEW_FORMAT_SEPARATOR, sld);
+
+        format!("{}{}{}", labels.join(sep), SUI_NEW_FORMAT_SEPARATOR, sld)
     }
 }
 

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -90,6 +90,22 @@ impl Domain {
     pub fn depth(&self) -> u8 {
         self.labels.len() as u8
     }
+
+    pub fn format(&self, separator: char, is_new_format: bool) -> String {
+        let mut labels = self.labels.clone();
+        let sep = separator.to_string();
+        labels.reverse();
+
+        // SAFETY: This is a safe operation because we only allow a
+        // domain's label vector size to be >= 2 (see `Domain::from_str`)
+        if is_new_format {
+            let _tld = labels.pop();
+            let sld = labels.pop().unwrap();
+            return format!("{}@{}", labels.join(&sep), sld);
+        };
+
+        labels.join(&sep)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -263,14 +279,9 @@ fn validate_label(label: &str) -> Result<&str, NameServiceError> {
 
 impl fmt::Display for Domain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let len = self.labels.len();
-        for (i, label) in self.labels.iter().rev().enumerate() {
-            f.write_str(label)?;
+        let output = self.format(ACCEPTED_SEPARATORS[0], false);
+        let _ = f.write_str(&output);
 
-            if i != len - 1 {
-                f.write_str(".")?;
-            }
-        }
         Ok(())
     }
 }

--- a/crates/sui-json-rpc/src/name_service.rs
+++ b/crates/sui-json-rpc/src/name_service.rs
@@ -91,6 +91,7 @@ impl Domain {
         self.labels.len() as u8
     }
 
+    /// Formats a domain into a string with the different available formats.
     pub fn format(&self, separator: char, is_new_format: bool) -> String {
         let mut labels = self.labels.clone();
         let sep = separator.to_string();
@@ -101,7 +102,7 @@ impl Domain {
         if is_new_format {
             let _tld = labels.pop();
             let sld = labels.pop().unwrap();
-            return format!("{}@{}", labels.join(&sep), sld);
+            return format!("{}{}{}", labels.join(&sep), SUI_NEW_FORMAT_SEPARATOR, sld);
         };
 
         labels.join(&sep)
@@ -280,7 +281,7 @@ fn validate_label(label: &str) -> Result<&str, NameServiceError> {
 impl fmt::Display for Domain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let output = self.format(ACCEPTED_SEPARATORS[0], false);
-        let _ = f.write_str(&output);
+        f.write_str(&output)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description 

Adds optional support for "@"(at) format naming in GraphQL.

Using this, you can get the default name in two formats:
1. Dot style: `manos.sui`
2. At style: `@manos`

Defaults to `dot` style for now. We wanna make the At style the default, but this would be a breaking change.

## Test Plan 

Tested the output conversions through unit tests.
Tested it live locally using mainnet.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
