### PR TITLE
[CI] run mysticeti workflow on PR

### DIFF
--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -1,7 +1,15 @@
 name: Mysticeti
 
 on:
-  # Allow triggering the workflow manually.
+  push:
+    branches:
+      - 'main'
+      - 'devnet'
+      - 'testnet'
+      - 'mainnet'
+      - 'releases/sui-*-release'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       sui_repo_ref:
@@ -9,10 +17,13 @@ on:
         type: string
         required: true
         default: main
-
   # Triggers the workflow every day at 05:00 UTC.
   schedule:
     - cron: '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   # Enable Mysticeti in tests.
@@ -45,8 +56,23 @@ env:
   RUSTDOCFLAGS: -D warnings
 
 jobs:
+  diff:
+    runs-on: [ubuntu-latest]
+    outputs:
+      isRust: ${{ steps.diff.outputs.isRust }}
+      isMove: ${{ steps.diff.outputs.isMove }}
+      isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref }}
+      - name: Detect Changes
+        uses: "./.github/actions/diffs"
+        id: diff
 
   test:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     env:
       # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
@@ -76,6 +102,8 @@ jobs:
         shell: bash
 
   test-extra:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     env:
       # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
@@ -90,6 +118,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
@@ -119,12 +149,16 @@ jobs:
         shell: bash
 
   simtest:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     runs-on: [ubuntu-ghcloud]
     env:
       MSIM_WATCHDOG_TIMEOUT_MS: 60000
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master

--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -15,8 +15,8 @@ on:
       sui_repo_ref:
         description: "Branch / commit to test"
         type: string
-        required: true
-        default: main
+        required: false
+        default: ''
   # Triggers the workflow every day at 05:00 UTC.
   schedule:
     - cron: '0 5 * * *'
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
-          ref: ${{ github.event.inputs.sui_repo_ref }}
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - name: Detect Changes
         uses: "./.github/actions/diffs"
         id: diff
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
-          ref: ${{ github.event.inputs.sui_repo_ref }}
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
-          ref: ${{ github.event.inputs.sui_repo_ref }}
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
-          ref: ${{ github.event.inputs.sui_repo_ref }}
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,12 @@ name: Rust
 
 on:
   push:
-    branches: [main, extensions, devnet]
+    branches:
+      - 'main'
+      - 'devnet'
+      - 'testnet'
+      - 'mainnet'
+      - 'releases/sui-*-release'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -3,7 +3,7 @@ name: Trigger builds for images and binaries
 on:
   workflow_dispatch:
   push:
-    branches:
+    branches: 
       - 'devnet'
       - 'testnet'
       - 'mainnet'

--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -3,7 +3,7 @@ name: Trigger builds for images and binaries
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - 'devnet'
       - 'testnet'
       - 'mainnet'


### PR DESCRIPTION
## Description 

This gives us early signals on test failures with Mysticeti.

Also, run Rust and Mysticeti tests on release branches.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
