### PR TITLE
[move-ide] Updates to support Move 2024 structs

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1432,7 +1432,7 @@ fn parsing_mod_ident_to_map_key(mod_ident: &P::ModuleIdent_) -> String {
 /// It's important that these are consistent between parsing AST and typed AST,
 fn parsing_mod_def_to_map_key(mod_def: &P::ModuleDefinition) -> Option<String> {
     // we assume that modules are declared using the PkgName::ModName pattern (which seems to be the
-    // standard practice) and while Move allows another ways of defining modules (i.e., with address
+    // standard practice) and while Move allows other ways of defining modules (i.e., with address
     // preceding a sequence of modules), this method is now deprecated
     //
     // TODO: make this function simply return String when the other way of defining modules is
@@ -2268,9 +2268,12 @@ impl<'a> TypingSymbolicator<'a> {
             for (fpos, fname, (_, t)) in fields {
                 self.add_type_id_use_def(t);
                 if !positional {
-                    // enter self-definition for field name (unwrap safe - done when inserting def),
-                    // but only if the fields are named (positional fields have "fake" locations and
-                    // could make the displayed results confusing)
+                    // Enter self-definition for field name (unwrap safe - done when inserting def),
+                    // but only if the fields are named. Positional fields, introduced in Move 2024
+                    // version of the language, have "fake" locations and could make the displayed
+                    // results confusing. The reason for "fake" locations is that a struct has one
+                    // internal representation in the compiler for both structs with named and
+                    // positional fields (and the latter's fields don't have the actual names).
                     let start = get_start_loc(&fpos, self.files, self.file_id_mapping).unwrap();
                     let field_info = DefInfo::Type(t.clone());
                     let ident_type_def_loc =

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -89,7 +89,7 @@ use vfs::{
 use move_command_line_common::files::FileHash;
 use move_compiler::{
     command_line::compiler::{construct_pre_compiled_lib, FullyCompiledProgram},
-    editions::Flavor,
+    editions::{Edition, FeatureGate, Flavor},
     expansion::ast::{self as E, Fields, ModuleIdent, ModuleIdent_, Value, Value_, Visibility},
     linters::LintLevel,
     naming::ast::{StructDefinition, StructFields, TParam, Type, TypeName_, Type_, UseFuns},
@@ -160,6 +160,8 @@ pub enum DefInfo {
         ModuleIdent_,
         /// Name
         Symbol,
+        /// Visibility
+        Visibility,
         /// Type args
         Vec<(Type, bool /* phantom */)>,
         /// Field names
@@ -230,6 +232,8 @@ struct FieldDef {
 struct StructDef {
     name_start: Position,
     field_defs: Vec<FieldDef>,
+    /// Does this struct have positional fields?
+    positional: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -397,18 +401,30 @@ impl fmt::Display for DefInfo {
                     ret_str,
                 )
             }
-            Self::Struct(mod_ident, name, type_args, field_names, field_types) => {
+            Self::Struct(mod_ident, name, visibility, type_args, field_names, field_types) => {
                 let type_args_str = struct_type_args_to_ide_string(type_args);
-                write!(
-                    f,
-                    "struct {}::{}{}{{\n{}\n}}",
-                    // this mod_ident conversion will ensure that only pkg name (without numerical
-                    // address) is displayed which is the same as in source
-                    expansion_mod_ident_to_map_key(mod_ident),
-                    name,
-                    type_args_str,
-                    typed_id_list_to_ide_string(field_names, field_types, true),
-                )
+                // the mod_ident conversions below will ensure that only pkg name (without numerical
+                // address) is displayed which is the same as in source
+                if field_names.len() == 0 {
+                    write!(
+                        f,
+                        "{}struct {}::{}{} {{}}",
+                        visibility_to_ide_string(visibility),
+                        expansion_mod_ident_to_map_key(mod_ident),
+                        name,
+                        type_args_str
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}struct {}::{}{} {{\n{}\n}}",
+                        visibility_to_ide_string(visibility),
+                        expansion_mod_ident_to_map_key(mod_ident),
+                        name,
+                        type_args_str,
+                        typed_id_list_to_ide_string(field_names, field_types, true),
+                    )
+                }
             }
             Self::Field(mod_ident, struct_name, name, t) => {
                 write!(
@@ -990,6 +1006,7 @@ pub fn get_symbols(
     // resolution graph diagnostics are only needed for CLI commands so ignore them by passing a
     // vector as the writer
     let resolution_graph = build_config.resolution_graph_for_package(pkg_path, &mut Vec::new())?;
+    let root_pkg_name = resolution_graph.graph.root_package_name;
 
     let overlay_fs_root = VfsPath::new(OverlayFS::new(&[
         VfsPath::new(MemoryFS::new()),
@@ -1062,6 +1079,7 @@ pub fn get_symbols(
         None
     };
 
+    let mut edition = None;
     build_plan.compile_with_driver_and_deps(dependencies, &mut std::io::sink(), |compiler| {
         // extract expansion AST
         let (files, compilation_result) = compiler
@@ -1093,8 +1111,10 @@ pub fn get_symbols(
             }
         };
         eprintln!("compiled to typed AST");
-        let (compiler, typed_program) = compiler.into_ast();
+        let (mut compiler, typed_program) = compiler.into_ast();
         typed_ast = Some(typed_program.clone());
+
+        edition = Some(compiler.compilation_env().edition(Some(root_pkg_name)));
 
         // compile to CFGIR for accurate diags
         eprintln!("compiling to CFGIR");
@@ -1136,6 +1156,7 @@ pub fn get_symbols(
 
     // uwrap's are safe - this function returns earlier (during diagnostics processing)
     // when failing to produce the ASTs
+    let parsed_program = parsed_ast.unwrap();
     let typed_modules = typed_ast.unwrap().inner.modules;
 
     let mut mod_outer_defs = BTreeMap::new();
@@ -1145,6 +1166,7 @@ pub fn get_symbols(
     let mut def_info = BTreeMap::new();
 
     pre_process_typed_modules(
+        &parsed_program,
         &typed_modules,
         &files,
         &file_id_mapping,
@@ -1155,10 +1177,12 @@ pub fn get_symbols(
         &mut file_mods,
         &mut references,
         &mut def_info,
+        &edition,
     );
 
     if let Some(libs) = compiled_libs.clone() {
         pre_process_typed_modules(
+            &parsed_program,
             &libs.typing.inner.modules,
             &files,
             &file_id_mapping,
@@ -1169,6 +1193,7 @@ pub fn get_symbols(
             &mut file_mods,
             &mut references,
             &mut def_info,
+            &edition,
         );
     }
 
@@ -1189,7 +1214,7 @@ pub fn get_symbols(
     };
 
     parsing_symbolicator.prog_symbols(
-        &parsed_ast.unwrap(),
+        &parsed_program,
         &mut mod_use_defs,
         &mut mod_to_alias_lengths,
     );
@@ -1246,6 +1271,7 @@ pub fn get_symbols(
 }
 
 fn pre_process_typed_modules(
+    parsed_program: &P::Program,
     typed_modules: &UniqueMap<ModuleIdent, ModuleDefinition>,
     files: &SimpleFiles<Symbol, String>,
     file_id_mapping: &HashMap<FileHash, usize>,
@@ -1256,10 +1282,11 @@ fn pre_process_typed_modules(
     file_mods: &mut BTreeMap<PathBuf, BTreeSet<ModuleDefs>>,
     references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
     def_info: &mut BTreeMap<DefLoc, DefInfo>,
+    edition: &Option<Edition>,
 ) {
     for (pos, module_ident, module_def) in typed_modules {
         let mod_ident_str = expansion_mod_ident_to_map_key(module_ident);
-        let (defs, symbols) = get_mod_outer_defs(
+        let (mut defs, symbols) = get_mod_outer_defs(
             &pos,
             &sp(pos, *module_ident),
             module_def,
@@ -1268,7 +1295,9 @@ fn pre_process_typed_modules(
             file_id_to_lines,
             references,
             def_info,
+            edition,
         );
+        mark_positional_struct(parsed_program, &mut defs, &mod_ident_str);
 
         let cloned_defs = defs.clone();
         let path = file_name_mapping.get(&cloned_defs.fhash.clone()).unwrap();
@@ -1279,6 +1308,51 @@ fn pre_process_typed_modules(
 
         mod_outer_defs.insert(mod_ident_str.clone(), defs);
         mod_use_defs.insert(mod_ident_str, symbols);
+    }
+}
+
+/// Marks symbolicator's struct metadata as having positional fields
+/// based on the information in the parsed AST.
+fn mark_positional_struct(
+    parsed_program: &P::Program,
+    defs: &mut ModuleDefs,
+    mod_ident_str: &String,
+) {
+    let Some(pkg_def) = parsed_program
+        .source_definitions
+        .iter()
+        .find(|pkg_def| {
+            if let P::Definition::Module(mod_def) = &pkg_def.def {
+                if let Some(parsed_mod_ident_str) = parsing_mod_def_to_map_key(mod_def) {
+                    return mod_ident_str == &parsed_mod_ident_str;
+                }
+            }
+            return false;
+        })
+        .or_else(|| {
+            parsed_program.lib_definitions.iter().find(|pkg_def| {
+                if let P::Definition::Module(mod_def) = &pkg_def.def {
+                    if let Some(parsed_mod_ident_str) = parsing_mod_def_to_map_key(mod_def) {
+                        return mod_ident_str == &parsed_mod_ident_str;
+                    }
+                }
+                return false;
+            })
+        })
+    else {
+        return;
+    };
+
+    if let P::Definition::Module(mod_def) = &pkg_def.def {
+        for member in &mod_def.members {
+            let P::ModuleMember::Struct(parsed_sdef) = member else {
+                continue;
+            };
+            let Some(sdef) = defs.structs.get_mut(&parsed_sdef.name.value()) else {
+                continue;
+            };
+            sdef.positional = matches!(parsed_sdef.fields, P::StructFields::Positional(_));
+        }
     }
 }
 
@@ -1294,7 +1368,7 @@ fn process_typed_modules<'a>(
         let mod_ident_str = expansion_mod_ident_to_map_key(module_ident);
         typing_symbolicator.use_defs = mod_use_defs.remove(&mod_ident_str).unwrap();
         typing_symbolicator.alias_lengths = mod_to_alias_lengths.get(&mod_ident_str).unwrap();
-        typing_symbolicator.mod_symbols(module_def);
+        typing_symbolicator.mod_symbols(module_def, &mod_ident_str);
 
         let fpath = match source_files.get(&pos.file_hash()) {
             Some((p, _)) => p,
@@ -1354,6 +1428,21 @@ fn parsing_mod_ident_to_map_key(mod_ident: &P::ModuleIdent_) -> String {
     format!("{}", mod_ident).to_string()
 }
 
+/// Produces module ident string of the form pkg_name::module_name to be used as a map key.
+/// It's important that these are consistent between parsing AST and typed AST,
+fn parsing_mod_def_to_map_key(mod_def: &P::ModuleDefinition) -> Option<String> {
+    // we assume that modules are declared using the PkgName::ModName pattern (which seems to be the
+    // standard practice) and while Move allows another ways of defining modules (i.e., with address
+    // preceding a sequence of modules), this method is now deprecated
+    //
+    // TODO: make this function simply return String when the other way of defining modules is
+    // removed
+    match mod_def.address {
+        Some(a) => Some(format!("{}::{}", a, mod_def.name).to_string()),
+        None => None,
+    }
+}
+
 /// Produces module ident string of the form pkg_name::module_name to be used as a map key
 /// It's important that these are consistent between parsing AST and typed AST,
 fn expansion_mod_ident_to_map_key(mod_ident: &E::ModuleIdent_) -> String {
@@ -1391,6 +1480,7 @@ fn get_mod_outer_defs(
     file_id_to_lines: &HashMap<usize, Vec<String>>,
     references: &mut BTreeMap<DefLoc, BTreeSet<UseLoc>>,
     def_info: &mut BTreeMap<DefLoc, DefInfo>,
+    edition: &Option<Edition>,
 ) -> (ModuleDefs, UseDefMap) {
     let mut structs = BTreeMap::new();
     let mut constants = BTreeMap::new();
@@ -1438,8 +1528,18 @@ fn get_mod_outer_defs(
             StructDef {
                 name_start,
                 field_defs,
+                positional: false, // will be set during parsed AST symbolication
             },
         );
+        let pub_struct = edition
+            .map(|e| e.supports(FeatureGate::PositionalFields))
+            .unwrap_or(false);
+        let visibility = if pub_struct {
+            // fake location OK as this is for display purposes only
+            Visibility::Public(Loc::invalid())
+        } else {
+            Visibility::Internal
+        };
         def_info.insert(
             DefLoc {
                 fhash,
@@ -1448,6 +1548,7 @@ fn get_mod_outer_defs(
             DefInfo::Struct(
                 mod_ident.value,
                 *name,
+                visibility,
                 def.type_parameters
                     .iter()
                     .map(|t| {
@@ -1650,16 +1751,8 @@ impl<'a> ParsingSymbolicator<'a> {
         mod_to_alias_lengths: &mut BTreeMap<String, BTreeMap<Position, usize>>,
     ) {
         // parsing symbolicator is currently only responsible for processing use declarations
-
-        // we optimistically assume that modules are declared using the PkgName::ModName pattern
-        // (which seems to be the standard practice) and while Move allows other ways of defining
-        // modules (e.g., with address preceding a sequence of modules) we will handle those only
-        // when deemed necessary (worst-case scenario for now is that imports will not feature
-        // advanced functionality, such as go-to-def for modules defined this way)
-        // TODO: handle retrieving address specified in a non-standard way if needed
-        let mod_ident_str = match mod_def.address {
-            Some(a) => format!("{}::{}", a, mod_def.name),
-            None => return,
+        let Some(mod_ident_str) = parsing_mod_def_to_map_key(mod_def) else {
+            return;
         };
 
         let use_defs = mod_use_defs.remove(&mod_ident_str).unwrap();
@@ -2041,7 +2134,7 @@ impl<'a> ParsingSymbolicator<'a> {
 
 impl<'a> TypingSymbolicator<'a> {
     /// Get symbols for the whole module
-    fn mod_symbols(&mut self, mod_def: &ModuleDefinition) {
+    fn mod_symbols(&mut self, mod_def: &ModuleDefinition, mod_ident_str: &String) {
         for (pos, name, fun) in &mod_def.functions {
             // enter self-definition for function name (unwrap safe - done when inserting def)
             let name_start = get_start_loc(&pos, self.files, self.file_id_mapping).unwrap();
@@ -2143,46 +2236,67 @@ impl<'a> TypingSymbolicator<'a> {
                 ),
             );
 
-            self.struct_symbols(s);
+            self.struct_symbols(s, name, mod_ident_str);
         }
         self.use_funs_symbols(&mod_def.use_funs);
     }
 
     /// Get symbols for struct definition
-    fn struct_symbols(&mut self, struct_def: &StructDefinition) {
+    fn struct_symbols(
+        &mut self,
+        struct_def: &StructDefinition,
+        struct_name: &Symbol,
+        mod_ident_str: &String,
+    ) {
         // create scope designated to contain type parameters (if any)
         let mut tp_scope = BTreeMap::new();
         for stp in &struct_def.type_parameters {
             self.add_type_param(&stp.param, &mut tp_scope);
         }
+
+        let positional = self
+            .mod_outer_defs
+            .get(mod_ident_str)
+            .map_or(false, |mod_defs| {
+                mod_defs
+                    .structs
+                    .get(struct_name)
+                    .map_or(false, |sdef| sdef.positional)
+            });
+
         self.type_params = tp_scope;
         if let StructFields::Defined(fields) = &struct_def.fields {
             for (fpos, fname, (_, t)) in fields {
                 self.add_type_id_use_def(t);
-                // enter self-definition for field name (unwrap safe - done when inserting def)
-                let start = get_start_loc(&fpos, self.files, self.file_id_mapping).unwrap();
-                let field_info = DefInfo::Type(t.clone());
-                let ident_type_def_loc = def_info_to_type_def_loc(self.mod_outer_defs, &field_info);
-                let doc_string = extract_doc_string(
-                    self.file_id_mapping,
-                    self.file_id_to_lines,
-                    &start,
-                    &fpos.file_hash(),
-                );
-                self.use_defs.insert(
-                    start.line,
-                    UseDef::new(
-                        self.references,
-                        self.alias_lengths,
-                        fpos.file_hash(),
-                        start,
-                        fpos.file_hash(),
-                        start,
-                        fname,
-                        ident_type_def_loc,
-                        doc_string,
-                    ),
-                );
+                if !positional {
+                    // enter self-definition for field name (unwrap safe - done when inserting def),
+                    // but only if the fields are named (positional fields have "fake" locations and
+                    // could make the displayed results confusing)
+                    let start = get_start_loc(&fpos, self.files, self.file_id_mapping).unwrap();
+                    let field_info = DefInfo::Type(t.clone());
+                    let ident_type_def_loc =
+                        def_info_to_type_def_loc(self.mod_outer_defs, &field_info);
+                    let doc_string = extract_doc_string(
+                        self.file_id_mapping,
+                        self.file_id_to_lines,
+                        &start,
+                        &fpos.file_hash(),
+                    );
+                    self.use_defs.insert(
+                        start.line,
+                        UseDef::new(
+                            self.references,
+                            self.alias_lengths,
+                            fpos.file_hash(),
+                            start,
+                            fpos.file_hash(),
+                            start,
+                            fname,
+                            ident_type_def_loc,
+                            doc_string,
+                        ),
+                    );
+                }
             }
         }
     }
@@ -3052,7 +3166,9 @@ fn def_info_to_type_def_loc(
     match def_info {
         DefInfo::Type(t) => type_def_loc(mod_outer_defs, t),
         DefInfo::Function(_, _, _, _, _, _, ret) => type_def_loc(mod_outer_defs, ret),
-        DefInfo::Struct(mod_ident, name, _, _, _) => find_struct(mod_outer_defs, mod_ident, name),
+        DefInfo::Struct(mod_ident, name, _, _, _, _) => {
+            find_struct(mod_outer_defs, mod_ident, name)
+        }
         DefInfo::Field(_, _, _, t) => type_def_loc(mod_outer_defs, t),
         DefInfo::Local(_, t, _) => type_def_loc(mod_outer_defs, t),
         DefInfo::Const(_, _, t, _) => type_def_loc(mod_outer_defs, t),
@@ -3683,7 +3799,7 @@ fn docstring_test() {
         4,
         11,
         "M6.move",
-        "struct Symbols::M6::DocumentedStruct{\n\tdocumented_field: u64\n}",
+        "struct Symbols::M6::DocumentedStruct {\n\tdocumented_field: u64\n}",
         Some((4, 11, "M6.move")),
         Some("This is a documented struct\nWith a multi-line docstring\n"),
     );
@@ -3745,7 +3861,7 @@ fn docstring_test() {
         4,
         11,
         "M6.move",
-        "struct Symbols::M6::DocumentedStruct{\n\tdocumented_field: u64\n}",
+        "struct Symbols::M6::DocumentedStruct {\n\tdocumented_field: u64\n}",
         Some((4, 11, "M6.move")),
         Some("This is a documented struct\nWith a multi-line docstring\n"),
     );
@@ -3760,7 +3876,7 @@ fn docstring_test() {
         4,
         11,
         "M6.move",
-        "struct Symbols::M6::DocumentedStruct{\n\tdocumented_field: u64\n}",
+        "struct Symbols::M6::DocumentedStruct {\n\tdocumented_field: u64\n}",
         Some((4, 11, "M6.move")),
         Some("This is a documented struct\nWith a multi-line docstring\n"),
     );
@@ -3840,7 +3956,7 @@ fn docstring_test() {
         3,
         11,
         "M7.move",
-        "struct Symbols::M7::OtherDocStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M7::OtherDocStruct {\n\tsome_field: u64\n}",
         Some((3, 11, "M7.move")),
         Some("Documented struct in another module\n"),
     );
@@ -3888,7 +4004,7 @@ fn docstring_test() {
         3,
         11,
         "M7.move",
-        "struct Symbols::M7::OtherDocStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M7::OtherDocStruct {\n\tsome_field: u64\n}",
         Some((3, 11, "M7.move")),
         Some("Documented struct in another module\n"),
     );
@@ -3960,7 +4076,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // const def name
@@ -4016,7 +4132,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // struct name in unpack (unpack function)
@@ -4030,7 +4146,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // field name in unpack (unpack function)
@@ -4100,7 +4216,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // struct name in pack (pack function)
@@ -4114,7 +4230,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // field name in pack (pack function)
@@ -4156,7 +4272,7 @@ fn symbols_test() {
         2,
         11,
         "M2.move",
-        "struct Symbols::M2::SomeOtherStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M2::SomeOtherStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
     // function name in a call (other_mod_struct function)
@@ -4198,7 +4314,7 @@ fn symbols_test() {
         2,
         11,
         "M2.move",
-        "struct Symbols::M2::SomeOtherStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M2::SomeOtherStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
     // function name (acq function)
@@ -4268,7 +4384,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // vector constructor first element struct type (vec function)
@@ -4282,7 +4398,7 @@ fn symbols_test() {
         2,
         11,
         "M1.move",
-        "struct Symbols::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct Symbols::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
     // vector constructor first element struct field (vec function)
@@ -4793,7 +4909,7 @@ fn symbols_test() {
         2,
         11,
         "M3.move",
-        "struct Symbols::M3::ParamStruct<T>{\n\tsome_field: T\n}",
+        "struct Symbols::M3::ParamStruct<T> {\n\tsome_field: T\n}",
         Some((2, 11, "M3.move")),
     );
     // generic type in struct field definition which itself is a struct
@@ -5366,7 +5482,7 @@ fn imports_test() {
         2,
         11,
         "M2.move",
-        "struct Symbols::M2::SomeOtherStruct{\n	some_field: u64\n}",
+        "struct Symbols::M2::SomeOtherStruct {\n	some_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
     // aliased mod use (alias name)
@@ -5380,7 +5496,7 @@ fn imports_test() {
         2,
         11,
         "M2.move",
-        "struct Symbols::M2::SomeOtherStruct{\n	some_field: u64\n}",
+        "struct Symbols::M2::SomeOtherStruct {\n	some_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
     // locally aliased mod use (actual mod name)
@@ -5422,7 +5538,7 @@ fn imports_test() {
         2,
         11,
         "M2.move",
-        "struct Symbols::M2::SomeOtherStruct{\n	some_field: u64\n}",
+        "struct Symbols::M2::SomeOtherStruct {\n	some_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
 }
@@ -5673,7 +5789,7 @@ fn parse_error_test() {
         2,
         11,
         "M2.move",
-        "struct ParseError::M2::SomeStruct{\n\tsome_field: u64\n}",
+        "struct ParseError::M2::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
 }
@@ -5768,7 +5884,7 @@ fn pretype_error_test() {
         2,
         11,
         "M2.move",
-        "struct PreTypeError::M2::SomeStruct{\n\tsome_field: u64\n}",
+        "struct PreTypeError::M2::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M2.move")),
     );
 }
@@ -5809,7 +5925,7 @@ fn pretype_error_with_deps_test() {
         2,
         11,
         "M1.move",
-        "struct PreTypeErrorDep::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "struct PreTypeErrorDep::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((2, 11, "M1.move")),
     );
 
@@ -5941,7 +6057,7 @@ fn dot_call_test() {
         5,
         18,
         "dot_call.move",
-        "struct Move2024::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "public struct Move2024::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((5, 18, "dot_call.move")),
     );
     // method in public module use fun decl
@@ -5997,7 +6113,7 @@ fn dot_call_test() {
         5,
         18,
         "dot_call.move",
-        "struct Move2024::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "public struct Move2024::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((5, 18, "dot_call.move")),
     );
     // method in public module use fun decl
@@ -6068,7 +6184,7 @@ fn dot_call_test() {
         5,
         18,
         "dot_call.move",
-        "struct Move2024::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "public struct Move2024::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((5, 18, "dot_call.move")),
     );
     // method in module use fun decl
@@ -6124,7 +6240,7 @@ fn dot_call_test() {
         5,
         18,
         "dot_call.move",
-        "struct Move2024::M1::SomeStruct{\n\tsome_field: u64\n}",
+        "public struct Move2024::M1::SomeStruct {\n\tsome_field: u64\n}",
         Some((5, 18, "dot_call.move")),
     );
     // method in block use fun decl
@@ -6240,6 +6356,130 @@ fn mod_ident_uniform_test() {
 }
 
 #[test]
+/// Checks if symbolication for positional struct fields work correctly and recognizes the
+/// visibility modifier.
+fn move2024_struct_test() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    path.push("tests/move-2024");
+
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(
+        &mut BTreeMap::new(),
+        ide_files_layer,
+        path.as_path(),
+        LintLevel::None,
+    )
+    .unwrap();
+    let symbols = symbols_opt.unwrap();
+
+    let mut fpath = path.clone();
+    fpath.push("sources/structs.move");
+    let cpath = dunce::canonicalize(&fpath).unwrap();
+
+    let mod_symbols = symbols.file_use_defs.get(&cpath).unwrap();
+
+    // struct def with no fields
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        0,
+        2,
+        18,
+        "structs.move",
+        2,
+        18,
+        "structs.move",
+        "public struct Move2024::structs::SomeStruct {}",
+        Some((2, 18, "structs.move")),
+    );
+    // struct def with positional fields
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        0,
+        4,
+        18,
+        "structs.move",
+        4,
+        18,
+        "structs.move",
+        "public struct Move2024::structs::Positional {\n\t0: u64,\n\t1: Move2024::structs::SomeStruct\n}",
+        Some((4, 18, "structs.move")),
+    );
+    // positional field type (in def)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        4,
+        34,
+        "structs.move",
+        2,
+        18,
+        "structs.move",
+        "public struct Move2024::structs::SomeStruct {}",
+        Some((2, 18, "structs.move")),
+    );
+    // fun param of a positional struct type
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        6,
+        19,
+        "structs.move",
+        6,
+        19,
+        "structs.move",
+        "positional: Move2024::structs::Positional",
+        Some((4, 18, "structs.move")),
+    );
+    // fun param type of a positional struct type
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        2,
+        6,
+        31,
+        "structs.move",
+        4,
+        18,
+        "structs.move",
+        "public struct Move2024::structs::Positional {\n\t0: u64,\n\t1: Move2024::structs::SomeStruct\n}",
+        Some((4, 18, "structs.move")),
+    );
+    // first positional field access (u64 type)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        7,
+        20,
+        "structs.move",
+        4,
+        29,
+        "structs.move",
+        "Move2024::structs::Positional\n0: u64",
+        None,
+    );
+    // first positional field access (struct type)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        3,
+        7,
+        34,
+        "structs.move",
+        4,
+        34,
+        "structs.move",
+        "Move2024::structs::Positional\n1: Move2024::structs::SomeStruct",
+        Some((2, 18, "structs.move")),
+    );
+}
+
+#[test]
 /// Tests symbolication of implicit structs and modules.
 fn implicit_uses_test() {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -6273,7 +6513,7 @@ fn implicit_uses_test() {
         76,
         18,
         "object.move",
-        "struct sui::object::UID{\n\tid: sui::object::ID\n}",
+        "public struct sui::object::UID {\n\tid: sui::object::ID\n}",
         Some((76, 18, "object.move")),
     );
     // implicit struct as parameter type
@@ -6287,7 +6527,7 @@ fn implicit_uses_test() {
         20,
         18,
         "tx_context.move",
-        "struct sui::tx_context::TxContext{\n\tepoch: u64,\n\tepoch_timestamp_ms: u64,\n\tids_created: u64,\n\tsender: address,\n\ttx_hash: vector<u8>\n}",
+        "public struct sui::tx_context::TxContext {\n\tepoch: u64,\n\tepoch_timestamp_ms: u64,\n\tids_created: u64,\n\tsender: address,\n\ttx_hash: vector<u8>\n}",
         Some((20, 18, "tx_context.move")),
     );
     // implicit module name in function call

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -405,7 +405,7 @@ impl fmt::Display for DefInfo {
                 let type_args_str = struct_type_args_to_ide_string(type_args);
                 // the mod_ident conversions below will ensure that only pkg name (without numerical
                 // address) is displayed which is the same as in source
-                if field_names.len() == 0 {
+                if field_names.is_empty() {
                     write!(
                         f,
                         "{}struct {}::{}{} {{}}",
@@ -1327,7 +1327,7 @@ fn mark_positional_struct(
                     return mod_ident_str == &parsed_mod_ident_str;
                 }
             }
-            return false;
+            false
         })
         .or_else(|| {
             parsed_program.lib_definitions.iter().find(|pkg_def| {
@@ -1336,7 +1336,7 @@ fn mark_positional_struct(
                         return mod_ident_str == &parsed_mod_ident_str;
                     }
                 }
-                return false;
+                false
             })
         })
     else {
@@ -1437,10 +1437,9 @@ fn parsing_mod_def_to_map_key(mod_def: &P::ModuleDefinition) -> Option<String> {
     //
     // TODO: make this function simply return String when the other way of defining modules is
     // removed
-    match mod_def.address {
-        Some(a) => Some(format!("{}::{}", a, mod_def.name).to_string()),
-        None => None,
-    }
+    mod_def
+        .address
+        .map(|a| format!("{}::{}", a, mod_def.name).to_string())
 }
 
 /// Produces module ident string of the form pkg_name::module_name to be used as a map key

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/sources/structs.move
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/sources/structs.move
@@ -1,0 +1,11 @@
+module Move2024::structs {
+
+    public struct SomeStruct {} has drop, copy;
+
+    public struct Positional(u64, SomeStruct) has drop, copy;
+
+    public fun foo(positional: Positional): (u64, SomeStruct) {
+        (positional.0, positional.1)
+    }
+
+}


### PR DESCRIPTION
## Description 

This PR adds IDE support for Move 2024 structs:
- positional fields
- public visibility modifier

## Test Plan 

A new test has been added