### PR TITLE
[data ingestion] archival workflow: ensure correct epoch on restart

### DIFF
--- a/crates/sui-data-ingestion/src/workers/archival.rs
+++ b/crates/sui-data-ingestion/src/workers/archival.rs
@@ -149,6 +149,10 @@ impl Worker for ArchivalWorker {
             return Ok(());
         }
         let epoch = checkpoint.checkpoint_summary.epoch;
+        if state.buffer.is_empty() {
+            assert!(epoch == state.epoch || epoch == state.epoch + 1);
+            state.epoch = epoch;
+        }
         let full_checkpoint_contents = FullCheckpointContents::from_contents_and_execution_data(
             checkpoint.checkpoint_contents,
             checkpoint


### PR DESCRIPTION
if the data ingestion daemon restarts on an epoch boundary, and the first checkpoint/task afterward is the beginning of a new epoch, the daemon uses incorrect epoch value from the archival MANIFEST(i.e. previous epoch)