### PR TITLE
[graphql][cherry-pick] Cherry pick build sha PR

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/sui-graphql-e2e-tests/tests/call/simple.exp
@@ -76,13 +76,13 @@ task 15 'run-graphql'. lines 66-71:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-sui-rpc-version": "2024.1.3",
+    "x-sui-rpc-version": "2024.1.3-testing-no-sha",
     "access-control-allow-origin": "*",
     "vary": "origin",
     "vary": "access-control-request-method",
     "vary": "access-control-request-headers",
 }
-Service version: 2024.1.3
+Service version: 2024.1.3-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/sui-graphql-rpc/src/config.rs
+++ b/crates/sui-graphql-rpc/src/config.rs
@@ -4,7 +4,7 @@
 use crate::types::big_int::BigInt;
 use async_graphql::*;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, time::Duration};
+use std::{collections::BTreeSet, fmt::Display, time::Duration};
 use sui_json_rpc::name_service::NameServiceConfig;
 
 use crate::functional_group::FunctionalGroup;
@@ -132,8 +132,51 @@ pub struct BackgroundTasksConfig {
     pub watermark_update_ms: u64,
 }
 
-#[derive(Debug)]
-pub struct Version(pub &'static str);
+/// The Version of the service. `year.month` represents the major release.
+/// New `patch` versions represent backwards compatible fixes for their major release.
+/// The `full` version is `year.month.patch-sha`.
+#[derive(Copy, Clone, Debug)]
+pub struct Version {
+    /// The year of this release.
+    pub year: &'static str,
+    /// The month of this release.
+    pub month: &'static str,
+    /// The patch is a positive number incremented for every compatible release on top of the major.month release.
+    pub patch: &'static str,
+    /// The commit sha for this release.
+    pub sha: &'static str,
+    /// The full version string.
+    /// Note that this extra field is used only for the uptime_metric function which requries a
+    /// &'static str.
+    pub full: &'static str,
+}
+
+impl Version {
+    /// Use for testing when you need the Version obj and a year.month &str
+    pub fn for_testing() -> Self {
+        Self {
+            year: env!("CARGO_PKG_VERSION_MAJOR"),
+            month: env!("CARGO_PKG_VERSION_MINOR"),
+            patch: env!("CARGO_PKG_VERSION_PATCH"),
+            sha: "testing-no-sha",
+            // note that this full field is needed for metrics but not for testing
+            full: const_str::concat!(
+                env!("CARGO_PKG_VERSION_MAJOR"),
+                ".",
+                env!("CARGO_PKG_VERSION_MINOR"),
+                ".",
+                env!("CARGO_PKG_VERSION_PATCH"),
+                "-testing-no-sha"
+            ),
+        }
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.full)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/sui-graphql-rpc/src/main.rs
+++ b/crates/sui-graphql-rpc/src/main.rs
@@ -23,18 +23,28 @@ const GIT_REVISION: &str = {
         revision
     } else {
         git_version::git_version!(
-            args = ["--always", "--abbrev=12", "--dirty", "--exclude", "*"],
+            args = ["--always", "--abbrev=40", "--dirty", "--exclude", "*"],
             fallback = "DIRTY"
         )
     }
 };
 
 // VERSION mimics what other sui binaries use for the same const
-static VERSION: Version = Version(const_str::concat!(
-    env!("CARGO_PKG_VERSION"),
-    "-",
-    GIT_REVISION
-));
+static VERSION: Version = Version {
+    year: env!("CARGO_PKG_VERSION_MAJOR"),
+    month: env!("CARGO_PKG_VERSION_MINOR"),
+    patch: env!("CARGO_PKG_VERSION_PATCH"),
+    sha: GIT_REVISION,
+    full: const_str::concat!(
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        ".",
+        env!("CARGO_PKG_VERSION_MINOR"),
+        ".",
+        env!("CARGO_PKG_VERSION_PATCH"),
+        "-",
+        GIT_REVISION
+    ),
+};
 
 #[tokio::main]
 async fn main() {

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -131,6 +131,7 @@ pub(crate) struct AppState {
     service: ServiceConfig,
     metrics: Metrics,
     cancellation_token: CancellationToken,
+    pub version: Version,
 }
 
 /// The high checkpoint watermark stamped on each GraphQL request. This is used to ensure
@@ -139,17 +140,19 @@ pub(crate) struct AppState {
 pub(crate) struct CheckpointWatermark(pub Arc<AtomicU64>);
 
 impl AppState {
-    fn new(
+    pub(crate) fn new(
         connection: ConnectionConfig,
         service: ServiceConfig,
         metrics: Metrics,
         cancellation_token: CancellationToken,
+        version: Version,
     ) -> Self {
         Self {
             connection,
             service,
             metrics,
             cancellation_token,
+            version,
         }
     }
 }
@@ -230,13 +233,16 @@ impl ServerBuilder {
                 .route("/health", axum::routing::get(health_checks))
                 .with_state(self.state.clone())
                 .route_layer(middleware::from_fn_with_state(
-                    self.state.metrics.clone(),
+                    self.state.version,
+                    set_version_middleware,
+                ))
+                .route_layer(middleware::from_fn_with_state(
+                    self.state.version,
                     check_version_middleware,
                 ))
                 .route_layer(CallbackLayer::new(MetricsMakeCallbackHandler {
                     metrics: self.state.metrics.clone(),
-                }))
-                .layer(middleware::from_fn(set_version_middleware));
+                }));
             self.router = Some(router);
         }
     }
@@ -336,12 +342,15 @@ impl ServerBuilder {
                 config.connection.prom_url, config.connection.prom_port
             ))
         })?;
+
         let registry_service = mysten_metrics::start_prometheus_server(prom_addr);
         info!("Starting Prometheus HTTP endpoint at {}", prom_addr);
         let registry = registry_service.default_registry();
         registry
             .register(mysten_metrics::uptime_metric(
-                "graphql", version.0, "unknown",
+                "graphql",
+                version.full,
+                "unknown",
             ))
             .unwrap();
 
@@ -352,6 +361,7 @@ impl ServerBuilder {
             config.service.clone(),
             metrics.clone(),
             cancellation_token,
+            *version,
         );
         let mut builder = ServerBuilder::new(state);
 
@@ -589,7 +599,7 @@ pub(crate) async fn update_watermark(
 pub mod tests {
     use super::*;
     use crate::{
-        config::{ConnectionConfig, Limits, ServiceConfig},
+        config::{ConnectionConfig, Limits, ServiceConfig, Version},
         context_data::db_data_provider::PgManager,
         extensions::query_limits_checker::QueryLimitsChecker,
         extensions::timeout::Timeout,
@@ -614,7 +624,7 @@ pub mod tests {
 
         let db_url: String = connection_config.db_url.clone();
         let reader = PgManager::reader(db_url).expect("Failed to create pg connection pool");
-
+        let version = Version::for_testing();
         let metrics = metrics();
         let db = Db::new(reader.clone(), service_config.limits, metrics.clone());
         let pg_conn_pool = PgManager::new(reader);
@@ -625,6 +635,7 @@ pub mod tests {
             service_config.clone(),
             metrics.clone(),
             cancellation_token.clone(),
+            version,
         );
         ServerBuilder::new(state)
             .context_data(db)

--- a/crates/sui-graphql-rpc/src/server/graphiql_server.rs
+++ b/crates/sui-graphql-rpc/src/server/graphiql_server.rs
@@ -23,7 +23,7 @@ pub async fn start_graphiql_server(
     cancellation_token: CancellationToken,
 ) -> Result<(), Error> {
     info!("Starting server with config: {:?}", server_config);
-    info!("Server version: {:?}", version);
+    info!("Server version: {}", version);
     start_graphiql_server_impl(
         ServerBuilder::from_config(server_config, version, cancellation_token).await?,
         server_config.ide.ide_title.clone(),

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -178,7 +178,7 @@ pub async fn start_graphql_server_with_fn_rpc(
 
     // Starts graphql server
     tokio::spawn(async move {
-        start_graphiql_server(&server_config, &Version("test"), cancellation_token)
+        start_graphiql_server(&server_config, &Version::for_testing(), cancellation_token)
             .await
             .unwrap();
     })


### PR DESCRIPTION
## Description 
Add the build sha into the existing version header.

## Test Plan 
👀

```bash
🚀 sui-graphql-rpc % curl -i -X POST http://127.0.0.1:8000 --data '{"query": "query {chainIdentifier}"}'
HTTP/1.1 200 OK
content-type: application/json
content-length: 39
x-sui-rpc-version: 2024.2.0-17a173450a86f16b06b5818f21397b808adb2d8c
access-control-allow-origin: *
vary: origin
vary: access-control-request-method
vary: access-control-request-headers
date: Thu, 21 Mar 2024 01:43:28 GMT
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration