### PR TITLE
[move-2024] Deprecate `address` blocks

### DIFF
--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml
@@ -1,0 +1,13 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml.expected
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/Move.toml.expected
@@ -1,0 +1,14 @@
+
+# TOML FILE
+
+[package]
+name = "A"
+edition = "2024.beta"
+
+# this is a comment
+[addresses]
+A = "0x42"
+std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
@@ -50,6 +50,19 @@ The following changes will be made.
 @@ -1 +1 @@
 -address 0x2{ module m {} module n {}}
 +/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */
+--- sources/address_migration3.move
++++ sources/address_migration3.move
+@@ -1,2 +1,2 @@
+-address A {
+-module m {
++/* address A { */
++module A::m {
+@@ -4 +4 @@
+-module n {
++module A::n {
+@@ -6 +6 @@
+-}
++/* } */
 
 
 ============================================================
@@ -57,6 +70,7 @@ Apply changes? (Y/n)
 Updating "sources/address_migration.move" . . .
 Updating "sources/address_migration1.move" . . .
 Updating "sources/address_migration2.move" . . .
+Updating "sources/address_migration3.move" . . .
 
 Changes complete
 Wrote patchfile out to: ./migration.patch
@@ -66,5 +80,6 @@ External Command `diff -r -s sources migration_sources`:
 Files sources/address_migration.move and migration_sources/address_migration.move are identical
 Files sources/address_migration1.move and migration_sources/address_migration1.move are identical
 Files sources/address_migration2.move and migration_sources/address_migration2.move are identical
+Files sources/address_migration3.move and migration_sources/address_migration3.move are identical
 External Command `diff -s Move.toml Move.toml.expected`:
 Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.exp
@@ -1,0 +1,70 @@
+Command `migrate`:
+Package toml does not specify an edition. As of 2024, Move requires all packages to define a language edition.
+
+Please select one of the following editions:
+
+1) 2024.beta
+2) legacy
+
+Selection (default=1): 
+
+Would you like the Move compiler to migrate your code to Move 2024? (Y/n) 
+Generated changes . . .
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING A
+
+The following changes will be made.
+============================================================
+
+--- sources/address_migration.move
++++ sources/address_migration.move
+@@ -1,2 +1,2 @@
+-address 0x2 {
+-module m {
++/* address 0x2 { */
++module 0x2::m {
+@@ -4 +4 @@
+-module n {
++module 0x2::n {
+@@ -6 +6 @@
+-}
++/* } */
+--- sources/address_migration1.move
++++ sources/address_migration1.move
+@@ -1 +1 @@
+-address /* some inline comment */ 0x2 
++/* address /* some inline comment */ 0x2 
+@@ -3,2 +3,2 @@
+-{
+-module m {
++{ */
++module 0x2::m {
+@@ -6 +6 @@
+-module n {
++module 0x2::n {
+@@ -8 +8 @@
+-/* an inline comment*/}
++/* an inline comment*//* } */
+--- sources/address_migration2.move
++++ sources/address_migration2.move
+@@ -1 +1 @@
+-address 0x2{ module m {} module n {}}
++/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */
+
+
+============================================================
+Apply changes? (Y/n) 
+Updating "sources/address_migration.move" . . .
+Updating "sources/address_migration1.move" . . .
+Updating "sources/address_migration2.move" . . .
+
+Changes complete
+Wrote patchfile out to: ./migration.patch
+
+Recorded edition in 'Move.toml'
+External Command `diff -r -s sources migration_sources`:
+Files sources/address_migration.move and migration_sources/address_migration.move are identical
+Files sources/address_migration1.move and migration_sources/address_migration1.move are identical
+Files sources/address_migration2.move and migration_sources/address_migration2.move are identical
+External Command `diff -s Move.toml Move.toml.expected`:
+Files Move.toml and Move.toml.expected are identical

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/args.txt
@@ -1,0 +1,3 @@
+migrate
+> diff -r -s sources migration_sources
+> diff -s Move.toml Move.toml.expected

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration.move
@@ -1,0 +1,6 @@
+/* address 0x2 { */
+module 0x2::m {
+}
+module 0x2::n {
+}
+/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration1.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration1.move
@@ -1,0 +1,8 @@
+/* address /* some inline comment */ 0x2 
+// a line comment
+{ */
+module 0x2::m {
+}
+module 0x2::n {
+}
+/* an inline comment*//* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration2.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration2.move
@@ -1,0 +1,1 @@
+/* address 0x2{ */ module 0x2::m {} module 0x2::n {}/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration3.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/migration_sources/address_migration3.move
@@ -1,0 +1,6 @@
+/* address A { */
+module A::m {
+}
+module A::n {
+}
+/* } */

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration.move
@@ -1,0 +1,6 @@
+address 0x2 {
+module m {
+}
+module n {
+}
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration1.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration1.move
@@ -1,0 +1,8 @@
+address /* some inline comment */ 0x2 
+// a line comment
+{
+module m {
+}
+module n {
+}
+/* an inline comment*/}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration2.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration2.move
@@ -1,0 +1,1 @@
+address 0x2{ module m {} module n {}}

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration3.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_address_block/sources/address_migration3.move
@@ -1,0 +1,6 @@
+address A {
+module m {
+}
+module n {
+}
+}

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/nested_use.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/nested_use.move
@@ -1,8 +1,7 @@
 //# init --edition 2024.alpha
 
 //# publish
-address 0x42 {
-module example {
+module 0x42::example {
     use std::{vector::{Self as vec, push_back}, string::{String, Self as str}};
 
     fun example(s: &mut String) {
@@ -11,5 +10,4 @@ module example {
         push_back(&mut v, 10);
         str::append_utf8(s, v);
     }
-}
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/public_package.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/public_package.exp
@@ -1,4 +1,4 @@
 processed 3 tasks
 
-task 2 'run'. lines 22-22:
+task 2 'run'. lines 20-20:
 return values: { false }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/public_package.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/public_package.move
@@ -1,21 +1,19 @@
 //# init --edition 2024.alpha
 
 //# publish
-address 0x42 {
-    module x {
-        public struct T has drop {}
+module 0x42::x {
+    public struct T has drop {}
 
-        public(package) fun new(): T {
-            T {}
-        }
+    public(package) fun new(): T {
+        T {}
     }
+}
 
-    module y {
-        use 0x42::x;
+module 0x42::y {
+    use 0x42::x;
 
-        public fun foo(): x::T {
-            x::new()
-        }
+    public fun foo(): x::T {
+        x::new()
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -355,6 +355,8 @@ codes!(
         NeedsGlobalQualification: { msg: "move 2024 migration: global qualification", severity: NonblockingError },
         RemoveFriend: { msg: "move 2024 migration: remove 'friend'", severity: NonblockingError },
         MakePubPackage: { msg: "move 2024 migration: make 'public(package)'", severity: NonblockingError },
+        AddressRemove: { msg: "move 2024 migration: address remove", severity: NonblockingError },
+        AddressAdd: { msg: "move 2024 migration: address add", severity: NonblockingError },
     ]
 );
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -99,6 +99,8 @@ enum MigrationChange {
     AddGlobalQual,
     RemoveFriend,
     MakePubPackage,
+    AddressRemove,
+    AddressAdd(String),
 }
 
 // All of the migration changes
@@ -897,6 +899,8 @@ impl Migration {
         const NEEDS_GLOBAL_QUAL: u8 = codes::Migration::NeedsGlobalQualification as u8;
         const REMOVE_FRIEND: u8 = codes::Migration::RemoveFriend as u8;
         const MAKE_PUB_PACKAGE: u8 = codes::Migration::MakePubPackage as u8;
+        const ADDRESS_REMOVE: u8 = codes::Migration::AddressRemove as u8;
+        const ADDRESS_ADD: u8 = codes::Migration::AddressAdd as u8;
 
         let FileByteSpan { file_id, byte_span } = self.find_file_location(&diag);
         let file_change_entry = self.changes.entry(file_id).or_default();
@@ -910,6 +914,11 @@ impl Migration {
             (CAT, NEEDS_GLOBAL_QUAL) => MigrationChange::AddGlobalQual,
             (CAT, REMOVE_FRIEND) => MigrationChange::RemoveFriend,
             (CAT, MAKE_PUB_PACKAGE) => MigrationChange::MakePubPackage,
+            (CAT, ADDRESS_REMOVE) => MigrationChange::AddressRemove,
+            (CAT, ADDRESS_ADD) => {
+                let insertion = diag.primary_msg().to_string();
+                MigrationChange::AddressAdd(insertion)
+            }
             _ => unreachable!(),
         };
         file_change_entry.push((byte_span, change));
@@ -961,6 +970,19 @@ impl Migration {
                 MigrationChange::MakePubPackage => {
                     let rest = &source_prefix[loc.end..];
                     output = format!("public(package){}{}", rest, output);
+                }
+                MigrationChange::AddressRemove => {
+                    let rest = &source_prefix[loc.end..];
+                    output = format!(
+                        "/* {} */{}{}",
+                        &source_prefix[loc.start..loc.end],
+                        rest,
+                        output
+                    );
+                }
+                MigrationChange::AddressAdd(insertion) => {
+                    let rest = &source_prefix[loc.start..];
+                    output = format!("{}{}{}", insertion, rest, output);
                 }
             }
             source_prefix = &source_prefix[..loc.start];

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -214,6 +214,10 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
+    pub fn loc_contents(&self, loc: Loc) -> &'input str {
+        &self.text[loc.start() as usize..loc.end() as usize]
+    }
+
     pub fn file_hash(&self) -> FileHash {
         self.file_hash
     }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/assign_non_simple_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/assign_non_simple_name.exp
@@ -1,124 +1,124 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:3:5
+  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:2:5
   │
-3 │     struct S {}
+2 │     struct S {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:7:23
+  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:6:23
   │
-6 │     use 0x42::X;
+5 │     use 0x42::X;
   │               - Alias previously defined here
-7 │     use 0x42::X::S as X;
+6 │     use 0x42::X::S as X;
   │                       ^ Duplicate module member or alias 'X'. Top level names in a namespace must be unique
 
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:9:5
+  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:8:5
   │
-9 │     struct R {}
+8 │     struct R {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E01003]: invalid modifier
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:10:5
-   │
-10 │     struct S<T> { f: T }
-   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-   │
-   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+  ┌─ tests/move_2024/expansion/assign_non_simple_name.move:9:5
+  │
+9 │     struct S<T> { f: T }
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:16:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:15:9
    │
-16 │         X::S = ();
+15 │         X::S = ();
    │         ^ Expected a module or address in this position, not a module member
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:17:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:16:9
    │
-17 │         Self::S<u64> = ();
+16 │         Self::S<u64> = ();
    │         ^^^^^^^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'Self::S {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:18:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:17:9
    │
-18 │         Self::R = ();
+17 │         Self::R = ();
    │         ^^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'Self::R {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:22:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:21:9
    │
-22 │         0x42::X::S = ();
+21 │         0x42::X::S = ();
    │         ^^^^^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'0x42::X::S {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:23:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:22:9
    │
-23 │         0x42::M::S<u64> = ();
+22 │         0x42::M::S<u64> = ();
    │         ^^^^^^^^^^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'0x42::M::S {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:24:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:23:9
    │
-24 │         0x42::M::R = ();
+23 │         0x42::M::R = ();
    │         ^^^^^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'0x42::M::R {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:28:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:27:9
    │
-28 │         x<u64> = ();
+27 │         x<u64> = ();
    │         ^^^^^^ Unexpected assignment of instantiated type without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'x {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:29:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:28:9
    │
-29 │         S<u64> = ();
+28 │         S<u64> = ();
    │         ^^^^^^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'S {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:33:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:32:9
    │
-33 │         X = ();
+32 │         X = ();
    │         ^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'X {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:34:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:33:9
    │
-34 │         S = ();
+33 │         S = ();
    │         ^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'S {}'
 
 error[E01009]: invalid assignment
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:35:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:34:9
    │
-35 │         R = ();
+34 │         R = ();
    │         ^ Unexpected assignment of module access without fields
    │
    = If you are trying to unpack a struct, try adding fields, e.g.'R {}'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:39:9
+   ┌─ tests/move_2024/expansion/assign_non_simple_name.move:38:9
    │
-39 │         Y = 0;
+38 │         Y = 0;
    │         ^ Invalid assignment. Unbound variable 'Y'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/assign_non_simple_name.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/assign_non_simple_name.move
@@ -1,8 +1,7 @@
-address 0x42 {
-module X {
+module 0x42::X {
     struct S {}
 }
-module M {
+module 0x42::M {
     use 0x42::X;
     use 0x42::X::S as X;
 
@@ -38,5 +37,4 @@ module M {
         // Should fail with unbound local even though it is not a valid local name
         Y = 0;
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_invalid_position.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_invalid_position.exp
@@ -1,24 +1,12 @@
 error[E02010]: invalid name
-  ┌─ tests/move_2024/expansion/macro_identifier_invalid_position.move:1:9
+  ┌─ tests/move_2024/expansion/macro_identifier_invalid_position.move:1:8
   │
-1 │ address $a {
-  │         ^^ Invalid address name '$a'. Identifiers starting with '$' can be used only for parameters and type paramters
+1 │ module $a::m {}
+  │        ^^ Invalid address name '$a'. Identifiers starting with '$' can be used only for parameters and type paramters
 
 error[E02010]: invalid name
   ┌─ tests/move_2024/expansion/macro_identifier_invalid_position.move:2:8
   │
-2 │ module $m {}
-  │        ^^ Invalid module name '$m'. Identifiers starting with '$' can be used only for parameters and type paramters
-
-error[E02010]: invalid name
-  ┌─ tests/move_2024/expansion/macro_identifier_invalid_position.move:5:8
-  │
-5 │ module $a::m {}
-  │        ^^ Invalid address name '$a'. Identifiers starting with '$' can be used only for parameters and type paramters
-
-error[E02010]: invalid name
-  ┌─ tests/move_2024/expansion/macro_identifier_invalid_position.move:6:8
-  │
-6 │ module $b::m {}
+2 │ module $b::m {}
   │        ^^ Invalid address name '$b'. Identifiers starting with '$' can be used only for parameters and type paramters
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_invalid_position.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/macro_identifier_invalid_position.move
@@ -1,6 +1,2 @@
-address $a {
-module $m {}
-}
-
 module $a::m {}
 module $b::m {}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/module_alias_as_type.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/module_alias_as_type.exp
@@ -1,6 +1,6 @@
 error[E03006]: unexpected name in this position
-  ┌─ tests/move_2024/expansion/module_alias_as_type.move:7:16
+  ┌─ tests/move_2024/expansion/module_alias_as_type.move:5:16
   │
-7 │     fun foo(x: X) { x; }
+5 │     fun foo(x: X) { x; }
   │                ^ Expected a type, function, or constant in this position, not a module
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/module_alias_as_type.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/module_alias_as_type.move
@@ -1,10 +1,6 @@
-address 0x2 {
+module 0x2::X {}
 
-module X {}
-
-module M {
+module 0x2::M {
     use 0x2::X;
     fun foo(x: X) { x; }
-}
-
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/positional_struct_lhs_unpack.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/positional_struct_lhs_unpack.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u16, u64) has copy, drop;
     public struct Bar()
 
@@ -14,5 +13,4 @@ module M {
         // `Call` expr to a `Unpack` expr.
         Bar() = x;
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_function_overlap_with_module.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_function_overlap_with_module.move
@@ -1,13 +1,11 @@
-address 0x2 {
-module X {
+module 0x2::X {
     public fun u() {}
 }
 
-module M {
+module 0x2::M {
     use 0x2::X::{Self, u as X};
     fun foo() {
         X();
         X::u()
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_as_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_as_invalid.exp
@@ -1,36 +1,36 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:3:5
+  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:2:5
   │
-3 │     struct S {}
+2 │     struct S {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 warning[W09001]: unused alias
-  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:8:26
+  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:7:26
   │
-8 │     use 0x2::X::{Self as B, foo, S};
+7 │     use 0x2::X::{Self as B, foo, S};
   │                          ^ Unused 'use' of alias 'B'. Consider removing it
   │
   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01003]: invalid modifier
-   ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:10:5
-   │
-10 │     struct X { f: X::S, f2: S }
-   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
-   │
-   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
+  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:9:5
+  │
+9 │     struct X { f: X::S, f2: S }
+  │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
+  │
+  = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:10:19
-   │
-10 │     struct X { f: X::S, f2: S }
-   │                   ^ Expected a module or address in this position, not a module member
+  ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:9:19
+  │
+9 │     struct X { f: X::S, f2: S }
+  │                   ^ Expected a module or address in this position, not a module member
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:12:9
+   ┌─ tests/move_2024/expansion/use_nested_self_as_invalid.move:11:9
    │
-12 │         X::foo();
+11 │         X::foo();
    │         ^ Expected a module or address in this position, not a module member
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_as_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_as_invalid.move
@@ -1,10 +1,9 @@
-address 0x2 {
-module X {
+module 0x2::X {
     struct S {}
     public fun foo() {}
 }
 
-module M {
+module 0x2::M {
     use 0x2::X::{Self as B, foo, S};
 
     struct X { f: X::S, f2: S }
@@ -12,5 +11,4 @@ module M {
         X::foo();
         foo()
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_duplicate.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_duplicate.exp
@@ -1,23 +1,23 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:3:5
+  ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:2:5
   │
-3 │     struct S {}
+2 │     struct S {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:9:17
+  ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:8:17
   │
-8 │     use 0x2::X;
+7 │     use 0x2::X;
   │              - Alias previously defined here
-9 │     use 0x2::X::Self;
+8 │     use 0x2::X::Self;
   │                 ^^^^ Duplicate module alias 'X'. Module aliases must be unique within a given namespace
 
 error[E01003]: invalid modifier
-   ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:11:5
+   ┌─ tests/move_2024/expansion/use_nested_self_duplicate.move:10:5
    │
-11 │     struct S { f: X::S }
+10 │     struct S { f: X::S }
    │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
    │
    = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_duplicate.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_nested_self_duplicate.move
@@ -1,10 +1,9 @@
-address 0x2 {
-module X {
+module 0x2::X {
     struct S {}
     public fun foo() {}
 }
 
-module M {
+module 0x2::M {
     use 0x2::X;
     use 0x2::X::Self;
 
@@ -12,5 +11,4 @@ module M {
     fun foo() {
         X::foo()
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_struct_overlap_with_module.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_struct_overlap_with_module.exp
@@ -1,30 +1,30 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:3:5
+  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:2:5
   │
-3 │     struct S {}
+2 │     struct S {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:7:29
+  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:6:29
   │
-7 │     use 0x2::X::{Self, S as X};
+6 │     use 0x2::X::{Self, S as X};
   │                  ----       ^ Duplicate module member or alias 'X'. Top level names in a namespace must be unique
   │                  │           
   │                  Alias previously defined here
 
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:8:5
+  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:7:5
   │
-8 │     struct A { f1: X, f2: X::S }
+7 │     struct A { f1: X, f2: X::S }
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E03006]: unexpected name in this position
-  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:8:27
+  ┌─ tests/move_2024/expansion/use_struct_overlap_with_module.move:7:27
   │
-8 │     struct A { f1: X, f2: X::S }
+7 │     struct A { f1: X, f2: X::S }
   │                           ^ Expected a module or address in this position, not a module member
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_struct_overlap_with_module.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_struct_overlap_with_module.move
@@ -1,10 +1,8 @@
-address 0x2 {
-module X {
+module 0x2::X {
     struct S {}
 }
 
-module M {
+module 0x2::M {
     use 0x2::X::{Self, S as X};
     struct A { f1: X, f2: X::S }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_fn_call_shadow.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_fn_call_shadow.exp
@@ -1,9 +1,9 @@
 error[E02001]: duplicate declaration, item, or annotation
-  ┌─ tests/move_2024/naming/positional_pack_fn_call_shadow.move:6:9
+  ┌─ tests/move_2024/naming/positional_pack_fn_call_shadow.move:5:9
   │
-4 │     public struct Foo(u64) has copy, drop;
+3 │     public struct Foo(u64) has copy, drop;
   │                   --- Alias previously defined here
-5 │ 
-6 │     fun Foo(_x: u64) { }
+4 │ 
+5 │     fun Foo(_x: u64) { }
   │         ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_fn_call_shadow.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_fn_call_shadow.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Valid positional field struct declaration
     public struct Foo(u64) has copy, drop;
 
@@ -9,5 +8,4 @@ module M {
         let _x = Foo(0);
         abort 0
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_non_positional_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_non_positional_struct.exp
@@ -1,18 +1,18 @@
 error[E03013]: positional call mismatch
-  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:7:18
+  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:6:18
   │
-7 │         let _x = Foo(0);
+6 │         let _x = Foo(0);
   │                  ^^^^^^ Invalid struct instantiation. Named struct declarations require named instantiations.
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:7:18
+  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:6:18
   │
-7 │         let _x = Foo(0);
+6 │         let _x = Foo(0);
   │                  ^^^^^^ Missing argument for field 'field' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:7:18
+  ┌─ tests/move_2024/naming/positional_pack_of_non_positional_struct.move:6:18
   │
-7 │         let _x = Foo(0);
+6 │         let _x = Foo(0);
   │                  ^^^^^^ Unbound field '0' in '0x42::M::Foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_non_positional_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_non_positional_struct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo { field: u64 } has copy, drop;
 
     fun x() {
@@ -7,5 +6,4 @@ module M {
         let _x = Foo(0);
         abort 0
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_positional_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_pack_of_positional_struct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64) has copy, drop;
 
     fun x() {
@@ -7,5 +6,3 @@ module M {
         abort 0
     }
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_lhs_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_lhs_unpack.exp
@@ -1,234 +1,234 @@
 error[E03009]: unbound variable
-  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:7:13
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:6:13
   │
-7 │         Foo(t, y) = x;
+6 │         Foo(t, y) = x;
   │             ^ Invalid assignment. Unbound variable 't'
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:8:9
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:7:9
   │
-8 │         Foo() = x;
+7 │         Foo() = x;
   │         ^^^^^ Missing assignment for field '0' in '0x42::M::Foo'
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:8:9
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:7:9
   │
-8 │         Foo() = x;
+7 │         Foo() = x;
   │         ^^^^^ Missing assignment for field '1' in '0x42::M::Foo'
 
 error[E04007]: incompatible types
-  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:9:9
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:8:9
   │
-6 │     fun f(x: Foo) {
+5 │     fun f(x: Foo) {
   │              --- Expected: '0x42::M::Foo'
   ·
-9 │         Bar() = x;
+8 │         Bar() = x;
   │         ^^^^^
   │         │
   │         Invalid deconstruction assignment
   │         Given: '0x42::M::Bar'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:10:9
-   │
- 6 │     fun f(x: Foo) {
-   │              --- Expected: '0x42::M::Foo'
-   ·
-10 │         Bar(_, _) = x;
-   │         ^^^^^^^^^
-   │         │
-   │         Invalid deconstruction assignment
-   │         Given: '0x42::M::Bar'
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:9:9
+  │
+5 │     fun f(x: Foo) {
+  │              --- Expected: '0x42::M::Foo'
+  ·
+9 │         Bar(_, _) = x;
+  │         ^^^^^^^^^
+  │         │
+  │         Invalid deconstruction assignment
+  │         Given: '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:10:9
-   │
-10 │         Bar(_, _) = x;
-   │         ^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:9:9
+  │
+9 │         Bar(_, _) = x;
+  │         ^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:10:9
-   │
-10 │         Bar(_, _) = x;
-   │         ^^^^^^^^^ Unbound field '1' in '0x42::M::Bar'
+  ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:9:9
+  │
+9 │         Bar(_, _) = x;
+  │         ^^^^^^^^^ Unbound field '1' in '0x42::M::Bar'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:14:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:13:13
    │
-14 │         let Foo() = x;
+13 │         let Foo() = x;
    │             ^^^^^ Missing binding for field '0' in '0x42::M::Foo'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:14:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:13:13
    │
-14 │         let Foo() = x;
+13 │         let Foo() = x;
    │             ^^^^^ Missing binding for field '1' in '0x42::M::Foo'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:14:13
    │
-13 │     fun g(x: Foo) {
+12 │     fun g(x: Foo) {
    │              --- Expected: '0x42::M::Foo'
-14 │         let Foo() = x;
-15 │         let Bar() = x;
+13 │         let Foo() = x;
+14 │         let Bar() = x;
    │             ^^^^^
    │             │
    │             Invalid deconstruction binding
    │             Given: '0x42::M::Bar'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:16:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:13
    │
-13 │     fun g(x: Foo) {
+12 │     fun g(x: Foo) {
    │              --- Expected: '0x42::M::Foo'
    ·
-16 │         let Bar(c, d) = x;
+15 │         let Bar(c, d) = x;
    │             ^^^^^^^^^
    │             │
    │             Invalid deconstruction binding
    │             Given: '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:16:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:13
    │
-16 │         let Bar(c, d) = x;
+15 │         let Bar(c, d) = x;
    │             ^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:16:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:13
    │
-16 │         let Bar(c, d) = x;
+15 │         let Bar(c, d) = x;
    │             ^^^^^^^^^ Unbound field '1' in '0x42::M::Bar'
 
 warning[W09002]: unused variable
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:16:17
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:17
    │
-16 │         let Bar(c, d) = x;
+15 │         let Bar(c, d) = x;
    │                 ^ Unused local variable 'c'. Consider removing or prefixing with an underscore: '_c'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:16:20
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:15:20
    │
-16 │         let Bar(c, d) = x;
+15 │         let Bar(c, d) = x;
    │                    ^ Unused local variable 'd'. Consider removing or prefixing with an underscore: '_d'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:20:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:19:9
    │
-19 │     fun h(x: Bar) {
+18 │     fun h(x: Bar) {
    │              --- Expected: '0x42::M::Bar'
-20 │         Foo(_, _) = x;
+19 │         Foo(_, _) = x;
    │         ^^^^^^^^^
    │         │
    │         Invalid deconstruction assignment
    │         Given: '0x42::M::Foo'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:21:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:20:13
    │
-21 │         Foo(t, y) = x;
+20 │         Foo(t, y) = x;
    │             ^ Invalid assignment. Unbound variable 't'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:22:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:21:9
    │
-19 │     fun h(x: Bar) {
+18 │     fun h(x: Bar) {
    │              --- Expected: '0x42::M::Bar'
    ·
-22 │         Foo() = x;
+21 │         Foo() = x;
    │         ^^^^^
    │         │
    │         Invalid deconstruction assignment
    │         Given: '0x42::M::Foo'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:22:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:21:9
    │
-22 │         Foo() = x;
+21 │         Foo() = x;
    │         ^^^^^ Missing assignment for field '0' in '0x42::M::Foo'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:22:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:21:9
    │
-22 │         Foo() = x;
+21 │         Foo() = x;
    │         ^^^^^ Missing assignment for field '1' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:23:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:22:9
    │
-23 │         Bar(_, _) = x;
+22 │         Bar(_, _) = x;
    │         ^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:23:9
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:22:9
    │
-23 │         Bar(_, _) = x;
+22 │         Bar(_, _) = x;
    │         ^^^^^^^^^ Unbound field '1' in '0x42::M::Bar'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:26:13
    │
-26 │     fun z(x: Bar) {
+25 │     fun z(x: Bar) {
    │              --- Expected: '0x42::M::Bar'
-27 │         let Foo(t, y) = x;
+26 │         let Foo(t, y) = x;
    │             ^^^^^^^^^
    │             │
    │             Invalid deconstruction binding
    │             Given: '0x42::M::Foo'
 
 warning[W09002]: unused variable
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:17
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:26:17
    │
-27 │         let Foo(t, y) = x;
+26 │         let Foo(t, y) = x;
    │                 ^ Unused local variable 't'. Consider removing or prefixing with an underscore: '_t'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:20
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:26:20
    │
-27 │         let Foo(t, y) = x;
+26 │         let Foo(t, y) = x;
    │                    ^ Unused local variable 'y'. Consider removing or prefixing with an underscore: '_y'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:28:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:13
    │
-26 │     fun z(x: Bar) {
+25 │     fun z(x: Bar) {
    │              --- Expected: '0x42::M::Bar'
-27 │         let Foo(t, y) = x;
-28 │         let Foo() = x;
+26 │         let Foo(t, y) = x;
+27 │         let Foo() = x;
    │             ^^^^^
    │             │
    │             Invalid deconstruction binding
    │             Given: '0x42::M::Foo'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:28:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:13
    │
-28 │         let Foo() = x;
+27 │         let Foo() = x;
    │             ^^^^^ Missing binding for field '0' in '0x42::M::Foo'
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:28:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:27:13
    │
-28 │         let Foo() = x;
+27 │         let Foo() = x;
    │             ^^^^^ Missing binding for field '1' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:29:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:28:13
    │
-29 │         let Bar(_, _) = x;
+28 │         let Bar(_, _) = x;
    │             ^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:29:13
+   ┌─ tests/move_2024/naming/positional_struct_lhs_unpack.move:28:13
    │
-29 │         let Bar(_, _) = x;
+28 │         let Bar(_, _) = x;
    │             ^^^^^^^^^ Unbound field '1' in '0x42::M::Bar'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_lhs_unpack.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_lhs_unpack.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u16, u64) has copy, drop;
     public struct Bar()
 
@@ -28,5 +27,4 @@ module M {
         let Foo() = x;
         let Bar(_, _) = x;
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_pack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_pack.exp
@@ -1,18 +1,18 @@
 error[E03013]: positional call mismatch
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:7:18
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:6:18
   │
-7 │         let _x = Foo { pos0: 0 };
+6 │         let _x = Foo { pos0: 0 };
   │                  ^^^^^^^^^^^^^^^ Invalid struct instantiation. Positional struct declarations require positional instantiations.
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:7:18
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:6:18
   │
-7 │         let _x = Foo { pos0: 0 };
+6 │         let _x = Foo { pos0: 0 };
   │                  ^^^^^^^^^^^^^^^ Missing argument for field '0' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:7:18
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_pack.move:6:18
   │
-7 │         let _x = Foo { pos0: 0 };
+6 │         let _x = Foo { pos0: 0 };
   │                  ^^^^^^^^^^^^^^^ Unbound field 'pos0' in '0x42::M::Foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_pack.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_pack.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64) has copy, drop;
 
     fun x() {
@@ -7,5 +6,4 @@ module M {
         let _x = Foo { pos0: 0 };
         abort 0
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_unpack.exp
@@ -1,52 +1,52 @@
 warning[W09002]: unused variable
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:6:13
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:5:13
   │
-6 │         let x = Foo(0);
+5 │         let x = Foo(0);
   │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03013]: positional call mismatch
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:8:13
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:7:13
   │
-8 │         let Foo { y: _ } = Foo(0);
+7 │         let Foo { y: _ } = Foo(0);
   │             ^^^^^^^^^^^^ Invalid deconstruction. Positional struct field declarations require positional deconstruction
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:8:13
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:7:13
   │
-8 │         let Foo { y: _ } = Foo(0);
+7 │         let Foo { y: _ } = Foo(0);
   │             ^^^^^^^^^^^^ Missing binding for field '0' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:8:13
+  ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:7:13
   │
-8 │         let Foo { y: _ } = Foo(0);
+7 │         let Foo { y: _ } = Foo(0);
   │             ^^^^^^^^^^^^ Unbound field 'y' in '0x42::M::Foo'
 
 warning[W09002]: unused variable
-   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:13:13
+   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:12:13
    │
-13 │         let x = Foo(0);
+12 │         let x = Foo(0);
    │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03013]: positional call mismatch
-   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:15:9
+   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:14:9
    │
-15 │         Foo { y: _ } = Foo(0);
+14 │         Foo { y: _ } = Foo(0);
    │         ^^^^^^^^^^^^ Invalid deconstruction. Positional struct field declarations require positional deconstruction
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:15:9
+   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:14:9
    │
-15 │         Foo { y: _ } = Foo(0);
+14 │         Foo { y: _ } = Foo(0);
    │         ^^^^^^^^^^^^ Missing assignment for field '0' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:15:9
+   ┌─ tests/move_2024/naming/positional_struct_non_positional_unpack.move:14:9
    │
-15 │         Foo { y: _ } = Foo(0);
+14 │         Foo { y: _ } = Foo(0);
    │         ^^^^^^^^^^^^ Unbound field 'y' in '0x42::M::Foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_unpack.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_struct_non_positional_unpack.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64) has copy, drop;
 
     fun x() {
@@ -16,5 +15,3 @@ module M {
         abort 0
     }
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_non_positional_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_non_positional_struct.exp
@@ -1,36 +1,36 @@
 error[E03013]: positional call mismatch
-  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:8:13
+  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:7:13
   │
-8 │         let Foo(_) = x;
+7 │         let Foo(_) = x;
   │             ^^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:8:13
+  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:7:13
   │
-8 │         let Foo(_) = x;
+7 │         let Foo(_) = x;
   │             ^^^^^^ Missing binding for field 'field' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:8:13
+  ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:7:13
   │
-8 │         let Foo(_) = x;
+7 │         let Foo(_) = x;
   │             ^^^^^^ Unbound field '0' in '0x42::M::Foo'
 
 error[E03013]: positional call mismatch
-   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:15:9
+   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:14:9
    │
-15 │         Foo(_) = x;
+14 │         Foo(_) = x;
    │         ^^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:15:9
+   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:14:9
    │
-15 │         Foo(_) = x;
+14 │         Foo(_) = x;
    │         ^^^^^^ Missing assignment for field 'field' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:15:9
+   ┌─ tests/move_2024/naming/positional_unpack_of_non_positional_struct.move:14:9
    │
-15 │         Foo(_) = x;
+14 │         Foo(_) = x;
    │         ^^^^^^ Unbound field '0' in '0x42::M::Foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_non_positional_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_non_positional_struct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo { field: u64 } has copy, drop;
 
     fun x() {
@@ -16,5 +15,3 @@ module M {
         abort 0
     }
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_positional_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/positional_unpack_of_positional_struct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64) has copy, drop;
 
     fun x() {
@@ -9,6 +8,3 @@ module M {
         abort 0
     }
 }
-}
-
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/standalone_module_ident.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/standalone_module_ident.exp
@@ -1,18 +1,24 @@
-error[E03006]: unexpected name in this position
-  ┌─ tests/move_2024/naming/standalone_module_ident.move:8:17
+error[E03002]: unbound module
+  ┌─ tests/move_2024/naming/standalone_module_ident.move:4:9
   │
-8 │         let x = X; x;
-  │                 ^ Expected a type, function, or constant in this position, not a module
+4 │     use 0x2::X;
+  │         ^^^^^^ Invalid 'use'. Unbound module: '0x2::X'
+
+error[E03005]: unbound unscoped name
+  ┌─ tests/move_2024/naming/standalone_module_ident.move:6:17
+  │
+6 │         let x = X; x;
+  │                 ^ Unbound constant 'X'
 
 error[E03006]: unexpected name in this position
-  ┌─ tests/move_2024/naming/standalone_module_ident.move:9:17
+  ┌─ tests/move_2024/naming/standalone_module_ident.move:7:17
   │
-9 │         let x = 0x2::X; x;
+7 │         let x = 0x2::X; x;
   │                 ^^^^^^ Unexpected module identifier. A module identifier is not a valid expression
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/naming/standalone_module_ident.move:10:17
-   │
-10 │         let y = 0x2::Y; y;
-   │                 ^^^^^^ Unexpected module identifier. A module identifier is not a valid expression
+  ┌─ tests/move_2024/naming/standalone_module_ident.move:8:17
+  │
+8 │         let y = 0x2::Y; y;
+  │                 ^^^^^^ Unexpected module identifier. A module identifier is not a valid expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/standalone_module_ident.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/standalone_module_ident.move
@@ -1,14 +1,10 @@
-address 0x2 {
+module 0x42::X {}
 
-module X {}
-
-module M {
+module 0x42::M {
     use 0x2::X;
     fun foo() {
         let x = X; x;
         let x = 0x2::X; x;
         let y = 0x2::Y; y;
     }
-}
-
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.exp
@@ -1,7 +1,7 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix.move:4:41
+  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix.move:3:41
   │
-4 │     public struct Foo has copy, drop {} has store;
+3 │     public struct Foo has copy, drop {} has store;
   │                       ---               ^^^ Duplicate ability declaration. Abilities can be declared before or after the field declarations, but not both.
   │                       │                  
   │                       Ability declaration previously given here

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // has both prefix and postfix ability declarations
     public struct Foo has copy, drop {} has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move:5:46
+  ┌─ tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move:4:46
   │
-5 │     public native struct Foo has copy, drop; has store;
+4 │     public native struct Foo has copy, drop; has store;
   │                                              ^^^
   │                                              │
   │                                              Unexpected 'has'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_and_postfix_native_struct.move
@@ -1,7 +1,5 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // has both invalid declaration since postfix ability declarations
     // are not allowed for native structs
     public native struct Foo has copy, drop; has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move:4:45
+  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move:3:45
   │
-4 │     public native struct Foo has copy, drop has store;
+3 │     public native struct Foo has copy, drop has store;
   │                                             ^^^
   │                                             │
   │                                             Unexpected 'has'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // has both prefix and invalid postfix ability declarations
     public native struct Foo has copy, drop has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.exp
@@ -1,6 +1,6 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move:4:46
+  ┌─ tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move:3:46
   │
-4 │     public native struct Foo has copy, drop, has store;
+3 │     public native struct Foo has copy, drop, has store;
   │                                              ^^^ Unexpected 'has'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_infix_postfix_no_fields_with_comma_sep.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // has both prefix and invalid postfix ability declarations
     public native struct Foo has copy, drop, has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.exp
@@ -1,14 +1,14 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move:4:5
+  ┌─ tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move:3:5
   │
-4 │     struct Foo has {} has copy;
+3 │     struct Foo has {} has copy;
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move:4:20
+  ┌─ tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move:3:20
   │
-4 │     struct Foo has {} has copy;
+3 │     struct Foo has {} has copy;
   │                    ^ Unexpected '{'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_invalid_infix_with_valid_postfix.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // invalid ability declaration
     struct Foo has {} has copy;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_no_abilities.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_no_abilities.exp
@@ -1,14 +1,14 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifier_no_abilities.move:4:5
+  ┌─ tests/move_2024/parser/ability_modifier_no_abilities.move:3:5
   │
-4 │     struct Foo has {}
+3 │     struct Foo has {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_no_abilities.move:4:20
+  ┌─ tests/move_2024/parser/ability_modifier_no_abilities.move:3:20
   │
-4 │     struct Foo has {}
+3 │     struct Foo has {}
   │                    ^ Unexpected '{'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_no_abilities.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_no_abilities.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // invalid ability declaration
     struct Foo has {}
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_commas.move:4:36
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_commas.move:3:36
   │
-4 │     public struct Foo {} has store copy;
+3 │     public struct Foo {} has store copy;
   │                                    ^^^^
   │                                    │
   │                                    Unexpected 'copy'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_commas.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Ability declarations require commas between them.
     public struct Foo {} has store copy;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:5:5
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move:4:5
   │
-5 │     public struct Bar has key {}
+4 │     public struct Bar has key {}
   │     ^^^^^^
   │     │
   │     Unexpected 'public'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_missing_semi_multiple_structs.move
@@ -1,8 +1,5 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Postfix ability declarations require semicolons at the end.
     public struct Foo {} has store
     public struct Bar has key {}
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.exp
@@ -1,6 +1,6 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move:5:1
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move:4:1
   │
-5 │ }
+4 │ }
   │ ^ Unexpected '}'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_no_semi.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Postfix ability declarations require at least one ability.
     public struct Foo {} has
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.exp
@@ -1,6 +1,6 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move:4:29
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move:3:29
   │
-4 │     public struct Foo {} has;
+3 │     public struct Foo {} has;
   │                             ^ Unexpected ';'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_abilities_with_semi.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Postfix ability declarations require at least one ability.
     public struct Foo {} has;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_fields.move:4:45
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_fields.move:3:45
   │
-4 │     public native struct Foo has copy, drop has store;
+3 │     public native struct Foo has copy, drop has store;
   │                                             ^^^
   │                                             │
   │                                             Unexpected 'has'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_fields.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // native structs cannot have suffix ability declarations.
     public native struct Foo has copy, drop has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_semi.move:5:1
+  ┌─ tests/move_2024/parser/ability_modifier_postfix_no_semi.move:4:1
   │
-5 │ }
+4 │ }
   │ ^
   │ │
   │ Unexpected '}'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_no_semi.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Postfix ability declarations require semicolons.
     public struct Foo {} has store
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_with_semi.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifier_postfix_with_semi.move
@@ -1,5 +1,3 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo {} has store;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.exp
@@ -1,22 +1,22 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:4:5
+  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:3:5
   │
-4 │     struct Foo has copy {} has;
+3 │     struct Foo has copy {} has;
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:4:28
+  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:3:28
   │
-4 │     struct Foo has copy {} has;
+3 │     struct Foo has copy {} has;
   │                ---         ^^^ Duplicate ability declaration. Abilities can be declared before or after the field declarations, but not both.
   │                │            
   │                Ability declaration previously given here
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:4:31
+  ┌─ tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move:3:31
   │
-4 │     struct Foo has copy {} has;
+3 │     struct Foo has copy {} has;
   │                               ^ Unexpected ';'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_infix_no_abilities_postfix.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // invalid ability declaration
     struct Foo has copy {} has;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.exp
@@ -1,14 +1,14 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move:4:5
+  ┌─ tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move:3:5
   │
-4 │     struct Foo has {} has;
+3 │     struct Foo has {} has;
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move:4:20
+  ┌─ tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move:3:20
   │
-4 │     struct Foo has {} has;
+3 │     struct Foo has {} has;
   │                    ^ Unexpected '{'. Expected a type ability, one of: 'copy', 'drop', 'store', or 'key'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/ability_modifies_no_abilities_infix_postfix.move
@@ -1,7 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // invalid ability declaration
     struct Foo has {} has;
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/friend_decl_qualified_struct.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/friend_decl_qualified_struct.exp
@@ -1,14 +1,14 @@
 error[E01003]: invalid modifier
-  ┌─ tests/move_2024/parser/friend_decl_qualified_struct.move:3:5
+  ┌─ tests/move_2024/parser/friend_decl_qualified_struct.move:2:5
   │
-3 │     struct A {}
+2 │     struct A {}
   │     ^^^^^^ Invalid struct declaration. Internal struct declarations are not yet supported
   │
   = Visibility annotations are required on struct declarations from the Move 2024 edition onwards.
 
 error[E03006]: unexpected name in this position
-  ┌─ tests/move_2024/parser/friend_decl_qualified_struct.move:7:12
+  ┌─ tests/move_2024/parser/friend_decl_qualified_struct.move:6:12
   │
-7 │     friend 0x42::A::A;
+6 │     friend 0x42::A::A;
   │            ^^^^^^^^^^ Unexpected module member identifier. A module member identifier is not a valid module
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/friend_decl_qualified_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/friend_decl_qualified_struct.move
@@ -1,9 +1,7 @@
-address 0x42 {
-module A {
+module 0x42::A {
     struct A {}
 }
 
-module M {
+module 0x42::M {
     friend 0x42::A::A;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.exp
@@ -1,42 +1,42 @@
 error[E03013]: positional call mismatch
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:13
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:13
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:13
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:13
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing binding for field 'f' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:13
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:13
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E03013]: positional call mismatch
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:21
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:21
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │                     ^^^^^^^^^^^^^^ Invalid deconstruction. Named struct field declarations require named deconstruction
 
 error[E04016]: too few arguments
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:21
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:21
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │                     ^^^^^^^^^^^^^^ Missing binding for field 'f' in '0x42::M::Bar'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:21
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:21
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │                     ^^^^^^^^^^^^^^ Unbound field '0' in '0x42::M::Bar'
 
 error[E04010]: cannot infer type
-   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:27:21
+   ┌─ tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move:26:21
    │
-27 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
+26 │         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
    │                     ^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_positional_struct_unpack_deeply_nested.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo<T>(T, u64) has drop;
 
     public struct Bar<T> {
@@ -27,5 +26,4 @@ module M {
         let Bar(Foo(Bar(Foo(x, y)), z)) = y;
         x + y + z
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/named_struct_with_positional_fields.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/named_struct_with_positional_fields.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/named_struct_with_positional_fields.move:4:26
+  ┌─ tests/move_2024/parser/named_struct_with_positional_fields.move:3:26
   │
-4 │     public struct Foo{u64, u16} has copy, drop;
+3 │     public struct Foo{u64, u16} has copy, drop;
   │                          ^
   │                          │
   │                          Unexpected ','

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/named_struct_with_positional_fields.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/named_struct_with_positional_fields.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Invalid positional field struct declaration
     public struct Foo{u64, u16} has copy, drop;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access.exp
@@ -1,40 +1,40 @@
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/positional_field_access.move:26:9
+   ┌─ tests/move_2024/parser/positional_field_access.move:25:9
    │
-26 │         y.0x0 + y.0xff
+25 │         y.0x0 + y.0xff
    │         ^^^^^ Unbound field '0x0' in '0x42::M::Foo'
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/positional_field_access.move:26:11
+   ┌─ tests/move_2024/parser/positional_field_access.move:25:11
    │
-26 │         y.0x0 + y.0xff
+25 │         y.0x0 + y.0xff
    │           ^^^ Invalid field access. Expected a decimal number but was given a hexadecimal
    │
    = Positional fields must be a decimal number in the range [0 .. 255] and not be typed, e.g. `0`
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/positional_field_access.move:26:17
+   ┌─ tests/move_2024/parser/positional_field_access.move:25:17
    │
-26 │         y.0x0 + y.0xff
+25 │         y.0x0 + y.0xff
    │                 ^^^^^^ Unbound field '0xff' in '0x42::M::Foo'
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/positional_field_access.move:26:19
+   ┌─ tests/move_2024/parser/positional_field_access.move:25:19
    │
-26 │         y.0x0 + y.0xff
+25 │         y.0x0 + y.0xff
    │                   ^^^^ Invalid field access. Expected a decimal number but was given a hexadecimal
    │
    = Positional fields must be a decimal number in the range [0 .. 255] and not be typed, e.g. `0`
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/positional_field_access.move:30:9
+   ┌─ tests/move_2024/parser/positional_field_access.move:29:9
    │
-30 │         y.1_0 + y.1_0_0
+29 │         y.1_0 + y.1_0_0
    │         ^^^^^ Unbound field '10' in '0x42::M::Foo'
 
 error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/positional_field_access.move:30:17
+   ┌─ tests/move_2024/parser/positional_field_access.move:29:17
    │
-30 │         y.1_0 + y.1_0_0
+29 │         y.1_0 + y.1_0_0
    │                 ^^^^^^^ Unbound field '100' in '0x42::M::Foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo<T>(T, u64) has drop;
 
     public struct Bar<T> {
@@ -29,5 +28,4 @@ module M {
     fun underscores(y: Foo<u64>): u64 {
         y.1_0 + y.1_0_0
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_greater_than_u8_max.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_greater_than_u8_max.exp
@@ -1,13 +1,13 @@
 error[E03010]: unbound field
-  ┌─ tests/move_2024/parser/positional_field_access_greater_than_u8_max.move:6:9
+  ┌─ tests/move_2024/parser/positional_field_access_greater_than_u8_max.move:5:9
   │
-6 │         y.256
+5 │         y.256
   │         ^^^^^ Unbound field '256' in '0x42::M::Foo'
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_field_access_greater_than_u8_max.move:6:11
+  ┌─ tests/move_2024/parser/positional_field_access_greater_than_u8_max.move:5:11
   │
-6 │         y.256
+5 │         y.256
   │           ^^^ Invalid field access. Expected a number less than or equal to 255
   │
   = Positional fields must be a decimal number in the range [0 .. 255] and not be typed, e.g. `0`

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_greater_than_u8_max.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_greater_than_u8_max.move
@@ -1,9 +1,7 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64)
 
     fun x(y: Foo): u64 {
         y.256
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_no_annotations.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_no_annotations.exp
@@ -1,13 +1,13 @@
 error[E03010]: unbound field
-  ┌─ tests/move_2024/parser/positional_field_access_no_annotations.move:6:9
+  ┌─ tests/move_2024/parser/positional_field_access_no_annotations.move:5:9
   │
-6 │         y.0_u8
+5 │         y.0_u8
   │         ^^^^^^ Unbound field '0_u8' in '0x42::M::Foo'
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_field_access_no_annotations.move:6:11
+  ┌─ tests/move_2024/parser/positional_field_access_no_annotations.move:5:11
   │
-6 │         y.0_u8
+5 │         y.0_u8
   │           ^^^^ Invalid field access. Expected a number less than or equal to 255
   │
   = Positional fields must be a decimal number in the range [0 .. 255] and not be typed, e.g. `0`

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_no_annotations.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_field_access_no_annotations.move
@@ -1,10 +1,7 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64)
 
     fun x(y: Foo): u64 {
         y.0_u8
     }
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_arg_assign.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_arg_assign.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_explicit_type_arg_assign.move:6:22
+  ┌─ tests/move_2024/parser/positional_struct_explicit_type_arg_assign.move:5:22
   │
-6 │         Foo <u64>(_) = Foo(0);
+5 │         Foo <u64>(_) = Foo(0);
   │                      ^
   │                      │
   │                      Unexpected '='

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_arg_assign.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_arg_assign.move
@@ -1,9 +1,7 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo<T>(T) has drop;
 
     fun should_fail() {
         Foo <u64>(_) = Foo(0);
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
@@ -1,37 +1,37 @@
 error[E03003]: unbound module member
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:17:17
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:17
    │
-17 │         let _ = Foo <u64>(0);
+16 │         let _ = Foo <u64>(0);
    │                 ^^^ Invalid module access. Unbound constant 'Foo' in module '0x42::M'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:17:17
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:17
    │
-17 │         let _ = Foo <u64>(0);
+16 │         let _ = Foo <u64>(0);
    │                 ^^^^^^^^
    │                 │
    │                 Invalid argument to '>'
    │                 Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:17:22
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:22
    │
-17 │         let _ = Foo <u64>(0);
+16 │         let _ = Foo <u64>(0);
    │                      ^^^ Unbound variable 'u64'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:17:25
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:25
    │
-17 │         let _ = Foo <u64>(0);
+16 │         let _ = Foo <u64>(0);
    │                 --------^--- Found: integer. It is not compatible with the other type.
    │                 │       │ 
    │                 │       Incompatible arguments to '>'
    │                 Found: 'bool'. It is not compatible with the other type.
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:17:26
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:26
    │
-17 │         let _ = Foo <u64>(0);
+16 │         let _ = Foo <u64>(0);
    │                 -------- ^^^ Invalid argument to '>'
    │                 │         
    │                 Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo<T>(T) has drop;
     public struct Bar<T>{ x: T } has drop;
 
@@ -16,5 +15,4 @@ module M {
     fun should_fail() {
         let _ = Foo <u64>(0);
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.exp
@@ -1,16 +1,16 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:4:23
+  ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:3:23
   │
-4 │     public struct Foo(fun)
+3 │     public struct Foo(fun)
   │                       ^^^
   │                       │
   │                       Unexpected 'fun'
   │                       Expected a type name
 
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:4:26
+  ┌─ tests/move_2024/parser/positional_struct_fields_keyword_field.move:3:26
   │
-4 │     public struct Foo(fun)
+3 │     public struct Foo(fun)
   │                          ^
   │                          │
   │                          Unexpected ')'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_keyword_field.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // keyword instead of a type
     public struct Foo(fun)
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_non_type_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_non_type_field.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_fields_non_type_field.move:4:27
+  ┌─ tests/move_2024/parser/positional_struct_fields_non_type_field.move:3:27
   │
-4 │     public struct Foo(Not a type)
+3 │     public struct Foo(Not a type)
   │                      -    ^ Expected ')'
   │                      │     
   │                      To match this '('

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_non_type_field.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_non_type_field.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Invalid type inside a positional struct
     public struct Foo(Not a type)
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_simple.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_simple.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Valid positional field struct declaration
     public struct Foo(u64) has copy, drop;
     public struct Bar has copy (u64) 
@@ -9,5 +8,4 @@ module M {
         u64,
         /** another field with another doc comment **/
         u64,)
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_simple_construct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_simple_construct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Valid positional field struct declaration
     public struct Foo(u64) has copy, drop;
     public struct Bar has copy (u64)
@@ -14,5 +13,4 @@ module M {
         let _x = Foo(0);
         abort 0
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_with_idents.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_with_idents.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_fields_with_idents.move:4:24
+  ┌─ tests/move_2024/parser/positional_struct_fields_with_idents.move:3:24
   │
-4 │     public struct Foo(x: u64) has copy, drop;
+3 │     public struct Foo(x: u64) has copy, drop;
   │                      - ^ Expected ')'
   │                      │  
   │                      To match this '('

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_with_idents.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_fields_with_idents.move
@@ -1,7 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Valid positional field struct declaration
     public struct Foo(x: u64) has copy, drop;
 }
-}
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_unpack.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_unpack.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo<T>(T, u64) has drop;
 
     public struct Bar<T> {
@@ -27,5 +26,4 @@ module M {
         let Bar{f: Foo(Foo(Bar{f: Foo(x, y)}, z), t)} = y;
         x + y + z + t
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_using_curlies.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_using_curlies.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_struct_using_curlies.move:4:29
+  ┌─ tests/move_2024/parser/positional_struct_using_curlies.move:3:29
   │
-4 │     public struct Foo { u64 }
+3 │     public struct Foo { u64 }
   │                             ^
   │                             │
   │                             Unexpected '}'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_using_curlies.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_using_curlies.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Positional struct declarations must use parenthesis and not braces
     public struct Foo { u64 }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_with_named_struct_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_with_named_struct_field.exp
@@ -1,7 +1,7 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/positional_with_named_struct_field.move:4:24
+  ┌─ tests/move_2024/parser/positional_with_named_struct_field.move:3:24
   │
-4 │     public struct Foo(f: u64) has copy, drop;
+3 │     public struct Foo(f: u64) has copy, drop;
   │                      - ^ Expected ')'
   │                      │  
   │                      To match this '('

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_with_named_struct_field.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_with_named_struct_field.move
@@ -1,6 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     // Invalid positional field struct declaration
     public struct Foo(f: u64) has copy, drop;
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.exp
@@ -1,0 +1,14 @@
+error[E13002]: feature is deprecated in specified edition
+  ┌─ tests/move_2024/parsing/address_normal_usage.move:1:1
+  │
+1 │ address 0x2 {
+  │ ^^^^^^^ 'address' blocks are deprecated. Use addresses directly in module definitions instead.
+2 │ module m {
+  │        - Replace with '0x2::m'
+3 │ }
+4 │ module m2 {
+  │        -- Replace with '0x2::m2'
+5 │ }
+6 │ module m3 {
+  │        -- Replace with '0x2::m3'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.migration.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.migration.exp
@@ -1,0 +1,16 @@
+--- tests/move_2024/parsing/address_normal_usage.move
++++ tests/move_2024/parsing/address_normal_usage.move
+@@ -1,2 +1,2 @@
+-address 0x2 {
+-module m {
++/* address 0x2 { */
++module 0x2::m {
+@@ -4,3 +4 @@
+-module m2 {
+-}
+-module m3 {
++module 0x2::m2 {
+@@ -7,0 +6 @@
++module 0x2::m3 {
+@@ -8,0 +8 @@
++/* } */

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_normal_usage.move
@@ -1,0 +1,8 @@
+address 0x2 {
+module m {
+}
+module m2 {
+}
+module m3 {
+}
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.exp
@@ -1,0 +1,9 @@
+error[E13002]: feature is deprecated in specified edition
+  ┌─ tests/move_2024/parsing/address_weird_formatting.move:1:1
+  │
+1 │ address 
+  │ ^^^^^^^ 'address' blocks are deprecated. Use addresses directly in module definitions instead.
+  ·
+6 │     module m {
+  │            - Replace with '0x2::m'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.migration.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.migration.exp
@@ -1,0 +1,12 @@
+--- tests/move_2024/parsing/address_weird_formatting.move
++++ tests/move_2024/parsing/address_weird_formatting.move
+@@ -1 +1 @@
+-address 
++/* address 
+@@ -5,3 +5,3 @@
+-{
+-    module m {
+-    }}
++{ */
++    module 0x2::m {
++    }/* } */

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parsing/address_weird_formatting.move
@@ -1,0 +1,7 @@
+address 
+// Some comments
+0x2 
+// This is terribly formatted. Who would do this??
+{
+    module m {
+    }}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/to_bytecode/positional_unpack_of_positional_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/to_bytecode/positional_unpack_of_positional_struct.move
@@ -1,5 +1,4 @@
-address 0x42 {
-module M {
+module 0x42::M {
     public struct Foo(u64) has copy, drop;
 
     fun x() {
@@ -9,6 +8,3 @@ module M {
         abort 0
     }
 }
-}
-
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_members_non_test_function.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_members_non_test_function.exp
@@ -1,12 +1,12 @@
 error[E03004]: unbound type
-   ┌─ tests/move_2024/unit_test/cross_module_members_non_test_function.move:23:23
+   ┌─ tests/move_2024/unit_test/cross_module_members_non_test_function.move:22:23
    │
-23 │     public fun bad(): Foo {
+22 │     public fun bad(): Foo {
    │                       ^^^ Unbound type 'Foo' in current scope
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/unit_test/cross_module_members_non_test_function.move:24:9
+   ┌─ tests/move_2024/unit_test/cross_module_members_non_test_function.move:23:9
    │
-24 │         P::build_foo()
+23 │         P::build_foo()
    │         ^ Could not resolve the name 'P'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_members_non_test_function.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_members_non_test_function.move
@@ -1,12 +1,11 @@
 // check that `use`'s are filtered out correctly in non-test mode
-address 0x1 {
-module P {
+module 0x1::P {
     public struct Foo has drop {}
 
     public fun build_foo(): Foo { Foo {} }
 }
 
-module Q {
+module 0x1::Q {
     #[test_only]
     use 0x1::P::{Self, Foo};
 
@@ -23,5 +22,4 @@ module Q {
     public fun bad(): Foo {
         P::build_foo()
     }
-}
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_test_only_module.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_test_only_module.exp
@@ -1,12 +1,12 @@
 error[E03002]: unbound module
-   ┌─ tests/move_2024/unit_test/cross_module_test_only_module.move:10:9
-   │
-10 │     use 0x1::M;
-   │         ^^^^^^ Invalid 'use'. Unbound module: '0x1::M'
+  ┌─ tests/move_2024/unit_test/cross_module_test_only_module.move:9:9
+  │
+9 │     use 0x1::M;
+  │         ^^^^^^ Invalid 'use'. Unbound module: '0x1::M'
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/unit_test/cross_module_test_only_module.move:13:9
+   ┌─ tests/move_2024/unit_test/cross_module_test_only_module.move:12:9
    │
-13 │         M::foo()
+12 │         M::foo()
    │         ^^^^^^ Unexpected module identifier. A module identifier is not a valid expression
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_test_only_module.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/cross_module_test_only_module.move
@@ -1,16 +1,14 @@
 // check that modules that are annotated as test_only are filtered out correctly
-address 0x1 {
 #[test_only]
-module M {
+module 0x1::M {
     public fun foo() { }
 }
 
-module Tests {
+module 0x1::Tests {
     // this use should cause an unbound module error as M should be filtered out
     use 0x1::M;
 
     fun bar() {
         M::foo()
     }
-}
 }


### PR DESCRIPTION
## Description 

Deprecated `address` blocks from Move 2024, and adds support for removing address blocks in migration mode.

The bottom commit are the actual changes + new tests, the top commit is the migration of all of the Move 2024 tests to not use address blocks. 

## Test Plan 

Added additional tests to make sure we error correctly in Move 2024, and that we can migrate correctly. 


