### PR TITLE
add new rpc routes

### DIFF
--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -176,10 +176,15 @@ impl JsonRpcServerBuilder {
 
         match server_type {
             Some(ServerType::WebSocket) => {
-                router = router.route(
-                    "/",
-                    axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
-                );
+                router = router
+                    .route(
+                        "/",
+                        axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
+                    )
+                    .route(
+                        "/subscribe",
+                        axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
+                    );
             }
             Some(ServerType::Http) => {
                 router = router
@@ -189,6 +194,10 @@ impl JsonRpcServerBuilder {
                     )
                     .route(
                         "/json-rpc",
+                        axum::routing::post(crate::axum_router::json_rpc_handler),
+                    )
+                    .route(
+                        "/public",
                         axum::routing::post(crate::axum_router::json_rpc_handler),
                     );
             }
@@ -203,7 +212,15 @@ impl JsonRpcServerBuilder {
                         axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
                     )
                     .route(
+                        "/subscribe",
+                        axum::routing::get(crate::axum_router::ws::ws_json_rpc_upgrade),
+                    )
+                    .route(
                         "/json-rpc",
+                        axum::routing::post(crate::axum_router::json_rpc_handler),
+                    )
+                    .route(
+                        "/public",
                         axum::routing::post(crate::axum_router::json_rpc_handler),
                     );
             }


### PR DESCRIPTION
Support indexer listening on `/public` (json-rpc) and sui-node listening on `/subscribe` (websockets).

- testing existing and new json-rpc routes (with indexer and sui-node):

```
curl -w "%{http_code}" http://localhost:9000/ -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200%
```

```
% curl -w "%{http_code}" http://localhost:9000/json-rpc -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200%
```

```
curl -w "%{http_code}" http://localhost:9000/public -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0", "method":"sui_getObject", "params":["0x2"], "id":1}'
{"jsonrpc":"2.0","result":{"data":{"objectId":"0x0000000000000000000000000000000000000000000000000000000000000002","version":"1","digest":"7WbYdh6bcvniPfyZjUnjoLziM1KYuqEreRv5CFBYxXBS"}},"id":1}200%
```

- testing existing and new websocket routes (with sui-node):

```
% wscat -c ws://localhost:9000 -P
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0", "id": 1, "method": "suix_subscribeTransaction", "params": [{"ChangedObject":"0x2"}]}
< {"jsonrpc":"2.0","result":2126515709876599,"id":1}
>
```

```
% wscat -c ws://localhost:9000/subscribe -P
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0", "id": 1, "method": "suix_subscribeTransaction", "params": [{"ChangedObject":"0x2"}]}
< {"jsonrpc":"2.0","result":3285488822574031,"id":1}
> 
```