### PR TITLE
[move-2024] Add method syntax to `sui-system`

### DIFF
--- a/crates/sui-framework/docs/sui-system/genesis.md
+++ b/crates/sui-framework/docs/sui-system/genesis.md
@@ -359,22 +359,19 @@ all the information we need in the system.
     ctx: &<b>mut</b> TxContext,
 ) {
     // Ensure this is only called at <a href="genesis.md#0x3_genesis">genesis</a>
-    <b>assert</b>!(<a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) == 0, <a href="genesis.md#0x3_genesis_ENotCalledAtGenesis">ENotCalledAtGenesis</a>);
+    <b>assert</b>!(ctx.epoch() == 0, <a href="genesis.md#0x3_genesis_ENotCalledAtGenesis">ENotCalledAtGenesis</a>);
 
     <b>let</b> <a href="genesis.md#0x3_genesis_TokenDistributionSchedule">TokenDistributionSchedule</a> {
         stake_subsidy_fund_mist,
         allocations,
     } = token_distribution_schedule;
 
-    <b>let</b> subsidy_fund = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(
-        &<b>mut</b> sui_supply,
-        stake_subsidy_fund_mist,
-    );
+    <b>let</b> subsidy_fund = sui_supply.split(stake_subsidy_fund_mist);
     <b>let</b> <a href="storage_fund.md#0x3_storage_fund">storage_fund</a> = <a href="../sui-framework/balance.md#0x2_balance_zero">balance::zero</a>();
 
     // Create all the `Validator` structs
-    <b>let</b> <b>mut</b> validators = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> count = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&genesis_validators);
+    <b>let</b> <b>mut</b> validators = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> count = genesis_validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; count) {
         <b>let</b> <a href="genesis.md#0x3_genesis_GenesisValidatorMetadata">GenesisValidatorMetadata</a> {
@@ -393,7 +390,7 @@ all the information we need in the system.
             p2p_address,
             primary_address,
             worker_address,
-        } = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&genesis_validators, i);
+        } = genesis_validators[i];
 
         <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator.md#0x3_validator_new">validator::new</a>(
             sui_address,
@@ -420,7 +417,7 @@ all the information we need in the system.
             <a href="genesis.md#0x3_genesis_EDuplicateValidator">EDuplicateValidator</a>,
         );
 
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> validators, <a href="validator.md#0x3_validator">validator</a>);
+        validators.push_back(<a href="validator.md#0x3_validator">validator</a>);
 
         i = i + 1;
     };
@@ -497,36 +494,35 @@ all the information we need in the system.
     ctx: &<b>mut</b> TxContext,
 ) {
 
-    <b>while</b> (!<a href="../move-stdlib/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&allocations)) {
+    <b>while</b> (!allocations.is_empty()) {
         <b>let</b> <a href="genesis.md#0x3_genesis_TokenAllocation">TokenAllocation</a> {
             recipient_address,
             amount_mist,
             staked_with_validator,
-        } = <a href="../move-stdlib/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> allocations);
+        } = allocations.pop_back();
 
-        <b>let</b> allocation_balance = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> sui_supply, amount_mist);
+        <b>let</b> allocation_balance = sui_supply.split(amount_mist);
 
-        <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&staked_with_validator)) {
-            <b>let</b> validator_address = <a href="../move-stdlib/option.md#0x1_option_destroy_some">option::destroy_some</a>(staked_with_validator);
+        <b>if</b> (staked_with_validator.is_some()) {
+            <b>let</b> validator_address = staked_with_validator.destroy_some();
             <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut">validator_set::get_validator_mut</a>(validators, validator_address);
-            <a href="validator.md#0x3_validator_request_add_stake_at_genesis">validator::request_add_stake_at_genesis</a>(
-                <a href="validator.md#0x3_validator">validator</a>,
+            <a href="validator.md#0x3_validator">validator</a>.request_add_stake_at_genesis(
                 allocation_balance,
                 recipient_address,
                 ctx
             );
         } <b>else</b> {
             <a href="../sui-framework/sui.md#0x2_sui_transfer">sui::transfer</a>(
-                <a href="../sui-framework/coin.md#0x2_coin_from_balance">coin::from_balance</a>(allocation_balance, ctx),
+                allocation_balance.into_coin(ctx),
                 recipient_address,
             );
         };
     };
-    <a href="../move-stdlib/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(allocations);
+    allocations.destroy_empty();
 
     // Provided allocations must fully allocate the sui_supply and there
     // should be none left at this point.
-    <a href="../sui-framework/balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(sui_supply);
+    sui_supply.destroy_zero();
 }
 </code></pre>
 
@@ -551,11 +547,11 @@ all the information we need in the system.
 
 <pre><code><b>fun</b> <a href="genesis.md#0x3_genesis_activate_validators">activate_validators</a>(validators: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;) {
     // Activate all <a href="genesis.md#0x3_genesis">genesis</a> validators
-    <b>let</b> count = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> count = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; count) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, i);
-        <a href="validator.md#0x3_validator_activate">validator::activate</a>(<a href="validator.md#0x3_validator">validator</a>, 0);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &<b>mut</b> validators[i];
+        <a href="validator.md#0x3_validator">validator</a>.activate(0);
 
         i = i + 1;
     };

--- a/crates/sui-framework/docs/sui-system/stake_subsidy.md
+++ b/crates/sui-framework/docs/sui-system/stake_subsidy.md
@@ -166,10 +166,10 @@ Advance the epoch counter and draw down the subsidy for the epoch.
     // Take the minimum of the reward amount and the remaining <a href="../sui-framework/balance.md#0x2_balance">balance</a> in
     // order <b>to</b> ensure we don't overdraft the remaining stake subsidy
     // <a href="../sui-framework/balance.md#0x2_balance">balance</a>
-    <b>let</b> to_withdraw = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(self.current_distribution_amount, <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>));
+    <b>let</b> to_withdraw = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(self.current_distribution_amount, self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>.value());
 
     // Drawn down the subsidy for this epoch.
-    <b>let</b> <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a> = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>, to_withdraw);
+    <b>let</b> <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a> = self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>.split(to_withdraw);
 
     self.distribution_counter = self.distribution_counter + 1;
 
@@ -205,7 +205,7 @@ Returns the amount of stake subsidy to be added at the end of the current epoch.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="stake_subsidy.md#0x3_stake_subsidy_current_epoch_subsidy_amount">current_epoch_subsidy_amount</a>(self: &<a href="stake_subsidy.md#0x3_stake_subsidy_StakeSubsidy">StakeSubsidy</a>): u64 {
-    <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(self.current_distribution_amount, <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>))
+    <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(self.current_distribution_amount, self.<a href="../sui-framework/balance.md#0x2_balance">balance</a>.value())
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-system/staking_pool.md
+++ b/crates/sui-framework/docs/sui-system/staking_pool.md
@@ -477,7 +477,7 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
     stake_activation_epoch: u64,
     ctx: &<b>mut</b> TxContext
 ) : <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
-    <b>let</b> sui_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&stake);
+    <b>let</b> sui_amount = stake.value();
     <b>assert</b>!(!<a href="staking_pool.md#0x3_staking_pool_is_inactive">is_inactive</a>(pool), <a href="staking_pool.md#0x3_staking_pool_EDelegationToInactivePool">EDelegationToInactivePool</a>);
     <b>assert</b>!(sui_amount &gt; 0, <a href="staking_pool.md#0x3_staking_pool_EDelegationOfZeroSui">EDelegationOfZeroSui</a>);
     <b>let</b> staked_sui = <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
@@ -520,12 +520,12 @@ A proportional amount of pool token withdraw is recorded and processed at epoch 
 ) : Balance&lt;SUI&gt; {
     <b>let</b> (pool_token_withdraw_amount, <b>mut</b> principal_withdraw) =
         <a href="staking_pool.md#0x3_staking_pool_withdraw_from_principal">withdraw_from_principal</a>(pool, staked_sui);
-    <b>let</b> principal_withdraw_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw);
+    <b>let</b> principal_withdraw_amount = principal_withdraw.value();
 
     <b>let</b> rewards_withdraw = <a href="staking_pool.md#0x3_staking_pool_withdraw_rewards">withdraw_rewards</a>(
-        pool, principal_withdraw_amount, pool_token_withdraw_amount, <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx)
+        pool, principal_withdraw_amount, pool_token_withdraw_amount, ctx.epoch()
     );
-    <b>let</b> total_sui_withdraw_amount = principal_withdraw_amount + <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&rewards_withdraw);
+    <b>let</b> total_sui_withdraw_amount = principal_withdraw_amount + rewards_withdraw.value();
 
     pool.pending_total_sui_withdraw = pool.pending_total_sui_withdraw + total_sui_withdraw_amount;
     pool.pending_pool_token_withdraw = pool.pending_pool_token_withdraw + pool_token_withdraw_amount;
@@ -534,7 +534,7 @@ A proportional amount of pool token withdraw is recorded and processed at epoch 
     <b>if</b> (<a href="staking_pool.md#0x3_staking_pool_is_inactive">is_inactive</a>(pool)) <a href="staking_pool.md#0x3_staking_pool_process_pending_stake_withdraw">process_pending_stake_withdraw</a>(pool);
 
     // TODO: implement withdraw bonding period here.
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> principal_withdraw, rewards_withdraw);
+    principal_withdraw.join(rewards_withdraw);
     principal_withdraw
 }
 </code></pre>
@@ -571,7 +571,10 @@ Returns values are amount of pool tokens withdrawn and withdrawn principal porti
 
     <b>let</b> exchange_rate_at_staking_epoch = <a href="staking_pool.md#0x3_staking_pool_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(pool, staked_sui.stake_activation_epoch);
     <b>let</b> principal_withdraw = <a href="staking_pool.md#0x3_staking_pool_unwrap_staked_sui">unwrap_staked_sui</a>(staked_sui);
-    <b>let</b> pool_token_withdraw_amount = <a href="staking_pool.md#0x3_staking_pool_get_token_amount">get_token_amount</a>(&exchange_rate_at_staking_epoch, <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&principal_withdraw));
+    <b>let</b> pool_token_withdraw_amount = <a href="staking_pool.md#0x3_staking_pool_get_token_amount">get_token_amount</a>(
+		&exchange_rate_at_staking_epoch,
+		principal_withdraw.value()
+	);
 
     (
         pool_token_withdraw_amount,
@@ -632,8 +635,8 @@ Called at epoch advancement times to add rewards (in SUI) to the staking pool.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_deposit_rewards">deposit_rewards</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>, rewards: Balance&lt;SUI&gt;) {
-    pool.sui_balance = pool.sui_balance + <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&rewards);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.rewards_pool, rewards);
+    pool.sui_balance = pool.sui_balance + rewards.value();
+    pool.rewards_pool.join(rewards);
 }
 </code></pre>
 
@@ -657,11 +660,10 @@ Called at epoch advancement times to add rewards (in SUI) to the staking pool.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_process_pending_stakes_and_withdraws">process_pending_stakes_and_withdraws</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>, ctx: &TxContext) {
-    <b>let</b> new_epoch = <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
+    <b>let</b> new_epoch = ctx.epoch() + 1;
     <a href="staking_pool.md#0x3_staking_pool_process_pending_stake_withdraw">process_pending_stake_withdraw</a>(pool);
     <a href="staking_pool.md#0x3_staking_pool_process_pending_stake">process_pending_stake</a>(pool);
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> pool.exchange_rates,
+    pool.exchange_rates.add(
         new_epoch,
         <a href="staking_pool.md#0x3_staking_pool_PoolTokenExchangeRate">PoolTokenExchangeRate</a> { sui_amount: pool.sui_balance, pool_token_amount: pool.pool_token_balance },
     );
@@ -769,8 +771,8 @@ portion because the principal portion was already taken out of the staker's self
     // This may happen when we are withdrawing everything from the pool and
     // the rewards pool <a href="../sui-framework/balance.md#0x2_balance">balance</a> may be less than reward_withdraw_amount.
     // TODO: FIGURE OUT EXACTLY WHY THIS CAN HAPPEN.
-    reward_withdraw_amount = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(reward_withdraw_amount, <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&pool.rewards_pool));
-    <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> pool.rewards_pool, reward_withdraw_amount)
+    reward_withdraw_amount = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(reward_withdraw_amount, pool.rewards_pool.value());
+    pool.rewards_pool.<a href="staking_pool.md#0x3_staking_pool_split">split</a>(reward_withdraw_amount)
 }
 </code></pre>
 
@@ -796,8 +798,7 @@ Called by <code><a href="validator.md#0x3_validator">validator</a></code> module
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_activate_staking_pool">activate_staking_pool</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>, activation_epoch: u64) {
     // Add the initial exchange rate <b>to</b> the <a href="../sui-framework/table.md#0x2_table">table</a>.
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> pool.exchange_rates,
+    pool.exchange_rates.add(
         activation_epoch,
         <a href="staking_pool.md#0x3_staking_pool_initial_exchange_rate">initial_exchange_rate</a>()
     );
@@ -805,7 +806,7 @@ Called by <code><a href="validator.md#0x3_validator">validator</a></code> module
     <b>assert</b>!(<a href="staking_pool.md#0x3_staking_pool_is_preactive">is_preactive</a>(pool), <a href="staking_pool.md#0x3_staking_pool_EPoolAlreadyActive">EPoolAlreadyActive</a>);
     <b>assert</b>!(!<a href="staking_pool.md#0x3_staking_pool_is_inactive">is_inactive</a>(pool), <a href="staking_pool.md#0x3_staking_pool_EActivationOfInactivePool">EActivationOfInactivePool</a>);
     // Fill in the active epoch.
-    <a href="../move-stdlib/option.md#0x1_option_fill">option::fill</a>(&<b>mut</b> pool.activation_epoch, activation_epoch);
+    pool.activation_epoch.fill(activation_epoch);
 }
 </code></pre>
 
@@ -901,7 +902,7 @@ withdraws can be made to the pool.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_staked_sui_amount">staked_sui_amount</a>(staked_sui: &<a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>): u64 { <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&staked_sui.principal) }
+<pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_staked_sui_amount">staked_sui_amount</a>(staked_sui: &<a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>): u64 { staked_sui.principal.value() }
 </code></pre>
 
 
@@ -949,7 +950,7 @@ Returns true if the input staking pool is preactive.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_is_preactive">is_preactive</a>(pool: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>): bool{
-    <a href="../move-stdlib/option.md#0x1_option_is_none">option::is_none</a>(&pool.activation_epoch)
+    pool.activation_epoch.is_none()
 }
 </code></pre>
 
@@ -974,7 +975,7 @@ Returns true if the input staking pool is inactive.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_is_inactive">is_inactive</a>(pool: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>): bool {
-    <a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&pool.deactivation_epoch)
+    pool.deactivation_epoch.is_some()
 }
 </code></pre>
 
@@ -1001,7 +1002,7 @@ All the other parameters of the StakedSui like <code>stake_activation_epoch</cod
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_split">split</a>(self: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>, split_amount: u64, ctx: &<b>mut</b> TxContext): <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
-    <b>let</b> original_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.principal);
+    <b>let</b> original_amount = self.principal.value();
     <b>assert</b>!(split_amount &lt;= original_amount, <a href="staking_pool.md#0x3_staking_pool_EInsufficientSuiTokenBalance">EInsufficientSuiTokenBalance</a>);
     <b>let</b> remaining_amount = original_amount - split_amount;
     // Both resulting parts should have at least <a href="staking_pool.md#0x3_staking_pool_MIN_STAKING_THRESHOLD">MIN_STAKING_THRESHOLD</a>.
@@ -1011,7 +1012,7 @@ All the other parameters of the StakedSui like <code>stake_activation_epoch</cod
         id: <a href="../sui-framework/object.md#0x2_object_new">object::new</a>(ctx),
         pool_id: self.pool_id,
         stake_activation_epoch: self.stake_activation_epoch,
-        principal: <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.principal, split_amount),
+        principal: self.principal.<a href="staking_pool.md#0x3_staking_pool_split">split</a>(split_amount),
     }
 }
 </code></pre>
@@ -1038,7 +1039,7 @@ transfer the newly split part to the sender address.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_split_staked_sui">split_staked_sui</a>(stake: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>, split_amount: u64, ctx: &<b>mut</b> TxContext) {
-    <a href="../sui-framework/transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="staking_pool.md#0x3_staking_pool_split">split</a>(stake, split_amount, ctx), <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <a href="../sui-framework/transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="staking_pool.md#0x3_staking_pool_split">split</a>(stake, split_amount, ctx), ctx.sender());
 }
 </code></pre>
 
@@ -1072,8 +1073,8 @@ Aborts if some of the staking parameters are incompatible (pool id, stake activa
         principal,
     } = other;
 
-    <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(id);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.principal, principal);
+    id.delete();
+    self.principal.join(principal);
 }
 </code></pre>
 
@@ -1127,14 +1128,14 @@ Returns true if all the staking parameters of the staked sui except the principa
     <b>if</b> (<a href="staking_pool.md#0x3_staking_pool_is_preactive_at_epoch">is_preactive_at_epoch</a>(pool, epoch)) {
         <b>return</b> <a href="staking_pool.md#0x3_staking_pool_initial_exchange_rate">initial_exchange_rate</a>()
     };
-    <b>let</b> clamped_epoch = <a href="../move-stdlib/option.md#0x1_option_get_with_default">option::get_with_default</a>(&pool.deactivation_epoch, epoch);
+    <b>let</b> clamped_epoch = pool.deactivation_epoch.get_with_default(epoch);
     <b>let</b> <b>mut</b> epoch = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(clamped_epoch, epoch);
-    <b>let</b> activation_epoch = *<a href="../move-stdlib/option.md#0x1_option_borrow">option::borrow</a>(&pool.activation_epoch);
+    <b>let</b> activation_epoch = *pool.activation_epoch.borrow();
 
     // Find the latest epoch that's earlier than the given epoch <b>with</b> an entry in the <a href="../sui-framework/table.md#0x2_table">table</a>
     <b>while</b> (epoch &gt;= activation_epoch) {
-        <b>if</b> (<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&pool.exchange_rates, epoch)) {
-            <b>return</b> *<a href="../sui-framework/table.md#0x2_table_borrow">table::borrow</a>(&pool.exchange_rates, epoch)
+        <b>if</b> (pool.exchange_rates.contains(epoch)) {
+            <b>return</b> pool.exchange_rates[epoch]
         };
         epoch = epoch - 1;
     };
@@ -1287,7 +1288,7 @@ Returns true if the provided staking pool is preactive at the provided epoch.
 
 <pre><code><b>fun</b> <a href="staking_pool.md#0x3_staking_pool_is_preactive_at_epoch">is_preactive_at_epoch</a>(pool: &<a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>, epoch: u64): bool{
     // Either the pool is currently preactive or the pool's starting epoch is later than the provided epoch.
-    <a href="staking_pool.md#0x3_staking_pool_is_preactive">is_preactive</a>(pool) || (*<a href="../move-stdlib/option.md#0x1_option_borrow">option::borrow</a>(&pool.activation_epoch) &gt; epoch)
+    <a href="staking_pool.md#0x3_staking_pool_is_preactive">is_preactive</a>(pool) || (*pool.activation_epoch.borrow() &gt; epoch)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-system/storage_fund.md
+++ b/crates/sui-framework/docs/sui-system/storage_fund.md
@@ -113,21 +113,21 @@ Called by <code><a href="sui_system.md#0x3_sui_system">sui_system</a></code> at 
     non_refundable_storage_fee_amount: u64,
 ) : Balance&lt;SUI&gt; {
     // Both the reinvestment and leftover rewards are not <b>to</b> be refunded so they go <b>to</b> the non-refundable <a href="../sui-framework/balance.md#0x2_balance">balance</a>.
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.non_refundable_balance, storage_fund_reinvestment);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.non_refundable_balance, leftover_staking_rewards);
+    self.non_refundable_balance.join(storage_fund_reinvestment);
+    self.non_refundable_balance.join(leftover_staking_rewards);
 
     // The storage charges for the epoch come from the storage rebate of the new objects created
     // and the new storage rebates of the objects modified during the epoch so we put the charges
     // into `total_object_storage_rebates`.
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.total_object_storage_rebates, storage_charges);
+    self.total_object_storage_rebates.join(storage_charges);
 
     // Split out the non-refundable portion of the storage rebate and put it into the non-refundable <a href="../sui-framework/balance.md#0x2_balance">balance</a>.
-    <b>let</b> non_refundable_storage_fee = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.total_object_storage_rebates, non_refundable_storage_fee_amount);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.non_refundable_balance, non_refundable_storage_fee);
+    <b>let</b> non_refundable_storage_fee = self.total_object_storage_rebates.split(non_refundable_storage_fee_amount);
+    self.non_refundable_balance.join(non_refundable_storage_fee);
 
     // `storage_rebates` <b>include</b> the already refunded rebates of deleted objects and <b>old</b> rebates of modified objects and
     // should be taken out of the `total_object_storage_rebates`.
-    <b>let</b> storage_rebate = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.total_object_storage_rebates, storage_rebate_amount);
+    <b>let</b> storage_rebate = self.total_object_storage_rebates.split(storage_rebate_amount);
 
     // The storage rebate <b>has</b> already been returned <b>to</b> individual transaction senders' gas coins
     // so we <b>return</b> the <a href="../sui-framework/balance.md#0x2_balance">balance</a> <b>to</b> be burnt at the very end of epoch change.
@@ -155,7 +155,7 @@ Called by <code><a href="sui_system.md#0x3_sui_system">sui_system</a></code> at 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="storage_fund.md#0x3_storage_fund_total_object_storage_rebates">total_object_storage_rebates</a>(self: &<a href="storage_fund.md#0x3_storage_fund_StorageFund">StorageFund</a>): u64 {
-    <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.total_object_storage_rebates)
+    self.total_object_storage_rebates.value()
 }
 </code></pre>
 
@@ -179,7 +179,7 @@ Called by <code><a href="sui_system.md#0x3_sui_system">sui_system</a></code> at 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="storage_fund.md#0x3_storage_fund_total_balance">total_balance</a>(self: &<a href="storage_fund.md#0x3_storage_fund_StorageFund">StorageFund</a>): u64 {
-    <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.total_object_storage_rebates) + <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.non_refundable_balance)
+    self.total_object_storage_rebates.value() + self.non_refundable_balance.value()
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-system/sui_system.md
+++ b/crates/sui-framework/docs/sui-system/sui_system.md
@@ -250,8 +250,7 @@ To produce a valid PoP, run [fn test_proof_of_possession].
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator_candidate">sui_system_state_inner::request_add_validator_candidate</a>(
-        self,
+    self.<a href="sui_system.md#0x3_sui_system_request_add_validator_candidate">request_add_validator_candidate</a>(
         pubkey_bytes,
         network_pubkey_bytes,
         worker_pubkey_bytes,
@@ -297,7 +296,7 @@ their staking pool becomes deactivate.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator_candidate">sui_system_state_inner::request_remove_validator_candidate</a>(self, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_remove_validator_candidate">request_remove_validator_candidate</a>(ctx)
 }
 </code></pre>
 
@@ -329,7 +328,7 @@ epoch has already reached the maximum.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator">sui_system_state_inner::request_add_validator</a>(self, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_add_validator">request_add_validator</a>(ctx)
 }
 </code></pre>
 
@@ -362,7 +361,7 @@ of the validator.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator">sui_system_state_inner::request_remove_validator</a>(self, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_remove_validator">request_remove_validator</a>(ctx)
 }
 </code></pre>
 
@@ -393,7 +392,7 @@ used for the reference gas price calculation at the end of the epoch.
     new_gas_price: u64,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_gas_price">sui_system_state_inner::request_set_gas_price</a>(self, cap, new_gas_price)
+    self.<a href="sui_system.md#0x3_sui_system_request_set_gas_price">request_set_gas_price</a>(cap, new_gas_price)
 }
 </code></pre>
 
@@ -423,7 +422,7 @@ This entry function is used to set new gas price for candidate validators
     new_gas_price: u64,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_gas_price">sui_system_state_inner::set_candidate_validator_gas_price</a>(self, cap, new_gas_price)
+    self.<a href="sui_system.md#0x3_sui_system_set_candidate_validator_gas_price">set_candidate_validator_gas_price</a>(cap, new_gas_price)
 }
 </code></pre>
 
@@ -454,7 +453,7 @@ the epoch.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_commission_rate">sui_system_state_inner::request_set_commission_rate</a>(self, new_commission_rate, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_set_commission_rate">request_set_commission_rate</a>(new_commission_rate, ctx)
 }
 </code></pre>
 
@@ -484,7 +483,7 @@ This entry function is used to set new commission rate for candidate validators
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_commission_rate">sui_system_state_inner::set_candidate_validator_commission_rate</a>(self, new_commission_rate, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_set_candidate_validator_commission_rate">set_candidate_validator_commission_rate</a>(new_commission_rate, ctx)
 }
 </code></pre>
 
@@ -515,7 +514,7 @@ Add stake to a validator's staking pool.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> staked_sui = <a href="sui_system.md#0x3_sui_system_request_add_stake_non_entry">request_add_stake_non_entry</a>(wrapper, stake, validator_address, ctx);
-    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, ctx.sender());
 }
 </code></pre>
 
@@ -546,7 +545,7 @@ The non-entry version of <code>request_add_stake</code>, which returns the stake
     ctx: &<b>mut</b> TxContext,
 ): StakedSui {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">sui_system_state_inner::request_add_stake</a>(self, stake, validator_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_add_stake">request_add_stake</a>(stake, validator_address, ctx)
 }
 </code></pre>
 
@@ -578,8 +577,8 @@ Add stake to a validator's staking pool using multiple coins.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <b>let</b> staked_sui = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">sui_system_state_inner::request_add_stake_mul_coin</a>(self, stakes, stake_amount, validator_address, ctx);
-    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <b>let</b> staked_sui = self.<a href="sui_system.md#0x3_sui_system_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(stakes, stake_amount, validator_address, ctx);
+    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, ctx.sender());
 }
 </code></pre>
 
@@ -609,7 +608,7 @@ Withdraw stake from a validator's staking pool.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> withdrawn_stake = <a href="sui_system.md#0x3_sui_system_request_withdraw_stake_non_entry">request_withdraw_stake_non_entry</a>(wrapper, staked_sui, ctx);
-    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(<a href="../sui-framework/coin.md#0x2_coin_from_balance">coin::from_balance</a>(withdrawn_stake, ctx), <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+    <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(withdrawn_stake.into_coin(ctx), ctx.sender());
 }
 </code></pre>
 
@@ -639,7 +638,7 @@ Non-entry version of <code>request_withdraw_stake</code> that returns the withdr
     ctx: &<b>mut</b> TxContext,
 ) : Balance&lt;SUI&gt; {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_withdraw_stake">sui_system_state_inner::request_withdraw_stake</a>(self, staked_sui, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_request_withdraw_stake">request_withdraw_stake</a>(staked_sui, ctx)
 }
 </code></pre>
 
@@ -674,7 +673,7 @@ This function is idempotent.
     reportee_addr: <b>address</b>,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_report_validator">sui_system_state_inner::report_validator</a>(self, cap, reportee_addr)
+    self.<a href="sui_system.md#0x3_sui_system_report_validator">report_validator</a>(cap, reportee_addr)
 }
 </code></pre>
 
@@ -707,7 +706,7 @@ Undo a <code>report_validator</code> action. Aborts if
     reportee_addr: <b>address</b>,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_undo_report_validator">sui_system_state_inner::undo_report_validator</a>(self, cap, reportee_addr)
+    self.<a href="sui_system.md#0x3_sui_system_undo_report_validator">undo_report_validator</a>(cap, reportee_addr)
 }
 </code></pre>
 
@@ -737,7 +736,7 @@ validator and registers it. The original object is thus revoked.
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_rotate_operation_cap">sui_system_state_inner::rotate_operation_cap</a>(self, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_rotate_operation_cap">rotate_operation_cap</a>(ctx)
 }
 </code></pre>
 
@@ -767,7 +766,7 @@ Update a validator's name.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_name">sui_system_state_inner::update_validator_name</a>(self, name, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_name">update_validator_name</a>(name, ctx)
 }
 </code></pre>
 
@@ -797,7 +796,7 @@ Update a validator's description
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_description">sui_system_state_inner::update_validator_description</a>(self, description, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_description">update_validator_description</a>(description, ctx)
 }
 </code></pre>
 
@@ -827,7 +826,7 @@ Update a validator's image url
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_image_url">sui_system_state_inner::update_validator_image_url</a>(self, image_url, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_image_url">update_validator_image_url</a>(image_url, ctx)
 }
 </code></pre>
 
@@ -857,7 +856,7 @@ Update a validator's project url
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_project_url">sui_system_state_inner::update_validator_project_url</a>(self, project_url, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_project_url">update_validator_project_url</a>(project_url, ctx)
 }
 </code></pre>
 
@@ -888,7 +887,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_address">sui_system_state_inner::update_validator_next_epoch_network_address</a>(self, network_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_network_address">update_validator_next_epoch_network_address</a>(network_address, ctx)
 }
 </code></pre>
 
@@ -918,7 +917,7 @@ Update candidate validator's network address.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_address">sui_system_state_inner::update_candidate_validator_network_address</a>(self, network_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_network_address">update_candidate_validator_network_address</a>(network_address, ctx)
 }
 </code></pre>
 
@@ -949,7 +948,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_p2p_address">sui_system_state_inner::update_validator_next_epoch_p2p_address</a>(self, p2p_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_p2p_address">update_validator_next_epoch_p2p_address</a>(p2p_address, ctx)
 }
 </code></pre>
 
@@ -979,7 +978,7 @@ Update candidate validator's p2p address.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_p2p_address">sui_system_state_inner::update_candidate_validator_p2p_address</a>(self, p2p_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_p2p_address">update_candidate_validator_p2p_address</a>(p2p_address, ctx)
 }
 </code></pre>
 
@@ -1010,7 +1009,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_primary_address">sui_system_state_inner::update_validator_next_epoch_primary_address</a>(self, primary_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(primary_address, ctx)
 }
 </code></pre>
 
@@ -1040,7 +1039,7 @@ Update candidate validator's narwhal primary address.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_primary_address">sui_system_state_inner::update_candidate_validator_primary_address</a>(self, primary_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_primary_address">update_candidate_validator_primary_address</a>(primary_address, ctx)
 }
 </code></pre>
 
@@ -1071,7 +1070,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_address">sui_system_state_inner::update_validator_next_epoch_worker_address</a>(self, worker_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_worker_address">update_validator_next_epoch_worker_address</a>(worker_address, ctx)
 }
 </code></pre>
 
@@ -1101,7 +1100,7 @@ Update candidate validator's narwhal worker address.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_address">sui_system_state_inner::update_candidate_validator_worker_address</a>(self, worker_address, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_worker_address">update_candidate_validator_worker_address</a>(worker_address, ctx)
 }
 </code></pre>
 
@@ -1133,7 +1132,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_protocol_pubkey">sui_system_state_inner::update_validator_next_epoch_protocol_pubkey</a>(self, protocol_pubkey, proof_of_possession, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_protocol_pubkey">update_validator_next_epoch_protocol_pubkey</a>(protocol_pubkey, proof_of_possession, ctx)
 }
 </code></pre>
 
@@ -1164,7 +1163,7 @@ Update candidate validator's public key of protocol key and proof of possession.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_protocol_pubkey">sui_system_state_inner::update_candidate_validator_protocol_pubkey</a>(self, protocol_pubkey, proof_of_possession, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_protocol_pubkey">update_candidate_validator_protocol_pubkey</a>(protocol_pubkey, proof_of_possession, ctx)
 }
 </code></pre>
 
@@ -1195,7 +1194,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_pubkey">sui_system_state_inner::update_validator_next_epoch_worker_pubkey</a>(self, worker_pubkey, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_worker_pubkey">update_validator_next_epoch_worker_pubkey</a>(worker_pubkey, ctx)
 }
 </code></pre>
 
@@ -1225,7 +1224,7 @@ Update candidate validator's public key of worker key.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_pubkey">sui_system_state_inner::update_candidate_validator_worker_pubkey</a>(self, worker_pubkey, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_worker_pubkey">update_candidate_validator_worker_pubkey</a>(worker_pubkey, ctx)
 }
 </code></pre>
 
@@ -1256,7 +1255,7 @@ The change will only take effects starting from the next epoch.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_pubkey">sui_system_state_inner::update_validator_next_epoch_network_pubkey</a>(self, network_pubkey, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_validator_next_epoch_network_pubkey">update_validator_next_epoch_network_pubkey</a>(network_pubkey, ctx)
 }
 </code></pre>
 
@@ -1286,7 +1285,7 @@ Update candidate validator's public key of network key.
     ctx: &TxContext,
 ) {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_pubkey">sui_system_state_inner::update_candidate_validator_network_pubkey</a>(self, network_pubkey, ctx)
+    self.<a href="sui_system.md#0x3_sui_system_update_candidate_validator_network_pubkey">update_candidate_validator_network_pubkey</a>(network_pubkey, ctx)
 }
 </code></pre>
 
@@ -1315,7 +1314,7 @@ Getter of the pool token exchange rate of a staking pool. Works for both active 
     pool_id: &ID
 ): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">sui_system_state_inner::pool_exchange_rates</a>(self, pool_id)
+    self.<a href="sui_system.md#0x3_sui_system_pool_exchange_rates">pool_exchange_rates</a>(pool_id)
 }
 </code></pre>
 
@@ -1341,7 +1340,7 @@ Getter returning addresses of the currently active validators.
 
 <pre><code><b>public</b> <b>fun</b> <a href="sui_system.md#0x3_sui_system_active_validator_addresses">active_validator_addresses</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(wrapper);
-    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">sui_system_state_inner::active_validator_addresses</a>(self)
+    self.<a href="sui_system.md#0x3_sui_system_active_validator_addresses">active_validator_addresses</a>()
 }
 </code></pre>
 
@@ -1387,9 +1386,8 @@ gas coins.
 ) : Balance&lt;SUI&gt; {
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
-    <b>assert</b>!(<a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="sui_system.md#0x3_sui_system_ENotSystemAddress">ENotSystemAddress</a>);
-    <b>let</b> storage_rebate = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">sui_system_state_inner::advance_epoch</a>(
-        self,
+    <b>assert</b>!(ctx.sender() == @0x0, <a href="sui_system.md#0x3_sui_system_ENotSystemAddress">ENotSystemAddress</a>);
+    <b>let</b> storage_rebate = self.<a href="sui_system.md#0x3_sui_system_advance_epoch">advance_epoch</a>(
         new_epoch,
         next_protocol_version,
         storage_reward,
@@ -1475,14 +1473,17 @@ gas coins.
 
 <pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> SuiSystemStateInnerV2 {
     <b>if</b> (self.version == 1) {
-      <b>let</b> v1 = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> self.id, self.version);
-      <b>let</b> v2 = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_v1_to_v2">sui_system_state_inner::v1_to_v2</a>(v1);
+      <b>let</b> v1: SuiSystemStateInner = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> self.id, self.version);
+      <b>let</b> v2 = v1.v1_to_v2();
       self.version = 2;
       <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> self.id, self.version, v2);
     };
 
-    <b>let</b> inner = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.version);
-    <b>assert</b>!(<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">sui_system_state_inner::system_state_version</a>(inner) == self.version, <a href="sui_system.md#0x3_sui_system_EWrongInnerVersion">EWrongInnerVersion</a>);
+    <b>let</b> inner: &<b>mut</b> SuiSystemStateInnerV2 = <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(
+        &<b>mut</b> self.id,
+        self.version
+    );
+    <b>assert</b>!(inner.system_state_version() == self.version, <a href="sui_system.md#0x3_sui_system_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui-system/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui-system/sui_system_state_inner.md
@@ -761,7 +761,7 @@ This function will be called only once in genesis.
     ctx: &<b>mut</b> TxContext,
 ): <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a> {
     <b>let</b> validators = <a href="validator_set.md#0x3_validator_set_new">validator_set::new</a>(validators, ctx);
-    <b>let</b> reference_gas_price = <a href="validator_set.md#0x3_validator_set_derive_reference_gas_price">validator_set::derive_reference_gas_price</a>(&validators);
+    <b>let</b> reference_gas_price = validators.derive_reference_gas_price();
     // This type is fixed <b>as</b> it's created at <a href="genesis.md#0x3_genesis">genesis</a>. It should not be updated during type upgrade.
     <b>let</b> system_state = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a> {
         epoch: 0,
@@ -952,7 +952,7 @@ To produce a valid PoP, run [fn test_proof_of_possession].
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator.md#0x3_validator_new">validator::new</a>(
-        <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
+        ctx.sender(),
         pubkey_bytes,
         network_pubkey_bytes,
         worker_pubkey_bytes,
@@ -970,7 +970,7 @@ To produce a valid PoP, run [fn test_proof_of_possession].
         ctx
     );
 
-    <a href="validator_set.md#0x3_validator_set_request_add_validator_candidate">validator_set::request_add_validator_candidate</a>(&<b>mut</b> self.validators, <a href="validator.md#0x3_validator">validator</a>, ctx);
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator_candidate">request_add_validator_candidate</a>(<a href="validator.md#0x3_validator">validator</a>, ctx);
 }
 </code></pre>
 
@@ -999,7 +999,7 @@ their staking pool becomes deactivate.
     self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <a href="validator_set.md#0x3_validator_set_request_remove_validator_candidate">validator_set::request_remove_validator_candidate</a>(&<b>mut</b> self.validators, ctx);
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator_candidate">request_remove_validator_candidate</a>(ctx);
 }
 </code></pre>
 
@@ -1031,11 +1031,11 @@ epoch has already reached the maximum.
     ctx: &TxContext,
 ) {
     <b>assert</b>!(
-        <a href="validator_set.md#0x3_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &lt; self.parameters.max_validator_count,
+        self.validators.next_epoch_validator_count() &lt; self.parameters.max_validator_count,
         <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ELimitExceeded">ELimitExceeded</a>,
     );
 
-    <a href="validator_set.md#0x3_validator_set_request_add_validator">validator_set::request_add_validator</a>(&<b>mut</b> self.validators, self.parameters.min_validator_joining_stake, ctx);
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator">request_add_validator</a>(self.parameters.min_validator_joining_stake, ctx);
 }
 </code></pre>
 
@@ -1070,17 +1070,14 @@ of the validator.
     // Only check <b>min</b> <a href="validator.md#0x3_validator">validator</a> condition <b>if</b> the current number of validators satisfy the constraint.
     // This is so that <b>if</b> we somehow already are in a state <b>where</b> we have less than <b>min</b> validators, it no longer matters
     // and is ok <b>to</b> stay so. This is useful for a test setup.
-    <b>if</b> (<a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(<a href="validator_set.md#0x3_validator_set_active_validators">validator_set::active_validators</a>(&self.validators)) &gt;= self.parameters.min_validator_count) {
+    <b>if</b> (self.validators.active_validators().length() &gt;= self.parameters.min_validator_count) {
         <b>assert</b>!(
-            <a href="validator_set.md#0x3_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &gt; self.parameters.min_validator_count,
+            self.validators.next_epoch_validator_count() &gt; self.parameters.min_validator_count,
             <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ELimitExceeded">ELimitExceeded</a>,
         );
     };
 
-    <a href="validator_set.md#0x3_validator_set_request_remove_validator">validator_set::request_remove_validator</a>(
-        &<b>mut</b> self.validators,
-        ctx,
-    )
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator">request_remove_validator</a>(ctx)
 }
 </code></pre>
 
@@ -1111,10 +1108,10 @@ used for the reference gas price calculation at the end of the epoch.
     new_gas_price: u64,
 ) {
     // Verify the represented <b>address</b> is an active or pending <a href="validator.md#0x3_validator">validator</a>, and the capability is still valid.
-    <b>let</b> verified_cap = <a href="validator_set.md#0x3_validator_set_verify_cap">validator_set::verify_cap</a>(&<b>mut</b> self.validators, cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>);
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_verified_cap">validator_set::get_validator_mut_with_verified_cap</a>(&<b>mut</b> self.validators, &verified_cap, <b>false</b> /* include_candidate */);
+    <b>let</b> verified_cap = self.validators.verify_cap(cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_verified_cap(&verified_cap, <b>false</b> /* include_candidate */);
 
-    <a href="validator.md#0x3_validator_request_set_gas_price">validator::request_set_gas_price</a>(<a href="validator.md#0x3_validator">validator</a>, verified_cap, new_gas_price);
+    <a href="validator.md#0x3_validator">validator</a>.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_gas_price">request_set_gas_price</a>(verified_cap, new_gas_price);
 }
 </code></pre>
 
@@ -1144,9 +1141,9 @@ This function is used to set new gas price for candidate validators
     new_gas_price: u64,
 ) {
     // Verify the represented <b>address</b> is an active or pending <a href="validator.md#0x3_validator">validator</a>, and the capability is still valid.
-    <b>let</b> verified_cap = <a href="validator_set.md#0x3_validator_set_verify_cap">validator_set::verify_cap</a>(&<b>mut</b> self.validators, cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ANY_VALIDATOR">ANY_VALIDATOR</a>);
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_verified_cap">validator_set::get_validator_mut_with_verified_cap</a>(&<b>mut</b> self.validators, &verified_cap, <b>true</b> /* include_candidate */);
-    <a href="validator.md#0x3_validator_set_candidate_gas_price">validator::set_candidate_gas_price</a>(candidate, verified_cap, new_gas_price)
+    <b>let</b> verified_cap = self.validators.verify_cap(cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ANY_VALIDATOR">ANY_VALIDATOR</a>);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_verified_cap(&verified_cap, <b>true</b> /* include_candidate */);
+    candidate.set_candidate_gas_price(verified_cap, new_gas_price)
 }
 </code></pre>
 
@@ -1176,8 +1173,7 @@ the epoch.
     new_commission_rate: u64,
     ctx: &TxContext,
 ) {
-    <a href="validator_set.md#0x3_validator_set_request_set_commission_rate">validator_set::request_set_commission_rate</a>(
-        &<b>mut</b> self.validators,
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_commission_rate">request_set_commission_rate</a>(
         new_commission_rate,
         ctx
     )
@@ -1209,8 +1205,8 @@ This function is used to set new commission rate for candidate validators
     new_commission_rate: u64,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_set_candidate_commission_rate">validator::set_candidate_commission_rate</a>(candidate, new_commission_rate)
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.set_candidate_commission_rate(new_commission_rate)
 }
 </code></pre>
 
@@ -1240,10 +1236,9 @@ Add stake to a validator's staking pool.
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) : StakedSui {
-    <a href="validator_set.md#0x3_validator_set_request_add_stake">validator_set::request_add_stake</a>(
-        &<b>mut</b> self.validators,
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(
         validator_address,
-        <a href="../sui-framework/coin.md#0x2_coin_into_balance">coin::into_balance</a>(stake),
+        stake.into_balance(),
         ctx,
     )
 }
@@ -1277,7 +1272,7 @@ Add stake to a validator's staking pool using multiple coins.
     ctx: &<b>mut</b> TxContext,
 ) : StakedSui {
     <b>let</b> <a href="../sui-framework/balance.md#0x2_balance">balance</a> = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_extract_coin_balance">extract_coin_balance</a>(stakes, stake_amount, ctx);
-    <a href="validator_set.md#0x3_validator_set_request_add_stake">validator_set::request_add_stake</a>(&<b>mut</b> self.validators, validator_address, <a href="../sui-framework/balance.md#0x2_balance">balance</a>, ctx)
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(validator_address, <a href="../sui-framework/balance.md#0x2_balance">balance</a>, ctx)
 }
 </code></pre>
 
@@ -1307,12 +1302,10 @@ Withdraw some portion of a stake from a validator's staking pool.
     ctx: &TxContext,
 ) : Balance&lt;SUI&gt; {
     <b>assert</b>!(
-        stake_activation_epoch(&staked_sui) &lt;= <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+        stake_activation_epoch(&staked_sui) &lt;= ctx.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>(),
         <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EStakeWithdrawBeforeActivation">EStakeWithdrawBeforeActivation</a>
     );
-    <a href="validator_set.md#0x3_validator_set_request_withdraw_stake">validator_set::request_withdraw_stake</a>(
-        &<b>mut</b> self.validators, staked_sui, ctx,
-    )
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_withdraw_stake">request_withdraw_stake</a>(staked_sui, ctx)
 }
 </code></pre>
 
@@ -1347,9 +1340,9 @@ This function is idempotent.
     reportee_addr: <b>address</b>,
 ) {
     // Reportee needs <b>to</b> be an active <a href="validator.md#0x3_validator">validator</a>
-    <b>assert</b>!(<a href="validator_set.md#0x3_validator_set_is_active_validator_by_sui_address">validator_set::is_active_validator_by_sui_address</a>(&self.validators, reportee_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ENotValidator">ENotValidator</a>);
+    <b>assert</b>!(self.validators.is_active_validator_by_sui_address(reportee_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ENotValidator">ENotValidator</a>);
     // Verify the represented reporter <b>address</b> is an active <a href="validator.md#0x3_validator">validator</a>, and the capability is still valid.
-    <b>let</b> verified_cap = <a href="validator_set.md#0x3_validator_set_verify_cap">validator_set::verify_cap</a>(&<b>mut</b> self.validators, cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
+    <b>let</b> verified_cap = self.validators.verify_cap(cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
     <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_report_validator_impl">report_validator_impl</a>(verified_cap, reportee_addr, &<b>mut</b> self.validator_report_records);
 }
 </code></pre>
@@ -1382,7 +1375,7 @@ Undo a <code>report_validator</code> action. Aborts if
     cap: &UnverifiedValidatorOperationCap,
     reportee_addr: <b>address</b>,
 ) {
-    <b>let</b> verified_cap = <a href="validator_set.md#0x3_validator_set_verify_cap">validator_set::verify_cap</a>(&<b>mut</b> self.validators, cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
+    <b>let</b> verified_cap = self.validators.verify_cap(cap, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>);
     <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_undo_report_validator_impl">undo_report_validator_impl</a>(verified_cap, reportee_addr, &<b>mut</b> self.validator_report_records);
 }
 </code></pre>
@@ -1411,14 +1404,14 @@ Undo a <code>report_validator</code> action. Aborts if
     reportee_addr: <b>address</b>,
     validator_report_records: &<b>mut</b> VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
 ) {
-    <b>let</b> reporter_address = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
+    <b>let</b> reporter_address = *verified_cap.verified_operation_cap_address();
     <b>assert</b>!(reporter_address != reportee_addr, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ECannotReportOneself">ECannotReportOneself</a>);
-    <b>if</b> (!<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(validator_report_records, &reportee_addr)) {
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(validator_report_records, reportee_addr, <a href="../sui-framework/vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(reporter_address));
+    <b>if</b> (!validator_report_records.contains(&reportee_addr)) {
+        validator_report_records.insert(reportee_addr, <a href="../sui-framework/vec_set.md#0x2_vec_set_singleton">vec_set::singleton</a>(reporter_address));
     } <b>else</b> {
-        <b>let</b> reporters = <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(validator_report_records, &reportee_addr);
-        <b>if</b> (!<a href="../sui-framework/vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &reporter_address)) {
-            <a href="../sui-framework/vec_set.md#0x2_vec_set_insert">vec_set::insert</a>(reporters, reporter_address);
+        <b>let</b> reporters = validator_report_records.get_mut(&reportee_addr);
+        <b>if</b> (!reporters.contains(&reporter_address)) {
+            reporters.insert(reporter_address);
         }
     }
 }
@@ -1448,15 +1441,15 @@ Undo a <code>report_validator</code> action. Aborts if
     reportee_addr: <b>address</b>,
     validator_report_records: &<b>mut</b> VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
 ) {
-    <b>assert</b>!(<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(validator_report_records, &reportee_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EReportRecordNotFound">EReportRecordNotFound</a>);
-    <b>let</b> reporters = <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(validator_report_records, &reportee_addr);
+    <b>assert</b>!(validator_report_records.contains(&reportee_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EReportRecordNotFound">EReportRecordNotFound</a>);
+    <b>let</b> reporters = validator_report_records.get_mut(&reportee_addr);
 
-    <b>let</b> reporter_addr = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
-    <b>assert</b>!(<a href="../sui-framework/vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &reporter_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EReportRecordNotFound">EReportRecordNotFound</a>);
+    <b>let</b> reporter_addr = *verified_cap.verified_operation_cap_address();
+    <b>assert</b>!(reporters.contains(&reporter_addr), <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EReportRecordNotFound">EReportRecordNotFound</a>);
 
-    <a href="../sui-framework/vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &reporter_addr);
-    <b>if</b> (<a href="../sui-framework/vec_set.md#0x2_vec_set_is_empty">vec_set::is_empty</a>(reporters)) {
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(validator_report_records, &reportee_addr);
+    reporters.remove(&reporter_addr);
+    <b>if</b> (reporters.is_empty()) {
+        validator_report_records.remove(&reportee_addr);
     }
 }
 </code></pre>
@@ -1486,8 +1479,8 @@ validator and registers it. The original object is thus revoked.
     self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_new_unverified_validator_operation_cap_and_transfer">validator::new_unverified_validator_operation_cap_and_transfer</a>(<a href="validator.md#0x3_validator">validator</a>, ctx);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.new_unverified_validator_operation_cap_and_transfer(ctx);
 }
 </code></pre>
 
@@ -1516,9 +1509,9 @@ Update a validator's name.
     name: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
 
-    <a href="validator.md#0x3_validator_update_name">validator::update_name</a>(<a href="validator.md#0x3_validator">validator</a>, name);
+    <a href="validator.md#0x3_validator">validator</a>.update_name(name);
 }
 </code></pre>
 
@@ -1547,8 +1540,8 @@ Update a validator's description
     description: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_description">validator::update_description</a>(<a href="validator.md#0x3_validator">validator</a>, description);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_description(description);
 }
 </code></pre>
 
@@ -1577,8 +1570,8 @@ Update a validator's image url
     image_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_image_url">validator::update_image_url</a>(<a href="validator.md#0x3_validator">validator</a>, image_url);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_image_url(image_url);
 }
 </code></pre>
 
@@ -1607,8 +1600,8 @@ Update a validator's project url
     project_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_project_url">validator::update_project_url</a>(<a href="validator.md#0x3_validator">validator</a>, project_url);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_project_url(project_url);
 }
 </code></pre>
 
@@ -1638,10 +1631,10 @@ The change will only take effects starting from the next epoch.
     network_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_network_address">validator::update_next_epoch_network_address</a>(<a href="validator.md#0x3_validator">validator</a>, network_address);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_network_address(network_address);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> :&Validator = <a href="validator.md#0x3_validator">validator</a>; // Force immutability for the following call
-    <a href="validator_set.md#0x3_validator_set_assert_no_pending_or_active_duplicates">validator_set::assert_no_pending_or_active_duplicates</a>(&self.validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.validators.assert_no_pending_or_active_duplicates(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -1670,8 +1663,8 @@ Update candidate validator's network address.
     network_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_network_address">validator::update_candidate_network_address</a>(candidate, network_address);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_network_address(network_address);
 }
 </code></pre>
 
@@ -1701,10 +1694,10 @@ The change will only take effects starting from the next epoch.
     p2p_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_p2p_address">validator::update_next_epoch_p2p_address</a>(<a href="validator.md#0x3_validator">validator</a>, p2p_address);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_p2p_address(p2p_address);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> :&Validator = <a href="validator.md#0x3_validator">validator</a>; // Force immutability for the following call
-    <a href="validator_set.md#0x3_validator_set_assert_no_pending_or_active_duplicates">validator_set::assert_no_pending_or_active_duplicates</a>(&self.validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.validators.assert_no_pending_or_active_duplicates(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -1733,8 +1726,8 @@ Update candidate validator's p2p address.
     p2p_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_p2p_address">validator::update_candidate_p2p_address</a>(candidate, p2p_address);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_p2p_address(p2p_address);
 }
 </code></pre>
 
@@ -1764,8 +1757,8 @@ The change will only take effects starting from the next epoch.
     primary_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_primary_address">validator::update_next_epoch_primary_address</a>(<a href="validator.md#0x3_validator">validator</a>, primary_address);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_primary_address(primary_address);
 }
 </code></pre>
 
@@ -1794,8 +1787,8 @@ Update candidate validator's narwhal primary address.
     primary_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_primary_address">validator::update_candidate_primary_address</a>(candidate, primary_address);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_primary_address(primary_address);
 }
 </code></pre>
 
@@ -1825,8 +1818,8 @@ The change will only take effects starting from the next epoch.
     worker_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_worker_address">validator::update_next_epoch_worker_address</a>(<a href="validator.md#0x3_validator">validator</a>, worker_address);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_worker_address(worker_address);
 }
 </code></pre>
 
@@ -1855,8 +1848,8 @@ Update candidate validator's narwhal worker address.
     worker_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_worker_address">validator::update_candidate_worker_address</a>(candidate, worker_address);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_worker_address(worker_address);
 }
 </code></pre>
 
@@ -1887,10 +1880,10 @@ The change will only take effects starting from the next epoch.
     proof_of_possession: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_protocol_pubkey">validator::update_next_epoch_protocol_pubkey</a>(<a href="validator.md#0x3_validator">validator</a>, protocol_pubkey, proof_of_possession);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_protocol_pubkey(protocol_pubkey, proof_of_possession);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> :&Validator = <a href="validator.md#0x3_validator">validator</a>; // Force immutability for the following call
-    <a href="validator_set.md#0x3_validator_set_assert_no_pending_or_active_duplicates">validator_set::assert_no_pending_or_active_duplicates</a>(&self.validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.validators.assert_no_pending_or_active_duplicates(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -1920,8 +1913,8 @@ Update candidate validator's public key of protocol key and proof of possession.
     proof_of_possession: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_protocol_pubkey">validator::update_candidate_protocol_pubkey</a>(candidate, protocol_pubkey, proof_of_possession);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_protocol_pubkey(protocol_pubkey, proof_of_possession);
 }
 </code></pre>
 
@@ -1951,10 +1944,10 @@ The change will only take effects starting from the next epoch.
     worker_pubkey: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_worker_pubkey">validator::update_next_epoch_worker_pubkey</a>(<a href="validator.md#0x3_validator">validator</a>, worker_pubkey);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_worker_pubkey(worker_pubkey);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> :&Validator = <a href="validator.md#0x3_validator">validator</a>; // Force immutability for the following call
-    <a href="validator_set.md#0x3_validator_set_assert_no_pending_or_active_duplicates">validator_set::assert_no_pending_or_active_duplicates</a>(&self.validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.validators.assert_no_pending_or_active_duplicates(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -1983,8 +1976,8 @@ Update candidate validator's public key of worker key.
     worker_pubkey: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_worker_pubkey">validator::update_candidate_worker_pubkey</a>(candidate, worker_pubkey);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_worker_pubkey(worker_pubkey);
 }
 </code></pre>
 
@@ -2014,10 +2007,10 @@ The change will only take effects starting from the next epoch.
     network_pubkey: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx">validator_set::get_validator_mut_with_ctx</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_next_epoch_network_pubkey">validator::update_next_epoch_network_pubkey</a>(<a href="validator.md#0x3_validator">validator</a>, network_pubkey);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.validators.get_validator_mut_with_ctx(ctx);
+    <a href="validator.md#0x3_validator">validator</a>.update_next_epoch_network_pubkey(network_pubkey);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> :&Validator = <a href="validator.md#0x3_validator">validator</a>; // Force immutability for the following call
-    <a href="validator_set.md#0x3_validator_set_assert_no_pending_or_active_duplicates">validator_set::assert_no_pending_or_active_duplicates</a>(&self.validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.validators.assert_no_pending_or_active_duplicates(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -2046,8 +2039,8 @@ Update candidate validator's public key of network key.
     network_pubkey: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
-    <b>let</b> candidate = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
-    <a href="validator.md#0x3_validator_update_candidate_network_pubkey">validator::update_candidate_network_pubkey</a>(candidate, network_pubkey);
+    <b>let</b> candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+    candidate.update_candidate_network_pubkey(network_pubkey);
 }
 </code></pre>
 
@@ -2108,46 +2101,45 @@ gas coins.
     };
 
     // Accumulate the gas summary during safe_mode before processing any rewards:
-    <b>let</b> safe_mode_storage_rewards = <a href="../sui-framework/balance.md#0x2_balance_withdraw_all">balance::withdraw_all</a>(&<b>mut</b> self.safe_mode_storage_rewards);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> storage_reward, safe_mode_storage_rewards);
-    <b>let</b> safe_mode_computation_rewards = <a href="../sui-framework/balance.md#0x2_balance_withdraw_all">balance::withdraw_all</a>(&<b>mut</b> self.safe_mode_computation_rewards);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> computation_reward, safe_mode_computation_rewards);
+    <b>let</b> safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();
+    storage_reward.join(safe_mode_storage_rewards);
+    <b>let</b> safe_mode_computation_rewards = self.safe_mode_computation_rewards.withdraw_all();
+    computation_reward.join(safe_mode_computation_rewards);
     storage_rebate_amount = storage_rebate_amount + self.safe_mode_storage_rebates;
     self.safe_mode_storage_rebates = 0;
     non_refundable_storage_fee_amount = non_refundable_storage_fee_amount + self.safe_mode_non_refundable_storage_fee;
     self.safe_mode_non_refundable_storage_fee = 0;
 
-    <b>let</b> total_validators_stake = <a href="validator_set.md#0x3_validator_set_total_stake">validator_set::total_stake</a>(&self.validators);
-    <b>let</b> storage_fund_balance = <a href="storage_fund.md#0x3_storage_fund_total_balance">storage_fund::total_balance</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>);
+    <b>let</b> total_validators_stake = self.validators.total_stake();
+    <b>let</b> storage_fund_balance = self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.total_balance();
     <b>let</b> total_stake = storage_fund_balance + total_validators_stake;
 
-    <b>let</b> storage_charge = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&storage_reward);
-    <b>let</b> computation_charge = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&computation_reward);
+    <b>let</b> storage_charge = storage_reward.value();
+    <b>let</b> computation_charge = computation_reward.value();
 
     // Include stake subsidy in the rewards given out <b>to</b> validators and stakers.
     // Delay distributing any stake subsidies until after `stake_subsidy_start_epoch`.
     // And <b>if</b> this epoch is shorter than the regular epoch duration, don't distribute any stake subsidy.
     <b>let</b> <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a> =
-        <b>if</b> (<a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) &gt;= self.parameters.stake_subsidy_start_epoch  &&
+        <b>if</b> (ctx.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>() &gt;= self.parameters.stake_subsidy_start_epoch  &&
             epoch_start_timestamp_ms &gt;= prev_epoch_start_timestamp + self.parameters.epoch_duration_ms)
         {
-            <a href="stake_subsidy.md#0x3_stake_subsidy_advance_epoch">stake_subsidy::advance_epoch</a>(&<b>mut</b> self.<a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>)
+            self.<a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>()
         } <b>else</b> {
             <a href="../sui-framework/balance.md#0x2_balance_zero">balance::zero</a>()
         };
 
-    <b>let</b> stake_subsidy_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&<a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>);
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> computation_reward, <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>);
+    <b>let</b> stake_subsidy_amount = <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>.value();
+    computation_reward.join(<a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>);
 
     <b>let</b> total_stake_u128 = (total_stake <b>as</b> u128);
     <b>let</b> computation_charge_u128 = (computation_charge <b>as</b> u128);
 
     <b>let</b> storage_fund_reward_amount = (storage_fund_balance <b>as</b> u128) * computation_charge_u128 / total_stake_u128;
-    <b>let</b> <b>mut</b> storage_fund_reward = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> computation_reward, (storage_fund_reward_amount <b>as</b> u64));
+    <b>let</b> <b>mut</b> storage_fund_reward = computation_reward.split((storage_fund_reward_amount <b>as</b> u64));
     <b>let</b> storage_fund_reinvestment_amount =
         storage_fund_reward_amount * (storage_fund_reinvest_rate <b>as</b> u128) / <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
-    <b>let</b> storage_fund_reinvestment = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(
-        &<b>mut</b> storage_fund_reward,
+    <b>let</b> storage_fund_reinvestment = storage_fund_reward.split(
         (storage_fund_reinvestment_amount <b>as</b> u64),
     );
 
@@ -2155,11 +2147,10 @@ gas coins.
     // Sanity check <b>to</b> make sure we are advancing <b>to</b> the right epoch.
     <b>assert</b>!(new_epoch == self.epoch, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_EAdvancedToWrongEpoch">EAdvancedToWrongEpoch</a>);
 
-    <b>let</b> computation_reward_amount_before_distribution = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&computation_reward);
-    <b>let</b> storage_fund_reward_amount_before_distribution = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&storage_fund_reward);
+    <b>let</b> computation_reward_amount_before_distribution = computation_reward.value();
+    <b>let</b> storage_fund_reward_amount_before_distribution = storage_fund_reward.value();
 
-    <a href="validator_set.md#0x3_validator_set_advance_epoch">validator_set::advance_epoch</a>(
-        &<b>mut</b> self.validators,
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>(
         &<b>mut</b> computation_reward,
         &<b>mut</b> storage_fund_reward,
         &<b>mut</b> self.validator_report_records,
@@ -2170,27 +2161,26 @@ gas coins.
         ctx,
     );
 
-    <b>let</b> new_total_stake = <a href="validator_set.md#0x3_validator_set_total_stake">validator_set::total_stake</a>(&self.validators);
+    <b>let</b> new_total_stake = self.validators.total_stake();
 
-    <b>let</b> computation_reward_amount_after_distribution = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&computation_reward);
-    <b>let</b> storage_fund_reward_amount_after_distribution = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&storage_fund_reward);
+    <b>let</b> computation_reward_amount_after_distribution = computation_reward.value();
+    <b>let</b> storage_fund_reward_amount_after_distribution = storage_fund_reward.value();
     <b>let</b> computation_reward_distributed = computation_reward_amount_before_distribution - computation_reward_amount_after_distribution;
     <b>let</b> storage_fund_reward_distributed = storage_fund_reward_amount_before_distribution - storage_fund_reward_amount_after_distribution;
 
     self.protocol_version = next_protocol_version;
 
     // Derive the reference gas price for the new epoch
-    self.reference_gas_price = <a href="validator_set.md#0x3_validator_set_derive_reference_gas_price">validator_set::derive_reference_gas_price</a>(&self.validators);
+    self.reference_gas_price = self.validators.derive_reference_gas_price();
     // Because of precision issues <b>with</b> integer divisions, we expect that there will be some
     // remaining <a href="../sui-framework/balance.md#0x2_balance">balance</a> in `storage_fund_reward` and `computation_reward`.
     // All of these go <b>to</b> the storage fund.
     <b>let</b> <b>mut</b> leftover_staking_rewards = storage_fund_reward;
-    <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> leftover_staking_rewards, computation_reward);
-    <b>let</b> leftover_storage_fund_inflow = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&leftover_staking_rewards);
+    leftover_staking_rewards.join(computation_reward);
+    <b>let</b> leftover_storage_fund_inflow = leftover_staking_rewards.value();
 
     <b>let</b> refunded_storage_rebate =
-        <a href="storage_fund.md#0x3_storage_fund_advance_epoch">storage_fund::advance_epoch</a>(
-            &<b>mut</b> self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>,
+        self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>(
             storage_reward,
             storage_fund_reinvestment,
             leftover_staking_rewards,
@@ -2207,7 +2197,7 @@ gas coins.
             storage_charge,
             storage_fund_reinvestment: (storage_fund_reinvestment_amount <b>as</b> u64),
             storage_rebate: storage_rebate_amount,
-            storage_fund_balance: <a href="storage_fund.md#0x3_storage_fund_total_balance">storage_fund::total_balance</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>),
+            storage_fund_balance: self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.total_balance(),
             stake_subsidy_amount,
             total_gas_fees: computation_charge,
             total_stake_rewards_distributed: computation_reward_distributed + storage_fund_reward_distributed,
@@ -2217,8 +2207,8 @@ gas coins.
     self.safe_mode = <b>false</b>;
     // Double check that the gas from safe mode <b>has</b> been processed.
     <b>assert</b>!(self.safe_mode_storage_rebates == 0
-        && <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.safe_mode_storage_rewards) == 0
-        && <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&self.safe_mode_computation_rewards) == 0, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ESafeModeGasNotProcessed">ESafeModeGasNotProcessed</a>);
+        && self.safe_mode_storage_rewards.value() == 0
+        && self.safe_mode_computation_rewards.value() == 0, <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ESafeModeGasNotProcessed">ESafeModeGasNotProcessed</a>);
 
     // Return the storage rebate split from storage fund that's already refunded <b>to</b> the transaction senders.
     // This will be burnt at the last step of epoch change programmable transaction.
@@ -2373,7 +2363,7 @@ Aborts if <code>validator_addr</code> is not an active validator.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): u64 {
-    <a href="validator_set.md#0x3_validator_set_validator_total_stake_amount">validator_set::validator_total_stake_amount</a>(&self.validators, validator_addr)
+    self.validators.validator_total_stake_amount(validator_addr)
 }
 </code></pre>
 
@@ -2400,7 +2390,7 @@ Aborts if <code>validator_addr</code> is not an active validator.
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): ID {
 
-    <a href="validator_set.md#0x3_validator_set_validator_staking_pool_id">validator_set::validator_staking_pool_id</a>(&self.validators, validator_addr)
+    self.validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(validator_addr)
 }
 </code></pre>
 
@@ -2426,7 +2416,7 @@ Returns reference to the staking pool mappings that map pool ids to active valid
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): &Table&lt;ID, <b>address</b>&gt; {
 
-    <a href="validator_set.md#0x3_validator_set_staking_pool_mappings">validator_set::staking_pool_mappings</a>(&self.validators)
+    self.validators.staking_pool_mappings()
 }
 </code></pre>
 
@@ -2452,8 +2442,8 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, addr: <b>address</b>): VecSet&lt;<b>address</b>&gt; {
 
-    <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.validator_report_records, &addr)) {
-        *<a href="../sui-framework/vec_map.md#0x2_vec_map_get">vec_map::get</a>(&self.validator_report_records, &addr)
+    <b>if</b> (self.validator_report_records.contains(&addr)) {
+        self.validator_report_records[&addr]
     } <b>else</b> {
         <a href="../sui-framework/vec_set.md#0x2_vec_set_empty">vec_set::empty</a>()
     }
@@ -2480,7 +2470,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_total_balance">get_storage_fund_total_balance</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
-    <a href="storage_fund.md#0x3_storage_fund_total_balance">storage_fund::total_balance</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>)
+    self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.total_balance()
 }
 </code></pre>
 
@@ -2504,7 +2494,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
-    <a href="storage_fund.md#0x3_storage_fund_total_object_storage_rebates">storage_fund::total_object_storage_rebates</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>)
+    self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.total_object_storage_rebates()
 }
 </code></pre>
 
@@ -2532,7 +2522,7 @@ Returns all the validators who are currently reporting <code>addr</code>
     pool_id: &ID
 ): &Table&lt;u64, PoolTokenExchangeRate&gt;  {
     <b>let</b> validators = &<b>mut</b> self.validators;
-    <a href="validator_set.md#0x3_validator_set_pool_exchange_rates">validator_set::pool_exchange_rates</a>(validators, pool_id)
+    validators.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_pool_exchange_rates">pool_exchange_rates</a>(pool_id)
 }
 </code></pre>
 
@@ -2557,7 +2547,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">active_validator_addresses</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
     <b>let</b> <a href="validator_set.md#0x3_validator_set">validator_set</a> = &self.validators;
-    <a href="validator_set.md#0x3_validator_set_active_validator_addresses">validator_set::active_validator_addresses</a>(<a href="validator_set.md#0x3_validator_set">validator_set</a>)
+    <a href="validator_set.md#0x3_validator_set">validator_set</a>.<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_active_validator_addresses">active_validator_addresses</a>()
 }
 </code></pre>
 
@@ -2582,19 +2572,19 @@ Extract required Balance from vector of Coin<SUI>, transfer the remainder back t
 
 
 <pre><code><b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_extract_coin_balance">extract_coin_balance</a>(<b>mut</b> coins: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Coin&lt;SUI&gt;&gt;, amount: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, ctx: &<b>mut</b> TxContext): Balance&lt;SUI&gt; {
-    <b>let</b> <b>mut</b> merged_coin = <a href="../move-stdlib/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> coins);
-    <a href="../sui-framework/pay.md#0x2_pay_join_vec">pay::join_vec</a>(&<b>mut</b> merged_coin, coins);
+    <b>let</b> <b>mut</b> merged_coin = coins.pop_back();
+    merged_coin.join_vec(coins);
 
-    <b>let</b> <b>mut</b> total_balance = <a href="../sui-framework/coin.md#0x2_coin_into_balance">coin::into_balance</a>(merged_coin);
+    <b>let</b> <b>mut</b> total_balance = merged_coin.into_balance();
     // <b>return</b> the full amount <b>if</b> amount is not specified
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&amount)) {
-        <b>let</b> amount = <a href="../move-stdlib/option.md#0x1_option_destroy_some">option::destroy_some</a>(amount);
-        <b>let</b> <a href="../sui-framework/balance.md#0x2_balance">balance</a> = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> total_balance, amount);
+    <b>if</b> (amount.is_some()) {
+        <b>let</b> amount = amount.destroy_some();
+        <b>let</b> <a href="../sui-framework/balance.md#0x2_balance">balance</a> = total_balance.split(amount);
         // <a href="../sui-framework/transfer.md#0x2_transfer">transfer</a> back the remainder <b>if</b> non zero.
-        <b>if</b> (<a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&total_balance) &gt; 0) {
-            <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(<a href="../sui-framework/coin.md#0x2_coin_from_balance">coin::from_balance</a>(total_balance, ctx), <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx));
+        <b>if</b> (total_balance.value() &gt; 0) {
+            <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(total_balance.into_coin(ctx), ctx.sender());
         } <b>else</b> {
-            <a href="../sui-framework/balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(total_balance);
+            total_balance.destroy_zero();
         };
         <a href="../sui-framework/balance.md#0x2_balance">balance</a>
     } <b>else</b> {

--- a/crates/sui-framework/docs/sui-system/validator.md
+++ b/crates/sui-framework/docs/sui-system/validator.md
@@ -752,14 +752,14 @@ Max gas price a validator can set is 100K MIST.
     ctx: &<b>mut</b> TxContext
 ): <a href="validator.md#0x3_validator_Validator">Validator</a> {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&net_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&p2p_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&primary_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&worker_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&name) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&description) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&image_url) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
-            && <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&project_url) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        net_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && p2p_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && primary_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && worker_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && name.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && description.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && image_url.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>
+            && project_url.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
     <b>assert</b>!(<a href="validator.md#0x3_validator_commission_rate">commission_rate</a> &lt;= <a href="validator.md#0x3_validator_MAX_COMMISSION_RATE">MAX_COMMISSION_RATE</a>, <a href="validator.md#0x3_validator_ECommissionRateTooHigh">ECommissionRateTooHigh</a>);
@@ -771,14 +771,14 @@ Max gas price a validator can set is 100K MIST.
         network_pubkey_bytes,
         worker_pubkey_bytes,
         proof_of_possession,
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(name)),
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(description)),
+        name.to_ascii_string().to_string(),
+        description.to_ascii_string().to_string(),
         <a href="../sui-framework/url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(image_url),
         <a href="../sui-framework/url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(project_url),
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(net_address)),
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(p2p_address)),
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(primary_address)),
-        <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(worker_address)),
+        net_address.to_ascii_string().to_string(),
+        p2p_address.to_ascii_string().to_string(),
+        primary_address.to_ascii_string().to_string(),
+        worker_address.to_ascii_string().to_string(),
         <a href="../sui-framework/bag.md#0x2_bag_new">bag::new</a>(ctx),
     );
 
@@ -815,7 +815,7 @@ Deactivate this validator's staking pool
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_deactivate">deactivate</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, deactivation_epoch: u64) {
-    <a href="staking_pool.md#0x3_staking_pool_deactivate_staking_pool">staking_pool::deactivate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, deactivation_epoch)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.deactivate_staking_pool(deactivation_epoch)
 }
 </code></pre>
 
@@ -839,7 +839,7 @@ Deactivate this validator's staking pool
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_activate">activate</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, activation_epoch: u64) {
-    <a href="staking_pool.md#0x3_staking_pool_activate_staking_pool">staking_pool::activate_staking_pool</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, activation_epoch);
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.activate_staking_pool(activation_epoch);
 }
 </code></pre>
 
@@ -895,15 +895,13 @@ Request to add stake to the validator's staking pool, processed at the end of th
     staker_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) : StakedSui {
-    <b>let</b> stake_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&stake);
+    <b>let</b> stake_amount = stake.value();
     <b>assert</b>!(stake_amount &gt; 0, <a href="validator.md#0x3_validator_EInvalidStakeAmount">EInvalidStakeAmount</a>);
-    <b>let</b> stake_epoch = <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
-    <b>let</b> staked_sui = <a href="staking_pool.md#0x3_staking_pool_request_add_stake">staking_pool::request_add_stake</a>(
-        &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, stake, stake_epoch, ctx
-    );
+    <b>let</b> stake_epoch = ctx.epoch() + 1;
+    <b>let</b> staked_sui = self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_request_add_stake">request_add_stake</a>(stake, stake_epoch, ctx);
     // Process stake right away <b>if</b> staking pool is preactive.
-    <b>if</b> (<a href="staking_pool.md#0x3_staking_pool_is_preactive">staking_pool::is_preactive</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)) {
-        <a href="staking_pool.md#0x3_staking_pool_process_pending_stake">staking_pool::process_pending_stake</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>);
+    <b>if</b> (self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>()) {
+        self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.process_pending_stake();
     };
     self.next_epoch_stake = self.next_epoch_stake + stake_amount;
     <a href="../sui-framework/event.md#0x2_event_emit">event::emit</a>(
@@ -911,7 +909,7 @@ Request to add stake to the validator's staking pool, processed at the end of th
             pool_id: <a href="validator.md#0x3_validator_staking_pool_id">staking_pool_id</a>(self),
             validator_address: self.metadata.sui_address,
             staker_address,
-            epoch: <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            epoch: ctx.epoch(),
             amount: stake_amount,
         }
     );
@@ -945,12 +943,11 @@ Request to add stake to the validator's staking pool at genesis
     staker_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) == 0, <a href="validator.md#0x3_validator_ECalledDuringNonGenesis">ECalledDuringNonGenesis</a>);
-    <b>let</b> stake_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&stake);
+    <b>assert</b>!(ctx.epoch() == 0, <a href="validator.md#0x3_validator_ECalledDuringNonGenesis">ECalledDuringNonGenesis</a>);
+    <b>let</b> stake_amount = stake.value();
     <b>assert</b>!(stake_amount &gt; 0, <a href="validator.md#0x3_validator_EInvalidStakeAmount">EInvalidStakeAmount</a>);
 
-    <b>let</b> staked_sui = <a href="staking_pool.md#0x3_staking_pool_request_add_stake">staking_pool::request_add_stake</a>(
-        &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>,
+    <b>let</b> staked_sui = self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_request_add_stake">request_add_stake</a>(
         stake,
         0, // epoch 0 -- <a href="genesis.md#0x3_genesis">genesis</a>
         ctx
@@ -959,7 +956,7 @@ Request to add stake to the validator's staking pool at genesis
     <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(staked_sui, staker_address);
 
     // Process stake right away
-    <a href="staking_pool.md#0x3_staking_pool_process_pending_stake">staking_pool::process_pending_stake</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>);
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.process_pending_stake();
     self.next_epoch_stake = self.next_epoch_stake + stake_amount;
 }
 </code></pre>
@@ -989,20 +986,19 @@ Request to withdraw stake from the validator's staking pool, processed at the en
     staked_sui: StakedSui,
     ctx: &TxContext,
 ) : Balance&lt;SUI&gt; {
-    <b>let</b> principal_amount = <a href="staking_pool.md#0x3_staking_pool_staked_sui_amount">staking_pool::staked_sui_amount</a>(&staked_sui);
-    <b>let</b> stake_activation_epoch = <a href="staking_pool.md#0x3_staking_pool_stake_activation_epoch">staking_pool::stake_activation_epoch</a>(&staked_sui);
-    <b>let</b> withdrawn_stake = <a href="staking_pool.md#0x3_staking_pool_request_withdraw_stake">staking_pool::request_withdraw_stake</a>(
-            &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, staked_sui, ctx);
-    <b>let</b> withdraw_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&withdrawn_stake);
+    <b>let</b> principal_amount = staked_sui.staked_sui_amount();
+    <b>let</b> stake_activation_epoch = staked_sui.stake_activation_epoch();
+    <b>let</b> withdrawn_stake = self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_request_withdraw_stake">request_withdraw_stake</a>(staked_sui, ctx);
+    <b>let</b> withdraw_amount = withdrawn_stake.value();
     <b>let</b> reward_amount = withdraw_amount - principal_amount;
     self.next_epoch_stake = self.next_epoch_stake - withdraw_amount;
     <a href="../sui-framework/event.md#0x2_event_emit">event::emit</a>(
         <a href="validator.md#0x3_validator_UnstakingRequestEvent">UnstakingRequestEvent</a> {
             pool_id: <a href="validator.md#0x3_validator_staking_pool_id">staking_pool_id</a>(self),
             validator_address: self.metadata.sui_address,
-            staker_address: <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx),
+            staker_address: ctx.sender(),
             stake_activation_epoch,
-            unstaking_epoch: <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx),
+            unstaking_epoch: ctx.epoch(),
             principal_amount,
             reward_amount,
         }
@@ -1038,7 +1034,7 @@ Need to present a <code>ValidatorOperationCap</code>.
     new_price: u64,
 ) {
     <b>assert</b>!(new_price &lt; <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>, <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>);
-    <b>let</b> validator_address = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
+    <b>let</b> validator_address = *verified_cap.verified_operation_cap_address();
     <b>assert</b>!(validator_address == self.metadata.sui_address, <a href="validator.md#0x3_validator_EInvalidCap">EInvalidCap</a>);
     self.next_epoch_gas_price = new_price;
 }
@@ -1071,7 +1067,7 @@ Set new gas price for the candidate validator.
 ) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
     <b>assert</b>!(new_price &lt; <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>, <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>);
-    <b>let</b> validator_address = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
+    <b>let</b> validator_address = *verified_cap.verified_operation_cap_address();
     <b>assert</b>!(validator_address == self.metadata.sui_address, <a href="validator.md#0x3_validator_EInvalidCap">EInvalidCap</a>);
     self.next_epoch_gas_price = new_price;
     self.gas_price = new_price;
@@ -1152,8 +1148,8 @@ Deposit stakes rewards into the validator's staking pool, called at the end of t
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_deposit_stake_rewards">deposit_stake_rewards</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, reward: Balance&lt;SUI&gt;) {
-    self.next_epoch_stake = self.next_epoch_stake + <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&reward);
-    <a href="staking_pool.md#0x3_staking_pool_deposit_rewards">staking_pool::deposit_rewards</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, reward);
+    self.next_epoch_stake = self.next_epoch_stake + reward.value();
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.deposit_rewards(reward);
 }
 </code></pre>
 
@@ -1178,7 +1174,7 @@ Process pending stakes and withdraws, called at the end of the epoch.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_process_pending_stakes_and_withdraws">process_pending_stakes_and_withdraws</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, ctx: &TxContext) {
-    <a href="staking_pool.md#0x3_staking_pool_process_pending_stakes_and_withdraws">staking_pool::process_pending_stakes_and_withdraws</a>(&<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, ctx);
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_process_pending_stakes_and_withdraws">process_pending_stakes_and_withdraws</a>(ctx);
     <b>assert</b>!(<a href="validator.md#0x3_validator_stake_amount">stake_amount</a>(self) == self.next_epoch_stake, <a href="validator.md#0x3_validator_EInvalidStakeAmount">EInvalidStakeAmount</a>);
 }
 </code></pre>
@@ -1204,7 +1200,7 @@ Returns true if the validator is preactive.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>): bool {
-    <a href="staking_pool.md#0x3_staking_pool_is_preactive">staking_pool::is_preactive</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>()
 }
 </code></pre>
 
@@ -1804,7 +1800,7 @@ Returns true if the validator is preactive.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_total_stake_amount">total_stake_amount</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>): u64 {
-    <a href="staking_pool.md#0x3_staking_pool_sui_balance">staking_pool::sui_balance</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.sui_balance()
 }
 </code></pre>
 
@@ -1828,7 +1824,7 @@ Returns true if the validator is preactive.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_stake_amount">stake_amount</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>): u64 {
-    <a href="staking_pool.md#0x3_staking_pool_sui_balance">staking_pool::sui_balance</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.sui_balance()
 }
 </code></pre>
 
@@ -1927,7 +1923,7 @@ Set the voting power of this validator, called only from validator_set.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_pending_stake_amount">pending_stake_amount</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>): u64 {
-    <a href="staking_pool.md#0x3_staking_pool_pending_stake_amount">staking_pool::pending_stake_amount</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_pending_stake_amount">pending_stake_amount</a>()
 }
 </code></pre>
 
@@ -1951,7 +1947,7 @@ Set the voting power of this validator, called only from validator_set.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_pending_stake_withdraw_amount">pending_stake_withdraw_amount</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>): u64 {
-    <a href="staking_pool.md#0x3_staking_pool_pending_stake_withdraw_amount">staking_pool::pending_stake_withdraw_amount</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_pending_stake_withdraw_amount">pending_stake_withdraw_amount</a>()
 }
 </code></pre>
 
@@ -2023,7 +2019,7 @@ Set the voting power of this validator, called only from validator_set.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator.md#0x3_validator_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(self: &<a href="validator.md#0x3_validator_Validator">Validator</a>, epoch: u64): PoolTokenExchangeRate {
-    <a href="staking_pool.md#0x3_staking_pool_pool_token_exchange_rate_at_epoch">staking_pool::pool_token_exchange_rate_at_epoch</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, epoch)
+    self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>.<a href="validator.md#0x3_validator_pool_token_exchange_rate_at_epoch">pool_token_exchange_rate_at_epoch</a>(epoch)
 }
 </code></pre>
 
@@ -2127,10 +2123,10 @@ Set the voting power of this validator, called only from validator_set.
 
 
 <pre><code><b>fun</b> <a href="validator.md#0x3_validator_is_equal_some_and_value">is_equal_some_and_value</a>&lt;T&gt;(a: &Option&lt;T&gt;, b: &T): bool {
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_none">option::is_none</a>(a)) {
+    <b>if</b> (a.is_none()) {
         <b>false</b>
     } <b>else</b> {
-        <a href="../move-stdlib/option.md#0x1_option_borrow">option::borrow</a>(a) == b
+        a.borrow() == b
     }
 }
 </code></pre>
@@ -2155,10 +2151,10 @@ Set the voting power of this validator, called only from validator_set.
 
 
 <pre><code><b>fun</b> <a href="validator.md#0x3_validator_is_equal_some">is_equal_some</a>&lt;T&gt;(a: &Option&lt;T&gt;, b: &Option&lt;T&gt;): bool {
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_none">option::is_none</a>(a) || <a href="../move-stdlib/option.md#0x1_option_is_none">option::is_none</a>(b)) {
+    <b>if</b> (a.is_none() || b.is_none()) {
         <b>false</b>
     } <b>else</b> {
-        <a href="../move-stdlib/option.md#0x1_option_borrow">option::borrow</a>(a) == <a href="../move-stdlib/option.md#0x1_option_borrow">option::borrow</a>(b)
+        a.borrow() == b.borrow()
     }
 }
 </code></pre>
@@ -2185,7 +2181,7 @@ and registers it, thus revoking the previous cap's permission.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_new_unverified_validator_operation_cap_and_transfer">new_unverified_validator_operation_cap_and_transfer</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, ctx: &<b>mut</b> TxContext) {
-    <b>let</b> <b>address</b> = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> <b>address</b> = ctx.sender();
     <b>assert</b>!(<b>address</b> == self.metadata.sui_address, <a href="validator.md#0x3_validator_ENewCapNotCreatedByValidatorItself">ENewCapNotCreatedByValidatorItself</a>);
     <b>let</b> new_id = <a href="validator_cap.md#0x3_validator_cap_new_unverified_validator_operation_cap_and_transfer">validator_cap::new_unverified_validator_operation_cap_and_transfer</a>(<b>address</b>, ctx);
     self.operation_cap_id = new_id;
@@ -2214,10 +2210,10 @@ Update name of the validator.
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_name">update_name</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, name: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&name) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        name.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    self.metadata.name = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(name));
+    self.metadata.name = name.to_ascii_string().to_string();
 }
 </code></pre>
 
@@ -2243,10 +2239,10 @@ Update description of the validator.
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_description">update_description</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, description: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&description) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        description.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    self.metadata.description = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(description));
+    self.metadata.description = description.to_ascii_string().to_string();
 }
 </code></pre>
 
@@ -2272,7 +2268,7 @@ Update image url of the validator.
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_image_url">update_image_url</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, image_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&image_url) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        image_url.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
     self.metadata.image_url = <a href="../sui-framework/url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(image_url);
@@ -2301,7 +2297,7 @@ Update project url of the validator.
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_project_url">update_project_url</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, project_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&project_url) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        project_url.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
     self.metadata.project_url = <a href="../sui-framework/url.md#0x2_url_new_unsafe_from_bytes">url::new_unsafe_from_bytes</a>(project_url);
@@ -2330,10 +2326,10 @@ Update network address of this validator, taking effects from next epoch
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_next_epoch_network_address">update_next_epoch_network_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, net_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&net_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        net_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> net_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(net_address));
+    <b>let</b> net_address = net_address.to_ascii_string().to_string();
     self.metadata.next_epoch_net_address = <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(net_address);
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2362,10 +2358,10 @@ Update network address of this candidate validator
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_candidate_network_address">update_candidate_network_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, net_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&net_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        net_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> net_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(net_address));
+    <b>let</b> net_address = net_address.to_ascii_string().to_string();
     self.metadata.net_address = net_address;
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2393,10 +2389,10 @@ Update p2p address of this validator, taking effects from next epoch
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_next_epoch_p2p_address">update_next_epoch_p2p_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, p2p_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&p2p_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        p2p_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> p2p_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(p2p_address));
+    <b>let</b> p2p_address = p2p_address.to_ascii_string().to_string();
     self.metadata.next_epoch_p2p_address = <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(p2p_address);
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2425,10 +2421,10 @@ Update p2p address of this candidate validator
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_candidate_p2p_address">update_candidate_p2p_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, p2p_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&p2p_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        p2p_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> p2p_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(p2p_address));
+    <b>let</b> p2p_address = p2p_address.to_ascii_string().to_string();
     self.metadata.p2p_address = p2p_address;
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2456,10 +2452,10 @@ Update primary address of this validator, taking effects from next epoch
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_next_epoch_primary_address">update_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, primary_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&primary_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        primary_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> primary_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(primary_address));
+    <b>let</b> primary_address = primary_address.to_ascii_string().to_string();
     self.metadata.next_epoch_primary_address = <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(primary_address);
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2488,10 +2484,10 @@ Update primary address of this candidate validator
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_candidate_primary_address">update_candidate_primary_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, primary_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&primary_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        primary_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> primary_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(primary_address));
+    <b>let</b> primary_address = primary_address.to_ascii_string().to_string();
     self.metadata.primary_address = primary_address;
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2519,10 +2515,10 @@ Update worker address of this validator, taking effects from next epoch
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_next_epoch_worker_address">update_next_epoch_worker_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, worker_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&worker_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        worker_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> worker_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(worker_address));
+    <b>let</b> worker_address = worker_address.to_ascii_string().to_string();
     self.metadata.next_epoch_worker_address = <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(worker_address);
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2551,10 +2547,10 @@ Update worker address of this candidate validator
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_update_candidate_worker_address">update_candidate_worker_address</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>, worker_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
     <b>assert</b>!(
-        <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&worker_address) &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
+        worker_address.length() &lt;= <a href="validator.md#0x3_validator_MAX_VALIDATOR_METADATA_LENGTH">MAX_VALIDATOR_METADATA_LENGTH</a>,
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
-    <b>let</b> worker_address = <a href="../move-stdlib/string.md#0x1_string_from_ascii">string::from_ascii</a>(<a href="../move-stdlib/ascii.md#0x1_ascii_string">ascii::string</a>(worker_address));
+    <b>let</b> worker_address = worker_address.to_ascii_string().to_string();
     self.metadata.worker_address = worker_address;
     <a href="validator.md#0x3_validator_validate_metadata">validate_metadata</a>(&self.metadata);
 }
@@ -2744,40 +2740,40 @@ advancing an epoch.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator.md#0x3_validator_effectuate_staged_metadata">effectuate_staged_metadata</a>(self: &<b>mut</b> <a href="validator.md#0x3_validator_Validator">Validator</a>) {
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_network_address">next_epoch_network_address</a>(self))) {
-        self.metadata.net_address = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_net_address);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_network_address">next_epoch_network_address</a>(self).is_some()) {
+        self.metadata.net_address = self.metadata.next_epoch_net_address.extract();
         self.metadata.next_epoch_net_address = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_p2p_address">next_epoch_p2p_address</a>(self))) {
-        self.metadata.p2p_address = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_p2p_address);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_p2p_address">next_epoch_p2p_address</a>(self).is_some()) {
+        self.metadata.p2p_address = self.metadata.next_epoch_p2p_address.extract();
         self.metadata.next_epoch_p2p_address = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_primary_address">next_epoch_primary_address</a>(self))) {
-        self.metadata.primary_address = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_primary_address);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_primary_address">next_epoch_primary_address</a>(self).is_some()) {
+        self.metadata.primary_address = self.metadata.next_epoch_primary_address.extract();
         self.metadata.next_epoch_primary_address = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self))) {
-        self.metadata.worker_address = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_worker_address);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_worker_address">next_epoch_worker_address</a>(self).is_some()) {
+        self.metadata.worker_address = self.metadata.next_epoch_worker_address.extract();
         self.metadata.next_epoch_worker_address = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_protocol_pubkey_bytes">next_epoch_protocol_pubkey_bytes</a>(self))) {
-        self.metadata.protocol_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_protocol_pubkey_bytes);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_protocol_pubkey_bytes">next_epoch_protocol_pubkey_bytes</a>(self).is_some()) {
+        self.metadata.protocol_pubkey_bytes = self.metadata.next_epoch_protocol_pubkey_bytes.extract();
         self.metadata.next_epoch_protocol_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
-        self.metadata.proof_of_possession = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_proof_of_possession);
+        self.metadata.proof_of_possession = self.metadata.next_epoch_proof_of_possession.extract();
         self.metadata.next_epoch_proof_of_possession = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_network_pubkey_bytes">next_epoch_network_pubkey_bytes</a>(self))) {
-        self.metadata.network_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_network_pubkey_bytes);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_network_pubkey_bytes">next_epoch_network_pubkey_bytes</a>(self).is_some()) {
+        self.metadata.network_pubkey_bytes = self.metadata.next_epoch_network_pubkey_bytes.extract();
         self.metadata.next_epoch_network_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(<a href="validator.md#0x3_validator_next_epoch_worker_pubkey_bytes">next_epoch_worker_pubkey_bytes</a>(self))) {
-        self.metadata.worker_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> self.metadata.next_epoch_worker_pubkey_bytes);
+    <b>if</b> (<a href="validator.md#0x3_validator_next_epoch_worker_pubkey_bytes">next_epoch_worker_pubkey_bytes</a>(self).is_some()) {
+        self.metadata.worker_pubkey_bytes = self.metadata.next_epoch_worker_pubkey_bytes.extract();
         self.metadata.next_epoch_worker_pubkey_bytes = <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>();
     };
 }

--- a/crates/sui-framework/docs/sui-system/validator_cap.md
+++ b/crates/sui-framework/docs/sui-system/validator_cap.md
@@ -164,7 +164,7 @@ or rotating an existing validaotr's <code>operation_cap_id</code>.
     // This function needs <b>to</b> be called only by the <a href="validator.md#0x3_validator">validator</a> itself, <b>except</b>
     // 1. in <a href="genesis.md#0x3_genesis">genesis</a> <b>where</b> all valdiators are created by @0x0
     // 2. in tests <b>where</b> @0x0 could be used <b>to</b> simplify the setup
-    <b>let</b> sender_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> sender_address = ctx.sender();
     <b>assert</b>!(sender_address == @0x0 || sender_address == validator_address, 0);
 
     <b>let</b> operation_cap = <a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a> {

--- a/crates/sui-framework/docs/sui-system/validator_set.md
+++ b/crates/sui-framework/docs/sui-system/validator_set.md
@@ -640,18 +640,18 @@ The epoch value corresponds to the first epoch this change takes place.
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator_set.md#0x3_validator_set_new">new</a>(init_active_validators: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, ctx: &<b>mut</b> TxContext): <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a> {
     <b>let</b> total_stake = <a href="validator_set.md#0x3_validator_set_calculate_total_stakes">calculate_total_stakes</a>(&init_active_validators);
     <b>let</b> <b>mut</b> staking_pool_mappings = <a href="../sui-framework/table.md#0x2_table_new">table::new</a>(ctx);
-    <b>let</b> num_validators = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&init_active_validators);
+    <b>let</b> num_validators = init_active_validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; num_validators) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&init_active_validators, i);
-        <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(&<b>mut</b> staking_pool_mappings, staking_pool_id(<a href="validator.md#0x3_validator">validator</a>), sui_address(<a href="validator.md#0x3_validator">validator</a>));
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &init_active_validators[i];
+        staking_pool_mappings.add(staking_pool_id(<a href="validator.md#0x3_validator">validator</a>), sui_address(<a href="validator.md#0x3_validator">validator</a>));
         i = i + 1;
     };
     <b>let</b> <b>mut</b> validators = <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a> {
         total_stake,
         active_validators: init_active_validators,
         pending_active_validators: <a href="../sui-framework/table_vec.md#0x2_table_vec_empty">table_vec::empty</a>(ctx),
-        pending_removals: <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>(),
+        pending_removals: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[],
         staking_pool_mappings,
         inactive_validators: <a href="../sui-framework/table.md#0x2_table_new">table::new</a>(ctx),
         validator_candidates: <a href="../sui-framework/table.md#0x2_table_new">table::new</a>(ctx),
@@ -696,16 +696,15 @@ Called by <code><a href="sui_system.md#0x3_sui_system">sui_system</a></code> to 
     );
     <b>let</b> validator_address = sui_address(&<a href="validator.md#0x3_validator">validator</a>);
     <b>assert</b>!(
-        !<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address),
+        !self.validator_candidates.contains(validator_address),
         <a href="validator_set.md#0x3_validator_set_EAlreadyValidatorCandidate">EAlreadyValidatorCandidate</a>
     );
 
-    <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">validator::is_preactive</a>(&<a href="validator.md#0x3_validator">validator</a>), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
+    <b>assert</b>!(<a href="validator.md#0x3_validator">validator</a>.is_preactive(), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
     // Add <a href="validator.md#0x3_validator">validator</a> <b>to</b> the candidates mapping and the pool id mappings so that users can start
     // staking <b>with</b> this candidate.
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(&<b>mut</b> self.staking_pool_mappings, staking_pool_id(&<a href="validator.md#0x3_validator">validator</a>), validator_address);
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> self.validator_candidates,
+    self.staking_pool_mappings.add(staking_pool_id(&<a href="validator.md#0x3_validator">validator</a>), validator_address);
+    self.validator_candidates.add(
         sui_address(&<a href="validator.md#0x3_validator">validator</a>),
         <a href="validator_wrapper.md#0x3_validator_wrapper_create_v1">validator_wrapper::create_v1</a>(<a href="validator.md#0x3_validator">validator</a>, ctx),
     );
@@ -733,26 +732,25 @@ Called by <code><a href="sui_system.md#0x3_sui_system">sui_system</a></code> to 
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator_set.md#0x3_validator_set_request_remove_validator_candidate">request_remove_validator_candidate</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, ctx: &<b>mut</b> TxContext) {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
      <b>assert</b>!(
-        <a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address),
+        self.validator_candidates.contains(validator_address),
         <a href="validator_set.md#0x3_validator_set_ENotValidatorCandidate">ENotValidatorCandidate</a>
     );
-    <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.validator_candidates, validator_address);
-    <b>let</b> <b>mut</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_wrapper.md#0x3_validator_wrapper_destroy">validator_wrapper::destroy</a>(wrapper);
-    <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">validator::is_preactive</a>(&<a href="validator.md#0x3_validator">validator</a>), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
+    <b>let</b> wrapper = self.validator_candidates.remove(validator_address);
+    <b>let</b> <b>mut</b> <a href="validator.md#0x3_validator">validator</a> = wrapper.destroy();
+    <b>assert</b>!(<a href="validator.md#0x3_validator">validator</a>.is_preactive(), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
 
     <b>let</b> staking_pool_id = staking_pool_id(&<a href="validator.md#0x3_validator">validator</a>);
 
     // Remove the <a href="validator.md#0x3_validator">validator</a>'s staking pool from mappings.
-    <a href="../sui-framework/table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.staking_pool_mappings, staking_pool_id);
+    self.staking_pool_mappings.remove(staking_pool_id);
 
     // Deactivate the staking pool.
-    <a href="validator.md#0x3_validator_deactivate">validator::deactivate</a>(&<b>mut</b> <a href="validator.md#0x3_validator">validator</a>, <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx));
+    <a href="validator.md#0x3_validator">validator</a>.deactivate(ctx.epoch());
 
     // Add <b>to</b> the inactive tables.
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> self.inactive_validators,
+    self.inactive_validators.add(
         staking_pool_id,
         <a href="validator_wrapper.md#0x3_validator_wrapper_create_v1">validator_wrapper::create_v1</a>(<a href="validator.md#0x3_validator">validator</a>, ctx),
     );
@@ -781,22 +779,22 @@ processed at the end of epoch.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator_set.md#0x3_validator_set_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, min_joining_stake_amount: u64, ctx: &TxContext) {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
     <b>assert</b>!(
-        <a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address),
+        self.validator_candidates.contains(validator_address),
         <a href="validator_set.md#0x3_validator_set_ENotValidatorCandidate">ENotValidatorCandidate</a>
     );
-    <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.validator_candidates, validator_address);
-    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_wrapper.md#0x3_validator_wrapper_destroy">validator_wrapper::destroy</a>(wrapper);
+    <b>let</b> wrapper = self.validator_candidates.remove(validator_address);
+    <b>let</b> <a href="validator.md#0x3_validator">validator</a> = wrapper.destroy();
     <b>assert</b>!(
         !<a href="validator_set.md#0x3_validator_set_is_duplicate_with_active_validator">is_duplicate_with_active_validator</a>(self, &<a href="validator.md#0x3_validator">validator</a>)
             && !<a href="validator_set.md#0x3_validator_set_is_duplicate_with_pending_validator">is_duplicate_with_pending_validator</a>(self, &<a href="validator.md#0x3_validator">validator</a>),
         <a href="validator_set.md#0x3_validator_set_EDuplicateValidator">EDuplicateValidator</a>
     );
-    <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">validator::is_preactive</a>(&<a href="validator.md#0x3_validator">validator</a>), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
-    <b>assert</b>!(<a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(&<a href="validator.md#0x3_validator">validator</a>) &gt;= min_joining_stake_amount, <a href="validator_set.md#0x3_validator_set_EMinJoiningStakeNotReached">EMinJoiningStakeNotReached</a>);
+    <b>assert</b>!(<a href="validator.md#0x3_validator">validator</a>.is_preactive(), <a href="validator_set.md#0x3_validator_set_EValidatorNotCandidate">EValidatorNotCandidate</a>);
+    <b>assert</b>!(<a href="validator.md#0x3_validator">validator</a>.total_stake_amount() &gt;= min_joining_stake_amount, <a href="validator_set.md#0x3_validator_set_EMinJoiningStakeNotReached">EMinJoiningStakeNotReached</a>);
 
-    <a href="../sui-framework/table_vec.md#0x2_table_vec_push_back">table_vec::push_back</a>(&<b>mut</b> self.pending_active_validators, <a href="validator.md#0x3_validator">validator</a>);
+    self.pending_active_validators.push_back(<a href="validator.md#0x3_validator">validator</a>);
 }
 </code></pre>
 
@@ -856,15 +854,15 @@ Only an active validator can request to be removed.
     self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>,
     ctx: &TxContext,
 ) {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
-    <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
-    <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
+    <b>assert</b>!(validator_index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
+    <b>let</b> validator_index = validator_index_opt.extract();
     <b>assert</b>!(
-        !<a href="../move-stdlib/vector.md#0x1_vector_contains">vector::contains</a>(&self.pending_removals, &validator_index),
+        !self.pending_removals.contains(&validator_index),
         <a href="validator_set.md#0x3_validator_set_EValidatorAlreadyRemoved">EValidatorAlreadyRemoved</a>
     );
-    <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.pending_removals, validator_index);
+    self.pending_removals.push_back(validator_index);
 }
 </code></pre>
 
@@ -897,10 +895,10 @@ Aborts in case the staking amount is smaller than MIN_STAKING_THRESHOLD
     stake: Balance&lt;SUI&gt;,
     ctx: &<b>mut</b> TxContext,
 ) : StakedSui {
-    <b>let</b> sui_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&stake);
+    <b>let</b> sui_amount = stake.value();
     <b>assert</b>!(sui_amount &gt;= <a href="validator_set.md#0x3_validator_set_MIN_STAKING_THRESHOLD">MIN_STAKING_THRESHOLD</a>, <a href="validator_set.md#0x3_validator_set_EStakingBelowThreshold">EStakingBelowThreshold</a>);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_candidate_or_active_validator_mut">get_candidate_or_active_validator_mut</a>(self, validator_address);
-    <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, stake, <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx), ctx)
+    <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_request_add_stake">request_add_stake</a>(stake, ctx.sender(), ctx)
 }
 </code></pre>
 
@@ -936,15 +934,15 @@ the stake and any rewards corresponding to it will be immediately processed.
 ) : Balance&lt;SUI&gt; {
     <b>let</b> staking_pool_id = pool_id(&staked_sui);
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> =
-        <b>if</b> (<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.staking_pool_mappings, staking_pool_id)) { // This is an active <a href="validator.md#0x3_validator">validator</a>.
-            <b>let</b> validator_address = *<a href="../sui-framework/table.md#0x2_table_borrow">table::borrow</a>(&self.staking_pool_mappings, pool_id(&staked_sui));
+        <b>if</b> (self.staking_pool_mappings.contains(staking_pool_id)) { // This is an active <a href="validator.md#0x3_validator">validator</a>.
+            <b>let</b> validator_address = self.staking_pool_mappings[pool_id(&staked_sui)];
             <a href="validator_set.md#0x3_validator_set_get_candidate_or_active_validator_mut">get_candidate_or_active_validator_mut</a>(self, validator_address)
         } <b>else</b> { // This is an inactive pool.
-            <b>assert</b>!(<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.inactive_validators, staking_pool_id), <a href="validator_set.md#0x3_validator_set_ENoPoolFound">ENoPoolFound</a>);
-            <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inactive_validators, staking_pool_id);
-            <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+            <b>assert</b>!(self.inactive_validators.contains(staking_pool_id), <a href="validator_set.md#0x3_validator_set_ENoPoolFound">ENoPoolFound</a>);
+            <b>let</b> wrapper = &<b>mut</b> self.inactive_validators[staking_pool_id];
+            wrapper.load_validator_maybe_upgrade()
         };
-    <a href="validator.md#0x3_validator_request_withdraw_stake">validator::request_withdraw_stake</a>(<a href="validator.md#0x3_validator">validator</a>, staked_sui, ctx)
+    <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_request_withdraw_stake">request_withdraw_stake</a>(staked_sui, ctx)
 }
 </code></pre>
 
@@ -972,9 +970,9 @@ the stake and any rewards corresponding to it will be immediately processed.
     new_commission_rate: u64,
     ctx: &TxContext,
 ) {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address);
-    <a href="validator.md#0x3_validator_request_set_commission_rate">validator::request_set_commission_rate</a>(<a href="validator.md#0x3_validator">validator</a>, new_commission_rate);
+    <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_request_set_commission_rate">request_set_commission_rate</a>(new_commission_rate);
 }
 </code></pre>
 
@@ -1015,15 +1013,15 @@ It does the following things:
     low_stake_grace_period: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> new_epoch = <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
+    <b>let</b> new_epoch = ctx.epoch() + 1;
     <b>let</b> total_voting_power = <a href="voting_power.md#0x3_voting_power_total_voting_power">voting_power::total_voting_power</a>();
 
     // Compute the reward distribution without taking into account the tallying rule slashing.
     <b>let</b> (unadjusted_staking_reward_amounts, unadjusted_storage_fund_reward_amounts) = <a href="validator_set.md#0x3_validator_set_compute_unadjusted_reward_distribution">compute_unadjusted_reward_distribution</a>(
         &self.active_validators,
         total_voting_power,
-        <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(computation_reward),
-        <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(storage_fund_reward),
+        computation_reward.value(),
+        storage_fund_reward.value(),
     );
 
     // Use the tallying rule report records for the epoch <b>to</b> compute validators that will be
@@ -1132,37 +1130,37 @@ It does the following things:
     ctx: &<b>mut</b> TxContext
 ) {
     // Iterate through all the active validators, record their low stake status, and kick them out <b>if</b> the condition is met.
-    <b>let</b> <b>mut</b> i = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&self.active_validators);
+    <b>let</b> <b>mut</b> i = self.active_validators.length();
     <b>while</b> (i &gt; 0) {
         i = i - 1;
-        <b>let</b> validator_ref = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.active_validators, i);
-        <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(validator_ref);
-        <b>let</b> stake = <a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(validator_ref);
+        <b>let</b> validator_ref = &self.active_validators[i];
+        <b>let</b> validator_address = validator_ref.sui_address();
+        <b>let</b> stake = validator_ref.total_stake_amount();
         <b>if</b> (stake &gt;= low_stake_threshold) {
             // The <a href="validator.md#0x3_validator">validator</a> is safe. We remove their entry from the at_risk map <b>if</b> there exists one.
-            <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.at_risk_validators, &validator_address)) {
-                <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(&<b>mut</b> self.at_risk_validators, &validator_address);
+            <b>if</b> (self.at_risk_validators.contains(&validator_address)) {
+               self.at_risk_validators.remove(&validator_address);
             }
         } <b>else</b> <b>if</b> (stake &gt;= very_low_stake_threshold) {
             // The stake is a bit below the threshold so we increment the entry of the <a href="validator.md#0x3_validator">validator</a> in the map.
             <b>let</b> new_low_stake_period =
-                <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.at_risk_validators, &validator_address)) {
-                    <b>let</b> num_epochs = <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(&<b>mut</b> self.at_risk_validators, &validator_address);
+                <b>if</b> (self.at_risk_validators.contains(&validator_address)) {
+                    <b>let</b> num_epochs = &<b>mut</b> self.at_risk_validators[&validator_address];
                     *num_epochs = *num_epochs + 1;
                     *num_epochs
                 } <b>else</b> {
-                    <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> self.at_risk_validators, validator_address, 1);
+                    self.at_risk_validators.insert(validator_address, 1);
                     1
                 };
 
             // If the grace period <b>has</b> passed, the <a href="validator.md#0x3_validator">validator</a> <b>has</b> <b>to</b> leave us.
             <b>if</b> (new_low_stake_period &gt; low_stake_grace_period) {
-                <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> self.active_validators, i);
+                <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.active_validators.remove(i);
                 <a href="validator_set.md#0x3_validator_set_process_validator_departure">process_validator_departure</a>(self, <a href="validator.md#0x3_validator">validator</a>, validator_report_records, <b>false</b> /* the <a href="validator.md#0x3_validator">validator</a> is kicked out involuntarily */, ctx);
             }
         } <b>else</b> {
             // The <a href="validator.md#0x3_validator">validator</a>'s stake is lower than the very low threshold so we kick them out immediately.
-            <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> self.active_validators, i);
+            <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.active_validators.remove(i);
             <a href="validator_set.md#0x3_validator_set_process_validator_departure">process_validator_departure</a>(self, <a href="validator.md#0x3_validator">validator</a>, validator_report_records, <b>false</b> /* the <a href="validator.md#0x3_validator">validator</a> is kicked out involuntarily */, ctx);
         }
     }
@@ -1192,11 +1190,11 @@ Effectutate pending next epoch metadata if they are staged.
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_effectuate_staged_metadata">effectuate_staged_metadata</a>(
     self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>,
 ) {
-    <b>let</b> num_validators = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&self.active_validators);
+    <b>let</b> num_validators = self.active_validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; num_validators) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, i);
-        <a href="validator.md#0x3_validator_effectuate_staged_metadata">validator::effectuate_staged_metadata</a>(<a href="validator.md#0x3_validator">validator</a>);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &<b>mut</b> self.active_validators[i];
+        <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_effectuate_staged_metadata">effectuate_staged_metadata</a>();
         i = i + 1;
     }
 }
@@ -1227,14 +1225,13 @@ gas price, weighted by stake.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_derive_reference_gas_price">derive_reference_gas_price</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
     <b>let</b> vs = &self.active_validators;
-    <b>let</b> num_validators = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(vs);
-    <b>let</b> <b>mut</b> entries = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
+    <b>let</b> num_validators = vs.length();
+    <b>let</b> <b>mut</b> entries = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; num_validators) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(vs, i);
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(
-            &<b>mut</b> entries,
-            pq::new_entry(<a href="validator.md#0x3_validator_gas_price">validator::gas_price</a>(v), <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(v))
+        <b>let</b> v = &vs[i];
+        entries.push_back(
+            pq::new_entry(v.gas_price(), v.<a href="voting_power.md#0x3_voting_power">voting_power</a>())
         );
         i = i + 1;
     };
@@ -1244,7 +1241,7 @@ gas price, weighted by stake.
     <b>let</b> threshold = <a href="voting_power.md#0x3_voting_power_total_voting_power">voting_power::total_voting_power</a>() - <a href="voting_power.md#0x3_voting_power_quorum_threshold">voting_power::quorum_threshold</a>();
     <b>let</b> <b>mut</b> result = 0;
     <b>while</b> (sum &lt; threshold) {
-        <b>let</b> (gas_price, <a href="voting_power.md#0x3_voting_power">voting_power</a>) = pq::pop_max(&<b>mut</b> pq);
+        <b>let</b> (gas_price, <a href="voting_power.md#0x3_voting_power">voting_power</a>) = pq.pop_max();
         result = gas_price;
         sum = sum + <a href="voting_power.md#0x3_voting_power">voting_power</a>;
     };
@@ -1297,7 +1294,7 @@ gas price, weighted by stake.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_validator_total_stake_amount">validator_total_stake_amount</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): u64 {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
-    <a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(<a href="validator.md#0x3_validator">validator</a>)
+    <a href="validator.md#0x3_validator">validator</a>.total_stake_amount()
 }
 </code></pre>
 
@@ -1322,7 +1319,7 @@ gas price, weighted by stake.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_validator_stake_amount">validator_stake_amount</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): u64 {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
-    <a href="validator.md#0x3_validator_stake_amount">validator::stake_amount</a>(<a href="validator.md#0x3_validator">validator</a>)
+    <a href="validator.md#0x3_validator">validator</a>.stake_amount()
 }
 </code></pre>
 
@@ -1347,7 +1344,7 @@ gas price, weighted by stake.
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): ID {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_ref">get_validator_ref</a>(&self.active_validators, validator_address);
-    <a href="validator.md#0x3_validator_staking_pool_id">validator::staking_pool_id</a>(<a href="validator.md#0x3_validator">validator</a>)
+    <a href="validator.md#0x3_validator">validator</a>.staking_pool_id()
 }
 </code></pre>
 
@@ -1399,14 +1396,14 @@ gas price, weighted by stake.
 ) : &Table&lt;u64, PoolTokenExchangeRate&gt; {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> =
         // If the pool id is recorded in the mapping, then it must be either candidate or active.
-        <b>if</b> (<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.staking_pool_mappings, *pool_id)) {
-            <b>let</b> validator_address = *<a href="../sui-framework/table.md#0x2_table_borrow">table::borrow</a>(&self.staking_pool_mappings, *pool_id);
+        <b>if</b> (self.staking_pool_mappings.contains(*pool_id)) {
+            <b>let</b> validator_address = self.staking_pool_mappings[*pool_id];
             <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_ref">get_active_or_pending_or_candidate_validator_ref</a>(self, validator_address, <a href="validator_set.md#0x3_validator_set_ANY_VALIDATOR">ANY_VALIDATOR</a>)
         } <b>else</b> { // otherwise it's inactive
-            <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.inactive_validators, *pool_id);
-            <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+            <b>let</b> wrapper = &<b>mut</b> self.inactive_validators[*pool_id];
+            wrapper.load_validator_maybe_upgrade()
         };
-    <a href="staking_pool.md#0x3_staking_pool_exchange_rates">staking_pool::exchange_rates</a>(<a href="validator.md#0x3_validator_get_staking_pool_ref">validator::get_staking_pool_ref</a>(<a href="validator.md#0x3_validator">validator</a>))
+	<a href="validator.md#0x3_validator">validator</a>.get_staking_pool_ref().exchange_rates()
 }
 </code></pre>
 
@@ -1431,7 +1428,7 @@ Get the total number of validators in the next epoch.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="validator_set.md#0x3_validator_set_next_epoch_validator_count">next_epoch_validator_count</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>): u64 {
-    <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&self.active_validators) - <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&self.pending_removals) + <a href="../sui-framework/table_vec.md#0x2_table_vec_length">table_vec::length</a>(&self.pending_active_validators)
+    self.active_validators.length() - self.pending_removals.length() + self.pending_active_validators.length()
 }
 </code></pre>
 
@@ -1459,7 +1456,7 @@ Returns true iff the address exists in active validators.
     self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>,
     validator_address: <b>address</b>,
 ): bool {
-    <a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&<a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address))
+   <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address).is_some()
 }
 </code></pre>
 
@@ -1534,12 +1531,12 @@ only the sui address but this function looks at more metadata.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_count_duplicates_vec">count_duplicates_vec</a>(validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, <a href="validator.md#0x3_validator">validator</a>: &Validator): u64 {
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> len = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>let</b> <b>mut</b> result = 0;
     <b>while</b> (i &lt; len) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
-        <b>if</b> (<a href="validator.md#0x3_validator_is_duplicate">validator::is_duplicate</a>(v, <a href="validator.md#0x3_validator">validator</a>)) {
+        <b>let</b> v = &validators[i];
+        <b>if</b> (v.is_duplicate(<a href="validator.md#0x3_validator">validator</a>)) {
             result = result + 1;
         };
         i = i + 1;
@@ -1593,12 +1590,12 @@ Checks whether <code>new_validator</code> is duplicate with any currently pendin
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_count_duplicates_tablevec">count_duplicates_tablevec</a>(validators: &TableVec&lt;Validator&gt;, <a href="validator.md#0x3_validator">validator</a>: &Validator): u64 {
-    <b>let</b> len = <a href="../sui-framework/table_vec.md#0x2_table_vec_length">table_vec::length</a>(validators);
+    <b>let</b> len = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>let</b> <b>mut</b> result = 0;
     <b>while</b> (i &lt; len) {
-        <b>let</b> v = <a href="../sui-framework/table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(validators, i);
-        <b>if</b> (<a href="validator.md#0x3_validator_is_duplicate">validator::is_duplicate</a>(v, <a href="validator.md#0x3_validator">validator</a>)) {
+        <b>let</b> v = &validators[i];
+        <b>if</b> (v.is_duplicate(<a href="validator.md#0x3_validator">validator</a>)) {
             result = result + 1;
         };
         i = i + 1;
@@ -1628,9 +1625,9 @@ Get mutable reference to either a candidate or an active validator by address.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_get_candidate_or_active_validator_mut">get_candidate_or_active_validator_mut</a>(self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, validator_address: <b>address</b>): &<b>mut</b> Validator {
-    <b>if</b> (<a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, validator_address)) {
-        <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.validator_candidates, validator_address);
-        <b>return</b> <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+    <b>if</b> (self.validator_candidates.contains(validator_address)) {
+        <b>let</b> wrapper = &<b>mut</b> self.validator_candidates[validator_address];
+        <b>return</b> wrapper.load_validator_maybe_upgrade()
     };
     <a href="validator_set.md#0x3_validator_set_get_validator_mut">get_validator_mut</a>(&<b>mut</b> self.active_validators, validator_address)
 }
@@ -1659,11 +1656,11 @@ If not found, returns (false, 0).
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, validator_address: <b>address</b>): Option&lt;u64&gt; {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
-        <b>if</b> (<a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(v) == validator_address) {
+        <b>let</b> v = &validators[i];
+        <b>if</b> (v.sui_address() == validator_address) {
             <b>return</b> <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(i)
         };
         i = i + 1;
@@ -1695,11 +1692,11 @@ If not found, returns (false, 0).
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(validators: &TableVec&lt;Validator&gt;, validator_address: <b>address</b>): Option&lt;u64&gt; {
-    <b>let</b> length = <a href="../sui-framework/table_vec.md#0x2_table_vec_length">table_vec::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> v = <a href="../sui-framework/table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(validators, i);
-        <b>if</b> (<a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(v) == validator_address) {
+        <b>let</b> v = &validators[i];
+        <b>if</b> (v.sui_address() == validator_address) {
             <b>return</b> <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(i)
         };
         i = i + 1;
@@ -1730,14 +1727,14 @@ Aborts if any address isn't in the given validator set.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_get_validator_indices">get_validator_indices</a>(validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, validator_addresses: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt; {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validator_addresses);
+    <b>let</b> length = validator_addresses.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>let</b> <b>mut</b> res = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
     <b>while</b> (i &lt; length) {
-        <b>let</b> addr = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validator_addresses, i);
+        <b>let</b> addr = validator_addresses[i];
         <b>let</b> index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(validators, addr);
-        <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&index_opt), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> res, <a href="../move-stdlib/option.md#0x1_option_destroy_some">option::destroy_some</a>(index_opt));
+        <b>assert</b>!(index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
+        res.push_back(index_opt.destroy_some());
         i = i + 1;
     };
     res
@@ -1768,9 +1765,9 @@ Aborts if any address isn't in the given validator set.
     validator_address: <b>address</b>,
 ): &<b>mut</b> Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(validators, validator_address);
-    <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
-    <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, validator_index)
+    <b>assert</b>!(validator_index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
+    <b>let</b> validator_index = validator_index_opt.extract();
+    &<b>mut</b> validators[validator_index]
 }
 </code></pre>
 
@@ -1803,19 +1800,19 @@ sender has the ability to modify the <code>Validator</code>.
     include_candidate: bool,
 ): &<b>mut</b> Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt)) {
-        <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-        <b>return</b> <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.active_validators, validator_index)
+    <b>if</b> (validator_index_opt.is_some()) {
+        <b>let</b> validator_index = validator_index_opt.extract();
+        <b>return</b> &<b>mut</b> self.active_validators[validator_index]
     };
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_active_validators, validator_address);
     // consider both pending validators and the candidate ones
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt)) {
-        <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-        <b>return</b> <a href="../sui-framework/table_vec.md#0x2_table_vec_borrow_mut">table_vec::borrow_mut</a>(&<b>mut</b> self.pending_active_validators, validator_index)
+    <b>if</b> (validator_index_opt.is_some()) {
+        <b>let</b> validator_index = validator_index_opt.extract();
+        <b>return</b> &<b>mut</b> self.pending_active_validators[validator_index]
     };
     <b>assert</b>!(include_candidate, <a href="validator_set.md#0x3_validator_set_ENotActiveOrPendingValidator">ENotActiveOrPendingValidator</a>);
-    <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.validator_candidates, validator_address);
-    <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+    <b>let</b> wrapper = &<b>mut</b> self.validator_candidates[validator_address];
+    wrapper.load_validator_maybe_upgrade()
 }
 </code></pre>
 
@@ -1843,7 +1840,7 @@ sender has the ability to modify the <code>Validator</code>.
     verified_cap: &ValidatorOperationCap,
     include_candidate: bool,
 ): &<b>mut</b> Validator {
-    <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_mut">get_active_or_pending_or_candidate_validator_mut</a>(self, *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(verified_cap), include_candidate)
+    <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_mut">get_active_or_pending_or_candidate_validator_mut</a>(self, *verified_cap.verified_operation_cap_address(), include_candidate)
 }
 </code></pre>
 
@@ -1870,7 +1867,7 @@ sender has the ability to modify the <code>Validator</code>.
     self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>,
     ctx: &TxContext,
 ): &<b>mut</b> Validator {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
     <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_mut">get_active_or_pending_or_candidate_validator_mut</a>(self, validator_address, <b>false</b>)
 }
 </code></pre>
@@ -1898,7 +1895,7 @@ sender has the ability to modify the <code>Validator</code>.
     self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>,
     ctx: &TxContext,
 ): &<b>mut</b> Validator {
-    <b>let</b> validator_address = <a href="../sui-framework/tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx);
+    <b>let</b> validator_address = ctx.sender();
     <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_mut">get_active_or_pending_or_candidate_validator_mut</a>(self, validator_address, <b>true</b>)
 }
 </code></pre>
@@ -1927,9 +1924,9 @@ sender has the ability to modify the <code>Validator</code>.
     validator_address: <b>address</b>,
 ): &Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(validators, validator_address);
-    <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
-    <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, validator_index)
+    <b>assert</b>!(validator_index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
+    <b>let</b> validator_index = validator_index_opt.extract();
+    &validators[validator_index]
 }
 </code></pre>
 
@@ -1958,17 +1955,16 @@ sender has the ability to modify the <code>Validator</code>.
     which_validator: u8,
 ): &Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt) || which_validator == <a href="validator_set.md#0x3_validator_set_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>) {
-        <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-        <b>return</b> <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.active_validators, validator_index)
+    <b>if</b> (validator_index_opt.is_some() || which_validator == <a href="validator_set.md#0x3_validator_set_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>) {
+        <b>let</b> validator_index = validator_index_opt.extract();
+        <b>return</b> &self.active_validators[validator_index]
     };
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_active_validators, validator_address);
-    <b>if</b> (<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt) || which_validator == <a href="validator_set.md#0x3_validator_set_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>) {
-        <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-        <b>return</b> <a href="../sui-framework/table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_active_validators, validator_index)
+    <b>if</b> (validator_index_opt.is_some() || which_validator == <a href="validator_set.md#0x3_validator_set_ACTIVE_OR_PENDING_VALIDATOR">ACTIVE_OR_PENDING_VALIDATOR</a>) {
+        <b>let</b> validator_index = validator_index_opt.extract();
+        <b>return</b> &self.pending_active_validators[validator_index]
     };
-    <b>let</b> wrapper = <a href="../sui-framework/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> self.validator_candidates, validator_address);
-    <a href="validator_wrapper.md#0x3_validator_wrapper_load_validator_maybe_upgrade">validator_wrapper::load_validator_maybe_upgrade</a>(wrapper)
+    self.validator_candidates[validator_address].load_validator_maybe_upgrade()
 }
 </code></pre>
 
@@ -1996,9 +1992,9 @@ sender has the ability to modify the <code>Validator</code>.
     validator_address: <b>address</b>,
 ): &Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator">find_validator</a>(&self.active_validators, validator_address);
-    <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
-    <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&self.active_validators, validator_index)
+    <b>assert</b>!(validator_index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAValidator">ENotAValidator</a>);
+    <b>let</b> validator_index = validator_index_opt.extract();
+    &self.active_validators[validator_index]
 }
 </code></pre>
 
@@ -2026,9 +2022,9 @@ sender has the ability to modify the <code>Validator</code>.
     validator_address: <b>address</b>,
 ): &Validator {
     <b>let</b> <b>mut</b> validator_index_opt = <a href="validator_set.md#0x3_validator_set_find_validator_from_table_vec">find_validator_from_table_vec</a>(&self.pending_active_validators, validator_address);
-    <b>assert</b>!(<a href="../move-stdlib/option.md#0x1_option_is_some">option::is_some</a>(&validator_index_opt), <a href="validator_set.md#0x3_validator_set_ENotAPendingValidator">ENotAPendingValidator</a>);
-    <b>let</b> validator_index = <a href="../move-stdlib/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> validator_index_opt);
-    <a href="../sui-framework/table_vec.md#0x2_table_vec_borrow">table_vec::borrow</a>(&self.pending_active_validators, validator_index)
+    <b>assert</b>!(validator_index_opt.is_some(), <a href="validator_set.md#0x3_validator_set_ENotAPendingValidator">ENotAPendingValidator</a>);
+    <b>let</b> validator_index = validator_index_opt.extract();
+    &self.pending_active_validators[validator_index]
 }
 </code></pre>
 
@@ -2059,13 +2055,13 @@ Otherwise, verify the Cap for au either active or pending validator.
     cap: &UnverifiedValidatorOperationCap,
     which_validator: u8,
 ): ValidatorOperationCap {
-    <b>let</b> cap_address = *<a href="validator_cap.md#0x3_validator_cap_unverified_operation_cap_address">validator_cap::unverified_operation_cap_address</a>(cap);
+    <b>let</b> cap_address = *cap.unverified_operation_cap_address();
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> =
         <b>if</b> (which_validator == <a href="validator_set.md#0x3_validator_set_ACTIVE_VALIDATOR_ONLY">ACTIVE_VALIDATOR_ONLY</a>)
             <a href="validator_set.md#0x3_validator_set_get_active_validator_ref">get_active_validator_ref</a>(self, cap_address)
         <b>else</b>
             <a href="validator_set.md#0x3_validator_set_get_active_or_pending_or_candidate_validator_ref">get_active_or_pending_or_candidate_validator_ref</a>(self, cap_address, which_validator);
-    <b>assert</b>!(<a href="validator.md#0x3_validator_operation_cap_id">validator::operation_cap_id</a>(<a href="validator.md#0x3_validator">validator</a>) == &<a href="../sui-framework/object.md#0x2_object_id">object::id</a>(cap), <a href="validator_set.md#0x3_validator_set_EInvalidCap">EInvalidCap</a>);
+    <b>assert</b>!(<a href="validator.md#0x3_validator">validator</a>.operation_cap_id() == &<a href="../sui-framework/object.md#0x2_object_id">object::id</a>(cap), <a href="validator_set.md#0x3_validator_set_EInvalidCap">EInvalidCap</a>);
     <a href="validator_cap.md#0x3_validator_cap_new_from_unverified">validator_cap::new_from_unverified</a>(cap)
 }
 </code></pre>
@@ -2097,9 +2093,9 @@ is removed from <code>validators</code> and its staking pool is put into the <co
     ctx: &<b>mut</b> TxContext,
 ) {
     <a href="validator_set.md#0x3_validator_set_sort_removal_list">sort_removal_list</a>(&<b>mut</b> self.pending_removals);
-    <b>while</b> (!<a href="../move-stdlib/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&self.pending_removals)) {
-        <b>let</b> index = <a href="../move-stdlib/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> self.pending_removals);
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> self.active_validators, index);
+    <b>while</b> (!self.pending_removals.is_empty()) {
+        <b>let</b> index = self.pending_removals.pop_back();
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = self.active_validators.remove(index);
         <a href="validator_set.md#0x3_validator_set_process_validator_departure">process_validator_departure</a>(self, <a href="validator.md#0x3_validator">validator</a>, validator_report_records, <b>true</b> /* the <a href="validator.md#0x3_validator">validator</a> removes itself voluntarily */, ctx);
     }
 }
@@ -2131,17 +2127,17 @@ is removed from <code>validators</code> and its staking pool is put into the <co
     is_voluntary: bool,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> new_epoch = <a href="../sui-framework/tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) + 1;
-    <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(&<a href="validator.md#0x3_validator">validator</a>);
+    <b>let</b> new_epoch = ctx.epoch() + 1;
+    <b>let</b> validator_address = <a href="validator.md#0x3_validator">validator</a>.sui_address();
     <b>let</b> validator_pool_id = staking_pool_id(&<a href="validator.md#0x3_validator">validator</a>);
 
     // Remove the <a href="validator.md#0x3_validator">validator</a> from our tables.
-    <a href="../sui-framework/table.md#0x2_table_remove">table::remove</a>(&<b>mut</b> self.staking_pool_mappings, validator_pool_id);
-    <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&self.at_risk_validators, &validator_address)) {
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(&<b>mut</b> self.at_risk_validators, &validator_address);
+    self.staking_pool_mappings.remove(validator_pool_id);
+    <b>if</b> (self.at_risk_validators.contains(&validator_address)) {
+        self.at_risk_validators.remove(&validator_address);
     };
 
-    self.total_stake = self.total_stake - <a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(&<a href="validator.md#0x3_validator">validator</a>);
+    self.total_stake = self.total_stake - <a href="validator.md#0x3_validator">validator</a>.total_stake_amount();
 
     <a href="validator_set.md#0x3_validator_set_clean_report_records_leaving_validator">clean_report_records_leaving_validator</a>(validator_report_records, validator_address);
 
@@ -2155,9 +2151,8 @@ is removed from <code>validators</code> and its staking pool is put into the <co
     );
 
     // Deactivate the <a href="validator.md#0x3_validator">validator</a> and its staking pool
-    <a href="validator.md#0x3_validator_deactivate">validator::deactivate</a>(&<b>mut</b> <a href="validator.md#0x3_validator">validator</a>, new_epoch);
-    <a href="../sui-framework/table.md#0x2_table_add">table::add</a>(
-        &<b>mut</b> self.inactive_validators,
+    <a href="validator.md#0x3_validator">validator</a>.deactivate(new_epoch);
+    self.inactive_validators.add(
         validator_pool_id,
         <a href="validator_wrapper.md#0x3_validator_wrapper_create_v1">validator_wrapper::create_v1</a>(<a href="validator.md#0x3_validator">validator</a>, ctx),
     );
@@ -2188,21 +2183,21 @@ is removed from <code>validators</code> and its staking pool is put into the <co
     leaving_validator_addr: <b>address</b>
 ) {
     // Remove the records about this <a href="validator.md#0x3_validator">validator</a>
-    <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(validator_report_records, &leaving_validator_addr)) {
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(validator_report_records, &leaving_validator_addr);
+    <b>if</b> (validator_report_records.contains(&leaving_validator_addr)) {
+        validator_report_records.remove(&leaving_validator_addr);
     };
 
     // Remove the reports submitted by this <a href="validator.md#0x3_validator">validator</a>
-    <b>let</b> reported_validators = <a href="../sui-framework/vec_map.md#0x2_vec_map_keys">vec_map::keys</a>(validator_report_records);
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&reported_validators);
+    <b>let</b> reported_validators = validator_report_records.keys();
+    <b>let</b> length = reported_validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> reported_validator_addr = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&reported_validators, i);
-        <b>let</b> reporters = <a href="../sui-framework/vec_map.md#0x2_vec_map_get_mut">vec_map::get_mut</a>(validator_report_records, reported_validator_addr);
-        <b>if</b> (<a href="../sui-framework/vec_set.md#0x2_vec_set_contains">vec_set::contains</a>(reporters, &leaving_validator_addr)) {
-            <a href="../sui-framework/vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(reporters, &leaving_validator_addr);
-            <b>if</b> (<a href="../sui-framework/vec_set.md#0x2_vec_set_is_empty">vec_set::is_empty</a>(reporters)) {
-                <a href="../sui-framework/vec_map.md#0x2_vec_map_remove">vec_map::remove</a>(validator_report_records, reported_validator_addr);
+        <b>let</b> reported_validator_addr = &reported_validators[i];
+        <b>let</b> reporters = &<b>mut</b> validator_report_records[reported_validator_addr];
+        <b>if</b> (reporters.contains(&leaving_validator_addr)) {
+            reporters.remove(&leaving_validator_addr);
+            <b>if</b> (reporters.is_empty()) {
+                validator_report_records.remove(reported_validator_addr);
             };
         };
         i = i + 1;
@@ -2233,17 +2228,17 @@ Process the pending new validators. They are activated and inserted into <code>v
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_process_pending_validators">process_pending_validators</a>(
     self: &<b>mut</b> <a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, new_epoch: u64,
 ) {
-    <b>while</b> (!<a href="../sui-framework/table_vec.md#0x2_table_vec_is_empty">table_vec::is_empty</a>(&self.pending_active_validators)) {
-        <b>let</b> <b>mut</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../sui-framework/table_vec.md#0x2_table_vec_pop_back">table_vec::pop_back</a>(&<b>mut</b> self.pending_active_validators);
-        <a href="validator.md#0x3_validator_activate">validator::activate</a>(&<b>mut</b> <a href="validator.md#0x3_validator">validator</a>, new_epoch);
+    <b>while</b> (!self.pending_active_validators.is_empty()) {
+        <b>let</b> <b>mut</b> <a href="validator.md#0x3_validator">validator</a> = self.pending_active_validators.pop_back();
+        <a href="validator.md#0x3_validator">validator</a>.activate(new_epoch);
         <a href="../sui-framework/event.md#0x2_event_emit">event::emit</a>(
             <a href="validator_set.md#0x3_validator_set_ValidatorJoinEvent">ValidatorJoinEvent</a> {
                 epoch: new_epoch,
-                validator_address: <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(&<a href="validator.md#0x3_validator">validator</a>),
+                validator_address: <a href="validator.md#0x3_validator">validator</a>.sui_address(),
                 staking_pool_id: staking_pool_id(&<a href="validator.md#0x3_validator">validator</a>),
             }
         );
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> self.active_validators, <a href="validator.md#0x3_validator">validator</a>);
+        self.active_validators.push_back(<a href="validator.md#0x3_validator">validator</a>);
     }
 }
 </code></pre>
@@ -2269,15 +2264,15 @@ Sort all the pending removal indexes.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_sort_removal_list">sort_removal_list</a>(withdraw_list: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(withdraw_list);
+    <b>let</b> length = withdraw_list.length();
     <b>let</b> <b>mut</b> i = 1;
     <b>while</b> (i &lt; length) {
-        <b>let</b> cur = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(withdraw_list, i);
+        <b>let</b> cur = withdraw_list[i];
         <b>let</b> <b>mut</b> j = i;
         <b>while</b> (j &gt; 0) {
             j = j - 1;
-            <b>if</b> (*<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(withdraw_list, j) &gt; cur) {
-                <a href="../move-stdlib/vector.md#0x1_vector_swap">vector::swap</a>(withdraw_list, j, j + 1);
+            <b>if</b> (withdraw_list[j] &gt; cur) {
+                withdraw_list.swap(j, j + 1);
             } <b>else</b> {
                 <b>break</b>
             };
@@ -2310,11 +2305,11 @@ Process all active validators' pending stake deposits and withdraws.
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_process_pending_stakes_and_withdraws">process_pending_stakes_and_withdraws</a>(
     validators: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, ctx: &TxContext
 ) {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, i);
-        <a href="validator.md#0x3_validator_process_pending_stakes_and_withdraws">validator::process_pending_stakes_and_withdraws</a>(<a href="validator.md#0x3_validator">validator</a>, ctx);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &<b>mut</b> validators[i];
+        <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_process_pending_stakes_and_withdraws">process_pending_stakes_and_withdraws</a>(ctx);
         i = i + 1;
     }
 }
@@ -2342,11 +2337,11 @@ Calculate the total active validator stake.
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_calculate_total_stakes">calculate_total_stakes</a>(validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;): u64 {
     <b>let</b> <b>mut</b> stake = 0;
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
-        stake = stake + <a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(v);
+        <b>let</b> v = &validators[i];
+        stake = stake + v.total_stake_amount();
         i = i + 1;
     };
     stake
@@ -2374,11 +2369,11 @@ Process the pending stake changes for each validator.
 
 
 <pre><code><b>fun</b> <a href="validator_set.md#0x3_validator_set_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>(validators: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;) {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, i);
-        <a href="validator.md#0x3_validator_adjust_stake_and_gas_price">validator::adjust_stake_and_gas_price</a>(<a href="validator.md#0x3_validator">validator</a>);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &<b>mut</b> validators[i];
+        <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_adjust_stake_and_gas_price">adjust_stake_and_gas_price</a>();
         i = i + 1;
     }
 }
@@ -2421,25 +2416,25 @@ as well as storage fund rewards.
     <b>let</b> <b>mut</b> total_storage_fund_reward_adjustment = 0;
     <b>let</b> <b>mut</b> individual_storage_fund_reward_adjustments = <a href="../sui-framework/vec_map.md#0x2_vec_map_empty">vec_map::empty</a>();
 
-    <b>while</b> (!<a href="../move-stdlib/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&slashed_validator_indices)) {
-        <b>let</b> validator_index = <a href="../move-stdlib/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> slashed_validator_indices);
+    <b>while</b> (!slashed_validator_indices.is_empty()) {
+        <b>let</b> validator_index = slashed_validator_indices.pop_back();
 
         // Use the slashing rate <b>to</b> compute the amount of staking rewards slashed from this punished <a href="validator.md#0x3_validator">validator</a>.
-        <b>let</b> unadjusted_staking_reward = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(unadjusted_staking_reward_amounts, validator_index);
+        <b>let</b> unadjusted_staking_reward = unadjusted_staking_reward_amounts[validator_index];
         <b>let</b> staking_reward_adjustment_u128 =
             (unadjusted_staking_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
             / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
 
         // Insert into individual mapping and record into the total adjustment sum.
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> individual_staking_reward_adjustments, validator_index, (staking_reward_adjustment_u128 <b>as</b> u64));
+        individual_staking_reward_adjustments.insert(validator_index, (staking_reward_adjustment_u128 <b>as</b> u64));
         total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 <b>as</b> u64);
 
         // Do the same thing for storage fund rewards.
-        <b>let</b> unadjusted_storage_fund_reward = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(unadjusted_storage_fund_reward_amounts, validator_index);
+        <b>let</b> unadjusted_storage_fund_reward = unadjusted_storage_fund_reward_amounts[validator_index];
         <b>let</b> storage_fund_reward_adjustment_u128 =
             (unadjusted_storage_fund_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
             / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
-        <a href="../sui-framework/vec_map.md#0x2_vec_map_insert">vec_map::insert</a>(&<b>mut</b> individual_storage_fund_reward_adjustments, validator_index, (storage_fund_reward_adjustment_u128 <b>as</b> u64));
+        individual_storage_fund_reward_adjustments.insert(validator_index, (storage_fund_reward_adjustment_u128 <b>as</b> u64));
         total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 <b>as</b> u64);
     };
 
@@ -2476,17 +2471,17 @@ non-performant validators according to the input threshold.
     <b>mut</b> validator_report_records: VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
 ): <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
     <b>let</b> <b>mut</b> slashed_validators = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
-    <b>while</b> (!<a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(&validator_report_records)) {
-        <b>let</b> (validator_address, reporters) = <a href="../sui-framework/vec_map.md#0x2_vec_map_pop">vec_map::pop</a>(&<b>mut</b> validator_report_records);
+    <b>while</b> (!validator_report_records.is_empty()) {
+        <b>let</b> (validator_address, reporters) = validator_report_records.pop();
         <b>assert</b>!(
             <a href="validator_set.md#0x3_validator_set_is_active_validator_by_sui_address">is_active_validator_by_sui_address</a>(self, validator_address),
             <a href="validator_set.md#0x3_validator_set_ENonValidatorInReportRecords">ENonValidatorInReportRecords</a>,
         );
         // Sum up the voting power of validators that have reported this <a href="validator.md#0x3_validator">validator</a> and check <b>if</b> it <b>has</b>
         // passed the slashing threshold.
-        <b>let</b> reporter_votes = <a href="validator_set.md#0x3_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(&self.active_validators, &<a href="../sui-framework/vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(reporters));
+        <b>let</b> reporter_votes = <a href="validator_set.md#0x3_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(&self.active_validators, &reporters.into_keys());
         <b>if</b> (reporter_votes &gt;= <a href="voting_power.md#0x3_voting_power_quorum_threshold">voting_power::quorum_threshold</a>()) {
-            <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> slashed_validators, validator_address);
+            slashed_validators.push_back(validator_address);
         }
     };
     slashed_validators
@@ -2522,21 +2517,21 @@ Returns the unadjusted amounts of staking reward and storage fund reward for eac
     total_staking_reward: u64,
     total_storage_fund_reward: u64,
 ): (<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
-    <b>let</b> <b>mut</b> staking_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> <b>mut</b> storage_fund_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> <b>mut</b> staking_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> <b>mut</b> storage_fund_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> length = validators.length();
     <b>let</b> storage_fund_reward_per_validator = total_storage_fund_reward / length;
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &validators[i];
         // Integer divisions will truncate the results. Because of this, we expect that at the end
         // there will be some reward remaining in `total_staking_reward`.
         // Use u128 <b>to</b> avoid multiplication overflow.
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(<a href="validator.md#0x3_validator">validator</a>) <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128);
         <b>let</b> reward_amount = <a href="voting_power.md#0x3_voting_power">voting_power</a> * (total_staking_reward <b>as</b> u128) / (total_voting_power <b>as</b> u128);
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> staking_reward_amounts, (reward_amount <b>as</b> u64));
+        staking_reward_amounts.push_back((reward_amount <b>as</b> u64));
         // Storage fund's share of the rewards are equally distributed among validators.
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> storage_fund_reward_amounts, storage_fund_reward_per_validator);
+        storage_fund_reward_amounts.push_back(storage_fund_reward_per_validator);
         i = i + 1;
     };
     (staking_reward_amounts, storage_fund_reward_amounts)
@@ -2577,26 +2572,26 @@ The staking rewards are shared with the stakers while the storage fund ones are 
     individual_storage_fund_reward_adjustments: VecMap&lt;u64, u64&gt;,
 ): (<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
     <b>let</b> total_unslashed_validator_voting_power = total_voting_power - total_slashed_validator_voting_power;
-    <b>let</b> <b>mut</b> adjusted_staking_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> <b>mut</b> adjusted_storage_fund_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>();
+    <b>let</b> <b>mut</b> adjusted_staking_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
+    <b>let</b> <b>mut</b> adjusted_storage_fund_reward_amounts = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
 
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
-    <b>let</b> num_unslashed_validators = length - <a href="../sui-framework/vec_map.md#0x2_vec_map_size">vec_map::size</a>(&individual_staking_reward_adjustments);
+    <b>let</b> length = validators.length();
+    <b>let</b> num_unslashed_validators = length - individual_staking_reward_adjustments.size();
 
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &validators[i];
         // Integer divisions will truncate the results. Because of this, we expect that at the end
         // there will be some reward remaining in `total_reward`.
         // Use u128 <b>to</b> avoid multiplication overflow.
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(<a href="validator.md#0x3_validator">validator</a>) <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128);
 
         // Compute adjusted staking reward.
-        <b>let</b> unadjusted_staking_reward_amount = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&unadjusted_staking_reward_amounts, i);
+        <b>let</b> unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
         <b>let</b> adjusted_staking_reward_amount =
             // If the <a href="validator.md#0x3_validator">validator</a> is one of the slashed ones, then subtract the adjustment.
-            <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&individual_staking_reward_adjustments, &i)) {
-                <b>let</b> adjustment = *<a href="../sui-framework/vec_map.md#0x2_vec_map_get">vec_map::get</a>(&individual_staking_reward_adjustments, &i);
+            <b>if</b> (individual_staking_reward_adjustments.contains(&i)) {
+                <b>let</b> adjustment = individual_staking_reward_adjustments[&i];
                 unadjusted_staking_reward_amount - adjustment
             } <b>else</b> {
                 // Otherwise the slashed rewards should be distributed among the unslashed
@@ -2605,21 +2600,21 @@ The staking rewards are shared with the stakers while the storage fund ones are 
                                / (total_unslashed_validator_voting_power <b>as</b> u128);
                 unadjusted_staking_reward_amount + (adjustment <b>as</b> u64)
             };
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> adjusted_staking_reward_amounts, adjusted_staking_reward_amount);
+        adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);
 
         // Compute adjusted storage fund reward.
-        <b>let</b> unadjusted_storage_fund_reward_amount = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(&unadjusted_storage_fund_reward_amounts, i);
+        <b>let</b> unadjusted_storage_fund_reward_amount = unadjusted_storage_fund_reward_amounts[i];
         <b>let</b> adjusted_storage_fund_reward_amount =
             // If the <a href="validator.md#0x3_validator">validator</a> is one of the slashed ones, then subtract the adjustment.
-            <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(&individual_storage_fund_reward_adjustments, &i)) {
-                <b>let</b> adjustment = *<a href="../sui-framework/vec_map.md#0x2_vec_map_get">vec_map::get</a>(&individual_storage_fund_reward_adjustments, &i);
+            <b>if</b> (individual_storage_fund_reward_adjustments.contains(&i)) {
+                <b>let</b> adjustment = individual_storage_fund_reward_adjustments[&i];
                 unadjusted_storage_fund_reward_amount - adjustment
             } <b>else</b> {
                 // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
                 <b>let</b> adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
                 unadjusted_storage_fund_reward_amount + adjustment
             };
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> adjusted_storage_fund_reward_amounts, adjusted_storage_fund_reward_amount);
+        adjusted_storage_fund_reward_amounts.push_back(adjusted_storage_fund_reward_amount);
 
         i = i + 1;
     };
@@ -2655,34 +2650,36 @@ The staking rewards are shared with the stakers while the storage fund ones are 
     storage_fund_reward: &<b>mut</b> Balance&lt;SUI&gt;,
     ctx: &<b>mut</b> TxContext
 ) {
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> length = validators.length();
     <b>assert</b>!(length &gt; 0, <a href="validator_set.md#0x3_validator_set_EValidatorSetEmpty">EValidatorSetEmpty</a>);
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, i);
-        <b>let</b> staking_reward_amount = *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(adjusted_staking_reward_amounts, i);
-        <b>let</b> <b>mut</b> staker_reward = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(staking_rewards, staking_reward_amount);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &<b>mut</b> validators[i];
+        <b>let</b> staking_reward_amount = adjusted_staking_reward_amounts[i];
+        <b>let</b> <b>mut</b> staker_reward = staking_rewards.split(staking_reward_amount);
 
         // Validator takes a cut of the rewards <b>as</b> commission.
-        <b>let</b> validator_commission_amount = (staking_reward_amount <b>as</b> u128) * (<a href="validator.md#0x3_validator_commission_rate">validator::commission_rate</a>(<a href="validator.md#0x3_validator">validator</a>) <b>as</b> u128) / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
+        <b>let</b> validator_commission_amount = (staking_reward_amount <b>as</b> u128) * (<a href="validator.md#0x3_validator">validator</a>.commission_rate() <b>as</b> u128) / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
 
         // The <a href="validator.md#0x3_validator">validator</a> reward = storage_fund_reward + commission.
-        <b>let</b> <b>mut</b> validator_reward = <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> staker_reward, (validator_commission_amount <b>as</b> u64));
+        <b>let</b> <b>mut</b> validator_reward = staker_reward.split((validator_commission_amount <b>as</b> u64));
 
         // Add storage fund rewards <b>to</b> the <a href="validator.md#0x3_validator">validator</a>'s reward.
-        <a href="../sui-framework/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> validator_reward, <a href="../sui-framework/balance.md#0x2_balance_split">balance::split</a>(storage_fund_reward, *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(adjusted_storage_fund_reward_amounts, i)));
+        validator_reward.join(
+	    	storage_fund_reward.split(adjusted_storage_fund_reward_amounts[i])
+	    );
 
         // Add rewards <b>to</b> the <a href="validator.md#0x3_validator">validator</a>. Don't try and distribute rewards though <b>if</b> the payout is zero.
-        <b>if</b> (<a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(&validator_reward) &gt; 0) {
-            <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(<a href="validator.md#0x3_validator">validator</a>);
-            <b>let</b> rewards_stake = <a href="validator.md#0x3_validator_request_add_stake">validator::request_add_stake</a>(<a href="validator.md#0x3_validator">validator</a>, validator_reward, validator_address, ctx);
+        <b>if</b> (validator_reward.value() &gt; 0) {
+            <b>let</b> validator_address = <a href="validator.md#0x3_validator">validator</a>.sui_address();
+            <b>let</b> rewards_stake = <a href="validator.md#0x3_validator">validator</a>.<a href="validator_set.md#0x3_validator_set_request_add_stake">request_add_stake</a>(validator_reward, validator_address, ctx);
             <a href="../sui-framework/transfer.md#0x2_transfer_public_transfer">transfer::public_transfer</a>(rewards_stake, validator_address);
         } <b>else</b> {
-            <a href="../sui-framework/balance.md#0x2_balance_destroy_zero">balance::destroy_zero</a>(validator_reward);
+            validator_reward.destroy_zero();
         };
 
         // Add rewards <b>to</b> stake staking pool <b>to</b> auto compound for stakers.
-        <a href="validator.md#0x3_validator_deposit_stake_rewards">validator::deposit_stake_rewards</a>(<a href="validator.md#0x3_validator">validator</a>, staker_reward);
+        <a href="validator.md#0x3_validator">validator</a>.deposit_stake_rewards(staker_reward);
         i = i + 1;
     }
 }
@@ -2717,31 +2714,31 @@ including stakes, rewards, performance, etc.
     report_records: &VecMap&lt;<b>address</b>, VecSet&lt;<b>address</b>&gt;&gt;,
     slashed_validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
 ) {
-    <b>let</b> num_validators = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(vs);
+    <b>let</b> num_validators = vs.length();
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; num_validators) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(vs, i);
-        <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(v);
+        <b>let</b> v = &vs[i];
+        <b>let</b> validator_address = v.sui_address();
         <b>let</b> tallying_rule_reporters =
-            <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_contains">vec_map::contains</a>(report_records, &validator_address)) {
-                <a href="../sui-framework/vec_set.md#0x2_vec_set_into_keys">vec_set::into_keys</a>(*<a href="../sui-framework/vec_map.md#0x2_vec_map_get">vec_map::get</a>(report_records, &validator_address))
+            <b>if</b> (report_records.contains(&validator_address)) {
+                report_records[&validator_address].into_keys()
             } <b>else</b> {
                 <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[]
             };
         <b>let</b> tallying_rule_global_score =
-            <b>if</b> (<a href="../move-stdlib/vector.md#0x1_vector_contains">vector::contains</a>(slashed_validators, &validator_address)) 0
+            <b>if</b> (slashed_validators.contains(&validator_address)) 0
             <b>else</b> 1;
         <a href="../sui-framework/event.md#0x2_event_emit">event::emit</a>(
             <a href="validator_set.md#0x3_validator_set_ValidatorEpochInfoEventV2">ValidatorEpochInfoEventV2</a> {
                 epoch: new_epoch,
                 validator_address,
-                reference_gas_survey_quote: <a href="validator.md#0x3_validator_gas_price">validator::gas_price</a>(v),
-                stake: <a href="validator.md#0x3_validator_total_stake_amount">validator::total_stake_amount</a>(v),
-                <a href="voting_power.md#0x3_voting_power">voting_power</a>: <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(v),
-                commission_rate: <a href="validator.md#0x3_validator_commission_rate">validator::commission_rate</a>(v),
-                pool_staking_reward: *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(pool_staking_reward_amounts, i),
-                storage_fund_staking_reward: *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(storage_fund_staking_reward_amounts, i),
-                pool_token_exchange_rate: <a href="validator.md#0x3_validator_pool_token_exchange_rate_at_epoch">validator::pool_token_exchange_rate_at_epoch</a>(v, new_epoch),
+                reference_gas_survey_quote: v.gas_price(),
+                stake: v.total_stake_amount(),
+                <a href="voting_power.md#0x3_voting_power">voting_power</a>: v.<a href="voting_power.md#0x3_voting_power">voting_power</a>(),
+                commission_rate: v.commission_rate(),
+                pool_staking_reward: pool_staking_reward_amounts[i],
+                storage_fund_staking_reward: storage_fund_staking_reward_amounts[i],
+                pool_token_exchange_rate: v.pool_token_exchange_rate_at_epoch(new_epoch),
                 tallying_rule_reporters,
                 tallying_rule_global_score,
             }
@@ -2774,10 +2771,10 @@ Sum up the total stake of a given list of validator addresses.
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_sum_voting_power_by_addresses">sum_voting_power_by_addresses</a>(vs: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, addresses: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;): u64 {
     <b>let</b> <b>mut</b> sum = 0;
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(addresses);
+    <b>let</b> length = addresses.length();
     <b>while</b> (i &lt; length) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_ref">get_validator_ref</a>(vs, *<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(addresses, i));
-        sum = sum + <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(<a href="validator.md#0x3_validator">validator</a>);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_ref">get_validator_ref</a>(vs, addresses[i]);
+        sum = sum + <a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>();
         i = i + 1;
     };
     sum
@@ -2830,7 +2827,7 @@ Returns true if the <code>addr</code> is a validator candidate.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_is_validator_candidate">is_validator_candidate</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, addr: <b>address</b>): bool {
-    <a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.validator_candidates, addr)
+    self.validator_candidates.contains(addr)
 }
 </code></pre>
 
@@ -2855,7 +2852,7 @@ Returns true if the staking pool identified by <code>staking_pool_id</code> is o
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="validator_set.md#0x3_validator_set_is_inactive_validator">is_inactive_validator</a>(self: &<a href="validator_set.md#0x3_validator_set_ValidatorSet">ValidatorSet</a>, staking_pool_id: ID): bool {
-    <a href="../sui-framework/table.md#0x2_table_contains">table::contains</a>(&self.inactive_validators, staking_pool_id)
+    self.inactive_validators.contains(staking_pool_id)
 }
 </code></pre>
 
@@ -2882,10 +2879,10 @@ Returns true if the staking pool identified by <code>staking_pool_id</code> is o
     <b>let</b> vs = &self.active_validators;
     <b>let</b> <b>mut</b> res = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> length = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(vs);
+    <b>let</b> length = vs.length();
     <b>while</b> (i &lt; length) {
-        <b>let</b> validator_address = <a href="validator.md#0x3_validator_sui_address">validator::sui_address</a>(<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(vs, i));
-        <a href="../move-stdlib/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> res, validator_address);
+        <b>let</b> validator_address = vs[i].sui_address();
+        res.push_back(validator_address);
         i = i + 1;
     };
     res

--- a/crates/sui-framework/docs/sui-system/voting_power.md
+++ b/crates/sui-framework/docs/sui-system/voting_power.md
@@ -197,7 +197,7 @@ at <code><a href="voting_power.md#0x3_voting_power_MAX_VOTING_POWER">MAX_VOTING_
     // have 100%. So we bound the threshold_pct <b>to</b> be always enough <b>to</b> find a solution.
     <b>let</b> threshold = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(
         <a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>,
-        <a href="../sui-framework/math.md#0x2_math_max">math::max</a>(<a href="voting_power.md#0x3_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a>, divide_and_round_up(<a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>, <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators))),
+        <a href="../sui-framework/math.md#0x2_math_max">math::max</a>(<a href="voting_power.md#0x3_voting_power_MAX_VOTING_POWER">MAX_VOTING_POWER</a>, divide_and_round_up(<a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>, validators.length())),
     );
     <b>let</b> (<b>mut</b> info_list, remaining_power) = <a href="voting_power.md#0x3_voting_power_init_voting_power_info">init_voting_power_info</a>(validators, threshold);
     <a href="voting_power.md#0x3_voting_power_adjust_voting_power">adjust_voting_power</a>(&<b>mut</b> info_list, threshold, remaining_power);
@@ -235,12 +235,12 @@ Anything beyond the threshold is added to the remaining_power, which is also ret
 ): (<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a>&gt;, u64) {
     <b>let</b> total_stake = <a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>(validators);
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> len = validators.length();
     <b>let</b> <b>mut</b> total_power = 0;
     <b>let</b> <b>mut</b> result = <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[];
     <b>while</b> (i &lt; len) {
-        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i);
-        <b>let</b> stake = <a href="validator.md#0x3_validator_total_stake">validator::total_stake</a>(<a href="validator.md#0x3_validator">validator</a>);
+        <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &validators[i];
+        <b>let</b> stake = <a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>();
         <b>let</b> adjusted_stake = (stake <b>as</b> u128) * (<a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a> <b>as</b> u128) / (total_stake <b>as</b> u128);
         <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>((adjusted_stake <b>as</b> u64), threshold);
         <b>let</b> info = <a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a> {
@@ -278,10 +278,10 @@ Sum up the total stake of all validators.
 
 <pre><code><b>fun</b> <a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>(validators: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;): u64 {
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(validators);
+    <b>let</b> len = validators.length();
     <b>let</b> <b>mut</b> total_stake =0 ;
     <b>while</b> (i &lt; len) {
-        total_stake = total_stake + <a href="validator.md#0x3_validator_total_stake">validator::total_stake</a>(<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(validators, i));
+        total_stake = total_stake + validators[i].<a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>();
         i = i + 1;
     };
     total_stake
@@ -311,11 +311,11 @@ using stake, in descending order.
 
 <pre><code><b>fun</b> <a href="voting_power.md#0x3_voting_power_insert">insert</a>(info_list: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a>&gt;, new_info: <a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a>) {
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(info_list);
-    <b>while</b> (i &lt; len && <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(info_list, i).stake &gt; new_info.stake) {
+    <b>let</b> len = info_list.length();
+    <b>while</b> (i &lt; len && info_list[i].stake &gt; new_info.stake) {
         i = i + 1;
     };
-    <a href="../move-stdlib/vector.md#0x1_vector_insert">vector::insert</a>(info_list, new_info, i);
+    info_list.<a href="voting_power.md#0x3_voting_power_insert">insert</a>(new_info, i);
 }
 </code></pre>
 
@@ -341,9 +341,9 @@ Distribute remaining_power to validators that are not capped at threshold.
 
 <pre><code><b>fun</b> <a href="voting_power.md#0x3_voting_power_adjust_voting_power">adjust_voting_power</a>(info_list: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a>&gt;, threshold: u64, <b>mut</b> remaining_power: u64) {
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(info_list);
+    <b>let</b> len = info_list.length();
     <b>while</b> (i &lt; len && remaining_power &gt; 0) {
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(info_list, i);
+        <b>let</b> v = &<b>mut</b> info_list[i];
         // planned is the amount of extra power we want <b>to</b> distribute <b>to</b> this <a href="validator.md#0x3_validator">validator</a>.
         <b>let</b> planned = divide_and_round_up(remaining_power, len - i);
         // target is the targeting power this <a href="validator.md#0x3_validator">validator</a> will reach, capped by threshold.
@@ -380,16 +380,16 @@ Update validators with the decided voting power.
 
 
 <pre><code><b>fun</b> <a href="voting_power.md#0x3_voting_power_update_voting_power">update_voting_power</a>(validators: &<b>mut</b> <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;, <b>mut</b> info_list: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a>&gt;) {
-    <b>while</b> (!<a href="../move-stdlib/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&info_list)) {
+    <b>while</b> (!info_list.is_empty()) {
         <b>let</b> <a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a> {
             validator_index,
             <a href="voting_power.md#0x3_voting_power">voting_power</a>,
             stake: _,
-        } = <a href="../move-stdlib/vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> info_list);
-        <b>let</b> v = <a href="../move-stdlib/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(validators, validator_index);
-        <a href="validator.md#0x3_validator_set_voting_power">validator::set_voting_power</a>(v, <a href="voting_power.md#0x3_voting_power">voting_power</a>);
+        } = info_list.pop_back();
+        <b>let</b> v = &<b>mut</b> validators[validator_index];
+        v.<a href="voting_power.md#0x3_voting_power_set_voting_power">set_voting_power</a>(<a href="voting_power.md#0x3_voting_power">voting_power</a>);
     };
-    <a href="../move-stdlib/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(info_list);
+    info_list.destroy_empty();
 }
 </code></pre>
 
@@ -416,10 +416,10 @@ Check a few invariants that must hold after setting the voting power.
 <pre><code><b>fun</b> <a href="voting_power.md#0x3_voting_power_check_invariants">check_invariants</a>(v: &<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;Validator&gt;) {
     // First check that the total voting power must be <a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a>.
     <b>let</b> <b>mut</b> i = 0;
-    <b>let</b> len = <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(v);
+    <b>let</b> len = v.length();
     <b>let</b> <b>mut</b> total = 0;
     <b>while</b> (i &lt; len) {
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(<a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(v, i));
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = v[i].<a href="voting_power.md#0x3_voting_power">voting_power</a>();
         <b>assert</b>!(<a href="voting_power.md#0x3_voting_power">voting_power</a> &gt; 0, <a href="voting_power.md#0x3_voting_power_EInvalidVotingPower">EInvalidVotingPower</a>);
         total = total + <a href="voting_power.md#0x3_voting_power">voting_power</a>;
         i = i + 1;
@@ -433,12 +433,12 @@ Check a few invariants that must hold after setting the voting power.
     <b>while</b> (a &lt; len) {
         <b>let</b> <b>mut</b> b = a + 1;
         <b>while</b> (b &lt; len) {
-            <b>let</b> validator_a = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(v, a);
-            <b>let</b> validator_b = <a href="../move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(v, b);
-            <b>let</b> stake_a = <a href="validator.md#0x3_validator_total_stake">validator::total_stake</a>(validator_a);
-            <b>let</b> stake_b = <a href="validator.md#0x3_validator_total_stake">validator::total_stake</a>(validator_b);
-            <b>let</b> power_a = <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(validator_a);
-            <b>let</b> power_b = <a href="validator.md#0x3_validator_voting_power">validator::voting_power</a>(validator_b);
+            <b>let</b> validator_a = &v[a];
+            <b>let</b> validator_b = &v[b];
+            <b>let</b> stake_a = validator_a.<a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>();
+            <b>let</b> stake_b = validator_b.<a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>();
+            <b>let</b> power_a = validator_a.<a href="voting_power.md#0x3_voting_power">voting_power</a>();
+            <b>let</b> power_b = validator_b.<a href="voting_power.md#0x3_voting_power">voting_power</a>();
             <b>if</b> (stake_a &gt; stake_b) {
                 <b>assert</b>!(power_a &gt;= power_b, <a href="voting_power.md#0x3_voting_power_ERelativePowerMismatch">ERelativePowerMismatch</a>);
             };

--- a/crates/sui-framework/packages/sui-system/sources/genesis.move
+++ b/crates/sui-framework/packages/sui-system/sources/genesis.move
@@ -2,19 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::genesis {
-    use std::vector;
 
     use sui::balance::{Self, Balance};
-    use sui::coin;
-    use sui::object::UID;
     use sui::sui::{Self, SUI};
     use sui_system::sui_system;
-    use sui::tx_context::{Self, TxContext};
     use sui_system::validator::{Self, Validator};
     use sui_system::validator_set;
     use sui_system::sui_system_state_inner;
     use sui_system::stake_subsidy;
-    use std::option::{Option, Self};
 
     public struct GenesisValidatorMetadata has drop, copy {
         name: vector<u8>,
@@ -90,22 +85,19 @@ module sui_system::genesis {
         ctx: &mut TxContext,
     ) {
         // Ensure this is only called at genesis
-        assert!(tx_context::epoch(ctx) == 0, ENotCalledAtGenesis);
+        assert!(ctx.epoch() == 0, ENotCalledAtGenesis);
 
         let TokenDistributionSchedule {
             stake_subsidy_fund_mist,
             allocations,
         } = token_distribution_schedule;
 
-        let subsidy_fund = balance::split(
-            &mut sui_supply,
-            stake_subsidy_fund_mist,
-        );
+        let subsidy_fund = sui_supply.split(stake_subsidy_fund_mist);
         let storage_fund = balance::zero();
 
         // Create all the `Validator` structs
-        let mut validators = vector::empty();
-        let count = vector::length(&genesis_validators);
+        let mut validators = vector[];
+        let count = genesis_validators.length();
         let mut i = 0;
         while (i < count) {
             let GenesisValidatorMetadata {
@@ -124,7 +116,7 @@ module sui_system::genesis {
                 p2p_address,
                 primary_address,
                 worker_address,
-            } = *vector::borrow(&genesis_validators, i);
+            } = genesis_validators[i];
 
             let validator = validator::new(
                 sui_address,
@@ -151,7 +143,7 @@ module sui_system::genesis {
                 EDuplicateValidator,
             );
 
-            vector::push_back(&mut validators, validator);
+            validators.push_back(validator);
 
             i = i + 1;
         };
@@ -208,45 +200,44 @@ module sui_system::genesis {
         ctx: &mut TxContext,
     ) {
 
-        while (!vector::is_empty(&allocations)) {
+        while (!allocations.is_empty()) {
             let TokenAllocation {
                 recipient_address,
                 amount_mist,
                 staked_with_validator,
-            } = vector::pop_back(&mut allocations);
+            } = allocations.pop_back();
 
-            let allocation_balance = balance::split(&mut sui_supply, amount_mist);
+            let allocation_balance = sui_supply.split(amount_mist);
 
-            if (option::is_some(&staked_with_validator)) {
-                let validator_address = option::destroy_some(staked_with_validator);
+            if (staked_with_validator.is_some()) {
+                let validator_address = staked_with_validator.destroy_some();
                 let validator = validator_set::get_validator_mut(validators, validator_address);
-                validator::request_add_stake_at_genesis(
-                    validator,
+                validator.request_add_stake_at_genesis(
                     allocation_balance,
                     recipient_address,
                     ctx
                 );
             } else {
                 sui::transfer(
-                    coin::from_balance(allocation_balance, ctx),
+                    allocation_balance.into_coin(ctx),
                     recipient_address,
                 );
             };
         };
-        vector::destroy_empty(allocations);
+        allocations.destroy_empty();
 
         // Provided allocations must fully allocate the sui_supply and there
         // should be none left at this point.
-        balance::destroy_zero(sui_supply);
+        sui_supply.destroy_zero();
     }
 
     fun activate_validators(validators: &mut vector<Validator>) {
         // Activate all genesis validators
-        let count = vector::length(validators);
+        let count = validators.length();
         let mut i = 0;
         while (i < count) {
-            let validator = vector::borrow_mut(validators, i);
-            validator::activate(validator, 0);
+            let validator = &mut validators[i];
+            validator.activate(0);
 
             i = i + 1;
         };

--- a/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
+++ b/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::stake_subsidy {
-    use sui::balance::{Self, Balance};
+    use sui::balance::Balance;
     use sui::math;
     use sui::sui::SUI;
     use sui::bag::Bag;
     use sui::bag;
-    use sui::tx_context::TxContext;
 
     /* friend sui_system::genesis; */
     /* friend sui_system::sui_system_state_inner; */
@@ -69,10 +68,10 @@ module sui_system::stake_subsidy {
         // Take the minimum of the reward amount and the remaining balance in
         // order to ensure we don't overdraft the remaining stake subsidy
         // balance
-        let to_withdraw = math::min(self.current_distribution_amount, balance::value(&self.balance));
+        let to_withdraw = math::min(self.current_distribution_amount, self.balance.value());
 
         // Drawn down the subsidy for this epoch.
-        let stake_subsidy = balance::split(&mut self.balance, to_withdraw);
+        let stake_subsidy = self.balance.split(to_withdraw);
 
         self.distribution_counter = self.distribution_counter + 1;
 
@@ -88,7 +87,7 @@ module sui_system::stake_subsidy {
 
     /// Returns the amount of stake subsidy to be added at the end of the current epoch.
     public fun current_epoch_subsidy_amount(self: &StakeSubsidy): u64 {
-        math::min(self.current_distribution_amount, balance::value(&self.balance))
+        math::min(self.current_distribution_amount, self.balance.value())
     }
 
     #[test_only]

--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -5,10 +5,6 @@
 module sui_system::staking_pool {
     use sui::balance::{Self, Balance};
     use sui::sui::SUI;
-    use std::option::{Self, Option};
-    use sui::tx_context::{Self, TxContext};
-    use sui::transfer;
-    use sui::object::{Self, ID, UID};
     use sui::math;
     use sui::table::{Self, Table};
     use sui::bag::Bag;
@@ -117,7 +113,7 @@ module sui_system::staking_pool {
         stake_activation_epoch: u64,
         ctx: &mut TxContext
     ) : StakedSui {
-        let sui_amount = balance::value(&stake);
+        let sui_amount = stake.value();
         assert!(!is_inactive(pool), EDelegationToInactivePool);
         assert!(sui_amount > 0, EDelegationOfZeroSui);
         let staked_sui = StakedSui {
@@ -140,12 +136,12 @@ module sui_system::staking_pool {
     ) : Balance<SUI> {
         let (pool_token_withdraw_amount, mut principal_withdraw) =
             withdraw_from_principal(pool, staked_sui);
-        let principal_withdraw_amount = balance::value(&principal_withdraw);
+        let principal_withdraw_amount = principal_withdraw.value();
 
         let rewards_withdraw = withdraw_rewards(
-            pool, principal_withdraw_amount, pool_token_withdraw_amount, tx_context::epoch(ctx)
+            pool, principal_withdraw_amount, pool_token_withdraw_amount, ctx.epoch()
         );
-        let total_sui_withdraw_amount = principal_withdraw_amount + balance::value(&rewards_withdraw);
+        let total_sui_withdraw_amount = principal_withdraw_amount + rewards_withdraw.value();
 
         pool.pending_total_sui_withdraw = pool.pending_total_sui_withdraw + total_sui_withdraw_amount;
         pool.pending_pool_token_withdraw = pool.pending_pool_token_withdraw + pool_token_withdraw_amount;
@@ -154,7 +150,7 @@ module sui_system::staking_pool {
         if (is_inactive(pool)) process_pending_stake_withdraw(pool);
 
         // TODO: implement withdraw bonding period here.
-        balance::join(&mut principal_withdraw, rewards_withdraw);
+        principal_withdraw.join(rewards_withdraw);
         principal_withdraw
     }
 
@@ -171,7 +167,10 @@ module sui_system::staking_pool {
 
         let exchange_rate_at_staking_epoch = pool_token_exchange_rate_at_epoch(pool, staked_sui.stake_activation_epoch);
         let principal_withdraw = unwrap_staked_sui(staked_sui);
-        let pool_token_withdraw_amount = get_token_amount(&exchange_rate_at_staking_epoch, balance::value(&principal_withdraw));
+        let pool_token_withdraw_amount = get_token_amount(
+		&exchange_rate_at_staking_epoch,
+		principal_withdraw.value()
+	);
 
         (
             pool_token_withdraw_amount,
@@ -194,16 +193,15 @@ module sui_system::staking_pool {
 
     /// Called at epoch advancement times to add rewards (in SUI) to the staking pool.
     public(package) fun deposit_rewards(pool: &mut StakingPool, rewards: Balance<SUI>) {
-        pool.sui_balance = pool.sui_balance + balance::value(&rewards);
-        balance::join(&mut pool.rewards_pool, rewards);
+        pool.sui_balance = pool.sui_balance + rewards.value();
+        pool.rewards_pool.join(rewards);
     }
 
     public(package) fun process_pending_stakes_and_withdraws(pool: &mut StakingPool, ctx: &TxContext) {
-        let new_epoch = tx_context::epoch(ctx) + 1;
+        let new_epoch = ctx.epoch() + 1;
         process_pending_stake_withdraw(pool);
         process_pending_stake(pool);
-        table::add(
-            &mut pool.exchange_rates,
+        pool.exchange_rates.add(
             new_epoch,
             PoolTokenExchangeRate { sui_amount: pool.sui_balance, pool_token_amount: pool.pool_token_balance },
         );
@@ -251,8 +249,8 @@ module sui_system::staking_pool {
         // This may happen when we are withdrawing everything from the pool and
         // the rewards pool balance may be less than reward_withdraw_amount.
         // TODO: FIGURE OUT EXACTLY WHY THIS CAN HAPPEN.
-        reward_withdraw_amount = math::min(reward_withdraw_amount, balance::value(&pool.rewards_pool));
-        balance::split(&mut pool.rewards_pool, reward_withdraw_amount)
+        reward_withdraw_amount = math::min(reward_withdraw_amount, pool.rewards_pool.value());
+        pool.rewards_pool.split(reward_withdraw_amount)
     }
 
     // ==== preactive pool related ====
@@ -260,8 +258,7 @@ module sui_system::staking_pool {
     /// Called by `validator` module to activate a staking pool.
     public(package) fun activate_staking_pool(pool: &mut StakingPool, activation_epoch: u64) {
         // Add the initial exchange rate to the table.
-        table::add(
-            &mut pool.exchange_rates,
+        pool.exchange_rates.add(
             activation_epoch,
             initial_exchange_rate()
         );
@@ -269,7 +266,7 @@ module sui_system::staking_pool {
         assert!(is_preactive(pool), EPoolAlreadyActive);
         assert!(!is_inactive(pool), EActivationOfInactivePool);
         // Fill in the active epoch.
-        option::fill(&mut pool.activation_epoch, activation_epoch);
+        pool.activation_epoch.fill(activation_epoch);
     }
 
     // ==== inactive pool related ====
@@ -289,7 +286,7 @@ module sui_system::staking_pool {
 
     public fun pool_id(staked_sui: &StakedSui): ID { staked_sui.pool_id }
 
-    public fun staked_sui_amount(staked_sui: &StakedSui): u64 { balance::value(&staked_sui.principal) }
+    public fun staked_sui_amount(staked_sui: &StakedSui): u64 { staked_sui.principal.value() }
 
     public fun stake_activation_epoch(staked_sui: &StakedSui): u64 {
         staked_sui.stake_activation_epoch
@@ -297,19 +294,19 @@ module sui_system::staking_pool {
 
     /// Returns true if the input staking pool is preactive.
     public fun is_preactive(pool: &StakingPool): bool{
-        option::is_none(&pool.activation_epoch)
+        pool.activation_epoch.is_none()
     }
 
     /// Returns true if the input staking pool is inactive.
     public fun is_inactive(pool: &StakingPool): bool {
-        option::is_some(&pool.deactivation_epoch)
+        pool.deactivation_epoch.is_some()
     }
 
     /// Split StakedSui `self` to two parts, one with principal `split_amount`,
     /// and the remaining principal is left in `self`.
     /// All the other parameters of the StakedSui like `stake_activation_epoch` or `pool_id` remain the same.
     public fun split(self: &mut StakedSui, split_amount: u64, ctx: &mut TxContext): StakedSui {
-        let original_amount = balance::value(&self.principal);
+        let original_amount = self.principal.value();
         assert!(split_amount <= original_amount, EInsufficientSuiTokenBalance);
         let remaining_amount = original_amount - split_amount;
         // Both resulting parts should have at least MIN_STAKING_THRESHOLD.
@@ -319,14 +316,14 @@ module sui_system::staking_pool {
             id: object::new(ctx),
             pool_id: self.pool_id,
             stake_activation_epoch: self.stake_activation_epoch,
-            principal: balance::split(&mut self.principal, split_amount),
+            principal: self.principal.split(split_amount),
         }
     }
 
     /// Split the given StakedSui to the two parts, one with principal `split_amount`,
     /// transfer the newly split part to the sender address.
     public entry fun split_staked_sui(stake: &mut StakedSui, split_amount: u64, ctx: &mut TxContext) {
-        transfer::transfer(split(stake, split_amount, ctx), tx_context::sender(ctx));
+        transfer::transfer(split(stake, split_amount, ctx), ctx.sender());
     }
 
     /// Consume the staked sui `other` and add its value to `self`.
@@ -340,8 +337,8 @@ module sui_system::staking_pool {
             principal,
         } = other;
 
-        object::delete(id);
-        balance::join(&mut self.principal, principal);
+        id.delete();
+        self.principal.join(principal);
     }
 
     /// Returns true if all the staking parameters of the staked sui except the principal are identical
@@ -356,14 +353,14 @@ module sui_system::staking_pool {
         if (is_preactive_at_epoch(pool, epoch)) {
             return initial_exchange_rate()
         };
-        let clamped_epoch = option::get_with_default(&pool.deactivation_epoch, epoch);
+        let clamped_epoch = pool.deactivation_epoch.get_with_default(epoch);
         let mut epoch = math::min(clamped_epoch, epoch);
-        let activation_epoch = *option::borrow(&pool.activation_epoch);
+        let activation_epoch = *pool.activation_epoch.borrow();
 
         // Find the latest epoch that's earlier than the given epoch with an entry in the table
         while (epoch >= activation_epoch) {
-            if (table::contains(&pool.exchange_rates, epoch)) {
-                return *table::borrow(&pool.exchange_rates, epoch)
+            if (pool.exchange_rates.contains(epoch)) {
+                return pool.exchange_rates[epoch]
             };
             epoch = epoch - 1;
         };
@@ -396,7 +393,7 @@ module sui_system::staking_pool {
     /// Returns true if the provided staking pool is preactive at the provided epoch.
     fun is_preactive_at_epoch(pool: &StakingPool, epoch: u64): bool{
         // Either the pool is currently preactive or the pool's starting epoch is later than the provided epoch.
-        is_preactive(pool) || (*option::borrow(&pool.activation_epoch) > epoch)
+        is_preactive(pool) || (*pool.activation_epoch.borrow() > epoch)
     }
 
     fun get_sui_amount(exchange_rate: &PoolTokenExchangeRate, token_amount: u64): u64 {
@@ -457,7 +454,7 @@ module sui_system::staking_pool {
             if (total_sui_withdraw_amount >= staked_amount)
                 total_sui_withdraw_amount - staked_amount
             else 0;
-        reward_withdraw_amount = math::min(reward_withdraw_amount, balance::value(&pool.rewards_pool));
+        reward_withdraw_amount = math::min(reward_withdraw_amount, pool.rewards_pool.value());
 
         staked_amount + reward_withdraw_amount
     }

--- a/crates/sui-framework/packages/sui-system/sources/storage_fund.move
+++ b/crates/sui-framework/packages/sui-system/sources/storage_fund.move
@@ -39,21 +39,21 @@ module sui_system::storage_fund {
         non_refundable_storage_fee_amount: u64,
     ) : Balance<SUI> {
         // Both the reinvestment and leftover rewards are not to be refunded so they go to the non-refundable balance.
-        balance::join(&mut self.non_refundable_balance, storage_fund_reinvestment);
-        balance::join(&mut self.non_refundable_balance, leftover_staking_rewards);
+        self.non_refundable_balance.join(storage_fund_reinvestment);
+        self.non_refundable_balance.join(leftover_staking_rewards);
 
         // The storage charges for the epoch come from the storage rebate of the new objects created
         // and the new storage rebates of the objects modified during the epoch so we put the charges
         // into `total_object_storage_rebates`.
-        balance::join(&mut self.total_object_storage_rebates, storage_charges);
+        self.total_object_storage_rebates.join(storage_charges);
 
         // Split out the non-refundable portion of the storage rebate and put it into the non-refundable balance.
-        let non_refundable_storage_fee = balance::split(&mut self.total_object_storage_rebates, non_refundable_storage_fee_amount);
-        balance::join(&mut self.non_refundable_balance, non_refundable_storage_fee);
+        let non_refundable_storage_fee = self.total_object_storage_rebates.split(non_refundable_storage_fee_amount);
+        self.non_refundable_balance.join(non_refundable_storage_fee);
 
         // `storage_rebates` include the already refunded rebates of deleted objects and old rebates of modified objects and
         // should be taken out of the `total_object_storage_rebates`.
-        let storage_rebate = balance::split(&mut self.total_object_storage_rebates, storage_rebate_amount);
+        let storage_rebate = self.total_object_storage_rebates.split(storage_rebate_amount);
 
         // The storage rebate has already been returned to individual transaction senders' gas coins
         // so we return the balance to be burnt at the very end of epoch change.
@@ -61,10 +61,10 @@ module sui_system::storage_fund {
     }
 
     public fun total_object_storage_rebates(self: &StorageFund): u64 {
-        balance::value(&self.total_object_storage_rebates)
+        self.total_object_storage_rebates.value()
     }
 
     public fun total_balance(self: &StorageFund): u64 {
-        balance::value(&self.total_object_storage_rebates) + balance::value(&self.non_refundable_balance)
+        self.total_object_storage_rebates.value() + self.non_refundable_balance.value()
     }
 }

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -41,25 +41,19 @@
 module sui_system::sui_system {
     use sui::balance::Balance;
 
-    use sui::coin::{Self, Coin};
-    use sui::object::UID;
+    use sui::coin::Coin;
     use sui_system::staking_pool::StakedSui;
     use sui::sui::SUI;
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
-    use sui::object::ID;
     use sui::table::Table;
     use sui_system::validator::Validator;
     use sui_system::validator_cap::UnverifiedValidatorOperationCap;
-    use sui_system::sui_system_state_inner::{Self, SystemParameters, SuiSystemStateInnerV2};
+    use sui_system::sui_system_state_inner::{Self, SystemParameters, SuiSystemStateInner, SuiSystemStateInnerV2};
     use sui_system::stake_subsidy::StakeSubsidy;
     use sui_system::staking_pool::PoolTokenExchangeRate;
-    use std::option;
     use sui::dynamic_field;
 
     #[test_only] use sui::balance;
     #[test_only] use sui_system::validator_set::ValidatorSet;
-    #[test_only] use sui_system::validator_set;
     #[test_only] use sui::vec_set::VecSet;
 
     /* friend sui_system::genesis; */
@@ -136,8 +130,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_validator_candidate(
-            self,
+        self.request_add_validator_candidate(
             pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,
@@ -163,7 +156,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_remove_validator_candidate(self, ctx)
+        self.request_remove_validator_candidate(ctx)
     }
 
     /// Called by a validator candidate to add themselves to the active validator set beginning next epoch.
@@ -175,7 +168,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_validator(self, ctx)
+        self.request_add_validator(ctx)
     }
 
     /// A validator can call this function to request a removal in the next epoch.
@@ -188,7 +181,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_remove_validator(self, ctx)
+        self.request_remove_validator(ctx)
     }
 
     /// A validator can call this entry function to submit a new gas price quote, to be
@@ -199,7 +192,7 @@ module sui_system::sui_system {
         new_gas_price: u64,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_set_gas_price(self, cap, new_gas_price)
+        self.request_set_gas_price(cap, new_gas_price)
     }
 
     /// This entry function is used to set new gas price for candidate validators
@@ -209,7 +202,7 @@ module sui_system::sui_system {
         new_gas_price: u64,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::set_candidate_validator_gas_price(self, cap, new_gas_price)
+        self.set_candidate_validator_gas_price(cap, new_gas_price)
     }
 
     /// A validator can call this entry function to set a new commission rate, updated at the end of
@@ -220,7 +213,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_set_commission_rate(self, new_commission_rate, ctx)
+        self.request_set_commission_rate(new_commission_rate, ctx)
     }
 
     /// This entry function is used to set new commission rate for candidate validators
@@ -230,7 +223,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::set_candidate_validator_commission_rate(self, new_commission_rate, ctx)
+        self.set_candidate_validator_commission_rate(new_commission_rate, ctx)
     }
 
     /// Add stake to a validator's staking pool.
@@ -241,7 +234,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let staked_sui = request_add_stake_non_entry(wrapper, stake, validator_address, ctx);
-        transfer::public_transfer(staked_sui, tx_context::sender(ctx));
+        transfer::public_transfer(staked_sui, ctx.sender());
     }
 
     /// The non-entry version of `request_add_stake`, which returns the staked SUI instead of transferring it to the sender.
@@ -252,7 +245,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ): StakedSui {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_stake(self, stake, validator_address, ctx)
+        self.request_add_stake(stake, validator_address, ctx)
     }
 
     /// Add stake to a validator's staking pool using multiple coins.
@@ -264,8 +257,8 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        let staked_sui = sui_system_state_inner::request_add_stake_mul_coin(self, stakes, stake_amount, validator_address, ctx);
-        transfer::public_transfer(staked_sui, tx_context::sender(ctx));
+        let staked_sui = self.request_add_stake_mul_coin(stakes, stake_amount, validator_address, ctx);
+        transfer::public_transfer(staked_sui, ctx.sender());
     }
 
     /// Withdraw stake from a validator's staking pool.
@@ -275,7 +268,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let withdrawn_stake = request_withdraw_stake_non_entry(wrapper, staked_sui, ctx);
-        transfer::public_transfer(coin::from_balance(withdrawn_stake, ctx), tx_context::sender(ctx));
+        transfer::public_transfer(withdrawn_stake.into_coin(ctx), ctx.sender());
     }
 
     /// Non-entry version of `request_withdraw_stake` that returns the withdrawn SUI instead of transferring it to the sender.
@@ -285,7 +278,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) : Balance<SUI> {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_withdraw_stake(self, staked_sui, ctx)
+        self.request_withdraw_stake(staked_sui, ctx)
     }
 
     /// Report a validator as a bad or non-performant actor in the system.
@@ -300,7 +293,7 @@ module sui_system::sui_system {
         reportee_addr: address,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::report_validator(self, cap, reportee_addr)
+        self.report_validator(cap, reportee_addr)
     }
 
 
@@ -314,7 +307,7 @@ module sui_system::sui_system {
         reportee_addr: address,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::undo_report_validator(self, cap, reportee_addr)
+        self.undo_report_validator(cap, reportee_addr)
     }
 
     // ==== validator metadata management functions ====
@@ -326,7 +319,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::rotate_operation_cap(self, ctx)
+        self.rotate_operation_cap(ctx)
     }
 
     /// Update a validator's name.
@@ -336,7 +329,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_name(self, name, ctx)
+        self.update_validator_name(name, ctx)
     }
 
     /// Update a validator's description
@@ -346,7 +339,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_description(self, description, ctx)
+        self.update_validator_description(description, ctx)
     }
 
     /// Update a validator's image url
@@ -356,7 +349,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_image_url(self, image_url, ctx)
+        self.update_validator_image_url(image_url, ctx)
     }
 
     /// Update a validator's project url
@@ -366,7 +359,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_project_url(self, project_url, ctx)
+        self.update_validator_project_url(project_url, ctx)
     }
 
     /// Update a validator's network address.
@@ -377,7 +370,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_network_address(self, network_address, ctx)
+        self.update_validator_next_epoch_network_address(network_address, ctx)
     }
 
     /// Update candidate validator's network address.
@@ -387,7 +380,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_network_address(self, network_address, ctx)
+        self.update_candidate_validator_network_address(network_address, ctx)
     }
 
     /// Update a validator's p2p address.
@@ -398,7 +391,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_p2p_address(self, p2p_address, ctx)
+        self.update_validator_next_epoch_p2p_address(p2p_address, ctx)
     }
 
     /// Update candidate validator's p2p address.
@@ -408,7 +401,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_p2p_address(self, p2p_address, ctx)
+        self.update_candidate_validator_p2p_address(p2p_address, ctx)
     }
 
     /// Update a validator's narwhal primary address.
@@ -419,7 +412,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_primary_address(self, primary_address, ctx)
+        self.update_validator_next_epoch_primary_address(primary_address, ctx)
     }
 
     /// Update candidate validator's narwhal primary address.
@@ -429,7 +422,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_primary_address(self, primary_address, ctx)
+        self.update_candidate_validator_primary_address(primary_address, ctx)
     }
 
     /// Update a validator's narwhal worker address.
@@ -440,7 +433,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_worker_address(self, worker_address, ctx)
+        self.update_validator_next_epoch_worker_address(worker_address, ctx)
     }
 
     /// Update candidate validator's narwhal worker address.
@@ -450,7 +443,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_worker_address(self, worker_address, ctx)
+        self.update_candidate_validator_worker_address(worker_address, ctx)
     }
 
     /// Update a validator's public key of protocol key and proof of possession.
@@ -462,7 +455,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_protocol_pubkey(self, protocol_pubkey, proof_of_possession, ctx)
+        self.update_validator_next_epoch_protocol_pubkey(protocol_pubkey, proof_of_possession, ctx)
     }
 
     /// Update candidate validator's public key of protocol key and proof of possession.
@@ -473,7 +466,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_protocol_pubkey(self, protocol_pubkey, proof_of_possession, ctx)
+        self.update_candidate_validator_protocol_pubkey(protocol_pubkey, proof_of_possession, ctx)
     }
 
     /// Update a validator's public key of worker key.
@@ -484,7 +477,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_worker_pubkey(self, worker_pubkey, ctx)
+        self.update_validator_next_epoch_worker_pubkey(worker_pubkey, ctx)
     }
 
     /// Update candidate validator's public key of worker key.
@@ -494,7 +487,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_worker_pubkey(self, worker_pubkey, ctx)
+        self.update_candidate_validator_worker_pubkey(worker_pubkey, ctx)
     }
 
     /// Update a validator's public key of network key.
@@ -505,7 +498,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_validator_next_epoch_network_pubkey(self, network_pubkey, ctx)
+        self.update_validator_next_epoch_network_pubkey(network_pubkey, ctx)
     }
 
     /// Update candidate validator's public key of network key.
@@ -515,7 +508,7 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(self);
-        sui_system_state_inner::update_candidate_validator_network_pubkey(self, network_pubkey, ctx)
+        self.update_candidate_validator_network_pubkey(network_pubkey, ctx)
     }
 
     /// Getter of the pool token exchange rate of a staking pool. Works for both active and inactive pools.
@@ -524,13 +517,13 @@ module sui_system::sui_system {
         pool_id: &ID
     ): &Table<u64, PoolTokenExchangeRate>  {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::pool_exchange_rates(self, pool_id)
+        self.pool_exchange_rates(pool_id)
     }
 
     /// Getter returning addresses of the currently active validators.
     public fun active_validator_addresses(wrapper: &mut SuiSystemState): vector<address> {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::active_validator_addresses(self)
+        self.active_validator_addresses()
     }
 
     #[allow(unused_function)]
@@ -557,9 +550,8 @@ module sui_system::sui_system {
     ) : Balance<SUI> {
         let self = load_system_state_mut(wrapper);
         // Validator will make a special system call with sender set as 0x0.
-        assert!(tx_context::sender(ctx) == @0x0, ENotSystemAddress);
-        let storage_rebate = sui_system_state_inner::advance_epoch(
-            self,
+        assert!(ctx.sender() == @0x0, ENotSystemAddress);
+        let storage_rebate = self.advance_epoch(
             new_epoch,
             next_protocol_version,
             storage_reward,
@@ -585,14 +577,17 @@ module sui_system::sui_system {
 
     fun load_inner_maybe_upgrade(self: &mut SuiSystemState): &mut SuiSystemStateInnerV2 {
         if (self.version == 1) {
-          let v1 = dynamic_field::remove(&mut self.id, self.version);
-          let v2 = sui_system_state_inner::v1_to_v2(v1);
+          let v1: SuiSystemStateInner = dynamic_field::remove(&mut self.id, self.version);
+          let v2 = v1.v1_to_v2();
           self.version = 2;
           dynamic_field::add(&mut self.id, self.version, v2);
         };
 
-        let inner = dynamic_field::borrow_mut(&mut self.id, self.version);
-        assert!(sui_system_state_inner::system_state_version(inner) == self.version, EWrongInnerVersion);
+        let inner: &mut SuiSystemStateInnerV2 = dynamic_field::borrow_mut(
+            &mut self.id,
+            self.version
+        );
+        assert!(inner.system_state_version() == self.version, EWrongInnerVersion);
         inner
     }
 
@@ -601,14 +596,14 @@ module sui_system::sui_system {
     /// since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
     public fun epoch(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::epoch(self)
+        self.epoch()
     }
 
     #[test_only]
     /// Returns unix timestamp of the start of current epoch
     public fun epoch_start_timestamp_ms(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::epoch_start_timestamp_ms(self)
+        self.epoch_start_timestamp_ms()
     }
 
     #[test_only]
@@ -616,7 +611,7 @@ module sui_system::sui_system {
     /// Aborts if `validator_addr` is not an active validator.
     public fun validator_stake_amount(wrapper: &mut SuiSystemState, validator_addr: address): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::validator_stake_amount(self, validator_addr)
+        self.validator_stake_amount(validator_addr)
     }
 
     #[test_only]
@@ -624,52 +619,52 @@ module sui_system::sui_system {
     /// Aborts if `validator_addr` is not an active validator.
     public fun validator_staking_pool_id(wrapper: &mut SuiSystemState, validator_addr: address): ID {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::validator_staking_pool_id(self, validator_addr)
+        self.validator_staking_pool_id(validator_addr)
     }
 
     #[test_only]
     /// Returns reference to the staking pool mappings that map pool ids to active validator addresses
     public fun validator_staking_pool_mappings(wrapper: &mut SuiSystemState): &Table<ID, address> {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::validator_staking_pool_mappings(self)
+        self.validator_staking_pool_mappings()
     }
 
     #[test_only]
     /// Returns all the validators who are currently reporting `addr`
     public fun get_reporters_of(wrapper: &mut SuiSystemState, addr: address): VecSet<address> {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::get_reporters_of(self, addr)
+        self.get_reporters_of(addr)
     }
 
     #[test_only]
     /// Return the current validator set
     public fun validators(wrapper: &mut SuiSystemState): &ValidatorSet {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::validators(self)
+        self.validators()
     }
 
     #[test_only]
     /// Return the currently active validator by address
     public fun active_validator_by_address(self: &mut SuiSystemState, validator_address: address): &Validator {
-        validator_set::get_active_validator_ref(validators(self), validator_address)
+        validators(self).get_active_validator_ref(validator_address)
     }
 
     #[test_only]
     /// Return the currently pending validator by address
     public fun pending_validator_by_address(self: &mut SuiSystemState, validator_address: address): &Validator {
-        validator_set::get_pending_validator_ref(validators(self), validator_address)
+        validators(self).get_pending_validator_ref(validator_address)
     }
 
     #[test_only]
     /// Return the currently candidate validator by address
     public fun candidate_validator_by_address(self: &mut SuiSystemState, validator_address: address): &Validator {
-        validator_set::get_candidate_validator_ref(validators(self), validator_address)
+        validators(self).get_candidate_validator_ref(validator_address)
     }
 
     #[test_only]
     public fun set_epoch_for_testing(wrapper: &mut SuiSystemState, epoch_num: u64) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::set_epoch_for_testing(self, epoch_num)
+        self.set_epoch_for_testing(epoch_num)
     }
 
     #[test_only]
@@ -679,25 +674,25 @@ module sui_system::sui_system {
         ctx: &TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_validator_for_testing(self, min_joining_stake_for_testing, ctx)
+        self.request_add_validator_for_testing(min_joining_stake_for_testing, ctx)
     }
 
     #[test_only]
     public fun get_storage_fund_total_balance(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::get_storage_fund_total_balance(self)
+        self.get_storage_fund_total_balance()
     }
 
     #[test_only]
     public fun get_storage_fund_object_rebates(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::get_storage_fund_object_rebates(self)
+        self.get_storage_fund_object_rebates()
     }
 
     #[test_only]
     public fun get_stake_subsidy_distribution_counter(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
-        sui_system_state_inner::get_stake_subsidy_distribution_counter(self)
+        self.get_stake_subsidy_distribution_counter()
     }
 
     // CAUTION: THIS CODE IS ONLY FOR TESTING AND THIS MACRO MUST NEVER EVER BE REMOVED.  Creates a
@@ -723,8 +718,7 @@ module sui_system::sui_system {
         ctx: &mut TxContext,
     ) {
         let self = load_system_state_mut(wrapper);
-        sui_system_state_inner::request_add_validator_candidate_for_testing(
-            self,
+        self.request_add_validator_candidate_for_testing(
             pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -3,23 +3,17 @@
 
 module sui_system::sui_system_state_inner {
     use sui::balance::{Self, Balance};
-    use sui::coin::{Self, Coin};
-    use sui::object::{ID};
+    use sui::coin::Coin;
     use sui_system::staking_pool::{stake_activation_epoch, StakedSui};
     use sui::sui::SUI;
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
     use sui_system::validator::{Self, Validator};
     use sui_system::validator_set::{Self, ValidatorSet};
-    use sui_system::validator_cap::{Self, UnverifiedValidatorOperationCap, ValidatorOperationCap};
-    use sui_system::stake_subsidy::{Self, StakeSubsidy};
+    use sui_system::validator_cap::{UnverifiedValidatorOperationCap, ValidatorOperationCap};
+    use sui_system::stake_subsidy::StakeSubsidy;
     use sui_system::storage_fund::{Self, StorageFund};
     use sui_system::staking_pool::PoolTokenExchangeRate;
     use sui::vec_map::{Self, VecMap};
     use sui::vec_set::{Self, VecSet};
-    use std::option;
-    use std::vector;
-    use sui::pay;
     use sui::event;
     use sui::table::Table;
     use sui::bag::Bag;
@@ -246,7 +240,7 @@ module sui_system::sui_system_state_inner {
         ctx: &mut TxContext,
     ): SuiSystemStateInner {
         let validators = validator_set::new(validators, ctx);
-        let reference_gas_price = validator_set::derive_reference_gas_price(&validators);
+        let reference_gas_price = validators.derive_reference_gas_price();
         // This type is fixed as it's created at genesis. It should not be updated during type upgrade.
         let system_state = SuiSystemStateInner {
             epoch: 0,
@@ -379,7 +373,7 @@ module sui_system::sui_system_state_inner {
         ctx: &mut TxContext,
     ) {
         let validator = validator::new(
-            tx_context::sender(ctx),
+            ctx.sender(),
             pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,
@@ -397,7 +391,7 @@ module sui_system::sui_system_state_inner {
             ctx
         );
 
-        validator_set::request_add_validator_candidate(&mut self.validators, validator, ctx);
+        self.validators.request_add_validator_candidate(validator, ctx);
     }
 
     /// Called by a validator candidate to remove themselves from the candidacy. After this call
@@ -406,7 +400,7 @@ module sui_system::sui_system_state_inner {
         self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
-        validator_set::request_remove_validator_candidate(&mut self.validators, ctx);
+        self.validators.request_remove_validator_candidate(ctx);
     }
 
     /// Called by a validator candidate to add themselves to the active validator set beginning next epoch.
@@ -418,11 +412,11 @@ module sui_system::sui_system_state_inner {
         ctx: &TxContext,
     ) {
         assert!(
-            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_count,
+            self.validators.next_epoch_validator_count() < self.parameters.max_validator_count,
             ELimitExceeded,
         );
 
-        validator_set::request_add_validator(&mut self.validators, self.parameters.min_validator_joining_stake, ctx);
+        self.validators.request_add_validator(self.parameters.min_validator_joining_stake, ctx);
     }
 
     /// A validator can call this function to request a removal in the next epoch.
@@ -437,17 +431,14 @@ module sui_system::sui_system_state_inner {
         // Only check min validator condition if the current number of validators satisfy the constraint.
         // This is so that if we somehow already are in a state where we have less than min validators, it no longer matters
         // and is ok to stay so. This is useful for a test setup.
-        if (vector::length(validator_set::active_validators(&self.validators)) >= self.parameters.min_validator_count) {
+        if (self.validators.active_validators().length() >= self.parameters.min_validator_count) {
             assert!(
-                validator_set::next_epoch_validator_count(&self.validators) > self.parameters.min_validator_count,
+                self.validators.next_epoch_validator_count() > self.parameters.min_validator_count,
                 ELimitExceeded,
             );
         };
 
-        validator_set::request_remove_validator(
-            &mut self.validators,
-            ctx,
-        )
+        self.validators.request_remove_validator(ctx)
     }
 
     /// A validator can call this function to submit a new gas price quote, to be
@@ -458,10 +449,10 @@ module sui_system::sui_system_state_inner {
         new_gas_price: u64,
     ) {
         // Verify the represented address is an active or pending validator, and the capability is still valid.
-        let verified_cap = validator_set::verify_cap(&mut self.validators, cap, ACTIVE_OR_PENDING_VALIDATOR);
-        let validator = validator_set::get_validator_mut_with_verified_cap(&mut self.validators, &verified_cap, false /* include_candidate */);
+        let verified_cap = self.validators.verify_cap(cap, ACTIVE_OR_PENDING_VALIDATOR);
+        let validator = self.validators.get_validator_mut_with_verified_cap(&verified_cap, false /* include_candidate */);
 
-        validator::request_set_gas_price(validator, verified_cap, new_gas_price);
+        validator.request_set_gas_price(verified_cap, new_gas_price);
     }
 
     /// This function is used to set new gas price for candidate validators
@@ -471,9 +462,9 @@ module sui_system::sui_system_state_inner {
         new_gas_price: u64,
     ) {
         // Verify the represented address is an active or pending validator, and the capability is still valid.
-        let verified_cap = validator_set::verify_cap(&mut self.validators, cap, ANY_VALIDATOR);
-        let candidate = validator_set::get_validator_mut_with_verified_cap(&mut self.validators, &verified_cap, true /* include_candidate */);
-        validator::set_candidate_gas_price(candidate, verified_cap, new_gas_price)
+        let verified_cap = self.validators.verify_cap(cap, ANY_VALIDATOR);
+        let candidate = self.validators.get_validator_mut_with_verified_cap(&verified_cap, true /* include_candidate */);
+        candidate.set_candidate_gas_price(verified_cap, new_gas_price)
     }
 
     /// A validator can call this function to set a new commission rate, updated at the end of
@@ -483,8 +474,7 @@ module sui_system::sui_system_state_inner {
         new_commission_rate: u64,
         ctx: &TxContext,
     ) {
-        validator_set::request_set_commission_rate(
-            &mut self.validators,
+        self.validators.request_set_commission_rate(
             new_commission_rate,
             ctx
         )
@@ -496,8 +486,8 @@ module sui_system::sui_system_state_inner {
         new_commission_rate: u64,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::set_candidate_commission_rate(candidate, new_commission_rate)
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.set_candidate_commission_rate(new_commission_rate)
     }
 
     /// Add stake to a validator's staking pool.
@@ -507,10 +497,9 @@ module sui_system::sui_system_state_inner {
         validator_address: address,
         ctx: &mut TxContext,
     ) : StakedSui {
-        validator_set::request_add_stake(
-            &mut self.validators,
+        self.validators.request_add_stake(
             validator_address,
-            coin::into_balance(stake),
+            stake.into_balance(),
             ctx,
         )
     }
@@ -524,7 +513,7 @@ module sui_system::sui_system_state_inner {
         ctx: &mut TxContext,
     ) : StakedSui {
         let balance = extract_coin_balance(stakes, stake_amount, ctx);
-        validator_set::request_add_stake(&mut self.validators, validator_address, balance, ctx)
+        self.validators.request_add_stake(validator_address, balance, ctx)
     }
 
     /// Withdraw some portion of a stake from a validator's staking pool.
@@ -534,12 +523,10 @@ module sui_system::sui_system_state_inner {
         ctx: &TxContext,
     ) : Balance<SUI> {
         assert!(
-            stake_activation_epoch(&staked_sui) <= tx_context::epoch(ctx),
+            stake_activation_epoch(&staked_sui) <= ctx.epoch(),
             EStakeWithdrawBeforeActivation
         );
-        validator_set::request_withdraw_stake(
-            &mut self.validators, staked_sui, ctx,
-        )
+        self.validators.request_withdraw_stake(staked_sui, ctx)
     }
 
     /// Report a validator as a bad or non-performant actor in the system.
@@ -554,9 +541,9 @@ module sui_system::sui_system_state_inner {
         reportee_addr: address,
     ) {
         // Reportee needs to be an active validator
-        assert!(validator_set::is_active_validator_by_sui_address(&self.validators, reportee_addr), ENotValidator);
+        assert!(self.validators.is_active_validator_by_sui_address(reportee_addr), ENotValidator);
         // Verify the represented reporter address is an active validator, and the capability is still valid.
-        let verified_cap = validator_set::verify_cap(&mut self.validators, cap, ACTIVE_VALIDATOR_ONLY);
+        let verified_cap = self.validators.verify_cap(cap, ACTIVE_VALIDATOR_ONLY);
         report_validator_impl(verified_cap, reportee_addr, &mut self.validator_report_records);
     }
 
@@ -570,7 +557,7 @@ module sui_system::sui_system_state_inner {
         cap: &UnverifiedValidatorOperationCap,
         reportee_addr: address,
     ) {
-        let verified_cap = validator_set::verify_cap(&mut self.validators, cap, ACTIVE_VALIDATOR_ONLY);
+        let verified_cap = self.validators.verify_cap(cap, ACTIVE_VALIDATOR_ONLY);
         undo_report_validator_impl(verified_cap, reportee_addr, &mut self.validator_report_records);
     }
 
@@ -579,14 +566,14 @@ module sui_system::sui_system_state_inner {
         reportee_addr: address,
         validator_report_records: &mut VecMap<address, VecSet<address>>,
     ) {
-        let reporter_address = *validator_cap::verified_operation_cap_address(&verified_cap);
+        let reporter_address = *verified_cap.verified_operation_cap_address();
         assert!(reporter_address != reportee_addr, ECannotReportOneself);
-        if (!vec_map::contains(validator_report_records, &reportee_addr)) {
-            vec_map::insert(validator_report_records, reportee_addr, vec_set::singleton(reporter_address));
+        if (!validator_report_records.contains(&reportee_addr)) {
+            validator_report_records.insert(reportee_addr, vec_set::singleton(reporter_address));
         } else {
-            let reporters = vec_map::get_mut(validator_report_records, &reportee_addr);
-            if (!vec_set::contains(reporters, &reporter_address)) {
-                vec_set::insert(reporters, reporter_address);
+            let reporters = validator_report_records.get_mut(&reportee_addr);
+            if (!reporters.contains(&reporter_address)) {
+                reporters.insert(reporter_address);
             }
         }
     }
@@ -596,15 +583,15 @@ module sui_system::sui_system_state_inner {
         reportee_addr: address,
         validator_report_records: &mut VecMap<address, VecSet<address>>,
     ) {
-        assert!(vec_map::contains(validator_report_records, &reportee_addr), EReportRecordNotFound);
-        let reporters = vec_map::get_mut(validator_report_records, &reportee_addr);
+        assert!(validator_report_records.contains(&reportee_addr), EReportRecordNotFound);
+        let reporters = validator_report_records.get_mut(&reportee_addr);
 
-        let reporter_addr = *validator_cap::verified_operation_cap_address(&verified_cap);
-        assert!(vec_set::contains(reporters, &reporter_addr), EReportRecordNotFound);
+        let reporter_addr = *verified_cap.verified_operation_cap_address();
+        assert!(reporters.contains(&reporter_addr), EReportRecordNotFound);
 
-        vec_set::remove(reporters, &reporter_addr);
-        if (vec_set::is_empty(reporters)) {
-            vec_map::remove(validator_report_records, &reportee_addr);
+        reporters.remove(&reporter_addr);
+        if (reporters.is_empty()) {
+            validator_report_records.remove(&reportee_addr);
         }
     }
 
@@ -616,8 +603,8 @@ module sui_system::sui_system_state_inner {
         self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::new_unverified_validator_operation_cap_and_transfer(validator, ctx);
+        let validator = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        validator.new_unverified_validator_operation_cap_and_transfer(ctx);
     }
 
     /// Update a validator's name.
@@ -626,9 +613,9 @@ module sui_system::sui_system_state_inner {
         name: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
+        let validator = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
 
-        validator::update_name(validator, name);
+        validator.update_name(name);
     }
 
     /// Update a validator's description
@@ -637,8 +624,8 @@ module sui_system::sui_system_state_inner {
         description: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_description(validator, description);
+        let validator = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        validator.update_description(description);
     }
 
     /// Update a validator's image url
@@ -647,8 +634,8 @@ module sui_system::sui_system_state_inner {
         image_url: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_image_url(validator, image_url);
+        let validator = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        validator.update_image_url(image_url);
     }
 
     /// Update a validator's project url
@@ -657,8 +644,8 @@ module sui_system::sui_system_state_inner {
         project_url: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_project_url(validator, project_url);
+        let validator = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        validator.update_project_url(project_url);
     }
 
     /// Update a validator's network address.
@@ -668,10 +655,10 @@ module sui_system::sui_system_state_inner {
         network_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_network_address(validator, network_address);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_network_address(network_address);
         let validator :&Validator = validator; // Force immutability for the following call
-        validator_set::assert_no_pending_or_active_duplicates(&self.validators, validator);
+        self.validators.assert_no_pending_or_active_duplicates(validator);
     }
 
     /// Update candidate validator's network address.
@@ -680,8 +667,8 @@ module sui_system::sui_system_state_inner {
         network_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_network_address(candidate, network_address);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_network_address(network_address);
     }
 
     /// Update a validator's p2p address.
@@ -691,10 +678,10 @@ module sui_system::sui_system_state_inner {
         p2p_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_p2p_address(validator, p2p_address);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_p2p_address(p2p_address);
         let validator :&Validator = validator; // Force immutability for the following call
-        validator_set::assert_no_pending_or_active_duplicates(&self.validators, validator);
+        self.validators.assert_no_pending_or_active_duplicates(validator);
     }
 
     /// Update candidate validator's p2p address.
@@ -703,8 +690,8 @@ module sui_system::sui_system_state_inner {
         p2p_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_p2p_address(candidate, p2p_address);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_p2p_address(p2p_address);
     }
 
     /// Update a validator's narwhal primary address.
@@ -714,8 +701,8 @@ module sui_system::sui_system_state_inner {
         primary_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_primary_address(validator, primary_address);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_primary_address(primary_address);
     }
 
     /// Update candidate validator's narwhal primary address.
@@ -724,8 +711,8 @@ module sui_system::sui_system_state_inner {
         primary_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_primary_address(candidate, primary_address);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_primary_address(primary_address);
     }
 
     /// Update a validator's narwhal worker address.
@@ -735,8 +722,8 @@ module sui_system::sui_system_state_inner {
         worker_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_worker_address(validator, worker_address);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_worker_address(worker_address);
     }
 
     /// Update candidate validator's narwhal worker address.
@@ -745,8 +732,8 @@ module sui_system::sui_system_state_inner {
         worker_address: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_worker_address(candidate, worker_address);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_worker_address(worker_address);
     }
 
     /// Update a validator's public key of protocol key and proof of possession.
@@ -757,10 +744,10 @@ module sui_system::sui_system_state_inner {
         proof_of_possession: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_protocol_pubkey(validator, protocol_pubkey, proof_of_possession);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_protocol_pubkey(protocol_pubkey, proof_of_possession);
         let validator :&Validator = validator; // Force immutability for the following call
-        validator_set::assert_no_pending_or_active_duplicates(&self.validators, validator);
+        self.validators.assert_no_pending_or_active_duplicates(validator);
     }
 
     /// Update candidate validator's public key of protocol key and proof of possession.
@@ -770,8 +757,8 @@ module sui_system::sui_system_state_inner {
         proof_of_possession: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_protocol_pubkey(candidate, protocol_pubkey, proof_of_possession);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_protocol_pubkey(protocol_pubkey, proof_of_possession);
     }
 
     /// Update a validator's public key of worker key.
@@ -781,10 +768,10 @@ module sui_system::sui_system_state_inner {
         worker_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_worker_pubkey(validator, worker_pubkey);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_worker_pubkey(worker_pubkey);
         let validator :&Validator = validator; // Force immutability for the following call
-        validator_set::assert_no_pending_or_active_duplicates(&self.validators, validator);
+        self.validators.assert_no_pending_or_active_duplicates(validator);
     }
 
     /// Update candidate validator's public key of worker key.
@@ -793,8 +780,8 @@ module sui_system::sui_system_state_inner {
         worker_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_worker_pubkey(candidate, worker_pubkey);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_worker_pubkey(worker_pubkey);
     }
 
     /// Update a validator's public key of network key.
@@ -804,10 +791,10 @@ module sui_system::sui_system_state_inner {
         network_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
-        let validator = validator_set::get_validator_mut_with_ctx(&mut self.validators, ctx);
-        validator::update_next_epoch_network_pubkey(validator, network_pubkey);
+        let validator = self.validators.get_validator_mut_with_ctx(ctx);
+        validator.update_next_epoch_network_pubkey(network_pubkey);
         let validator :&Validator = validator; // Force immutability for the following call
-        validator_set::assert_no_pending_or_active_duplicates(&self.validators, validator);
+        self.validators.assert_no_pending_or_active_duplicates(validator);
     }
 
     /// Update candidate validator's public key of network key.
@@ -816,8 +803,8 @@ module sui_system::sui_system_state_inner {
         network_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
-        let candidate = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
-        validator::update_candidate_network_pubkey(candidate, network_pubkey);
+        let candidate = self.validators.get_validator_mut_with_ctx_including_candidates(ctx);
+        candidate.update_candidate_network_pubkey(network_pubkey);
     }
 
     /// This function should be called at the end of an epoch, and advances the system to the next epoch.
@@ -858,46 +845,45 @@ module sui_system::sui_system_state_inner {
         };
 
         // Accumulate the gas summary during safe_mode before processing any rewards:
-        let safe_mode_storage_rewards = balance::withdraw_all(&mut self.safe_mode_storage_rewards);
-        balance::join(&mut storage_reward, safe_mode_storage_rewards);
-        let safe_mode_computation_rewards = balance::withdraw_all(&mut self.safe_mode_computation_rewards);
-        balance::join(&mut computation_reward, safe_mode_computation_rewards);
+        let safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();
+        storage_reward.join(safe_mode_storage_rewards);
+        let safe_mode_computation_rewards = self.safe_mode_computation_rewards.withdraw_all();
+        computation_reward.join(safe_mode_computation_rewards);
         storage_rebate_amount = storage_rebate_amount + self.safe_mode_storage_rebates;
         self.safe_mode_storage_rebates = 0;
         non_refundable_storage_fee_amount = non_refundable_storage_fee_amount + self.safe_mode_non_refundable_storage_fee;
         self.safe_mode_non_refundable_storage_fee = 0;
 
-        let total_validators_stake = validator_set::total_stake(&self.validators);
-        let storage_fund_balance = storage_fund::total_balance(&self.storage_fund);
+        let total_validators_stake = self.validators.total_stake();
+        let storage_fund_balance = self.storage_fund.total_balance();
         let total_stake = storage_fund_balance + total_validators_stake;
 
-        let storage_charge = balance::value(&storage_reward);
-        let computation_charge = balance::value(&computation_reward);
+        let storage_charge = storage_reward.value();
+        let computation_charge = computation_reward.value();
 
         // Include stake subsidy in the rewards given out to validators and stakers.
         // Delay distributing any stake subsidies until after `stake_subsidy_start_epoch`.
         // And if this epoch is shorter than the regular epoch duration, don't distribute any stake subsidy.
         let stake_subsidy =
-            if (tx_context::epoch(ctx) >= self.parameters.stake_subsidy_start_epoch  &&
+            if (ctx.epoch() >= self.parameters.stake_subsidy_start_epoch  &&
                 epoch_start_timestamp_ms >= prev_epoch_start_timestamp + self.parameters.epoch_duration_ms)
             {
-                stake_subsidy::advance_epoch(&mut self.stake_subsidy)
+                self.stake_subsidy.advance_epoch()
             } else {
                 balance::zero()
             };
 
-        let stake_subsidy_amount = balance::value(&stake_subsidy);
-        balance::join(&mut computation_reward, stake_subsidy);
+        let stake_subsidy_amount = stake_subsidy.value();
+        computation_reward.join(stake_subsidy);
 
         let total_stake_u128 = (total_stake as u128);
         let computation_charge_u128 = (computation_charge as u128);
 
         let storage_fund_reward_amount = (storage_fund_balance as u128) * computation_charge_u128 / total_stake_u128;
-        let mut storage_fund_reward = balance::split(&mut computation_reward, (storage_fund_reward_amount as u64));
+        let mut storage_fund_reward = computation_reward.split((storage_fund_reward_amount as u64));
         let storage_fund_reinvestment_amount =
             storage_fund_reward_amount * (storage_fund_reinvest_rate as u128) / BASIS_POINT_DENOMINATOR;
-        let storage_fund_reinvestment = balance::split(
-            &mut storage_fund_reward,
+        let storage_fund_reinvestment = storage_fund_reward.split(
             (storage_fund_reinvestment_amount as u64),
         );
 
@@ -905,11 +891,10 @@ module sui_system::sui_system_state_inner {
         // Sanity check to make sure we are advancing to the right epoch.
         assert!(new_epoch == self.epoch, EAdvancedToWrongEpoch);
 
-        let computation_reward_amount_before_distribution = balance::value(&computation_reward);
-        let storage_fund_reward_amount_before_distribution = balance::value(&storage_fund_reward);
+        let computation_reward_amount_before_distribution = computation_reward.value();
+        let storage_fund_reward_amount_before_distribution = storage_fund_reward.value();
 
-        validator_set::advance_epoch(
-            &mut self.validators,
+        self.validators.advance_epoch(
             &mut computation_reward,
             &mut storage_fund_reward,
             &mut self.validator_report_records,
@@ -920,27 +905,26 @@ module sui_system::sui_system_state_inner {
             ctx,
         );
 
-        let new_total_stake = validator_set::total_stake(&self.validators);
+        let new_total_stake = self.validators.total_stake();
 
-        let computation_reward_amount_after_distribution = balance::value(&computation_reward);
-        let storage_fund_reward_amount_after_distribution = balance::value(&storage_fund_reward);
+        let computation_reward_amount_after_distribution = computation_reward.value();
+        let storage_fund_reward_amount_after_distribution = storage_fund_reward.value();
         let computation_reward_distributed = computation_reward_amount_before_distribution - computation_reward_amount_after_distribution;
         let storage_fund_reward_distributed = storage_fund_reward_amount_before_distribution - storage_fund_reward_amount_after_distribution;
 
         self.protocol_version = next_protocol_version;
 
         // Derive the reference gas price for the new epoch
-        self.reference_gas_price = validator_set::derive_reference_gas_price(&self.validators);
+        self.reference_gas_price = self.validators.derive_reference_gas_price();
         // Because of precision issues with integer divisions, we expect that there will be some
         // remaining balance in `storage_fund_reward` and `computation_reward`.
         // All of these go to the storage fund.
         let mut leftover_staking_rewards = storage_fund_reward;
-        balance::join(&mut leftover_staking_rewards, computation_reward);
-        let leftover_storage_fund_inflow = balance::value(&leftover_staking_rewards);
+        leftover_staking_rewards.join(computation_reward);
+        let leftover_storage_fund_inflow = leftover_staking_rewards.value();
 
         let refunded_storage_rebate =
-            storage_fund::advance_epoch(
-                &mut self.storage_fund,
+            self.storage_fund.advance_epoch(
                 storage_reward,
                 storage_fund_reinvestment,
                 leftover_staking_rewards,
@@ -957,7 +941,7 @@ module sui_system::sui_system_state_inner {
                 storage_charge,
                 storage_fund_reinvestment: (storage_fund_reinvestment_amount as u64),
                 storage_rebate: storage_rebate_amount,
-                storage_fund_balance: storage_fund::total_balance(&self.storage_fund),
+                storage_fund_balance: self.storage_fund.total_balance(),
                 stake_subsidy_amount,
                 total_gas_fees: computation_charge,
                 total_stake_rewards_distributed: computation_reward_distributed + storage_fund_reward_distributed,
@@ -967,8 +951,8 @@ module sui_system::sui_system_state_inner {
         self.safe_mode = false;
         // Double check that the gas from safe mode has been processed.
         assert!(self.safe_mode_storage_rebates == 0
-            && balance::value(&self.safe_mode_storage_rewards) == 0
-            && balance::value(&self.safe_mode_computation_rewards) == 0, ESafeModeGasNotProcessed);
+            && self.safe_mode_storage_rewards.value() == 0
+            && self.safe_mode_computation_rewards.value() == 0, ESafeModeGasNotProcessed);
 
         // Return the storage rebate split from storage fund that's already refunded to the transaction senders.
         // This will be burnt at the last step of epoch change programmable transaction.
@@ -1003,38 +987,38 @@ module sui_system::sui_system_state_inner {
     /// Returns the total amount staked with `validator_addr`.
     /// Aborts if `validator_addr` is not an active validator.
     public(package) fun validator_stake_amount(self: &SuiSystemStateInnerV2, validator_addr: address): u64 {
-        validator_set::validator_total_stake_amount(&self.validators, validator_addr)
+        self.validators.validator_total_stake_amount(validator_addr)
     }
 
     /// Returns the staking pool id of a given validator.
     /// Aborts if `validator_addr` is not an active validator.
     public(package) fun validator_staking_pool_id(self: &SuiSystemStateInnerV2, validator_addr: address): ID {
 
-        validator_set::validator_staking_pool_id(&self.validators, validator_addr)
+        self.validators.validator_staking_pool_id(validator_addr)
     }
 
     /// Returns reference to the staking pool mappings that map pool ids to active validator addresses
     public(package) fun validator_staking_pool_mappings(self: &SuiSystemStateInnerV2): &Table<ID, address> {
 
-        validator_set::staking_pool_mappings(&self.validators)
+        self.validators.staking_pool_mappings()
     }
 
     /// Returns all the validators who are currently reporting `addr`
     public(package) fun get_reporters_of(self: &SuiSystemStateInnerV2, addr: address): VecSet<address> {
 
-        if (vec_map::contains(&self.validator_report_records, &addr)) {
-            *vec_map::get(&self.validator_report_records, &addr)
+        if (self.validator_report_records.contains(&addr)) {
+            self.validator_report_records[&addr]
         } else {
             vec_set::empty()
         }
     }
 
     public(package) fun get_storage_fund_total_balance(self: &SuiSystemStateInnerV2): u64 {
-        storage_fund::total_balance(&self.storage_fund)
+        self.storage_fund.total_balance()
     }
 
     public(package) fun get_storage_fund_object_rebates(self: &SuiSystemStateInnerV2): u64 {
-        storage_fund::total_object_storage_rebates(&self.storage_fund)
+        self.storage_fund.total_object_storage_rebates()
     }
 
     public(package) fun pool_exchange_rates(
@@ -1042,30 +1026,30 @@ module sui_system::sui_system_state_inner {
         pool_id: &ID
     ): &Table<u64, PoolTokenExchangeRate>  {
         let validators = &mut self.validators;
-        validator_set::pool_exchange_rates(validators, pool_id)
+        validators.pool_exchange_rates(pool_id)
     }
 
     public(package) fun active_validator_addresses(self: &SuiSystemStateInnerV2): vector<address> {
         let validator_set = &self.validators;
-        validator_set::active_validator_addresses(validator_set)
+        validator_set.active_validator_addresses()
     }
 
     #[allow(lint(self_transfer))]
     /// Extract required Balance from vector of Coin<SUI>, transfer the remainder back to sender.
     fun extract_coin_balance(mut coins: vector<Coin<SUI>>, amount: option::Option<u64>, ctx: &mut TxContext): Balance<SUI> {
-        let mut merged_coin = vector::pop_back(&mut coins);
-        pay::join_vec(&mut merged_coin, coins);
+        let mut merged_coin = coins.pop_back();
+        merged_coin.join_vec(coins);
 
-        let mut total_balance = coin::into_balance(merged_coin);
+        let mut total_balance = merged_coin.into_balance();
         // return the full amount if amount is not specified
-        if (option::is_some(&amount)) {
-            let amount = option::destroy_some(amount);
-            let balance = balance::split(&mut total_balance, amount);
+        if (amount.is_some()) {
+            let amount = amount.destroy_some();
+            let balance = total_balance.split(amount);
             // transfer back the remainder if non zero.
-            if (balance::value(&total_balance) > 0) {
-                transfer::public_transfer(coin::from_balance(total_balance, ctx), tx_context::sender(ctx));
+            if (total_balance.value() > 0) {
+                transfer::public_transfer(total_balance.into_coin(ctx), ctx.sender());
             } else {
-                balance::destroy_zero(total_balance);
+                total_balance.destroy_zero();
             };
             balance
         } else {
@@ -1082,24 +1066,24 @@ module sui_system::sui_system_state_inner {
     #[test_only]
     /// Return the currently active validator by address
     public(package) fun active_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
-        validator_set::get_active_validator_ref(validators(self), validator_address)
+        self.validators().get_active_validator_ref(validator_address)
     }
 
     #[test_only]
     /// Return the currently pending validator by address
     public(package) fun pending_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
-        validator_set::get_pending_validator_ref(validators(self), validator_address)
+        self.validators().get_pending_validator_ref(validator_address)
     }
 
     #[test_only]
     /// Return the currently candidate validator by address
     public(package) fun candidate_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
-        validator_set::get_candidate_validator_ref(validators(self), validator_address)
+        validators(self).get_candidate_validator_ref(validator_address)
     }
 
     #[test_only]
     public(package) fun get_stake_subsidy_distribution_counter(self: &SuiSystemStateInnerV2): u64 {
-        stake_subsidy::get_distribution_counter(&self.stake_subsidy)
+        self.stake_subsidy.get_distribution_counter()
     }
 
     #[test_only]
@@ -1114,11 +1098,11 @@ module sui_system::sui_system_state_inner {
         ctx: &TxContext,
     ) {
         assert!(
-            validator_set::next_epoch_validator_count(&self.validators) < self.parameters.max_validator_count,
+            self.validators.next_epoch_validator_count() < self.parameters.max_validator_count,
             ELimitExceeded,
         );
 
-        validator_set::request_add_validator(&mut self.validators, min_joining_stake_for_testing, ctx);
+        self.validators.request_add_validator(min_joining_stake_for_testing, ctx);
     }
 
     // CAUTION: THIS CODE IS ONLY FOR TESTING AND THIS MACRO MUST NEVER EVER BE REMOVED.  Creates a
@@ -1144,7 +1128,7 @@ module sui_system::sui_system_state_inner {
         ctx: &mut TxContext,
     ) {
         let validator = validator::new_for_testing(
-            tx_context::sender(ctx),
+            ctx.sender(),
             pubkey_bytes,
             network_pubkey_bytes,
             worker_pubkey_bytes,
@@ -1164,7 +1148,7 @@ module sui_system::sui_system_state_inner {
             ctx
         );
 
-        validator_set::request_add_validator_candidate(&mut self.validators, validator, ctx);
+        self.validators.request_add_validator_candidate(validator, ctx);
     }
 
 }

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -3,18 +3,13 @@
 
 #[allow(unused_const)]
 module sui_system::validator {
-    use std::ascii;
-    use std::vector;
     use std::bcs;
 
-    use sui::balance::{Self, Balance};
+    use sui::balance::Balance;
     use sui::sui::SUI;
-    use sui::tx_context::{Self, TxContext};
     use sui_system::validator_cap::{Self, ValidatorOperationCap};
-    use sui::object::{Self, ID};
-    use std::option::{Option, Self};
     use sui_system::staking_pool::{Self, PoolTokenExchangeRate, StakedSui, StakingPool};
-    use std::string::{Self, String};
+    use std::string::String;
     use sui::transfer;
     use sui::url::Url;
     use sui::url;
@@ -242,14 +237,14 @@ module sui_system::validator {
         ctx: &mut TxContext
     ): Validator {
         assert!(
-            vector::length(&net_address) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&p2p_address) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&primary_address) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&worker_address) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&name) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&description) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&image_url) <= MAX_VALIDATOR_METADATA_LENGTH
-                && vector::length(&project_url) <= MAX_VALIDATOR_METADATA_LENGTH,
+            net_address.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && p2p_address.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && primary_address.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && worker_address.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && name.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && description.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && image_url.length() <= MAX_VALIDATOR_METADATA_LENGTH
+                && project_url.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
         assert!(commission_rate <= MAX_COMMISSION_RATE, ECommissionRateTooHigh);
@@ -261,14 +256,14 @@ module sui_system::validator {
             network_pubkey_bytes,
             worker_pubkey_bytes,
             proof_of_possession,
-            string::from_ascii(ascii::string(name)),
-            string::from_ascii(ascii::string(description)),
+            name.to_ascii_string().to_string(),
+            description.to_ascii_string().to_string(),
             url::new_unsafe_from_bytes(image_url),
             url::new_unsafe_from_bytes(project_url),
-            string::from_ascii(ascii::string(net_address)),
-            string::from_ascii(ascii::string(p2p_address)),
-            string::from_ascii(ascii::string(primary_address)),
-            string::from_ascii(ascii::string(worker_address)),
+            net_address.to_ascii_string().to_string(),
+            p2p_address.to_ascii_string().to_string(),
+            primary_address.to_ascii_string().to_string(),
+            worker_address.to_ascii_string().to_string(),
             bag::new(ctx),
         );
 
@@ -285,11 +280,11 @@ module sui_system::validator {
 
     /// Deactivate this validator's staking pool
     public(package) fun deactivate(self: &mut Validator, deactivation_epoch: u64) {
-        staking_pool::deactivate_staking_pool(&mut self.staking_pool, deactivation_epoch)
+        self.staking_pool.deactivate_staking_pool(deactivation_epoch)
     }
 
     public(package) fun activate(self: &mut Validator, activation_epoch: u64) {
-        staking_pool::activate_staking_pool(&mut self.staking_pool, activation_epoch);
+        self.staking_pool.activate_staking_pool(activation_epoch);
     }
 
     /// Process pending stake and pending withdraws, and update the gas price.
@@ -305,15 +300,13 @@ module sui_system::validator {
         staker_address: address,
         ctx: &mut TxContext,
     ) : StakedSui {
-        let stake_amount = balance::value(&stake);
+        let stake_amount = stake.value();
         assert!(stake_amount > 0, EInvalidStakeAmount);
-        let stake_epoch = tx_context::epoch(ctx) + 1;
-        let staked_sui = staking_pool::request_add_stake(
-            &mut self.staking_pool, stake, stake_epoch, ctx
-        );
+        let stake_epoch = ctx.epoch() + 1;
+        let staked_sui = self.staking_pool.request_add_stake(stake, stake_epoch, ctx);
         // Process stake right away if staking pool is preactive.
-        if (staking_pool::is_preactive(&self.staking_pool)) {
-            staking_pool::process_pending_stake(&mut self.staking_pool);
+        if (self.staking_pool.is_preactive()) {
+            self.staking_pool.process_pending_stake();
         };
         self.next_epoch_stake = self.next_epoch_stake + stake_amount;
         event::emit(
@@ -321,7 +314,7 @@ module sui_system::validator {
                 pool_id: staking_pool_id(self),
                 validator_address: self.metadata.sui_address,
                 staker_address,
-                epoch: tx_context::epoch(ctx),
+                epoch: ctx.epoch(),
                 amount: stake_amount,
             }
         );
@@ -335,12 +328,11 @@ module sui_system::validator {
         staker_address: address,
         ctx: &mut TxContext,
     ) {
-        assert!(tx_context::epoch(ctx) == 0, ECalledDuringNonGenesis);
-        let stake_amount = balance::value(&stake);
+        assert!(ctx.epoch() == 0, ECalledDuringNonGenesis);
+        let stake_amount = stake.value();
         assert!(stake_amount > 0, EInvalidStakeAmount);
 
-        let staked_sui = staking_pool::request_add_stake(
-            &mut self.staking_pool,
+        let staked_sui = self.staking_pool.request_add_stake(
             stake,
             0, // epoch 0 -- genesis
             ctx
@@ -349,7 +341,7 @@ module sui_system::validator {
         transfer::public_transfer(staked_sui, staker_address);
 
         // Process stake right away
-        staking_pool::process_pending_stake(&mut self.staking_pool);
+        self.staking_pool.process_pending_stake();
         self.next_epoch_stake = self.next_epoch_stake + stake_amount;
     }
 
@@ -359,20 +351,19 @@ module sui_system::validator {
         staked_sui: StakedSui,
         ctx: &TxContext,
     ) : Balance<SUI> {
-        let principal_amount = staking_pool::staked_sui_amount(&staked_sui);
-        let stake_activation_epoch = staking_pool::stake_activation_epoch(&staked_sui);
-        let withdrawn_stake = staking_pool::request_withdraw_stake(
-                &mut self.staking_pool, staked_sui, ctx);
-        let withdraw_amount = balance::value(&withdrawn_stake);
+        let principal_amount = staked_sui.staked_sui_amount();
+        let stake_activation_epoch = staked_sui.stake_activation_epoch();
+        let withdrawn_stake = self.staking_pool.request_withdraw_stake(staked_sui, ctx);
+        let withdraw_amount = withdrawn_stake.value();
         let reward_amount = withdraw_amount - principal_amount;
         self.next_epoch_stake = self.next_epoch_stake - withdraw_amount;
         event::emit(
             UnstakingRequestEvent {
                 pool_id: staking_pool_id(self),
                 validator_address: self.metadata.sui_address,
-                staker_address: tx_context::sender(ctx),
+                staker_address: ctx.sender(),
                 stake_activation_epoch,
-                unstaking_epoch: tx_context::epoch(ctx),
+                unstaking_epoch: ctx.epoch(),
                 principal_amount,
                 reward_amount,
             }
@@ -388,7 +379,7 @@ module sui_system::validator {
         new_price: u64,
     ) {
         assert!(new_price < MAX_VALIDATOR_GAS_PRICE, EGasPriceHigherThanThreshold);
-        let validator_address = *validator_cap::verified_operation_cap_address(&verified_cap);
+        let validator_address = *verified_cap.verified_operation_cap_address();
         assert!(validator_address == self.metadata.sui_address, EInvalidCap);
         self.next_epoch_gas_price = new_price;
     }
@@ -401,7 +392,7 @@ module sui_system::validator {
     ) {
         assert!(is_preactive(self), ENotValidatorCandidate);
         assert!(new_price < MAX_VALIDATOR_GAS_PRICE, EGasPriceHigherThanThreshold);
-        let validator_address = *validator_cap::verified_operation_cap_address(&verified_cap);
+        let validator_address = *verified_cap.verified_operation_cap_address();
         assert!(validator_address == self.metadata.sui_address, EInvalidCap);
         self.next_epoch_gas_price = new_price;
         self.gas_price = new_price;
@@ -422,19 +413,19 @@ module sui_system::validator {
 
     /// Deposit stakes rewards into the validator's staking pool, called at the end of the epoch.
     public(package) fun deposit_stake_rewards(self: &mut Validator, reward: Balance<SUI>) {
-        self.next_epoch_stake = self.next_epoch_stake + balance::value(&reward);
-        staking_pool::deposit_rewards(&mut self.staking_pool, reward);
+        self.next_epoch_stake = self.next_epoch_stake + reward.value();
+        self.staking_pool.deposit_rewards(reward);
     }
 
     /// Process pending stakes and withdraws, called at the end of the epoch.
     public(package) fun process_pending_stakes_and_withdraws(self: &mut Validator, ctx: &TxContext) {
-        staking_pool::process_pending_stakes_and_withdraws(&mut self.staking_pool, ctx);
+        self.staking_pool.process_pending_stakes_and_withdraws(ctx);
         assert!(stake_amount(self) == self.next_epoch_stake, EInvalidStakeAmount);
     }
 
     /// Returns true if the validator is preactive.
     public fun is_preactive(self: &Validator): bool {
-        staking_pool::is_preactive(&self.staking_pool)
+        self.staking_pool.is_preactive()
     }
 
     public fun metadata(self: &Validator): &ValidatorMetadata {
@@ -536,11 +527,11 @@ module sui_system::validator {
     // TODO: this and `delegate_amount` and `total_stake` all seem to return the same value?
     // two of the functions can probably be removed.
     public fun total_stake_amount(self: &Validator): u64 {
-        staking_pool::sui_balance(&self.staking_pool)
+        self.staking_pool.sui_balance()
     }
 
     public fun stake_amount(self: &Validator): u64 {
-        staking_pool::sui_balance(&self.staking_pool)
+        self.staking_pool.sui_balance()
     }
 
     /// Return the total amount staked with this validator
@@ -559,11 +550,11 @@ module sui_system::validator {
     }
 
     public fun pending_stake_amount(self: &Validator): u64 {
-        staking_pool::pending_stake_amount(&self.staking_pool)
+        self.staking_pool.pending_stake_amount()
     }
 
     public fun pending_stake_withdraw_amount(self: &Validator): u64 {
-        staking_pool::pending_stake_withdraw_amount(&self.staking_pool)
+        self.staking_pool.pending_stake_withdraw_amount()
     }
 
     public fun gas_price(self: &Validator): u64 {
@@ -575,7 +566,7 @@ module sui_system::validator {
     }
 
     public fun pool_token_exchange_rate_at_epoch(self: &Validator, epoch: u64): PoolTokenExchangeRate {
-        staking_pool::pool_token_exchange_rate_at_epoch(&self.staking_pool, epoch)
+        self.staking_pool.pool_token_exchange_rate_at_epoch(epoch)
     }
 
     public fun staking_pool_id(self: &Validator): ID {
@@ -620,18 +611,18 @@ module sui_system::validator {
     }
 
     fun is_equal_some_and_value<T>(a: &Option<T>, b: &T): bool {
-        if (option::is_none(a)) {
+        if (a.is_none()) {
             false
         } else {
-            option::borrow(a) == b
+            a.borrow() == b
         }
     }
 
     fun is_equal_some<T>(a: &Option<T>, b: &Option<T>): bool {
-        if (option::is_none(a) || option::is_none(b)) {
+        if (a.is_none() || b.is_none()) {
             false
         } else {
-            option::borrow(a) == option::borrow(b)
+            a.borrow() == b.borrow()
         }
     }
 
@@ -640,7 +631,7 @@ module sui_system::validator {
     /// Create a new `UnverifiedValidatorOperationCap`, transfer to the validator,
     /// and registers it, thus revoking the previous cap's permission.
     public(package) fun new_unverified_validator_operation_cap_and_transfer(self: &mut Validator, ctx: &mut TxContext) {
-        let address = tx_context::sender(ctx);
+        let address = ctx.sender();
         assert!(address == self.metadata.sui_address, ENewCapNotCreatedByValidatorItself);
         let new_id = validator_cap::new_unverified_validator_operation_cap_and_transfer(address, ctx);
         self.operation_cap_id = new_id;
@@ -649,25 +640,25 @@ module sui_system::validator {
     /// Update name of the validator.
     public(package) fun update_name(self: &mut Validator, name: vector<u8>) {
         assert!(
-            vector::length(&name) <= MAX_VALIDATOR_METADATA_LENGTH,
+            name.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        self.metadata.name = string::from_ascii(ascii::string(name));
+        self.metadata.name = name.to_ascii_string().to_string();
     }
 
     /// Update description of the validator.
     public(package) fun update_description(self: &mut Validator, description: vector<u8>) {
         assert!(
-            vector::length(&description) <= MAX_VALIDATOR_METADATA_LENGTH,
+            description.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        self.metadata.description = string::from_ascii(ascii::string(description));
+        self.metadata.description = description.to_ascii_string().to_string();
     }
 
     /// Update image url of the validator.
     public(package) fun update_image_url(self: &mut Validator, image_url: vector<u8>) {
         assert!(
-            vector::length(&image_url) <= MAX_VALIDATOR_METADATA_LENGTH,
+            image_url.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
         self.metadata.image_url = url::new_unsafe_from_bytes(image_url);
@@ -676,7 +667,7 @@ module sui_system::validator {
     /// Update project url of the validator.
     public(package) fun update_project_url(self: &mut Validator, project_url: vector<u8>) {
         assert!(
-            vector::length(&project_url) <= MAX_VALIDATOR_METADATA_LENGTH,
+            project_url.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
         self.metadata.project_url = url::new_unsafe_from_bytes(project_url);
@@ -685,10 +676,10 @@ module sui_system::validator {
     /// Update network address of this validator, taking effects from next epoch
     public(package) fun update_next_epoch_network_address(self: &mut Validator, net_address: vector<u8>) {
         assert!(
-            vector::length(&net_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            net_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let net_address = string::from_ascii(ascii::string(net_address));
+        let net_address = net_address.to_ascii_string().to_string();
         self.metadata.next_epoch_net_address = option::some(net_address);
         validate_metadata(&self.metadata);
     }
@@ -697,10 +688,10 @@ module sui_system::validator {
     public(package) fun update_candidate_network_address(self: &mut Validator, net_address: vector<u8>) {
         assert!(is_preactive(self), ENotValidatorCandidate);
         assert!(
-            vector::length(&net_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            net_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let net_address = string::from_ascii(ascii::string(net_address));
+        let net_address = net_address.to_ascii_string().to_string();
         self.metadata.net_address = net_address;
         validate_metadata(&self.metadata);
     }
@@ -708,10 +699,10 @@ module sui_system::validator {
     /// Update p2p address of this validator, taking effects from next epoch
     public(package) fun update_next_epoch_p2p_address(self: &mut Validator, p2p_address: vector<u8>) {
         assert!(
-            vector::length(&p2p_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            p2p_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let p2p_address = string::from_ascii(ascii::string(p2p_address));
+        let p2p_address = p2p_address.to_ascii_string().to_string();
         self.metadata.next_epoch_p2p_address = option::some(p2p_address);
         validate_metadata(&self.metadata);
     }
@@ -720,10 +711,10 @@ module sui_system::validator {
     public(package) fun update_candidate_p2p_address(self: &mut Validator, p2p_address: vector<u8>) {
         assert!(is_preactive(self), ENotValidatorCandidate);
         assert!(
-            vector::length(&p2p_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            p2p_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let p2p_address = string::from_ascii(ascii::string(p2p_address));
+        let p2p_address = p2p_address.to_ascii_string().to_string();
         self.metadata.p2p_address = p2p_address;
         validate_metadata(&self.metadata);
     }
@@ -731,10 +722,10 @@ module sui_system::validator {
     /// Update primary address of this validator, taking effects from next epoch
     public(package) fun update_next_epoch_primary_address(self: &mut Validator, primary_address: vector<u8>) {
         assert!(
-            vector::length(&primary_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            primary_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let primary_address = string::from_ascii(ascii::string(primary_address));
+        let primary_address = primary_address.to_ascii_string().to_string();
         self.metadata.next_epoch_primary_address = option::some(primary_address);
         validate_metadata(&self.metadata);
     }
@@ -743,10 +734,10 @@ module sui_system::validator {
     public(package) fun update_candidate_primary_address(self: &mut Validator, primary_address: vector<u8>) {
         assert!(is_preactive(self), ENotValidatorCandidate);
         assert!(
-            vector::length(&primary_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            primary_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let primary_address = string::from_ascii(ascii::string(primary_address));
+        let primary_address = primary_address.to_ascii_string().to_string();
         self.metadata.primary_address = primary_address;
         validate_metadata(&self.metadata);
     }
@@ -754,10 +745,10 @@ module sui_system::validator {
     /// Update worker address of this validator, taking effects from next epoch
     public(package) fun update_next_epoch_worker_address(self: &mut Validator, worker_address: vector<u8>) {
         assert!(
-            vector::length(&worker_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            worker_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let worker_address = string::from_ascii(ascii::string(worker_address));
+        let worker_address = worker_address.to_ascii_string().to_string();
         self.metadata.next_epoch_worker_address = option::some(worker_address);
         validate_metadata(&self.metadata);
     }
@@ -766,10 +757,10 @@ module sui_system::validator {
     public(package) fun update_candidate_worker_address(self: &mut Validator, worker_address: vector<u8>) {
         assert!(is_preactive(self), ENotValidatorCandidate);
         assert!(
-            vector::length(&worker_address) <= MAX_VALIDATOR_METADATA_LENGTH,
+            worker_address.length() <= MAX_VALIDATOR_METADATA_LENGTH,
             EValidatorMetadataExceedingLengthLimit
         );
-        let worker_address = string::from_ascii(ascii::string(worker_address));
+        let worker_address = worker_address.to_ascii_string().to_string();
         self.metadata.worker_address = worker_address;
         validate_metadata(&self.metadata);
     }
@@ -819,40 +810,40 @@ module sui_system::validator {
     /// NOTE: this function SHOULD ONLY be called by validator_set when
     /// advancing an epoch.
     public(package) fun effectuate_staged_metadata(self: &mut Validator) {
-        if (option::is_some(next_epoch_network_address(self))) {
-            self.metadata.net_address = option::extract(&mut self.metadata.next_epoch_net_address);
+        if (next_epoch_network_address(self).is_some()) {
+            self.metadata.net_address = self.metadata.next_epoch_net_address.extract();
             self.metadata.next_epoch_net_address = option::none();
         };
 
-        if (option::is_some(next_epoch_p2p_address(self))) {
-            self.metadata.p2p_address = option::extract(&mut self.metadata.next_epoch_p2p_address);
+        if (next_epoch_p2p_address(self).is_some()) {
+            self.metadata.p2p_address = self.metadata.next_epoch_p2p_address.extract();
             self.metadata.next_epoch_p2p_address = option::none();
         };
 
-        if (option::is_some(next_epoch_primary_address(self))) {
-            self.metadata.primary_address = option::extract(&mut self.metadata.next_epoch_primary_address);
+        if (next_epoch_primary_address(self).is_some()) {
+            self.metadata.primary_address = self.metadata.next_epoch_primary_address.extract();
             self.metadata.next_epoch_primary_address = option::none();
         };
 
-        if (option::is_some(next_epoch_worker_address(self))) {
-            self.metadata.worker_address = option::extract(&mut self.metadata.next_epoch_worker_address);
+        if (next_epoch_worker_address(self).is_some()) {
+            self.metadata.worker_address = self.metadata.next_epoch_worker_address.extract();
             self.metadata.next_epoch_worker_address = option::none();
         };
 
-        if (option::is_some(next_epoch_protocol_pubkey_bytes(self))) {
-            self.metadata.protocol_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_protocol_pubkey_bytes);
+        if (next_epoch_protocol_pubkey_bytes(self).is_some()) {
+            self.metadata.protocol_pubkey_bytes = self.metadata.next_epoch_protocol_pubkey_bytes.extract();
             self.metadata.next_epoch_protocol_pubkey_bytes = option::none();
-            self.metadata.proof_of_possession = option::extract(&mut self.metadata.next_epoch_proof_of_possession);
+            self.metadata.proof_of_possession = self.metadata.next_epoch_proof_of_possession.extract();
             self.metadata.next_epoch_proof_of_possession = option::none();
         };
 
-        if (option::is_some(next_epoch_network_pubkey_bytes(self))) {
-            self.metadata.network_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_network_pubkey_bytes);
+        if (next_epoch_network_pubkey_bytes(self).is_some()) {
+            self.metadata.network_pubkey_bytes = self.metadata.next_epoch_network_pubkey_bytes.extract();
             self.metadata.next_epoch_network_pubkey_bytes = option::none();
         };
 
-        if (option::is_some(next_epoch_worker_pubkey_bytes(self))) {
-            self.metadata.worker_pubkey_bytes = option::extract(&mut self.metadata.next_epoch_worker_pubkey_bytes);
+        if (next_epoch_worker_pubkey_bytes(self).is_some()) {
+            self.metadata.worker_pubkey_bytes = self.metadata.next_epoch_worker_pubkey_bytes.extract();
             self.metadata.next_epoch_worker_pubkey_bytes = option::none();
         };
     }
@@ -931,14 +922,14 @@ module sui_system::validator {
                 network_pubkey_bytes,
                 worker_pubkey_bytes,
                 proof_of_possession,
-                string::from_ascii(ascii::string(name)),
-                string::from_ascii(ascii::string(description)),
+                name.to_ascii_string().to_string(),
+                description.to_ascii_string().to_string(),
                 url::new_unsafe_from_bytes(image_url),
                 url::new_unsafe_from_bytes(project_url),
-                string::from_ascii(ascii::string(net_address)),
-                string::from_ascii(ascii::string(p2p_address)),
-                string::from_ascii(ascii::string(primary_address)),
-                string::from_ascii(ascii::string(worker_address)),
+                net_address.to_ascii_string().to_string(),
+                p2p_address.to_ascii_string().to_string(),
+                primary_address.to_ascii_string().to_string(),
+                worker_address.to_ascii_string().to_string(),
                 bag::new(ctx),
             ),
             gas_price,
@@ -947,15 +938,15 @@ module sui_system::validator {
         );
 
         // Add the validator's starting stake to the staking pool if there exists one.
-        if (option::is_some(&initial_stake_option)) {
+        if (initial_stake_option.is_some()) {
             request_add_stake_at_genesis(
                 &mut validator,
-                option::extract(&mut initial_stake_option),
+                initial_stake_option.extract(),
                 sui_address, // give the stake to the validator
                 ctx
             );
         };
-        option::destroy_none(initial_stake_option);
+        initial_stake_option.destroy_none();
 
         if (is_active_at_genesis) {
             activate(&mut validator, 0);

--- a/crates/sui-framework/packages/sui-system/sources/validator_cap.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_cap.move
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::validator_cap {
-    use sui::object::{Self, ID, UID};
-    use sui::transfer;
-    use sui::tx_context::{Self, TxContext};
     /* friend sui_system::sui_system_state_inner; */
     /* friend sui_system::validator; */
     /* friend sui_system::validator_set; */
@@ -53,7 +50,7 @@ module sui_system::validator_cap {
         // This function needs to be called only by the validator itself, except
         // 1. in genesis where all valdiators are created by @0x0
         // 2. in tests where @0x0 could be used to simplify the setup
-        let sender_address = tx_context::sender(ctx);
+        let sender_address = ctx.sender();
         assert!(sender_address == @0x0 || sender_address == validator_address, 0);
 
         let operation_cap = UnverifiedValidatorOperationCap {

--- a/crates/sui-framework/packages/sui-system/sources/validator_set.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_set.move
@@ -2,23 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui_system::validator_set {
-    use std::option::{Self, Option};
-    use std::vector;
 
-    use sui::balance::{Self, Balance};
+    use sui::balance::Balance;
     use sui::sui::SUI;
-    use sui::tx_context::{Self, TxContext};
-    use sui_system::validator::{Self, Validator, staking_pool_id, sui_address};
+    use sui_system::validator::{Validator, staking_pool_id, sui_address};
     use sui_system::validator_cap::{Self, UnverifiedValidatorOperationCap, ValidatorOperationCap};
-    use sui_system::staking_pool::{Self, PoolTokenExchangeRate, StakedSui, pool_id};
-    use sui::object::{Self, ID};
+    use sui_system::staking_pool::{PoolTokenExchangeRate, StakedSui, pool_id};
     use sui::priority_queue as pq;
     use sui::vec_map::{Self, VecMap};
-    use sui::vec_set::{Self, VecSet};
+    use sui::vec_set::VecSet;
     use sui::table::{Self, Table};
     use sui::event;
     use sui::table_vec::{Self, TableVec};
-    use sui::transfer;
     use sui_system::voting_power;
     use sui_system::validator_wrapper::ValidatorWrapper;
     use sui_system::validator_wrapper;
@@ -152,18 +147,18 @@ module sui_system::validator_set {
     public(package) fun new(init_active_validators: vector<Validator>, ctx: &mut TxContext): ValidatorSet {
         let total_stake = calculate_total_stakes(&init_active_validators);
         let mut staking_pool_mappings = table::new(ctx);
-        let num_validators = vector::length(&init_active_validators);
+        let num_validators = init_active_validators.length();
         let mut i = 0;
         while (i < num_validators) {
-            let validator = vector::borrow(&init_active_validators, i);
-            table::add(&mut staking_pool_mappings, staking_pool_id(validator), sui_address(validator));
+            let validator = &init_active_validators[i];
+            staking_pool_mappings.add(staking_pool_id(validator), sui_address(validator));
             i = i + 1;
         };
         let mut validators = ValidatorSet {
             total_stake,
             active_validators: init_active_validators,
             pending_active_validators: table_vec::empty(ctx),
-            pending_removals: vector::empty(),
+            pending_removals: vector[],
             staking_pool_mappings,
             inactive_validators: table::new(ctx),
             validator_candidates: table::new(ctx),
@@ -191,16 +186,15 @@ module sui_system::validator_set {
         );
         let validator_address = sui_address(&validator);
         assert!(
-            !table::contains(&self.validator_candidates, validator_address),
+            !self.validator_candidates.contains(validator_address),
             EAlreadyValidatorCandidate
         );
 
-        assert!(validator::is_preactive(&validator), EValidatorNotCandidate);
+        assert!(validator.is_preactive(), EValidatorNotCandidate);
         // Add validator to the candidates mapping and the pool id mappings so that users can start
         // staking with this candidate.
-        table::add(&mut self.staking_pool_mappings, staking_pool_id(&validator), validator_address);
-        table::add(
-            &mut self.validator_candidates,
+        self.staking_pool_mappings.add(staking_pool_id(&validator), validator_address);
+        self.validator_candidates.add(
             sui_address(&validator),
             validator_wrapper::create_v1(validator, ctx),
         );
@@ -208,26 +202,25 @@ module sui_system::validator_set {
 
     /// Called by `sui_system` to remove a validator candidate, and move them to `inactive_validators`.
     public(package) fun request_remove_validator_candidate(self: &mut ValidatorSet, ctx: &mut TxContext) {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
          assert!(
-            table::contains(&self.validator_candidates, validator_address),
+            self.validator_candidates.contains(validator_address),
             ENotValidatorCandidate
         );
-        let wrapper = table::remove(&mut self.validator_candidates, validator_address);
-        let mut validator = validator_wrapper::destroy(wrapper);
-        assert!(validator::is_preactive(&validator), EValidatorNotCandidate);
+        let wrapper = self.validator_candidates.remove(validator_address);
+        let mut validator = wrapper.destroy();
+        assert!(validator.is_preactive(), EValidatorNotCandidate);
 
         let staking_pool_id = staking_pool_id(&validator);
 
         // Remove the validator's staking pool from mappings.
-        table::remove(&mut self.staking_pool_mappings, staking_pool_id);
+        self.staking_pool_mappings.remove(staking_pool_id);
 
         // Deactivate the staking pool.
-        validator::deactivate(&mut validator, tx_context::epoch(ctx));
+        validator.deactivate(ctx.epoch());
 
         // Add to the inactive tables.
-        table::add(
-            &mut self.inactive_validators,
+        self.inactive_validators.add(
             staking_pool_id,
             validator_wrapper::create_v1(validator, ctx),
         );
@@ -236,22 +229,22 @@ module sui_system::validator_set {
     /// Called by `sui_system` to add a new validator to `pending_active_validators`, which will be
     /// processed at the end of epoch.
     public(package) fun request_add_validator(self: &mut ValidatorSet, min_joining_stake_amount: u64, ctx: &TxContext) {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
         assert!(
-            table::contains(&self.validator_candidates, validator_address),
+            self.validator_candidates.contains(validator_address),
             ENotValidatorCandidate
         );
-        let wrapper = table::remove(&mut self.validator_candidates, validator_address);
-        let validator = validator_wrapper::destroy(wrapper);
+        let wrapper = self.validator_candidates.remove(validator_address);
+        let validator = wrapper.destroy();
         assert!(
             !is_duplicate_with_active_validator(self, &validator)
                 && !is_duplicate_with_pending_validator(self, &validator),
             EDuplicateValidator
         );
-        assert!(validator::is_preactive(&validator), EValidatorNotCandidate);
-        assert!(validator::total_stake_amount(&validator) >= min_joining_stake_amount, EMinJoiningStakeNotReached);
+        assert!(validator.is_preactive(), EValidatorNotCandidate);
+        assert!(validator.total_stake_amount() >= min_joining_stake_amount, EMinJoiningStakeNotReached);
 
-        table_vec::push_back(&mut self.pending_active_validators, validator);
+        self.pending_active_validators.push_back(validator);
     }
 
     public(package) fun assert_no_pending_or_active_duplicates(self: &ValidatorSet, validator: &Validator) {
@@ -271,15 +264,15 @@ module sui_system::validator_set {
         self: &mut ValidatorSet,
         ctx: &TxContext,
     ) {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
         let mut validator_index_opt = find_validator(&self.active_validators, validator_address);
-        assert!(option::is_some(&validator_index_opt), ENotAValidator);
-        let validator_index = option::extract(&mut validator_index_opt);
+        assert!(validator_index_opt.is_some(), ENotAValidator);
+        let validator_index = validator_index_opt.extract();
         assert!(
-            !vector::contains(&self.pending_removals, &validator_index),
+            !self.pending_removals.contains(&validator_index),
             EValidatorAlreadyRemoved
         );
-        vector::push_back(&mut self.pending_removals, validator_index);
+        self.pending_removals.push_back(validator_index);
     }
 
 
@@ -295,10 +288,10 @@ module sui_system::validator_set {
         stake: Balance<SUI>,
         ctx: &mut TxContext,
     ) : StakedSui {
-        let sui_amount = balance::value(&stake);
+        let sui_amount = stake.value();
         assert!(sui_amount >= MIN_STAKING_THRESHOLD, EStakingBelowThreshold);
         let validator = get_candidate_or_active_validator_mut(self, validator_address);
-        validator::request_add_stake(validator, stake, tx_context::sender(ctx), ctx)
+        validator.request_add_stake(stake, ctx.sender(), ctx)
     }
 
     /// Called by `sui_system`, to withdraw some share of a stake from the validator. The share to withdraw
@@ -314,15 +307,15 @@ module sui_system::validator_set {
     ) : Balance<SUI> {
         let staking_pool_id = pool_id(&staked_sui);
         let validator =
-            if (table::contains(&self.staking_pool_mappings, staking_pool_id)) { // This is an active validator.
-                let validator_address = *table::borrow(&self.staking_pool_mappings, pool_id(&staked_sui));
+            if (self.staking_pool_mappings.contains(staking_pool_id)) { // This is an active validator.
+                let validator_address = self.staking_pool_mappings[pool_id(&staked_sui)];
                 get_candidate_or_active_validator_mut(self, validator_address)
             } else { // This is an inactive pool.
-                assert!(table::contains(&self.inactive_validators, staking_pool_id), ENoPoolFound);
-                let wrapper = table::borrow_mut(&mut self.inactive_validators, staking_pool_id);
-                validator_wrapper::load_validator_maybe_upgrade(wrapper)
+                assert!(self.inactive_validators.contains(staking_pool_id), ENoPoolFound);
+                let wrapper = &mut self.inactive_validators[staking_pool_id];
+                wrapper.load_validator_maybe_upgrade()
             };
-        validator::request_withdraw_stake(validator, staked_sui, ctx)
+        validator.request_withdraw_stake(staked_sui, ctx)
     }
 
     // ==== validator config setting functions ====
@@ -332,9 +325,9 @@ module sui_system::validator_set {
         new_commission_rate: u64,
         ctx: &TxContext,
     ) {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
         let validator = get_validator_mut(&mut self.active_validators, validator_address);
-        validator::request_set_commission_rate(validator, new_commission_rate);
+        validator.request_set_commission_rate(new_commission_rate);
     }
 
 
@@ -358,15 +351,15 @@ module sui_system::validator_set {
         low_stake_grace_period: u64,
         ctx: &mut TxContext,
     ) {
-        let new_epoch = tx_context::epoch(ctx) + 1;
+        let new_epoch = ctx.epoch() + 1;
         let total_voting_power = voting_power::total_voting_power();
 
         // Compute the reward distribution without taking into account the tallying rule slashing.
         let (unadjusted_staking_reward_amounts, unadjusted_storage_fund_reward_amounts) = compute_unadjusted_reward_distribution(
             &self.active_validators,
             total_voting_power,
-            balance::value(computation_reward),
-            balance::value(storage_fund_reward),
+            computation_reward.value(),
+            storage_fund_reward.value(),
         );
 
         // Use the tallying rule report records for the epoch to compute validators that will be
@@ -455,37 +448,37 @@ module sui_system::validator_set {
         ctx: &mut TxContext
     ) {
         // Iterate through all the active validators, record their low stake status, and kick them out if the condition is met.
-        let mut i = vector::length(&self.active_validators);
+        let mut i = self.active_validators.length();
         while (i > 0) {
             i = i - 1;
-            let validator_ref = vector::borrow(&self.active_validators, i);
-            let validator_address = validator::sui_address(validator_ref);
-            let stake = validator::total_stake_amount(validator_ref);
+            let validator_ref = &self.active_validators[i];
+            let validator_address = validator_ref.sui_address();
+            let stake = validator_ref.total_stake_amount();
             if (stake >= low_stake_threshold) {
                 // The validator is safe. We remove their entry from the at_risk map if there exists one.
-                if (vec_map::contains(&self.at_risk_validators, &validator_address)) {
-                    vec_map::remove(&mut self.at_risk_validators, &validator_address);
+                if (self.at_risk_validators.contains(&validator_address)) {
+                   self.at_risk_validators.remove(&validator_address);
                 }
             } else if (stake >= very_low_stake_threshold) {
                 // The stake is a bit below the threshold so we increment the entry of the validator in the map.
                 let new_low_stake_period =
-                    if (vec_map::contains(&self.at_risk_validators, &validator_address)) {
-                        let num_epochs = vec_map::get_mut(&mut self.at_risk_validators, &validator_address);
+                    if (self.at_risk_validators.contains(&validator_address)) {
+                        let num_epochs = &mut self.at_risk_validators[&validator_address];
                         *num_epochs = *num_epochs + 1;
                         *num_epochs
                     } else {
-                        vec_map::insert(&mut self.at_risk_validators, validator_address, 1);
+                        self.at_risk_validators.insert(validator_address, 1);
                         1
                     };
 
                 // If the grace period has passed, the validator has to leave us.
                 if (new_low_stake_period > low_stake_grace_period) {
-                    let validator = vector::remove(&mut self.active_validators, i);
+                    let validator = self.active_validators.remove(i);
                     process_validator_departure(self, validator, validator_report_records, false /* the validator is kicked out involuntarily */, ctx);
                 }
             } else {
                 // The validator's stake is lower than the very low threshold so we kick them out immediately.
-                let validator = vector::remove(&mut self.active_validators, i);
+                let validator = self.active_validators.remove(i);
                 process_validator_departure(self, validator, validator_report_records, false /* the validator is kicked out involuntarily */, ctx);
             }
         }
@@ -495,11 +488,11 @@ module sui_system::validator_set {
     fun effectuate_staged_metadata(
         self: &mut ValidatorSet,
     ) {
-        let num_validators = vector::length(&self.active_validators);
+        let num_validators = self.active_validators.length();
         let mut i = 0;
         while (i < num_validators) {
-            let validator = vector::borrow_mut(&mut self.active_validators, i);
-            validator::effectuate_staged_metadata(validator);
+            let validator = &mut self.active_validators[i];
+            validator.effectuate_staged_metadata();
             i = i + 1;
         }
     }
@@ -510,14 +503,13 @@ module sui_system::validator_set {
     /// gas price, weighted by stake.
     public fun derive_reference_gas_price(self: &ValidatorSet): u64 {
         let vs = &self.active_validators;
-        let num_validators = vector::length(vs);
-        let mut entries = vector::empty();
+        let num_validators = vs.length();
+        let mut entries = vector[];
         let mut i = 0;
         while (i < num_validators) {
-            let v = vector::borrow(vs, i);
-            vector::push_back(
-                &mut entries,
-                pq::new_entry(validator::gas_price(v), validator::voting_power(v))
+            let v = &vs[i];
+            entries.push_back(
+                pq::new_entry(v.gas_price(), v.voting_power())
             );
             i = i + 1;
         };
@@ -527,7 +519,7 @@ module sui_system::validator_set {
         let threshold = voting_power::total_voting_power() - voting_power::quorum_threshold();
         let mut result = 0;
         while (sum < threshold) {
-            let (gas_price, voting_power) = pq::pop_max(&mut pq);
+            let (gas_price, voting_power) = pq.pop_max();
             result = gas_price;
             sum = sum + voting_power;
         };
@@ -542,17 +534,17 @@ module sui_system::validator_set {
 
     public fun validator_total_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
         let validator = get_validator_ref(&self.active_validators, validator_address);
-        validator::total_stake_amount(validator)
+        validator.total_stake_amount()
     }
 
     public fun validator_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
         let validator = get_validator_ref(&self.active_validators, validator_address);
-        validator::stake_amount(validator)
+        validator.stake_amount()
     }
 
     public fun validator_staking_pool_id(self: &ValidatorSet, validator_address: address): ID {
         let validator = get_validator_ref(&self.active_validators, validator_address);
-        validator::staking_pool_id(validator)
+        validator.staking_pool_id()
     }
 
     public fun staking_pool_mappings(self: &ValidatorSet): &Table<ID, address> {
@@ -564,19 +556,19 @@ module sui_system::validator_set {
     ) : &Table<u64, PoolTokenExchangeRate> {
         let validator =
             // If the pool id is recorded in the mapping, then it must be either candidate or active.
-            if (table::contains(&self.staking_pool_mappings, *pool_id)) {
-                let validator_address = *table::borrow(&self.staking_pool_mappings, *pool_id);
+            if (self.staking_pool_mappings.contains(*pool_id)) {
+                let validator_address = self.staking_pool_mappings[*pool_id];
                 get_active_or_pending_or_candidate_validator_ref(self, validator_address, ANY_VALIDATOR)
             } else { // otherwise it's inactive
-                let wrapper = table::borrow_mut(&mut self.inactive_validators, *pool_id);
-                validator_wrapper::load_validator_maybe_upgrade(wrapper)
+                let wrapper = &mut self.inactive_validators[*pool_id];
+                wrapper.load_validator_maybe_upgrade()
             };
-        staking_pool::exchange_rates(validator::get_staking_pool_ref(validator))
+	validator.get_staking_pool_ref().exchange_rates()
     }
 
     /// Get the total number of validators in the next epoch.
     public(package) fun next_epoch_validator_count(self: &ValidatorSet): u64 {
-        vector::length(&self.active_validators) - vector::length(&self.pending_removals) + table_vec::length(&self.pending_active_validators)
+        self.active_validators.length() - self.pending_removals.length() + self.pending_active_validators.length()
     }
 
     /// Returns true iff the address exists in active validators.
@@ -584,7 +576,7 @@ module sui_system::validator_set {
         self: &ValidatorSet,
         validator_address: address,
     ): bool {
-        option::is_some(&find_validator(&self.active_validators, validator_address))
+       find_validator(&self.active_validators, validator_address).is_some()
     }
 
     // ==== private helpers ====
@@ -601,12 +593,12 @@ module sui_system::validator_set {
     }
 
     fun count_duplicates_vec(validators: &vector<Validator>, validator: &Validator): u64 {
-        let len = vector::length(validators);
+        let len = validators.length();
         let mut i = 0;
         let mut result = 0;
         while (i < len) {
-            let v = vector::borrow(validators, i);
-            if (validator::is_duplicate(v, validator)) {
+            let v = &validators[i];
+            if (v.is_duplicate(validator)) {
                 result = result + 1;
             };
             i = i + 1;
@@ -620,12 +612,12 @@ module sui_system::validator_set {
     }
 
     fun count_duplicates_tablevec(validators: &TableVec<Validator>, validator: &Validator): u64 {
-        let len = table_vec::length(validators);
+        let len = validators.length();
         let mut i = 0;
         let mut result = 0;
         while (i < len) {
-            let v = table_vec::borrow(validators, i);
-            if (validator::is_duplicate(v, validator)) {
+            let v = &validators[i];
+            if (v.is_duplicate(validator)) {
                 result = result + 1;
             };
             i = i + 1;
@@ -635,9 +627,9 @@ module sui_system::validator_set {
 
     /// Get mutable reference to either a candidate or an active validator by address.
     fun get_candidate_or_active_validator_mut(self: &mut ValidatorSet, validator_address: address): &mut Validator {
-        if (table::contains(&self.validator_candidates, validator_address)) {
-            let wrapper = table::borrow_mut(&mut self.validator_candidates, validator_address);
-            return validator_wrapper::load_validator_maybe_upgrade(wrapper)
+        if (self.validator_candidates.contains(validator_address)) {
+            let wrapper = &mut self.validator_candidates[validator_address];
+            return wrapper.load_validator_maybe_upgrade()
         };
         get_validator_mut(&mut self.active_validators, validator_address)
     }
@@ -646,11 +638,11 @@ module sui_system::validator_set {
     /// Returns (true, index) if the validator is found, and the index is its index in the list.
     /// If not found, returns (false, 0).
     fun find_validator(validators: &vector<Validator>, validator_address: address): Option<u64> {
-        let length = vector::length(validators);
+        let length = validators.length();
         let mut i = 0;
         while (i < length) {
-            let v = vector::borrow(validators, i);
-            if (validator::sui_address(v) == validator_address) {
+            let v = &validators[i];
+            if (v.sui_address() == validator_address) {
                 return option::some(i)
             };
             i = i + 1;
@@ -662,11 +654,11 @@ module sui_system::validator_set {
     /// Returns (true, index) if the validator is found, and the index is its index in the list.
     /// If not found, returns (false, 0).
     fun find_validator_from_table_vec(validators: &TableVec<Validator>, validator_address: address): Option<u64> {
-        let length = table_vec::length(validators);
+        let length = validators.length();
         let mut i = 0;
         while (i < length) {
-            let v = table_vec::borrow(validators, i);
-            if (validator::sui_address(v) == validator_address) {
+            let v = &validators[i];
+            if (v.sui_address() == validator_address) {
                 return option::some(i)
             };
             i = i + 1;
@@ -678,14 +670,14 @@ module sui_system::validator_set {
     /// Given a vector of validator addresses, return their indices in the validator set.
     /// Aborts if any address isn't in the given validator set.
     fun get_validator_indices(validators: &vector<Validator>, validator_addresses: &vector<address>): vector<u64> {
-        let length = vector::length(validator_addresses);
+        let length = validator_addresses.length();
         let mut i = 0;
         let mut res = vector[];
         while (i < length) {
-            let addr = *vector::borrow(validator_addresses, i);
+            let addr = validator_addresses[i];
             let index_opt = find_validator(validators, addr);
-            assert!(option::is_some(&index_opt), ENotAValidator);
-            vector::push_back(&mut res, option::destroy_some(index_opt));
+            assert!(index_opt.is_some(), ENotAValidator);
+            res.push_back(index_opt.destroy_some());
             i = i + 1;
         };
         res
@@ -696,9 +688,9 @@ module sui_system::validator_set {
         validator_address: address,
     ): &mut Validator {
         let mut validator_index_opt = find_validator(validators, validator_address);
-        assert!(option::is_some(&validator_index_opt), ENotAValidator);
-        let validator_index = option::extract(&mut validator_index_opt);
-        vector::borrow_mut(validators, validator_index)
+        assert!(validator_index_opt.is_some(), ENotAValidator);
+        let validator_index = validator_index_opt.extract();
+        &mut validators[validator_index]
     }
 
     /// Get mutable reference to an active or (if active does not exist) pending or (if pending and
@@ -711,19 +703,19 @@ module sui_system::validator_set {
         include_candidate: bool,
     ): &mut Validator {
         let mut validator_index_opt = find_validator(&self.active_validators, validator_address);
-        if (option::is_some(&validator_index_opt)) {
-            let validator_index = option::extract(&mut validator_index_opt);
-            return vector::borrow_mut(&mut self.active_validators, validator_index)
+        if (validator_index_opt.is_some()) {
+            let validator_index = validator_index_opt.extract();
+            return &mut self.active_validators[validator_index]
         };
         let mut validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
         // consider both pending validators and the candidate ones
-        if (option::is_some(&validator_index_opt)) {
-            let validator_index = option::extract(&mut validator_index_opt);
-            return table_vec::borrow_mut(&mut self.pending_active_validators, validator_index)
+        if (validator_index_opt.is_some()) {
+            let validator_index = validator_index_opt.extract();
+            return &mut self.pending_active_validators[validator_index]
         };
         assert!(include_candidate, ENotActiveOrPendingValidator);
-        let wrapper = table::borrow_mut(&mut self.validator_candidates, validator_address);
-        validator_wrapper::load_validator_maybe_upgrade(wrapper)
+        let wrapper = &mut self.validator_candidates[validator_address];
+        wrapper.load_validator_maybe_upgrade()
     }
 
     public(package) fun get_validator_mut_with_verified_cap(
@@ -731,14 +723,14 @@ module sui_system::validator_set {
         verified_cap: &ValidatorOperationCap,
         include_candidate: bool,
     ): &mut Validator {
-        get_active_or_pending_or_candidate_validator_mut(self, *validator_cap::verified_operation_cap_address(verified_cap), include_candidate)
+        get_active_or_pending_or_candidate_validator_mut(self, *verified_cap.verified_operation_cap_address(), include_candidate)
     }
 
     public(package) fun get_validator_mut_with_ctx(
         self: &mut ValidatorSet,
         ctx: &TxContext,
     ): &mut Validator {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
         get_active_or_pending_or_candidate_validator_mut(self, validator_address, false)
     }
 
@@ -746,7 +738,7 @@ module sui_system::validator_set {
         self: &mut ValidatorSet,
         ctx: &TxContext,
     ): &mut Validator {
-        let validator_address = tx_context::sender(ctx);
+        let validator_address = ctx.sender();
         get_active_or_pending_or_candidate_validator_mut(self, validator_address, true)
     }
 
@@ -755,9 +747,9 @@ module sui_system::validator_set {
         validator_address: address,
     ): &Validator {
         let mut validator_index_opt = find_validator(validators, validator_address);
-        assert!(option::is_some(&validator_index_opt), ENotAValidator);
-        let validator_index = option::extract(&mut validator_index_opt);
-        vector::borrow(validators, validator_index)
+        assert!(validator_index_opt.is_some(), ENotAValidator);
+        let validator_index = validator_index_opt.extract();
+        &validators[validator_index]
     }
 
     public(package) fun get_active_or_pending_or_candidate_validator_ref(
@@ -766,17 +758,16 @@ module sui_system::validator_set {
         which_validator: u8,
     ): &Validator {
         let mut validator_index_opt = find_validator(&self.active_validators, validator_address);
-        if (option::is_some(&validator_index_opt) || which_validator == ACTIVE_VALIDATOR_ONLY) {
-            let validator_index = option::extract(&mut validator_index_opt);
-            return vector::borrow(&self.active_validators, validator_index)
+        if (validator_index_opt.is_some() || which_validator == ACTIVE_VALIDATOR_ONLY) {
+            let validator_index = validator_index_opt.extract();
+            return &self.active_validators[validator_index]
         };
         let mut validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
-        if (option::is_some(&validator_index_opt) || which_validator == ACTIVE_OR_PENDING_VALIDATOR) {
-            let validator_index = option::extract(&mut validator_index_opt);
-            return table_vec::borrow(&self.pending_active_validators, validator_index)
+        if (validator_index_opt.is_some() || which_validator == ACTIVE_OR_PENDING_VALIDATOR) {
+            let validator_index = validator_index_opt.extract();
+            return &self.pending_active_validators[validator_index]
         };
-        let wrapper = table::borrow_mut(&mut self.validator_candidates, validator_address);
-        validator_wrapper::load_validator_maybe_upgrade(wrapper)
+        self.validator_candidates[validator_address].load_validator_maybe_upgrade()
     }
 
     public fun get_active_validator_ref(
@@ -784,9 +775,9 @@ module sui_system::validator_set {
         validator_address: address,
     ): &Validator {
         let mut validator_index_opt = find_validator(&self.active_validators, validator_address);
-        assert!(option::is_some(&validator_index_opt), ENotAValidator);
-        let validator_index = option::extract(&mut validator_index_opt);
-        vector::borrow(&self.active_validators, validator_index)
+        assert!(validator_index_opt.is_some(), ENotAValidator);
+        let validator_index = validator_index_opt.extract();
+        &self.active_validators[validator_index]
     }
 
     public fun get_pending_validator_ref(
@@ -794,9 +785,9 @@ module sui_system::validator_set {
         validator_address: address,
     ): &Validator {
         let mut validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
-        assert!(option::is_some(&validator_index_opt), ENotAPendingValidator);
-        let validator_index = option::extract(&mut validator_index_opt);
-        table_vec::borrow(&self.pending_active_validators, validator_index)
+        assert!(validator_index_opt.is_some(), ENotAPendingValidator);
+        let validator_index = validator_index_opt.extract();
+        &self.pending_active_validators[validator_index]
     }
 
     #[test_only]
@@ -804,8 +795,7 @@ module sui_system::validator_set {
         self: &ValidatorSet,
         validator_address: address,
     ): &Validator {
-        let wrapper = table::borrow(&self.validator_candidates, validator_address);
-        validator_wrapper::get_inner_validator_ref(wrapper)
+        self.validator_candidates[validator_address].get_inner_validator_ref()
     }
 
     /// Verify the capability is valid for a Validator.
@@ -816,13 +806,13 @@ module sui_system::validator_set {
         cap: &UnverifiedValidatorOperationCap,
         which_validator: u8,
     ): ValidatorOperationCap {
-        let cap_address = *validator_cap::unverified_operation_cap_address(cap);
+        let cap_address = *cap.unverified_operation_cap_address();
         let validator =
             if (which_validator == ACTIVE_VALIDATOR_ONLY)
                 get_active_validator_ref(self, cap_address)
             else
                 get_active_or_pending_or_candidate_validator_ref(self, cap_address, which_validator);
-        assert!(validator::operation_cap_id(validator) == &object::id(cap), EInvalidCap);
+        assert!(validator.operation_cap_id() == &object::id(cap), EInvalidCap);
         validator_cap::new_from_unverified(cap)
     }
 
@@ -834,9 +824,9 @@ module sui_system::validator_set {
         ctx: &mut TxContext,
     ) {
         sort_removal_list(&mut self.pending_removals);
-        while (!vector::is_empty(&self.pending_removals)) {
-            let index = vector::pop_back(&mut self.pending_removals);
-            let validator = vector::remove(&mut self.active_validators, index);
+        while (!self.pending_removals.is_empty()) {
+            let index = self.pending_removals.pop_back();
+            let validator = self.active_validators.remove(index);
             process_validator_departure(self, validator, validator_report_records, true /* the validator removes itself voluntarily */, ctx);
         }
     }
@@ -848,17 +838,17 @@ module sui_system::validator_set {
         is_voluntary: bool,
         ctx: &mut TxContext,
     ) {
-        let new_epoch = tx_context::epoch(ctx) + 1;
-        let validator_address = validator::sui_address(&validator);
+        let new_epoch = ctx.epoch() + 1;
+        let validator_address = validator.sui_address();
         let validator_pool_id = staking_pool_id(&validator);
 
         // Remove the validator from our tables.
-        table::remove(&mut self.staking_pool_mappings, validator_pool_id);
-        if (vec_map::contains(&self.at_risk_validators, &validator_address)) {
-            vec_map::remove(&mut self.at_risk_validators, &validator_address);
+        self.staking_pool_mappings.remove(validator_pool_id);
+        if (self.at_risk_validators.contains(&validator_address)) {
+            self.at_risk_validators.remove(&validator_address);
         };
 
-        self.total_stake = self.total_stake - validator::total_stake_amount(&validator);
+        self.total_stake = self.total_stake - validator.total_stake_amount();
 
         clean_report_records_leaving_validator(validator_report_records, validator_address);
 
@@ -872,9 +862,8 @@ module sui_system::validator_set {
         );
 
         // Deactivate the validator and its staking pool
-        validator::deactivate(&mut validator, new_epoch);
-        table::add(
-            &mut self.inactive_validators,
+        validator.deactivate(new_epoch);
+        self.inactive_validators.add(
             validator_pool_id,
             validator_wrapper::create_v1(validator, ctx),
         );
@@ -885,21 +874,21 @@ module sui_system::validator_set {
         leaving_validator_addr: address
     ) {
         // Remove the records about this validator
-        if (vec_map::contains(validator_report_records, &leaving_validator_addr)) {
-            vec_map::remove(validator_report_records, &leaving_validator_addr);
+        if (validator_report_records.contains(&leaving_validator_addr)) {
+            validator_report_records.remove(&leaving_validator_addr);
         };
 
         // Remove the reports submitted by this validator
-        let reported_validators = vec_map::keys(validator_report_records);
-        let length = vector::length(&reported_validators);
+        let reported_validators = validator_report_records.keys();
+        let length = reported_validators.length();
         let mut i = 0;
         while (i < length) {
-            let reported_validator_addr = vector::borrow(&reported_validators, i);
-            let reporters = vec_map::get_mut(validator_report_records, reported_validator_addr);
-            if (vec_set::contains(reporters, &leaving_validator_addr)) {
-                vec_set::remove(reporters, &leaving_validator_addr);
-                if (vec_set::is_empty(reporters)) {
-                    vec_map::remove(validator_report_records, reported_validator_addr);
+            let reported_validator_addr = &reported_validators[i];
+            let reporters = &mut validator_report_records[reported_validator_addr];
+            if (reporters.contains(&leaving_validator_addr)) {
+                reporters.remove(&leaving_validator_addr);
+                if (reporters.is_empty()) {
+                    validator_report_records.remove(reported_validator_addr);
                 };
             };
             i = i + 1;
@@ -910,31 +899,31 @@ module sui_system::validator_set {
     fun process_pending_validators(
         self: &mut ValidatorSet, new_epoch: u64,
     ) {
-        while (!table_vec::is_empty(&self.pending_active_validators)) {
-            let mut validator = table_vec::pop_back(&mut self.pending_active_validators);
-            validator::activate(&mut validator, new_epoch);
+        while (!self.pending_active_validators.is_empty()) {
+            let mut validator = self.pending_active_validators.pop_back();
+            validator.activate(new_epoch);
             event::emit(
                 ValidatorJoinEvent {
                     epoch: new_epoch,
-                    validator_address: validator::sui_address(&validator),
+                    validator_address: validator.sui_address(),
                     staking_pool_id: staking_pool_id(&validator),
                 }
             );
-            vector::push_back(&mut self.active_validators, validator);
+            self.active_validators.push_back(validator);
         }
     }
 
     /// Sort all the pending removal indexes.
     fun sort_removal_list(withdraw_list: &mut vector<u64>) {
-        let length = vector::length(withdraw_list);
+        let length = withdraw_list.length();
         let mut i = 1;
         while (i < length) {
-            let cur = *vector::borrow(withdraw_list, i);
+            let cur = withdraw_list[i];
             let mut j = i;
             while (j > 0) {
                 j = j - 1;
-                if (*vector::borrow(withdraw_list, j) > cur) {
-                    vector::swap(withdraw_list, j, j + 1);
+                if (withdraw_list[j] > cur) {
+                    withdraw_list.swap(j, j + 1);
                 } else {
                     break
                 };
@@ -947,11 +936,11 @@ module sui_system::validator_set {
     fun process_pending_stakes_and_withdraws(
         validators: &mut vector<Validator>, ctx: &TxContext
     ) {
-        let length = vector::length(validators);
+        let length = validators.length();
         let mut i = 0;
         while (i < length) {
-            let validator = vector::borrow_mut(validators, i);
-            validator::process_pending_stakes_and_withdraws(validator, ctx);
+            let validator = &mut validators[i];
+            validator.process_pending_stakes_and_withdraws(ctx);
             i = i + 1;
         }
     }
@@ -959,11 +948,11 @@ module sui_system::validator_set {
     /// Calculate the total active validator stake.
     fun calculate_total_stakes(validators: &vector<Validator>): u64 {
         let mut stake = 0;
-        let length = vector::length(validators);
+        let length = validators.length();
         let mut i = 0;
         while (i < length) {
-            let v = vector::borrow(validators, i);
-            stake = stake + validator::total_stake_amount(v);
+            let v = &validators[i];
+            stake = stake + v.total_stake_amount();
             i = i + 1;
         };
         stake
@@ -971,11 +960,11 @@ module sui_system::validator_set {
 
     /// Process the pending stake changes for each validator.
     fun adjust_stake_and_gas_price(validators: &mut vector<Validator>) {
-        let length = vector::length(validators);
+        let length = validators.length();
         let mut i = 0;
         while (i < length) {
-            let validator = vector::borrow_mut(validators, i);
-            validator::adjust_stake_and_gas_price(validator);
+            let validator = &mut validators[i];
+            validator.adjust_stake_and_gas_price();
             i = i + 1;
         }
     }
@@ -998,25 +987,25 @@ module sui_system::validator_set {
         let mut total_storage_fund_reward_adjustment = 0;
         let mut individual_storage_fund_reward_adjustments = vec_map::empty();
 
-        while (!vector::is_empty(&slashed_validator_indices)) {
-            let validator_index = vector::pop_back(&mut slashed_validator_indices);
+        while (!slashed_validator_indices.is_empty()) {
+            let validator_index = slashed_validator_indices.pop_back();
 
             // Use the slashing rate to compute the amount of staking rewards slashed from this punished validator.
-            let unadjusted_staking_reward = *vector::borrow(unadjusted_staking_reward_amounts, validator_index);
+            let unadjusted_staking_reward = unadjusted_staking_reward_amounts[validator_index];
             let staking_reward_adjustment_u128 =
                 (unadjusted_staking_reward as u128) * (reward_slashing_rate as u128)
                 / BASIS_POINT_DENOMINATOR;
 
             // Insert into individual mapping and record into the total adjustment sum.
-            vec_map::insert(&mut individual_staking_reward_adjustments, validator_index, (staking_reward_adjustment_u128 as u64));
+            individual_staking_reward_adjustments.insert(validator_index, (staking_reward_adjustment_u128 as u64));
             total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 as u64);
 
             // Do the same thing for storage fund rewards.
-            let unadjusted_storage_fund_reward = *vector::borrow(unadjusted_storage_fund_reward_amounts, validator_index);
+            let unadjusted_storage_fund_reward = unadjusted_storage_fund_reward_amounts[validator_index];
             let storage_fund_reward_adjustment_u128 =
                 (unadjusted_storage_fund_reward as u128) * (reward_slashing_rate as u128)
                 / BASIS_POINT_DENOMINATOR;
-            vec_map::insert(&mut individual_storage_fund_reward_adjustments, validator_index, (storage_fund_reward_adjustment_u128 as u64));
+            individual_storage_fund_reward_adjustments.insert(validator_index, (storage_fund_reward_adjustment_u128 as u64));
             total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 as u64);
         };
 
@@ -1033,17 +1022,17 @@ module sui_system::validator_set {
         mut validator_report_records: VecMap<address, VecSet<address>>,
     ): vector<address> {
         let mut slashed_validators = vector[];
-        while (!vec_map::is_empty(&validator_report_records)) {
-            let (validator_address, reporters) = vec_map::pop(&mut validator_report_records);
+        while (!validator_report_records.is_empty()) {
+            let (validator_address, reporters) = validator_report_records.pop();
             assert!(
                 is_active_validator_by_sui_address(self, validator_address),
                 ENonValidatorInReportRecords,
             );
             // Sum up the voting power of validators that have reported this validator and check if it has
             // passed the slashing threshold.
-            let reporter_votes = sum_voting_power_by_addresses(&self.active_validators, &vec_set::into_keys(reporters));
+            let reporter_votes = sum_voting_power_by_addresses(&self.active_validators, &reporters.into_keys());
             if (reporter_votes >= voting_power::quorum_threshold()) {
-                vector::push_back(&mut slashed_validators, validator_address);
+                slashed_validators.push_back(validator_address);
             }
         };
         slashed_validators
@@ -1059,21 +1048,21 @@ module sui_system::validator_set {
         total_staking_reward: u64,
         total_storage_fund_reward: u64,
     ): (vector<u64>, vector<u64>) {
-        let mut staking_reward_amounts = vector::empty();
-        let mut storage_fund_reward_amounts = vector::empty();
-        let length = vector::length(validators);
+        let mut staking_reward_amounts = vector[];
+        let mut storage_fund_reward_amounts = vector[];
+        let length = validators.length();
         let storage_fund_reward_per_validator = total_storage_fund_reward / length;
         let mut i = 0;
         while (i < length) {
-            let validator = vector::borrow(validators, i);
+            let validator = &validators[i];
             // Integer divisions will truncate the results. Because of this, we expect that at the end
             // there will be some reward remaining in `total_staking_reward`.
             // Use u128 to avoid multiplication overflow.
-            let voting_power: u128 = (validator::voting_power(validator) as u128);
+            let voting_power: u128 = (validator.voting_power() as u128);
             let reward_amount = voting_power * (total_staking_reward as u128) / (total_voting_power as u128);
-            vector::push_back(&mut staking_reward_amounts, (reward_amount as u64));
+            staking_reward_amounts.push_back((reward_amount as u64));
             // Storage fund's share of the rewards are equally distributed among validators.
-            vector::push_back(&mut storage_fund_reward_amounts, storage_fund_reward_per_validator);
+            storage_fund_reward_amounts.push_back(storage_fund_reward_per_validator);
             i = i + 1;
         };
         (staking_reward_amounts, storage_fund_reward_amounts)
@@ -1094,26 +1083,26 @@ module sui_system::validator_set {
         individual_storage_fund_reward_adjustments: VecMap<u64, u64>,
     ): (vector<u64>, vector<u64>) {
         let total_unslashed_validator_voting_power = total_voting_power - total_slashed_validator_voting_power;
-        let mut adjusted_staking_reward_amounts = vector::empty();
-        let mut adjusted_storage_fund_reward_amounts = vector::empty();
+        let mut adjusted_staking_reward_amounts = vector[];
+        let mut adjusted_storage_fund_reward_amounts = vector[];
 
-        let length = vector::length(validators);
-        let num_unslashed_validators = length - vec_map::size(&individual_staking_reward_adjustments);
+        let length = validators.length();
+        let num_unslashed_validators = length - individual_staking_reward_adjustments.size();
 
         let mut i = 0;
         while (i < length) {
-            let validator = vector::borrow(validators, i);
+            let validator = &validators[i];
             // Integer divisions will truncate the results. Because of this, we expect that at the end
             // there will be some reward remaining in `total_reward`.
             // Use u128 to avoid multiplication overflow.
-            let voting_power: u128 = (validator::voting_power(validator) as u128);
+            let voting_power: u128 = (validator.voting_power() as u128);
 
             // Compute adjusted staking reward.
-            let unadjusted_staking_reward_amount = *vector::borrow(&unadjusted_staking_reward_amounts, i);
+            let unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
             let adjusted_staking_reward_amount =
                 // If the validator is one of the slashed ones, then subtract the adjustment.
-                if (vec_map::contains(&individual_staking_reward_adjustments, &i)) {
-                    let adjustment = *vec_map::get(&individual_staking_reward_adjustments, &i);
+                if (individual_staking_reward_adjustments.contains(&i)) {
+                    let adjustment = individual_staking_reward_adjustments[&i];
                     unadjusted_staking_reward_amount - adjustment
                 } else {
                     // Otherwise the slashed rewards should be distributed among the unslashed
@@ -1122,21 +1111,21 @@ module sui_system::validator_set {
                                    / (total_unslashed_validator_voting_power as u128);
                     unadjusted_staking_reward_amount + (adjustment as u64)
                 };
-            vector::push_back(&mut adjusted_staking_reward_amounts, adjusted_staking_reward_amount);
+            adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);
 
             // Compute adjusted storage fund reward.
-            let unadjusted_storage_fund_reward_amount = *vector::borrow(&unadjusted_storage_fund_reward_amounts, i);
+            let unadjusted_storage_fund_reward_amount = unadjusted_storage_fund_reward_amounts[i];
             let adjusted_storage_fund_reward_amount =
                 // If the validator is one of the slashed ones, then subtract the adjustment.
-                if (vec_map::contains(&individual_storage_fund_reward_adjustments, &i)) {
-                    let adjustment = *vec_map::get(&individual_storage_fund_reward_adjustments, &i);
+                if (individual_storage_fund_reward_adjustments.contains(&i)) {
+                    let adjustment = individual_storage_fund_reward_adjustments[&i];
                     unadjusted_storage_fund_reward_amount - adjustment
                 } else {
                     // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
                     let adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
                     unadjusted_storage_fund_reward_amount + adjustment
                 };
-            vector::push_back(&mut adjusted_storage_fund_reward_amounts, adjusted_storage_fund_reward_amount);
+            adjusted_storage_fund_reward_amounts.push_back(adjusted_storage_fund_reward_amount);
 
             i = i + 1;
         };
@@ -1152,34 +1141,36 @@ module sui_system::validator_set {
         storage_fund_reward: &mut Balance<SUI>,
         ctx: &mut TxContext
     ) {
-        let length = vector::length(validators);
+        let length = validators.length();
         assert!(length > 0, EValidatorSetEmpty);
         let mut i = 0;
         while (i < length) {
-            let validator = vector::borrow_mut(validators, i);
-            let staking_reward_amount = *vector::borrow(adjusted_staking_reward_amounts, i);
-            let mut staker_reward = balance::split(staking_rewards, staking_reward_amount);
+            let validator = &mut validators[i];
+            let staking_reward_amount = adjusted_staking_reward_amounts[i];
+            let mut staker_reward = staking_rewards.split(staking_reward_amount);
 
             // Validator takes a cut of the rewards as commission.
-            let validator_commission_amount = (staking_reward_amount as u128) * (validator::commission_rate(validator) as u128) / BASIS_POINT_DENOMINATOR;
+            let validator_commission_amount = (staking_reward_amount as u128) * (validator.commission_rate() as u128) / BASIS_POINT_DENOMINATOR;
 
             // The validator reward = storage_fund_reward + commission.
-            let mut validator_reward = balance::split(&mut staker_reward, (validator_commission_amount as u64));
+            let mut validator_reward = staker_reward.split((validator_commission_amount as u64));
 
             // Add storage fund rewards to the validator's reward.
-            balance::join(&mut validator_reward, balance::split(storage_fund_reward, *vector::borrow(adjusted_storage_fund_reward_amounts, i)));
+            validator_reward.join(
+	    	storage_fund_reward.split(adjusted_storage_fund_reward_amounts[i])
+	    );
 
             // Add rewards to the validator. Don't try and distribute rewards though if the payout is zero.
-            if (balance::value(&validator_reward) > 0) {
-                let validator_address = validator::sui_address(validator);
-                let rewards_stake = validator::request_add_stake(validator, validator_reward, validator_address, ctx);
+            if (validator_reward.value() > 0) {
+                let validator_address = validator.sui_address();
+                let rewards_stake = validator.request_add_stake(validator_reward, validator_address, ctx);
                 transfer::public_transfer(rewards_stake, validator_address);
             } else {
-                balance::destroy_zero(validator_reward);
+                validator_reward.destroy_zero();
             };
 
             // Add rewards to stake staking pool to auto compound for stakers.
-            validator::deposit_stake_rewards(validator, staker_reward);
+            validator.deposit_stake_rewards(staker_reward);
             i = i + 1;
         }
     }
@@ -1194,31 +1185,31 @@ module sui_system::validator_set {
         report_records: &VecMap<address, VecSet<address>>,
         slashed_validators: &vector<address>,
     ) {
-        let num_validators = vector::length(vs);
+        let num_validators = vs.length();
         let mut i = 0;
         while (i < num_validators) {
-            let v = vector::borrow(vs, i);
-            let validator_address = validator::sui_address(v);
+            let v = &vs[i];
+            let validator_address = v.sui_address();
             let tallying_rule_reporters =
-                if (vec_map::contains(report_records, &validator_address)) {
-                    vec_set::into_keys(*vec_map::get(report_records, &validator_address))
+                if (report_records.contains(&validator_address)) {
+                    report_records[&validator_address].into_keys()
                 } else {
                     vector[]
                 };
             let tallying_rule_global_score =
-                if (vector::contains(slashed_validators, &validator_address)) 0
+                if (slashed_validators.contains(&validator_address)) 0
                 else 1;
             event::emit(
                 ValidatorEpochInfoEventV2 {
                     epoch: new_epoch,
                     validator_address,
-                    reference_gas_survey_quote: validator::gas_price(v),
-                    stake: validator::total_stake_amount(v),
-                    voting_power: validator::voting_power(v),
-                    commission_rate: validator::commission_rate(v),
-                    pool_staking_reward: *vector::borrow(pool_staking_reward_amounts, i),
-                    storage_fund_staking_reward: *vector::borrow(storage_fund_staking_reward_amounts, i),
-                    pool_token_exchange_rate: validator::pool_token_exchange_rate_at_epoch(v, new_epoch),
+                    reference_gas_survey_quote: v.gas_price(),
+                    stake: v.total_stake_amount(),
+                    voting_power: v.voting_power(),
+                    commission_rate: v.commission_rate(),
+                    pool_staking_reward: pool_staking_reward_amounts[i],
+                    storage_fund_staking_reward: storage_fund_staking_reward_amounts[i],
+                    pool_token_exchange_rate: v.pool_token_exchange_rate_at_epoch(new_epoch),
                     tallying_rule_reporters,
                     tallying_rule_global_score,
                 }
@@ -1231,10 +1222,10 @@ module sui_system::validator_set {
     public fun sum_voting_power_by_addresses(vs: &vector<Validator>, addresses: &vector<address>): u64 {
         let mut sum = 0;
         let mut i = 0;
-        let length = vector::length(addresses);
+        let length = addresses.length();
         while (i < length) {
-            let validator = get_validator_ref(vs, *vector::borrow(addresses, i));
-            sum = sum + validator::voting_power(validator);
+            let validator = get_validator_ref(vs, addresses[i]);
+            sum = sum + validator.voting_power();
             i = i + 1;
         };
         sum
@@ -1247,22 +1238,22 @@ module sui_system::validator_set {
 
     /// Returns true if the `addr` is a validator candidate.
     public fun is_validator_candidate(self: &ValidatorSet, addr: address): bool {
-        table::contains(&self.validator_candidates, addr)
+        self.validator_candidates.contains(addr)
     }
 
     /// Returns true if the staking pool identified by `staking_pool_id` is of an inactive validator.
     public fun is_inactive_validator(self: &ValidatorSet, staking_pool_id: ID): bool {
-        table::contains(&self.inactive_validators, staking_pool_id)
+        self.inactive_validators.contains(staking_pool_id)
     }
 
     public(package) fun active_validator_addresses(self: &ValidatorSet): vector<address> {
         let vs = &self.active_validators;
         let mut res = vector[];
         let mut i = 0;
-        let length = vector::length(vs);
+        let length = vs.length();
         while (i < length) {
-            let validator_address = validator::sui_address(vector::borrow(vs, i));
-            vector::push_back(&mut res, validator_address);
+            let validator_address = vs[i].sui_address();
+            res.push_back(validator_address);
             i = i + 1;
         };
         res

--- a/crates/sui-framework/packages/sui-system/sources/validator_wrapper.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_wrapper.move
@@ -5,7 +5,6 @@ module sui_system::validator_wrapper {
     use sui::versioned::Versioned;
     use sui_system::validator::Validator;
     use sui::versioned;
-    use sui::tx_context::TxContext;
 
     /* friend sui_system::validator_set; */
 

--- a/crates/sui-framework/packages/sui-system/sources/voting_power.move
+++ b/crates/sui-framework/packages/sui-system/sources/voting_power.move
@@ -3,8 +3,6 @@
 
 module sui_system::voting_power {
     use sui_system::validator::Validator;
-    use std::vector;
-    use sui_system::validator;
     use sui::math;
     use sui::math::divide_and_round_up;
 
@@ -54,7 +52,7 @@ module sui_system::voting_power {
         // have 100%. So we bound the threshold_pct to be always enough to find a solution.
         let threshold = math::min(
             TOTAL_VOTING_POWER,
-            math::max(MAX_VOTING_POWER, divide_and_round_up(TOTAL_VOTING_POWER, vector::length(validators))),
+            math::max(MAX_VOTING_POWER, divide_and_round_up(TOTAL_VOTING_POWER, validators.length())),
         );
         let (mut info_list, remaining_power) = init_voting_power_info(validators, threshold);
         adjust_voting_power(&mut info_list, threshold, remaining_power);
@@ -72,12 +70,12 @@ module sui_system::voting_power {
     ): (vector<VotingPowerInfoV2>, u64) {
         let total_stake = total_stake(validators);
         let mut i = 0;
-        let len = vector::length(validators);
+        let len = validators.length();
         let mut total_power = 0;
         let mut result = vector[];
         while (i < len) {
-            let validator = vector::borrow(validators, i);
-            let stake = validator::total_stake(validator);
+            let validator = &validators[i];
+            let stake = validator.total_stake();
             let adjusted_stake = (stake as u128) * (TOTAL_VOTING_POWER as u128) / (total_stake as u128);
             let voting_power = math::min((adjusted_stake as u64), threshold);
             let info = VotingPowerInfoV2 {
@@ -95,10 +93,10 @@ module sui_system::voting_power {
     /// Sum up the total stake of all validators.
     fun total_stake(validators: &vector<Validator>): u64 {
         let mut i = 0;
-        let len = vector::length(validators);
+        let len = validators.length();
         let mut total_stake =0 ;
         while (i < len) {
-            total_stake = total_stake + validator::total_stake(vector::borrow(validators, i));
+            total_stake = total_stake + validators[i].total_stake();
             i = i + 1;
         };
         total_stake
@@ -108,19 +106,19 @@ module sui_system::voting_power {
     /// using stake, in descending order.
     fun insert(info_list: &mut vector<VotingPowerInfoV2>, new_info: VotingPowerInfoV2) {
         let mut i = 0;
-        let len = vector::length(info_list);
-        while (i < len && vector::borrow(info_list, i).stake > new_info.stake) {
+        let len = info_list.length();
+        while (i < len && info_list[i].stake > new_info.stake) {
             i = i + 1;
         };
-        vector::insert(info_list, new_info, i);
+        info_list.insert(new_info, i);
     }
 
     /// Distribute remaining_power to validators that are not capped at threshold.
     fun adjust_voting_power(info_list: &mut vector<VotingPowerInfoV2>, threshold: u64, mut remaining_power: u64) {
         let mut i = 0;
-        let len = vector::length(info_list);
+        let len = info_list.length();
         while (i < len && remaining_power > 0) {
-            let v = vector::borrow_mut(info_list, i);
+            let v = &mut info_list[i];
             // planned is the amount of extra power we want to distribute to this validator.
             let planned = divide_and_round_up(remaining_power, len - i);
             // target is the targeting power this validator will reach, capped by threshold.
@@ -137,26 +135,26 @@ module sui_system::voting_power {
 
     /// Update validators with the decided voting power.
     fun update_voting_power(validators: &mut vector<Validator>, mut info_list: vector<VotingPowerInfoV2>) {
-        while (!vector::is_empty(&info_list)) {
+        while (!info_list.is_empty()) {
             let VotingPowerInfoV2 {
                 validator_index,
                 voting_power,
                 stake: _,
-            } = vector::pop_back(&mut info_list);
-            let v = vector::borrow_mut(validators, validator_index);
-            validator::set_voting_power(v, voting_power);
+            } = info_list.pop_back();
+            let v = &mut validators[validator_index];
+            v.set_voting_power(voting_power);
         };
-        vector::destroy_empty(info_list);
+        info_list.destroy_empty();
     }
 
     /// Check a few invariants that must hold after setting the voting power.
     fun check_invariants(v: &vector<Validator>) {
         // First check that the total voting power must be TOTAL_VOTING_POWER.
         let mut i = 0;
-        let len = vector::length(v);
+        let len = v.length();
         let mut total = 0;
         while (i < len) {
-            let voting_power = validator::voting_power(vector::borrow(v, i));
+            let voting_power = v[i].voting_power();
             assert!(voting_power > 0, EInvalidVotingPower);
             total = total + voting_power;
             i = i + 1;
@@ -170,12 +168,12 @@ module sui_system::voting_power {
         while (a < len) {
             let mut b = a + 1;
             while (b < len) {
-                let validator_a = vector::borrow(v, a);
-                let validator_b = vector::borrow(v, b);
-                let stake_a = validator::total_stake(validator_a);
-                let stake_b = validator::total_stake(validator_b);
-                let power_a = validator::voting_power(validator_a);
-                let power_b = validator::voting_power(validator_b);
+                let validator_a = &v[a];
+                let validator_b = &v[b];
+                let stake_a = validator_a.total_stake();
+                let stake_b = validator_b.total_stake();
+                let power_a = validator_a.voting_power();
+                let power_b = validator_b.voting_power();
                 if (stake_a > stake_b) {
                     assert!(power_a >= power_b, ERelativePowerMismatch);
                 };

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x3257c39e87e755fd5b03b18232b78258d5d0515723c736865211808486b1b419"
+            id: "0x22d2d8fa7ef42ab775c601971f3923a2ef5439f74960041fca227a60cfeac20a"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf81a5571116e01722e97ae9747350d833cdfebc8eb8a93ada708025426652d93"
+      operation_cap_id: "0x647055b796d1ab16354639748fe365d0d480555396435a93c741d6c28395d2c8"
       gas_price: 1000
       staking_pool:
-        id: "0xfddffe284fae43ee13b38d349e38a37466e4a08aa4baf33757649d018757af39"
+        id: "0x6bb471f4066b8dfababbab53472894ac4aabc2e89d175e0407ee7701e7494a3d"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x6cb4fbe42943ee5b151a3fbf2f598b4b488318d102fa8b61c10c37a79c545d50"
+          id: "0xf9eef9bd1dbc59e4317acc477661094774714e7dc07cf2f45129514955b22281"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x24f419be038bbb2a5c7035f0f0cb007ff36832c4cecf07d23f446fd7f37459b1"
+            id: "0x10b3dae6a81ced3f5ce3630c63022207f8097582b0bc13ec27b60385495f3b5e"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x491f1c32136a11ed7c5a1357af8f4de5a8b036d0085c1a20139c488d092c7b5a"
+          id: "0xaf494d0503c4b3a9559ffa1fc635d7b28cce50f0c26a6dfbafc7f0c404b1bf1c"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x0fa914b6b5dfce464b301b62d954d4b96c0b7334a6623243ddced29c501e4761"
+      id: "0x66a5a4237f935174431d03e19cd16750229a479434d4d1d49d9b4c293c6cd0c3"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x94e3779ae22112f40df8f71376a5290794eb79dd972e2cb113d5311e2d5cf94d"
+    id: "0xe31c94b834c60f7dd250fabb150717e609b514eb840c6cd406cd866260520938"
     size: 1
   inactive_validators:
-    id: "0x2253a380a7255e2406e642d3cef9abc88b433c4153e7bbbcf7b123049974b147"
+    id: "0x86862a8220f49117291980e11f6ca9a53c48df3e504ba07068305c694103282b"
     size: 0
   validator_candidates:
-    id: "0xc2f1bba1f93a4db8f3b1d1240d460b34bc8e44c7375b332d89e108b08baa84a2"
+    id: "0xdad41c6f028bd1e333ec7a18a97fb18036a70295868ffa437164b063e853dbef"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xe56c345d2ddf88ada7949750bc1926823dadbf96f18ccea372e92157d6865a63"
+      id: "0x8a1553175f20baa24bbd029acb2bd0f254e3979560e6e5d4873ff7b6c892c81f"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x0323b9a322f595f80c7aa4502619eae6e2014bbcdd9b2bd67af427d01ecef998"
+      id: "0x5bc4f37d5cc1b6a77399d5757b9f4ec57c637f419469cdbd97381e5c8c33c9a6"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x0aaa40a984efa073c06b50a1ce9d1f9c2d2ef091ca1e81e3ea65b3847f918094"
+      id: "0xdeb70ba1d5870a66d0ffa47936cf3d85f5692c3e1cc0c3bb4061f03c90a2cd79"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xf6810ae1ab20d518b9267e653fc407da9ce05779a74fa14957ba4aeaca8a8b4a"
+    id: "0xe4cd3f3777509f9d4c174116337f8991b968eb50fe1d5f3b9c743fb09b69edf1"
   size: 0
 


### PR DESCRIPTION
## Description 

This updates the `sui-system` library to use method syntax.

No new use funs.

## Test Plan 

Tests still work, plus manual bytecode diffing between old and new versions.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
