### PR TITLE
[move-2024] Update sui framework tests to Move 2024

### DIFF
--- a/crates/sui-framework/packages/sui-framework/tests/address_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/address_tests.move
@@ -3,11 +3,7 @@
 
 #[test_only]
 module sui::address_tests {
-    use std::ascii;
-    use std::string;
     use sui::address;
-    use sui::object;
-    use sui::tx_context;
 
     #[test]
     fun from_bytes_ok() {
@@ -89,24 +85,24 @@ module sui::address_tests {
 
     #[test]
     fun to_ascii_string_ok() {
-        assert!(@0x0.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
-        assert!(@0x1.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
-        assert!(@0x10.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
-        assert!(@0xff.to_ascii_string() == ascii::string(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
-        assert!(@0x101.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
-        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_ascii_string() == ascii::string(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
-        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_ascii_string() == ascii::string(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
+        assert!(@0x0.to_ascii_string() == b"0000000000000000000000000000000000000000000000000000000000000000".to_ascii_string(), 0);
+        assert!(@0x1.to_ascii_string() == b"0000000000000000000000000000000000000000000000000000000000000001".to_ascii_string(), 0);
+        assert!(@0x10.to_ascii_string() == b"0000000000000000000000000000000000000000000000000000000000000010".to_ascii_string(), 0);
+        assert!(@0xff.to_ascii_string() == b"00000000000000000000000000000000000000000000000000000000000000ff".to_ascii_string(), 0);
+        assert!(@0x101.to_ascii_string() == b"0000000000000000000000000000000000000000000000000000000000000101".to_ascii_string(), 0);
+        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_ascii_string() == b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe".to_ascii_string(), 0);
+        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_ascii_string() == b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_ascii_string(), 0);
     }
 
      #[test]
     fun to_string_ok() {
-        assert!(@0x0.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
-        assert!(@0x1.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
-        assert!(@0x10.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
-        assert!(@0xff.to_string() == string::utf8(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
-        assert!(@0x101.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
-        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_string() == string::utf8(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
-        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_string() == string::utf8(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
+        assert!(@0x0.to_string() == b"0000000000000000000000000000000000000000000000000000000000000000".to_string(), 0);
+        assert!(@0x1.to_string() == b"0000000000000000000000000000000000000000000000000000000000000001".to_string(), 0);
+        assert!(@0x10.to_string() == b"0000000000000000000000000000000000000000000000000000000000000010".to_string(), 0);
+        assert!(@0xff.to_string() == b"00000000000000000000000000000000000000000000000000000000000000ff".to_string(), 0);
+        assert!(@0x101.to_string() == b"0000000000000000000000000000000000000000000000000000000000000101".to_string(), 0);
+        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_string() == b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe".to_string(), 0);
+        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_string() == b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string(), 0);
     }
 
     #[test]

--- a/crates/sui-framework/packages/sui-framework/tests/address_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/address_tests.move
@@ -5,7 +5,6 @@
 module sui::address_tests {
     use std::ascii;
     use std::string;
-    use std::vector;
     use sui::address;
     use sui::object;
     use sui::tx_context;
@@ -27,12 +26,12 @@ module sui::address_tests {
         let mut ctx = tx_context::dummy();
         let uid = object::new(&mut ctx);
 
-        let mut bytes = object::uid_to_bytes(&uid);
-        vector::pop_back(&mut bytes);
+        let mut bytes = uid.to_bytes();
+        bytes.pop_back();
 
         let _ = address::from_bytes(bytes);
 
-        object::delete(uid);
+        uid.delete();
     }
 
     #[test]
@@ -41,23 +40,23 @@ module sui::address_tests {
         let mut ctx = tx_context::dummy();
         let uid = object::new(&mut ctx);
 
-        let mut bytes = object::uid_to_bytes(&uid);
-        vector::push_back(&mut bytes, 0x42);
+        let mut bytes = uid.to_bytes();
+        bytes.push_back(0x42);
 
         let _ = address::from_bytes(bytes);
 
-        object::delete(uid);
+        uid.delete();
     }
 
     #[test]
     fun to_u256_ok() {
-        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000000")) == 0, 0);
-        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000001")) == 1, 0);
-        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000010")) == 16, 0);
-        assert!(address::to_u256(address::from_bytes(x"00000000000000000000000000000000000000000000000000000000000000ff")) == 255, 0);
-        assert!(address::to_u256(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000100")) == 256, 0);
-        assert!(address::to_u256(address::from_bytes(x"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")) == address::max() - 1, 0);
-        assert!(address::to_u256(address::from_bytes(x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")) == address::max(), 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000000").to_u256() == 0, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000001").to_u256() == 1, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000010").to_u256() == 16, 0);
+        assert!(address::from_bytes(x"00000000000000000000000000000000000000000000000000000000000000ff").to_u256() == 255, 0);
+        assert!(address::from_bytes(x"0000000000000000000000000000000000000000000000000000000000000100").to_u256() == 256, 0);
+        assert!(address::from_bytes(x"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe").to_u256() == address::max() - 1, 0);
+        assert!(address::from_bytes(x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").to_u256() == address::max(), 0);
     }
 
     #[test]
@@ -79,35 +78,35 @@ module sui::address_tests {
 
     #[test]
     fun to_bytes_ok() {
-        assert!(address::to_bytes(@0x0) == x"0000000000000000000000000000000000000000000000000000000000000000", 0);
-        assert!(address::to_bytes(@0x1) == x"0000000000000000000000000000000000000000000000000000000000000001", 0);
-        assert!(address::to_bytes(@0x10) == x"0000000000000000000000000000000000000000000000000000000000000010", 0);
-        assert!(address::to_bytes(@0xff) == x"00000000000000000000000000000000000000000000000000000000000000ff", 0);
-        assert!(address::to_bytes(@0x101) == x"0000000000000000000000000000000000000000000000000000000000000101", 0);
-        assert!(address::to_bytes(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe) == x"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe", 0);
-        assert!(address::to_bytes(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) == x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0);
+        assert!(@0x0.to_bytes() == x"0000000000000000000000000000000000000000000000000000000000000000", 0);
+        assert!(@0x1.to_bytes() == x"0000000000000000000000000000000000000000000000000000000000000001", 0);
+        assert!(@0x10.to_bytes() == x"0000000000000000000000000000000000000000000000000000000000000010", 0);
+        assert!(@0xff.to_bytes() == x"00000000000000000000000000000000000000000000000000000000000000ff", 0);
+        assert!(@0x101.to_bytes() == x"0000000000000000000000000000000000000000000000000000000000000101", 0);
+        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_bytes() == x"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe", 0);
+        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_bytes() == x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0);
     }
 
     #[test]
     fun to_ascii_string_ok() {
-        assert!(address::to_ascii_string(@0x0) == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
-        assert!(address::to_ascii_string(@0x1) == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
-        assert!(address::to_ascii_string(@0x10) == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
-        assert!(address::to_ascii_string(@0xff) == ascii::string(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
-        assert!(address::to_ascii_string(@0x101) == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
-        assert!(address::to_ascii_string(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe) == ascii::string(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
-        assert!(address::to_ascii_string(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) == ascii::string(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
+        assert!(@0x0.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
+        assert!(@0x1.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
+        assert!(@0x10.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
+        assert!(@0xff.to_ascii_string() == ascii::string(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
+        assert!(@0x101.to_ascii_string() == ascii::string(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
+        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_ascii_string() == ascii::string(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
+        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_ascii_string() == ascii::string(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
     }
 
      #[test]
     fun to_string_ok() {
-        assert!(address::to_string(@0x0) == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
-        assert!(address::to_string(@0x1) == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
-        assert!(address::to_string(@0x10) == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
-        assert!(address::to_string(@0xff) == string::utf8(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
-        assert!(address::to_string(@0x101) == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
-        assert!(address::to_string(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe) == string::utf8(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
-        assert!(address::to_string(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) == string::utf8(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
+        assert!(@0x0.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000000"), 0);
+        assert!(@0x1.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000001"), 0);
+        assert!(@0x10.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000010"), 0);
+        assert!(@0xff.to_string() == string::utf8(b"00000000000000000000000000000000000000000000000000000000000000ff"), 0);
+        assert!(@0x101.to_string() == string::utf8(b"0000000000000000000000000000000000000000000000000000000000000101"), 0);
+        assert!(@0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe.to_string() == string::utf8(b"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"), 0);
+        assert!(@0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.to_string() == string::utf8(b"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), 0);
     }
 
     #[test]

--- a/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
@@ -21,8 +21,7 @@ module sui::authenticator_state_tests {
 
     #[test]
     fun authenticator_state_tests_basic() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
         authenticator_state::create_for_testing(scenario.ctx());
         scenario.next_tx(@0x0);
@@ -62,13 +61,12 @@ module sui::authenticator_state_tests {
         assert!(&recorded_jwks[0] == &jwk1, 0);
 
         test_scenario::return_shared(auth_state);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun authenticator_state_tests_deduplication() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
         authenticator_state::create_for_testing(scenario.ctx());
         scenario.next_tx(@0x0);
@@ -101,13 +99,12 @@ module sui::authenticator_state_tests {
         assert!(&recorded_jwks[2] == &jwk4, 0);
 
         test_scenario::return_shared(auth_state);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun authenticator_state_tests_expiry_edge_cases() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
         authenticator_state::create_for_testing(scenario.ctx());
         scenario.next_tx(@0x0);
@@ -173,6 +170,6 @@ module sui::authenticator_state_tests {
         assert!(&recorded_jwks[2] == &jwk6, 0);
 
         test_scenario::return_shared(auth_state);
-        scenario_val.end();
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
@@ -5,8 +5,7 @@
 #[test_only]
 #[allow(unused_use)]
 module sui::authenticator_state_tests {
-    use std::string::{String, utf8};
-    use std::vector;
+    use std::string::{String};
 
     use sui::test_scenario::{Self, Scenario};
     use sui::authenticator_state::{
@@ -30,37 +29,37 @@ module sui::authenticator_state_tests {
 
         let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
 
-        let jwk1 = create_active_jwk(utf8(b"iss1"), utf8(b"key1"), utf8(b"key1_payload"), 1);
-        let jwk2 = create_active_jwk(utf8(b"iss1"), utf8(b"key2"), utf8(b"key2_payload"), 1);
-        let jwk3 = create_active_jwk(utf8(b"iss1"), utf8(b"key3"), utf8(b"key3_payload"), 1);
+        let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 1);
+        let jwk2 = create_active_jwk(b"iss1".to_string(), b"key2".to_string(), b"key2_payload".to_string(), 1);
+        let jwk3 = create_active_jwk(b"iss1".to_string(), b"key3".to_string(), b"key3_payload".to_string(), 1);
 
 
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk1, jwk3], test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk1, jwk3], test_scenario::ctx(scenario));
 
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk1, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk3, 0);
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(&recorded_jwks[0] == &jwk1, 0);
+        assert!(&recorded_jwks[1] == &jwk3, 0);
 
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk2], test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk1, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk2, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk3, 0);
+        auth_state.update_authenticator_state_for_testing(vector[jwk2], test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(&recorded_jwks[0] == &jwk1, 0);
+        assert!(&recorded_jwks[1] == &jwk2, 0);
+        assert!(&recorded_jwks[2] == &jwk3, 0);
 
-        expire_jwks_for_testing(&mut auth_state, 1, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
+        auth_state.expire_jwks_for_testing(1, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
 
-        let jwk1 = create_active_jwk(utf8(b"iss1"), utf8(b"key1"), utf8(b"key1_payload"), 2);
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk1], test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk1, 0);
+        let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 2);
+        auth_state.update_authenticator_state_for_testing(vector[jwk1], test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
+        assert!(&recorded_jwks[0] == &jwk1, 0);
 
-        expire_jwks_for_testing(&mut auth_state, 2, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 1, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk1, 0);
+        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 1, 0);
+        assert!(&recorded_jwks[0] == &jwk1, 0);
 
         test_scenario::return_shared(auth_state);
         test_scenario::end(scenario_val);
@@ -76,30 +75,30 @@ module sui::authenticator_state_tests {
 
         let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
 
-        let jwk1 = create_active_jwk(utf8(b"https://accounts.google.com"), utf8(b"kid2"), utf8(b"k1"), 0);
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk1], test_scenario::ctx(scenario));
+        let jwk1 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid2".to_string(), b"k1".to_string(), 0);
+        auth_state.update_authenticator_state_for_testing(vector[jwk1], test_scenario::ctx(scenario));
 
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 1, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk1, 0);
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 1, 0);
+        assert!(&recorded_jwks[0] == &jwk1, 0);
 
-        let jwk2 = create_active_jwk(utf8(b"https://www.facebook.com"), utf8(b"kid1"), utf8(b"k2"), 0);
-        let jwk3 = create_active_jwk(utf8(b"https://accounts.google.com"), utf8(b"kid2"), utf8(b"k3"), 0);
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk2, jwk3], test_scenario::ctx(scenario));
+        let jwk2 = create_active_jwk(b"https://www.facebook.com".to_string(), b"kid1".to_string(), b"k2".to_string(), 0);
+        let jwk3 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid2".to_string(), b"k3".to_string(), 0);
+        auth_state.update_authenticator_state_for_testing(vector[jwk2, jwk3], test_scenario::ctx(scenario));
 
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 2, 0);
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 2, 0);
         // jwk2 sorts before 1, and 3 is dropped because its a duplicated
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk2, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk1, 0);
+        assert!(&recorded_jwks[0] == &jwk2, 0);
+        assert!(&recorded_jwks[1] == &jwk1, 0);
 
-        let jwk4 = create_active_jwk(utf8(b"https://accounts.google.com"), utf8(b"kid4"), utf8(b"k4"), 0);
-        update_authenticator_state_for_testing(&mut auth_state, vector[jwk4], test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk2, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk1, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk4, 0);
+        let jwk4 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid4".to_string(), b"k4".to_string(), 0);
+        auth_state.update_authenticator_state_for_testing(vector[jwk4], test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
+        assert!(&recorded_jwks[0] == &jwk2, 0);
+        assert!(&recorded_jwks[1] == &jwk1, 0);
+        assert!(&recorded_jwks[2] == &jwk4, 0);
 
         test_scenario::return_shared(auth_state);
         test_scenario::end(scenario_val);
@@ -116,62 +115,62 @@ module sui::authenticator_state_tests {
         let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
 
         // expire on an empty state
-        expire_jwks_for_testing(&mut auth_state, 1, test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(1, test_scenario::ctx(scenario));
 
-        let jwk1 = create_active_jwk(utf8(b"iss1"), utf8(b"key1"), utf8(b"key1_payload"), 1);
-        let jwk2 = create_active_jwk(utf8(b"iss2"), utf8(b"key2"), utf8(b"key2_payload"), 1);
-        let jwk3 = create_active_jwk(utf8(b"iss3"), utf8(b"key3"), utf8(b"key3_payload"), 1);
+        let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 1);
+        let jwk2 = create_active_jwk(b"iss2".to_string(), b"key2".to_string(), b"key2_payload".to_string(), 1);
+        let jwk3 = create_active_jwk(b"iss3".to_string(), b"key3".to_string(), b"key3_payload".to_string(), 1);
 
-        update_authenticator_state_for_testing(
-            &mut auth_state, vector[jwk1, jwk2, jwk3], test_scenario::ctx(scenario)
+        auth_state.update_authenticator_state_for_testing(
+            vector[jwk1, jwk2, jwk3], test_scenario::ctx(scenario)
         );
 
         // because none of the issuers have a jwk in epoch 2, we expire nothing
-        expire_jwks_for_testing(&mut auth_state, 2, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
+        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
 
         // now add a new jwk for iss1 in epoch 2
-        let jwk4 = create_active_jwk(utf8(b"iss1"), utf8(b"key4"), utf8(b"key4_payload"), 2);
-        update_authenticator_state_for_testing(
-            &mut auth_state, vector[jwk4], test_scenario::ctx(scenario)
+        let jwk4 = create_active_jwk(b"iss1".to_string(), b"key4".to_string(), b"key4_payload".to_string(), 2);
+        auth_state.update_authenticator_state_for_testing(
+            vector[jwk4], test_scenario::ctx(scenario)
         );
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 4, 0);
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 4, 0);
 
         // now iss2 has one jwk in epoch 2, so we expire the one from epoch 1
-        expire_jwks_for_testing(&mut auth_state, 2, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk4, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk2, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk3, 0);
+        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
+        assert!(&recorded_jwks[0] == &jwk4, 0);
+        assert!(&recorded_jwks[1] == &jwk2, 0);
+        assert!(&recorded_jwks[2] == &jwk3, 0);
 
         // now add two new keys in epoch 3
-        let jwk5 = create_active_jwk(utf8(b"iss2"), utf8(b"key5"), utf8(b"key5_payload"), 3);
-        let jwk6 = create_active_jwk(utf8(b"iss3"), utf8(b"key6"), utf8(b"key6_payload"), 3);
-        update_authenticator_state_for_testing(
-            &mut auth_state, vector[jwk5, jwk6], test_scenario::ctx(scenario)
+        let jwk5 = create_active_jwk(b"iss2".to_string(), b"key5".to_string(), b"key5_payload".to_string(), 3);
+        let jwk6 = create_active_jwk(b"iss3".to_string(), b"key6".to_string(), b"key6_payload".to_string(), 3);
+        auth_state.update_authenticator_state_for_testing(
+            vector[jwk5, jwk6], test_scenario::ctx(scenario)
         );
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 5, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk5, 0);
-        assert!(vector::borrow(&recorded_jwks, 4) == &jwk6, 0);
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 5, 0);
+        assert!(&recorded_jwks[2] == &jwk5, 0);
+        assert!(&recorded_jwks[4] == &jwk6, 0);
 
         // now iss2 and iss3 have one jwk in epoch 3, so we expire the one from epoch 1
-        expire_jwks_for_testing(&mut auth_state, 3, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk4, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk5, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk6, 0);
+        auth_state.expire_jwks_for_testing(3, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
+        assert!(&recorded_jwks[0] == &jwk4, 0);
+        assert!(&recorded_jwks[1] == &jwk5, 0);
+        assert!(&recorded_jwks[2] == &jwk6, 0);
 
-        expire_jwks_for_testing(&mut auth_state, 3, test_scenario::ctx(scenario));
-        let recorded_jwks = get_active_jwks_for_testing(&auth_state, test_scenario::ctx(scenario));
-        assert!(vector::length(&recorded_jwks) == 3, 0);
-        assert!(vector::borrow(&recorded_jwks, 0) == &jwk4, 0);
-        assert!(vector::borrow(&recorded_jwks, 1) == &jwk5, 0);
-        assert!(vector::borrow(&recorded_jwks, 2) == &jwk6, 0);
+        auth_state.expire_jwks_for_testing(3, test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        assert!(recorded_jwks.length() == 3, 0);
+        assert!(&recorded_jwks[0] == &jwk4, 0);
+        assert!(&recorded_jwks[1] == &jwk5, 0);
+        assert!(&recorded_jwks[2] == &jwk6, 0);
 
 
 

--- a/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
@@ -5,7 +5,7 @@
 #[test_only]
 #[allow(unused_use)]
 module sui::authenticator_state_tests {
-    use std::string::{String};
+    use std::string::String;
 
     use sui::test_scenario;
     use sui::authenticator_state::{
@@ -17,7 +17,6 @@ module sui::authenticator_state_tests {
         expire_jwks_for_testing,
         ActiveJwk,
     };
-    use sui::tx_context;
 
     #[test]
     fun authenticator_state_tests_basic() {

--- a/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/authenticator_state_tests.move
@@ -7,7 +7,7 @@
 module sui::authenticator_state_tests {
     use std::string::{String};
 
-    use sui::test_scenario::{Self, Scenario};
+    use sui::test_scenario;
     use sui::authenticator_state::{
         Self,
         AuthenticatorState,
@@ -24,45 +24,45 @@ module sui::authenticator_state_tests {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        authenticator_state::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        authenticator_state::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
+        let mut auth_state = scenario.take_shared<AuthenticatorState>();
 
         let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 1);
         let jwk2 = create_active_jwk(b"iss1".to_string(), b"key2".to_string(), b"key2_payload".to_string(), 1);
         let jwk3 = create_active_jwk(b"iss1".to_string(), b"key3".to_string(), b"key3_payload".to_string(), 1);
 
 
-        auth_state.update_authenticator_state_for_testing(vector[jwk1, jwk3], test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk1, jwk3], scenario.ctx());
 
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(&recorded_jwks[0] == &jwk1, 0);
         assert!(&recorded_jwks[1] == &jwk3, 0);
 
-        auth_state.update_authenticator_state_for_testing(vector[jwk2], test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk2], scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(&recorded_jwks[0] == &jwk1, 0);
         assert!(&recorded_jwks[1] == &jwk2, 0);
         assert!(&recorded_jwks[2] == &jwk3, 0);
 
-        auth_state.expire_jwks_for_testing(1, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(1, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
 
         let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 2);
-        auth_state.update_authenticator_state_for_testing(vector[jwk1], test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk1], scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
         assert!(&recorded_jwks[0] == &jwk1, 0);
 
-        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(2, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 1, 0);
         assert!(&recorded_jwks[0] == &jwk1, 0);
 
         test_scenario::return_shared(auth_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -70,38 +70,38 @@ module sui::authenticator_state_tests {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        authenticator_state::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        authenticator_state::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
+        let mut auth_state = scenario.take_shared<AuthenticatorState>();
 
         let jwk1 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid2".to_string(), b"k1".to_string(), 0);
-        auth_state.update_authenticator_state_for_testing(vector[jwk1], test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk1], scenario.ctx());
 
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 1, 0);
         assert!(&recorded_jwks[0] == &jwk1, 0);
 
         let jwk2 = create_active_jwk(b"https://www.facebook.com".to_string(), b"kid1".to_string(), b"k2".to_string(), 0);
         let jwk3 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid2".to_string(), b"k3".to_string(), 0);
-        auth_state.update_authenticator_state_for_testing(vector[jwk2, jwk3], test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk2, jwk3], scenario.ctx());
 
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 2, 0);
         // jwk2 sorts before 1, and 3 is dropped because its a duplicated
         assert!(&recorded_jwks[0] == &jwk2, 0);
         assert!(&recorded_jwks[1] == &jwk1, 0);
 
         let jwk4 = create_active_jwk(b"https://accounts.google.com".to_string(), b"kid4".to_string(), b"k4".to_string(), 0);
-        auth_state.update_authenticator_state_for_testing(vector[jwk4], test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.update_authenticator_state_for_testing(vector[jwk4], scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
         assert!(&recorded_jwks[0] == &jwk2, 0);
         assert!(&recorded_jwks[1] == &jwk1, 0);
         assert!(&recorded_jwks[2] == &jwk4, 0);
 
         test_scenario::return_shared(auth_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -109,38 +109,38 @@ module sui::authenticator_state_tests {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        authenticator_state::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        authenticator_state::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut auth_state = test_scenario::take_shared<AuthenticatorState>(scenario);
+        let mut auth_state = scenario.take_shared<AuthenticatorState>();
 
         // expire on an empty state
-        auth_state.expire_jwks_for_testing(1, test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(1, scenario.ctx());
 
         let jwk1 = create_active_jwk(b"iss1".to_string(), b"key1".to_string(), b"key1_payload".to_string(), 1);
         let jwk2 = create_active_jwk(b"iss2".to_string(), b"key2".to_string(), b"key2_payload".to_string(), 1);
         let jwk3 = create_active_jwk(b"iss3".to_string(), b"key3".to_string(), b"key3_payload".to_string(), 1);
 
         auth_state.update_authenticator_state_for_testing(
-            vector[jwk1, jwk2, jwk3], test_scenario::ctx(scenario)
+            vector[jwk1, jwk2, jwk3], scenario.ctx()
         );
 
         // because none of the issuers have a jwk in epoch 2, we expire nothing
-        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(2, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
 
         // now add a new jwk for iss1 in epoch 2
         let jwk4 = create_active_jwk(b"iss1".to_string(), b"key4".to_string(), b"key4_payload".to_string(), 2);
         auth_state.update_authenticator_state_for_testing(
-            vector[jwk4], test_scenario::ctx(scenario)
+            vector[jwk4], scenario.ctx()
         );
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 4, 0);
 
         // now iss2 has one jwk in epoch 2, so we expire the one from epoch 1
-        auth_state.expire_jwks_for_testing(2, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(2, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
         assert!(&recorded_jwks[0] == &jwk4, 0);
         assert!(&recorded_jwks[1] == &jwk2, 0);
@@ -150,31 +150,29 @@ module sui::authenticator_state_tests {
         let jwk5 = create_active_jwk(b"iss2".to_string(), b"key5".to_string(), b"key5_payload".to_string(), 3);
         let jwk6 = create_active_jwk(b"iss3".to_string(), b"key6".to_string(), b"key6_payload".to_string(), 3);
         auth_state.update_authenticator_state_for_testing(
-            vector[jwk5, jwk6], test_scenario::ctx(scenario)
+            vector[jwk5, jwk6], scenario.ctx()
         );
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 5, 0);
         assert!(&recorded_jwks[2] == &jwk5, 0);
         assert!(&recorded_jwks[4] == &jwk6, 0);
 
         // now iss2 and iss3 have one jwk in epoch 3, so we expire the one from epoch 1
-        auth_state.expire_jwks_for_testing(3, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(3, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
         assert!(&recorded_jwks[0] == &jwk4, 0);
         assert!(&recorded_jwks[1] == &jwk5, 0);
         assert!(&recorded_jwks[2] == &jwk6, 0);
 
-        auth_state.expire_jwks_for_testing(3, test_scenario::ctx(scenario));
-        let recorded_jwks = auth_state.get_active_jwks_for_testing(test_scenario::ctx(scenario));
+        auth_state.expire_jwks_for_testing(3, scenario.ctx());
+        let recorded_jwks = auth_state.get_active_jwks_for_testing(scenario.ctx());
         assert!(recorded_jwks.length() == 3, 0);
         assert!(&recorded_jwks[0] == &jwk4, 0);
         assert!(&recorded_jwks[1] == &jwk5, 0);
         assert!(&recorded_jwks[2] == &jwk6, 0);
-
-
 
         test_scenario::return_shared(auth_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/bag_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/bag_tests.move
@@ -3,7 +3,7 @@
 
 #[test_only]
 module sui::bag_tests {
-    use sui::bag::{Self, add, contains_with_type, borrow, borrow_mut, remove};
+    use sui::bag::Self;
     use sui::test_scenario as ts;
 
     #[test]
@@ -12,28 +12,28 @@ module sui::bag_tests {
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
         // add fields
-        add(&mut bag, b"hello", 0);
-        add(&mut bag, 1, 1u8);
+        bag.add(b"hello", 0);
+        bag.add(1, 1u8);
         // check they exist
-        assert!(contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
-        assert!(contains_with_type<u64, u8>(&bag, 1), 0);
+        assert!(bag.contains_with_type<vector<u8>, u64>(b"hello"), 0);
+        assert!(bag.contains_with_type<u64, u8>(1), 0);
         // check the values
-        assert!(*borrow(&bag, b"hello") == 0, 0);
-        assert!(*borrow(&bag, 1) == 1u8, 0);
+        assert!(bag[b"hello"] == 0, 0);
+        assert!(bag[1] == 1u8, 0);
         // mutate them
-        *borrow_mut(&mut bag, b"hello") = *borrow(&bag, b"hello") * 2;
-        *borrow_mut(&mut bag, 1) = *borrow(&bag, 1) * 2u8;
+        *(&mut bag[b"hello"]) = bag[b"hello"] * 2;
+        *(&mut bag[1]) = bag[1] * 2u8;
         // check the new value
-        assert!(*borrow(&bag, b"hello") == 0, 0);
-        assert!(*borrow(&bag, 1) == 2u8, 0);
+        assert!(bag[b"hello"] == 0, 0);
+        assert!(bag[1] == 2u8, 0);
         // remove the value and check it
-        assert!(remove(&mut bag, b"hello") == 0, 0);
-        assert!(remove(&mut bag, 1) == 2u8, 0);
+        assert!(bag.remove(b"hello") == 0, 0);
+        assert!(bag.remove(1) == 2u8, 0);
         // verify that they are not there
-        assert!(!contains_with_type<vector<u8>, u64>(&bag, b"hello"), 0);
-        assert!(!contains_with_type<u64, u8>(&bag, 1), 0);
+        assert!(!bag.contains_with_type<vector<u8>, u64>(b"hello"), 0);
+        assert!(!bag.contains_with_type<u64, u8>(1), 0);
         ts::end(scenario);
-        bag::destroy_empty(bag);
+        bag.destroy_empty();
     }
 
     #[test]
@@ -42,8 +42,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, b"hello", 0u8);
-        add(&mut bag, b"hello", 1u8);
+        bag.add(b"hello", 0u8);
+        bag.add(b"hello", 1u8);
         abort 42
     }
 
@@ -53,8 +53,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, b"hello", 0u128);
-        add(&mut bag, b"hello", 1u8);
+        bag.add(b"hello", 0u128);
+        bag.add(b"hello", 1u8);
         abort 42
     }
 
@@ -64,7 +64,7 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let bag = bag::new(ts::ctx(&mut scenario));
-        borrow<u64, u64>(&bag, 0);
+        (&bag[0] : &u64);
         abort 42
     }
 
@@ -74,8 +74,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, 0, 0);
-        borrow<u64, u8>(&bag, 0);
+        bag.add(0u64, 0u64);
+        (&bag[0]: &u8);
         abort 42
     }
 
@@ -85,7 +85,7 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        borrow_mut<u64, u64>(&mut bag, 0);
+        (&mut bag[0]: &mut u64);
         abort 42
     }
 
@@ -95,8 +95,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, 0, 0);
-        borrow_mut<u64, u8>(&mut bag, 0);
+        bag.add(0u64, 0u64);
+        (&mut bag[0]: &mut u8);
         abort 42
     }
 
@@ -106,7 +106,7 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        remove<u64, u64>(&mut bag, 0);
+        bag.remove<u64, u64>(0);
         abort 42
     }
 
@@ -116,8 +116,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, 0, 0);
-        remove<u64, u8>(&mut bag, 0);
+        bag.add(0, 0);
+        bag.remove<u64, u8>(0);
         abort 42
     }
 
@@ -127,8 +127,8 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        add(&mut bag, 0, 0);
-        bag::destroy_empty(bag);
+        bag.add(0, 0);
+        bag.destroy_empty();
         ts::end(scenario);
     }
 
@@ -137,13 +137,13 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        assert!(!contains_with_type<u64, u64>(&bag, 0), 0);
-        add(&mut bag, 0, 0);
-        assert!(contains_with_type<u64, u64>(&bag, 0), 0);
-        assert!(!contains_with_type<u64, u64>(&bag, 1), 0);
+        assert!(!bag.contains_with_type<u64, u64>(0), 0);
+        bag.add(0, 0);
+        assert!(bag.contains_with_type<u64, u64>(0), 0);
+        assert!(!bag.contains_with_type<u64, u64>(1), 0);
         ts::end(scenario);
-        bag::remove<u64, u64>(&mut bag, 0);
-        bag::destroy_empty(bag);
+        bag.remove<u64, u64>(0);
+        bag.destroy_empty();
     }
 
     #[test]
@@ -151,17 +151,17 @@ module sui::bag_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut bag = bag::new(ts::ctx(&mut scenario));
-        assert!(bag::is_empty(&bag), 0);
-        assert!(bag::length(&bag) == 0, 0);
-        add(&mut bag, 0, 0);
-        assert!(!bag::is_empty(&bag), 0);
-        assert!(bag::length(&bag) == 1, 0);
-        add(&mut bag, 1, 0);
-        assert!(!bag::is_empty(&bag), 0);
-        assert!(bag::length(&bag) == 2, 0);
-        bag::remove<u64, u64>(&mut bag, 0);
-        bag::remove<u64, u64>(&mut bag, 1);
+        assert!(bag.is_empty(), 0);
+        assert!(bag.length() == 0, 0);
+        bag.add(0, 0);
+        assert!(!bag.is_empty(), 0);
+        assert!(bag.length() == 1, 0);
+        bag.add(1, 0);
+        assert!(!bag.is_empty(), 0);
+        assert!(bag.length() == 2, 0);
+        bag.remove<u64, u64>(0);
+        bag.remove<u64, u64>(1);
         ts::end(scenario);
-        bag::destroy_empty(bag);
+        bag.destroy_empty();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/bag_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/bag_tests.move
@@ -4,13 +4,13 @@
 #[test_only]
 module sui::bag_tests {
     use sui::bag::Self;
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
 
     #[test]
     fun simple_all_functions() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         // add fields
         bag.add(b"hello", 0);
         bag.add(1, 1u8);
@@ -32,7 +32,7 @@ module sui::bag_tests {
         // verify that they are not there
         assert!(!bag.contains_with_type<vector<u8>, u64>(b"hello"), 0);
         assert!(!bag.contains_with_type<u64, u8>(1), 0);
-        ts::end(scenario);
+        scenario.end();
         bag.destroy_empty();
     }
 
@@ -40,8 +40,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(b"hello", 0u8);
         bag.add(b"hello", 1u8);
         abort 42
@@ -51,8 +51,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate_mismatched_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(b"hello", 0u128);
         bag.add(b"hello", 1u8);
         abort 42
@@ -62,8 +62,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let bag = bag::new(scenario.ctx());
         (&bag[0] : &u64);
         abort 42
     }
@@ -72,8 +72,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(0u64, 0u64);
         (&bag[0]: &u8);
         abort 42
@@ -83,8 +83,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_mut_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         (&mut bag[0]: &mut u64);
         abort 42
     }
@@ -93,8 +93,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_mut_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(0u64, 0u64);
         (&mut bag[0]: &mut u8);
         abort 42
@@ -104,8 +104,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun remove_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.remove<u64, u64>(0);
         abort 42
     }
@@ -114,8 +114,8 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun remove_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(0, 0);
         bag.remove<u64, u8>(0);
         abort 42
@@ -125,23 +125,23 @@ module sui::bag_tests {
     #[expected_failure(abort_code = sui::bag::EBagNotEmpty)]
     fun destroy_non_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         bag.add(0, 0);
         bag.destroy_empty();
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun sanity_check_contains() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         assert!(!bag.contains_with_type<u64, u64>(0), 0);
         bag.add(0, 0);
         assert!(bag.contains_with_type<u64, u64>(0), 0);
         assert!(!bag.contains_with_type<u64, u64>(1), 0);
-        ts::end(scenario);
+        scenario.end();
         bag.remove<u64, u64>(0);
         bag.destroy_empty();
     }
@@ -149,8 +149,8 @@ module sui::bag_tests {
     #[test]
     fun sanity_check_size() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut bag = bag::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut bag = bag::new(scenario.ctx());
         assert!(bag.is_empty(), 0);
         assert!(bag.length() == 0, 0);
         bag.add(0, 0);
@@ -161,7 +161,7 @@ module sui::bag_tests {
         assert!(bag.length() == 2, 0);
         bag.remove<u64, u64>(0);
         bag.remove<u64, u64>(1);
-        ts::end(scenario);
+        scenario.end();
         bag.destroy_empty();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
@@ -14,10 +14,10 @@ module sui::coin_balance_tests {
         let mut scenario = test_scenario::begin(@0x1);
 
         let balance = balance::zero<SUI>();
-        let coin = coin::from_balance(balance, scenario.ctx());
-        let balance = coin::into_balance(coin);
+        let coin = balance.into_coin(scenario.ctx());
+        let balance = coin.into_balance();
 
-        balance::destroy_zero(balance);
+        balance.destroy_zero();
 
         let mut coin = coin::mint_for_testing<SUI>(100, scenario.ctx());
         let balance_mut = coin::balance_mut(&mut coin);
@@ -26,12 +26,12 @@ module sui::coin_balance_tests {
         assert!(sub_balance.value() == 50, 0);
         assert!(coin.value() == 50, 0);
 
-        let mut balance = coin::into_balance(coin);
+        let mut balance = coin.into_balance();
         balance.join(sub_balance);
 
         assert!(balance.value() == 100, 0);
 
-        let coin = coin::from_balance(balance, scenario.ctx());
+        let coin = balance.into_coin(scenario.ctx());
         pay::keep(coin, scenario.ctx());
         scenario.end();
     }

--- a/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
@@ -22,15 +22,15 @@ module sui::coin_balance_tests {
 
         let mut coin = coin::mint_for_testing<SUI>(100, ctx(test));
         let balance_mut = coin::balance_mut(&mut coin);
-        let sub_balance = balance::split(balance_mut, 50);
+        let sub_balance = balance_mut.split(50);
 
-        assert!(balance::value(&sub_balance) == 50, 0);
-        assert!(coin::value(&coin) == 50, 0);
+        assert!(sub_balance.value() == 50, 0);
+        assert!(coin.value() == 50, 0);
 
         let mut balance = coin::into_balance(coin);
-        balance::join(&mut balance, sub_balance);
+        balance.join(sub_balance);
 
-        assert!(balance::value(&balance) == 100, 0);
+        assert!(balance.value() == 100, 0);
 
         let coin = coin::from_balance(balance, ctx(test));
         pay::keep(coin, ctx(test));

--- a/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/balance_tests.move
@@ -3,7 +3,7 @@
 
 #[test_only]
 module sui::coin_balance_tests {
-    use sui::test_scenario::{Self, ctx};
+    use sui::test_scenario;
     use sui::pay;
     use sui::coin;
     use sui::balance;
@@ -12,15 +12,14 @@ module sui::coin_balance_tests {
     #[test]
     fun type_morphing() {
         let mut scenario = test_scenario::begin(@0x1);
-        let test = &mut scenario;
 
         let balance = balance::zero<SUI>();
-        let coin = coin::from_balance(balance, ctx(test));
+        let coin = coin::from_balance(balance, scenario.ctx());
         let balance = coin::into_balance(coin);
 
         balance::destroy_zero(balance);
 
-        let mut coin = coin::mint_for_testing<SUI>(100, ctx(test));
+        let mut coin = coin::mint_for_testing<SUI>(100, scenario.ctx());
         let balance_mut = coin::balance_mut(&mut coin);
         let sub_balance = balance_mut.split(50);
 
@@ -32,8 +31,8 @@ module sui::coin_balance_tests {
 
         assert!(balance.value() == 100, 0);
 
-        let coin = coin::from_balance(balance, ctx(test));
-        pay::keep(coin, ctx(test));
-        test_scenario::end(scenario);
+        let coin = coin::from_balance(balance, scenario.ctx());
+        pay::keep(coin, scenario.ctx());
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
@@ -11,12 +11,12 @@ module sui::clock_tests {
         let mut ctx = tx_context::dummy();
         let mut clock = clock::create_for_testing(&mut ctx);
 
-        clock::increment_for_testing(&mut clock, 42);
-        assert!(clock::timestamp_ms(&clock) == 42, 1);
+        clock.increment_for_testing(42);
+        assert!(clock.timestamp_ms() == 42, 1);
 
-        clock::set_for_testing(&mut clock, 50);
-        assert!(clock::timestamp_ms(&clock) == 50, 1);
+        clock.set_for_testing(50);
+        assert!(clock.timestamp_ms() == 50, 1);
 
-        clock::destroy_for_testing(clock);
+        clock.destroy_for_testing();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::clock_tests {
     use sui::clock;
-    use sui::tx_context;
 
     #[test]
     fun creating_a_clock_and_incrementing_it() {

--- a/crates/sui-framework/packages/sui-framework/tests/coin_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/coin_tests.move
@@ -26,11 +26,11 @@ module sui::coin_tests {
         let witness = COIN_TESTS{};
         let (treasury, mut metadata) = coin::create_currency(witness, 6, b"COIN_TESTS", b"coin_name", b"description", option::some(url::new_unsafe_from_bytes(b"icon_url")), ctx);
 
-        let decimals = coin::get_decimals(&metadata);
-        let symbol_bytes = ascii::as_bytes(&coin::get_symbol<COIN_TESTS>(&metadata));
-        let name_bytes = string::bytes(&coin::get_name<COIN_TESTS>(&metadata));
-        let description_bytes = string::bytes(&coin::get_description<COIN_TESTS>(&metadata));
-        let icon_url = ascii::as_bytes(&url::inner_url(option::borrow(&coin::get_icon_url<COIN_TESTS>(&metadata))));
+        let decimals = metadata.get_decimals();
+        let symbol_bytes = ascii::as_bytes(&metadata.get_symbol<COIN_TESTS>());
+        let name_bytes = string::bytes(&metadata.get_name<COIN_TESTS>());
+        let description_bytes = string::bytes(&metadata.get_description<COIN_TESTS>());
+        let icon_url = ascii::as_bytes(&url::inner_url(option::borrow(&metadata.get_icon_url<COIN_TESTS>())));
 
         assert!(decimals == 6, 0);
         assert!(*symbol_bytes == b"COIN_TESTS", 0);
@@ -39,15 +39,15 @@ module sui::coin_tests {
         assert!(*icon_url == b"icon_url", 0);
 
         // Update
-        coin::update_symbol<COIN_TESTS>(&treasury, &mut metadata, ascii::string(b"NEW_COIN_TESTS"));
-        coin::update_name<COIN_TESTS>(&treasury, &mut metadata, string::utf8(b"new_coin_name"));
-        coin::update_description<COIN_TESTS>(&treasury, &mut metadata, string::utf8(b"new_description"));
-        coin::update_icon_url<COIN_TESTS>(&treasury, &mut metadata, ascii::string(b"new_icon_url"));
+        treasury.update_symbol<COIN_TESTS>(&mut metadata, b"NEW_COIN_TESTS".to_ascii_string());
+        treasury.update_name<COIN_TESTS>(&mut metadata, b"new_coin_name".to_string());
+        treasury.update_description<COIN_TESTS>(&mut metadata, b"new_description".to_string());
+        treasury.update_icon_url<COIN_TESTS>(&mut metadata, b"new_icon_url".to_ascii_string());
 
-        let symbol_bytes = ascii::as_bytes(&coin::get_symbol<COIN_TESTS>(&metadata));
-        let name_bytes = string::bytes(&coin::get_name<COIN_TESTS>(&metadata));
-        let description_bytes = string::bytes(&coin::get_description<COIN_TESTS>(&metadata));
-        let icon_url = ascii::as_bytes(&url::inner_url(option::borrow(&coin::get_icon_url<COIN_TESTS>(&metadata))));
+        let symbol_bytes = metadata.get_symbol<COIN_TESTS>().as_bytes();
+        let name_bytes = metadata.get_name<COIN_TESTS>().bytes();
+        let description_bytes = metadata.get_description<COIN_TESTS>().bytes();
+        let icon_url = url::inner_url(metadata.get_icon_url<COIN_TESTS>().borrow()).as_bytes();
 
         assert!(*symbol_bytes == b"NEW_COIN_TESTS", 0);
         assert!(*name_bytes == b"new_coin_name", 0);
@@ -68,14 +68,14 @@ module sui::coin_tests {
 
         let balance = coin::mint_balance<COIN_TESTS>(&mut treasury, 1000);
         let coin = coin::from_balance(balance, test_scenario::ctx(test));
-        let value = coin::value(&coin);
+        let value = coin.value();
         assert!(value == 1000, 0);
         pay::keep(coin, test_scenario::ctx(test));
 
         coin::mint_and_transfer<COIN_TESTS>(&mut treasury, 42, TEST_ADDR, test_scenario::ctx(test));
         test_scenario::next_epoch(test, TEST_ADDR); // needed or else we won't have a value for `most_recent_id_for_address` coming up next.
         let coin = test_scenario::take_from_address<Coin<COIN_TESTS>>(test, TEST_ADDR);
-        let value = coin::value(&coin);
+        let value = coin.value();
         assert!(value == 42, 0);
         pay::keep(coin, test_scenario::ctx(test));
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
@@ -7,7 +7,6 @@ module sui::bls12381_tests {
     use sui::bls12381;
     use sui::group_ops;
     use std::hash::sha2_256;
-    use std::vector;
     use sui::test_utils::assert_eq;
 
     const ORDER_BYTES: vector<u8> = x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001";
@@ -106,7 +105,7 @@ module sui::bls12381_tests {
             round = round >> 8;
             i = i - 1;
         };
-        vector::append(&mut prev_sig, round_bytes);
+        prev_sig.append(round_bytes);
         sha2_256(prev_sig)
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
@@ -101,7 +101,7 @@ module sui::bls12381_tests {
         let mut i = 7;
         while (i > 0) {
             let curr_byte = round % 0x100;
-            let curr_element = vector::borrow_mut(&mut round_bytes, i);
+            let curr_element = &mut round_bytes[i];
             *curr_element = (curr_byte as u8);
             round = round >> 8;
             i = i - 1;
@@ -515,15 +515,15 @@ module sui::bls12381_tests {
         let mut i = 1;
         let mut expected_result = bls12381::g1_identity();
         let g = bls12381::g1_generator();
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector[];
         while (i < 20) {
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g1_mul(&base_scalar, &g);
             let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g1_mul(&exponent_scalar, &base);
-            vector::push_back(&mut elements, base);
-            vector::push_back(&mut scalars, exponent_scalar);
+            elements.push_back(base);
+            scalars.push_back(exponent_scalar);
             expected_result = bls12381::g1_add(&expected_result, &base_exp);
             i = i + 1;
         };
@@ -535,12 +535,12 @@ module sui::bls12381_tests {
     fun test_msm_g1_id() {
         let mut i = 1;
         let expected_result = bls12381::g1_identity();
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector[];
         while (i < 33) {
             let scalar = bls12381::scalar_from_u64(i);
-            vector::push_back(&mut scalars, scalar);
-            vector::push_back(&mut elements, bls12381::g1_identity());
+            scalars.push_back(scalar);
+            elements.push_back(bls12381::g1_identity());
             i = i + 1;
         };
         let result = bls12381::g1_multi_scalar_multiplication(&scalars, &elements);
@@ -550,19 +550,19 @@ module sui::bls12381_tests {
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_empty_g1_msm() {
-        let scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
+        let scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let elements: vector<group_ops::Element<bls12381::G1>> = vector[];
         let _ = bls12381::g1_multi_scalar_multiplication(&scalars, &elements);
     }
 
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_diff_length_g1_msm() {
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        vector::push_back(&mut scalars, bls12381::scalar_zero());
-        vector::push_back(&mut scalars, bls12381::scalar_one());
-        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
-        vector::push_back(&mut elements, bls12381::g1_generator());
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        scalars.push_back(bls12381::scalar_zero());
+        scalars.push_back(bls12381::scalar_one());
+        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector[];
+        elements.push_back(bls12381::g1_generator());
         let _ = bls12381::g1_multi_scalar_multiplication(&scalars, &elements);
     }
 
@@ -572,16 +572,16 @@ module sui::bls12381_tests {
         let mut i = 1;
         let mut expected_result = bls12381::g1_identity();
         let g = bls12381::g1_generator();
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector::empty();
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let mut elements: vector<group_ops::Element<bls12381::G1>> = vector[];
         while (i < 34) {
             // this limit is defined in the protocol config
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g1_mul(&base_scalar, &g);
             let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g1_mul(&exponent_scalar, &base);
-            vector::push_back(&mut elements, base);
-            vector::push_back(&mut scalars, exponent_scalar);
+            elements.push_back(base);
+            scalars.push_back(exponent_scalar);
             expected_result = bls12381::g1_add(&expected_result, &base_exp);
             i = i + 1;
         };
@@ -594,15 +594,15 @@ module sui::bls12381_tests {
         let mut i = 1;
         let mut expected_result = bls12381::g2_identity();
         let g = bls12381::g2_generator();
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector::empty();
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector[];
         while (i < 20) {
             let base_scalar = bls12381::scalar_from_u64(i);
             let base = bls12381::g2_mul(&base_scalar, &g);
             let exponent_scalar = bls12381::scalar_from_u64(i + 100);
             let base_exp = bls12381::g2_mul(&exponent_scalar, &base);
-            vector::push_back(&mut elements, base);
-            vector::push_back(&mut scalars, exponent_scalar);
+            elements.push_back(base);
+            scalars.push_back(exponent_scalar);
             expected_result = bls12381::g2_add(&expected_result, &base_exp);
             i = i + 1;
         };
@@ -614,12 +614,12 @@ module sui::bls12381_tests {
     fun test_msm_g2_id() {
         let mut i = 1;
         let expected_result = bls12381::g2_identity();
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector::empty();
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector[];
         while (i < 20) {
             let scalar = bls12381::scalar_from_u64(i);
-            vector::push_back(&mut scalars, scalar);
-            vector::push_back(&mut elements, bls12381::g2_identity());
+            scalars.push_back(scalar);
+            elements.push_back(bls12381::g2_identity());
             i = i + 1;
         };
         let result = bls12381::g2_multi_scalar_multiplication(&scalars, &elements);
@@ -629,19 +629,19 @@ module sui::bls12381_tests {
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_empty_g2_msm() {
-        let scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        let elements: vector<group_ops::Element<bls12381::G2>> = vector::empty();
+        let scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        let elements: vector<group_ops::Element<bls12381::G2>> = vector[];
         let _ = bls12381::g2_multi_scalar_multiplication(&scalars, &elements);
     }
 
     #[test]
     #[expected_failure(abort_code = group_ops::EInvalidInput)]
     fun test_diff_length_g2_msm() {
-        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector::empty();
-        vector::push_back(&mut scalars, bls12381::scalar_zero());
-        vector::push_back(&mut scalars, bls12381::scalar_one());
-        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector::empty();
-        vector::push_back(&mut elements, bls12381::g2_generator());
+        let mut scalars: vector<group_ops::Element<bls12381::Scalar>> = vector[];
+        scalars.push_back(bls12381::scalar_zero());
+        scalars.push_back(bls12381::scalar_one());
+        let mut elements: vector<group_ops::Element<bls12381::G2>> = vector[];
+        elements.push_back(bls12381::g2_generator());
         let _ = bls12381::g2_multi_scalar_multiplication(&scalars, &elements);
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecdsa_k1_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::ecdsa_k1_tests {
     use sui::ecdsa_k1;
-    use std::vector;
     use sui::hash;
 
     #[test]
@@ -49,7 +48,7 @@ module sui::ecdsa_k1_tests {
         let sig = x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd88600";
         let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 0);
         assert!(verify == false, 0);
-        
+
         let sig_1 = x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd88601";
         let verify_1 = ecdsa_k1::secp256k1_verify(&sig_1, &pk, &msg, 0);
         assert!(verify_1 == false, 0);
@@ -63,7 +62,7 @@ module sui::ecdsa_k1_tests {
         let sig = x"7e4237ebfbc36613e166bfc5f6229360a9c1949242da97ca04867e4de57b2df30c8340bcb320328cf46d71bda51fcb519e3ce53b348eec62de852e350edbd886";
         let verify = ecdsa_k1::secp256k1_verify(&sig, &pk, &msg, 0);
         assert!(verify == true, 0);
-        
+
         // verify with sha256 hash
         let sig = x"e5847245b38548547f613aaea3421ad47f5b95a222366fb9f9b8c57568feb19c7077fc31e7d83e00acc1347d08c3e1ad50a4eeb6ab044f25c861ddc7be5b8f9f";
         let pk = x"02337cca2171fdbfcfd657fa59881f46269f1e590b5ffab6023686c7ad2ecc2c1c";
@@ -98,7 +97,7 @@ module sui::ecdsa_k1_tests {
     // Helper Move function to recover signature directly to an ETH address.
     fun ecrecover_eth_address(mut sig: vector<u8>, msg: vector<u8>): vector<u8> {
         // Normalize the last byte of the signature to be 0 or 1.
-        let v = vector::borrow_mut(&mut sig, 64);
+        let v = &mut sig[64];
         if (*v == 27) {
             *v = 0;
         } else if (*v == 28) {
@@ -112,21 +111,21 @@ module sui::ecdsa_k1_tests {
         let uncompressed = ecdsa_k1::decompress_pubkey(&pubkey);
 
         // Take the last 64 bytes of the uncompressed pubkey.
-        let mut uncompressed_64 = vector::empty<u8>();
+        let mut uncompressed_64 = vector<u8>[];
         let mut i = 1;
         while (i < 65) {
-            let value = vector::borrow(&uncompressed, i);
-            vector::push_back(&mut uncompressed_64, *value);
+            let value = &uncompressed[i];
+            uncompressed_64.push_back(*value);
             i = i + 1;
         };
 
         // Take the last 20 bytes of the hash of the 64-bytes uncompressed pubkey.
         let hashed = hash::keccak256(&uncompressed_64);
-        let mut addr = vector::empty<u8>();
+        let mut addr = vector<u8>[];
         let mut i = 12;
         while (i < 32) {
-            let value = vector::borrow(&hashed, i);
-            vector::push_back(&mut addr, *value);
+            let value = &hashed[i];
+            addr.push_back(*value);
             i = i + 1;
         };
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/groth16_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/groth16_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::groth16_tests {
     use sui::groth16;
-    use std::vector;
     use sui::groth16::{bls12381, bn254};
 
     #[test]
@@ -17,16 +16,16 @@ module sui::groth16_tests {
         let expected_gamma_bytes = x"8398b153643614fc1071a54e288edb6402f1d9e00d3408c76d95c16885cc992dff5c6ebee3b739cb22359ab2d126026a1626c43ea7b898a7c1d2904c1bd4bbce5d0b1b16fab8535a52d1b08a5217df2e912ee1b0f4140892afa31d479f78dfbc";
         let expected_delta_bytes = x"a2ab58a209ad00df6c86ab14841e8daa7a380a6853f28bacf38aad9903b6149fff4b119dea16de8aa3e5050b9d563a01009e061a950c233f66511c8fae2a8c58503059821df7f6defbba8f93d26e412cc07b66a9f3cdd740cce5c8488ce94fc8";
 
-        let delta_bytes = vector::pop_back(&mut arr);
+        let delta_bytes = arr.pop_back();
         assert!(delta_bytes == expected_delta_bytes, 0);
 
-        let gamma_bytes = vector::pop_back(&mut arr);
+        let gamma_bytes = arr.pop_back();
         assert!(gamma_bytes == expected_gamma_bytes, 0);
 
-        let alpha_bytes = vector::pop_back(&mut arr);
+        let alpha_bytes = arr.pop_back();
         assert!(alpha_bytes == expected_alpha_bytes, 0);
 
-        let vk_bytes = vector::pop_back(&mut arr);
+        let vk_bytes = arr.pop_back();
         assert!(vk_bytes == expected_vk_bytes, 0);
    }
 
@@ -57,7 +56,7 @@ module sui::groth16_tests {
         assert!(groth16::verify_groth16_proof(&curve, &pvk, &inputs, &proof) == true, 0);
 
         // Invalid prepared verifying key.
-        vector::pop_back(&mut vk_bytes);
+        vk_bytes.pop_back();
         let invalid_pvk = groth16::pvk_from_bytes(vk_bytes, alpha_bytes, gamma_bytes, delta_bytes);
         assert!(groth16::verify_groth16_proof(&curve, &invalid_pvk, &inputs, &proof) == false, 0);
 
@@ -100,16 +99,16 @@ module sui::groth16_tests {
         let expected_gamma_bytes = x"6030ca5b462a3502d560df7ff62b7f1215195233f688320de19e4b3a2a2cb6120ae49bcc0abbd3cbbf06b29b489edbf86e3b679f4e247464992145f468e3c00d";
         let expected_delta_bytes = x"b41e5e09002a7170cb4cc56ae96b152d17b6b0d1b9333b41f2325c3c8a9d2e2df98f8e2315884fae52b3c6bb329df0359daac4eff4d2e7ce729078b10d79d4af";
 
-        let delta_bytes = vector::pop_back(&mut arr);
+        let delta_bytes = arr.pop_back();
         assert!(delta_bytes == expected_delta_bytes, 0);
 
-        let gamma_bytes = vector::pop_back(&mut arr);
+        let gamma_bytes = arr.pop_back();
         assert!(gamma_bytes == expected_gamma_bytes, 0);
 
-        let alpha_bytes = vector::pop_back(&mut arr);
+        let alpha_bytes = arr.pop_back();
         assert!(alpha_bytes == expected_alpha_bytes, 0);
 
-        let vk_bytes = vector::pop_back(&mut arr);
+        let vk_bytes = arr.pop_back();
         assert!(vk_bytes == expected_vk_bytes, 0);
     }
 
@@ -140,7 +139,7 @@ module sui::groth16_tests {
         assert!(groth16::verify_groth16_proof(&curve, &pvk, &inputs, &proof) == true, 0);
 
         // Invalid prepared verifying key.
-        vector::pop_back(&mut vk_bytes);
+        vk_bytes.pop_back();
         let invalid_pvk = groth16::pvk_from_bytes(vk_bytes, alpha_bytes, gamma_bytes, delta_bytes);
         assert!(groth16::verify_groth16_proof(&curve, &invalid_pvk, &inputs, &proof) == false, 0);
 

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_id_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_id_tests.move
@@ -4,17 +4,16 @@
 #[test_only]
 module sui::zklogin_verified_id_tests {
     use sui::zklogin_verified_id::{check_zklogin_id, verify_zklogin_id};
-    use std::string::utf8;
     use sui::test_scenario;
 
     #[test]
     #[expected_failure(abort_code = sui::zklogin_verified_id::EFunctionDisabled)]
     fun test_check_zklogin_id() {
         let address = @0x1c6b623a2f2c91333df730c98d220f11484953b391a3818680f922c264cc0c6b;
-        let kc_name = utf8(b"sub");
-        let kc_value = utf8(b"106294049240999307923");
-        let aud = utf8(b"575519204237-msop9ep45u2uo98hapqmngv8d84qdc8k.apps.googleusercontent.com");
-        let iss = utf8(b"https://accounts.google.com");
+        let kc_name = b"sub".to_string();
+        let kc_value = b"106294049240999307923".to_string();
+        let aud = b"575519204237-msop9ep45u2uo98hapqmngv8d84qdc8k.apps.googleusercontent.com".to_string();
+        let iss = b"https://accounts.google.com".to_string();
         let salt_hash = 15232766888716517538274372547598053531354666056102343895255590477425668733026u256;
         check_zklogin_id(address, &kc_name, &kc_value, &iss, &aud, salt_hash);
     }
@@ -24,10 +23,10 @@ module sui::zklogin_verified_id_tests {
     fun test_verified_id() {
         let address = @0x1c6b623a2f2c91333df730c98d220f11484953b391a3818680f922c264cc0c6b;
 
-        let kc_name = utf8(b"sub");
-        let kc_value = utf8(b"106294049240999307923");
-        let aud = utf8(b"575519204237-msop9ep45u2uo98hapqmngv8d84qdc8k.apps.googleusercontent.com");
-        let iss = utf8(b"https://accounts.google.com");
+        let kc_name = b"sub".to_string();
+        let kc_value = b"106294049240999307923".to_string();
+        let aud = b"575519204237-msop9ep45u2uo98hapqmngv8d84qdc8k.apps.googleusercontent.com".to_string();
+        let iss = b"https://accounts.google.com".to_string();
         let salt_hash = 15232766888716517538274372547598053531354666056102343895255590477425668733026u256;
 
         let mut scenario = test_scenario::begin(address);

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_id_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_id_tests.move
@@ -30,11 +30,10 @@ module sui::zklogin_verified_id_tests {
         let iss = utf8(b"https://accounts.google.com");
         let salt_hash = 15232766888716517538274372547598053531354666056102343895255590477425668733026u256;
 
-        let mut scenario_val = test_scenario::begin(address);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(address);
         {
-            verify_zklogin_id(kc_name, kc_value, iss, aud, salt_hash, test_scenario::ctx(scenario));
+            verify_zklogin_id(kc_name, kc_value, iss, aud, salt_hash, scenario.ctx());
         };
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_issuer_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_issuer_tests.move
@@ -32,18 +32,17 @@ module sui::zklogin_verified_issuer_tests {
 
         assert!(check_zklogin_issuer(address,  address_seed, &iss), 0);
 
-        let mut scenario_val = test_scenario::begin(address);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(address);
         {
-            verify_zklogin_issuer(address_seed, iss, test_scenario::ctx(scenario));
+            verify_zklogin_issuer(address_seed, iss, scenario.ctx());
         };
-        test_scenario::next_tx(scenario, address);
+        scenario.next_tx(address);
         {
-            assert!(test_scenario::has_most_recent_for_sender<VerifiedIssuer>(scenario), 0);
-            delete(test_scenario::take_from_sender<VerifiedIssuer>(scenario));
-            assert!(!test_scenario::has_most_recent_for_sender<VerifiedIssuer>(scenario), 1);
+            assert!(scenario.has_most_recent_for_sender<VerifiedIssuer>(), 0);
+            delete(scenario.take_from_sender<VerifiedIssuer>());
+            assert!(!scenario.has_most_recent_for_sender<VerifiedIssuer>(), 1);
         };
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
@@ -52,11 +51,10 @@ module sui::zklogin_verified_issuer_tests {
         let other_address = @0x1;
         let iss = utf8(b"https://accounts.google.com");
         let address_seed = 3006596378422062745101035755700472756930796952630484939867684134047976874601u256;
-        let mut scenario_val = test_scenario::begin(other_address);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(other_address);
         {
-            verify_zklogin_issuer(address_seed, iss, test_scenario::ctx(scenario));
+            verify_zklogin_issuer(address_seed, iss, scenario.ctx());
         };
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_issuer_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/zklogin_verified_issuer_tests.move
@@ -4,13 +4,12 @@
 #[test_only]
 module sui::zklogin_verified_issuer_tests {
     use sui::zklogin_verified_issuer::{check_zklogin_issuer, delete, verify_zklogin_issuer, VerifiedIssuer};
-    use std::string::utf8;
     use sui::test_scenario;
 
     #[test]
     fun test_check_zklogin_issuer() {
         let address = @0x1c6b623a2f2c91333df730c98d220f11484953b391a3818680f922c264cc0c6b;
-        let iss = utf8(b"https://accounts.google.com");
+        let iss = b"https://accounts.google.com".to_string();
         let address_seed = 3006596378422062745101035755700472756930796952630484939867684134047976874601u256;
         assert!(check_zklogin_issuer(address,  address_seed, &iss,), 0);
 
@@ -20,14 +19,14 @@ module sui::zklogin_verified_issuer_tests {
         let other_address_seed = 1234u256;
         assert!(!check_zklogin_issuer(address, other_address_seed, &iss), 2);
 
-        let other_iss = utf8(b"https://other.issuer.com");
+        let other_iss = b"https://other.issuer.com".to_string();
         assert!(!check_zklogin_issuer(address, address_seed, &other_iss), 3);
     }
 
     #[test]
     fun test_verified_issuer() {
         let address = @0x1c6b623a2f2c91333df730c98d220f11484953b391a3818680f922c264cc0c6b;
-        let iss = utf8(b"https://accounts.google.com");
+        let iss = b"https://accounts.google.com".to_string();
         let address_seed = 3006596378422062745101035755700472756930796952630484939867684134047976874601u256;
 
         assert!(check_zklogin_issuer(address,  address_seed, &iss), 0);
@@ -49,7 +48,7 @@ module sui::zklogin_verified_issuer_tests {
     #[expected_failure(abort_code = sui::zklogin_verified_issuer::EInvalidProof)]
     fun test_invalid_verified_issuer() {
         let other_address = @0x1;
-        let iss = utf8(b"https://accounts.google.com");
+        let iss = b"https://accounts.google.com".to_string();
         let address_seed = 3006596378422062745101035755700472756930796952630484939867684134047976874601u256;
         let mut scenario = test_scenario::begin(other_address);
         {

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::dynamic_field_tests {
     use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
-    use sui::object;
     use sui::test_scenario as ts;
 
     #[test]
@@ -41,7 +40,7 @@ module sui::dynamic_field_tests {
         assert!(!exists_with_type<vector<u8>, u64>(&id, b""), 0);
         assert!(!exists_with_type<bool, u64>(&id, false), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     #[test]
@@ -139,7 +138,7 @@ module sui::dynamic_field_tests {
         assert!(exists_with_type<u64, u64>(&id, 0), 0);
         assert!(!exists_with_type<u64, u8>(&id, 0), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     // should be able to do delete a UID even though it has a dynamic field
@@ -151,6 +150,6 @@ module sui::dynamic_field_tests {
         add(&mut id, 0, 0);
         assert!(exists_with_type<u64, u64>(&id, 0), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
@@ -4,13 +4,13 @@
 #[test_only]
 module sui::dynamic_field_tests {
     use sui::dynamic_field::{add, exists_with_type, borrow, borrow_mut, remove};
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
 
     #[test]
     fun simple_all_functions() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         // add fields
         add<u64, u64>(&mut id, 0, 0);
         add<vector<u8>, u64>(&mut id, b"", 1);
@@ -39,7 +39,7 @@ module sui::dynamic_field_tests {
         assert!(!exists_with_type<u64, u64>(&id, 0), 0);
         assert!(!exists_with_type<vector<u8>, u64>(&id, b""), 0);
         assert!(!exists_with_type<bool, u64>(&id, false), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
@@ -47,8 +47,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add<u64, u64>(&mut id, 0, 0);
         add<u64, u64>(&mut id, 0, 1);
         abort 42
@@ -58,8 +58,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate_mismatched_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add<u64, u64>(&mut id, 0, 0u64);
         add<u64, u8>(&mut id, 0, 1u8);
         abort 42
@@ -69,8 +69,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let id = scenario.new_object();
         borrow<u64, u64>(&id, 0);
         abort 42
     }
@@ -79,8 +79,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, 0);
         borrow<u64, u8>(&id, 0);
         abort 42
@@ -90,8 +90,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_mut_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         borrow_mut<u64, u64>(&mut id, 0);
         abort 42
     }
@@ -100,8 +100,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_mut_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, 0);
         borrow_mut<u64, u8>(&mut id, 0);
         abort 42
@@ -111,8 +111,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun remove_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         remove<u64, u64>(&mut id, 0);
         abort 42
     }
@@ -121,8 +121,8 @@ module sui::dynamic_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun remove_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, 0);
         remove<u64, u8>(&mut id, 0);
         abort 42
@@ -131,13 +131,13 @@ module sui::dynamic_field_tests {
     #[test]
     fun sanity_check_exists() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         assert!(!exists_with_type<u64, u64>(&id, 0), 0);
         add(&mut id, 0, 0);
         assert!(exists_with_type<u64, u64>(&id, 0), 0);
         assert!(!exists_with_type<u64, u8>(&id, 0), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
@@ -145,11 +145,11 @@ module sui::dynamic_field_tests {
     #[test]
     fun delete_uid_with_fields() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, 0);
         assert!(exists_with_type<u64, u64>(&id, 0), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::dynamic_object_field_tests {
-    use std::option;
     use sui::dynamic_object_field::{
         add,
         borrow,
@@ -13,7 +12,6 @@ module sui::dynamic_object_field_tests {
         remove,
         id as field_id,
     };
-    use sui::object::{Self, UID};
     use sui::test_scenario;
 
     public struct Counter has key, store {
@@ -45,9 +43,9 @@ module sui::dynamic_object_field_tests {
         assert!(exists_(&id, b""), 0);
         assert!(exists_(&id, false), 0);
         // check the IDs
-        assert!(option::borrow(&field_id(&id, 0)) == &id1, 0);
-        assert!(option::borrow(&field_id(&id, b"")) == &id2, 0);
-        assert!(option::borrow(&field_id(&id, false)) == &id3, 0);
+        assert!(field_id(&id, 0).borrow() == &id1, 0);
+        assert!(field_id(&id, b"").borrow() == &id2, 0);
+        assert!(field_id(&id, false).borrow() == &id3, 0);
         // check the values
         assert!(count(borrow(&id, 0)) == 0, 0);
         assert!(count(borrow(&id, b"")) == 0, 0);
@@ -216,8 +214,8 @@ module sui::dynamic_object_field_tests {
         bump(borrow_mut(&mut id2, 0));
         assert!(count(borrow(&id2, 0)) == 2, 0);
         scenario.end();
-        object::delete(id1);
-        object::delete(id2);
+        id1.delete();
+        id2.delete();
     }
 
     fun new(scenario: &mut test_scenario::Scenario): Counter {

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
@@ -69,7 +69,7 @@ module sui::dynamic_object_field_tests {
         assert!(!exists_(&id, b""), 0);
         assert!(!exists_(&id, false), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     #[test]
@@ -154,7 +154,7 @@ module sui::dynamic_object_field_tests {
         let mut id = ts::new_object(&mut scenario);
         add(&mut id, 0, new(&mut scenario));
         let Fake { id } = remove<u64, Fake>(&mut id, 0);
-        object::delete(id);
+        id.delete();
         abort 42
     }
 
@@ -168,7 +168,7 @@ module sui::dynamic_object_field_tests {
         assert!(exists_<u64>(&id, 0), 0);
         assert!(!exists_<u8>(&id, 0), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     #[test]
@@ -183,7 +183,7 @@ module sui::dynamic_object_field_tests {
         assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     // should be able to do delete a UID even though it has a dynamic field
@@ -195,7 +195,7 @@ module sui::dynamic_object_field_tests {
         add(&mut id, 0, new(&mut scenario));
         assert!(exists_<u64>(&id, 0), 0);
         ts::end(scenario);
-        object::delete(id);
+        id.delete();
     }
 
     // transfer an object field from one "parent" to another
@@ -235,7 +235,7 @@ module sui::dynamic_object_field_tests {
 
     fun destroy(counter: Counter): u64 {
         let Counter { id, count } = counter;
-        object::delete(id);
+        id.delete();
         count
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
@@ -14,7 +14,7 @@ module sui::dynamic_object_field_tests {
         id as field_id,
     };
     use sui::object::{Self, UID};
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
 
     public struct Counter has key, store {
         id: UID,
@@ -28,8 +28,8 @@ module sui::dynamic_object_field_tests {
     #[test]
     fun simple_all_functions() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         let counter1 = new(&mut scenario);
         let id1 = object::id(&counter1);
         let counter2 = new(&mut scenario);
@@ -68,7 +68,7 @@ module sui::dynamic_object_field_tests {
         assert!(!exists_(&id, 0), 0);
         assert!(!exists_(&id, b""), 0);
         assert!(!exists_(&id, false), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
@@ -76,8 +76,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add<u64, Counter>(&mut id, 0, new(&mut scenario));
         add<u64, Counter>(&mut id, 0, new(&mut scenario));
         abort 42
@@ -87,10 +87,10 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate_mismatched_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add<u64, Counter>(&mut id, 0, new(&mut scenario));
-        add<u64, Fake>(&mut id, 0, Fake { id: ts::new_object(&mut scenario) });
+        add<u64, Fake>(&mut id, 0, Fake { id: scenario.new_object() });
         abort 42
     }
 
@@ -98,8 +98,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let id = scenario.new_object();
         borrow<u64, Counter>(&id, 0);
         abort 42
     }
@@ -108,8 +108,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, new(&mut scenario));
         borrow<u64, Fake>(&id, 0);
         abort 42
@@ -119,8 +119,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_mut_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         borrow_mut<u64, Counter>(&mut id, 0);
         abort 42
     }
@@ -129,8 +129,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun borrow_mut_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, new(&mut scenario));
         borrow_mut<u64, Fake>(&mut id, 0);
         abort 42
@@ -140,8 +140,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun remove_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         destroy(remove<u64, Counter>(&mut id, 0));
         abort 42
     }
@@ -150,8 +150,8 @@ module sui::dynamic_object_field_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
     fun remove_wrong_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, new(&mut scenario));
         let Fake { id } = remove<u64, Fake>(&mut id, 0);
         id.delete();
@@ -161,28 +161,28 @@ module sui::dynamic_object_field_tests {
     #[test]
     fun sanity_check_exists() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         assert!(!exists_<u64>(&id, 0), 0);
         add(&mut id, 0, new(&mut scenario));
         assert!(exists_<u64>(&id, 0), 0);
         assert!(!exists_<u8>(&id, 0), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
     #[test]
     fun sanity_check_exists_with_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         assert!(!exists_with_type<u64, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u64, Fake>(&id, 0), 0);
         add(&mut id, 0, new(&mut scenario));
         assert!(exists_with_type<u64, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u8, Counter>(&id, 0), 0);
         assert!(!exists_with_type<u8, Fake>(&id, 0), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
@@ -190,11 +190,11 @@ module sui::dynamic_object_field_tests {
     #[test]
     fun delete_uid_with_fields() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id = scenario.new_object();
         add(&mut id, 0, new(&mut scenario));
         assert!(exists_<u64>(&id, 0), 0);
-        ts::end(scenario);
+        scenario.end();
         id.delete();
     }
 
@@ -202,9 +202,9 @@ module sui::dynamic_object_field_tests {
     #[test]
     fun transfer_object() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut id1 = ts::new_object(&mut scenario);
-        let mut id2 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut id1 = scenario.new_object();
+        let mut id2 = scenario.new_object();
         add(&mut id1, 0, new(&mut scenario));
         assert!(exists_<u64>(&id1, 0), 0);
         assert!(!exists_<u64>(&id2, 0), 0);
@@ -215,13 +215,13 @@ module sui::dynamic_object_field_tests {
         assert!(exists_<u64>(&id2, 0), 0);
         bump(borrow_mut(&mut id2, 0));
         assert!(count(borrow(&id2, 0)) == 2, 0);
-        ts::end(scenario);
+        scenario.end();
         object::delete(id1);
         object::delete(id2);
     }
 
-    fun new(scenario: &mut ts::Scenario): Counter {
-        Counter { id: ts::new_object(scenario), count: 0 }
+    fun new(scenario: &mut test_scenario::Scenario): Counter {
+        Counter { id: scenario.new_object(), count: 0 }
     }
 
     fun count(counter: &Counter): u64 {

--- a/crates/sui-framework/packages/sui-framework/tests/id_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/id_tests.move
@@ -3,9 +3,6 @@
 
 #[test_only]
 module sui::id_tests {
-    use sui::object;
-    use sui::tx_context;
-
     const EIdBytesMismatch: u64 = 0;
 
     public struct Object has key {

--- a/crates/sui-framework/packages/sui-framework/tests/id_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/id_tests.move
@@ -16,10 +16,10 @@ module sui::id_tests {
     fun test_get_id() {
         let mut ctx = tx_context::dummy();
         let id = object::new(&mut ctx);
-        let obj_id = object::uid_to_inner(&id);
+        let obj_id = id.to_inner();
         let obj = Object { id };
         assert!(object::id(&obj) == obj_id, EIdBytesMismatch);
         let Object { id } = obj;
-        object::delete(id);
+        id.delete();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_borrow_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_borrow_tests.move
@@ -5,7 +5,6 @@
 /// Tests for borrowing mechanics.
 module sui::kiosk_borrow_tests {
     use sui::kiosk_test_utils::{Self as utils, Asset};
-    use sui::kiosk;
 
     const AMT: u64 = 1000;
 
@@ -17,13 +16,13 @@ module sui::kiosk_borrow_tests {
         let (item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &cap, item);
-        let _item_ref = kiosk::borrow<Asset>(&kiosk, &cap, id);
+        kiosk.place(&cap, item);
+        let _item_ref = kiosk.borrow<Asset>(&cap, id);
 
-        kiosk::list<Asset>(&mut kiosk, &cap, id, AMT);
-        let _item_ref = kiosk::borrow<Asset>(&kiosk, &cap, id);
+        kiosk.list<Asset>(&cap, id, AMT);
+        let _item_ref = kiosk.borrow<Asset>(&cap, id);
 
-        let item = kiosk::take<Asset>(&mut kiosk, &cap, id);
+        let item = kiosk.take<Asset>(&cap, id);
         utils::return_assets(vector[ item ]);
         utils::return_kiosk(kiosk, cap, ctx);
     }
@@ -36,7 +35,7 @@ module sui::kiosk_borrow_tests {
         let (kiosk, _cap) = utils::get_kiosk(ctx);
         let (_kiosk, cap) = utils::get_kiosk(ctx);
 
-        let _item_ref = kiosk::borrow<Asset>(&kiosk, &cap, id);
+        let _item_ref = kiosk.borrow<Asset>(&cap, id);
 
         abort 1337
     }
@@ -48,7 +47,7 @@ module sui::kiosk_borrow_tests {
         let (_item, id) = utils::get_asset(ctx);
         let (kiosk, cap) = utils::get_kiosk(ctx);
 
-        let _item_ref = kiosk::borrow<Asset>(&kiosk, &cap, id);
+        let _item_ref: &Asset = &kiosk[&cap, id];
 
         abort 1337
     }
@@ -61,10 +60,10 @@ module sui::kiosk_borrow_tests {
         let (item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &cap, item);
-        let _item_mut = kiosk::borrow_mut<Asset>(&mut kiosk, &cap, id);
+        kiosk.place(&cap, item);
+        let _item_mut: &mut Asset = &mut kiosk[&cap, id];
 
-        let item = kiosk::take<Asset>(&mut kiosk, &cap, id);
+        let item = kiosk.take<Asset>(&cap, id);
         utils::return_assets(vector[ item ]);
         utils::return_kiosk(kiosk, cap, ctx);
     }
@@ -76,7 +75,7 @@ module sui::kiosk_borrow_tests {
         let (_item, id) = utils::get_asset(ctx);
         let (mut kiosk, _cap) = utils::get_kiosk(ctx);
         let (_kiosk, cap) = utils::get_kiosk(ctx);
-        let _item_mut = kiosk::borrow_mut<Asset>(&mut kiosk, &cap, id);
+        let _item_mut: &mut Asset = &mut kiosk[&cap, id];
 
         abort 1337
     }
@@ -87,7 +86,7 @@ module sui::kiosk_borrow_tests {
         let ctx = &mut utils::ctx();
         let (_item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
-        let _item_mut = kiosk::borrow_mut<Asset>(&mut kiosk, &cap, id);
+        let _item_mut: &mut Asset = &mut kiosk[&cap, id];
 
         abort 1337
     }
@@ -99,8 +98,8 @@ module sui::kiosk_borrow_tests {
         let (item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &cap, item, AMT);
-        let _item_mut = kiosk::borrow_mut<Asset>(&mut kiosk, &cap, id);
+        kiosk.place_and_list(&cap, item, AMT);
+        let _item_mut: &mut Asset = &mut kiosk[&cap, id];
 
         abort 1337
     }
@@ -113,13 +112,13 @@ module sui::kiosk_borrow_tests {
         let (item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &cap, item);
-        let (item, potato) = kiosk::borrow_val<Asset>(&mut kiosk, &cap, id);
+        kiosk.place(&cap, item);
+        let (item, potato) = kiosk.borrow_val<Asset>(&cap, id);
         assert!(sui::object::id(&item) == id, 0);
-        kiosk::return_val(&mut kiosk, item, potato);
-        assert!(kiosk::has_item(&kiosk, id), 0);
+        kiosk.return_val(item, potato);
+        assert!(kiosk.has_item(id), 0);
 
-        let item = kiosk::take<Asset>(&mut kiosk, &cap, id);
+        let item = kiosk.take<Asset>(&cap, id);
         utils::return_assets(vector[ item ]);
         utils::return_kiosk(kiosk, cap, ctx);
     }
@@ -131,7 +130,7 @@ module sui::kiosk_borrow_tests {
         let (_item, id) = utils::get_asset(ctx);
         let (mut kiosk, _cap) = utils::get_kiosk(ctx);
         let (_kiosk, cap) = utils::get_kiosk(ctx);
-        let (_item, _borrow) = kiosk::borrow_val<Asset>(&mut kiosk, &cap, id);
+        let (_item, _borrow) = kiosk.borrow_val<Asset>(&cap, id);
 
         abort 1337
     }
@@ -142,7 +141,7 @@ module sui::kiosk_borrow_tests {
         let ctx = &mut utils::ctx();
         let (_item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
-        let (_item, _borrow) = kiosk::borrow_val<Asset>(&mut kiosk, &cap, id);
+        let (_item, _borrow) = kiosk.borrow_val<Asset>(&cap, id);
 
         abort 1337
     }
@@ -154,8 +153,8 @@ module sui::kiosk_borrow_tests {
         let (item, id) = utils::get_asset(ctx);
         let (mut kiosk, cap) = utils::get_kiosk(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &cap, item, AMT);
-        let (_item, _borrow) = kiosk::borrow_val<Asset>(&mut kiosk, &cap, id);
+        kiosk.place_and_list(&cap, item, AMT);
+        let (_item, _borrow) = kiosk.borrow_val<Asset>(&cap, id);
 
         abort 1337
     }
@@ -166,16 +165,16 @@ module sui::kiosk_borrow_tests {
         let ctx = &mut utils::ctx();
         let (item_1, id_1) = utils::get_asset(ctx);
         let (mut kiosk_1, cap_1) = utils::get_kiosk(ctx);
-        kiosk::place(&mut kiosk_1, &cap_1, item_1);
+        kiosk_1.place(&cap_1, item_1);
 
         let (item_2, id_2) = utils::get_asset(ctx);
         let (mut kiosk_2, cap_2) = utils::get_kiosk(ctx);
-        kiosk::place(&mut kiosk_2, &cap_2, item_2);
+        kiosk_2.place(&cap_2, item_2);
 
-        let (item, _borrow) = kiosk::borrow_val<Asset>(&mut kiosk_1, &cap_1, id_1);
-        let (_item, borrow) = kiosk::borrow_val<Asset>(&mut kiosk_2, &cap_2, id_2);
+        let (item, _borrow) = kiosk_1.borrow_val<Asset>(&cap_1, id_1);
+        let (_item, borrow) = kiosk_2.borrow_val<Asset>(&cap_2, id_2);
 
-        kiosk::return_val(&mut kiosk_1, item, borrow);
+        kiosk_1.return_val(item, borrow);
 
         abort 1337
     }
@@ -186,16 +185,16 @@ module sui::kiosk_borrow_tests {
         let ctx = &mut utils::ctx();
         let (item_1, id_1) = utils::get_asset(ctx);
         let (mut kiosk_1, cap_1) = utils::get_kiosk(ctx);
-        kiosk::place(&mut kiosk_1, &cap_1, item_1);
+        kiosk_1.place(&cap_1, item_1);
 
         let (item_2, id_2) = utils::get_asset(ctx);
         let (mut kiosk_2, cap_2) = utils::get_kiosk(ctx);
-        kiosk::place(&mut kiosk_2, &cap_2, item_2);
+        kiosk_2.place(&cap_2, item_2);
 
-        let (item, _borrow) = kiosk::borrow_val<Asset>(&mut kiosk_1, &cap_1, id_1);
-        let (_item, borrow) = kiosk::borrow_val<Asset>(&mut kiosk_2, &cap_2, id_2);
+        let (item, _borrow) = kiosk_1.borrow_val<Asset>(&cap_1, id_1);
+        let (_item, borrow) = kiosk_2.borrow_val<Asset>(&cap_2, id_2);
 
-        kiosk::return_val(&mut kiosk_2, item, borrow);
+        kiosk_2.return_val(item, borrow);
 
         abort 1337
     }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extension_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extension_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::kiosk_marketplace_ext {
-    use sui::bag;
     use sui::sui::SUI;
     use sui::coin::Coin;
     use sui::kiosk_extension as ext;
@@ -43,11 +42,7 @@ module sui::kiosk_marketplace_ext {
         assert!(kiosk.has_access(cap), ENotOwner);
         assert!(ext::is_installed<Ext<Market>>(kiosk), ENotInstalled);
 
-        bag::add(
-            ext::storage_mut(Ext<Market> {}, kiosk),
-            Bid<T> {},
-            bid
-        );
+        ext::storage_mut(Ext<Market> {}, kiosk).add(Bid<T> {}, bid);
     }
 
     /// Collection bidding: offer the `T` and receive the bid.
@@ -58,10 +53,7 @@ module sui::kiosk_marketplace_ext {
         policy: &TransferPolicy<T>,
         lock: bool
     ): (TransferRequest<T>, TransferRequest<Market>) {
-        let bid: Coin<SUI> = bag::remove(
-            ext::storage_mut(Ext<Market> {}, destination),
-            Bid<T> {}
-        );
+        let bid: Coin<SUI> = ext::storage_mut(Ext<Market> {}, destination).remove(Bid<T> {});
 
         // form the request while we have all the data (not yet consumed)
         let market_request = policy::new_request(

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extension_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extension_tests.move
@@ -5,9 +5,7 @@
 module sui::kiosk_marketplace_ext {
     use sui::bag;
     use sui::sui::SUI;
-    use sui::coin::{Self, Coin};
-    use sui::object::{Self, ID};
-    use sui::tx_context::TxContext;
+    use sui::coin::Coin;
     use sui::kiosk_extension as ext;
     use sui::kiosk::{Self, KioskOwnerCap, Kiosk, PurchaseCap};
     use sui::transfer_policy::{Self as policy, TransferPolicy, TransferRequest};
@@ -42,7 +40,7 @@ module sui::kiosk_marketplace_ext {
     public fun bid<Market, T: key + store>(
         kiosk: &mut Kiosk, cap: &KioskOwnerCap, bid: Coin<SUI>
     ) {
-        assert!(kiosk::has_access(kiosk, cap), ENotOwner);
+        assert!(kiosk.has_access(cap), ENotOwner);
         assert!(ext::is_installed<Ext<Market>>(kiosk), ENotInstalled);
 
         bag::add(
@@ -67,11 +65,11 @@ module sui::kiosk_marketplace_ext {
 
         // form the request while we have all the data (not yet consumed)
         let market_request = policy::new_request(
-            kiosk::purchase_cap_item(&purchase_cap), coin::value(&bid), object::id(source)
+            kiosk::purchase_cap_item(&purchase_cap), bid.value(), object::id(source)
         );
 
         assert!(kiosk::purchase_cap_kiosk(&purchase_cap) == object::id(source), EIncorrectKiosk);
-        assert!(kiosk::purchase_cap_min_price(&purchase_cap) <= coin::value(&bid), EIncorrectAmount);
+        assert!(kiosk::purchase_cap_min_price(&purchase_cap) <= bid.value(), EIncorrectAmount);
 
         let (item, request) = kiosk::purchase_with_cap(source, purchase_cap, bid);
 
@@ -92,15 +90,9 @@ module sui::kiosk_marketplace_ext {
     public fun list<Market, T: key + store>(
         kiosk: &mut Kiosk, cap: &KioskOwnerCap, item_id: ID, price: u64, ctx: &mut TxContext
     ) {
-        let purchase_cap = kiosk::list_with_purchase_cap<T>(
-            kiosk, cap, item_id, price, ctx
-        );
+        let purchase_cap = kiosk.list_with_purchase_cap<T>(cap, item_id, price, ctx);
 
-        bag::add(
-            ext::storage_mut(Ext<Market> {}, kiosk),
-            item_id,
-            purchase_cap
-        );
+        ext::storage_mut(Ext<Market> {}, kiosk).add(item_id, purchase_cap);
     }
 
     /// Purchase an item from the Kiosk while following the Marketplace policy.
@@ -109,14 +101,11 @@ module sui::kiosk_marketplace_ext {
         item_id: ID,
         payment: Coin<SUI>,
     ): (T, TransferRequest<T>, TransferRequest<Market>) {
-        let purchase_cap: PurchaseCap<T> = bag::remove(
-            ext::storage_mut(Ext<Market> {}, kiosk),
-            item_id
-        );
+        let purchase_cap: PurchaseCap<T> = ext::storage_mut(Ext<Market> {}, kiosk).remove(item_id);
 
-        assert!(coin::value(&payment) == kiosk::purchase_cap_min_price(&purchase_cap), EIncorrectAmount);
-        let market_request = policy::new_request(item_id, coin::value(&payment), object::id(kiosk));
-        let (item, request) = kiosk::purchase_with_cap(kiosk, purchase_cap, payment);
+        assert!(payment.value() == kiosk::purchase_cap_min_price(&purchase_cap), EIncorrectAmount);
+        let market_request = policy::new_request(item_id, payment.value(), object::id(kiosk));
+        let (item, request) = kiosk.purchase_with_cap(purchase_cap, payment);
 
         (
             item,
@@ -133,13 +122,9 @@ module sui::kiosk_marketplace_ext {
         cap: &KioskOwnerCap,
         item_id: ID,
     ) {
-        assert!(kiosk::has_access(kiosk, cap), ENotOwner);
-        let purchase_cap: PurchaseCap<T> = bag::remove(
-            ext::storage_mut(Ext<Market> {}, kiosk),
-            item_id
-        );
-
-        kiosk::return_purchase_cap(kiosk, purchase_cap);
+        assert!(kiosk.has_access(cap), ENotOwner);
+        let purchase_cap: PurchaseCap<T> = ext::storage_mut(Ext<Market> {}, kiosk).remove(item_id);
+        kiosk.return_purchase_cap(purchase_cap);
     }
 }
 
@@ -148,7 +133,6 @@ module sui::kiosk_marketplace_ext {
 module sui::kiosk_extensions_tests {
     use sui::kiosk_test_utils::{Self as test};
     use sui::kiosk_extension as ext;
-    use sui::kiosk;
 
     /// The `Ext` witness to use for testing.
     public struct Extension has drop {}
@@ -239,7 +223,7 @@ module sui::kiosk_extensions_tests {
         ext::add(Extension {}, &mut kiosk, &owner_cap, 2, ctx);
         ext::place(Extension {}, &mut kiosk, asset, &policy);
 
-        let asset = kiosk::take(&mut kiosk, &owner_cap, asset_id);
+        let asset = kiosk.take(&owner_cap, asset_id);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
         test::return_policy(policy, policy_cap, ctx);

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_locked_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_locked_tests.move
@@ -4,11 +4,8 @@
 #[test_only]
 /// Test illustrating how an asset can be forever locked in the Kiosk.
 module sui::kiosk_locked_test {
-    use sui::kiosk;
     use sui::item_locked_policy as locked_policy;
     use sui::kiosk_test_utils::{Self as test, Asset};
-    use sui::transfer_policy as policy;
-    use sui::transfer;
 
     #[test]
     fun test_item_always_locked() {
@@ -24,19 +21,19 @@ module sui::kiosk_locked_test {
         // - require "PlacedWitness" on purchase
         // - place an asset into the Kiosk so it can only be sold
         locked_policy::set(&mut policy, &policy_cap);
-        kiosk::lock(&mut kiosk, &kiosk_cap, &policy, item);
-        kiosk::list<Asset>(&mut kiosk, &kiosk_cap, item_id, 1000);
+        kiosk.lock(&kiosk_cap, &policy, item);
+        kiosk.list<Asset>(&kiosk_cap, item_id, 1000);
 
         // Bob the Buyer
         // - places the item into his Kiosk and gets the proof
         // - prove placing and confirm request
         let (mut bob_kiosk, bob_kiosk_cap) = test::get_kiosk(ctx);
-        let (item, mut request) = kiosk::purchase<Asset>(&mut kiosk, item_id, payment);
-        kiosk::lock(&mut bob_kiosk, &bob_kiosk_cap, &policy, item);
+        let (item, mut request) = kiosk.purchase<Asset>(item_id, payment);
+        bob_kiosk.lock(&bob_kiosk_cap, &policy, item);
 
         // The difference!
         locked_policy::prove(&mut request, &bob_kiosk);
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         // Carl the Cleaner;
         // - cleans up and transfer Kiosk to himself

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_test_utils.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_test_utils.move
@@ -72,7 +72,7 @@ module sui::kiosk_test_utils {
     public fun return_assets(mut assets: vector<Asset>) {
         while (vector::length(&assets) > 0) {
             let Asset { id } = vector::pop_back(&mut assets);
-            object::delete(id)
+            id.delete()
         };
 
         vector::destroy_empty(assets)

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_test_utils.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_test_utils.move
@@ -3,12 +3,9 @@
 
 #[test_only]
 module sui::kiosk_test_utils {
-    use std::vector;
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
-    use sui::object::{Self, ID, UID};
     use sui::package::{Self, Publisher};
-    use sui::tx_context::{Self, TxContext};
     use sui::transfer_policy::{Self as policy, TransferPolicy, TransferPolicyCap};
     use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
 
@@ -43,7 +40,7 @@ module sui::kiosk_test_utils {
     /// Prepare: Asset
     public fun get_asset(ctx: &mut TxContext): (Asset, ID) {
         let uid = object::new(ctx);
-        let id = object::uid_to_inner(&uid);
+        let id = uid.to_inner();
         (Asset { id: uid }, id)
     }
 
@@ -53,28 +50,28 @@ module sui::kiosk_test_utils {
     }
 
     public fun return_publisher(publisher: Publisher) {
-        package::burn_publisher(publisher)
+        publisher.burn_publisher()
     }
 
     /// Cleanup: TransferPolicy
     public fun return_policy(policy: TransferPolicy<Asset>, cap: TransferPolicyCap<Asset>, ctx: &mut TxContext): u64 {
-        let profits = policy::destroy_and_withdraw(policy, cap, ctx);
-        coin::burn_for_testing(profits)
+        let profits = policy.destroy_and_withdraw(cap, ctx);
+        profits.burn_for_testing()
     }
 
     /// Cleanup: Kiosk
     public fun return_kiosk(kiosk: Kiosk, cap: KioskOwnerCap, ctx: &mut TxContext): u64 {
-        let profits = kiosk::close_and_withdraw(kiosk, cap, ctx);
-        coin::burn_for_testing(profits)
+        let profits = kiosk.close_and_withdraw(cap, ctx);
+        profits.burn_for_testing()
     }
 
     /// Cleanup: vector<Asset>
     public fun return_assets(mut assets: vector<Asset>) {
-        while (vector::length(&assets) > 0) {
-            let Asset { id } = vector::pop_back(&mut assets);
+        while (assets.length() > 0) {
+            let Asset { id } = assets.pop_back();
             id.delete()
         };
 
-        vector::destroy_empty(assets)
+        assets.destroy_empty()
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
@@ -8,9 +8,7 @@
 /// - [ ] test withdraw methods
 module sui::kiosk_tests {
     use sui::kiosk_test_utils::{Self as test, Asset};
-    use sui::transfer_policy as policy;
     use sui::sui::SUI;
-    use sui::kiosk;
     use sui::coin;
 
     const AMT: u64 = 10_000;
@@ -20,13 +18,13 @@ module sui::kiosk_tests {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        let old_owner = kiosk::owner(&kiosk);
-        kiosk::set_owner(&mut kiosk, &owner_cap, ctx);
-        assert!(kiosk::owner(&kiosk) == old_owner, 0);
+        let old_owner = kiosk.owner();
+        kiosk.set_owner(&owner_cap, ctx);
+        assert!(kiosk.owner() == old_owner, 0);
 
-        kiosk::set_owner_custom(&mut kiosk, &owner_cap, @0xA11CE);
-        assert!(kiosk::owner(&kiosk) != old_owner, 0);
-        assert!(kiosk::owner(&kiosk) == @0xA11CE, 0);
+        kiosk.set_owner_custom(&owner_cap, @0xA11CE);
+        assert!(kiosk.owner() != old_owner, 0);
+        assert!(kiosk.owner() == @0xA11CE, 0);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
     }
@@ -38,11 +36,11 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, policy_cap) = test::get_policy(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
+        kiosk.place(&owner_cap, asset);
 
-        assert!(kiosk::has_item(&kiosk, item_id), 0);
-        let asset = kiosk::take(&mut kiosk, &owner_cap, item_id);
-        assert!(!kiosk::has_item(&kiosk, item_id), 0);
+        assert!(kiosk.has_item(item_id), 0);
+        let asset = kiosk.take(&owner_cap, item_id);
+        assert!(!kiosk.has_item(item_id), 0);
 
         test::return_policy(policy, policy_cap, ctx);
         test::return_kiosk(kiosk, owner_cap, ctx);
@@ -57,8 +55,8 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, _policy_cap) = test::get_policy(ctx);
 
-        kiosk::lock(&mut kiosk, &owner_cap, &policy, asset);
-        let _asset = kiosk::take<Asset>(&mut kiosk, &owner_cap, item_id);
+        kiosk.lock(&owner_cap, &policy, asset);
+        let _asset = kiosk.take<Asset>(&owner_cap, item_id);
         abort 1337
     }
 
@@ -69,12 +67,12 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, policy_cap) = test::get_policy(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &owner_cap, asset, AMT);
-        assert!(kiosk::is_listed(&kiosk, item_id), 0);
+        kiosk.place_and_list(&owner_cap, asset, AMT);
+        assert!(kiosk.is_listed(item_id), 0);
         let payment = coin::mint_for_testing<SUI>(AMT, ctx);
-        let (asset, request) = kiosk::purchase(&mut kiosk, item_id, payment);
-        assert!(!kiosk::is_listed(&kiosk, item_id), 0);
-        policy::confirm_request(&policy, request);
+        let (asset, request) = kiosk.purchase(item_id, payment);
+        assert!(!kiosk.is_listed(item_id), 0);
+        policy.confirm_request(request);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
         test::return_assets(vector[ asset ]);
@@ -88,11 +86,11 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, policy_cap) = test::get_policy(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &owner_cap, asset, AMT);
-        assert!(kiosk::is_listed(&kiosk, item_id), 0);
-        kiosk::delist<Asset>(&mut kiosk, &owner_cap, item_id);
-        assert!(!kiosk::is_listed(&kiosk, item_id), 0);
-        let asset = kiosk::take(&mut kiosk, &owner_cap, item_id);
+        kiosk.place_and_list(&owner_cap, asset, AMT);
+        assert!(kiosk.is_listed(item_id), 0);
+        kiosk.delist<Asset>(&owner_cap, item_id);
+        assert!(!kiosk.is_listed(item_id), 0);
+        let asset = kiosk.take(&owner_cap, item_id);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
         test::return_assets(vector[ asset ]);
@@ -106,8 +104,8 @@ module sui::kiosk_tests {
         let (asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        kiosk::delist<Asset>(&mut kiosk, &owner_cap, item_id);
+        kiosk.place(&owner_cap, asset);
+        kiosk.delist<Asset>(&owner_cap, item_id);
 
         abort 1337
     }
@@ -119,12 +117,10 @@ module sui::kiosk_tests {
         let (asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        let _cap = kiosk::list_with_purchase_cap<Asset>(
-            &mut kiosk, &owner_cap, item_id, 100, ctx
-        );
+        kiosk.place(&owner_cap, asset);
+        let _cap = kiosk.list_with_purchase_cap<Asset>(&owner_cap, item_id, 100, ctx);
 
-        kiosk::delist<Asset>(&mut kiosk, &owner_cap, item_id);
+        kiosk.delist<Asset>(&owner_cap, item_id);
         abort 1337
     }
 
@@ -138,8 +134,8 @@ module sui::kiosk_tests {
         let (asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        kiosk::delist<WrongAsset>(&mut kiosk, &owner_cap, item_id);
+        kiosk.place(&owner_cap, asset);
+        kiosk.delist<WrongAsset>(&owner_cap, item_id);
 
         abort 1337
     }
@@ -151,7 +147,7 @@ module sui::kiosk_tests {
         let (_asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::delist<Asset>(&mut kiosk, &owner_cap, item_id);
+        kiosk.delist<Asset>(&owner_cap, item_id);
 
         abort 1337
     }
@@ -164,10 +160,10 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, _policy_cap) = test::get_policy(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &owner_cap, asset, AMT);
+        kiosk.place_and_list(&owner_cap, asset, AMT);
         let payment = coin::mint_for_testing<SUI>(AMT + 1, ctx);
-        let (_asset, request) = kiosk::purchase(&mut kiosk, item_id, payment);
-        policy::confirm_request(&policy, request);
+        let (_asset, request) = kiosk.purchase(item_id, payment);
+        policy.confirm_request(request);
 
         abort 1337
     }
@@ -179,13 +175,13 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, policy_cap) = test::get_policy(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        let purchase_cap = kiosk::list_with_purchase_cap(&mut kiosk, &owner_cap, item_id, AMT, ctx);
+        kiosk.place(&owner_cap, asset);
+        let purchase_cap = kiosk.list_with_purchase_cap(&owner_cap, item_id, AMT, ctx);
         let payment = coin::mint_for_testing<SUI>(AMT, ctx);
-        assert!(kiosk::is_listed_exclusively(&kiosk, item_id), 0);
-        let (asset, request) = kiosk::purchase_with_cap(&mut kiosk, purchase_cap, payment);
-        assert!(!kiosk::is_listed_exclusively(&kiosk, item_id), 0);
-        policy::confirm_request(&policy, request);
+        assert!(kiosk.is_listed_exclusively(item_id), 0);
+        let (asset, request) = kiosk.purchase_with_cap(purchase_cap, payment);
+        assert!(!kiosk.is_listed_exclusively(item_id), 0);
+        policy.confirm_request(request);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
         test::return_assets(vector[ asset ]);
@@ -199,10 +195,10 @@ module sui::kiosk_tests {
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
         let (policy, policy_cap) = test::get_policy(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        let purchase_cap = kiosk::list_with_purchase_cap<test::Asset>(&mut kiosk, &owner_cap, item_id, AMT, ctx);
-        kiosk::return_purchase_cap(&mut kiosk, purchase_cap);
-        let asset = kiosk::take(&mut kiosk, &owner_cap, item_id);
+        kiosk.place(&owner_cap, asset);
+        let purchase_cap = kiosk.list_with_purchase_cap<test::Asset>(&owner_cap, item_id, AMT, ctx);
+        kiosk.return_purchase_cap(purchase_cap);
+        let asset = kiosk.take(&owner_cap, item_id);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
         test::return_assets(vector[ asset ]);
@@ -216,7 +212,7 @@ module sui::kiosk_tests {
         let (_asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::list<Asset>(&mut kiosk, &owner_cap, item_id, AMT);
+        kiosk.list<Asset>(&owner_cap, item_id, AMT);
 
         abort 1337
     }
@@ -228,7 +224,7 @@ module sui::kiosk_tests {
         let (_asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        let _purchase_cap = kiosk::list_with_purchase_cap<Asset>(&mut kiosk, &owner_cap, item_id, AMT, ctx);
+        let _purchase_cap = kiosk.list_with_purchase_cap<Asset>(&owner_cap, item_id, AMT, ctx);
 
         abort 1337
     }
@@ -240,8 +236,8 @@ module sui::kiosk_tests {
         let (asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place_and_list(&mut kiosk, &owner_cap, asset, AMT);
-        let _purchase_cap = kiosk::list_with_purchase_cap<test::Asset>(&mut kiosk, &owner_cap, item_id, AMT, ctx);
+        kiosk.place_and_list(&owner_cap, asset, AMT);
+        let _purchase_cap = kiosk.list_with_purchase_cap<test::Asset>(&owner_cap, item_id, AMT, ctx);
 
         abort 1337
     }
@@ -253,10 +249,10 @@ module sui::kiosk_tests {
         let (asset, item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
-        let purchase_cap = kiosk::list_with_purchase_cap<test::Asset>(&mut kiosk, &owner_cap, item_id, AMT, ctx);
-        kiosk::list<test::Asset>(&mut kiosk, &owner_cap, item_id, AMT);
-        kiosk::return_purchase_cap(&mut kiosk, purchase_cap);
+        kiosk.place(&owner_cap, asset);
+        let purchase_cap = kiosk.list_with_purchase_cap<test::Asset>(&owner_cap, item_id, AMT, ctx);
+        kiosk.list<test::Asset>(&owner_cap, item_id, AMT);
+        kiosk.return_purchase_cap(purchase_cap);
 
         abort 1337
     }
@@ -269,7 +265,7 @@ module sui::kiosk_tests {
         let (asset, _item_id) = test::get_asset(ctx);
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::place(&mut kiosk, &owner_cap, asset);
+        kiosk.place(&owner_cap, asset);
         test::return_kiosk(kiosk, owner_cap, ctx);
 
         abort 1337
@@ -279,9 +275,9 @@ module sui::kiosk_tests {
     fun test_withdraw_default() {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
-        let profits = kiosk::withdraw(&mut kiosk, &owner_cap, std::option::none(), ctx);
+        let profits = kiosk.withdraw(&owner_cap, option::none(), ctx);
 
-        coin::burn_for_testing(profits);
+        profits.burn_for_testing();
         test::return_kiosk(kiosk, owner_cap, ctx);
     }
 
@@ -290,7 +286,7 @@ module sui::kiosk_tests {
     fun test_withdraw_more_than_there_is() {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
-        let _profits = kiosk::withdraw(&mut kiosk, &owner_cap, std::option::some(100), ctx);
+        let _profits = kiosk.withdraw(&owner_cap, option::some(100), ctx);
 
         abort 1337
     }
@@ -300,8 +296,8 @@ module sui::kiosk_tests {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::set_allow_extensions(&mut kiosk, &owner_cap, false);
-        let _uid_mut = kiosk::uid_mut_as_owner(&mut kiosk, &owner_cap);
+        kiosk.set_allow_extensions(&owner_cap, false);
+        let _uid_mut = kiosk.uid_mut_as_owner(&owner_cap);
         test::return_kiosk(kiosk, owner_cap, ctx);
     }
 
@@ -310,7 +306,7 @@ module sui::kiosk_tests {
         let ctx = &mut test::ctx();
         let (kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        let uid = kiosk::uid(&kiosk);
+        let uid = kiosk.uid();
         assert!(sui::object::uid_to_inner(uid) == sui::object::id(&kiosk), 0);
 
         test::return_kiosk(kiosk, owner_cap, ctx);
@@ -322,8 +318,8 @@ module sui::kiosk_tests {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::set_allow_extensions(&mut kiosk, &owner_cap, false);
-        let _ = kiosk::uid_mut(&mut kiosk);
+        kiosk.set_allow_extensions(&owner_cap, false);
+        let _ = kiosk.uid_mut();
 
         abort 1337
     }
@@ -333,8 +329,8 @@ module sui::kiosk_tests {
         let ctx = &mut test::ctx();
         let (mut kiosk, owner_cap) = test::get_kiosk(ctx);
 
-        kiosk::set_allow_extensions(&mut kiosk, &owner_cap, false);
-        let _ = kiosk::uid(&kiosk);
+        kiosk.set_allow_extensions(&owner_cap, false);
+        let _ = kiosk.uid();
 
         test::return_kiosk(kiosk, owner_cap, ctx);
     }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/fixed_commission_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/fixed_commission_policy.test.move
@@ -44,7 +44,7 @@ module sui::fixed_commission {
     public fun pay<T>(
         policy: &mut TransferPolicy<T>, request: &mut TransferRequest<T>, coin: Coin<SUI>
     ) {
-        let paid = policy::paid(request);
+        let paid = request.paid();
         let config: &Commission = policy::get_rule(Rule {}, policy);
 
         assert!(paid == config.amount, EIncorrectAmount);

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/item_placed_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/item_placed_policy.test.move
@@ -25,7 +25,7 @@ module sui::item_locked_policy {
 
     /// Prove that an item a
     public fun prove<T>(request: &mut TransferRequest<T>, kiosk: &Kiosk) {
-        let item = policy::item(request);
+        let item = request.item();
         assert!(kiosk::has_item(kiosk, item) && kiosk::is_locked(kiosk, item), ENotInKiosk);
         policy::add_receipt(Rule {}, request)
     }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/royalty_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/royalty_policy.test.move
@@ -6,7 +6,6 @@
 module sui::royalty_policy {
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
-    use sui::tx_context::TxContext;
     use sui::transfer_policy::{
         Self as policy,
         TransferPolicy,
@@ -64,13 +63,12 @@ module sui::royalty_policy_tests {
     use sui::coin;
     use sui::sui::SUI;
     use sui::royalty_policy;
-    use sui::tx_context::dummy as ctx;
     use sui::transfer_policy as policy;
     use sui::transfer_policy_tests as test;
 
     #[test]
     fun test_default_flow() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         // 1% royalty
@@ -92,7 +90,7 @@ module sui::royalty_policy_tests {
     #[test]
     #[expected_failure(abort_code = sui::royalty_policy::EIncorrectArgument)]
     fun test_incorrect_config() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         royalty_policy::set(&mut policy, &cap, 11_000);
@@ -102,7 +100,7 @@ module sui::royalty_policy_tests {
     #[test]
     #[expected_failure(abort_code = sui::royalty_policy::EInsufficientAmount)]
     fun test_insufficient_amount() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         // 1% royalty

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/witness_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/witness_policy.test.move
@@ -48,7 +48,6 @@ module sui::witness_policy {
 #[test_only]
 module sui::witness_policy_tests {
     use sui::witness_policy;
-    use sui::tx_context::dummy as ctx;
     use sui::transfer_policy as policy;
     use sui::transfer_policy_tests::{
         Self as test,
@@ -63,7 +62,7 @@ module sui::witness_policy_tests {
 
     #[test]
     fun test_default_flow() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         // set the lock policy and require `Proof` on every transfer.
@@ -79,7 +78,7 @@ module sui::witness_policy_tests {
     #[test]
     #[expected_failure(abort_code = sui::transfer_policy::EPolicyNotSatisfied)]
     fun test_no_proof() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         // set the lock policy and require `Proof` on every transfer.
@@ -93,7 +92,7 @@ module sui::witness_policy_tests {
     #[test]
     #[expected_failure(abort_code = sui::witness_policy::ERuleNotFound)]
     fun test_wrong_proof() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = test::prepare(ctx);
 
         // set the lock policy and require `Proof` on every transfer.

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/witness_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/witness_policy.test.move
@@ -71,7 +71,7 @@ module sui::witness_policy_tests {
         let mut request = policy::new_request(test::fresh_id(ctx), 0, test::fresh_id(ctx));
 
         witness_policy::prove(Proof {}, &policy, &mut request);
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
         test::wrapup(policy, cap, ctx);
     }
 
@@ -85,7 +85,7 @@ module sui::witness_policy_tests {
         witness_policy::set<Asset, Proof>(&mut policy, &cap);
         let request = policy::new_request(test::fresh_id(ctx), 0, test::fresh_id(ctx));
 
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
         test::wrapup(policy, cap, ctx);
     }
 
@@ -101,7 +101,7 @@ module sui::witness_policy_tests {
         let mut request = policy::new_request(test::fresh_id(ctx), 0, test::fresh_id(ctx));
 
         witness_policy::prove(Cheat {}, &policy, &mut request);
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
         test::wrapup(policy, cap, ctx);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
@@ -15,11 +15,8 @@ module sui::malicious_policy {
 #[test_only]
 module sui::transfer_policy_tests {
     use sui::transfer_policy::{Self as policy, TransferPolicy, TransferPolicyCap};
-    use sui::tx_context::{Self, TxContext, dummy as ctx};
-    use sui::object::{Self, ID, UID};
     use sui::dummy_policy;
     use sui::malicious_policy;
-    use sui::vec_set;
     use sui::package;
     use sui::coin;
 
@@ -29,12 +26,12 @@ module sui::transfer_policy_tests {
     #[test]
     /// No policy set;
     fun test_default_flow() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (policy, cap) = prepare(ctx);
 
         // time to make a new transfer request
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         wrapup(policy, cap, ctx);
     }
@@ -42,19 +39,19 @@ module sui::transfer_policy_tests {
     #[test]
     /// Policy set and completed;
     fun test_rule_completed() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = prepare(ctx);
 
-        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
+        assert!(policy.rules().size() == 0, 0);
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        assert!(vec_set::size(policy::rules(&policy)) == 1, 1);
+        assert!(policy.rules().size() == 1, 1);
 
         let mut request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
 
         dummy_policy::pay(&mut policy, &mut request, coin::mint_for_testing(10_000, ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         let profits = wrapup(policy, cap, ctx);
 
@@ -64,26 +61,26 @@ module sui::transfer_policy_tests {
     #[test]
     /// Policy set and completed; rule removed; empty policy works
     fun test_remove_rule_completed() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = prepare(ctx);
 
-        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
+        assert!(policy.rules().size() == 0, 0);
 
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        assert!(vec_set::size(policy::rules(&policy)) == 1, 0);
+        assert!(policy.rules().size() == 1, 0);
 
         let mut request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
         dummy_policy::pay(&mut policy, &mut request, coin::mint_for_testing(10_000, ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         // remove policy and start over - this time ignore dummy_policy
-        policy::remove_rule<Asset, dummy_policy::Rule, dummy_policy::Config>(&mut policy, &cap);
+        policy.remove_rule<Asset, dummy_policy::Rule, dummy_policy::Config>(&cap);
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
-        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
+        assert!(policy.rules().size() == 0, 0);
         assert!(wrapup(policy, cap, ctx) == 10_000, 0);
     }
 
@@ -91,14 +88,14 @@ module sui::transfer_policy_tests {
     #[expected_failure(abort_code = sui::transfer_policy::EPolicyNotSatisfied)]
     /// Policy set but not satisfied;
     fun test_rule_ignored() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = prepare(ctx);
 
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         wrapup(policy, cap, ctx);
     }
@@ -107,7 +104,7 @@ module sui::transfer_policy_tests {
     #[expected_failure(abort_code = sui::transfer_policy::ERuleAlreadySet)]
     /// Attempt to add another policy;
     fun test_rule_exists() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = prepare(ctx);
 
         // now require everyone to pay any amount
@@ -115,7 +112,7 @@ module sui::transfer_policy_tests {
         dummy_policy::set(&mut policy, &cap);
 
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         wrapup(policy, cap, ctx);
     }
@@ -124,7 +121,7 @@ module sui::transfer_policy_tests {
     #[expected_failure(abort_code = sui::transfer_policy::EIllegalRule)]
     /// Attempt to cheat by using another rule approval;
     fun test_rule_swap() {
-        let ctx = &mut ctx();
+        let ctx = &mut tx_context::dummy();
         let (mut policy, cap) = prepare(ctx);
 
         // now require everyone to pay any amount
@@ -133,7 +130,7 @@ module sui::transfer_policy_tests {
 
         // try to add receipt from another rule
         malicious_policy::cheat(&mut request);
-        policy::confirm_request(&policy, request);
+        policy.confirm_request(request);
 
         wrapup(policy, cap, ctx);
     }
@@ -141,16 +138,16 @@ module sui::transfer_policy_tests {
     public fun prepare(ctx: &mut TxContext): (TransferPolicy<Asset>, TransferPolicyCap<Asset>) {
         let publisher = package::test_claim(OTW {}, ctx);
         let (policy, cap) = policy::new<Asset>(&publisher, ctx);
-        package::burn_publisher(publisher);
+        publisher.burn_publisher();
         (policy, cap)
     }
 
     public fun wrapup(policy: TransferPolicy<Asset>, cap: TransferPolicyCap<Asset>, ctx: &mut TxContext): u64 {
-        let profits = policy::destroy_and_withdraw(policy, cap, ctx);
-        coin::burn_for_testing(profits)
+        let profits = policy.destroy_and_withdraw(cap, ctx);
+        profits.burn_for_testing()
     }
 
     public fun fresh_id(ctx: &mut TxContext): ID {
-        object::id_from_address(tx_context::fresh_object_address(ctx))
+        tx_context::fresh_object_address(ctx).to_id()
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
@@ -148,6 +148,6 @@ module sui::transfer_policy_tests {
     }
 
     public fun fresh_id(ctx: &mut TxContext): ID {
-        tx_context::fresh_object_address(ctx).to_id()
+        ctx.fresh_object_address().to_id()
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
@@ -324,7 +324,7 @@ module sui::linked_table_tests {
         assert!(n == keys.length(), 0);
         if (n == 0) {
             assert!(table.front().is_none(), 0);
-            assert!(table.front().is_none(), 0);
+            assert!(table.back().is_none(), 0);
             return
         };
 

--- a/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
@@ -3,27 +3,9 @@
 
 #[test_only]
 module sui::linked_table_tests {
-    use std::option;
-    use std::vector;
     use sui::linked_table::{
         Self,
         LinkedTable,
-        front,
-        back,
-        push_front,
-        push_back,
-        borrow,
-        borrow_mut,
-        prev,
-        next,
-        remove,
-        pop_front,
-        pop_back,
-        contains,
-        length,
-        is_empty,
-        destroy_empty,
-        drop,
     };
     use sui::test_scenario as ts;
     use sui::tx_context::TxContext;
@@ -35,54 +17,54 @@ module sui::linked_table_tests {
         let mut table = linked_table::new(ts::ctx(&mut scenario));
         check_ordering(&table, &vector[]);
         // add fields
-        push_back(&mut table, b"hello", 0);
+        table.push_back(b"hello", 0);
         check_ordering(&table, &vector[b"hello"]);
-        push_back(&mut table, b"goodbye", 1);
+        table.push_back(b"goodbye", 1);
         // check they exist
-        assert!(contains(&table, b"hello"), 0);
-        assert!(contains(&table, b"goodbye"), 0);
-        assert!(!is_empty(&table), 0);
+        assert!(table.contains(b"hello"), 0);
+        assert!(table.contains(b"goodbye"), 0);
+        assert!(!table.is_empty(), 0);
         // check the values
-        assert!(*borrow(&table, b"hello") == 0, 0);
-        assert!(*borrow(&table, b"goodbye") == 1, 0);
+        assert!(table[b"hello"] == 0, 0);
+        assert!(table[b"goodbye"] == 1, 0);
         // mutate them
-        *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
-        *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+        *(&mut table[b"hello"]) = table[b"hello"] * 2;
+        *(&mut table[b"goodbye"]) = table[b"goodbye"] * 2;
         // check the new value
-        assert!(*borrow(&table, b"hello") == 0, 0);
-        assert!(*borrow(&table, b"goodbye") == 2, 0);
+        assert!(table[b"hello"] == 0, 0);
+        assert!(table[b"goodbye"] == 2, 0);
         // check the ordering
         check_ordering(&table, &vector[b"hello", b"goodbye"]);
         // add to the front
-        push_front(&mut table, b"!!!", 2);
+        table.push_front(b"!!!", 2);
         check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye"]);
         // add to the back
-        push_back(&mut table, b"?", 3);
+        table.push_back(b"?", 3);
         check_ordering(&table, &vector[b"!!!", b"hello", b"goodbye", b"?"]);
         // pop front
-        let (front_k, front_v) = pop_front(&mut table);
+        let (front_k, front_v) = table.pop_front();
         assert!(front_k == b"!!!", 0);
         assert!(front_v == 2, 0);
         check_ordering(&table, &vector[b"hello", b"goodbye", b"?"]);
         // remove middle
-        assert!(remove(&mut table, b"goodbye") == 2, 0);
+        assert!(table.remove(b"goodbye") == 2, 0);
         check_ordering(&table, &vector[b"hello", b"?"]);
         // pop back
-        let (back_k, back_v) = pop_back(&mut table);
+        let (back_k, back_v) = table.pop_back();
         assert!(back_k == b"?", 0);
         assert!(back_v == 3, 0);
         check_ordering(&table, &vector[b"hello"]);
         // remove the value and check it
-        assert!(remove(&mut table, b"hello") == 0, 0);
+        assert!(table.remove(b"hello") == 0, 0);
         check_ordering(&table, &vector[]);
         // verify that they are not there
-        assert!(!contains(&table, b"!!!"), 0);
-        assert!(!contains(&table, b"goodbye"), 0);
-        assert!(!contains(&table, b"hello"), 0);
-        assert!(!contains(&table, b"?"), 0);
-        assert!(is_empty(&table), 0);
+        assert!(!table.contains(b"!!!"), 0);
+        assert!(!table.contains(b"goodbye"), 0);
+        assert!(!table.contains(b"hello"), 0);
+        assert!(!table.contains(b"?"), 0);
+        assert!(table.is_empty(), 0);
         ts::end(scenario);
-        destroy_empty(table);
+        table.destroy_empty();
     }
 
     #[test]
@@ -90,10 +72,10 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        assert!(option::is_none(front(&table)), 0);
-        assert!(option::is_none(back(&table)), 0);
+        assert!(table.front().is_none(), 0);
+        assert!(table.back().is_none(), 0);
         ts::end(scenario);
-        drop(table)
+        table.drop()
     }
 
     #[test]
@@ -102,11 +84,11 @@ module sui::linked_table_tests {
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
         check_ordering(&table, &vector[]);
-        push_front(&mut table, b"hello", 0);
-        assert!(contains(&table, b"hello"), 0);
+        table.push_front(b"hello", 0);
+        assert!(table.contains(b"hello"), 0);
         check_ordering(&table, &vector[b"hello"]);
         ts::end(scenario);
-        drop(table)
+        table.drop()
     }
 
     #[test]
@@ -115,11 +97,11 @@ module sui::linked_table_tests {
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
         check_ordering(&table, &vector[]);
-        push_back(&mut table, b"hello", 0);
-        assert!(contains(&table, b"hello"), 0);
+        table.push_back(b"hello", 0);
+        assert!(table.contains(b"hello"), 0);
         check_ordering(&table, &vector[b"hello"]);
         ts::end(scenario);
-        drop(table)
+        table.drop()
     }
 
     #[test]
@@ -128,8 +110,8 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        push_front(&mut table, b"hello", 0);
-        push_front(&mut table, b"hello", 0);
+        table.push_front(b"hello", 0);
+        table.push_front(b"hello", 0);
         abort 42
     }
 
@@ -139,8 +121,8 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        push_back(&mut table, b"hello", 0);
-        push_back(&mut table, b"hello", 0);
+        table.push_back(b"hello", 0);
+        table.push_back(b"hello", 0);
         abort 42
     }
 
@@ -150,8 +132,8 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        push_back(&mut table, b"hello", 0);
-        push_front(&mut table, b"hello", 0);
+        table.push_back(b"hello", 0);
+        table.push_front(b"hello", 0);
         abort 42
     }
 
@@ -161,7 +143,7 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        borrow(&table, 0);
+        &table[0];
         abort 42
     }
 
@@ -171,7 +153,7 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        borrow_mut(&mut table, 0);
+        &mut table[0];
         abort 42
     }
 
@@ -181,7 +163,7 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        remove(&mut table, 0);
+        table.remove(0);
         abort 42
     }
 
@@ -191,7 +173,7 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        pop_front(&mut table);
+        table.pop_front();
         abort 42
     }
 
@@ -201,7 +183,7 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
-        pop_back(&mut table);
+        table.pop_back();
         abort 42
     }
 
@@ -211,8 +193,8 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        push_back(&mut table, 0, 0);
-        destroy_empty(table);
+        table.push_back(0, 0);
+        table.destroy_empty();
         ts::end(scenario);
     }
 
@@ -221,12 +203,12 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        assert!(!contains(&table, 0), 0);
-        push_back(&mut table, 0, 0);
-        assert!(contains<u64, u64>(&table, 0), 0);
-        assert!(!contains<u64, u64>(&table, 1), 0);
+        assert!(!table.contains(0), 0);
+        table.push_back(0, 0);
+        assert!(table.contains<u64, u64>(0), 0);
+        assert!(!table.contains<u64, u64>(1), 0);
         ts::end(scenario);
-        drop(table);
+        table.drop();
     }
 
     #[test]
@@ -234,10 +216,10 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        push_back(&mut table, 0, 0);
-        assert!(length(&table) == 1, 0);
+        table.push_back(0, 0);
+        assert!(table.length() == 1, 0);
         ts::end(scenario);
-        drop(table);
+        table.drop();
     }
 
     #[test]
@@ -245,16 +227,16 @@ module sui::linked_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = linked_table::new(ts::ctx(&mut scenario));
-        assert!(is_empty(&table), 0);
-        assert!(length(&table) == 0, 0);
-        push_back(&mut table, 0, 0);
-        assert!(!is_empty(&table), 0);
-        assert!(length(&table) == 1, 0);
-        push_back(&mut table, 1, 0);
-        assert!(!is_empty(&table), 0);
-        assert!(length(&table) == 2, 0);
+        assert!(table.is_empty(), 0);
+        assert!(table.length() == 0, 0);
+        table.push_back(0, 0);
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 1, 0);
+        table.push_back(1, 0);
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 2, 0);
         ts::end(scenario);
-        drop(table);
+        table.drop();
     }
 
     #[test]
@@ -274,15 +256,15 @@ module sui::linked_table_tests {
         ];
         let mut i = 0;
         let mut j = 0;
-        let n = vector::length(&all_bools);
+        let n = all_bools.length();
         // all_bools indicate possible orderings of accessing the front vs the back of the
         // table
         // test all orderings of building up and tearing down the table, while mimicing
         // the ordering in a vector, and checking the keys have the same order in the table
         while (i < n) {
-            let pushes = vector::borrow(&all_bools, i);
+            let pushes = &all_bools[i];
             while (j < n) {
-                let pops = vector::borrow(&all_bools, j);
+                let pops = &all_bools[j];
                 build_up_and_tear_down(&keys, &values, pushes, pops, ctx);
                 j = j + 1;
             };
@@ -301,22 +283,22 @@ module sui::linked_table_tests {
         ctx: &mut TxContext,
     ) {
         let mut table = linked_table::new(ctx);
-        let n = vector::length(keys);
-        assert!(vector::length(values) == n, 0);
-        assert!(vector::length(pushes) == n, 0);
-        assert!(vector::length(pops) == n, 0);
+        let n = keys.length();
+        assert!(values.length() == n, 0);
+        assert!(pushes.length() == n, 0);
+        assert!(pops.length() == n, 0);
 
         let mut i = 0;
         let mut order = vector[];
         while (i < n) {
-            let k = *vector::borrow(keys, i);
-            let v = *vector::borrow(values, i);
-            if (*vector::borrow(pushes, i)) {
-                push_front(&mut table, k, v);
-                vector::insert(&mut order, k, 0);
+            let k = keys[i];
+            let v = values[i];
+            if (pushes[i]) {
+                table.push_front(k, v);
+                order.insert(k, 0);
             } else {
-                push_front(&mut table, k, v);
-                vector::push_back(&mut order, k);
+                table.push_front(k, v);
+                order.push_back(k);
             };
             i = i + 1;
         };
@@ -324,43 +306,43 @@ module sui::linked_table_tests {
         check_ordering(&table, &order);
         let mut i = 0;
         while (i < n) {
-            let (table_k, order_k) = if (*vector::borrow(pops, i)) {
-                let (table_k, _) = pop_front(&mut table);
-                (table_k, vector::remove(&mut order, 0))
+            let (table_k, order_k) = if (pops[i]) {
+                let (table_k, _) = table.pop_front();
+                (table_k, order.remove(0))
             } else {
-                let (table_k, _) = pop_back(&mut table);
-                (table_k, vector::pop_back(&mut order))
+                let (table_k, _) = table.pop_back();
+                (table_k, order.pop_back())
             };
             assert!(table_k == order_k, 0);
             check_ordering(&table, &order);
             i = i + 1;
         };
-        destroy_empty(table)
+        table.destroy_empty()
     }
 
     fun check_ordering<K: copy + drop + store, V: store>(table: &LinkedTable<K, V>, keys: &vector<K>) {
-        let n = length(table);
-        assert!(n == vector::length(keys), 0);
+        let n = table.length();
+        assert!(n == keys.length(), 0);
         if (n == 0) {
-            assert!(option::is_none(front(table)), 0);
-            assert!(option::is_none(back(table)), 0);
+            assert!(table.front().is_none(), 0);
+            assert!(table.front().is_none(), 0);
             return
         };
 
         let mut i = 0;
         while (i < n) {
-            let cur = *vector::borrow(keys, i);
+            let cur = keys[i];
             if (i == 0) {
-                assert!(option::borrow(front(table)) == &cur, 0);
-                assert!(option::is_none(prev(table, cur)), 0);
+                assert!(table.front().borrow() == &cur, 0);
+                assert!(table.prev(cur).is_none(), 0);
             } else {
-                assert!(option::borrow(prev(table, cur)) == vector::borrow(keys, i - 1), 0);
+                assert!(table.prev(cur).borrow() == &keys[i - 1], 0);
             };
             if (i + 1 == n) {
-                assert!(option::borrow(back(table)) == &cur, 0);
-                assert!(option::is_none(next(table, cur)), 0);
+                assert!(table.back().borrow() == &cur, 0);
+                assert!(table.next(cur).is_none(), 0);
             } else {
-                assert!(option::borrow(next(table, cur)) == vector::borrow(keys, i + 1), 0);
+                assert!(table.next(cur).borrow() == &keys[i + 1], 0);
             };
 
             i = i + 1;

--- a/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
@@ -7,14 +7,14 @@ module sui::linked_table_tests {
         Self,
         LinkedTable,
     };
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
     use sui::tx_context::TxContext;
 
     #[test]
     fun simple_all_functions() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         check_ordering(&table, &vector[]);
         // add fields
         table.push_back(b"hello", 0);
@@ -63,44 +63,44 @@ module sui::linked_table_tests {
         assert!(!table.contains(b"hello"), 0);
         assert!(!table.contains(b"?"), 0);
         assert!(table.is_empty(), 0);
-        ts::end(scenario);
+        scenario.end();
         table.destroy_empty();
     }
 
     #[test]
     fun front_back_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let table = linked_table::new<u64, u64>(scenario.ctx());
         assert!(table.front().is_none(), 0);
         assert!(table.back().is_none(), 0);
-        ts::end(scenario);
+        scenario.end();
         table.drop()
     }
 
     #[test]
     fun push_front_singleton() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         check_ordering(&table, &vector[]);
         table.push_front(b"hello", 0);
         assert!(table.contains(b"hello"), 0);
         check_ordering(&table, &vector[b"hello"]);
-        ts::end(scenario);
+        scenario.end();
         table.drop()
     }
 
     #[test]
     fun push_back_singleton() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         check_ordering(&table, &vector[]);
         table.push_back(b"hello", 0);
         assert!(table.contains(b"hello"), 0);
         check_ordering(&table, &vector[b"hello"]);
-        ts::end(scenario);
+        scenario.end();
         table.drop()
     }
 
@@ -108,8 +108,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun push_front_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         table.push_front(b"hello", 0);
         table.push_front(b"hello", 0);
         abort 42
@@ -119,8 +119,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun push_back_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         table.push_back(b"hello", 0);
         table.push_back(b"hello", 0);
         abort 42
@@ -130,8 +130,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun push_mixed_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         table.push_back(b"hello", 0);
         table.push_front(b"hello", 0);
         abort 42
@@ -141,8 +141,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let table = linked_table::new<u64, u64>(scenario.ctx());
         &table[0];
         abort 42
     }
@@ -151,8 +151,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_mut_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new<u64, u64>(scenario.ctx());
         &mut table[0];
         abort 42
     }
@@ -161,8 +161,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun remove_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new<u64, u64>(scenario.ctx());
         table.remove(0);
         abort 42
     }
@@ -171,8 +171,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = linked_table::ETableIsEmpty)]
     fun pop_front_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new<u64, u64>(scenario.ctx());
         table.pop_front();
         abort 42
     }
@@ -181,8 +181,8 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = linked_table::ETableIsEmpty)]
     fun pop_back_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new<u64, u64>(scenario.ctx());
         table.pop_back();
         abort 42
     }
@@ -191,42 +191,42 @@ module sui::linked_table_tests {
     #[expected_failure(abort_code = linked_table::ETableNotEmpty)]
     fun destroy_non_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         table.push_back(0, 0);
         table.destroy_empty();
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun sanity_check_contains() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         assert!(!table.contains(0), 0);
         table.push_back(0, 0);
         assert!(table.contains<u64, u64>(0), 0);
         assert!(!table.contains<u64, u64>(1), 0);
-        ts::end(scenario);
+        scenario.end();
         table.drop();
     }
 
     #[test]
     fun sanity_check_drop() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         table.push_back(0, 0);
         assert!(table.length() == 1, 0);
-        ts::end(scenario);
+        scenario.end();
         table.drop();
     }
 
     #[test]
     fun sanity_check_size() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = linked_table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = linked_table::new(scenario.ctx());
         assert!(table.is_empty(), 0);
         assert!(table.length() == 0, 0);
         table.push_back(0, 0);
@@ -235,15 +235,15 @@ module sui::linked_table_tests {
         table.push_back(1, 0);
         assert!(!table.is_empty(), 0);
         assert!(table.length() == 2, 0);
-        ts::end(scenario);
+        scenario.end();
         table.drop();
     }
 
     #[test]
     fun test_all_orderings() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let ctx = ts::ctx(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let ctx = scenario.ctx();
         let keys = vector[b"a", b"b", b"c"];
         let values = vector[3, 2, 1];
         let all_bools = vector[
@@ -270,7 +270,7 @@ module sui::linked_table_tests {
             };
             i = i + 1;
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     fun build_up_and_tear_down<K: copy + drop + store, V: copy + drop + store>(

--- a/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/linked_table_tests.move
@@ -8,7 +8,6 @@ module sui::linked_table_tests {
         LinkedTable,
     };
     use sui::test_scenario;
-    use sui::tx_context::TxContext;
 
     #[test]
     fun simple_all_functions() {

--- a/crates/sui-framework/packages/sui-framework/tests/object_bag_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_bag_tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 module sui::object_bag_tests {
     use sui::object_bag;
-    use sui::object::{Self, UID};
     use sui::test_scenario;
 
     public struct Counter has key, store {

--- a/crates/sui-framework/packages/sui-framework/tests/object_bag_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_bag_tests.move
@@ -21,9 +21,9 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        let counter1 = new_counter(&mut scenario);
+        let counter1 = new(&mut scenario);
         let id1 = object::id(&counter1);
-        let counter2 = new_counter(&mut scenario);
+        let counter2 = new(&mut scenario);
         let id2 = object::id(&counter2);
         // add fields
         bag.add(b"hello", counter1);
@@ -41,13 +41,13 @@ module sui::object_bag_tests {
         assert!((&bag[1] : &Counter).count() == 0, 0);
         // mutate them
         bump(&mut bag[b"hello"]);
-        bump(&mut bag[1]);
+        bump(bump(&mut bag[1]));
         // check the new value
         assert!((&bag[b"hello"] : &Counter).count() == 1, 0);
-        assert!((&bag[1] : &Counter).count() == 1, 0);
+        assert!((&bag[1] : &Counter).count() == 2, 0);
         // remove the value and check it
         assert!(bag.remove<vector<u8>, Counter>(b"hello").destroy() == 1, 0);
-        assert!(bag.remove<u64, Counter>(1).destroy() == 1, 0);
+        assert!(bag.remove<u64, Counter>(1).destroy() == 2, 0);
         // verify that they are not there
         assert!(!bag.contains(b"hello"), 0);
         assert!(!bag.contains(1), 0);
@@ -61,8 +61,8 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        bag.add(b"hello", new_counter(&mut scenario));
-        bag.add(b"hello", new_counter(&mut scenario));
+        bag.add(b"hello", new(&mut scenario));
+        bag.add(b"hello", new(&mut scenario));
         abort 42
     }
 
@@ -102,7 +102,7 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        let counter = new_counter(&mut scenario);
+        let counter = new(&mut scenario);
         bag.add(0, counter);
         bag.destroy_empty();
         scenario.end();
@@ -113,7 +113,7 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        let counter = new_counter(&mut scenario);
+        let counter = new(&mut scenario);
         assert!(!bag.contains(0), 0);
         bag.add(0, counter);
         assert!(bag.contains(0), 0);
@@ -128,7 +128,7 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        let counter = new_counter(&mut scenario);
+        let counter = new(&mut scenario);
         assert!(!bag.contains_with_type<u64, Counter>(0), 0);
         assert!(!bag.contains_with_type<u64, Fake>(0), 0);
         bag.add(0, counter);
@@ -145,8 +145,8 @@ module sui::object_bag_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut bag = object_bag::new(scenario.ctx());
-        let counter1 = new_counter(&mut scenario);
-        let counter2 = new_counter(&mut scenario);
+        let counter1 = new(&mut scenario);
+        let counter2 = new(&mut scenario);
         assert!(bag.is_empty(), 0);
         assert!(bag.length() == 0, 0);
         bag.add(0, counter1);
@@ -168,7 +168,7 @@ module sui::object_bag_tests {
         let mut scenario = test_scenario::begin(sender);
         let mut bag1 = object_bag::new(scenario.ctx());
         let mut bag2 = object_bag::new(scenario.ctx());
-        bag1.add(0, new_counter(&mut scenario));
+        bag1.add(0, new(&mut scenario));
         assert!(bag1.contains(0), 0);
         assert!(!bag2.contains(0), 0);
         bump(&mut bag1[0]);
@@ -184,7 +184,7 @@ module sui::object_bag_tests {
         bag2.destroy_empty();
     }
 
-    fun new_counter(scenario: &mut test_scenario::Scenario): Counter {
+    fun new(scenario: &mut test_scenario::Scenario): Counter {
         Counter { id: scenario.new_object(), count: 0 }
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
@@ -3,8 +3,7 @@
 
 #[test_only]
 module sui::object_table_tests {
-    use std::option;
-    use sui::object_table::{Self, add, contains, borrow, borrow_mut, remove, value_id};
+    use sui::object_table::{Self, add};
     use sui::object::{Self, UID};
     use sui::test_scenario as ts;
 
@@ -23,31 +22,31 @@ module sui::object_table_tests {
         let counter2 = new(&mut scenario);
         let id2 = object::id(&counter2);
         // add fields
-        add(&mut table, b"hello", counter1);
-        add(&mut table, b"goodbye", counter2);
+        table.add(b"hello", counter1);
+        table.add(b"goodbye", counter2);
         // check they exist
-        assert!(contains(&table, b"hello"), 0);
-        assert!(contains(&table, b"goodbye"), 0);
+        assert!(table.contains(b"hello"), 0);
+        assert!(table.contains(b"goodbye"), 0);
         // check the IDs
-        assert!(option::borrow(&value_id(&table, b"hello")) == &id1, 0);
-        assert!(option::borrow(&value_id(&table, b"goodbye")) == &id2, 0);
+        assert!(table.value_id(b"hello").borrow() == &id1, 0);
+        assert!(table.value_id(b"goodbye").borrow() == &id2, 0);
         // check the values
-        assert!(count(borrow(&table, b"hello")) == 0, 0);
-        assert!(count(borrow(&table, b"goodbye")) == 0, 0);
+        assert!(count(&table[b"hello"]) == 0, 0);
+        assert!(count(&table[b"goodbye"]) == 0, 0);
         // mutate them
-        bump(borrow_mut(&mut table, b"hello"));
-        bump(bump(borrow_mut(&mut table, b"goodbye")));
+        bump(&mut table[b"hello"]);
+        bump(bump(&mut table[b"goodbye"]));
         // check the new value
-        assert!(count(borrow(&table, b"hello")) == 1, 0);
-        assert!(count(borrow(&table, b"goodbye")) == 2, 0);
+        assert!(count(&table[b"hello"]) == 1, 0);
+        assert!(count(&table[b"goodbye"]) == 2, 0);
         // remove the value and check it
-        assert!(destroy(remove(&mut table, b"hello")) == 1, 0);
-        assert!(destroy(remove(&mut table, b"goodbye")) == 2, 0);
+        assert!(table.remove(b"hello").destroy() == 1, 0);
+        assert!(table.remove(b"goodbye").destroy() == 2, 0);
         // verify that they are not there
-        assert!(!contains(&table, b"hello"), 0);
-        assert!(!contains(&table, b"goodbye"), 0);
+        assert!(!table.contains(b"hello"), 0);
+        assert!(!table.contains(b"goodbye"), 0);
         ts::end(scenario);
-        object_table::destroy_empty(table);
+        table.destroy_empty();
     }
 
     #[test]
@@ -56,8 +55,8 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new(ts::ctx(&mut scenario));
-        add(&mut table, b"hello", new(&mut scenario));
-        add(&mut table, b"hello", new(&mut scenario));
+        table.add(b"hello", new(&mut scenario));
+        table.add(b"hello", new(&mut scenario));
         abort 42
     }
 
@@ -67,7 +66,7 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-        borrow(&table, 0);
+        &table[0];
         abort 42
     }
 
@@ -77,7 +76,7 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-        borrow_mut(&mut table, 0);
+        &mut table[0];
         abort 42
     }
 
@@ -87,7 +86,7 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-        destroy(remove(&mut table, 0));
+        table.remove(0).destroy();
         abort 42
     }
 
@@ -97,8 +96,8 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new(ts::ctx(&mut scenario));
-        add(&mut table, 0, new(&mut scenario));
-        object_table::destroy_empty(table);
+        table.add(0, new(&mut scenario));
+        table.destroy_empty();
         ts::end(scenario);
     }
 
@@ -107,13 +106,13 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new(ts::ctx(&mut scenario));
-        assert!(!contains(&table, 0), 0);
-        add(&mut table, 0, new(&mut scenario));
-        assert!(contains(&table, 0), 0);
-        assert!(!contains(&table, 1), 0);
+        assert!(!table.contains(0), 0);
+        table.add(0, new(&mut scenario));
+        assert!(table.contains(0), 0);
+        assert!(!table.contains(1), 0);
         ts::end(scenario);
-        destroy(remove(&mut table, 0));
-        object_table::destroy_empty(table)
+        table.remove(0).destroy();
+        table.destroy_empty()
     }
 
     #[test]
@@ -121,18 +120,18 @@ module sui::object_table_tests {
         let sender = @0x0;
         let mut scenario = ts::begin(sender);
         let mut table = object_table::new(ts::ctx(&mut scenario));
-        assert!(object_table::is_empty(&table), 0);
-        assert!(object_table::length(&table) == 0, 0);
-        add(&mut table, 0, new(&mut scenario));
-        assert!(!object_table::is_empty(&table), 0);
-        assert!(object_table::length(&table) == 1, 0);
-        add(&mut table, 1, new(&mut scenario));
-        assert!(!object_table::is_empty(&table), 0);
-        assert!(object_table::length(&table) == 2, 0);
+        assert!(table.is_empty(), 0);
+        assert!(table.length() == 0, 0);
+        table.add(0, new(&mut scenario));
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 1, 0);
+        table.add(1, new(&mut scenario));
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 2, 0);
         ts::end(scenario);
-        destroy(remove(&mut table, 0));
-        destroy(remove(&mut table, 1));
-        object_table::destroy_empty(table);
+        table.remove(0).destroy();
+        table.remove(1).destroy();
+        table.destroy_empty();
     }
 
     // transfer an object field from one "parent" to another
@@ -142,20 +141,20 @@ module sui::object_table_tests {
         let mut scenario = ts::begin(sender);
         let mut table1 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
         let mut table2 = object_table::new<u64, Counter>(ts::ctx(&mut scenario));
-        add(&mut table1, 0, new(&mut scenario));
-        assert!(contains(&table1, 0), 0);
-        assert!(!contains(&table2, 0), 0);
-        bump(borrow_mut(&mut table1, 0));
-        let c = remove(&mut table1, 0);
-        add(&mut table2, 0, c);
-        assert!(!contains(&table1, 0), 0);
-        assert!(contains(&table2, 0), 0);
-        bump(borrow_mut(&mut table2, 0));
-        assert!(count(borrow(&table2, 0)) == 2, 0);
+        table1.add(0, new(&mut scenario));
+        assert!(table1.contains(0), 0);
+        assert!(!table2.contains(0), 0);
+        bump(&mut table1[0]);
+        let c = table1.remove(0);
+        table2.add(0, c);
+        assert!(!table1.contains(0), 0);
+        assert!(table2.contains(0), 0);
+        bump(&mut table2[0]);
+        assert!(&table2[0].count() == 2, 0);
         ts::end(scenario);
-        destroy(remove(&mut table2, 0));
-        object_table::destroy_empty(table1);
-        object_table::destroy_empty(table2);
+        table2.remove(0).destroy();
+        table1.destroy_empty();
+        table2.destroy_empty();
     }
 
     fun new(scenario: &mut ts::Scenario): Counter {

--- a/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
@@ -173,7 +173,7 @@ module sui::object_table_tests {
 
     fun destroy(counter: Counter): u64 {
         let Counter { id, count } = counter;
-        object::delete(id);
+        id.delete();
         count
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_table_tests.move
@@ -15,7 +15,7 @@ module sui::object_table_tests {
     fun simple_all_functions() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new(scenario.ctx());
         let counter1 = new(&mut scenario);
         let id1 = object::id(&counter1);
         let counter2 = new(&mut scenario);
@@ -53,7 +53,7 @@ module sui::object_table_tests {
     fun add_duplicate() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new(scenario.ctx());
         table.add(b"hello", new(&mut scenario));
         table.add(b"hello", new(&mut scenario));
         abort 42
@@ -64,7 +64,7 @@ module sui::object_table_tests {
     fun borrow_missing() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let table = object_table::new<u64, Counter>(test_scenario::ctx(&mut scenario));
+        let table = object_table::new<u64, Counter>(scenario.ctx());
         &table[0];
         abort 42
     }
@@ -74,7 +74,7 @@ module sui::object_table_tests {
     fun borrow_mut_missing() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new<u64, Counter>(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new<u64, Counter>(scenario.ctx());
         &mut table[0];
         abort 42
     }
@@ -84,7 +84,7 @@ module sui::object_table_tests {
     fun remove_missing() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new<u64, Counter>(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new<u64, Counter>(scenario.ctx());
         table.remove(0).destroy();
         abort 42
     }
@@ -94,7 +94,7 @@ module sui::object_table_tests {
     fun destroy_non_empty() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new(scenario.ctx());
         table.add(0, new(&mut scenario));
         table.destroy_empty();
         scenario.end();
@@ -104,7 +104,7 @@ module sui::object_table_tests {
     fun sanity_check_contains() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new(scenario.ctx());
         assert!(!table.contains(0), 0);
         table.add(0, new(&mut scenario));
         assert!(table.contains(0), 0);
@@ -118,7 +118,7 @@ module sui::object_table_tests {
     fun sanity_check_size() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table = object_table::new(test_scenario::ctx(&mut scenario));
+        let mut table = object_table::new(scenario.ctx());
         assert!(table.is_empty(), 0);
         assert!(table.length() == 0, 0);
         table.add(0, new(&mut scenario));
@@ -138,8 +138,8 @@ module sui::object_table_tests {
     fun transfer_object() {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
-        let mut table1 = object_table::new<u64, Counter>(test_scenario::ctx(&mut scenario));
-        let mut table2 = object_table::new<u64, Counter>(test_scenario::ctx(&mut scenario));
+        let mut table1 = object_table::new<u64, Counter>(scenario.ctx());
+        let mut table2 = object_table::new<u64, Counter>(scenario.ctx());
         table1.add(0, new(&mut scenario));
         assert!(table1.contains(0), 0);
         assert!(!table2.contains(0), 0);
@@ -149,7 +149,7 @@ module sui::object_table_tests {
         assert!(!table1.contains(0), 0);
         assert!(table2.contains(0), 0);
         bump(&mut table2[0]);
-        assert!(&table2[0].count() == 2, 0);
+        assert!(table2[0].count() == 2, 0);
         scenario.end();
         table2.remove(0).destroy();
         table1.destroy_empty();
@@ -157,7 +157,7 @@ module sui::object_table_tests {
     }
 
     fun new(scenario: &mut test_scenario::Scenario): Counter {
-        Counter { id: test_scenario::new_object(scenario), count: 0 }
+        Counter { id: scenario.new_object(), count: 0 }
     }
 
     fun count(counter: &Counter): u64 {

--- a/crates/sui-framework/packages/sui-framework/tests/object_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_tests.move
@@ -18,10 +18,10 @@ module sui::object_tests {
         let uid0 = object::new(&mut ctx);
         let uid1 = object::new(&mut ctx);
 
-        let addr0 = object::uid_to_address(&uid0);
-        let byte0 = object::uid_to_bytes(&uid0);
-        let addr1 = object::uid_to_address(&uid1);
-        let byte1 = object::uid_to_bytes(&uid1);
+        let addr0 = uid0.to_address();
+        let byte0 = uid0.to_bytes();
+        let addr1 = uid1.to_address();
+        let byte1 = uid1.to_bytes();
 
         assert!(addr0 != addr1, EDifferentAddress);
         assert!(byte0 != byte1, EDifferentBytes);
@@ -29,7 +29,7 @@ module sui::object_tests {
         assert!(addr0 == address::from_bytes(byte0), EAddressRoundTrip);
         assert!(addr1 == address::from_bytes(byte1), EAddressRoundTrip);
 
-        object::delete(uid0);
-        object::delete(uid1);
+        uid0.delete();
+        uid1.delete();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/object_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/object_tests.move
@@ -4,8 +4,6 @@
 #[test_only]
 module sui::object_tests {
     use sui::address;
-    use sui::object;
-    use sui::tx_context;
 
     const EDifferentAddress: u64 = 0xF000;
     const EDifferentBytes: u64 = 0xF001;

--- a/crates/sui-framework/packages/sui-framework/tests/package_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/package_tests.move
@@ -3,13 +3,9 @@
 
 #[test_only]
 module sui::package_tests {
-    use std::ascii;
-    use sui::address;
-    use std::vector;
-    use sui::object::id_from_address as id;
     use sui::package::{Self, UpgradeCap, UpgradeTicket};
     use sui::test_utils;
-    use sui::test_scenario::{Self as test, Scenario, ctx};
+    use sui::test_scenario::{Self, Scenario};
 
     /// OTW for the package_tests module -- it can't actually be a OTW
     /// (name matching module name) because we need to be able to
@@ -21,61 +17,60 @@ module sui::package_tests {
 
     #[test]
     fun test_from_package() {
-        let mut test = test::begin(@0x1);
-        let pub = package::test_claim(TEST_OTW {}, ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let pub = package::test_claim(TEST_OTW {}, scenario.ctx());
 
-        assert!(package::from_package<CustomType>(&pub), 0);
-        assert!(package::from_package<Scenario>(&pub), 0);
-        assert!(&address::to_ascii_string(@0x2) == package::published_package(&pub), 0);
+        assert!(pub.from_package<CustomType>(), 0);
+        assert!(pub.from_package<Scenario>(), 0);
+        assert!(&@0x2.to_ascii_string() == pub.published_package(), 0);
 
-        package::burn_publisher(pub);
-        test::end(test);
+        pub.burn_publisher();
+        scenario.end();
     }
 
     #[test]
     fun test_from_module() {
-        let mut test = test::begin(@0x1);
-        let pub = package::test_claim(TEST_OTW {}, ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let pub = package::test_claim(TEST_OTW {}, scenario.ctx());
 
-        assert!(package::from_module<CustomType>(&pub), 0);
-        assert!(package::from_module<Scenario>(&pub) == false, 0);
+        assert!(pub.from_module<CustomType>(), 0);
+        assert!(pub.from_module<Scenario>() == false, 0);
 
-        assert!(&ascii::string(b"package_tests") == package::published_module(&pub), 0);
+        assert!(&b"package_tests".to_ascii_string() == pub.published_module(), 0);
 
-        package::burn_publisher(pub);
-        test::end(test);
+        pub.burn_publisher();
+        scenario.end();
     }
 
     #[test]
     fun test_restrict_upgrade_policy() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
 
-        assert!(package::upgrade_policy(&cap) == package::compatible_policy(), 0);
-        package::only_additive_upgrades(&mut cap);
-        assert!(package::upgrade_policy(&cap) == package::additive_policy(), 1);
-        package::only_dep_upgrades(&mut cap);
-        assert!(package::upgrade_policy(&cap) == package::dep_only_policy(), 2);
-        package::make_immutable(cap);
+        assert!(cap.upgrade_policy() == package::compatible_policy(), 0);
+        cap.only_additive_upgrades();
+        assert!(cap.upgrade_policy() == package::additive_policy(), 1);
+        cap.only_dep_upgrades();
+        assert!(cap.upgrade_policy() == package::dep_only_policy(), 2);
+        cap.make_immutable();
 
-        test::end(test);
+        scenario.end();
     }
 
     fun check_ticket(cap: &mut UpgradeCap, policy: u8, digest: vector<u8>): UpgradeTicket {
-        let ticket = package::authorize_upgrade(
-            cap,
+        let ticket = cap.authorize_upgrade(
             policy,
             digest,
         );
-        test_utils::assert_eq(package::ticket_policy(&ticket), policy);
-        test_utils::assert_ref_eq(package::ticket_digest(&ticket), &digest);
+        test_utils::assert_eq(ticket.ticket_policy(), policy);
+        test_utils::assert_ref_eq(ticket.ticket_digest(), &digest);
         ticket
     }
 
     #[test]
     fun test_upgrade_policy_reflected_in_ticket() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
         let mut policies = vector[
             package::dep_only_policy(),
             package::compatible_policy(),
@@ -83,62 +78,60 @@ module sui::package_tests {
             // Add more policies here when they exist.
         ];
 
-        while (!vector::is_empty(&policies)) {
-            let policy = vector::pop_back(&mut policies);
+        while (!policies.is_empty()) {
+            let policy = policies.pop_back();
             let ticket = check_ticket(&mut cap, policy, sui::hash::blake2b256(&vector[policy]));
-            let receipt = package::test_upgrade(ticket);
-            package::commit_upgrade(&mut cap, receipt);
+            let receipt = ticket.test_upgrade();
+            cap.commit_upgrade(receipt);
         };
 
-        package::make_immutable(cap);
-        test::end(test);
+        cap.make_immutable();
+        scenario.end();
     }
 
 
     #[test]
     fun test_full_upgrade_flow() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
-        package::only_additive_upgrades(&mut cap);
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
+        cap.only_additive_upgrades();
 
-        let version = package::version(&cap);
-        let ticket = package::authorize_upgrade(
-            &mut cap,
+        let version = cap.version();
+        let ticket = cap.authorize_upgrade(
             package::dep_only_policy(),
             sui::hash::blake2b256(&b"package contents"),
         );
 
-        test_utils::assert_eq(package::ticket_policy(&ticket), package::dep_only_policy());
-        let receipt = package::test_upgrade(ticket);
-        package::commit_upgrade(&mut cap, receipt);
-        assert!(package::version(&cap) == version + 1, 0);
+        test_utils::assert_eq(ticket.ticket_policy(), package::dep_only_policy());
+        let receipt = ticket.test_upgrade();
+        cap.commit_upgrade(receipt);
+        assert!(cap.version() == version + 1, 0);
 
-        package::make_immutable(cap);
-        test::end(test);
+        cap.make_immutable();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::package::ETooPermissive)]
     fun test_failure_to_widen_upgrade_policy() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
 
-        package::only_dep_upgrades(&mut cap);
-        assert!(package::upgrade_policy(&cap) == package::dep_only_policy(), 1);
+        cap.only_dep_upgrades();
+        assert!(cap.upgrade_policy() == package::dep_only_policy(), 1);
 
-        package::only_additive_upgrades(&mut cap);
+        cap.only_additive_upgrades();
         abort 0
     }
 
     #[test]
     #[expected_failure(abort_code = sui::package::ETooPermissive)]
     fun test_failure_to_authorize_overly_permissive_upgrade() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
-        package::only_dep_upgrades(&mut cap);
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
+        cap.only_dep_upgrades();
 
-        let _ticket = package::authorize_upgrade(
-            &mut cap,
+        let _ticket = cap.authorize_upgrade(
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents"),
         );
@@ -149,19 +142,17 @@ module sui::package_tests {
     #[test]
     #[expected_failure(abort_code = sui::package::EAlreadyAuthorized)]
     fun test_failure_to_authorize_multiple_upgrades() {
-        let mut test = test::begin(@0x1);
-        let mut cap = package::test_publish(id(@0x42), ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap = package::test_publish(@0x42.to_id(), scenario.ctx());
 
-        let _ticket0 = package::authorize_upgrade(
-            &mut cap,
+        let _ticket0 = cap.authorize_upgrade(
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents 0"),
         );
 
         // It's an error to try and issue more than one simultaneous
         // upgrade ticket -- this should abort.
-        let _ticket1 = package::authorize_upgrade(
-            &mut cap,
+        let _ticket1 = cap.authorize_upgrade(
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents 1"),
         );
@@ -172,22 +163,21 @@ module sui::package_tests {
     #[test]
     #[expected_failure(abort_code = sui::package::EWrongUpgradeCap)]
     fun test_failure_to_commit_upgrade_to_wrong_cap() {
-        let mut test = test::begin(@0x1);
-        let mut cap0 = package::test_publish(id(@0x42), ctx(&mut test));
-        let mut cap1 = package::test_publish(id(@0x43), ctx(&mut test));
+        let mut scenario = test_scenario::begin(@0x1);
+        let mut cap0 = package::test_publish(@0x42.to_id(), scenario.ctx());
+        let mut cap1 = package::test_publish(@0x43.to_id(), scenario.ctx());
 
-        let ticket1 = package::authorize_upgrade(
-            &mut cap1,
+        let ticket1 = cap1.authorize_upgrade(
             package::dep_only_policy(),
             sui::hash::blake2b256(&b"package contents 1"),
         );
 
-        test_utils::assert_eq(package::ticket_policy(&ticket1), package::dep_only_policy());
-        let receipt1 = package::test_upgrade(ticket1);
+        test_utils::assert_eq(ticket1.ticket_policy(), package::dep_only_policy());
+        let receipt1 = ticket1.test_upgrade();
 
         // Trying to update a cap with the receipt from some other cap
         // should fail with an abort.
-        package::commit_upgrade(&mut cap0, receipt1);
+        cap0.commit_upgrade(receipt1);
         abort 0
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -14,8 +14,7 @@ module sui::pay_tests {
 
     #[test]
     fun test_coin_split_n() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -40,13 +39,12 @@ module sui::pay_tests {
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun test_coin_split_n_to_vec() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -64,13 +62,12 @@ module sui::pay_tests {
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun test_split_vec() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -91,13 +88,12 @@ module sui::pay_tests {
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun test_split_and_transfer() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -112,14 +108,13 @@ module sui::pay_tests {
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = balance::ENotEnough)]
     fun test_split_and_transfer_fail() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -128,17 +123,16 @@ module sui::pay_tests {
         coin.split_and_transfer(20, TEST_SENDER_ADDR, scenario.ctx());
         scenario.next_tx(TEST_SENDER_ADDR);
         let coin_transfer_fail = scenario.take_from_sender<Coin<SUI>>();
-        assert!(&coin_transfer_fail.value() == 7, 0);
+        assert!(coin_transfer_fail.value() == 7, 0);
 
         test_utils::destroy(coin);
         test_utils::destroy(coin_transfer_fail);
-        scenario_val.end();
+        scenario.end();
     }
 
     #[test]
     fun test_join_vec_and_transfer() {
-        let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
         let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
@@ -156,6 +150,6 @@ module sui::pay_tests {
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
-        scenario_val.end();
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module sui::pay_tests {
     use std::vector;
-    use sui::test_scenario::{Self};
+    use sui::test_scenario;
     use sui::coin::{Self, Coin};
     use sui::pay;
     use sui::balance;
@@ -17,103 +17,103 @@ module sui::pay_tests {
     fun test_coin_split_n() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        pay::divide_and_keep(&mut coin, 3, test_scenario::ctx(scenario));
+        scenario.next_tx(TEST_SENDER_ADDR);
+        pay::divide_and_keep(&mut coin, 3, scenario.ctx());
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin2 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin2 = scenario.take_from_sender<Coin<SUI>>();
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        assert!(coin::value(&coin1) == 3, 0);
-        assert!(coin::value(&coin2) == 3, 0);
-        assert!(coin::value(&coin) == 4, 0);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        assert!(coin1.value() == 3, 0);
+        assert!(coin2.value() == 3, 0);
+        assert!(coin.value() == 4, 0);
         assert!(
-            !test_scenario::has_most_recent_for_sender<Coin<SUI>>(scenario),
+            !scenario.has_most_recent_for_sender<Coin<SUI>>(),
             1
         );
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_coin_split_n_to_vec() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let mut split_coins = coin::divide_into_n(&mut coin, 3, test_scenario::ctx(scenario));
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let mut split_coins = coin.divide_into_n(3, scenario.ctx());
 
         assert!(vector::length(&split_coins) == 2, 0);
         let coin1 = vector::pop_back(&mut split_coins);
         let coin2 = vector::pop_back(&mut split_coins);
-        assert!(coin::value(&coin1) == 3, 0);
-        assert!(coin::value(&coin2) == 3, 0);
-        assert!(coin::value(&coin) == 4, 0);
+        assert!(coin1.value() == 3, 0);
+        assert!(coin2.value() == 3, 0);
+        assert!(coin.value() == 4, 0);
 
         vector::destroy_empty(split_coins);
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_split_vec() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        scenario.next_tx(TEST_SENDER_ADDR);
         let v = vector[1, 4];
-        pay::split_vec(&mut coin, v, test_scenario::ctx(scenario));
+        pay::split_vec(&mut coin, v, scenario.ctx());
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin2 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin2 = scenario.take_from_sender<Coin<SUI>>();
 
-        assert!(coin::value(&coin1) == 4, 0);
-        assert!(coin::value(&coin2) == 1, 0);
-        assert!(coin::value(&coin) == 5, 0);
+        assert!(coin1.value() == 4, 0);
+        assert!(coin2.value() == 1, 0);
+        assert!(coin.value() == 5, 0);
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_split_and_transfer() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        scenario.next_tx(TEST_SENDER_ADDR);
         // Send 3 of 10
-        pay::split_and_transfer(&mut coin, 3, TEST_SENDER_ADDR, test_scenario::ctx(scenario));
+        pay::split_and_transfer(&mut coin, 3, TEST_SENDER_ADDR, scenario.ctx());
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        assert!(coin::value(&coin1) == 3, 0);
-        assert!(coin::value(&coin) == 7, 0);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
+        assert!(coin1.value() == 3, 0);
+        assert!(coin.value() == 7, 0);
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -121,42 +121,42 @@ module sui::pay_tests {
     fun test_split_and_transfer_fail() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        scenario.next_tx(TEST_SENDER_ADDR);
         // Send 20 of 10 (should fail)
-        pay::split_and_transfer(&mut coin, 20, TEST_SENDER_ADDR, test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin_transfer_fail = test_scenario::take_from_sender<Coin<SUI>>(scenario);
-        assert!(coin::value(&coin_transfer_fail) == 7, 0);
+        pay::split_and_transfer(&mut coin, 20, TEST_SENDER_ADDR, scenario.ctx());
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin_transfer_fail = scenario.take_from_sender<Coin<SUI>>();
+        assert!(&coin_transfer_fail.value() == 7, 0);
 
         test_utils::destroy(coin);
         test_utils::destroy(coin_transfer_fail);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_join_vec_and_transfer() {
         let mut scenario_val = test_scenario::begin(TEST_SENDER_ADDR);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
+        scenario.next_tx(TEST_SENDER_ADDR);
         // divide_into_n with `n = 4` creates a vector of `n-1` = `3` coins containing balance `2`
-        let coin_vector = coin::divide_into_n(&mut coin, 4, test_scenario::ctx(scenario));
+        let coin_vector = coin.divide_into_n(4, scenario.ctx());
         pay::join_vec_and_transfer(coin_vector, TEST_SENDER_ADDR);
 
-        test_scenario::next_tx(scenario, TEST_SENDER_ADDR);
-        let coin1 = test_scenario::take_from_sender<Coin<SUI>>(scenario);
+        scenario.next_tx(TEST_SENDER_ADDR);
+        let coin1 = scenario.take_from_sender<Coin<SUI>>();
 
         // result is `3` coins of balance `2`
-        assert!(coin::value(&coin1) == 6, 0);
-        assert!(coin::value(&coin) == 4, 0);
+        assert!(coin1.value() == 6, 0);
+        assert!(coin.value() == 4, 0);
 
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::pay_tests {
-    use std::vector;
     use sui::test_scenario;
     use sui::coin::{Self, Coin};
     use sui::pay;
@@ -21,7 +20,7 @@ module sui::pay_tests {
         let mut coin = coin::mint_for_testing<SUI>(10, ctx);
 
         scenario.next_tx(TEST_SENDER_ADDR);
-        pay::divide_and_keep(&mut coin, 3, scenario.ctx());
+        coin.divide_and_keep(3, scenario.ctx());
 
         scenario.next_tx(TEST_SENDER_ADDR);
         let coin1 = scenario.take_from_sender<Coin<SUI>>();
@@ -61,7 +60,7 @@ module sui::pay_tests {
         assert!(coin2.value() == 3, 0);
         assert!(coin.value() == 4, 0);
 
-        vector::destroy_empty(split_coins);
+        split_coins.destroy_empty();
         test_utils::destroy(coin);
         test_utils::destroy(coin1);
         test_utils::destroy(coin2);
@@ -77,7 +76,7 @@ module sui::pay_tests {
 
         scenario.next_tx(TEST_SENDER_ADDR);
         let v = vector[1, 4];
-        pay::split_vec(&mut coin, v, scenario.ctx());
+        coin.split_vec(v, scenario.ctx());
 
         scenario.next_tx(TEST_SENDER_ADDR);
         let coin1 = scenario.take_from_sender<Coin<SUI>>();
@@ -104,7 +103,7 @@ module sui::pay_tests {
 
         scenario.next_tx(TEST_SENDER_ADDR);
         // Send 3 of 10
-        pay::split_and_transfer(&mut coin, 3, TEST_SENDER_ADDR, scenario.ctx());
+        coin.split_and_transfer(3, TEST_SENDER_ADDR, scenario.ctx());
 
         scenario.next_tx(TEST_SENDER_ADDR);
         let coin1 = scenario.take_from_sender<Coin<SUI>>();
@@ -126,7 +125,7 @@ module sui::pay_tests {
 
         scenario.next_tx(TEST_SENDER_ADDR);
         // Send 20 of 10 (should fail)
-        pay::split_and_transfer(&mut coin, 20, TEST_SENDER_ADDR, scenario.ctx());
+        coin.split_and_transfer(20, TEST_SENDER_ADDR, scenario.ctx());
         scenario.next_tx(TEST_SENDER_ADDR);
         let coin_transfer_fail = scenario.take_from_sender<Coin<SUI>>();
         assert!(&coin_transfer_fail.value() == 7, 0);

--- a/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/pay_tests.move
@@ -54,9 +54,9 @@ module sui::pay_tests {
         scenario.next_tx(TEST_SENDER_ADDR);
         let mut split_coins = coin.divide_into_n(3, scenario.ctx());
 
-        assert!(vector::length(&split_coins) == 2, 0);
-        let coin1 = vector::pop_back(&mut split_coins);
-        let coin2 = vector::pop_back(&mut split_coins);
+        assert!(split_coins.length() == 2, 0);
+        let coin1 = split_coins.pop_back();
+        let coin2 = split_coins.pop_back();
         assert!(coin1.value() == 3, 0);
         assert!(coin2.value() == 3, 0);
         assert!(coin.value() == 4, 0);

--- a/crates/sui-framework/packages/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/prover_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::prover_tests {
-    use sui::object::UID;
 
     public struct Obj has key, store {
         id: UID

--- a/crates/sui-framework/packages/sui-framework/tests/prover_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/prover_tests.move
@@ -27,7 +27,7 @@ module sui::prover_tests {
 
     public fun simple_delete(o: Obj) {
         let Obj { id } = o;
-        sui::object::delete(id);
+        id.delete();
     }
 
     // ====================================================================

--- a/crates/sui-framework/packages/sui-framework/tests/random_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/random_tests.move
@@ -22,18 +22,14 @@ module sui::random_tests {
 
     #[test]
     fun random_test_basic_flow() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
-
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
@@ -591,95 +587,89 @@ module sui::random_tests {
         let _output = generate_u128_in_range(&mut gen, 511, 500);
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun random_tests_update_after_epoch_change() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
-
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             vector[0, 1, 2, 3],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
         update_randomness_state_for_testing(
             &mut random_state,
             1,
             vector[4, 5, 6, 7],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
 
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
 
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             vector[8, 9, 10, 11],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = random::EInvalidRandomnessUpdate)]
     fun random_tests_duplicate() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
-
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             vector[0, 1, 2, 3],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             vector[0, 1, 2, 3],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = random::EInvalidRandomnessUpdate)]
     fun random_tests_out_of_order() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
-
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
+        let mut random_state = scenario.take_shared<Random>();
         update_randomness_state_for_testing(
             &mut random_state,
             0,
             vector[0, 1, 2, 3],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
         update_randomness_state_for_testing(
             &mut random_state,
             3,
             vector[0, 1, 2, 3],
-            test_scenario::ctx(scenario),
+            scenario.ctx()
         );
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/random_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/random_tests.move
@@ -13,7 +13,10 @@ module sui::random_tests {
 
     #[test]
     fun random_test_basic_flow() {
-        let scenario = test_scenario::begin(@0x0);
+        let mut scenario = test_scenario::begin(@0x0);
+
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
         let mut random_state = scenario.take_shared<Random>();
         random_state.update_randomness_state_for_testing(
@@ -390,11 +393,11 @@ module sui::random_tests {
         // check that numbers indeed eventaually move to all positions
         loop {
             gen.shuffle(&mut v);
-            if ((v.borrow[4] == 1u16)) break;
+            if ((v[4] == 1u16)) break;
         };
         loop {
             gen.shuffle(&mut v);
-            if ((v.borrow[0] == 2u16)) break;
+            if ((v[0] == 2u16)) break;
         };
 
         let mut v: vector<u32> = vector[];

--- a/crates/sui-framework/packages/sui-framework/tests/random_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/random_tests.move
@@ -4,19 +4,10 @@
 #[test_only]
 #[allow(unused_use)]
 module sui::random_tests {
-    use std::vector;
     use sui::test_utils::assert_eq;
     use sui::bcs;
     use sui::test_scenario;
-    use sui::random::{
-        Self,
-        Random,
-        update_randomness_state_for_testing, new_generator, generator_seed, generator_counter, generator_buffer,
-        generate_bytes,
-        generate_u256, generate_u128, generate_u64, generate_u32, generate_u16, generate_u8, generate_u128_in_range,
-        generate_u64_in_range, generate_u32_in_range, generate_u16_in_range, generate_u8_in_range, generate_bool,
-        shuffle,
-    };
+    use sui::random::{Self, Random};
 
     // TODO: add a test from https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-22r1a.pdf ?
 
@@ -25,18 +16,17 @@ module sui::random_tests {
         let scenario = test_scenario::begin(@0x0);
 
         let mut random_state = scenario.take_shared<Random>();
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
             scenario.ctx(),
         );
 
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let _o256 = generate_u256(&mut gen);
+        let mut gen = random_state.new_generator(scenario.ctx());
+        let _o256 = gen.generate_u256();
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
@@ -45,546 +35,527 @@ module sui::random_tests {
         let global_random2 = x"2F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1A";
 
         // Create Random
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::end(scenario_val);
+        let mut scenario = test_scenario::begin(@0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.end();
 
         // Set random to global_random1
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut scenario = test_scenario::begin(@0x0);
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             global_random1,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
-        test_scenario::next_tx(scenario, @0x0);
-        let gen1 = new_generator(&random_state, test_scenario::ctx(scenario));
+        scenario.next_tx(@0x0);
+        let gen1 = random_state.new_generator(scenario.ctx());
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
 
         // Set random again to global_random1
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut scenario = test_scenario::begin(@0x0);
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             1,
             global_random1,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
-        test_scenario::next_tx(scenario, @0x0);
-        let gen2 = new_generator(&random_state, test_scenario::ctx(scenario));
+        scenario.next_tx(@0x0);
+        let gen2 = random_state.new_generator(scenario.ctx());
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
 
         // Set random to global_random2
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut scenario = test_scenario::begin(@0x0);
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             2,
             global_random2,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
-        test_scenario::next_tx(scenario, @0x0);
-        let gen3 = new_generator(&random_state, test_scenario::ctx(scenario));
-        let gen4 = new_generator(&random_state, test_scenario::ctx(scenario));
+        scenario.next_tx(@0x0);
+        let gen3 = random_state.new_generator(scenario.ctx());
+        let gen4 = random_state.new_generator(scenario.ctx());
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
 
-        assert!(generator_counter(&gen1) == 0, 0);
-        assert!(vector::is_empty(generator_buffer(&gen1)), 0);
-        assert!(generator_seed(&gen1) == generator_seed(&gen2), 0);
-        assert!(generator_seed(&gen1) != generator_seed(&gen3), 0);
-        assert!(generator_seed(&gen3) != generator_seed(&gen4), 0);
+        assert!(gen1.generator_counter() == 0, 0);
+        assert!(gen1.generator_buffer().is_empty(), 0);
+        assert!(gen1.generator_seed() == gen2.generator_seed(), 0);
+        assert!(gen1.generator_seed() != gen3.generator_seed(), 0);
+        assert!(gen3.generator_seed() != gen4.generator_seed(), 0);
     }
 
     #[test]
     fun random_tests_regression() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // Regression (not critical for security, but still an indication that something is wrong).
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let o256 = generate_u256(&mut gen);
+        let mut gen = random_state.new_generator(scenario.ctx());
+        let o256 = gen.generate_u256();
         assert!(o256 == 85985798878417437391783029796051418802193098452099584085821130568389745847195, 0);
-        let o128 = generate_u128(&mut gen);
+        let o128 = gen.generate_u128();
         assert!(o128 == 332057125240408555349883177059479920214, 0);
-        let o64 = generate_u64(&mut gen);
+        let o64 = gen.generate_u64();
         assert!(o64 == 13202990749492462163, 0);
-        let o32 = generate_u32(&mut gen);
+        let o32 = gen.generate_u32();
         assert!(o32 == 3316307786, 0);
-        let o16 = generate_u16(&mut gen);
+        let o16 = gen.generate_u16();
         assert!(o16 == 5961, 0);
-        let o8 = generate_u8(&mut gen);
+        let o8 = gen.generate_u8();
         assert!(o8 == 222, 0);
-        let output = generate_u128_in_range(&mut gen, 51, 123456789);
+        let output = gen.generate_u128_in_range(51, 123456789);
         assert!(output == 99859235, 0);
-        let output = generate_u64_in_range(&mut gen, 51, 123456789);
+        let output = gen.generate_u64_in_range(51, 123456789);
         assert!(output == 87557915, 0);
-        let output = generate_u32_in_range(&mut gen, 51, 123456789);
+        let output = gen.generate_u32_in_range(51, 123456789);
         assert!(output == 57096277, 0);
-        let output = generate_u16_in_range(&mut gen, 51, 1234);
+        let output = gen.generate_u16_in_range(51, 1234);
         assert!(output == 349, 0);
-        let output = generate_u8_in_range(&mut gen, 51, 123);
+        let output = gen.generate_u8_in_range(51, 123);
         assert!(output == 60, 0);
-        let output = generate_bytes(&mut gen, 11);
+        let output = gen.generate_bytes(11);
         assert!(output == x"252cfdbb59205fcc509c9e", 0);
-        let output = generate_bool(&mut gen);
+        let output = gen.generate_bool();
         assert!(output == true, 0);
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_bytes() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
+        let mut gen = random_state.new_generator(scenario.ctx());
 
         // Check the output size & internal generator state
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output = generate_bytes(&mut gen, 1);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 31, 0);
-        assert!(vector::length(&output) == 1, 0);
-        let output = generate_bytes(&mut gen, 2);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 29, 0);
-        assert!(vector::length(&output) == 2, 0);
-        let output = generate_bytes(&mut gen, 29);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 0, 0);
-        assert!(vector::length(&output) == 29, 0);
-        let output = generate_bytes(&mut gen, 11);
-        assert!(generator_counter(&gen) == 2, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 21, 0);
-        assert!(vector::length(&output) == 11, 0);
-        let output = generate_bytes(&mut gen, 32 * 2);
-        assert!(generator_counter(&gen) == 4, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 21, 0);
-        assert!(vector::length(&output) == 32 * 2, 0);
-        let output = generate_bytes(&mut gen, 32 * 5 + 5);
-        assert!(generator_counter(&gen) == 9, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 16, 0);
-        assert!(vector::length(&output) == 32 * 5 + 5, 0);
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output = gen.generate_bytes(1);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 31, 0);
+        assert!(output.length() == 1, 0);
+        let output = gen.generate_bytes(2);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 29, 0);
+        assert!(output.length() == 2, 0);
+        let output = gen.generate_bytes(29);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 0, 0);
+        assert!(output.length() == 29, 0);
+        let output = gen.generate_bytes(11);
+        assert!(gen.generator_counter() == 2, 0);
+        assert!(gen.generator_buffer().length() == 21, 0);
+        assert!(output.length() == 11, 0);
+        let output = gen.generate_bytes(32 * 2);
+        assert!(gen.generator_counter() == 4, 0);
+        assert!(gen.generator_buffer().length() == 21, 0);
+        assert!(output.length() == 32 * 2, 0);
+        let output = gen.generate_bytes(32 * 5 + 5);
+        assert!(gen.generator_counter() == 9, 0);
+        assert!(gen.generator_buffer().length() == 16, 0);
+        assert!(output.length() == 32 * 5 + 5, 0);
 
         // Sanity check that the output is not all zeros.
-        let output = generate_bytes(&mut gen, 10);
+        let output = gen.generate_bytes(10);
         let mut i = 0;
         loop {
             // should break before the overflow
-            if (*vector::borrow(&output, i) != 0u8) break;
+            if (output[i] != 0u8) break;
             i = i + 1;
         };
 
         // Sanity check that 2 different outputs are different.
-        let output1 = generate_bytes(&mut gen, 10);
-        let output2 = generate_bytes(&mut gen, 10);
+        let output1 = gen.generate_bytes(10);
+        let output2 = gen.generate_bytes(10);
         i = 0;
         loop {
             // should break before the overflow
-            if (vector::borrow(&output1, i) != vector::borrow(&output2, i)) break;
+            if (&output1[i] != &output2[i]) break;
             i = i + 1;
         };
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun random_tests_uints() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // u256
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u256(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 0, 0);
-        let output2 = generate_u256(&mut gen);
-        assert!(generator_counter(&gen) == 2, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 0, 0);
+        let mut gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u256();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 0, 0);
+        let output2 = gen.generate_u256();
+        assert!(gen.generator_counter() == 2, 0);
+        assert!(gen.generator_buffer().length() == 0, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u8(&mut gen);
-        let _output4 = generate_u256(&mut gen);
-        assert!(generator_counter(&gen) == 4, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 31, 0);
+        let _output3 = gen.generate_u8();
+        let _output4 = gen.generate_u256();
+        assert!(gen.generator_counter() == 4, 0);
+        assert!(gen.generator_buffer().length() == 31, 0);
         // Check that we indeed generate all bytes as random
         let mut i = 0;
         while (i < 32) {
-            let x = generate_u256(&mut gen);
+            let x = gen.generate_u256();
             let x_bytes = bcs::to_bytes(&x);
-            if (*vector::borrow(&x_bytes, i) != 0u8) i = i + 1;
+            if (x_bytes[i] != 0u8) i = i + 1;
         };
 
         // u128
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u128(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 16, 0);
-        let output2 = generate_u128(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 0, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u128();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 16, 0);
+        let output2 = gen.generate_u128();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 0, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u8(&mut gen);
-        let _output4 = generate_u128(&mut gen);
-        assert!(generator_counter(&gen) == 2, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 15, 0);
+        let _output3 = gen.generate_u8();
+        let _output4 = gen.generate_u128();
+        assert!(gen.generator_counter() == 2, 0);
+        assert!(gen.generator_buffer().length() == 15, 0);
         let mut i = 0;
         while (i < 16) {
-            let x = generate_u128(&mut gen);
+            let x = gen.generate_u128();
             let x_bytes = bcs::to_bytes(&x);
-            if (*vector::borrow(&x_bytes, i) != 0u8) i = i + 1;
+            if (x_bytes[i] != 0u8) i = i + 1;
         };
 
         // u64
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u64(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 24, 0);
-        let output2 = generate_u64(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 16, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u64();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 24, 0);
+        let output2 = gen.generate_u64();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 16, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u8(&mut gen);
-        let _output4 = generate_u64(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 7, 0);
+        let _output3 = gen.generate_u8();
+        let _output4 = gen.generate_u64();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 7, 0);
         let mut i = 0;
         while (i < 8) {
-            let x = generate_u64(&mut gen);
+            let x = gen.generate_u64();
             let x_bytes = bcs::to_bytes(&x);
-            if (*vector::borrow(&x_bytes, i) != 0u8) i = i + 1;
+            if (x_bytes[i] != 0u8) i = i + 1;
         };
 
         // u32
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u32(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 28, 0);
-        let output2 = generate_u32(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 24, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u32();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 28, 0);
+        let output2 = gen.generate_u32();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 24, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u8(&mut gen);
-        let _output4 = generate_u32(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 19, 0);
+        let _output3 = gen.generate_u8();
+        let _output4 = gen.generate_u32();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 19, 0);
         let mut i = 0;
         while (i < 4) {
-            let x = generate_u32(&mut gen);
+            let x = gen.generate_u32();
             let x_bytes = bcs::to_bytes(&x);
-            if (*vector::borrow(&x_bytes, i) != 0u8) i = i + 1;
+            if (x_bytes[i] != 0u8) i = i + 1;
         };
 
         // u16
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u16(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 30, 0);
-        let output2 = generate_u16(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 28, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u16();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 30, 0);
+        let output2 = gen.generate_u16();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 28, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u8(&mut gen);
-        let _output4 = generate_u16(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 25, 0);
+        let _output3 = gen.generate_u8();
+        let _output4 = gen.generate_u16();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 25, 0);
         let mut i = 0;
         while (i < 2) {
-            let x = generate_u16(&mut gen);
+            let x = gen.generate_u16();
             let x_bytes = bcs::to_bytes(&x);
-            if (*vector::borrow(&x_bytes, i) != 0u8) i = i + 1;
+            if (x_bytes[i] != 0u8) i = i + 1;
         };
 
         // u8
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_u8(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 31, 0);
-        let output2 = generate_u8(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 30, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_u8();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 31, 0);
+        let output2 = gen.generate_u8();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 30, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u128(&mut gen);
-        let _output4 = generate_u8(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 13, 0);
+        let _output3 = gen.generate_u128();
+        let _output4 = gen.generate_u8();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 13, 0);
         loop {
-            let x = generate_u8(&mut gen);
+            let x = gen.generate_u8();
             if (x != 0u8) break
         };
 
         // bool
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        assert!(vector::is_empty(generator_buffer(&gen)), 0);
-        let output1 = generate_bool(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 31, 0);
-        let output2 = generate_bool(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 30, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        assert!(gen.generator_buffer().is_empty(), 0);
+        let output1 = gen.generate_bool();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 31, 0);
+        let output2 = gen.generate_bool();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 30, 0);
         assert!(output1 != output2, 0);
-        let _output3 = generate_u128(&mut gen);
-        let _output4 = generate_u8(&mut gen);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 13, 0);
+        let _output3 = gen.generate_u128();
+        let _output4 = gen.generate_u8();
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 13, 0);
         let mut saw_false = false;
         loop {
-            let x = generate_bool(&mut gen);
+            let x = gen.generate_bool();
             saw_false = saw_false || !x;
             if (x && saw_false) break;
         };
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun test_shuffle() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
+        let mut gen = random_state.new_generator(scenario.ctx());
         let mut v: vector<u16> = vector[0, 1, 2, 3, 4];
-        shuffle(&mut gen, &mut v);
-        assert!(vector::length(&v) == 5, 0);
+        gen.shuffle(&mut v);
+        assert!(v.length() == 5, 0);
         let mut i: u16 = 0;
         while (i < 5) {
-            assert!(vector::contains(&v, &i), 0);
+            assert!(v.contains(&i), 0);
             i = i + 1;
         };
 
         // check that numbers indeed eventaually move to all positions
         loop {
-            shuffle(&mut gen, &mut v);
-            if ((*vector::borrow(&v, 4) == 1u16)) break;
+            gen.shuffle(&mut v);
+            if ((v.borrow[4] == 1u16)) break;
         };
         loop {
-            shuffle(&mut gen, &mut v);
-            if ((*vector::borrow(&v, 0) == 2u16)) break;
+            gen.shuffle(&mut v);
+            if ((v.borrow[0] == 2u16)) break;
         };
 
         let mut v: vector<u32> = vector[];
-        shuffle(&mut gen, &mut v);
-        assert!(vector::length(&v) == 0, 0);
+        gen.shuffle(&mut v);
+        assert!(v.length() == 0, 0);
 
         let mut v: vector<u32> = vector[321];
-        shuffle(&mut gen, &mut v);
-        assert!(vector::length(&v) == 1, 0);
-        assert!(*vector::borrow(&v, 0) == 321u32, 0);
+        gen.shuffle(&mut v);
+        assert!(v.length() == 1, 0);
+        assert!(v[0] == 321u32, 0);
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     fun random_tests_in_range() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // generate_u128_in_range
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let output1 = generate_u128_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 8, 0);
-        let output2 = generate_u128_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 2, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 16, 0);
+        let mut gen = random_state.new_generator(scenario.ctx());
+        let output1 = gen.generate_u128_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 8, 0);
+        let output2 = gen.generate_u128_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 2, 0);
+        assert!(gen.generator_buffer().length() == 16, 0);
         assert!(output1 != output2, 0);
-        let output = generate_u128_in_range(&mut gen, 123454321, 123454321 + 1);
+        let output = gen.generate_u128_in_range(123454321, 123454321 + 1);
         assert!((output == 123454321) || (output == 123454321 + 1), 0);
         // test the edge case of u128_in_range (covers also the other in_range functions)
-        let _output = generate_u128_in_range(&mut gen, 0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+        let _output = gen.generate_u128_in_range(0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
         let mut i = 0;
         while (i < 50) {
-            let min = generate_u128(&mut gen);
-            let max = min + (generate_u64(&mut gen) as u128);
-            let output = generate_u128_in_range(&mut gen, min, max);
+            let min = gen.generate_u128();
+            let max = min + (gen.generate_u64() as u128);
+            let output = gen.generate_u128_in_range(min, max);
             assert!(output >= min, 0);
             assert!(output <= max, 0);
             i = i + 1;
         };
 
         // generate_u64_in_range
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let output1 = generate_u64_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 16, 0);
-        let output2 = generate_u64_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 0, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        let output1 = gen.generate_u64_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 16, 0);
+        let output2 = gen.generate_u64_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 0, 0);
         assert!(output1 != output2, 0);
-        let output = generate_u64_in_range(&mut gen, 123454321, 123454321 + 1);
+        let output = gen.generate_u64_in_range(123454321, 123454321 + 1);
         assert!((output == 123454321) || (output == 123454321 + 1), 0);
         let mut i = 0;
         while (i < 50) {
-            let min = generate_u64(&mut gen);
-            let max = min + (generate_u32(&mut gen) as u64);
-            let output = generate_u64_in_range(&mut gen, min, max);
+            let min = gen.generate_u64();
+            let max = min + (gen.generate_u32() as u64);
+            let output = gen.generate_u64_in_range(min, max);
             assert!(output >= min, 0);
             assert!(output <= max, 0);
             i = i + 1;
         };
 
         // generate_u32_in_range
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let output1 = generate_u32_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 20, 0);
-        let output2 = generate_u32_in_range(&mut gen, 11, 123454321);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 8, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        let output1 = gen.generate_u32_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 20, 0);
+        let output2 = gen.generate_u32_in_range(11, 123454321);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 8, 0);
         assert!(output1 != output2, 0);
-        let output = generate_u32_in_range(&mut gen, 123454321, 123454321 + 1);
+        let output = gen.generate_u32_in_range(123454321, 123454321 + 1);
         assert!((output == 123454321) || (output == 123454321 + 1), 0);
         let mut i = 0;
         while (i < 50) {
-            let min = generate_u32(&mut gen);
-            let max = min + (generate_u16(&mut gen) as u32);
-            let output = generate_u32_in_range(&mut gen, min, max);
+            let min = gen.generate_u32();
+            let max = min + (gen.generate_u16() as u32);
+            let output = gen.generate_u32_in_range(min, max);
             assert!(output >= min, 0);
             assert!(output <= max, 0);
             i = i + 1;
         };
 
         // generate_u16_in_range
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let output1 = generate_u16_in_range(&mut gen, 11, 12345);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 22, 0);
-        let output2 = generate_u16_in_range(&mut gen, 11, 12345);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 12, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        let output1 = gen.generate_u16_in_range(11, 12345);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 22, 0);
+        let output2 = gen.generate_u16_in_range(11, 12345);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 12, 0);
         assert!(output1 != output2, 0);
-        let output = generate_u16_in_range(&mut gen, 12345, 12345 + 1);
+        let output = gen.generate_u16_in_range(12345, 12345 + 1);
         assert!((output == 12345) || (output == 12345 + 1), 0);
         let mut i = 0;
         while (i < 50) {
-            let min = generate_u16(&mut gen);
-            let max = min + (generate_u8(&mut gen) as u16);
-            let output = generate_u16_in_range(&mut gen, min, max);
+            let min = gen.generate_u16();
+            let max = min + (gen.generate_u8() as u16);
+            let output = gen.generate_u16_in_range(min, max);
             assert!(output >= min, 0);
             assert!(output <= max, 0);
             i = i + 1;
         };
 
         // generate_u8_in_range
-        gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let output1 = generate_u8_in_range(&mut gen, 11, 123);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 23, 0);
-        let output2 = generate_u8_in_range(&mut gen, 11, 123);
-        assert!(generator_counter(&gen) == 1, 0);
-        assert!(vector::length(generator_buffer(&gen)) == 14, 0);
+        gen = random_state.new_generator(scenario.ctx());
+        let output1 = gen.generate_u8_in_range(11, 123);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 23, 0);
+        let output2 = gen.generate_u8_in_range(11, 123);
+        assert!(gen.generator_counter() == 1, 0);
+        assert!(gen.generator_buffer().length() == 14, 0);
         assert!(output1 != output2, 0);
-        let output = generate_u8_in_range(&mut gen, 123, 123 + 1);
+        let output = gen.generate_u8_in_range(123, 123 + 1);
         assert!((output == 123) || (output == 123 + 1), 0);
         let mut i = 0;
         while (i < 50) {
-            let (min, max) = (generate_u8(&mut gen), generate_u8(&mut gen));
+            let (min, max) = (gen.generate_u8(), gen.generate_u8());
             let (min, max) = if (min < max) (min, max) else (max, min);
             let (min, max) = if (min == max) (min, max + 1) else (min, max);
-            let output = generate_u8_in_range(&mut gen, min, max);
+            let output = gen.generate_u8_in_range(min, max);
             assert!(output >= min, 0);
             assert!(output <= max, 0);
             i = i + 1;
         };
 
         // in range with min=max should return min
-        assert_eq(generate_u32_in_range(&mut gen, 123, 123), 123);
+        assert_eq(gen.generate_u32_in_range(123, 123), 123);
 
         test_scenario::return_shared(random_state);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = random::EInvalidRange)]
     fun random_tests_invalid_range() {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(@0x0);
 
-        random::create_for_testing(test_scenario::ctx(scenario));
-        test_scenario::next_tx(scenario, @0x0);
+        random::create_for_testing(scenario.ctx());
+        scenario.next_tx(@0x0);
 
-        let mut random_state = test_scenario::take_shared<Random>(scenario);
-        update_randomness_state_for_testing(
-            &mut random_state,
+        let mut random_state = scenario.take_shared<Random>();
+        random_state.update_randomness_state_for_testing(
             0,
             x"1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F1F",
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
-        let mut gen = new_generator(&random_state, test_scenario::ctx(scenario));
-        let _output = generate_u128_in_range(&mut gen, 511, 500);
+        let mut gen = random_state.new_generator(scenario.ctx());
+        let _output = gen.generate_u128_in_range(511, 500);
 
         test_scenario::return_shared(random_state);
         scenario.end();
@@ -597,14 +568,12 @@ module sui::random_tests {
         scenario.next_tx(@0x0);
 
         let mut random_state = scenario.take_shared<Random>();
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             vector[0, 1, 2, 3],
             scenario.ctx()
         );
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             1,
             vector[4, 5, 6, 7],
             scenario.ctx()
@@ -612,8 +581,7 @@ module sui::random_tests {
 
         scenario.next_epoch(@0x0);
 
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             vector[8, 9, 10, 11],
             scenario.ctx()
@@ -631,14 +599,12 @@ module sui::random_tests {
         scenario.next_tx(@0x0);
 
         let mut random_state = scenario.take_shared<Random>();
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             vector[0, 1, 2, 3],
             scenario.ctx()
         );
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             vector[0, 1, 2, 3],
             scenario.ctx()
@@ -656,14 +622,12 @@ module sui::random_tests {
         scenario.next_tx(@0x0);
 
         let mut random_state = scenario.take_shared<Random>();
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             0,
             vector[0, 1, 2, 3],
             scenario.ctx()
         );
-        update_randomness_state_for_testing(
-            &mut random_state,
+        random_state.update_randomness_state_for_testing(
             3,
             vector[0, 1, 2, 3],
             scenario.ctx()

--- a/crates/sui-framework/packages/sui-framework/tests/table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/table_tests.move
@@ -12,28 +12,28 @@ module sui::table_tests {
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new(scenario.ctx());
         // add fields
-        add(&mut table, b"hello", 0);
-        add(&mut table, b"goodbye", 1);
+        table.add(b"hello", 0);
+        table.add(b"goodbye", 1);
         // check they exist
-        assert!(contains(&table, b"hello"), 0);
-        assert!(contains(&table, b"goodbye"), 0);
+        assert!(table.contains(b"hello"), 0);
+        assert!(table.contains(b"goodbye"), 0);
         // check the values
-        assert!(*borrow(&table, b"hello") == 0, 0);
-        assert!(*borrow(&table, b"goodbye") == 1, 0);
+        assert!(table[b"hello"] == 0, 0);
+        assert!(table[b"goodbye"] == 1, 0);
         // mutate them
-        *borrow_mut(&mut table, b"hello") = *borrow(&table, b"hello") * 2;
-        *borrow_mut(&mut table, b"goodbye") = *borrow(&table, b"goodbye") * 2;
+        *&mut table[b"hello"] = table[b"hello"] * 2;
+        *&mut table[b"goodbye"] = table[b"goodbye"] * 2;
         // check the new value
-        assert!(*borrow(&table, b"hello") == 0, 0);
-        assert!(*borrow(&table, b"goodbye") == 2, 0);
+        assert!(table[b"hello"] == 0, 0);
+        assert!(table[b"goodbye"] == 2, 0);
         // remove the value and check it
-        assert!(remove(&mut table, b"hello") == 0, 0);
-        assert!(remove(&mut table, b"goodbye") == 2, 0);
+        assert!(table.remove(b"hello") == 0, 0);
+        assert!(table.remove(b"goodbye") == 2, 0);
         // verify that they are not there
-        assert!(!contains(&table, b"hello"), 0);
-        assert!(!contains(&table, b"goodbye"), 0);
+        assert!(!table.contains(b"hello"), 0);
+        assert!(!table.contains(b"goodbye"), 0);
         scenario.end();
-        table::destroy_empty(table);
+        table.destroy_empty();
     }
 
     #[test]
@@ -42,8 +42,8 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new(scenario.ctx());
-        add(&mut table, b"hello", 0);
-        add(&mut table, b"hello", 1);
+        table.add(b"hello", 0);
+        table.add(b"hello", 1);
         abort 42
     }
 
@@ -53,7 +53,7 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let table = table::new<u64, u64>(scenario.ctx());
-        borrow(&table, 0);
+        &table[0];
         abort 42
     }
 
@@ -63,7 +63,7 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        borrow_mut(&mut table, 0);
+        &mut table[0];
         abort 42
     }
 
@@ -73,7 +73,7 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        remove(&mut table, 0);
+        table.remove(0);
         abort 42
     }
 
@@ -83,8 +83,8 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        add(&mut table, 0, 0);
-        table::destroy_empty(table);
+        table.add(0, 0);
+        table.destroy_empty();
         scenario.end();
     }
 
@@ -93,12 +93,12 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        assert!(!contains(&table, 0), 0);
-        add(&mut table, 0, 0);
+        assert!(!table.contains(0), 0);
+        table.add(0, 0);
         assert!(contains<u64, u64>(&table, 0), 0);
         assert!(!contains<u64, u64>(&table, 1), 0);
         scenario.end();
-        table::drop(table);
+        table.drop();
     }
 
     #[test]
@@ -106,10 +106,10 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        add(&mut table, 0, 0);
-        assert!(table::length(&table) == 1, 0);
+        table.add(0, 0);
+        assert!(table.length() == 1, 0);
         scenario.end();
-        table::drop(table);
+        table.drop();
     }
 
     #[test]
@@ -117,15 +117,15 @@ module sui::table_tests {
         let sender = @0x0;
         let mut scenario = test_scenario::begin(sender);
         let mut table = table::new<u64, u64>(scenario.ctx());
-        assert!(table::is_empty(&table), 0);
-        assert!(table::length(&table) == 0, 0);
-        add(&mut table, 0, 0);
-        assert!(!table::is_empty(&table), 0);
-        assert!(table::length(&table) == 1, 0);
-        add(&mut table, 1, 0);
-        assert!(!table::is_empty(&table), 0);
-        assert!(table::length(&table) == 2, 0);
+        assert!(table.is_empty(), 0);
+        assert!(table.length() == 0, 0);
+        table.add(0, 0);
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 1, 0);
+        table.add(1, 0);
+        assert!(!table.is_empty(), 0);
+        assert!(table.length() == 2, 0);
         scenario.end();
-        table::drop(table);
+        table.drop();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/table_tests.move
@@ -4,13 +4,13 @@
 #[test_only]
 module sui::table_tests {
     use sui::table::{Self, add, contains, borrow, borrow_mut, remove};
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
 
     #[test]
     fun simple_all_functions() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new(scenario.ctx());
         // add fields
         add(&mut table, b"hello", 0);
         add(&mut table, b"goodbye", 1);
@@ -32,7 +32,7 @@ module sui::table_tests {
         // verify that they are not there
         assert!(!contains(&table, b"hello"), 0);
         assert!(!contains(&table, b"goodbye"), 0);
-        ts::end(scenario);
+        scenario.end();
         table::destroy_empty(table);
     }
 
@@ -40,8 +40,8 @@ module sui::table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
     fun add_duplicate() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new(scenario.ctx());
         add(&mut table, b"hello", 0);
         add(&mut table, b"hello", 1);
         abort 42
@@ -51,8 +51,8 @@ module sui::table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let table = table::new<u64, u64>(scenario.ctx());
         borrow(&table, 0);
         abort 42
     }
@@ -61,8 +61,8 @@ module sui::table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun borrow_mut_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         borrow_mut(&mut table, 0);
         abort 42
     }
@@ -71,8 +71,8 @@ module sui::table_tests {
     #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
     fun remove_missing() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         remove(&mut table, 0);
         abort 42
     }
@@ -81,42 +81,42 @@ module sui::table_tests {
     #[expected_failure(abort_code = sui::table::ETableNotEmpty)]
     fun destroy_non_empty() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         add(&mut table, 0, 0);
         table::destroy_empty(table);
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun sanity_check_contains() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         assert!(!contains(&table, 0), 0);
         add(&mut table, 0, 0);
         assert!(contains<u64, u64>(&table, 0), 0);
         assert!(!contains<u64, u64>(&table, 1), 0);
-        ts::end(scenario);
+        scenario.end();
         table::drop(table);
     }
 
     #[test]
     fun sanity_check_drop() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         add(&mut table, 0, 0);
         assert!(table::length(&table) == 1, 0);
-        ts::end(scenario);
+        scenario.end();
         table::drop(table);
     }
 
     #[test]
     fun sanity_check_size() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut table = table::new<u64, u64>(ts::ctx(&mut scenario));
+        let mut scenario = test_scenario::begin(sender);
+        let mut table = table::new<u64, u64>(scenario.ctx());
         assert!(table::is_empty(&table), 0);
         assert!(table::length(&table) == 0, 0);
         add(&mut table, 0, 0);
@@ -125,7 +125,7 @@ module sui::table_tests {
         add(&mut table, 1, 0);
         assert!(!table::is_empty(&table), 0);
         assert!(table::length(&table) == 2, 0);
-        ts::end(scenario);
+        scenario.end();
         table::drop(table);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/table_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/table_tests.move
@@ -3,7 +3,7 @@
 
 #[test_only]
 module sui::table_tests {
-    use sui::table::{Self, add, contains, borrow, borrow_mut, remove};
+    use sui::table;
     use sui::test_scenario;
 
     #[test]
@@ -95,8 +95,8 @@ module sui::table_tests {
         let mut table = table::new<u64, u64>(scenario.ctx());
         assert!(!table.contains(0), 0);
         table.add(0, 0);
-        assert!(contains<u64, u64>(&table, 0), 0);
-        assert!(!contains<u64, u64>(&table, 1), 0);
+        assert!(table.contains<u64, u64>(0), 0);
+        assert!(!table.contains<u64, u64>(1), 0);
         scenario.end();
         table.drop();
     }

--- a/crates/sui-framework/packages/sui-framework/tests/table_vec_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/table_vec_tests.move
@@ -4,101 +4,101 @@
 #[test_only]
 module sui::table_vec_tests {
     use sui::table_vec;
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
 
     const TEST_SENDER_ADDR: address = @0x1;
 
     #[test]
     fun simple_all_functions() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
 
-        let mut table_vec = table_vec::empty<u64>(ts::ctx(&mut scenario));
-        assert!(table_vec::length(&table_vec) == 0, 0);
+        let mut table_vec = table_vec::empty<u64>(scenario.ctx());
+        assert!(table_vec.length() == 0, 0);
 
-        table_vec::push_back(&mut table_vec, 7);
-        let mut_value = table_vec::borrow_mut(&mut table_vec, 0);
+        table_vec.push_back(7);
+        let mut_value = &mut table_vec[0];
         *mut_value = *mut_value + 1;
-        let value = table_vec::borrow(&table_vec, 0);
+        let value = &table_vec[0];
         assert!(*value == 8, 0);
 
-        table_vec::push_back(&mut table_vec, 5);
-        table_vec::swap(&mut table_vec, 0, 1);
+        table_vec.push_back(5);
+        table_vec.swap(0, 1);
 
-        let value = table_vec::swap_remove(&mut table_vec, 0);
+        let value = table_vec.swap_remove(0);
         assert!(value == 5, 0);
 
-        let value = table_vec::pop_back(&mut table_vec);
+        let value = table_vec.pop_back();
         assert!(value == 8, 0);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::ETableNonEmpty)]
     fun destroy_non_empty_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let table_vec = table_vec::singleton(1, scenario.ctx());
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun pop_back_empty_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let mut table_vec = table_vec::empty<u64>(ts::ctx(&mut scenario));
-        table_vec::pop_back(&mut table_vec);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let mut table_vec = table_vec::empty<u64>(scenario.ctx());
+        table_vec.pop_back();
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun borrow_out_of_bounds_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        let _ = table_vec::borrow(&table_vec, 77);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let table_vec = table_vec::singleton(1, scenario.ctx());
+        let _ = &table_vec[77];
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun borrow_mut_out_of_bounds_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let mut table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        let _ = table_vec::borrow_mut(&mut table_vec, 77);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let mut table_vec = table_vec::singleton(1, scenario.ctx());
+        let _ = &mut table_vec[77];
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun swap_out_of_bounds_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let mut table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        table_vec::swap(&mut table_vec, 0, 77);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let mut table_vec = table_vec::singleton(1, scenario.ctx());
+        table_vec.swap(0, 77);
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     fun swap_same_index_succeeds() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let mut table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        table_vec::swap(&mut table_vec, 0, 0);
-        table_vec::pop_back(&mut table_vec);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let mut table_vec = table_vec::singleton(1, scenario.ctx());
+        table_vec.swap(0, 0);
+        table_vec.pop_back();
+        table_vec.destroy_empty();
+        scenario.end();
     }
 
     #[test]
     #[expected_failure(abort_code = sui::table_vec::EIndexOutOfBound)]
     fun swap_same_index_out_of_bounds_aborts() {
-        let mut scenario = ts::begin(TEST_SENDER_ADDR);
-        let mut table_vec = table_vec::singleton(1, ts::ctx(&mut scenario));
-        table_vec::swap(&mut table_vec, 77, 77);
-        table_vec::destroy_empty(table_vec);
-        ts::end(scenario);
+        let mut scenario = test_scenario::begin(TEST_SENDER_ADDR);
+        let mut table_vec = table_vec::singleton(1, scenario.ctx());
+        table_vec.swap(77, 77);
+        table_vec.destroy_empty();
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/test_random_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_random_tests.move
@@ -12,13 +12,13 @@ module sui::test_random_tests {
         let lengths = vector[1, 31, 32, 33, 63, 64, 65];
 
         let mut i = 0;
-        while (i < vector::length(&lengths)) {
-            let length = *vector::borrow(&lengths, i);
+        while (i < lengths.length()) {
+            let length = lengths[i];
 
             // The length should be the requested length
             let mut random1 = new(b"seed");
             let bytes = next_bytes(&mut random1, length);
-            assert!(vector::length(&bytes) == length, 0);
+            assert!(bytes.length() == length, 0);
 
             // Two generators with different seeds should give different outputs
             let mut random1 = new(b"seed 1");
@@ -71,8 +71,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u8_in_range(&mut random, upper_bound) < upper_bound, 0);
@@ -103,8 +103,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u16_in_range(&mut random, upper_bound) < upper_bound, 0);
@@ -135,8 +135,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u32_in_range(&mut random, upper_bound) < upper_bound, 0);
@@ -167,8 +167,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u64_in_range(&mut random, upper_bound) < upper_bound, 0);
@@ -199,8 +199,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u128_in_range(&mut random, upper_bound) < upper_bound, 0);
@@ -255,8 +255,8 @@ module sui::test_random_tests {
         let mut i = 0;
         let bounds = vector[1, 7, 8, 9, 15, 16, 17];
         let tests = 10;
-        while (i < vector::length(&bounds)) {
-            let upper_bound = *vector::borrow(&bounds, i);
+        while (i < bounds.length()) {
+            let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
                 assert!(next_u256_in_range(&mut random, upper_bound) < upper_bound, 0);

--- a/crates/sui-framework/packages/sui-framework/tests/test_random_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_random_tests.move
@@ -3,9 +3,7 @@
 
 #[test_only]
 module sui::test_random_tests {
-    use sui::test_random::{new, next_bool, next_u8, next_u8_in_range, next_u16, next_u16_in_range, next_u32, next_u32_in_range, next_u64, next_u64_in_range, next_u128, next_u128_in_range, next_u256, next_u256_in_range};
-    use std::vector;
-    use sui::test_random::next_bytes;
+    use sui::test_random::new;
 
     #[test]
     fun test_next_bytes() {
@@ -17,20 +15,20 @@ module sui::test_random_tests {
 
             // The length should be the requested length
             let mut random1 = new(b"seed");
-            let bytes = next_bytes(&mut random1, length);
+            let bytes = random1.next_bytes(length);
             assert!(bytes.length() == length, 0);
 
             // Two generators with different seeds should give different outputs
             let mut random1 = new(b"seed 1");
             let mut random2 = new(b"seed 2");
-            assert!(next_bytes(&mut random1, length) !=
-                next_bytes(&mut random2, length), 2);
+            assert!(random1.next_bytes(length) !=
+                random2.next_bytes(length), 2);
 
             // Two generators with the same seed should give the same output
             let mut random1 = new(b"seed");
             let mut random2 = new(b"seed");
-            assert!(next_bytes(&mut random1, length) ==
-                next_bytes(&mut random2, length), 3);
+            assert!(random1.next_bytes(length) ==
+                random2.next_bytes(length), 3);
 
             i = i + 1;
         }
@@ -40,28 +38,28 @@ module sui::test_random_tests {
     fun test_next_bool() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_bool(&mut random) == false, 0);
-        assert!(next_bool(&mut random) == false, 1);
-        assert!(next_bool(&mut random) == true, 2);
-        assert!(next_bool(&mut random) == false, 3);
-        assert!(next_bool(&mut random) == false, 4);
-        assert!(next_bool(&mut random) == true, 5);
-        assert!(next_bool(&mut random) == true, 6);
-        assert!(next_bool(&mut random) == true, 7);
+        assert!(random.next_bool() == false, 0);
+        assert!(random.next_bool() == false, 1);
+        assert!(random.next_bool() == true, 2);
+        assert!(random.next_bool() == false, 3);
+        assert!(random.next_bool() == false, 4);
+        assert!(random.next_bool() == true, 5);
+        assert!(random.next_bool() == true, 6);
+        assert!(random.next_bool() == true, 7);
     }
 
     #[test]
     fun test_next_u8() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_u8(&mut random) == 228, 0);
-        assert!(next_u8(&mut random) == 182, 1);
-        assert!(next_u8(&mut random) == 229, 2);
-        assert!(next_u8(&mut random) == 184, 3);
-        assert!(next_u8(&mut random) == 40, 4);
-        assert!(next_u8(&mut random) == 199, 5);
-        assert!(next_u8(&mut random) == 63, 6);
-        assert!(next_u8(&mut random) == 51, 7);
+        assert!(random.next_u8() == 228, 0);
+        assert!(random.next_u8() == 182, 1);
+        assert!(random.next_u8() == 229, 2);
+        assert!(random.next_u8() == 184, 3);
+        assert!(random.next_u8() == 40, 4);
+        assert!(random.next_u8() == 199, 5);
+        assert!(random.next_u8() == 63, 6);
+        assert!(random.next_u8() == 51, 7);
     }
 
     #[test]
@@ -75,7 +73,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u8_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u8_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;
@@ -86,14 +84,14 @@ module sui::test_random_tests {
     fun test_next_u16() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_u16(&mut random) == 23524, 0);
-        assert!(next_u16(&mut random) == 30390, 1);
-        assert!(next_u16(&mut random) == 60645, 2);
-        assert!(next_u16(&mut random) == 2488, 3);
-        assert!(next_u16(&mut random) == 5672, 4);
-        assert!(next_u16(&mut random) == 36807, 5);
-        assert!(next_u16(&mut random) == 54591, 6);
-        assert!(next_u16(&mut random) == 41523, 7);
+        assert!(random.next_u16() == 23524, 0);
+        assert!(random.next_u16() == 30390, 1);
+        assert!(random.next_u16() == 60645, 2);
+        assert!(random.next_u16() == 2488, 3);
+        assert!(random.next_u16() == 5672, 4);
+        assert!(random.next_u16() == 36807, 5);
+        assert!(random.next_u16() == 54591, 6);
+        assert!(random.next_u16() == 41523, 7);
     }
 
     #[test]
@@ -107,7 +105,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u16_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u16_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;
@@ -118,14 +116,14 @@ module sui::test_random_tests {
     fun test_next_u32() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_u32(&mut random) == 2356042724, 0);
-        assert!(next_u32(&mut random) == 2194372278, 1);
-        assert!(next_u32(&mut random) == 1943727333, 2);
-        assert!(next_u32(&mut random) == 3674540472, 3);
-        assert!(next_u32(&mut random) == 560141864, 4);
-        assert!(next_u32(&mut random) == 2309459911, 5);
-        assert!(next_u32(&mut random) == 2130498879, 6);
-        assert!(next_u32(&mut random) == 2063835699, 7);
+        assert!(random.next_u32() == 2356042724, 0);
+        assert!(random.next_u32() == 2194372278, 1);
+        assert!(random.next_u32() == 1943727333, 2);
+        assert!(random.next_u32() == 3674540472, 3);
+        assert!(random.next_u32() == 560141864, 4);
+        assert!(random.next_u32() == 2309459911, 5);
+        assert!(random.next_u32() == 2130498879, 6);
+        assert!(random.next_u32() == 2063835699, 7);
     }
 
     #[test]
@@ -139,7 +137,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u32_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u32_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;
@@ -150,14 +148,14 @@ module sui::test_random_tests {
     fun test_next_u64() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_u64(&mut random) == 5845420307181886436, 0);
-        assert!(next_u64(&mut random) == 7169586959492019894, 1);
-        assert!(next_u64(&mut random) == 8821413273700855013, 2);
-        assert!(next_u64(&mut random) == 17006289909767801272, 3);
-        assert!(next_u64(&mut random) == 8349531451798263336, 4);
-        assert!(next_u64(&mut random) == 1662646395949518791, 5);
-        assert!(next_u64(&mut random) == 17661794895045383487, 6);
-        assert!(next_u64(&mut random) == 12177043863244087859, 7);
+        assert!(random.next_u64() == 5845420307181886436, 0);
+        assert!(random.next_u64() == 7169586959492019894, 1);
+        assert!(random.next_u64() == 8821413273700855013, 2);
+        assert!(random.next_u64() == 17006289909767801272, 3);
+        assert!(random.next_u64() == 8349531451798263336, 4);
+        assert!(random.next_u64() == 1662646395949518791, 5);
+        assert!(random.next_u64() == 17661794895045383487, 6);
+        assert!(random.next_u64() == 12177043863244087859, 7);
     }
 
     #[test]
@@ -171,7 +169,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u64_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u64_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;
@@ -182,14 +180,14 @@ module sui::test_random_tests {
     fun test_next_u128() {
         // Compare with test vector
         let mut random = new(b"seed");
-        assert!(next_u128(&mut random) == 69353424864165392191432166318042668004, 0);
-        assert!(next_u128(&mut random) == 12194030816161474852776228502914168502, 1);
-        assert!(next_u128(&mut random) == 206987904376642456854249538403010538725, 2);
-        assert!(next_u128(&mut random) == 197466311403128565716545068165788666296, 3);
-        assert!(next_u128(&mut random) == 15530841291297409371230861184202905128, 4);
-        assert!(next_u128(&mut random) == 165552967413296855339223280683074424775, 5);
-        assert!(next_u128(&mut random) == 8783412497932783467700075003507430719, 6);
-        assert!(next_u128(&mut random) == 253037866491608363794848265776744604211, 7);
+        assert!(random.next_u128() == 69353424864165392191432166318042668004, 0);
+        assert!(random.next_u128() == 12194030816161474852776228502914168502, 1);
+        assert!(random.next_u128() == 206987904376642456854249538403010538725, 2);
+        assert!(random.next_u128() == 197466311403128565716545068165788666296, 3);
+        assert!(random.next_u128() == 15530841291297409371230861184202905128, 4);
+        assert!(random.next_u128() == 165552967413296855339223280683074424775, 5);
+        assert!(random.next_u128() == 8783412497932783467700075003507430719, 6);
+        assert!(random.next_u128() == 253037866491608363794848265776744604211, 7);
     }
 
     #[test]
@@ -203,7 +201,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u128_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u128_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;
@@ -215,35 +213,35 @@ module sui::test_random_tests {
         // Compare with test vector
         let mut random = new(b"seed");
         assert!(
-            next_u256(&mut random) == 86613847811709056614394817717810651756872989141966064397767345384420144995300,
+            random.next_u256() == 86613847811709056614394817717810651756872989141966064397767345384420144995300,
             0
         );
         assert!(
-            next_u256(&mut random) == 77800816446193124932998172029673839405392227151477062245771844997605157992118,
+            random.next_u256() == 77800816446193124932998172029673839405392227151477062245771844997605157992118,
             1
         );
         assert!(
-            next_u256(&mut random) == 45725748659421166954417450578509602234536262489471512215816310423253128244453,
+            random.next_u256() == 45725748659421166954417450578509602234536262489471512215816310423253128244453,
             2
         );
         assert!(
-            next_u256(&mut random) == 19696026105199390416727112585766461108620822978182620644600554326664686143928,
+            random.next_u256() == 19696026105199390416727112585766461108620822978182620644600554326664686143928,
             3
         );
         assert!(
-            next_u256(&mut random) == 4837202928086718576193880638295431461498764555598430221157283092238776342056,
+            random.next_u256() == 4837202928086718576193880638295431461498764555598430221157283092238776342056,
             4
         );
         assert!(
-            next_u256(&mut random) == 64381219501514114493056586541507267846517000509074341237350219945295894515655,
+            random.next_u256() == 64381219501514114493056586541507267846517000509074341237350219945295894515655,
             5
         );
         assert!(
-            next_u256(&mut random) == 112652690078173752677112416039396981893266964593788132944794761758835606345023,
+            random.next_u256() == 112652690078173752677112416039396981893266964593788132944794761758835606345023,
             6
         );
         assert!(
-            next_u256(&mut random) == 64098809897132458178637712714755106201123339790293900115362940842770040070707,
+            random.next_u256() == 64098809897132458178637712714755106201123339790293900115362940842770040070707,
             7
         );
     }
@@ -259,7 +257,7 @@ module sui::test_random_tests {
             let upper_bound = bounds[i];
             let mut j = 0;
             while (j < tests) {
-                assert!(next_u256_in_range(&mut random, upper_bound) < upper_bound, 0);
+                assert!(random.next_u256_in_range(upper_bound) < upper_bound, 0);
                 j = j + 1;
             };
             i = i + 1;

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module sui::test_scenario_tests {
     use sui::object;
-    use sui::test_scenario as ts;
+    use sui::test_scenario;
     use sui::transfer;
     use sui::tx_context;
 
@@ -24,109 +24,109 @@ module sui::test_scenario_tests {
     #[test]
     fun test_wrap_unwrap() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             transfer::transfer(obj, copy sender);
         };
         // now, object gets wrapped
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let id = ts::new_object(&mut scenario);
-            let child = ts::take_from_sender<Object>(&scenario);
+            let id = scenario.new_object();
+            let child = scenario.take_from_sender<Object>();
             let wrapper = Wrapper { id, child };
             transfer::transfer(wrapper, copy sender);
         };
         // wrapped object should no longer be removable, but wrapper should be
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
-            assert!(ts::has_most_recent_for_sender<Wrapper>(&scenario), 1);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0);
+            assert!(scenario.has_most_recent_for_sender<Wrapper>(), 1);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_remove_then_return() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             transfer::public_transfer(obj, copy sender);
         };
         // object gets removed, then returned
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let object = ts::take_from_sender<Object>(&scenario);
-            ts::return_to_sender(&scenario, object);
+            let object = scenario.take_from_sender<Object>();
+            scenario.return_to_sender(object);
         };
         // Object should remain accessible
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(scenario.has_most_recent_for_sender<Object>(), 0);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_return_and_update() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             transfer::public_transfer(obj, copy sender);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let mut obj = ts::take_from_sender<Object>(&scenario);
+            let mut obj = scenario.take_from_sender<Object>();
             assert!(obj.value == 10, 0);
             obj.value = 100;
-            ts::return_to_sender(&scenario, obj);
+            scenario.return_to_sender(obj);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj = ts::take_from_sender<Object>(&scenario);
+            let obj = scenario.take_from_sender<Object>();
             assert!(obj.value == 100, 1);
-            ts::return_to_sender(&scenario, obj);
+            scenario.return_to_sender(obj);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_remove_during_tx() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             transfer::public_transfer(obj, copy sender);
             // an object transferred during the tx shouldn't be available in that tx
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0)
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0)
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    #[expected_failure(abort_code = test_scenario::EEmptyInventory)]
     fun test_double_remove() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             transfer::public_transfer(obj, copy sender);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_from_sender<Object>(&scenario);
-            let obj2 = ts::take_from_sender<Object>(&scenario);
-            ts::return_to_sender(&scenario, obj1);
-            ts::return_to_sender(&scenario, obj2);
+            let obj1 = scenario.take_from_sender<Object>();
+            let obj2 = scenario.take_from_sender<Object>();
+            scenario.return_to_sender(obj1);
+            scenario.return_to_sender(obj2);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
@@ -136,88 +136,88 @@ module sui::test_scenario_tests {
         let addr1 = @0x0;
         let addr2 = @0x1;
         let addr3 = @0x2;
-        let mut scenario = ts::begin(addr1);
+        let mut scenario = test_scenario::begin(addr1);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj = Object { id, value: 10 };
             // self-transfer
             transfer::public_transfer(obj, copy addr1);
         };
         // addr1 -> addr2
-        ts::next_tx(&mut scenario, addr1);
+        scenario.next_tx(addr1);
         {
-            let obj = ts::take_from_sender<Object>(&scenario);
+            let obj = scenario.take_from_sender<Object>();
             transfer::public_transfer(obj, copy addr2)
         };
         // addr1 cannot access
-        ts::next_tx(&mut scenario, addr1);
+        scenario.next_tx(addr1);
         {
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0);
         };
         // addr2 -> addr3
-        ts::next_tx(&mut scenario, addr2);
+        scenario.next_tx(addr2);
         {
-            let obj = ts::take_from_sender<Object>(&scenario);
+            let obj = scenario.take_from_sender<Object>();
             transfer::public_transfer(obj, copy addr3)
         };
         // addr1 cannot access
-        ts::next_tx(&mut scenario, addr1);
+        scenario.next_tx(addr1);
         {
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0);
         };
         // addr2 cannot access
-        ts::next_tx(&mut scenario, addr2);
+        scenario.next_tx(addr2);
         {
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0);
         };
         // addr3 *can* access
-        ts::next_tx(&mut scenario, addr3);
+        scenario.next_tx(addr3);
         {
-            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(scenario.has_most_recent_for_sender<Object>(), 0);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_transfer_then_delete() {
         let tx1_sender = @0x0;
         let tx2_sender = @0x1;
-        let mut scenario = ts::begin(tx1_sender);
+        let mut scenario = test_scenario::begin(tx1_sender);
         // send an object to tx2_sender
         let id_bytes;
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             id_bytes = object::uid_to_inner(&id);
             let obj = Object { id, value: 100 };
             transfer::public_transfer(obj, copy tx2_sender);
             // sender cannot access the object
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 0);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 0);
         };
         // check that tx2_sender can get the object, and it's the same one
-        ts::next_tx(&mut scenario, tx2_sender);
+        scenario.next_tx(tx2_sender);
         {
-            assert!(ts::has_most_recent_for_sender<Object>(&scenario), 1);
-            let received_obj = ts::take_from_sender<Object>(&scenario);
+            assert!(scenario.has_most_recent_for_sender<Object>(), 1);
+            let received_obj = scenario.take_from_sender<Object>();
             let Object { id: received_id, value } = received_obj;
             assert!(object::uid_to_inner(&received_id) == id_bytes, EIdBytesMismatch);
             assert!(value == 100, EValueMismatch);
             object::delete(received_id);
         };
         // check that the object is no longer accessible after deletion
-        ts::next_tx(&mut scenario, tx2_sender);
+        scenario.next_tx(tx2_sender);
         {
-            assert!(!ts::has_most_recent_for_sender<Object>(&scenario), 2);
+            assert!(!scenario.has_most_recent_for_sender<Object>(), 2);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_get_owned_obj_ids() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        let uid3 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
+        let uid2 = scenario.new_object();
+        let uid3 = scenario.new_object();
         let id1 = object::uid_to_inner(&uid1);
         let id2 = object::uid_to_inner(&uid2);
         let id3 = object::uid_to_inner(&uid3);
@@ -229,19 +229,19 @@ module sui::test_scenario_tests {
             transfer::public_transfer(obj2, copy sender);
             transfer::public_transfer(obj3, copy sender);
         };
-        ts::next_tx(&mut scenario, sender);
-        let ids = ts::ids_for_sender<Object>(&scenario);
+        scenario.next_tx(sender);
+        let ids = scenario.ids_for_sender<Object>();
         assert!(ids == vector[id1, id2, id3], EValueMismatch);
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_take_owned_by_id() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        let uid3 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
+        let uid2 = scenario.new_object();
+        let uid3 = scenario.new_object();
         let id1 = object::uid_to_inner(&uid1);
         let id2 = object::uid_to_inner(&uid2);
         let id3 = object::uid_to_inner(&uid3);
@@ -253,43 +253,43 @@ module sui::test_scenario_tests {
             transfer::public_transfer(obj2, copy sender);
             transfer::public_transfer(obj3, copy sender);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_from_sender_by_id<Object>(&scenario, id1);
-            let obj3 = ts::take_from_sender_by_id<Object>(&scenario, id3);
-            let obj2 = ts::take_from_sender_by_id<Object>(&scenario, id2);
+            let obj1 = scenario.take_from_sender_by_id<Object>(id1);
+            let obj3 = scenario.take_from_sender_by_id<Object>(id3);
+            let obj2 = scenario.take_from_sender_by_id<Object>(id2);
             assert!(obj1.value == 10, EValueMismatch);
             assert!(obj2.value == 20, EValueMismatch);
             assert!(obj3.value == 30, EValueMismatch);
-            ts::return_to_sender(&scenario, obj1);
-            ts::return_to_sender(&scenario, obj2);
-            ts::return_to_sender(&scenario, obj3);
+            scenario.return_to_sender(obj1);
+            scenario.return_to_sender(obj2);
+            scenario.return_to_sender(obj3);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_get_last_created_object_id() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let id_addr = object::uid_to_address(&id);
             let obj = Object { id, value: 10 };
             transfer::public_transfer(obj, copy sender);
-            let ctx = ts::ctx(&mut scenario);
+            let ctx = scenario.ctx();
             assert!(id_addr == tx_context::last_created_object_id(ctx), 0);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_take_shared_by_id() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        let uid3 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
+        let uid2 = scenario.new_object();
+        let uid3 = scenario.new_object();
         let id1 = object::uid_to_inner(&uid1);
         let id2 = object::uid_to_inner(&uid2);
         let id3 = object::uid_to_inner(&uid3);
@@ -301,67 +301,67 @@ module sui::test_scenario_tests {
             transfer::public_share_object(obj2);
             transfer::public_share_object(obj3)
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_shared_by_id<Object>(&scenario, id1);
-            let obj3 = ts::take_shared_by_id<Object>(&scenario, id3);
-            let obj2 = ts::take_shared_by_id<Object>(&scenario, id2);
+            let obj1 = scenario.take_shared_by_id<Object>(id1);
+            let obj3 = scenario.take_shared_by_id<Object>(id3);
+            let obj2 = scenario.take_shared_by_id<Object>(id2);
             assert!(obj1.value == 10, EValueMismatch);
             assert!(obj2.value == 20, EValueMismatch);
             assert!(obj3.value == 30, EValueMismatch);
-            ts::return_shared(obj1);
-            ts::return_shared(obj2);
-            ts::return_shared(obj3);
+            test_scenario::return_shared(obj1);
+            test_scenario::return_shared(obj2);
+            test_scenario::return_shared(obj3);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_take_shared() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
         {
             let obj1 = Object { id: uid1, value: 10 };
             transfer::public_share_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            assert!(ts::has_most_recent_shared<Object>(), 1);
-            let obj1 = ts::take_shared<Object>(&scenario);
+            assert!(test_scenario::has_most_recent_shared<Object>(), 1);
+            let obj1 = scenario.take_shared<Object>();
             assert!(obj1.value == 10, EValueMismatch);
-            ts::return_shared(obj1);
+            test_scenario::return_shared(obj1);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_delete_shared() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
         {
             let obj1 = Object { id: uid1, value: 10 };
             transfer::public_share_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            assert!(ts::has_most_recent_shared<Object>(), 1);
-            let obj1 = ts::take_shared<Object>(&scenario);
+            assert!(test_scenario::has_most_recent_shared<Object>(), 1);
+            let obj1 = scenario.take_shared<Object>();
             assert!(obj1.value == 10, EValueMismatch);
             let Object { id, value: _ } = obj1;
             id.delete();
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_take_immutable_by_id() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        let uid3 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
+        let uid2 = scenario.new_object();
+        let uid3 = scenario.new_object();
         let id1 = object::uid_to_inner(&uid1);
         let id2 = object::uid_to_inner(&uid2);
         let id3 = object::uid_to_inner(&uid3);
@@ -373,61 +373,61 @@ module sui::test_scenario_tests {
             transfer::public_freeze_object(obj2);
             transfer::public_freeze_object(obj3)
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_immutable_by_id<Object>(&scenario, id1);
-            let obj3 = ts::take_immutable_by_id<Object>(&scenario, id3);
-            let obj2 = ts::take_immutable_by_id<Object>(&scenario, id2);
+            let obj1 = scenario.take_immutable_by_id<Object>(id1);
+            let obj3 = scenario.take_immutable_by_id<Object>(id3);
+            let obj2 = scenario.take_immutable_by_id<Object>(id2);
             assert!(obj1.value == 10, EValueMismatch);
             assert!(obj2.value == 20, EValueMismatch);
             assert!(obj3.value == 30, EValueMismatch);
-            ts::return_immutable(obj1);
-            ts::return_immutable(obj2);
-            ts::return_immutable(obj3);
+            test_scenario::return_immutable(obj1);
+            test_scenario::return_immutable(obj2);
+            test_scenario::return_immutable(obj3);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_take_immutable() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
         {
             let obj1 = Object { id: uid1, value: 10 };
             transfer::public_freeze_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            assert!(ts::has_most_recent_immutable<Object>(), 1);
-            let obj1 = ts::take_immutable<Object>(&scenario);
+            assert!(test_scenario::has_most_recent_immutable<Object>(), 1);
+            let obj1 = scenario.take_immutable<Object>();
             assert!(obj1.value == 10, EValueMismatch);
-            ts::return_immutable(obj1);
+            test_scenario::return_immutable(obj1);
         };
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_unreturned_objects() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid1 = ts::new_object(&mut scenario);
-        let uid2 = ts::new_object(&mut scenario);
-        let uid3 = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid1 = scenario.new_object();
+        let uid2 = scenario.new_object();
+        let uid3 = scenario.new_object();
         {
             transfer::public_share_object(Object { id: uid1, value: 10 });
             transfer::public_freeze_object(Object { id: uid2, value: 10 });
             transfer::public_transfer(Object { id: uid3, value: 10 }, sender);
         };
-        ts::next_tx(&mut scenario, sender);
-        let shared = ts::take_shared<Object>(&scenario);
-        let imm = ts::take_immutable<Object>(&scenario);
-        let owned = ts::take_from_sender<Object>(&scenario);
-        ts::next_tx(&mut scenario, sender);
-        ts::next_epoch(&mut scenario, sender);
-        ts::next_tx(&mut scenario, sender);
-        ts::next_epoch(&mut scenario, sender);
-        ts::end(scenario);
+        scenario.next_tx(sender);
+        let shared = scenario.take_shared<Object>();
+        let imm = scenario.take_immutable<Object>();
+        let owned = scenario.take_from_sender<Object>();
+        scenario.next_tx(sender);
+        scenario.next_epoch(sender);
+        scenario.next_tx(sender);
+        scenario.next_epoch(sender);
+        scenario.end();
         transfer::public_share_object(shared);
         transfer::public_freeze_object(imm);
         transfer::public_transfer(owned, sender);
@@ -436,230 +436,230 @@ module sui::test_scenario_tests {
     #[test]
     fun test_later_epoch() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
 
-        let ts0 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        let ts0 = tx_context::epoch_timestamp_ms(scenario.ctx());
 
         // epoch timestamp doesn't change between transactions
-        ts::next_tx(&mut scenario, sender);
-        let ts1 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        scenario.next_tx(sender);
+        let ts1 = tx_context::epoch_timestamp_ms(scenario.ctx());
         assert!(ts1 == ts0, 0);
 
         // ...or between epochs when `next_epoch` is used
-        ts::next_epoch(&mut scenario, sender);
-        let ts2 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        scenario.next_epoch(sender);
+        let ts2 = tx_context::epoch_timestamp_ms(scenario.ctx());
         assert!(ts2 == ts1, 1);
 
         // ...but does change when `later_epoch` is used
-        ts::later_epoch(&mut scenario, 42, sender);
-        let ts3 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        scenario.later_epoch(42, sender);
+        let ts3 = tx_context::epoch_timestamp_ms(scenario.ctx());
         assert!(ts3 == ts2 + 42, 2);
 
         // ...and persists across further transactions
-        ts::next_tx(&mut scenario, sender);
-        let ts4 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        scenario.next_tx(sender);
+        let ts4 = tx_context::epoch_timestamp_ms(scenario.ctx());
         assert!(ts4 == ts3, 3);
 
         // ...and epochs
-        ts::next_epoch(&mut scenario, sender);
-        let ts5 = tx_context::epoch_timestamp_ms(ts::ctx(&mut scenario));
+        scenario.next_epoch(sender);
+        let ts5 = tx_context::epoch_timestamp_ms(scenario.ctx());
         assert!(ts5 == ts4, 4);
 
-        ts::end(scenario);
+        scenario.end();
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_invalid_shared_usage() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj1 = Object { id, value: 10 };
             transfer::public_share_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_shared<Object>(&scenario);
+            let obj1 = scenario.take_shared<Object>();
             transfer::public_freeze_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_invalid_immutable_usage() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj1 = Object { id, value: 10 };
             transfer::public_freeze_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            let obj1 = ts::take_immutable<Object>(&scenario);
+            let obj1 = scenario.take_immutable<Object>();
             transfer::public_transfer(obj1, @0x0);
         };
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_modify_immutable() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
+        let mut scenario = test_scenario::begin(sender);
         {
-            let id = ts::new_object(&mut scenario);
+            let id = scenario.new_object();
             let obj1 = Object { id, value: 10 };
             transfer::public_freeze_object(obj1);
         };
-        ts::next_tx(&mut scenario, sender);
-        let mut obj1 = ts::take_immutable<Object>(&scenario);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
+        let mut obj1 = scenario.take_immutable<Object>();
+        scenario.next_tx(sender);
         obj1.value = 100;
-        ts::next_tx(&mut scenario, sender);
-        ts::return_immutable(obj1);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
+        test_scenario::return_immutable(obj1);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    #[expected_failure(abort_code = test_scenario::ECantReturnObject)]
     fun test_invalid_address_return() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let id = ts::new_object(&mut scenario);
-        ts::return_to_sender(&scenario, Object { id, value: 10 });
+        let mut scenario = test_scenario::begin(sender);
+        let id = scenario.new_object();
+        scenario.return_to_sender(Object { id, value: 10 });
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    #[expected_failure(abort_code = test_scenario::ECantReturnObject)]
     fun test_invalid_shared_return() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let id = ts::new_object(&mut scenario);
-        ts::return_shared(Object { id, value: 10 });
+        let mut scenario = test_scenario::begin(sender);
+        let id = scenario.new_object();
+        test_scenario::return_shared(Object { id, value: 10 });
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::ECantReturnObject)]
+    #[expected_failure(abort_code = test_scenario::ECantReturnObject)]
     fun test_invalid_immutable_return() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let id = ts::new_object(&mut scenario);
-        ts::return_immutable(Object { id, value: 10 });
+        let mut scenario = test_scenario::begin(sender);
+        let id = scenario.new_object();
+        test_scenario::return_immutable(Object { id, value: 10 });
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    #[expected_failure(abort_code = test_scenario::EEmptyInventory)]
     fun test_empty_inventory() {
         let sender = @0x0;
-        let scenario = ts::begin(sender);
-        ts::return_to_sender(&scenario, ts::take_from_sender<Object>(&scenario));
+        let scenario = test_scenario::begin(sender);
+        scenario.return_to_sender(scenario.take_from_sender<Object>());
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    #[expected_failure(abort_code = test_scenario::EEmptyInventory)]
     fun test_empty_inventory_shared() {
         let sender = @0x0;
-        let scenario = ts::begin(sender);
-        ts::return_to_sender(&scenario, ts::take_shared<Object>(&scenario));
+        let scenario = test_scenario::begin(sender);
+        scenario.return_to_sender(scenario.take_shared<Object>());
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EEmptyInventory)]
+    #[expected_failure(abort_code = test_scenario::EEmptyInventory)]
     fun test_empty_inventory_immutable() {
         let sender = @0x0;
-        let scenario = ts::begin(sender);
-        ts::return_to_sender(&scenario, ts::take_immutable<Object>(&scenario));
+        let scenario = test_scenario::begin(sender);
+        scenario.return_to_sender(scenario.take_immutable<Object>());
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_object_not_found() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
-        ts::return_to_sender(&scenario, ts::take_from_sender_by_id<Object>(&scenario, id));
+        scenario.return_to_sender(scenario.take_from_sender_by_id<Object>(id));
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_object_not_found_shared() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
-        ts::return_to_sender(&scenario, ts::take_shared_by_id<Object>(&scenario, id));
+        scenario.return_to_sender(scenario.take_shared_by_id<Object>(id));
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_object_not_found_immutable() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
-        ts::return_to_sender(&scenario, ts::take_immutable_by_id<Object>(&scenario, id));
+        scenario.return_to_sender(scenario.take_immutable_by_id<Object>(id));
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_wrong_object_type() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
         transfer::public_transfer(Object { id: uid, value: 10 }, sender);
-        ts::return_to_sender(&scenario, ts::take_from_sender_by_id<Wrapper>(&scenario, id));
+        scenario.return_to_sender(scenario.take_from_sender_by_id<Wrapper>(id));
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_wrong_object_type_shared() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
         transfer::public_share_object(Object { id: uid, value: 10 });
-        ts::return_shared(ts::take_shared_by_id<Wrapper>(&scenario, id));
+        test_scenario::return_shared(scenario.take_shared_by_id<Object>(id));
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EObjectNotFound)]
+    #[expected_failure(abort_code = test_scenario::EObjectNotFound)]
     fun test_wrong_object_type_immutable() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let uid = scenario.new_object();
         let id = object::uid_to_inner(&uid);
         transfer::public_freeze_object(Object { id: uid, value: 10 });
-        ts::return_immutable(ts::take_immutable_by_id<Wrapper>(&scenario, id));
+        test_scenario::return_immutable(scenario.take_immutable_by_id<Object>(id));
         abort 42
     }
 
     #[test]
     fun test_dynamic_field_still_borrowed() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
         sui::dynamic_field::add(&mut parent, b"", 10);
         let r = sui::dynamic_field::borrow<vector<u8>, u64>(&parent, b"");
-        ts::end(scenario);
+        scenario.end();
         assert!(*r == 10, 0);
         object::delete(parent);
     }
@@ -667,12 +667,12 @@ module sui::test_scenario_tests {
     #[test]
     fun test_dynamic_object_field_still_borrowed() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let id = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let id = scenario.new_object();
         sui::dynamic_object_field::add(&mut parent, b"", Object { id, value: 10});
         let obj = sui::dynamic_object_field::borrow<vector<u8>, Object>(&parent, b"");
-        ts::end(scenario);
+        scenario.end();
         assert!(obj.value == 10, 0);
         object::delete(parent);
     }
@@ -680,95 +680,95 @@ module sui::test_scenario_tests {
     #[test]
     fun test_dynamic_object_field_not_retrievable() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let uid = scenario.new_object();
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
         transfer::public_transfer(obj, sender);
-        ts::next_tx(&mut scenario, sender);
-        assert!(ts::has_most_recent_for_address<Object>(sender), 0);
-        let obj = ts::take_from_sender<Object>(&scenario);
+        scenario.next_tx(sender);
+        assert!(test_scenario::has_most_recent_for_address<Object>(sender), 0);
+        let obj = scenario.take_from_sender<Object>();
         assert!(object::id(&obj) == id, 0);
-        assert!(!ts::has_most_recent_for_address<Object>(sender), 0);
+        assert!(!test_scenario::has_most_recent_for_address<Object>(sender), 0);
         sui::dynamic_object_field::add(&mut parent, b"", obj);
-        ts::next_tx(&mut scenario, sender);
-        assert!(!ts::has_most_recent_for_address<Object>(sender), 0);
-        ts::end(scenario);
+        scenario.next_tx(sender);
+        assert!(!test_scenario::has_most_recent_for_address<Object>(sender), 0);
+        scenario.end();
         object::delete(parent);
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_dynamic_field_shared_misuse() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let uid = scenario.new_object();
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
         transfer::public_share_object(obj);
-        ts::next_tx(&mut scenario, sender);
-        let obj = ts::take_shared<Object>(&scenario);
+        scenario.next_tx(sender);
+        let obj = scenario.take_shared<Object>();
         assert!(object::id(&obj) == id, 0);
         // wraps the object
         sui::dynamic_field::add(&mut parent, b"", obj);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_dynamic_field_immutable_misuse() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let uid = scenario.new_object();
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
         transfer::public_freeze_object(obj);
-        ts::next_tx(&mut scenario, sender);
-        let obj = ts::take_immutable<Object>(&scenario);
+        scenario.next_tx(sender);
+        let obj = scenario.take_immutable<Object>();
         assert!(object::id(&obj) == id, 0);
         // wraps the object
         sui::dynamic_field::add(&mut parent, b"", obj);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_dynamic_object_field_shared_misuse() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let uid = scenario.new_object();
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
         transfer::public_share_object(obj);
-        ts::next_tx(&mut scenario, sender);
-        let obj = ts::take_shared<Object>(&scenario);
+        scenario.next_tx(sender);
+        let obj = scenario.take_shared<Object>();
         assert!(object::id(&obj) == id, 0);
         sui::dynamic_object_field::add(&mut parent, b"", obj);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 
     #[test]
-    #[expected_failure(abort_code = ts::EInvalidSharedOrImmutableUsage)]
+    #[expected_failure(abort_code = test_scenario::EInvalidSharedOrImmutableUsage)]
     fun test_dynamic_object_field_immutable_misuse() {
         let sender = @0x0;
-        let mut scenario = ts::begin(sender);
-        let mut parent = ts::new_object(&mut scenario);
-        let uid = ts::new_object(&mut scenario);
+        let mut scenario = test_scenario::begin(sender);
+        let mut parent = scenario.new_object();
+        let uid = scenario.new_object();
         let obj = Object { id: uid, value: 10};
         let id = object::id(&obj);
         transfer::public_freeze_object(obj);
-        ts::next_tx(&mut scenario, sender);
-        let obj = ts::take_immutable<Object>(&scenario);
+        scenario.next_tx(sender);
+        let obj = scenario.take_immutable<Object>();
         assert!(object::id(&obj) == id, 0);
         sui::dynamic_object_field::add(&mut parent, b"", obj);
-        ts::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         abort 42
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -633,7 +633,7 @@ module sui::test_scenario_tests {
         let uid = scenario.new_object();
         let id = uid.to_inner();
         transfer::public_share_object(Object { id: uid, value: 10 });
-        test_scenario::return_shared(scenario.take_shared_by_id<Object>(id));
+        test_scenario::return_shared(scenario.take_shared_by_id<Wrapper>(id));
         abort 42
     }
 
@@ -645,7 +645,7 @@ module sui::test_scenario_tests {
         let uid = scenario.new_object();
         let id = uid.to_inner();
         transfer::public_freeze_object(Object { id: uid, value: 10 });
-        test_scenario::return_immutable(scenario.take_immutable_by_id<Object>(id));
+        test_scenario::return_immutable(scenario.take_immutable_by_id<Wrapper>(id));
         abort 42
     }
 

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -350,7 +350,7 @@ module sui::test_scenario_tests {
             let obj1 = ts::take_shared<Object>(&scenario);
             assert!(obj1.value == 10, EValueMismatch);
             let Object { id, value: _ } = obj1;
-            object::delete(id);
+            id.delete();
         };
         ts::end(scenario);
     }

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
@@ -7,7 +7,6 @@
 ///
 /// It also tests custom actions which can be implemented by policy owner.
 module sui::token_actions_tests {
-    use std::string;
     use sui::token;
     use sui::token_test_utils as test;
 
@@ -21,17 +20,17 @@ module sui::token_actions_tests {
         let token = test::mint(1000, ctx);
         let request = token::transfer(token, @0x2, ctx);
 
-        assert!(token::action(&request) == token::transfer_action(), 0);
-        assert!(token::amount(&request) == 1000, 1);
-        assert!(token::sender(&request) == @0x0, 2);
+        assert!(request.action() == token::transfer_action(), 0);
+        assert!(request.amount() == 1000, 1);
+        assert!(request.sender() == @0x0, 2);
 
-        let recipient = token::recipient(&request);
+        let recipient = request.recipient();
 
-        assert!(option::is_some(&recipient), 3);
-        assert!(option::borrow(&recipient) == &@0x2, 4);
-        assert!(option::is_none(&token::spent(&request)), 5);
+        assert!(recipient.is_some(), 3);
+        assert!(recipient.borrow() == &@0x2, 4);
+        assert!(request.spent().is_none(), 5);
 
-        token::confirm_with_policy_cap(&cap, request, ctx);
+        cap.confirm_with_policy_cap(request, ctx);
         test::return_policy(policy, cap);
     }
 
@@ -45,14 +44,14 @@ module sui::token_actions_tests {
         let token = test::mint(1000, ctx);
         let request = token::spend(token, ctx);
 
-        token::allow(&mut policy, &cap, token::spend_action(), ctx);
+        policy.allow(&cap, token::spend_action(), ctx);
 
-        assert!(token::action(&request) == token::spend_action(), 0);
-        assert!(token::amount(&request) == 1000, 1);
-        assert!(token::sender(&request) == @0x0, 2);
-        assert!(option::is_none(&token::recipient(&request)), 3);
-        assert!(option::is_some(&token::spent(&request)), 4);
-        assert!(option::borrow(&token::spent(&request)) == &1000, 5);
+        assert!(request.action() == token::spend_action(), 0);
+        assert!(request.amount() == 1000, 1);
+        assert!(request.sender() == @0x0, 2);
+        assert!(request.recipient().is_none(), 3);
+        assert!(option::is_some(&request.spent()), 4);
+        assert!(option::borrow(&request.spent()) == &1000, 5);
 
         token::confirm_request_mut(&mut policy, request, ctx);
 
@@ -69,25 +68,25 @@ module sui::token_actions_tests {
         let (policy, cap) = test::get_policy(ctx);
 
         let token = test::mint(1000, ctx);
-        let (coin, to_request) = token::to_coin(token, ctx);
+        let (coin, to_request) = token.to_coin(ctx);
 
-        assert!(token::action(&to_request) == token::to_coin_action(), 0);
-        assert!(token::amount(&to_request) == 1000, 1);
-        assert!(token::sender(&to_request) == @0x0, 2);
-        assert!(option::is_none(&token::recipient(&to_request)), 3);
-        assert!(option::is_none(&token::spent(&to_request)), 4);
+        assert!(to_request.action() == token::to_coin_action(), 0);
+        assert!(to_request.amount() == 1000, 1);
+        assert!(to_request.sender() == @0x0, 2);
+        assert!(to_request.recipient().is_none(), 3);
+        assert!(to_request.spent().is_none(), 4);
 
         let (token, from_request) = token::from_coin(coin, ctx);
 
-        assert!(token::action(&from_request) == token::from_coin_action(), 5);
-        assert!(token::amount(&from_request) == 1000, 6);
-        assert!(token::sender(&from_request) == @0x0, 7);
-        assert!(option::is_none(&token::recipient(&from_request)), 8);
-        assert!(option::is_none(&token::spent(&from_request)), 9);
+        assert!(from_request.action() == token::from_coin_action(), 5);
+        assert!(from_request.amount() == 1000, 6);
+        assert!(from_request.sender() == @0x0, 7);
+        assert!(from_request.recipient().is_none(), 8);
+        assert!(from_request.spent().is_none(), 9);
 
-        token::keep(token, ctx);
-        token::confirm_with_policy_cap(&cap, to_request, ctx);
-        token::confirm_with_policy_cap(&cap, from_request, ctx);
+        token.keep(ctx);
+        cap.confirm_with_policy_cap(to_request, ctx);
+        cap.confirm_with_policy_cap(from_request, ctx);
         test::return_policy(policy, cap);
     }
 
@@ -98,9 +97,9 @@ module sui::token_actions_tests {
     fun test_custom_action() {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, cap) = test::get_policy(ctx);
-        let custom_action = string::utf8(b"custom");
+        let custom_action = b"custom".to_string();
 
-        token::allow(&mut policy, &cap, custom_action, ctx);
+        policy.allow(&cap, custom_action, ctx);
 
         let request = token::new_request(
             custom_action,
@@ -110,13 +109,13 @@ module sui::token_actions_tests {
             ctx
         );
 
-        assert!(token::action(&request) == custom_action, 0);
-        assert!(token::amount(&request) == 1000, 1);
-        assert!(token::sender(&request) == @0x0, 2);
-        assert!(option::is_none(&token::recipient(&request)), 3);
-        assert!(option::is_none(&token::spent(&request)), 4);
+        assert!(request.action() == custom_action, 0);
+        assert!(request.amount() == 1000, 1);
+        assert!(request.sender() == @0x0, 2);
+        assert!(request.recipient().is_none(), 3);
+        assert!(request.spent().is_none(), 4);
 
-        token::confirm_request(&policy, request, ctx);
+        policy.confirm_request(request, ctx);
         test::return_policy(policy, cap);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
@@ -50,8 +50,8 @@ module sui::token_actions_tests {
         assert!(request.amount() == 1000, 1);
         assert!(request.sender() == @0x0, 2);
         assert!(request.recipient().is_none(), 3);
-        assert!(option::is_some(&request.spent()), 4);
-        assert!(option::borrow(&request.spent()) == &1000, 5);
+        assert!(request.spent().is_some(), 4);
+        assert!(request.spent().borrow() == &1000, 5);
 
         token::confirm_request_mut(&mut policy, request, ctx);
 

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_actions_tests.move
@@ -7,7 +7,6 @@
 ///
 /// It also tests custom actions which can be implemented by policy owner.
 module sui::token_actions_tests {
-    use std::option;
     use std::string;
     use sui::token;
     use sui::token_test_utils as test;

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_public_actions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_public_actions_tests.move
@@ -14,15 +14,15 @@ module sui::token_public_actions_tests {
         let ctx = &mut test::ctx(@0x0);
         let mut token = test::mint(100, ctx);
 
-        let split = token::split(&mut token, 50, ctx);
+        let split = token.split(50, ctx);
         let zero = token::zero<TEST>(ctx);
 
-        token::join(&mut token, split);
-        token::join(&mut token, zero);
+        token.join(split);
+        token.join(zero);
 
-        let zero = token::split(&mut token, 0, ctx);
-        token::destroy_zero(zero);
-        token::keep(token, ctx);
+        let zero = token.split(0, ctx);
+        zero.destroy_zero();
+        token.keep(ctx);
     }
 
     #[test, expected_failure(abort_code = token::ENotZero)]
@@ -31,7 +31,7 @@ module sui::token_public_actions_tests {
         let ctx = &mut test::ctx(@0x0);
         let token = test::mint(100, ctx);
 
-        token::destroy_zero(token)
+        token.destroy_zero()
     }
 
     #[test, expected_failure(abort_code = token::EBalanceTooLow)]
@@ -40,7 +40,7 @@ module sui::token_public_actions_tests {
         let ctx = &mut test::ctx(@0x0);
         let mut token = test::mint(0, ctx);
 
-        let _t = token::split(&mut token, 100, ctx);
+        let _t = token.split(100, ctx);
 
         abort 1337
     }

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_request_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_request_tests.move
@@ -5,7 +5,6 @@
 /// This module implements tests for the request formation and approval in the
 /// `TokenPolicy`.
 module sui::token_request_tests {
-    use std::string;
     use std::option::none;
     use sui::token;
     use sui::token_test_utils::{Self as test, TEST};
@@ -18,13 +17,13 @@ module sui::token_request_tests {
     fun test_request_confirm() {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, cap) = test::get_policy(ctx);
-        let action = string::utf8(b"test");
+        let action = b"test".to_string();
 
-        token::allow(&mut policy, &cap, action, ctx);
+        policy.allow(&cap, action, ctx);
 
         let request = token::new_request(action, 100, none(), none(), ctx);
 
-        token::confirm_request(&policy, request, ctx);
+        policy.confirm_request(request, ctx);
         test::return_policy(policy, cap)
     }
 
@@ -35,8 +34,8 @@ module sui::token_request_tests {
         let (policy, cap) = test::get_policy(ctx);
         let token = test::mint(100, ctx);
 
-        let request = token::transfer(token, @0x2, ctx);
-        token::confirm_with_policy_cap(&cap, request, ctx);
+        let request = token.transfer(@0x2, ctx);
+        cap.confirm_with_policy_cap(request, ctx);
         test::return_policy(policy, cap);
     }
 
@@ -46,16 +45,16 @@ module sui::token_request_tests {
     fun test_request_confirm_excessive_approvals_pass() {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, cap) = test::get_policy(ctx);
-        let action = string::utf8(b"test");
+        let action = b"test".to_string();
 
-        token::add_rule_for_action<TEST, Rule1>(&mut policy, &cap, action, ctx);
+        policy.add_rule_for_action<TEST, Rule1>(&cap, action, ctx);
 
         let mut request = token::new_request(action, 100, none(), none(), ctx);
 
         token::add_approval(Rule1 {}, &mut request, ctx);
         token::add_approval(Rule2 {}, &mut request, ctx);
 
-        token::confirm_request(&policy, request, ctx);
+        policy.confirm_request(request, ctx);
         test::return_policy(policy, cap)
     }
 
@@ -64,11 +63,11 @@ module sui::token_request_tests {
     fun test_request_confirm_unknown_action_fail() {
         let ctx = &mut test::ctx(@0x0);
         let (policy, cap) = test::get_policy(ctx);
-        let action = string::utf8(b"test");
+        let action = b"test".to_string();
 
         let request = token::new_request(action, 100, none(), none(), ctx);
 
-        token::confirm_request(&policy, request, ctx);
+        policy.confirm_request(request, ctx);
         test::return_policy(policy, cap)
     }
 
@@ -77,14 +76,14 @@ module sui::token_request_tests {
     fun test_request_confirm_not_approved_fail() {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, cap) = test::get_policy(ctx);
-        let action = string::utf8(b"test");
+        let action = b"test".to_string();
 
-        token::add_rule_for_action<TEST, Rule1>(&mut policy, &cap, action, ctx);
+        policy.add_rule_for_action<TEST, Rule1>(&cap, action, ctx);
 
         let mut request = token::new_request(action, 100, none(), none(), ctx);
 
         token::add_approval(Rule2 {}, &mut request, ctx);
-        token::confirm_request(&policy, request, ctx);
+        policy.confirm_request(request, ctx);
 
         abort 1337
     }
@@ -95,9 +94,9 @@ module sui::token_request_tests {
         let ctx = &mut test::ctx(@0x0);
         let (_policy, cap) = test::get_policy(ctx);
         let token = test::mint(100, ctx);
-        let request = token::spend(token, ctx);
+        let request = token.spend(ctx);
 
-        token::confirm_with_policy_cap(&cap, request, ctx);
+        cap.confirm_with_policy_cap(request, ctx);
 
         abort 1337
     }
@@ -108,10 +107,10 @@ module sui::token_request_tests {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, cap) = test::get_policy(ctx);
         let token = test::mint(100, ctx);
-        let request = token::transfer(token, @0x2, ctx);
+        let request = token.transfer(@0x2, ctx);
 
-        token::allow(&mut policy, &cap, token::transfer_action(), ctx);
-        token::confirm_request_mut(&mut policy, request, ctx);
+        policy.allow(&cap, token::transfer_action(), ctx);
+        policy.confirm_request_mut(request, ctx);
 
         abort 1337
     }
@@ -122,9 +121,9 @@ module sui::token_request_tests {
         let ctx = &mut test::ctx(@0x0);
         let (mut policy, _cap) = test::get_policy(ctx);
         let token = test::mint(100, ctx);
-        let request = token::spend(token, ctx);
+        let request = token.spend(ctx);
 
-        token::confirm_request_mut(&mut policy, request, ctx);
+        policy.confirm_request_mut(request, ctx);
 
         abort 1337
     }

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_test_utils.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_test_utils.move
@@ -34,7 +34,7 @@ module sui::token_test_utils {
 
     /// Gracefully unpack policy after the tests have been performed.
     public fun return_policy(policy: TokenPolicy<TEST>, cap: TokenPolicyCap<TEST>) {
-        token::burn_policy_for_testing(policy, cap)
+        policy.burn_policy_for_testing(cap)
     }
 
     /// Mint a test token.
@@ -44,6 +44,6 @@ module sui::token_test_utils {
 
     /// Burn a test token.
     public fun burn(token: Token<TEST>) {
-        token::burn_for_testing(token)
+        token.burn_for_testing()
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_test_utils.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_test_utils.move
@@ -5,7 +5,6 @@
 /// This module defines base testing utilities for the
 module sui::token_test_utils {
     use sui::coin::{Self, TreasuryCap};
-    use sui::tx_context::{Self, TxContext};
     use sui::token::{Self, Token, TokenPolicy, TokenPolicyCap};
 
     /// The type of the test Token.

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_treasury_cap_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_treasury_cap_tests.move
@@ -18,11 +18,11 @@ module sui::token_treasury_cap_tests {
         let mut treasury_cap = test::get_treasury_cap(ctx);
 
         let token = token::mint(&mut treasury_cap, 1000, ctx);
-        let request = token::spend(token, ctx);
+        let request = token.spend(ctx);
 
-        token::allow(&mut policy, &cap, token::spend_action(), ctx);
-        token::confirm_request_mut(&mut policy, request, ctx);
-        token::flush(&mut policy, &mut treasury_cap, ctx);
+        policy.allow(&cap, token::spend_action(), ctx);
+        policy.confirm_request_mut(request, ctx);
+        policy.flush(&mut treasury_cap, ctx);
 
         test::return_treasury_cap(treasury_cap);
         test::return_policy(policy, cap);

--- a/crates/sui-framework/packages/sui-framework/tests/token/token_treasury_cap_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/token/token_treasury_cap_tests.move
@@ -36,7 +36,7 @@ module sui::token_treasury_cap_tests {
         let mut treasury_cap = test::get_treasury_cap(ctx);
 
         let token = token::mint(&mut treasury_cap, 1000, ctx);
-        let request = token::spend(token, ctx);
+        let request = token.spend(ctx);
 
         token::confirm_with_treasury_cap(&mut treasury_cap, request, ctx);
         test::return_treasury_cap(treasury_cap);

--- a/crates/sui-framework/packages/sui-framework/tests/tx_context_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/tx_context_tests.move
@@ -3,20 +3,18 @@
 
 #[test_only]
 module sui::tx_context_tests {
-    use sui::object;
-    use sui::tx_context;
 
     #[test]
     fun test_id_generation() {
         let mut ctx = tx_context::dummy();
-        assert!(tx_context::get_ids_created(&ctx) == 0, 0);
+        assert!(ctx.get_ids_created() == 0, 0);
 
         let id1 = object::new(&mut ctx);
         let id2 = object::new(&mut ctx);
 
         // new_id should always produce fresh ID's
         assert!(&id1 != &id2, 1);
-        assert!(tx_context::get_ids_created(&ctx) == 2, 2);
+        assert!(ctx.get_ids_created() == 2, 2);
         id1.delete();
         id2.delete();
     }

--- a/crates/sui-framework/packages/sui-framework/tests/tx_context_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/tx_context_tests.move
@@ -17,8 +17,8 @@ module sui::tx_context_tests {
         // new_id should always produce fresh ID's
         assert!(&id1 != &id2, 1);
         assert!(tx_context::get_ids_created(&ctx) == 2, 2);
-        object::delete(id1);
-        object::delete(id2);
+        id1.delete();
+        id2.delete();
     }
 
 }

--- a/crates/sui-framework/packages/sui-framework/tests/url_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/url_tests.move
@@ -4,14 +4,13 @@
 #[test_only]
 module sui::url_tests {
     use sui::url;
-    use std::ascii::Self;
 
     const EUrlStringMismatch: u64 = 1;
 
     #[test]
     fun test_basic_url() {
         // url strings are not currently validated
-        let url_str = ascii::string(x"414243454647");
+        let url_str = x"414243454647".to_ascii_string();
 
         let url = url::new_unsafe(url_str);
         assert!(url::inner_url(&url) == url_str, EUrlStringMismatch);

--- a/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
@@ -3,82 +3,81 @@
 
 #[test_only]
 module sui::vec_map_tests {
-    use std::vector;
     use sui::vec_map::{Self, VecMap};
 
     #[test]
     #[expected_failure(abort_code = vec_map::EKeyAlreadyExists)]
     fun duplicate_key_abort() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 1, true);
-        vec_map::insert(&mut m, 1, false);
+        m.insert(1, true);
+        m.insert(1, false);
     }
 
     #[test]
     #[expected_failure(abort_code = vec_map::EKeyDoesNotExist)]
     fun nonexistent_key_get() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 1, true);
+        m.insert(1, true);
         let k = 2;
-        let _v = vec_map::get(&m, &k);
+        let _v = &m[&k];
     }
 
     #[test]
     #[expected_failure(abort_code = vec_map::EKeyDoesNotExist)]
     fun nonexistent_key_get_idx_or_abort() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 1, true);
+        m.insert(1, true);
         let k = 2;
-        let _idx = vec_map::get_idx(&m, &k);
+        let _idx = m.get_idx(&k);
     }
 
     #[test]
     #[expected_failure(abort_code = vec_map::EIndexOutOfBounds)]
     fun out_of_bounds_get_entry_by_idx() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 1, true);
+        m.insert(1, true);
         let idx = 1;
-        let (_key, _val) = vec_map::get_entry_by_idx(&m, idx);
+        let (_key, _val) = m.get_entry_by_idx(idx);
     }
 
     #[test]
     #[expected_failure(abort_code = vec_map::EIndexOutOfBounds)]
     fun out_of_bounds_remove_entry_by_idx() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 10, true);
+        m.insert(10, true);
         let idx = 1;
-        let (_key, _val) = vec_map::remove_entry_by_idx(&mut m, idx);
+        let (_key, _val) = m.remove_entry_by_idx(idx);
     }
 
     #[test]
     fun remove_entry_by_idx() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 5, 50);
-        vec_map::insert(&mut m, 6, 60);
-        vec_map::insert(&mut m, 7, 70);
+        m.insert(5, 50);
+        m.insert(6, 60);
+        m.insert(7, 70);
 
-        let (key, val) = vec_map::remove_entry_by_idx(&mut m, 0);
+        let (key, val) = m.remove_entry_by_idx(0);
         assert!(key == 5 && val == 50, 0);
-        assert!(vec_map::size(&m) == 2, 0);
+        assert!(m.size() == 2, 0);
 
-        let (key, val) = vec_map::remove_entry_by_idx(&mut m, 1);
+        let (key, val) = m.remove_entry_by_idx(1);
         assert!(key == 7 && val == 70, 0);
-        assert!(vec_map::size(&m) == 1, 0);
+        assert!(m.size() == 1, 0);
     }
 
     #[test]
     #[expected_failure(abort_code = vec_map::EMapNotEmpty)]
     fun destroy_non_empty() {
         let mut m = vec_map::empty();
-        vec_map::insert(&mut m, 1, true);
-        vec_map::destroy_empty(m)
+        m.insert(1, true);
+        m.destroy_empty()
     }
 
     #[test]
     fun destroy_empty() {
         let m: VecMap<u64, u64> = vec_map::empty();
         assert!(m.is_empty(), 0);
-        vec_map::destroy_empty(m)
+        m.destroy_empty()
     }
 
     #[test]
@@ -88,7 +87,7 @@ module sui::vec_map_tests {
         while (i < 10) {
             let k = i + 2;
             let v = i + 5;
-            vec_map::insert(&mut m, k, v);
+            m.insert(k, v);
             i = i + 1;
         };
         assert!(!m.is_empty(), 0);
@@ -98,16 +97,16 @@ module sui::vec_map_tests {
         while (i < 10) {
             let k = i + 2;
             assert!(m.contains(&k), 2);
-            let v = *vec_map::get(&m, &k);
+            let v = m[&k];
             assert!(v == i + 5, 3);
-            assert!(vec_map::get_idx(&m, &k) == i, 4);
-            let (other_k, other_v) = vec_map::get_entry_by_idx(&m, i);
+            assert!(m.get_idx(&k) == i, 4);
+            let (other_k, other_v) = m.get_entry_by_idx(i);
             assert!(*other_k == k, 5);
             assert!(*other_v == v, 6);
             i = i + 1;
         };
         // remove all the elements
-        let (keys, values) = vec_map::into_keys_values(copy m);
+        let (keys, values) = (copy m).into_keys_values();
         let mut i = 0;
         while (i < 10) {
             let k = i + 2;
@@ -125,11 +124,11 @@ module sui::vec_map_tests {
     fun return_list_of_keys() {
         let mut m = vec_map::empty();
 
-        assert!(vec_map::keys(&m) == vector[], 0);
+        assert!(m.keys() == vector[], 0);
 
-        vec_map::insert(&mut m, 1, true);
-        vec_map::insert(&mut m, 5, false);
+        m.insert(1, true);
+        m.insert(5, false);
 
-        assert!(vec_map::keys(&m) == vector[1, 5], 1);
+        assert!(m.keys() == vector[1, 5], 1);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_map_tests.move
@@ -77,7 +77,7 @@ module sui::vec_map_tests {
     #[test]
     fun destroy_empty() {
         let m: VecMap<u64, u64> = vec_map::empty();
-        assert!(vec_map::is_empty(&m), 0);
+        assert!(m.is_empty(), 0);
         vec_map::destroy_empty(m)
     }
 
@@ -91,13 +91,13 @@ module sui::vec_map_tests {
             vec_map::insert(&mut m, k, v);
             i = i + 1;
         };
-        assert!(!vec_map::is_empty(&m), 0);
+        assert!(!m.is_empty(), 0);
         assert!(vec_map::size(&m) == 10, 1);
         let mut i = 0;
         // make sure the elements are as expected in all of the getter APIs we expose
         while (i < 10) {
             let k = i + 2;
-            assert!(vec_map::contains(&m, &k), 2);
+            assert!(m.contains(&k), 2);
             let v = *vec_map::get(&m, &k);
             assert!(v == i + 5, 3);
             assert!(vec_map::get_idx(&m, &k) == i, 4);
@@ -111,11 +111,11 @@ module sui::vec_map_tests {
         let mut i = 0;
         while (i < 10) {
             let k = i + 2;
-            let (other_k, v) = vec_map::remove(&mut m, &k);
+            let (other_k, v) = m.remove(&k);
             assert!(k == other_k, 7);
             assert!(v == i + 5, 8);
-            assert!(*vector::borrow(&keys, i) == k, 9);
-            assert!(*vector::borrow(&values, i) == v, 10);
+            assert!(keys[i] == k, 9);
+            assert!(values[i] == v, 10);
 
             i = i + 1;
         }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
@@ -20,7 +20,7 @@ module sui::vec_set_tests {
         let mut m = vec_set::empty();
         vec_set::insert(&mut m, 1);
         let k = 2;
-        vec_set::remove(&mut m, &k);
+        m.remove(&k);
     }
 
     #[test]
@@ -32,13 +32,13 @@ module sui::vec_set_tests {
             vec_set::insert(&mut m, k);
             i = i + 1;
         };
-        assert!(!vec_set::is_empty(&m), 0);
+        assert!(!m.is_empty(), 0);
         assert!(vec_set::size(&m) == 10, 1);
         let mut i = 0;
         // make sure the elements are as expected in all of the getter APIs we expose
         while (i < 10) {
             let k = i + 2;
-            assert!(vec_set::contains(&m, &k), 2);
+            assert!(m.contains(&k), 2);
             i = i + 1;
         };
         // remove all the elements
@@ -46,8 +46,8 @@ module sui::vec_set_tests {
         let mut i = 0;
         while (i < 10) {
             let k = i + 2;
-            vec_set::remove(&mut m, &k);
-            assert!(*vector::borrow(&keys, i) == k, 9);
+            m.remove(&k);
+            assert!(keys[i] == k, 9);
             i = i + 1;
         }
     }

--- a/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
@@ -3,22 +3,21 @@
 
 #[test_only]
 module sui::vec_set_tests {
-    use std::vector;
     use sui::vec_set;
 
     #[test]
     #[expected_failure(abort_code = vec_set::EKeyAlreadyExists)]
     fun duplicate_key_abort() {
         let mut m = vec_set::empty();
-        vec_set::insert(&mut m, 1);
-        vec_set::insert(&mut m, 1);
+        m.insert(1);
+        m.insert(1);
     }
 
     #[test]
     #[expected_failure(abort_code = vec_set::EKeyDoesNotExist)]
     fun nonexistent_key_remove() {
         let mut m = vec_set::empty();
-        vec_set::insert(&mut m, 1);
+        m.insert(1);
         let k = 2;
         m.remove(&k);
     }
@@ -29,11 +28,11 @@ module sui::vec_set_tests {
         let mut i = 0;
         while (i < 10) {
             let k = i + 2;
-            vec_set::insert(&mut m, k);
+            m.insert(k);
             i = i + 1;
         };
         assert!(!m.is_empty(), 0);
-        assert!(vec_set::size(&m) == 10, 1);
+        assert!(m.size() == 10, 1);
         let mut i = 0;
         // make sure the elements are as expected in all of the getter APIs we expose
         while (i < 10) {
@@ -42,7 +41,7 @@ module sui::vec_set_tests {
             i = i + 1;
         };
         // remove all the elements
-        let keys = vec_set::into_keys(copy m);
+        let keys = (copy m).into_keys();
         let mut i = 0;
         while (i < 10) {
             let k = i + 2;
@@ -55,11 +54,11 @@ module sui::vec_set_tests {
     #[test]
     fun test_keys() {
         let mut m = vec_set::empty();
-        vec_set::insert(&mut m, 1);
-        vec_set::insert(&mut m, 2);
-        vec_set::insert(&mut m, 3);
+        m.insert(1);
+        m.insert(2);
+        m.insert(3);
 
-        assert!(vec_set::size(&m) == 3, 0);
-        assert!(vec_set::keys(&m) == &vector[1, 2, 3], 1);
+        assert!(m.size() == 3, 0);
+        assert!(m.keys() == &vector[1, 2, 3], 1);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/verifier_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/verifier_tests.move
@@ -15,11 +15,10 @@ module sui::verifier_tests {
         use sui::test_scenario;
         let admin = @0xBABE;
 
-        let mut scenario_val = test_scenario::begin(admin);
-        let scenario = &mut scenario_val;
+        let mut scenario = test_scenario::begin(admin);
         let otw = VERIFIER_TESTS{};
-        init(otw, test_scenario::ctx(scenario));
-        test_scenario::end(scenario_val);
+        init(otw, scenario.ctx());
+        scenario.end();
     }
 
     fun is_otw(witness: VERIFIER_TESTS): bool {

--- a/crates/sui-framework/packages/sui-framework/tests/versioned_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/versioned_tests.move
@@ -3,7 +3,6 @@
 
 #[test_only]
 module sui::versioned_tests {
-    use sui::tx_context;
     use sui::versioned;
 
     #[test]


### PR DESCRIPTION
## Description 

This largely converts the sui framework tests to move 2024 syntax.

## Test Plan 

Lots of hand-review, plus the tests still work. In addition, I used local bytecode diffing.

Note that the following files have bytecode changes and should be reviewed with additional care:

- authenticator_state_tests.move
- balance_tests.move
- coin_tests.move
- ecdsa_k1_tests.move
- pay_tests.move
- random_tests.move
- test_scenario_tests.move
- verifier_tests.move
- zklogin_verified_id_tests.move
- zklogin_verified_issuer_tests.move

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
