### PR TITLE
[move-2024] Add method syntax to Move stdlib tests

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -6,91 +6,89 @@
 #[test_only]
 module std::ascii_tests {
     use std::ascii;
-    use std::vector;
-    use std::option;
 
     #[test]
     fun test_ascii_chars() {
         let mut i = 0;
         let end = 128;
-        let mut vec = vector::empty();
+        let mut vec = vector[];
 
         while (i < end) {
             assert!(ascii::is_valid_char(i), 0);
-            vector::push_back(&mut vec, i);
+            vec.push_back(i);
             i = i + 1;
         };
 
-        let str = ascii::string(vec);
-        assert!(vector::length(ascii::as_bytes(&str)) == 128, 0);
-        assert!(!ascii::all_characters_printable(&str), 1);
-        assert!(vector::length(&ascii::into_bytes(str)) == 128, 2);
+        let str = vec.to_ascii_string();
+        assert!(str.as_bytes().length() == 128, 0);
+        assert!(!str.all_characters_printable(), 1);
+        assert!(str.into_bytes().length() == 128, 2);
     }
 
     #[test]
     fun test_ascii_push_chars() {
         let mut i = 0;
         let end = 128;
-        let mut str = ascii::string(vector::empty());
+        let mut str = vector[].to_ascii_string();
 
         while (i < end) {
-            ascii::push_char(&mut str, ascii::char(i));
+            str.push_char(ascii::char(i));
             i = i + 1;
         };
 
-        assert!(vector::length(ascii::as_bytes(&str)) == 128, 0);
-        assert!(ascii::length(&str) == 128, 0);
-        assert!(!ascii::all_characters_printable(&str), 1);
+        assert!(str.as_bytes().length() == 128, 0);
+        assert!(str.length() == 128, 0);
+        assert!(!str.all_characters_printable(), 1);
     }
 
     #[test]
     fun test_ascii_push_char_pop_char() {
         let mut i = 0;
         let end = 128;
-        let mut str = ascii::string(vector::empty());
+        let mut str = vector[].to_ascii_string();
 
         while (i < end) {
-            ascii::push_char(&mut str, ascii::char(i));
+            str.push_char(ascii::char(i));
             i = i + 1;
         };
 
         while (i > 0) {
-            let char = ascii::pop_char(&mut str);
+            let char = str.pop_char();
             assert!(ascii::byte(char) == i - 1, 0);
             i = i - 1;
         };
 
-        assert!(vector::length(ascii::as_bytes(&str)) == 0, 0);
-        assert!(ascii::length(&str) == 0, 0);
-        assert!(ascii::all_characters_printable(&str), 1);
+        assert!(str.as_bytes().length() == 0, 0);
+        assert!(str.length() == 0, 0);
+        assert!(str.all_characters_printable(), 1);
     }
 
     #[test]
     fun test_printable_chars() {
         let mut i = 0x20;
         let end = 0x7E;
-        let mut vec = vector::empty();
+        let mut vec = vector[];
 
         while (i <= end) {
             assert!(ascii::is_printable_char(i), 0);
-            vector::push_back(&mut vec, i);
+            vec.push_back(i);
             i = i + 1;
         };
 
-        let str = ascii::string(vec);
-        assert!(ascii::all_characters_printable(&str), 0);
+        let str = vec.to_ascii_string();
+        assert!(str.all_characters_printable(), 0);
     }
 
     #[test]
     fun printable_chars_dont_allow_tab() {
-        let str = ascii::string(vector::singleton(0x09));
-        assert!(!ascii::all_characters_printable(&str), 0);
+        let str = vector[0x09].to_ascii_string();
+        assert!(!str.all_characters_printable(), 0);
     }
 
     #[test]
     fun printable_chars_dont_allow_newline() {
-        let str = ascii::string(vector::singleton(0x0A));
-        assert!(!ascii::all_characters_printable(&str), 0);
+        let str = vector[0x0A].to_ascii_string();
+        assert!(!str.all_characters_printable(), 0);
     }
 
     #[test]
@@ -98,8 +96,8 @@ module std::ascii_tests {
         let mut i = 128u8;
         let end = 255u8;
         while (i < end) {
-            let try_str = ascii::try_string(vector::singleton(i));
-            assert!(option::is_none(&try_str), 0);
+            let try_str = vector[i].try_to_ascii_string();
+            assert!(try_str.is_none(), 0);
             i = i + 1;
         };
     }
@@ -109,16 +107,16 @@ module std::ascii_tests {
         let mut i = 0;
         let end = 0x09;
         while (i < end) {
-            let str = ascii::string(vector::singleton(i));
-            assert!(!ascii::all_characters_printable(&str), 0);
+            let str = vector[i].to_ascii_string();
+            assert!(!str.all_characters_printable(), 0);
             i = i + 1;
         };
 
         let mut i = 0x0B;
         let end = 0x0F;
         while (i <= end) {
-            let str = ascii::string(vector::singleton(i));
-            assert!(!ascii::all_characters_printable(&str), 0);
+            let str = vector[i].to_ascii_string();
+            assert!(!str.all_characters_printable(), 0);
             i = i + 1;
         };
     }

--- a/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
@@ -12,12 +12,12 @@ module std::bit_vector_tests {
         let mut bitvector = bit_vector::new(k);
         let mut index = 0;
         while (index < k) {
-            bit_vector::set(&mut bitvector, index);
-            assert!(bit_vector::is_index_set(&bitvector, index), 0);
+            bitvector.set(index);
+            assert!(bitvector.is_index_set(index), 0);
             index = index + 1;
             let mut index_to_right = index;
             while (index_to_right < k) {
-                assert!(!bit_vector::is_index_set(&bitvector, index_to_right), 1);
+                assert!(!bitvector.is_index_set(index_to_right), 1);
                 index_to_right = index_to_right + 1;
             };
         };
@@ -25,12 +25,12 @@ module std::bit_vector_tests {
         index = 0;
 
         while (index < k) {
-            bit_vector::unset(&mut bitvector, index);
-            assert!(!bit_vector::is_index_set(&bitvector, index), 0);
+            bitvector.unset(index);
+            assert!(!bitvector.is_index_set(index), 0);
             index = index + 1;
             let mut index_to_right = index;
             while (index_to_right < k) {
-                assert!(bit_vector::is_index_set(&bitvector, index_to_right), 1);
+                assert!(bitvector.is_index_set(index_to_right), 1);
                 index_to_right = index_to_right + 1;
             };
         };
@@ -40,21 +40,21 @@ module std::bit_vector_tests {
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun set_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
-        bit_vector::set(&mut bitvector, bit_vector::word_size());
+        bitvector.set(bit_vector::word_size());
     }
 
     #[test]
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun unset_bit_out_of_bounds() {
         let mut bitvector = bit_vector::new(bit_vector::word_size());
-        bit_vector::unset(&mut bitvector, bit_vector::word_size());
+        bitvector.unset(bit_vector::word_size());
     }
 
     #[test]
     #[expected_failure(abort_code = bit_vector::EINDEX)]
     fun index_bit_out_of_bounds() {
-        let mut bitvector = bit_vector::new(bit_vector::word_size());
-        bit_vector::is_index_set(&mut bitvector, bit_vector::word_size());
+        let bitvector = bit_vector::new(bit_vector::word_size());
+        bitvector.is_index_set(bit_vector::word_size());
     }
 
     #[test]
@@ -70,28 +70,28 @@ module std::bit_vector_tests {
     #[test]
     fun longest_sequence_no_set_zero_index() {
         let bitvector = bit_vector::new(100);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 0, 0);
+        assert!(bitvector.longest_set_sequence_starting_at(0) == 0, 0);
     }
 
     #[test]
     fun longest_sequence_one_set_zero_index() {
         let mut bitvector = bit_vector::new(100);
-        bit_vector::set(&mut bitvector, 1);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 0, 0);
+        bitvector.set(1);
+        assert!(bitvector.longest_set_sequence_starting_at(0) == 0, 0);
     }
 
     #[test]
     fun longest_sequence_no_set_nonzero_index() {
         let bitvector = bit_vector::new(100);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 51) == 0, 0);
+        assert!(bitvector.longest_set_sequence_starting_at(51) == 0, 0);
     }
 
     #[test]
     fun longest_sequence_two_set_nonzero_index() {
         let mut bitvector = bit_vector::new(100);
-        bit_vector::set(&mut bitvector, 50);
-        bit_vector::set(&mut bitvector, 52);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 51) == 0, 0);
+        bitvector.set(50);
+        bitvector.set(52);
+        assert!(bitvector.longest_set_sequence_starting_at(51) == 0, 0);
     }
 
     #[test]
@@ -99,18 +99,18 @@ module std::bit_vector_tests {
         let mut bitvector = bit_vector::new(100);
         let mut i = 0;
         while (i < 20) {
-            bit_vector::set(&mut bitvector, i);
+            bitvector.set(i);
             i = i + 1;
         };
         // create a break in the run
         i = i + 1;
         while (i < 100) {
-            bit_vector::set(&mut bitvector, i);
+            bitvector.set(i);
             i = i + 1;
         };
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 20, 0);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 20) == 0, 0);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21, 0);
+        assert!(bitvector.longest_set_sequence_starting_at(0) == 20, 0);
+        assert!(bitvector.longest_set_sequence_starting_at(20) == 0, 0);
+        assert!(bitvector.longest_set_sequence_starting_at(21) == 100 - 21, 0);
     }
 
     #[test]
@@ -120,15 +120,15 @@ module std::bit_vector_tests {
 
         let mut i = 0;
         while (i < bitlen) {
-            bit_vector::set(&mut bitvector, i);
+            bitvector.set(i);
             i = i + 1;
         };
 
         i = bitlen - 1;
         while (i > 0) {
-            assert!(bit_vector::is_index_set(&bitvector, i), 0);
-            bit_vector::shift_left(&mut bitvector, 1);
-            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            assert!(bitvector.is_index_set(i), 0);
+            bitvector.shift_left(1);
+            assert!(!bitvector.is_index_set( i), 1);
             i = i - 1;
         };
     }
@@ -139,19 +139,19 @@ module std::bit_vector_tests {
         let shift_amount = 133;
         let mut bitvector = bit_vector::new(bitlen);
 
-        bit_vector::set(&mut bitvector, 201);
-        assert!(bit_vector::is_index_set(&bitvector, 201), 0);
+        bitvector.set(201);
+        assert!(bitvector.is_index_set(201), 0);
 
-        bit_vector::shift_left(&mut bitvector, shift_amount);
-        assert!(bit_vector::is_index_set(&bitvector, 201 - shift_amount), 1);
-        assert!(!bit_vector::is_index_set(&bitvector, 201), 2);
+        bitvector.shift_left(shift_amount);
+        assert!(bitvector.is_index_set(201 - shift_amount), 1);
+        assert!(!bitvector.is_index_set(201), 2);
 
         // Make sure this shift clears all the bits
-        bit_vector::shift_left(&mut bitvector, bitlen  - 1);
+        bitvector.shift_left(bitlen  - 1);
 
         let mut i = 0;
         while (i < bitlen) {
-            assert!(!bit_vector::is_index_set(&bitvector, i), 3);
+            assert!(!bitvector.is_index_set(i), 3);
             i = i + 1;
         }
     }
@@ -166,23 +166,23 @@ module std::bit_vector_tests {
         let mut i = 0;
 
         while (i < bitlen) {
-            bit_vector::set(&mut bitvector, i);
+            bitvector.set(i);
             i = i + 1;
         };
 
-        bit_vector::unset(&mut bitvector, chosen_index);
-        assert!(!bit_vector::is_index_set(&bitvector, chosen_index), 0);
+        bitvector.unset(chosen_index);
+        assert!(!bitvector.is_index_set(chosen_index), 0);
 
-        bit_vector::shift_left(&mut bitvector, shift_amount);
+        bitvector.shift_left(shift_amount);
 
         i = 0;
 
         while (i < bitlen) {
             // only chosen_index - shift_amount and the remaining bits should be BitVector::unset
             if ((i == chosen_index - shift_amount) || (i >= bitlen - shift_amount)) {
-                assert!(!bit_vector::is_index_set(&bitvector, i), 1);
+                assert!(!bitvector.is_index_set(i), 1);
             } else {
-                assert!(bit_vector::is_index_set(&bitvector, i), 2);
+                assert!(bitvector.is_index_set(i), 2);
             };
             i = i + 1;
         }
@@ -195,14 +195,14 @@ module std::bit_vector_tests {
 
         let mut i = 0;
         while (i < bitlen) {
-            bit_vector::set(&mut bitvector, i);
+            bitvector.set(i);
             i = i + 1;
         };
 
-        bit_vector::shift_left(&mut bitvector, bitlen - 1);
+        bitvector.shift_left(bitlen - 1);
         i = bitlen - 1;
         while (i > 0) {
-            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            assert!(!bitvector.is_index_set( i), 1);
             i = i - 1;
         };
     }
@@ -211,7 +211,7 @@ module std::bit_vector_tests {
     fun shift_left_more_than_size() {
         let bitlen = 133;
         let mut bitvector = bit_vector::new(bitlen);
-        bit_vector::shift_left(&mut bitvector, bitlen);
+        bitvector.shift_left(bitlen);
     }
 
     #[test]
@@ -223,6 +223,6 @@ module std::bit_vector_tests {
     #[test]
     fun single_bit_bitvector() {
         let bitvector = bit_vector::new(1);
-        assert!(bit_vector::length(&bitvector) == 1, 0);
+        assert!(bitvector.length() == 1, 0);
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
@@ -33,7 +33,7 @@ module std::fixed_point32_tests {
     #[test]
     fun create_zero() {
         let x = fixed_point32::create_from_rational(0, 1);
-        assert!(fixed_point32::is_zero(x), 0);
+        assert!(x.is_zero(), 0);
     }
 
     #[test]
@@ -99,7 +99,7 @@ module std::fixed_point32_tests {
         assert!(not_three == 2, 0);
 
         // Try again with a fraction slightly larger than 1/3.
-        let f = fixed_point32::create_from_raw_value(fixed_point32::get_raw_value(f) + 1);
+        let f = fixed_point32::create_from_raw_value(f.get_raw_value() + 1);
         let three = fixed_point32::multiply_u64(9, f);
         assert!(three == 3, 1);
     }
@@ -108,7 +108,7 @@ module std::fixed_point32_tests {
     fun create_from_rational_max_numerator_denominator() {
         // Test creating a 1.0 fraction from the maximum u64 value.
         let f = fixed_point32::create_from_rational(18446744073709551615, 18446744073709551615);
-        let one = fixed_point32::get_raw_value(f);
+        let one = f.get_raw_value();
         assert!(one == 4294967296, 0); // 0x1.00000000
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -6,20 +6,19 @@
 #[test_only]
 module std::option_tests {
     use std::option;
-    use std::vector;
 
     #[test]
     fun option_none_is_none() {
         let none = option::none<u64>();
-        assert!(option::is_none(&none), 0);
-        assert!(!option::is_some(&none), 1);
+        assert!(none.is_none(), 0);
+        assert!(!none.is_some(), 1);
     }
 
     #[test]
     fun option_some_is_some() {
         let some = option::some(5);
-        assert!(!option::is_none(&some), 0);
-        assert!(option::is_some(&some), 1);
+        assert!(!some.is_none(), 0);
+        assert!(some.is_some(), 1);
     }
 
     #[test]
@@ -27,46 +26,46 @@ module std::option_tests {
         let none = option::none<u64>();
         let some = option::some(5);
         let some_other = option::some(6);
-        assert!(option::contains(&some, &5), 0);
-        assert!(option::contains(&some_other, &6), 1);
-        assert!(!option::contains(&none, &5), 2);
-        assert!(!option::contains(&some_other, &5), 3);
+        assert!(some.contains(&5), 0);
+        assert!(some_other.contains(&6), 1);
+        assert!(!none.contains(&5), 2);
+        assert!(!some_other.contains(&5), 3);
     }
 
     #[test]
     fun option_borrow_some() {
         let some = option::some(5);
         let some_other = option::some(6);
-        assert!(*option::borrow(&some) == 5, 3);
-        assert!(*option::borrow(&some_other) == 6, 4);
+        assert!(*some.borrow() == 5, 3);
+        assert!(*some_other.borrow() == 6, 4);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
     fun option_borrow_none() {
-        option::borrow(&option::none<u64>());
+        option::none<u64>().borrow();
     }
 
     #[test]
     fun borrow_mut_some() {
         let mut some = option::some(1);
-        let ref = option::borrow_mut(&mut some);
+        let ref = some.borrow_mut();
         *ref = 10;
-        assert!(*option::borrow(&some) == 10, 0);
+        assert!(*some.borrow() == 10, 0);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
     fun borrow_mut_none() {
-        option::borrow_mut(&mut option::none<u64>());
+        option::none<u64>().borrow_mut();
     }
 
     #[test]
     fun borrow_with_default() {
         let none = option::none<u64>();
         let some = option::some(5);
-        assert!(*option::borrow_with_default(&some, &7) == 5, 0);
-        assert!(*option::borrow_with_default(&none, &7) == 7, 1);
+        assert!(*some.borrow_with_default(&7) == 5, 0);
+        assert!(*none.borrow_with_default(&7) == 7, 1);
     }
 
     #[test]
@@ -80,96 +79,96 @@ module std::option_tests {
     #[test]
     fun extract_some() {
         let mut opt = option::some(1);
-        assert!(option::extract(&mut opt) == 1, 0);
-        assert!(option::is_none(&opt), 1);
+        assert!(opt.extract() == 1, 0);
+        assert!(opt.is_none(), 1);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
     fun extract_none() {
-        option::extract(&mut option::none<u64>());
+        option::none<u64>().extract();
     }
 
     #[test]
     fun swap_some() {
         let mut some = option::some(5);
-        assert!(option::swap(&mut some, 1) == 5, 0);
-        assert!(*option::borrow(&some) == 1, 1);
+        assert!(some.swap(1) == 5, 0);
+        assert!(*some.borrow() == 1, 1);
     }
 
     #[test]
     fun swap_or_fill_some() {
         let mut some = option::some(5);
-        assert!(option::swap_or_fill(&mut some, 1) == option::some(5), 0);
-        assert!(*option::borrow(&some) == 1, 1);
+        assert!(some.swap_or_fill(1) == option::some(5), 0);
+        assert!(*some.borrow() == 1, 1);
     }
 
     #[test]
     fun swap_or_fill_none() {
         let mut none = option::none();
-        assert!(option::swap_or_fill(&mut none, 1) == option::none(), 0);
-        assert!(*option::borrow(&none) == 1, 1);
+        assert!(none.swap_or_fill(1) == option::none(), 0);
+        assert!(*none.borrow() == 1, 1);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
     fun swap_none() {
-        option::swap(&mut option::none<u64>(), 1);
+        option::none<u64>().swap(1);
     }
 
     #[test]
     fun fill_none() {
         let mut none = option::none<u64>();
-        option::fill(&mut none, 3);
-        assert!(option::is_some(&none), 0);
-        assert!(*option::borrow(&none) == 3, 1);
+        none.fill(3);
+        assert!(none.is_some(), 0);
+        assert!(*none.borrow() == 3, 1);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_IS_SET)]
     fun fill_some() {
-        option::fill(&mut option::some(3), 0);
+        option::some(3).fill(0);
     }
 
     #[test]
     fun destroy_with_default() {
-        assert!(option::destroy_with_default(option::none<u64>(), 4) == 4, 0);
-        assert!(option::destroy_with_default(option::some(4), 5) == 4, 1);
+        assert!(option::none<u64>().destroy_with_default(4) == 4, 0);
+        assert!(option::some(4).destroy_with_default(5) == 4, 1);
     }
 
     #[test]
     fun destroy_some() {
-        assert!(option::destroy_some(option::some(4)) == 4, 0);
+        assert!(option::some(4).destroy_some() == 4, 0);
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
     fun destroy_some_none() {
-        option::destroy_some(option::none<u64>());
+        option::none<u64>().destroy_some();
     }
 
     #[test]
     fun destroy_none() {
-        option::destroy_none(option::none<u64>());
+        option::none<u64>().destroy_none();
     }
 
     #[test]
     #[expected_failure(abort_code = option::EOPTION_IS_SET)]
     fun destroy_none_some() {
-        option::destroy_none(option::some<u64>(0));
+        option::some<u64>(0).destroy_none();
     }
 
     #[test]
     fun into_vec_some() {
-        let mut v = option::to_vec(option::some<u64>(0));
-        assert!(vector::length(&v) == 1, 0);
-        let x = vector::pop_back(&mut v);
+        let mut v = option::some<u64>(0).to_vec();
+        assert!(v.length() == 1, 0);
+        let x = v.pop_back();
         assert!(x == 0, 1);
     }
 
     #[test]
     fun into_vec_none() {
-        let v: vector<u64> = option::to_vec(option::none());
-        assert!(vector::is_empty(&v), 0);
+        let v: vector<u64> = option::none().to_vec();
+        assert!(v.is_empty(), 0);
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -10,74 +10,74 @@ module std::string_tests {
     #[test]
     fun test_valid_utf8() {
         let sparkle_heart = vector[240, 159, 146, 150];
-        let s = string::utf8(sparkle_heart);
-        assert!(string::length(&s) == 4, 22);
+        let s = sparkle_heart.to_string();
+        assert!(s.length() == 4, 22);
     }
 
     #[test]
     #[expected_failure(abort_code = string::EINVALID_UTF8)]
     fun test_invalid_utf8() {
         let no_sparkle_heart = vector[0, 159, 146, 150];
-        let s = string::utf8(no_sparkle_heart);
-        assert!(string::length(&s) == 1, 22);
+        let s = no_sparkle_heart.to_string();
+        assert!(s.length() == 1, 22);
     }
 
     #[test]
     fun test_sub_string() {
-        let s = string::utf8(b"abcd");
-        let sub = string::sub_string(&s, 2, 4);
-        assert!(sub == string::utf8(b"cd"), 22)
+        let s = b"abcd".to_string();
+        let sub = s.sub_string(2, 4);
+        assert!(sub == b"cd".to_string(), 22)
     }
 
     #[test]
     #[expected_failure(abort_code = string::EINVALID_INDEX)]
     fun test_sub_string_invalid_boundary() {
         let sparkle_heart = vector[240, 159, 146, 150];
-        let s = string::utf8(sparkle_heart);
-        let _sub = string::sub_string(&s, 1, 4);
+        let s = sparkle_heart.to_string();
+        let _sub = s.sub_string(1, 4);
     }
 
     #[test]
     #[expected_failure(abort_code = string::EINVALID_INDEX)]
     fun test_sub_string_invalid_index() {
-        let s = string::utf8(b"abcd");
-        let _sub = string::sub_string(&s, 4, 5);
+        let s = b"abcd".to_string();
+        let _sub = s.sub_string(4, 5);
     }
 
     #[test]
     fun test_sub_string_empty() {
-        let s = string::utf8(b"abcd");
-        let sub = string::sub_string(&s, 4, 4);
-        assert!(string::is_empty(&sub), 22)
+        let s = b"abcd".to_string();
+        let sub = s.sub_string(4, 4);
+        assert!(sub.is_empty(), 22)
     }
 
     #[test]
     fun test_index_of() {
-        let s = string::utf8(b"abcd");
-        let r = string::utf8(b"bc");
-        let p = string::index_of(&s, &r);
+        let s = b"abcd".to_string();
+        let r = b"bc".to_string();
+        let p = s.index_of(&r);
         assert!(p == 1, 22)
     }
 
     #[test]
     fun test_index_of_fail() {
-        let s = string::utf8(b"abcd");
-        let r = string::utf8(b"bce");
-        let p = string::index_of(&s, &r);
+        let s = b"abcd".to_string();
+        let r = b"bce".to_string();
+        let p = s.index_of(&r);
         assert!(p == 4, 22)
     }
 
     #[test]
     fun test_append() {
-        let mut s = string::utf8(b"abcd");
-        string::append(&mut s, string::utf8(b"ef"));
-        assert!(s == string::utf8(b"abcdef"), 22)
+        let mut s = b"abcd".to_string();
+        s.append(b"ef".to_string());
+        assert!(s == b"abcdef".to_string(), 22)
     }
 
     #[test]
     fun test_insert() {
-        let mut s = string::utf8(b"abcd");
-        string::insert(&mut s, 1, string::utf8(b"xy"));
-        assert!(s == string::utf8(b"axybcd"), 22)
+        let mut s = b"abcd".to_string();
+        s.insert(1, b"xy".to_string());
+        assert!(s == b"axybcd".to_string(), 22)
     }
 }

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -5,7 +5,7 @@
 
 #[test_only]
 module std::vector_tests {
-    use std::vector as V;
+    use std::vector;
 
     public struct R has store { }
     public struct Droppable has drop {}
@@ -13,83 +13,83 @@ module std::vector_tests {
 
     #[test]
     fun test_singleton_contains() {
-        assert!(*V::borrow(&V::singleton(0), 0) == 0, 0);
-        assert!(*V::borrow(&V::singleton(true), 0) == true, 0);
-        assert!(*V::borrow(&V::singleton(@0x1), 0) == @0x1, 0);
+        assert!(vector[0][0] == 0, 0);
+        assert!(vector[true][0] == true, 0);
+        assert!(vector[@0x1][0] == @0x1, 0);
     }
 
     #[test]
     fun test_singleton_len() {
-        assert!(V::length(&V::singleton(0)) == 1, 0);
-        assert!(V::length(&V::singleton(true)) == 1, 0);
-        assert!(V::length(&V::singleton(@0x1)) == 1, 0);
+        assert!(&vector[0].length() == 1, 0);
+        assert!(&vector[true].length() == 1, 0);
+        assert!(&vector[@0x1].length() == 1, 0);
     }
 
     #[test]
     fun test_empty_is_empty() {
-        assert!(V::is_empty(&V::empty<u64>()), 0);
+        assert!(vector<u64>[].is_empty(), 0);
     }
 
     #[test]
     fun append_empties_is_empty() {
-        let mut v1 = V::empty<u64>();
-        let v2 = V::empty<u64>();
-        V::append(&mut v1, v2);
-        assert!(V::is_empty(&v1), 0);
+        let mut v1 = vector<u64>[];
+        let v2 = vector<u64>[];
+        v1.append(v2);
+        assert!(v1.is_empty(), 0);
     }
 
     #[test]
     fun append_respects_order_empty_lhs() {
-        let mut v1 = V::empty();
-        let mut v2 = V::empty();
-        V::push_back(&mut v2, 0);
-        V::push_back(&mut v2, 1);
-        V::push_back(&mut v2, 2);
-        V::push_back(&mut v2, 3);
-        V::append(&mut v1, v2);
-        assert!(!V::is_empty(&v1), 0);
-        assert!(V::length(&v1) == 4, 1);
-        assert!(*V::borrow(&v1, 0) == 0, 2);
-        assert!(*V::borrow(&v1, 1) == 1, 3);
-        assert!(*V::borrow(&v1, 2) == 2, 4);
-        assert!(*V::borrow(&v1, 3) == 3, 5);
+        let mut v1 = vector[];
+        let mut v2 = vector[];
+        v2.push_back(0);
+        v2.push_back(1);
+        v2.push_back(2);
+        v2.push_back(3);
+        v1.append(v2);
+        assert!(!v1.is_empty(), 0);
+        assert!(v1.length() == 4, 1);
+        assert!(v1[0] == 0, 2);
+        assert!(v1[1] == 1, 3);
+        assert!(v1[2] == 2, 4);
+        assert!(v1[3] == 3, 5);
     }
 
     #[test]
     fun append_respects_order_empty_rhs() {
-        let mut v1 = V::empty();
-        let v2 = V::empty();
-        V::push_back(&mut v1, 0);
-        V::push_back(&mut v1, 1);
-        V::push_back(&mut v1, 2);
-        V::push_back(&mut v1, 3);
-        V::append(&mut v1, v2);
-        assert!(!V::is_empty(&v1), 0);
-        assert!(V::length(&v1) == 4, 1);
-        assert!(*V::borrow(&v1, 0) == 0, 2);
-        assert!(*V::borrow(&v1, 1) == 1, 3);
-        assert!(*V::borrow(&v1, 2) == 2, 4);
-        assert!(*V::borrow(&v1, 3) == 3, 5);
+        let mut v1 = vector[];
+        let v2 = vector[];
+        v1.push_back(0);
+        v1.push_back(1);
+        v1.push_back(2);
+        v1.push_back(3);
+        v1.append(v2);
+        assert!(!v1.is_empty(), 0);
+        assert!(v1.length() == 4, 1);
+        assert!(v1[0] == 0, 2);
+        assert!(v1[1] == 1, 3);
+        assert!(v1[2] == 2, 4);
+        assert!(v1[3] == 3, 5);
     }
 
     #[test]
     fun append_respects_order_nonempty_rhs_lhs() {
-        let mut v1 = V::empty();
-        let mut v2 = V::empty();
-        V::push_back(&mut v1, 0);
-        V::push_back(&mut v1, 1);
-        V::push_back(&mut v1, 2);
-        V::push_back(&mut v1, 3);
-        V::push_back(&mut v2, 4);
-        V::push_back(&mut v2, 5);
-        V::push_back(&mut v2, 6);
-        V::push_back(&mut v2, 7);
-        V::append(&mut v1, v2);
-        assert!(!V::is_empty(&v1), 0);
-        assert!(V::length(&v1) == 8, 1);
+        let mut v1 = vector[];
+        let mut v2 = vector[];
+        v1.push_back(0);
+        v1.push_back(1);
+        v1.push_back(2);
+        v1.push_back(3);
+        v2.push_back(4);
+        v2.push_back(5);
+        v2.push_back(6);
+        v2.push_back(7);
+        v1.append(v2);
+        assert!(!v1.is_empty(), 0);
+        assert!(v1.length() == 8, 1);
         let mut i = 0;
         while (i < 8) {
-            assert!(*V::borrow(&v1, i) == i, i);
+            assert!(v1[i] == i, i);
             i = i + 1;
         }
     }
@@ -97,335 +97,337 @@ module std::vector_tests {
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun borrow_out_of_range() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 7);
-        V::borrow(&v, 1);
+        let mut v = vector[];
+        v.push_back(7);
+        &v[1];
     }
 
     #[test]
     fun vector_contains() {
-        let mut vec = V::empty();
-        assert!(!V::contains(&vec, &0), 1);
+        let mut vec = vector[];
+        assert!(!vec.contains(&0), 1);
 
-        V::push_back(&mut vec, 0);
-        assert!(V::contains(&vec, &0), 2);
-        assert!(!V::contains(&vec, &1), 3);
+        vec.push_back(0);
+        assert!(vec.contains(&0), 2);
+        assert!(!vec.contains(&1), 3);
 
-        V::push_back(&mut vec, 1);
-        assert!(V::contains(&vec, &0), 4);
-        assert!(V::contains(&vec, &1), 5);
-        assert!(!V::contains(&vec, &2), 6);
+        vec.push_back(1);
+        assert!(vec.contains(&0), 4);
+        assert!(vec.contains(&1), 5);
+        assert!(!vec.contains(&2), 6);
 
-        V::push_back(&mut vec, 2);
-        assert!(V::contains(&vec, &0), 7);
-        assert!(V::contains(&vec, &1), 8);
-        assert!(V::contains(&vec, &2), 9);
-        assert!(!V::contains(&vec, &3), 10);
+        vec.push_back(2);
+        assert!(vec.contains(&0), 7);
+        assert!(vec.contains(&1), 8);
+        assert!(vec.contains(&2), 9);
+        assert!(!vec.contains(&3), 10);
     }
 
     #[test]
     fun destroy_empty() {
-        V::destroy_empty(V::empty<u64>());
-        V::destroy_empty(V::empty<R>());
+        vector<u64>[].destroy_empty();
+        vector<R>[].destroy_empty();
+        vector::empty<u64>().destroy_empty();
+        vector::empty<R>().destroy_empty();
     }
 
     #[test]
     fun destroy_empty_with_pops() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 42);
-        V::pop_back(&mut v);
-        V::destroy_empty(v);
+        let mut v = vector[];
+        v.push_back(42);
+        v.pop_back();
+        v.destroy_empty();
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 3, location = Self)]
     fun destroy_non_empty() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 42);
-        V::destroy_empty(v);
+        let mut v = vector[];
+        v.push_back(42);
+        v.destroy_empty();
     }
 
     #[test]
     fun get_set_work() {
-        let mut vec = V::empty();
-        V::push_back(&mut vec, 0);
-        V::push_back(&mut vec, 1);
-        assert!(*V::borrow(&vec, 1) == 1, 0);
-        assert!(*V::borrow(&vec, 0) == 0, 1);
+        let mut vec = vector[];
+        vec.push_back(0);
+        vec.push_back(1);
+        assert!(vec[1] == 1, 0);
+        assert!(vec[0] == 0, 1);
 
-        *V::borrow_mut(&mut vec, 0) = 17;
-        assert!(*V::borrow(&vec, 1) == 1, 0);
-        assert!(*V::borrow(&vec, 0) == 17, 0);
+        *&mut vec[0] = 17;
+        assert!(vec[1] == 1, 0);
+        assert!(vec[0] == 17, 0);
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 2, location = Self)]
     fun pop_out_of_range() {
-        let mut v = V::empty<u64>();
-        V::pop_back(&mut v);
+        let mut v = vector<u64>[];
+        v.pop_back();
     }
 
     #[test]
     fun swap_different_indices() {
-        let mut vec = V::empty();
-        V::push_back(&mut vec, 0);
-        V::push_back(&mut vec, 1);
-        V::push_back(&mut vec, 2);
-        V::push_back(&mut vec, 3);
-        V::swap(&mut vec, 0, 3);
-        V::swap(&mut vec, 1, 2);
-        assert!(*V::borrow(&vec, 0) == 3, 0);
-        assert!(*V::borrow(&vec, 1) == 2, 0);
-        assert!(*V::borrow(&vec, 2) == 1, 0);
-        assert!(*V::borrow(&vec, 3) == 0, 0);
+        let mut vec = vector[];
+        vec.push_back(0);
+        vec.push_back(1);
+        vec.push_back(2);
+        vec.push_back(3);
+        vec.swap(0, 3);
+        vec.swap(1, 2);
+        assert!(vec[0] == 3, 0);
+        assert!(vec[1] == 2, 0);
+        assert!(vec[2] == 1, 0);
+        assert!(vec[3] == 0, 0);
     }
 
     #[test]
     fun swap_same_index() {
-        let mut vec = V::empty();
-        V::push_back(&mut vec, 0);
-        V::push_back(&mut vec, 1);
-        V::push_back(&mut vec, 2);
-        V::push_back(&mut vec, 3);
-        V::swap(&mut vec, 1, 1);
-        assert!(*V::borrow(&vec, 0) == 0, 0);
-        assert!(*V::borrow(&vec, 1) == 1, 0);
-        assert!(*V::borrow(&vec, 2) == 2, 0);
-        assert!(*V::borrow(&vec, 3) == 3, 0);
+        let mut vec = vector[];
+        vec.push_back(0);
+        vec.push_back(1);
+        vec.push_back(2);
+        vec.push_back(3);
+        vec.swap(1, 1);
+        assert!(vec[0] == 0, 0);
+        assert!(vec[1] == 1, 0);
+        assert!(vec[2] == 2, 0);
+        assert!(vec[3] == 3, 0);
     }
 
     #[test]
     fun remove_singleton_vector() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        assert!(V::remove(&mut v, 0) == 0, 0);
-        assert!(V::length(&v) == 0, 0);
+        let mut v = vector[];
+        v.push_back(0);
+        assert!(v.remove(0) == 0, 0);
+        assert!(v.length() == 0, 0);
     }
 
     #[test]
     fun remove_nonsingleton_vector() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        assert!(V::remove(&mut v, 1) == 1, 0);
-        assert!(V::length(&v) == 3, 0);
-        assert!(*V::borrow(&v, 0) == 0, 0);
-        assert!(*V::borrow(&v, 1) == 2, 0);
-        assert!(*V::borrow(&v, 2) == 3, 0);
+        assert!(v.remove(1) == 1, 0);
+        assert!(v.length() == 3, 0);
+        assert!(v[0] == 0, 0);
+        assert!(v[1] == 2, 0);
+        assert!(v[2] == 3, 0);
     }
 
     #[test]
     fun remove_nonsingleton_vector_last_elem() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        assert!(V::remove(&mut v, 3) == 3, 0);
-        assert!(V::length(&v) == 3, 0);
-        assert!(*V::borrow(&v, 0) == 0, 0);
-        assert!(*V::borrow(&v, 1) == 1, 0);
-        assert!(*V::borrow(&v, 2) == 2, 0);
+        assert!(v.remove(3) == 3, 0);
+        assert!(v.length() == 3, 0);
+        assert!(v[0] == 0, 0);
+        assert!(v[1] == 1, 0);
+        assert!(v[2] == 2, 0);
     }
 
     #[test]
-    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
     fun remove_empty_vector() {
-        let mut v = V::empty<u64>();
-        V::remove(&mut v, 0);
+        let mut v = vector<u64>[];
+        v.remove(0);
     }
 
     #[test]
-    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = vector::EINDEX_OUT_OF_BOUNDS)]
     fun remove_out_of_bound_index() {
-        let mut v = V::empty<u64>();
-        V::push_back(&mut v, 0);
-        V::remove(&mut v, 1);
+        let mut v = vector<u64>[];
+        v.push_back(0);
+        v.remove(1);
     }
 
     #[test]
     fun reverse_vector_empty() {
-        let mut v = V::empty<u64>();
-        let is_empty = V::is_empty(&v);
-        V::reverse(&mut v);
-        assert!(is_empty == V::is_empty(&v), 0);
+        let mut v = vector<u64>[];
+        let is_empty = v.is_empty();
+        v.reverse();
+        assert!(is_empty == v.is_empty(), 0);
     }
 
     #[test]
     fun reverse_singleton_vector() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        assert!(*V::borrow(&v, 0) == 0, 1);
-        V::reverse(&mut v);
-        assert!(*V::borrow(&v, 0) == 0, 2);
+        let mut v = vector[];
+        v.push_back(0);
+        assert!(v[0] == 0, 1);
+        v.reverse();
+        assert!(v[0] == 0, 2);
     }
 
     #[test]
     fun reverse_vector_nonempty_even_length() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        assert!(*V::borrow(&v, 0) == 0, 1);
-        assert!(*V::borrow(&v, 1) == 1, 2);
-        assert!(*V::borrow(&v, 2) == 2, 3);
-        assert!(*V::borrow(&v, 3) == 3, 4);
+        assert!(v[0] == 0, 1);
+        assert!(v[1] == 1, 2);
+        assert!(v[2] == 2, 3);
+        assert!(v[3] == 3, 4);
 
-        V::reverse(&mut v);
+        v.reverse();
 
-        assert!(*V::borrow(&v, 3) == 0, 5);
-        assert!(*V::borrow(&v, 2) == 1, 6);
-        assert!(*V::borrow(&v, 1) == 2, 7);
-        assert!(*V::borrow(&v, 0) == 3, 8);
+        assert!(v[3] == 0, 5);
+        assert!(v[2] == 1, 6);
+        assert!(v[1] == 2, 7);
+        assert!(v[0] == 3, 8);
     }
 
     #[test]
     fun reverse_vector_nonempty_odd_length_non_singleton() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
 
-        assert!(*V::borrow(&v, 0) == 0, 1);
-        assert!(*V::borrow(&v, 1) == 1, 2);
-        assert!(*V::borrow(&v, 2) == 2, 3);
+        assert!(v[0] == 0, 1);
+        assert!(v[1] == 1, 2);
+        assert!(v[2] == 2, 3);
 
-        V::reverse(&mut v);
+        v.reverse();
 
-        assert!(*V::borrow(&v, 2) == 0, 4);
-        assert!(*V::borrow(&v, 1) == 1, 5);
-        assert!(*V::borrow(&v, 0) == 2, 6);
+        assert!(v[2] == 0, 4);
+        assert!(v[1] == 1, 5);
+        assert!(v[0] == 2, 6);
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun swap_empty() {
-        let mut v = V::empty<u64>();
-        V::swap(&mut v, 0, 0);
+        let mut v = vector<u64>[];
+        v.swap(0, 0);
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = Self)]
     fun swap_out_of_range() {
-        let mut v = V::empty<u64>();
+        let mut v = vector<u64>[];
 
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        V::swap(&mut v, 1, 10);
+        v.swap(1, 10);
     }
 
     #[test]
-    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
     fun swap_remove_empty() {
-        let mut v = V::empty<u64>();
-        V::swap_remove(&mut v, 0);
+        let mut v = vector<u64>[];
+        v.swap_remove(0);
     }
 
     #[test]
     fun swap_remove_singleton() {
-        let mut v = V::empty<u64>();
-        V::push_back(&mut v, 0);
-        assert!(V::swap_remove(&mut v, 0) == 0, 0);
-        assert!(V::is_empty(&v), 1);
+        let mut v = vector<u64>[];
+        v.push_back(0);
+        assert!(v.swap_remove(0) == 0, 0);
+        assert!(v.is_empty(), 1);
     }
 
     #[test]
     fun swap_remove_inside_vector() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        assert!(*V::borrow(&v, 0) == 0, 1);
-        assert!(*V::borrow(&v, 1) == 1, 2);
-        assert!(*V::borrow(&v, 2) == 2, 3);
-        assert!(*V::borrow(&v, 3) == 3, 4);
+        assert!(v[0] == 0, 1);
+        assert!(v[1] == 1, 2);
+        assert!(v[2] == 2, 3);
+        assert!(v[3] == 3, 4);
 
-        assert!(V::swap_remove(&mut v, 1) == 1, 5);
-        assert!(V::length(&v) == 3, 6);
+        assert!(v.swap_remove(1) == 1, 5);
+        assert!(v.length() == 3, 6);
 
-        assert!(*V::borrow(&v, 0) == 0, 7);
-        assert!(*V::borrow(&v, 1) == 3, 8);
-        assert!(*V::borrow(&v, 2) == 2, 9);
+        assert!(v[0] == 0, 7);
+        assert!(v[1] == 3, 8);
+        assert!(v[2] == 2, 9);
 
     }
 
     #[test]
     fun swap_remove_end_of_vector() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::push_back(&mut v, 1);
-        V::push_back(&mut v, 2);
-        V::push_back(&mut v, 3);
+        let mut v = vector[];
+        v.push_back(0);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
 
-        assert!(*V::borrow(&v, 0) == 0, 1);
-        assert!(*V::borrow(&v, 1) == 1, 2);
-        assert!(*V::borrow(&v, 2) == 2, 3);
-        assert!(*V::borrow(&v, 3) == 3, 4);
+        assert!(v[0] == 0, 1);
+        assert!(v[1] == 1, 2);
+        assert!(v[2] == 2, 3);
+        assert!(v[3] == 3, 4);
 
-        assert!(V::swap_remove(&mut v, 3) == 3, 5);
-        assert!(V::length(&v) == 3, 6);
+        assert!(v.swap_remove(3) == 3, 5);
+        assert!(v.length() == 3, 6);
 
-        assert!(*V::borrow(&v, 0) == 0, 7);
-        assert!(*V::borrow(&v, 1) == 1, 8);
-        assert!(*V::borrow(&v, 2) == 2, 9);
+        assert!(v[0] == 0, 7);
+        assert!(v[1] == 1, 8);
+        assert!(v[2] == 2, 9);
     }
 
     #[test]
     #[expected_failure(vector_error, minor_status = 1, location = std::vector)]
     fun swap_remove_out_of_range() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 0);
-        V::swap_remove(&mut v, 1);
+        let mut v = vector[];
+        v.push_back(0);
+        v.swap_remove(1);
     }
 
     #[test]
     fun push_back_and_borrow() {
-        let mut v = V::empty();
-        V::push_back(&mut v, 7);
-        assert!(!V::is_empty(&v), 0);
-        assert!(V::length(&v) == 1, 1);
-        assert!(*V::borrow(&v, 0) == 7, 2);
+        let mut v = vector[];
+        v.push_back(7);
+        assert!(!v.is_empty(), 0);
+        assert!(v.length() == 1, 1);
+        assert!(v[0] == 7, 2);
 
-        V::push_back(&mut v, 8);
-        assert!(V::length(&v) == 2, 3);
-        assert!(*V::borrow(&v, 0) == 7, 4);
-        assert!(*V::borrow(&v, 1) == 8, 5);
+        v.push_back(8);
+        assert!(v.length() == 2, 3);
+        assert!(v[0] == 7, 4);
+        assert!(v[1] == 8, 5);
     }
 
     #[test]
     fun index_of_empty_not_has() {
-        let v = V::empty();
-        let (has, index) = V::index_of(&v, &true);
+        let v = vector[];
+        let (has, index) = v.index_of(&true);
         assert!(!has, 0);
         assert!(index == 0, 1);
     }
 
     #[test]
     fun index_of_nonempty_not_has() {
-        let mut v = V::empty();
-        V::push_back(&mut v, false);
-        let (has, index) = V::index_of(&v, &true);
+        let mut v = vector[];
+        v.push_back(false);
+        let (has, index) = v.index_of(&true);
         assert!(!has, 0);
         assert!(index == 0, 1);
     }
 
     #[test]
     fun index_of_nonempty_has() {
-        let mut v = V::empty();
-        V::push_back(&mut v, false);
-        V::push_back(&mut v, true);
-        let (has, index) = V::index_of(&v, &true);
+        let mut v = vector[];
+        v.push_back(false);
+        v.push_back(true);
+        let (has, index) = v.index_of(&true);
         assert!(has, 0);
         assert!(index == 1, 1);
     }
@@ -433,59 +435,59 @@ module std::vector_tests {
     // index_of will return the index first occurence that is equal
     #[test]
     fun index_of_nonempty_has_multiple_occurences() {
-        let mut v = V::empty();
-        V::push_back(&mut v, false);
-        V::push_back(&mut v, true);
-        V::push_back(&mut v, true);
-        let (has, index) = V::index_of(&v, &true);
+        let mut v = vector[];
+        v.push_back(false);
+        v.push_back(true);
+        v.push_back(true);
+        let (has, index) = v.index_of(&true);
         assert!(has, 0);
         assert!(index == 1, 1);
     }
 
     #[test]
     fun length() {
-        let mut empty = V::empty();
-        assert!(V::length(&empty) == 0, 0);
+        let mut empty = vector[];
+        assert!(empty.length() == 0, 0);
         let mut i = 0;
         let max_len = 42;
         while (i < max_len) {
-            V::push_back(&mut empty, i);
-            assert!(V::length(&empty) == i + 1, i);
+            empty.push_back(i);
+            assert!(empty.length() == i + 1, i);
             i = i + 1;
         }
     }
 
     #[test]
     fun pop_push_back() {
-        let mut v = V::empty();
+        let mut v = vector[];
         let mut i = 0;
         let max_len = 42;
 
         while (i < max_len) {
-            V::push_back(&mut v, i);
+            v.push_back(i);
             i = i + 1;
         };
 
         while (i > 0) {
-            assert!(V::pop_back(&mut v) == i - 1, i);
+            assert!(v.pop_back() == i - 1, i);
             i = i - 1;
         };
     }
 
     #[test_only]
     fun test_natives_with_type<T>(mut x1: T, mut x2: T): (T, T) {
-        let mut v = V::empty();
-        assert!(V::length(&v) == 0, 0);
-        V::push_back(&mut v, x1);
-        assert!(V::length(&v) == 1, 1);
-        V::push_back(&mut v, x2);
-        assert!(V::length(&v) == 2, 2);
-        V::swap(&mut v, 0, 1);
-        x1 = V::pop_back(&mut v);
-        assert!(V::length(&v) == 1, 3);
-        x2 = V::pop_back(&mut v);
-        assert!(V::length(&v) == 0, 4);
-        V::destroy_empty(v);
+        let mut v = vector[];
+        assert!(v.length() == 0, 0);
+        v.push_back(x1);
+        assert!(v.length() == 1, 1);
+        v.push_back(x2);
+        assert!(v.length() == 2, 2);
+        v.swap(0, 1);
+        x1 = v.pop_back();
+        assert!(v.length() == 1, 3);
+        x2 = v.pop_back();
+        assert!(v.length() == 0, 4);
+        v.destroy_empty();
         (x1, x2)
     }
 
@@ -500,7 +502,7 @@ module std::vector_tests {
         test_natives_with_type<bool>(true, false);
         test_natives_with_type<address>(@0x1, @0x2);
 
-        test_natives_with_type<vector<u8>>(V::empty(), V::empty());
+        test_natives_with_type<vector<u8>>(vector[], vector[]);
 
         test_natives_with_type<Droppable>(Droppable{}, Droppable{});
         (NotDroppable {}, NotDroppable {}) = test_natives_with_type<NotDroppable>(
@@ -512,48 +514,48 @@ module std::vector_tests {
     #[test]
     fun test_insert() {
         let mut v = vector[7];
-        V::insert(&mut v, 6, 0);
+        v.insert(6, 0);
         assert!(v == vector[6, 7], 0);
 
         let mut v = vector[7, 9];
-        V::insert(&mut v, 8, 1);
+        v.insert(8, 1);
         assert!(v == vector[7, 8, 9], 0);
 
         let mut v = vector[6, 7];
-        V::insert(&mut v, 5, 0);
+        v.insert(5, 0);
         assert!(v == vector[5, 6, 7], 0);
 
         let mut v = vector[5, 6, 8];
-        V::insert(&mut v, 7, 2);
+        v.insert(7, 2);
         assert!(v == vector[5, 6, 7, 8], 0);
     }
 
     #[test]
     fun insert_at_end() {
         let mut v = vector[];
-        V::insert(&mut v, 6, 0);
+        v.insert(6, 0);
         assert!(v == vector[6], 0);
 
-        V::insert(&mut v, 7, 1);
+        v.insert(7, 1);
         assert!(v == vector[6, 7], 0);
     }
 
     #[test]
-    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    #[expected_failure(abort_code = std::vector::EINDEX_OUT_OF_BOUNDS)]
     fun insert_out_of_range() {
         let mut v = vector[7];
-        V::insert(&mut v, 6, 2);
+        v.insert(6, 2);
     }
 
     #[test]
     fun size_limit_ok() {
-        let mut v = V::empty();
+        let mut v = vector[];
         let mut i = 0;
         // Limit is currently 1024 * 54
         let max_len = 1024 * 53;
 
         while (i < max_len) {
-            V::push_back(&mut v, i);
+            v.push_back(i);
             i = i + 1;
         };
     }
@@ -561,13 +563,13 @@ module std::vector_tests {
     #[test]
     #[expected_failure(out_of_gas, location = Self)]
     fun size_limit_fail() {
-        let mut v = V::empty();
+        let mut v = vector[];
         let mut i = 0;
         // Choose value beyond limit
         let max_len = 1024 * 1024;
 
         while (i < max_len) {
-            V::push_back(&mut v, i);
+            v.push_back(i);
             i = i + 1;
         };
     }


### PR DESCRIPTION
## Description 

Title

Note that the vector tests changed around quite a bit in the generated bytecode. I hand-checked that it appears to perform the same, but the usage of `vector[]` changes things quite a bit.

## Test Plan 

`sui move test` plus local disassembly diff


---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
