### PR TITLE
[move][easy] Add a development edition for Move source language

### DIFF
--- a/external-crates/move/crates/move-compiler/src/editions/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/editions/mod.rs
@@ -127,6 +127,8 @@ const E2024_BETA_FEATURES: &[FeatureGate] = &[
     FeatureGate::AutoborrowEq,
 ];
 
+const DEVELOPMENT_FEATURES: &[FeatureGate] = &[];
+
 const E2024_MIGRATION_FEATURES: &[FeatureGate] = &[FeatureGate::Move2024Migration];
 
 impl Edition {
@@ -146,6 +148,10 @@ impl Edition {
         edition: symbol!("2024"),
         release: Some(symbol!("migration")),
     };
+    pub const DEVELOPMENT: Self = Self {
+        edition: symbol!("development"),
+        release: None,
+    };
 
     const SEP: &'static str = ".";
 
@@ -154,6 +160,7 @@ impl Edition {
         Self::E2024_ALPHA,
         Self::E2024_BETA,
         Self::E2024_MIGRATION,
+        Self::DEVELOPMENT,
     ];
     pub const VALID: &'static [Self] = &[Self::LEGACY, Self::E2024_ALPHA, Self::E2024_BETA];
 
@@ -168,6 +175,7 @@ impl Edition {
             Self::E2024_ALPHA => Some(Self::E2024_BETA),
             Self::E2024_BETA => Some(Self::LEGACY),
             Self::E2024_MIGRATION => Some(Self::E2024_BETA),
+            Self::DEVELOPMENT => Some(Self::E2024_ALPHA),
             _ => self.unknown_edition_panic(),
         }
     }
@@ -190,6 +198,11 @@ impl Edition {
             Self::E2024_MIGRATION => {
                 let mut features = self.prev().unwrap().features();
                 features.extend(E2024_MIGRATION_FEATURES);
+                features
+            }
+            Self::DEVELOPMENT => {
+                let mut features = self.prev().unwrap().features();
+                features.extend(DEVELOPMENT_FEATURES);
                 features
             }
             _ => self.unknown_edition_panic(),

--- a/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
@@ -27,6 +27,7 @@ const MIGRATION_EXT: &str = "migration";
 const LINTER_DIR: &str = "linter";
 const SUI_MODE_DIR: &str = "sui_mode";
 const MOVE_2024_DIR: &str = "move_2024";
+const DEV_DIR: &str = "development";
 
 fn default_testing_addresses(flavor: Flavor) -> BTreeMap<String, NumericalAddress> {
     let mut mapping = vec![
@@ -50,14 +51,17 @@ fn default_testing_addresses(flavor: Flavor) -> BTreeMap<String, NumericalAddres
 }
 
 fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
-    let lint = path.components().any(|c| c.as_os_str() == LINTER_DIR);
-    let flavor = if path.components().any(|c| c.as_os_str() == SUI_MODE_DIR) {
+    let path_contains = |s| path.components().any(|c| c.as_os_str() == s);
+    let lint = path_contains(LINTER_DIR);
+    let flavor = if path_contains(SUI_MODE_DIR) {
         Flavor::Sui
     } else {
         Flavor::default()
     };
-    let edition = if path.components().any(|c| c.as_os_str() == MOVE_2024_DIR) {
+    let edition = if path_contains(MOVE_2024_DIR) {
         Edition::E2024_ALPHA
+    } else if path_contains(DEV_DIR) {
+        Edition::DEVELOPMENT
     } else {
         Edition::default()
     };

--- a/external-crates/move/crates/move-symbol-pool/src/lib.rs
+++ b/external-crates/move/crates/move-symbol-pool/src/lib.rs
@@ -92,6 +92,7 @@ static_symbols!(
     "lint",
     "migration",
     "beta",
+    "development",
 );
 
 /// The global, unique cache of strings.


### PR DESCRIPTION
## Description 

Adds a development edition for the Move source language. Will be useful for future source language developments so we can land and test them before exposing them to developers.

## Test Plan 

Ensure existing tests pass.

