### PR TITLE
move lock: derive toolchain edition and flavor from manifest

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -158,23 +158,12 @@ impl BuildConfig {
         let print_diags_to_stderr = self.print_diags_to_stderr;
         let run_bytecode_verifier = self.run_bytecode_verifier;
         let resolution_graph = self.resolution_graph(&path)?;
-        let result = build_from_resolution_graph(
+        build_from_resolution_graph(
             path.clone(),
             resolution_graph,
             run_bytecode_verifier,
             print_diags_to_stderr,
-        );
-        if let Ok(ref compiled) = result {
-            compiled
-                .package
-                .compiled_package_info
-                .build_flags
-                .update_lock_file_toolchain_version(&path, env!("CARGO_PKG_VERSION").into())
-                .map_err(|e| SuiError::ModuleBuildFailure {
-                    error: format!("Failed to update Move.lock toolchain version: {e}"),
-                })?;
-        }
-        result
+        )
     }
 
     pub fn resolution_graph(mut self, path: &Path) -> SuiResult<ResolvedGraph> {

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -60,7 +60,7 @@ impl Build {
             run_bytecode_verifier: true,
             print_diags_to_stderr: true,
         }
-        .build(rerooted_path)?;
+        .build(rerooted_path.clone())?;
         if dump_bytecode_as_base64 {
             check_invalid_dependencies(&pkg.dependency_ids.invalid)?;
             if !with_unpublished_deps {
@@ -88,6 +88,11 @@ impl Build {
             layout_filename.push(STRUCT_LAYOUTS_FILENAME);
             fs::write(layout_filename, layout_str)?
         }
+
+        pkg.package
+            .compiled_package_info
+            .build_flags
+            .update_lock_file_toolchain_version(&rerooted_path, env!("CARGO_PKG_VERSION").into())?;
 
         Ok(())
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1766,7 +1766,7 @@ pub(crate) async fn compile_package(
         check_unpublished_dependencies(&dependencies.unpublished)?;
     };
     let compiled_package = build_from_resolution_graph(
-        package_path,
+        package_path.clone(),
         resolution_graph,
         run_bytecode_verifier,
         print_diags_to_stderr,
@@ -1815,6 +1815,16 @@ pub(crate) async fn compile_package(
     } else {
         eprintln!("{}", "Skipping dependency verification".bold().yellow());
     }
+
+    compiled_package
+        .package
+        .compiled_package_info
+        .build_flags
+        .update_lock_file_toolchain_version(&package_path, env!("CARGO_PKG_VERSION").into())
+        .map_err(|e| SuiError::ModuleBuildFailure {
+            error: format!("Failed to update Move.lock toolchain version: {e}"),
+        })?;
+
     Ok((dependencies, compiled_modules, compiled_package, package_id))
 }
 

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -11,7 +11,7 @@ pub mod package_hooks;
 pub mod resolution;
 pub mod source_package;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::*;
 use lock_file::LockFile;
 use move_compiler::{
@@ -22,7 +22,11 @@ use move_core_types::account_address::AccountAddress;
 use move_model::model::GlobalEnv;
 use resolution::{dependency_graph::DependencyGraphBuilder, resolution_graph::ResolvedGraph};
 use serde::{Deserialize, Serialize};
-use source_package::{layout::SourcePackageLayout, parsed_manifest::DependencyKind};
+use source_package::{
+    layout::SourcePackageLayout,
+    manifest_parser::{parse_move_manifest_string, parse_source_manifest},
+    parsed_manifest::DependencyKind,
+};
 use std::{
     collections::BTreeMap,
     io::{BufRead, Write},
@@ -326,20 +330,34 @@ impl BuildConfig {
 
     pub fn update_lock_file_toolchain_version(
         &self,
-        path: &PathBuf,
+        path: &Path,
         compiler_version: String,
     ) -> Result<()> {
         let Some(lock_file) = self.lock_file.as_ref() else {
             return Ok(());
         };
+        let path = &SourcePackageLayout::try_find_root(path)
+            .map_err(|e| anyhow!("Unable to find package root for {}: {e}", path.display()))?;
+
+        // Resolve edition and flavor from `Move.toml` or assign defaults.
+        let manifest_string =
+            std::fs::read_to_string(path.join(SourcePackageLayout::Manifest.path()))?;
+        let toml_manifest = parse_move_manifest_string(manifest_string.clone())?;
+        let root_manifest = parse_source_manifest(toml_manifest)?;
+        let edition = root_manifest
+            .package
+            .edition
+            .or(self.default_edition)
+            .unwrap_or_default();
+        let flavor = root_manifest
+            .package
+            .flavor
+            .or(self.default_flavor)
+            .unwrap_or_default();
+
         let install_dir = self.install_dir.as_ref().unwrap_or(path).to_owned();
         let mut lock = LockFile::from(install_dir, lock_file)?;
-        update_compiler_toolchain(
-            &mut lock,
-            compiler_version,
-            self.default_edition.unwrap_or_default(),
-            self.default_flavor.unwrap_or_default(),
-        )?;
+        update_compiler_toolchain(&mut lock, compiler_version, edition, flavor)?;
         let _mutx = PackageLock::lock();
         lock.commit(lock_file)?;
         Ok(())

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -157,8 +157,19 @@ flavor = "sui"
 #[test]
 fn update_lock_file_toolchain_version() {
     let pkg = create_test_package().unwrap();
-    let lock_path = pkg.path().join("Move.lock");
+    let move_manifest = pkg.path().join("Move.toml");
+    // The 2024.beta in the manifest should override defaults.
+    fs::write(
+        &move_manifest,
+        r#"
+          [package]
+          name = "test"
+          edition = "2024.beta"
+        "#,
+    )
+    .unwrap();
 
+    let lock_path = pkg.path().join("Move.lock");
     let lock = LockFile::new(
         pkg.path().to_path_buf(),
         /* manifest_digest */ "42".to_string(),
@@ -184,7 +195,7 @@ fn update_lock_file_toolchain_version() {
 
     let expected = expect![[r#"
         compiler-version = "0.0.1"
-        edition = "2024.alpha"
+        edition = "2024.beta"
         flavor = "sui"
     "#]];
     expected.assert_eq(&toml);


### PR DESCRIPTION
## Description 

Ensures toolchain versioning records `edition`/`flavor` derived from `Move.toml` when available. This was not the case before, because I was under the impression that `BuildConfig` reflects the current edition ([source and comment](https://sourcegraph.com/github.com/MystenLabs/sui@ed652f36766c4dec90de307278d64528b1697624/-/blob/external-crates/move/crates/move-package/src/compilation/compiled_package.rs?L71-72)) but this is not the case: [`compiler_config`](https://sourcegraph.com/github.com/MystenLabs/sui@ed652f36766c4dec90de307278d64528b1697624/-/blob/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs?L522) is really the function that merges both `BuildConfig` flags (specified on the command line) and `Move.toml` with edition. The result of that computation (`PackageConfig`) is also discarded after compilation / resolution graph uses. So, for simplicity, and without needing to rely on the resolution graph computed value, this PR updates toolchain versioning to record edition in a similar way to `compiler_config`: by parsing the manifest and merging extracted values.

## Test Plan 

Updated test(s).

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- The `Move.lock` will be populated with the edition corresponding to that in the `Move.toml`, if it exists.

- The `Move.lock` will be generated and populated with toolchain versioning information on `sui client publish`.
