### PR TITLE
Allow constants as standalone value paths

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2287,6 +2287,10 @@ struct ExpDotted {
     base: T::Exp,
     base_type: N::Type,
     accessors: Vec<ExpDottedAccess>,
+    // This should only be used in the functions grouped here, nowhere else. This is for tracking
+    // if a constant appears plainly in a `use`/`copy` position, and suppresses constant usage
+    // warning if so.
+    warn_on_constant: bool,
 }
 
 impl ExpDotted {
@@ -2333,6 +2337,7 @@ fn process_exp_dotted(
                 base_kind,
                 base_type,
                 accessors,
+                warn_on_constant: true,
             }
         }
         N::ExpDotted_::Dot(ndot, field) => {
@@ -2535,7 +2540,6 @@ fn resolve_exp_dotted(
             copy_exp
         }
         DottedUsage::Use => {
-            warn_on_constant_borrow(context, edotted.base.exp.loc, &edotted.base);
             if edotted.accessors.is_empty() {
                 Box::new(edotted.base)
             } else {
@@ -2604,10 +2608,22 @@ fn borrow_exp_dotted(context: &mut Context, mut_: bool, ed: ExpDotted) -> Box<T:
         base_type,
         base_kind,
         accessors,
+        mut warn_on_constant,
     } = ed;
 
+    // If we have accessors, we are definitely going to actually borrow and that means we'll copy
+    // a base constant, so we should warn if we do.
+    warn_on_constant = warn_on_constant || !accessors.is_empty();
+
     let mut exp = match base_kind {
-        BaseRefKind::Owned => exp_to_borrow(context, loc, mut_, Box::new(base), base_type),
+        BaseRefKind::Owned => exp_to_borrow_(
+            context,
+            loc,
+            mut_,
+            Box::new(base),
+            base_type,
+            warn_on_constant,
+        ),
         BaseRefKind::ImmRef | BaseRefKind::MutRef => Box::new(base),
     };
 
@@ -2703,21 +2719,18 @@ fn exp_dotted_to_owned(context: &mut Context, usage: DottedUsage, ed: ExpDotted)
         )));
         return make_error_exp(context, ed.loc);
     };
-    let borrow_exp = borrow_exp_dotted(context, false, ed);
     let case = match usage {
         DottedUsage::Move(_) => {
-            context.env.add_diag(ice!((
-                borrow_exp.exp.loc,
-                "Invalid dotted usage 'move' in to_owned"
-            )));
-            return make_error_exp(context, borrow_exp.exp.loc);
+            context
+                .env
+                .add_diag(ice!((ed.loc, "Invalid dotted usage 'move' in to_owned")));
+            return make_error_exp(context, ed.loc);
         }
         DottedUsage::Borrow(_) => {
-            context.env.add_diag(ice!((
-                borrow_exp.exp.loc,
-                "Invalid dotted usage 'borrow' in to_owned"
-            )));
-            return make_error_exp(context, borrow_exp.exp.loc);
+            context
+                .env
+                .add_diag(ice!((ed.loc, "Invalid dotted usage 'borrow' in to_owned")));
+            return make_error_exp(context, ed.loc);
         }
         DottedUsage::Use => "implicit copy",
         DottedUsage::Copy(loc) => {
@@ -2727,6 +2740,13 @@ fn exp_dotted_to_owned(context: &mut Context, usage: DottedUsage, ed: ExpDotted)
             "'copy'"
         }
     };
+    // If we are going to an owned value and we have a constant with no accessors, we're fine to
+    // not warn about its usage.
+    let mut edotted = ed;
+    if edotted.accessors.is_empty() {
+        edotted.warn_on_constant = false;
+    }
+    let borrow_exp = borrow_exp_dotted(context, false, edotted);
     let eloc = borrow_exp.exp.loc;
     context.add_ability_constraint(
         eloc,
@@ -2756,11 +2776,27 @@ fn exp_to_borrow(
     eb: Box<T::Exp>,
     base_type: Type,
 ) -> Box<T::Exp> {
+    exp_to_borrow_(
+        context, loc, mut_, eb, base_type, /* warn_on_constant */ true,
+    )
+}
+
+fn exp_to_borrow_(
+    context: &mut Context,
+    loc: Loc,
+    mut_: bool,
+    eb: Box<T::Exp>,
+    base_type: Type,
+    warn_on_constant: bool,
+) -> Box<T::Exp> {
     use Type_::*;
     use T::UnannotatedExp_ as TE;
-    warn_on_constant_borrow(context, eb.exp.loc, &eb);
+    if warn_on_constant {
+        warn_on_constant_borrow(context, eb.exp.loc, &eb)
+    };
     let eb_ty = eb.ty;
     let sp!(ebloc, eb_) = eb.exp;
+    let ref_ty = Ref(mut_, Box::new(base_type));
     let e_ = match eb_ {
         TE::Use(v) => TE::BorrowLocal(mut_, v),
         eb_ => {
@@ -2773,7 +2809,7 @@ fn exp_to_borrow(
             TE::TempBorrow(mut_, Box::new(T::exp(eb_ty, sp(ebloc, eb_))))
         }
     };
-    let ty = sp(loc, Ref(mut_, Box::new(base_type)));
+    let ty = sp(loc, ref_ty);
     Box::new(T::exp(ty, sp(loc, e_)))
 }
 
@@ -2812,12 +2848,14 @@ fn method_call(
 fn method_call_resolve(
     context: &mut Context,
     loc: Loc,
-    mut edotted: ExpDotted,
+    edotted: ExpDotted,
     method: Name,
     ty_args_opt: Option<Vec<Type>>,
 ) -> Option<(ModuleIdent, FunctionName, ResolvedFunctionType, T::Exp)> {
     use TypeName_ as TN;
     use Type_ as Ty;
+
+    let mut edotted = edotted;
 
     edotted.loc = loc;
     let edotted_ty = core::unfold_type(&context.subst, edotted.last_type());

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/all_index_paths.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/all_index_paths.exp
@@ -8,144 +8,160 @@ warning[W09001]: unused alias
    = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E04012]: invalid type for constant
-   ┌─ tests/move_2024/typing/all_index_paths.move:44:16
+   ┌─ tests/move_2024/typing/all_index_paths.move:46:16
    │
-44 │     const VEC: vector<X> = vector[];
+46 │     const VEC: vector<X> = vector[];
    │                ^^^^^^^^^
    │                │      │
    │                │      Found: 'a::m::X'. But expected one of: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'bool', 'address', 'vector<_>'
    │                Unpermitted constant type
 
 error[E01013]: invalid 'move' or 'copy'
-   ┌─ tests/move_2024/typing/all_index_paths.move:61:9
+   ┌─ tests/move_2024/typing/all_index_paths.move:63:9
    │
-61 │         copy t.u.vs[n].w.xs[m+1].deref();
+63 │         copy t.u.vs[n].w.xs[m+1].deref();
    │         ^^^^ --------------------------- Expected a name or path access, e.g. 'x' or 'e.f'
    │         │     
    │         Invalid 'copy' of expression
 
 error[E01013]: invalid 'move' or 'copy'
-   ┌─ tests/move_2024/typing/all_index_paths.move:62:9
+   ┌─ tests/move_2024/typing/all_index_paths.move:64:9
    │
-62 │         copy t.u.vs[n].w.xs[m+1].deref().id();
+64 │         copy t.u.vs[n].w.xs[m+1].deref().id();
    │         ^^^^ -------------------------------- Expected a name or path access, e.g. 'x' or 'e.f'
    │         │     
    │         Invalid 'copy' of expression
 
 warning[W04028]: implicit copy of a constant
-   ┌─ tests/move_2024/typing/all_index_paths.move:63:14
+   ┌─ tests/move_2024/typing/all_index_paths.move:65:14
    │
-63 │         copy VEC[n+1];
+65 │         copy VEC[n+1];
    │              ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
    │
    = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01013]: invalid 'move' or 'copy'
-   ┌─ tests/move_2024/typing/all_index_paths.move:64:9
+   ┌─ tests/move_2024/typing/all_index_paths.move:66:9
    │
-64 │         copy VEC[n+1].id_u64();
+66 │         copy VEC[n+1].id_u64();
    │         ^^^^ ----------------- Expected a name or path access, e.g. 'x' or 'e.f'
    │         │     
    │         Invalid 'copy' of expression
 
-error[E04027]: invalid 'move' usage
-   ┌─ tests/move_2024/typing/all_index_paths.move:81:9
+error[E01013]: invalid 'move' or 'copy'
+   ┌─ tests/move_2024/typing/all_index_paths.move:67:9
    │
-81 │         move t2.u;
+67 │         copy VEC.id();
+   │         ^^^^ -------- Expected a name or path access, e.g. 'x' or 'e.f'
+   │         │     
+   │         Invalid 'copy' of expression
+
+error[E04027]: invalid 'move' usage
+   ┌─ tests/move_2024/typing/all_index_paths.move:84:9
+   │
+84 │         move t2.u;
    │         ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
-
-error[E04027]: invalid 'move' usage
-   ┌─ tests/move_2024/typing/all_index_paths.move:82:10
-   │
-82 │         (move t2.u).vs[2];
-   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
-
-error[E04027]: invalid 'move' usage
-   ┌─ tests/move_2024/typing/all_index_paths.move:83:10
-   │
-83 │         (move t2.u).vs[2].w;
-   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
-
-error[E04027]: invalid 'move' usage
-   ┌─ tests/move_2024/typing/all_index_paths.move:84:10
-   │
-84 │         (move t2.u).vs[2].w.xs[m+1];
-   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
 
 error[E04027]: invalid 'move' usage
    ┌─ tests/move_2024/typing/all_index_paths.move:85:10
    │
-85 │         (move t2.u).vs[2].w.xs[m+1].y;
+85 │         (move t2.u).vs[2];
    │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
 
 error[E04027]: invalid 'move' usage
    ┌─ tests/move_2024/typing/all_index_paths.move:86:10
    │
-86 │         (move t2.u).vs[2].w.xs[m+1].y.z;
+86 │         (move t2.u).vs[2].w;
    │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
 
+error[E04027]: invalid 'move' usage
+   ┌─ tests/move_2024/typing/all_index_paths.move:87:10
+   │
+87 │         (move t2.u).vs[2].w.xs[m+1];
+   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
+
+error[E04027]: invalid 'move' usage
+   ┌─ tests/move_2024/typing/all_index_paths.move:88:10
+   │
+88 │         (move t2.u).vs[2].w.xs[m+1].y;
+   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
+
+error[E04027]: invalid 'move' usage
+   ┌─ tests/move_2024/typing/all_index_paths.move:89:10
+   │
+89 │         (move t2.u).vs[2].w.xs[m+1].y.z;
+   │          ^^^^ Invalid 'move'. 'move' works only with variables, e.g. 'move x'. 'move' on a path access is not supported
+
+error[E01013]: invalid 'move' or 'copy'
+   ┌─ tests/move_2024/typing/all_index_paths.move:90:9
+   │
+90 │         move VEC.id();
+   │         ^^^^ -------- Expected a name or path access, e.g. 'x' or 'e.f'
+   │         │     
+   │         Invalid 'move' of expression
+
 error[E04004]: expected a single non-reference type
-    ┌─ tests/move_2024/typing/all_index_paths.move:100:9
+    ┌─ tests/move_2024/typing/all_index_paths.move:104:9
     │
- 16 │     fun ref_unused(_x: &X) { }
+ 18 │     fun ref_unused(_x: &X) { }
     │         ---------- Expected a single non-reference type, but found: '()'
     ·
-100 │         &t2.u.vs[2].w.xs[m+1].ref_unused(); // invalid -- trying to borrow `()`
+104 │         &t2.u.vs[2].w.xs[m+1].ref_unused(); // invalid -- trying to borrow `()`
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrow
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:104:10
+    ┌─ tests/move_2024/typing/all_index_paths.move:108:10
     │
-104 │         &VEC[n+1];
+108 │         &VEC[n+1];
     │          ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:105:10
+    ┌─ tests/move_2024/typing/all_index_paths.move:109:10
     │
-105 │         &VEC[n+1].id();
+109 │         &VEC[n+1].id();
     │          ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E04004]: expected a single non-reference type
-    ┌─ tests/move_2024/typing/all_index_paths.move:119:9
+    ┌─ tests/move_2024/typing/all_index_paths.move:124:9
     │
- 16 │     fun ref_unused(_x: &X) { }
+ 18 │     fun ref_unused(_x: &X) { }
     │         ---------- Expected a single non-reference type, but found: '()'
     ·
-119 │         &mut t2.u.vs[2].w.xs[m+1].ref_unused(); // invalid -- trying to borrow `()`
+124 │         &mut t2.u.vs[2].w.xs[m+1].ref_unused(); // invalid -- trying to borrow `()`
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrow
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:123:14
+    ┌─ tests/move_2024/typing/all_index_paths.move:128:14
     │
-123 │         &mut VEC[n+1];
+128 │         &mut VEC[n+1];
     │              ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:124:14
+    ┌─ tests/move_2024/typing/all_index_paths.move:129:14
     │
-124 │         &mut VEC[n+1].id();
+129 │         &mut VEC[n+1].id();
     │              ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:139:9
+    ┌─ tests/move_2024/typing/all_index_paths.move:145:9
     │
-139 │         VEC[n+1];
+145 │         VEC[n+1];
     │         ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W04028]: implicit copy of a constant
-    ┌─ tests/move_2024/typing/all_index_paths.move:140:9
+    ┌─ tests/move_2024/typing/all_index_paths.move:146:9
     │
-140 │         VEC[n+1].id();
+146 │         VEC[n+1].id();
     │         ^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
     │
     = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/all_index_paths.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/all_index_paths.move
@@ -12,6 +12,8 @@ module a::m {
 
     fun id_w(w: W): W { w }
     fun id(x: X): X { x }
+    fun vec_id<T>(v: vector<T>): vector<T> { v }
+    use fun vec_id as vector.id;
 
     fun ref_unused(_x: &X) { }
 
@@ -62,6 +64,7 @@ module a::m {
         copy t.u.vs[n].w.xs[m+1].deref().id();
         copy VEC[n+1];
         copy VEC[n+1].id_u64();
+        copy VEC.id();
     }
 
     fun all_index_move(t: T, t2: T, n: u64, m: u64) {
@@ -84,6 +87,7 @@ module a::m {
         (move t2.u).vs[2].w.xs[m+1];
         (move t2.u).vs[2].w.xs[m+1].y;
         (move t2.u).vs[2].w.xs[m+1].y.z;
+        move VEC.id();
     }
 
     fun all_index_borrow(t: T, t2: T, n: u64, m: u64) {
@@ -103,6 +107,7 @@ module a::m {
         &(&t2.u.vs[2].w.xs[m+1]).deref();
         &VEC[n+1];
         &VEC[n+1].id();
+        &VEC.id();
     }
 
     fun all_index_borrow_mut(mut t: T, mut t2: T, n: u64, m: u64) {
@@ -122,6 +127,7 @@ module a::m {
         (&mut t2.u.vs[2].w).xs[m+1].deref();
         &mut VEC[n+1];
         &mut VEC[n+1].id();
+        &mut VEC.id();
     }
 
     fun all_index_use(t: T, t2: T, n: u64, m: u64) {
@@ -138,5 +144,6 @@ module a::m {
         t2.u.vs[2].w.xs[m+1].id();
         VEC[n+1];
         VEC[n+1].id();
+        VEC.id();
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject.move
@@ -1,0 +1,15 @@
+module 0x42::m {
+
+    const ZERO: u64 = 0;
+
+    fun add1(n: u64): u64 {
+        n + 1
+    }
+
+    use fun add1 as u64.add1;
+
+    fun one(): u64 {
+       ZERO.add1()
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject_invalid.exp
@@ -1,0 +1,16 @@
+warning[W04028]: implicit copy of a constant
+   ┌─ tests/move_2024/typing/const_method_subject_invalid.move:12:8
+   │
+12 │        ZERO.add1_mut()
+   │        ^^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
+   │
+   = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W04028]: implicit copy of a constant
+   ┌─ tests/move_2024/typing/const_method_subject_invalid.move:22:8
+   │
+22 │        ZERO.deref_and_add()
+   │        ^^^^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
+   │
+   = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/const_method_subject_invalid.move
@@ -1,0 +1,25 @@
+module 0x42::m {
+
+    const ZERO: u64 = 0;
+
+    fun add1_mut(n: &mut u64) {
+        *n = *n + 1;
+    }
+
+    use fun add1_mut as u64.add1_mut;
+
+    fun mut_ref() {
+       ZERO.add1_mut()
+    }
+
+    fun deref_and_add(n: &u64): u64 {
+        *n + 1
+    }
+
+    use fun deref_and_add as u64.deref_and_add;
+
+    fun imm_ref(): u64 {
+       ZERO.deref_and_add()
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/implicit_const_copy_method.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/implicit_const_copy_method.exp
@@ -1,12 +1,4 @@
 warning[W04028]: implicit copy of a constant
-  ┌─ tests/move_2024/typing/implicit_const_copy_method.move:7:9
-  │
-7 │         C.next();
-  │         ^ This access will make a new copy of the constant. Consider binding the value to a variable first to make this copy explicit
-  │
-  = This warning can be suppressed with '#[allow(implicit_const_copy)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
-warning[W04028]: implicit copy of a constant
   ┌─ tests/move_2024/typing/implicit_const_copy_method.move:8:9
   │
 8 │         BYTES.length();


### PR DESCRIPTION
## Description 

This allows constants to be used in some positions that were previously errors.

## Test Plan 

New and updated tests

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
