### PR TITLE
Add TestEffectsBuilder

### DIFF
--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -13,6 +13,7 @@ use std::{
 use sui_framework::BuiltInFramework;
 use sui_macros::{register_fail_point_async, sim_test};
 use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::effects::TestEffectsBuilder;
 use sui_types::{
     base_types::{random_object_ref, SuiAddress},
     crypto::{deterministic_random_account_key, get_key_pair_from_rng, AccountKeyPair},
@@ -161,7 +162,7 @@ impl Scenario {
             .build_and_sign(&keypair);
 
         let tx = VerifiedTransaction::new_unchecked(tx);
-        let effects = TransactionEffects::new_with_tx(tx.inner());
+        let effects = TestEffectsBuilder::new(tx.inner()).build();
 
         TransactionOutputs {
             transaction: Arc::new(tx),
@@ -703,7 +704,7 @@ async fn test_missing_reverts_panic() {
 
 #[tokio::test]
 #[should_panic(expected = "transaction must exist")]
-async fn test_revert_commited_tx_panics() {
+async fn test_revert_committed_tx_panics() {
     telemetry_subscribers::init_for_testing();
     Scenario::iterate(|mut s| async move {
         s.with_created(&[1]);

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -26,7 +26,7 @@ use sui_types::crypto::{
     NetworkKeyPair, SuiKeyPair,
 };
 use sui_types::crypto::{AuthorityKeyPair, Signer};
-use sui_types::effects::{SignedTransactionEffects, TransactionEffects};
+use sui_types::effects::{SignedTransactionEffects, TestEffectsBuilder};
 use sui_types::error::SuiError;
 use sui_types::transaction::ObjectArg;
 use sui_types::transaction::{
@@ -180,15 +180,11 @@ pub fn create_fake_cert_and_effect_digest<'a>(
         committee,
     )
     .unwrap();
-    let effects = dummy_transaction_effects(&transaction);
+    let effects = TestEffectsBuilder::new(transaction.data()).build();
     (
         ExecutionDigests::new(*transaction.digest(), effects.digest()),
         cert,
     )
-}
-
-pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
-    TransactionEffects::new_with_tx(tx)
 }
 
 pub fn compile_basics_package() -> CompiledPackage {

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -13,7 +13,9 @@ use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::digests::{
     CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
 };
-use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
+use sui_types::effects::{
+    TestEffectsBuilder, TransactionEffects, TransactionEffectsAPI, TransactionEvents,
+};
 use sui_types::error::SuiResult;
 use sui_types::event::Event;
 use sui_types::messages_checkpoint::{
@@ -37,7 +39,7 @@ fn random_tx() -> Transaction {
 
 fn random_fx() -> TransactionEffects {
     let tx = random_tx();
-    TransactionEffects::new_with_tx(&tx)
+    TestEffectsBuilder::new(tx.data()).build()
 }
 
 fn random_events() -> TransactionEvents {

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -14,9 +14,7 @@ use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
 #[cfg(debug_assertions)]
 use crate::is_system_package;
-use crate::message_envelope::Message;
 use crate::object::{Owner, OBJECT_START_VERSION};
-use crate::transaction::SenderSignedData;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 #[cfg(debug_assertions)]
@@ -450,34 +448,6 @@ impl TransactionEffectsV2 {
         result.check_invariant();
 
         result
-    }
-
-    pub fn new_with_tx_and_gas(tx: &SenderSignedData, gas_object: (ObjectRef, Owner)) -> Self {
-        Self {
-            transaction_digest: tx.digest(),
-            lamport_version: gas_object.0 .1,
-            changed_objects: vec![(
-                gas_object.0 .0,
-                EffectsObjectChange {
-                    input_state: ObjectIn::Exist((
-                        (SequenceNumber::default(), ObjectDigest::MIN),
-                        gas_object.1,
-                    )),
-                    output_state: ObjectOut::ObjectWrite((gas_object.0 .2, gas_object.1)),
-                    id_operation: IDOperation::None,
-                },
-            )],
-            gas_object_index: Some(0),
-            ..Default::default()
-        }
-    }
-
-    pub fn new_with_tx_and_status(tx: &SenderSignedData, status: ExecutionStatus) -> Self {
-        Self {
-            transaction_digest: tx.digest(),
-            status,
-            ..Default::default()
-        }
     }
 
     /// This function demonstrates what's the invariant of the effects.

--- a/crates/sui-types/src/effects/test_effects_builder.rs
+++ b/crates/sui-types/src/effects/test_effects_builder.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::base_types::{ObjectID, SequenceNumber};
+use crate::digests::ObjectDigest;
+use crate::effects::{EffectsObjectChange, IDOperation, ObjectIn, ObjectOut, TransactionEffects};
+use crate::execution::SharedInput;
+use crate::execution_status::ExecutionStatus;
+use crate::gas::GasCostSummary;
+use crate::message_envelope::Message;
+use crate::object::Owner;
+use crate::transaction::{InputObjectKind, SenderSignedData, TransactionDataAPI};
+use std::collections::BTreeMap;
+
+pub struct TestEffectsBuilder {
+    transaction: SenderSignedData,
+    /// Override the execution status if provided.
+    status: Option<ExecutionStatus>,
+    /// Provide the assigned versions for all shared objects.
+    shared_input_versions: BTreeMap<ObjectID, SequenceNumber>,
+}
+
+impl TestEffectsBuilder {
+    pub fn new(transaction: &SenderSignedData) -> Self {
+        Self {
+            transaction: transaction.clone(),
+            status: None,
+            shared_input_versions: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_status(mut self, status: ExecutionStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn with_shared_input_versions(
+        mut self,
+        versions: BTreeMap<ObjectID, SequenceNumber>,
+    ) -> Self {
+        assert!(self.shared_input_versions.is_empty());
+        self.shared_input_versions = versions;
+        self
+    }
+
+    pub fn build(self) -> TransactionEffects {
+        let status = self.status.unwrap_or_else(|| ExecutionStatus::Success);
+        // TODO: This does not yet support deleted shared objects.
+        let shared_objects = self
+            .shared_input_versions
+            .iter()
+            .map(|(id, version)| SharedInput::Existing((*id, *version, ObjectDigest::MIN)))
+            .collect();
+        let executed_epoch = 0;
+        let lamport_version = SequenceNumber::lamport_increment(
+            self.transaction
+                .transaction_data()
+                .input_objects()
+                .unwrap()
+                .iter()
+                .filter_map(|kind| kind.version())
+                .chain(
+                    self.transaction
+                        .transaction_data()
+                        .receiving_objects()
+                        .iter()
+                        .map(|oref| oref.1),
+                )
+                .chain(self.shared_input_versions.values().copied()),
+        );
+        let sender = self.transaction.transaction_data().sender();
+        // TODO: Include receiving objects in the object changes as well.
+        let changed_objects = self
+            .transaction
+            .transaction_data()
+            .input_objects()
+            .unwrap()
+            .iter()
+            .filter_map(|kind| match kind {
+                InputObjectKind::ImmOrOwnedMoveObject(oref) => Some((
+                    oref.0,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::Exist((
+                            (oref.1, oref.2),
+                            Owner::AddressOwner(sender),
+                        )),
+                        output_state: ObjectOut::ObjectWrite((
+                            // Digest must change with a mutation.
+                            ObjectDigest::MAX,
+                            Owner::AddressOwner(sender),
+                        )),
+                        id_operation: IDOperation::None,
+                    },
+                )),
+                InputObjectKind::MovePackage(_) => None,
+                InputObjectKind::SharedMoveObject {
+                    id,
+                    initial_shared_version,
+                    mutable,
+                } => mutable.then_some((
+                    *id,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::Exist((
+                            (
+                                *self
+                                    .shared_input_versions
+                                    .get(id)
+                                    .unwrap_or(initial_shared_version),
+                                ObjectDigest::MIN,
+                            ),
+                            Owner::Shared {
+                                initial_shared_version: *initial_shared_version,
+                            },
+                        )),
+                        output_state: ObjectOut::ObjectWrite((
+                            // Digest must change with a mutation.
+                            ObjectDigest::MAX,
+                            Owner::Shared {
+                                initial_shared_version: *initial_shared_version,
+                            },
+                        )),
+                        id_operation: IDOperation::None,
+                    },
+                )),
+            })
+            .collect();
+        let gas_object_id = self.transaction.transaction_data().gas()[0].0;
+        let event_digest = None;
+        let dependencies = vec![];
+        TransactionEffects::new_from_execution_v2(
+            status,
+            executed_epoch,
+            GasCostSummary::default(),
+            shared_objects,
+            self.transaction.digest(),
+            lamport_version,
+            changed_objects,
+            Some(gas_object_id),
+            event_digest,
+            dependencies,
+        )
+    }
+}

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -11,7 +11,7 @@ use crate::crypto::{
     AuthorityStrongQuorumSignInfo,
 };
 use crate::digests::Digest;
-use crate::effects::{TransactionEffects, TransactionEffectsAPI};
+use crate::effects::{TestEffectsBuilder, TransactionEffectsAPI};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
 use crate::message_envelope::{
@@ -613,7 +613,7 @@ impl FullCheckpointContents {
             ),
             vec![&key],
         );
-        let effects = TransactionEffects::new_with_tx(&transaction);
+        let effects = TestEffectsBuilder::new(transaction.data()).build();
         let exe_data = ExecutionData {
             transaction,
             effects,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -16,7 +16,7 @@ use crate::crypto::{
     AuthoritySignInfoTrait, SuiAuthoritySignature,
 };
 use crate::digests::TransactionEventsDigest;
-use crate::effects::{SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI};
+use crate::effects::{SignedTransactionEffects, TestEffectsBuilder, TransactionEffectsAPI};
 use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
 use crate::object::Owner;
@@ -457,7 +457,7 @@ fn test_empty_bitmap() {
 fn test_digest_caching() {
     let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
     // TODO: refactor this test to not reuse the same keys for user and authority signing
-    let (a1, sec1): (_, AuthorityKeyPair) = get_key_pair();
+    let (_a1, sec1): (_, AuthorityKeyPair) = get_key_pair();
     let (_a2, sec2): (_, AuthorityKeyPair) = get_key_pair();
 
     let (sa1, _ssec1): (_, AccountKeyPair) = get_key_pair();
@@ -512,10 +512,7 @@ fn test_digest_caching() {
     // cached digest was not serialized/deserialized
     assert_ne!(initial_digest, *deserialized_tx.digest());
 
-    let effects = TransactionEffects::new_with_tx_and_gas(
-        &transaction,
-        (random_object_ref(), Owner::AddressOwner(a1)),
-    );
+    let effects = TestEffectsBuilder::new(transaction.data()).build();
 
     let mut signed_effects = SignedTransactionEffects::new(
         committee.epoch(),


### PR DESCRIPTION
## Description 

Add a builder to create test effects from transactions. This will make it easier to test some components.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
