### PR TITLE
[graphql] Adds epoch to the update watermark to keep track of the last known epoch

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -586,7 +586,7 @@ pub(crate) async fn update_watermark(
                         return;
                     },
                     _ = tokio::time::sleep(sleep_ms) => {
-                        let new_checkpoint= match Checkpoint::query_latest_at(db, None).await {
+                        let new_checkpoint = match Checkpoint::latest_checkpoint_seq_num_epoch_id(db).await {
                             Ok(checkpoint) => checkpoint,
                             Err(e) => {
                                 error!("{}", e);
@@ -595,8 +595,8 @@ pub(crate) async fn update_watermark(
                             }
                         };
                         if let Some(checkpoint) = new_checkpoint {
-                            checkpoint_viewed_at.0.store(checkpoint.stored.sequence_number as u64, Relaxed);
-                            epoch.0.store(checkpoint.stored.epoch as u64, Relaxed)
+                            checkpoint_viewed_at.0.store(checkpoint.0, Relaxed);
+                            epoch.0.store(checkpoint.1, Relaxed)
                         }
                     }
         }

--- a/crates/sui-graphql-rpc/src/types/checkpoint.rs
+++ b/crates/sui-graphql-rpc/src/types/checkpoint.rs
@@ -247,7 +247,7 @@ impl Checkpoint {
     /// Look up the latest `Checkpoint` from the database, optionally filtered by a consistency
     /// cursor (querying for a consistency cursor in the past looks for the latest checkpoint as of
     /// that cursor).
-    async fn query_latest_at(
+    pub(crate) async fn query_latest_at(
         db: &Db,
         checkpoint_viewed_at: Option<u64>,
     ) -> Result<Option<Self>, Error> {


### PR DESCRIPTION
## Description 

Adds epoch to the update watermark to keep track of the last known epoch. It supersedes #16806 with a simpler implementation as per that thread.

This will be later used for a cache on the last epoch for computing APYs and stake rewards.

## Test Plan 
Current tests 👀 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
