### PR TITLE
[move-2024] Update sui system tests to Move 2024 / Method Syntax

### DIFF
--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -189,6 +189,9 @@ module sui_system::staking_pool {
         principal
     }
 
+    /// Allows calling `.into_balance()` on `StakedSui` to invoke `unwrap_staked_sui`
+    public use fun unwrap_staked_sui as StakedSui.into_balance;
+
     // ==== functions called at epoch boundaries ===
 
     /// Called at epoch advancement times to add rewards (in SUI) to the staking pool.
@@ -288,6 +291,9 @@ module sui_system::staking_pool {
 
     public fun staked_sui_amount(staked_sui: &StakedSui): u64 { staked_sui.principal.value() }
 
+    /// Allows calling `.amount()` on `StakedSui` to invoke `staked_sui_amount`
+    public use fun staked_sui_amount as StakedSui.amount;
+
     public fun stake_activation_epoch(staked_sui: &StakedSui): u64 {
         staked_sui.stake_activation_epoch
     }
@@ -326,6 +332,9 @@ module sui_system::staking_pool {
         transfer::transfer(split(stake, split_amount, ctx), ctx.sender());
     }
 
+    /// Allows calling `.split_to_sender()` on `StakedSui` to invoke `split_staked_sui`
+    public use fun split_staked_sui as StakedSui.split_to_sender;
+
     /// Consume the staked sui `other` and add its value to `self`.
     /// Aborts if some of the staking parameters are incompatible (pool id, stake activation epoch, etc.)
     public entry fun join_staked_sui(self: &mut StakedSui, other: StakedSui) {
@@ -341,12 +350,14 @@ module sui_system::staking_pool {
         self.principal.join(principal);
     }
 
+    /// Allows calling `.join()` on `StakedSui` to invoke `join_staked_sui`
+    public use fun join_staked_sui as StakedSui.join;
+
     /// Returns true if all the staking parameters of the staked sui except the principal are identical
     public fun is_equal_staking_metadata(self: &StakedSui, other: &StakedSui): bool {
         (self.pool_id == other.pool_id) &&
         (self.stake_activation_epoch == other.stake_activation_epoch)
     }
-
 
     public fun pool_token_exchange_rate_at_epoch(pool: &StakingPool, epoch: u64): PoolTokenExchangeRate {
         // If the pool is preactive then the exchange rate is always 1:1.

--- a/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
@@ -10,15 +10,14 @@ module sui_system::stake_tests {
     use sui::test_utils::assert_eq;
     use sui_system::validator_set;
     use sui::test_utils;
-    use sui::table::{Self, Table};
-    use std::vector;
+    use sui::table::Table;
 
     use sui_system::governance_test_utils::{
-        Self,
         add_validator,
         add_validator_candidate,
         advance_epoch,
         advance_epoch_with_reward_amounts,
+        assert_validator_total_stake_amounts,
         create_validator_for_testing,
         create_sui_system_state_for_testing,
         stake_with,
@@ -49,36 +48,36 @@ module sui_system::stake_tests {
         set_up_sui_system_state();
         let mut scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            let ctx = test_scenario::ctx(scenario);
-            staking_pool::split_staked_sui(&mut staked_sui, 20 * MIST_PER_SUI, ctx);
-            test_scenario::return_to_sender(scenario, staked_sui);
+            let mut staked_sui = scenario.take_from_sender<StakedSui>();
+            let ctx = scenario.ctx();
+            staked_sui.split_to_sender(20 * MIST_PER_SUI, ctx);
+            scenario.return_to_sender(staked_sui);
         };
 
         // Verify the correctness of the split and send the join txn
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let staked_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
-            assert!(vector::length(&staked_sui_ids) == 2, 101); // staked sui split to 2 coins
+            let staked_sui_ids = scenario.ids_for_sender<StakedSui>();
+            assert!(staked_sui_ids.length() == 2, 101); // staked sui split to 2 coins
 
-            let mut part1 = test_scenario::take_from_sender_by_id<StakedSui>(scenario, *vector::borrow(&staked_sui_ids, 0));
-            let part2 = test_scenario::take_from_sender_by_id<StakedSui>(scenario, *vector::borrow(&staked_sui_ids, 1));
+            let mut part1 = scenario.take_from_sender_by_id<StakedSui>(staked_sui_ids[0]);
+            let part2 = scenario.take_from_sender_by_id<StakedSui>(staked_sui_ids[1]);
 
-            let amount1 = staking_pool::staked_sui_amount(&part1);
-            let amount2 = staking_pool::staked_sui_amount(&part2);
+            let amount1 = part1.amount();
+            let amount2 = part2.amount();
             assert!(amount1 == 20 * MIST_PER_SUI || amount1 == 40 * MIST_PER_SUI, 102);
             assert!(amount2 == 20 * MIST_PER_SUI || amount2 == 40 * MIST_PER_SUI, 103);
             assert!(amount1 + amount2 == 60 * MIST_PER_SUI, 104);
 
-            staking_pool::join_staked_sui(&mut part1, part2);
-            assert!(staking_pool::staked_sui_amount(&part1) == 60 * MIST_PER_SUI, 105);
-            test_scenario::return_to_sender(scenario, part1);
+            part1.join(part2);
+            assert!(part1.amount() == 60 * MIST_PER_SUI, 105);
+            scenario.return_to_sender(part1);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -88,22 +87,22 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
         // Create two instances of staked sui w/ different epoch activations
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
-        governance_test_utils::advance_epoch(scenario);
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+        advance_epoch(scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
 
         // Verify that these cannot be merged
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let staked_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
-            let mut part1 = test_scenario::take_from_sender_by_id<StakedSui>(scenario, *vector::borrow(&staked_sui_ids, 0));
-            let part2 = test_scenario::take_from_sender_by_id<StakedSui>(scenario, *vector::borrow(&staked_sui_ids, 1));
+            let staked_sui_ids = scenario.ids_for_sender<StakedSui>();
+            let mut part1 = scenario.take_from_sender_by_id<StakedSui>(staked_sui_ids[0]);
+            let part2 = scenario.take_from_sender_by_id<StakedSui>(staked_sui_ids[1]);
 
-            staking_pool::join_staked_sui(&mut part1, part2);
+            part1.join(part2);
 
-            test_scenario::return_to_sender(scenario, part1);
+            scenario.return_to_sender(part1);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -113,17 +112,17 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
         // Stake 2 SUI
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 2, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 2, scenario);
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            let ctx = test_scenario::ctx(scenario);
+            let mut staked_sui = scenario.take_from_sender<StakedSui>();
+            let ctx = scenario.ctx();
             // The remaining amount after splitting is below the threshold so this should fail.
-            staking_pool::split_staked_sui(&mut staked_sui, 1 * MIST_PER_SUI + 1, ctx);
-            test_scenario::return_to_sender(scenario, staked_sui);
+            staked_sui.split_to_sender(1 * MIST_PER_SUI + 1, ctx);
+            scenario.return_to_sender(staked_sui);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -133,18 +132,18 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
         // Stake 2 SUI
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 2, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 2, scenario);
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            let ctx = test_scenario::ctx(scenario);
+            let mut staked_sui = scenario.take_from_sender<StakedSui>();
+            let ctx = scenario.ctx();
             // The remaining amount after splitting is below the threshold so this should fail.
-            let stake = staking_pool::split(&mut staked_sui, 1 * MIST_PER_SUI + 1, ctx);
+            let stake = staked_sui.split(1 * MIST_PER_SUI + 1, ctx);
             test_utils::destroy(stake);
-            test_scenario::return_to_sender(scenario, staked_sui);
+            scenario.return_to_sender(staked_sui);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -153,56 +152,56 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
 
             // Create a stake to VALIDATOR_ADDR_1.
             sui_system::request_add_stake(
                 system_state_mut_ref, coin::mint_for_testing(60 * MIST_PER_SUI, ctx), VALIDATOR_ADDR_1, ctx);
 
-            assert!(sui_system::validator_stake_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 100 * MIST_PER_SUI, 101);
-            assert!(sui_system::validator_stake_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 100 * MIST_PER_SUI, 102);
+            assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_1) == 100 * MIST_PER_SUI, 101);
+            assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_2) == 100 * MIST_PER_SUI, 102);
 
             test_scenario::return_shared(system_state);
         };
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
 
-            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            assert!(staking_pool::staked_sui_amount(&staked_sui) == 60 * MIST_PER_SUI, 105);
+            let staked_sui = scenario.take_from_sender<StakedSui>();
+            assert!(staked_sui.amount() == 60 * MIST_PER_SUI, 105);
 
 
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
-            assert!(sui_system::validator_stake_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 160 * MIST_PER_SUI, 103);
-            assert!(sui_system::validator_stake_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 100 * MIST_PER_SUI, 104);
+            assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_1) == 160 * MIST_PER_SUI, 103);
+            assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_2) == 100 * MIST_PER_SUI, 104);
 
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
 
             // Unstake from VALIDATOR_ADDR_1
-            sui_system::request_withdraw_stake(system_state_mut_ref, staked_sui, ctx);
+            system_state_mut_ref.request_withdraw_stake(staked_sui, ctx);
 
-            assert!(sui_system::validator_stake_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 160 * MIST_PER_SUI, 107);
+            assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_1) == 160 * MIST_PER_SUI, 107);
             test_scenario::return_shared(system_state);
         };
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-            assert!(sui_system::validator_stake_amount(&mut system_state, VALIDATOR_ADDR_1) == 100 * MIST_PER_SUI, 107);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
+            assert!(system_state.validator_stake_amount(VALIDATOR_ADDR_1) == 100 * MIST_PER_SUI, 107);
             test_scenario::return_shared(system_state);
         };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -220,11 +219,11 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
 
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
-        governance_test_utils::assert_validator_total_stake_amounts(
+        assert_validator_total_stake_amounts(
             vector[VALIDATOR_ADDR_1, VALIDATOR_ADDR_2],
             vector[200 * MIST_PER_SUI, 100 * MIST_PER_SUI],
             scenario
@@ -232,36 +231,36 @@ module sui_system::stake_tests {
 
         if (should_distribute_rewards) {
             // Each validator pool gets 30 MIST and each validator gets an additional 10 MIST.
-            governance_test_utils::advance_epoch_with_reward_amounts(0, 80, scenario);
+            advance_epoch_with_reward_amounts(0, 80, scenario);
         } else {
-            governance_test_utils::advance_epoch(scenario);
+            advance_epoch(scenario);
         };
 
-        governance_test_utils::remove_validator(VALIDATOR_ADDR_1, scenario);
+        remove_validator(VALIDATOR_ADDR_1, scenario);
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         let reward_amt = if (should_distribute_rewards) 15 * MIST_PER_SUI else 0;
         let validator_reward_amt = if (should_distribute_rewards) 10 * MIST_PER_SUI else 0;
 
         // Make sure stake withdrawal happens
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
             assert!(!validator_set::is_active_validator_by_sui_address(
-                        sui_system::validators(system_state_mut_ref),
+                        system_state_mut_ref.validators(),
                         VALIDATOR_ADDR_1
                     ), 0);
 
-            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            assert_eq(staking_pool::staked_sui_amount(&staked_sui), 100 * MIST_PER_SUI);
+            let staked_sui = scenario.take_from_sender<StakedSui>();
+            assert_eq(staked_sui.amount(), 100 * MIST_PER_SUI);
 
             // Unstake from VALIDATOR_ADDR_1
             assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 0);
-            let ctx = test_scenario::ctx(scenario);
-            sui_system::request_withdraw_stake(system_state_mut_ref, staked_sui, ctx);
+            let ctx = scenario.ctx();
+            system_state_mut_ref.request_withdraw_stake(staked_sui, ctx);
 
             // Make sure they have all of their stake.
             assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 100 * MIST_PER_SUI + reward_amt);
@@ -277,7 +276,7 @@ module sui_system::stake_tests {
         // Make sure have all of their stake. NB there is no epoch change. This is immediate.
         assert_eq(total_sui_balance(VALIDATOR_ADDR_1, scenario), 100 * MIST_PER_SUI + reward_amt + validator_reward_amt);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -302,18 +301,18 @@ module sui_system::stake_tests {
         let validator_reward_amt = 10 * MIST_PER_SUI;
 
         // Make sure stake withdrawal happens
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
-            let staked_sui = test_scenario::take_from_sender<StakedSui>(scenario);
-            assert_eq(staking_pool::staked_sui_amount(&staked_sui), 100 * MIST_PER_SUI);
+            let staked_sui = scenario.take_from_sender<StakedSui>();
+            assert_eq(staked_sui.amount(), 100 * MIST_PER_SUI);
 
             // Unstake from VALIDATOR_ADDR_1
             assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 0);
-            let ctx = test_scenario::ctx(scenario);
-            sui_system::request_withdraw_stake(system_state_mut_ref, staked_sui, ctx);
+            let ctx = scenario.ctx();
+            system_state_mut_ref.request_withdraw_stake(staked_sui, ctx);
 
             // Make sure they have all of their stake.
             assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 100 * MIST_PER_SUI + reward_amt);
@@ -329,7 +328,7 @@ module sui_system::stake_tests {
         // Make sure have all of their stake. NB there is no epoch change. This is immediate.
         assert_eq(total_sui_balance(VALIDATOR_ADDR_1, scenario), 100 * MIST_PER_SUI + reward_amt + validator_reward_amt);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -339,22 +338,22 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
 
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
-        governance_test_utils::remove_validator(VALIDATOR_ADDR_1, scenario);
+        remove_validator(VALIDATOR_ADDR_1, scenario);
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         // Make sure the validator is no longer active.
-        test_scenario::next_tx(scenario, STAKER_ADDR_1);
+        scenario.next_tx(STAKER_ADDR_1);
         {
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
             assert!(!validator_set::is_active_validator_by_sui_address(
-                        sui_system::validators(system_state_mut_ref),
+                        system_state_mut_ref.validators(),
                         VALIDATOR_ADDR_1
                     ), 0);
 
@@ -362,9 +361,9 @@ module sui_system::stake_tests {
         };
 
         // Now try and stake to the old validator/staking pool. This should fail!
-        governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
+        stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -373,20 +372,20 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
 
-        governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, b"name5", b"/ip4/127.0.0.1/udp/85", NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+        add_validator_candidate(NEW_VALIDATOR_ADDR, b"name5", b"/ip4/127.0.0.1/udp/85", NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
         // Delegate 100 MIST to the preactive validator
-        governance_test_utils::stake_with(STAKER_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+        stake_with(STAKER_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
 
         // Advance epoch twice with some rewards
         advance_epoch_with_reward_amounts(0, 400, scenario);
         advance_epoch_with_reward_amounts(0, 900, scenario);
 
         // Unstake from the preactive validator. There should be no rewards earned.
-        governance_test_utils::unstake(STAKER_ADDR_1, 0, scenario);
+        unstake(STAKER_ADDR_1, 0, scenario);
         assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 100 * MIST_PER_SUI);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -396,15 +395,15 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
 
-        governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, b"name4", b"/ip4/127.0.0.1/udp/84", NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
+        add_validator_candidate(NEW_VALIDATOR_ADDR, b"name4", b"/ip4/127.0.0.1/udp/84", NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
-        governance_test_utils::add_validator(NEW_VALIDATOR_ADDR, scenario);
+        add_validator(NEW_VALIDATOR_ADDR, scenario);
 
         // Delegate 100 SUI to the pending validator. This should fail because pending active validators don't accept
         // new stakes or withdraws.
-        governance_test_utils::stake_with(STAKER_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
+        stake_with(STAKER_ADDR_1, NEW_VALIDATOR_ADDR, 100, scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -448,7 +447,7 @@ module sui_system::stake_tests {
         // so in total she has about 50 + 5 + 24 = 79 SUI.
         assert_eq(total_sui_balance(STAKER_ADDR_2, scenario), 78862939078);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -478,7 +477,7 @@ module sui_system::stake_tests {
         unstake(STAKER_ADDR_1, 0, scenario);
         assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 130006000000);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -507,7 +506,7 @@ module sui_system::stake_tests {
         unstake(STAKER_ADDR_1, 0, scenario);
         assert_eq(total_sui_balance(STAKER_ADDR_1, scenario), 100 * MIST_PER_SUI);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -516,54 +515,54 @@ module sui_system::stake_tests {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
         stake_with(@0x42, @0x2, 100, scenario); // stakes 100 SUI with 0x2
-        test_scenario::next_tx(scenario, @0x42);
-        let staked_sui = test_scenario::take_from_address<StakedSui>(scenario, @0x42);
-        let pool_id = staking_pool::pool_id(&staked_sui);
+        scenario.next_tx(@0x42);
+        let staked_sui = scenario.take_from_address<StakedSui>(@0x42);
+        let pool_id = staked_sui.pool_id();
         test_scenario::return_to_address(@0x42, staked_sui);
         advance_epoch(scenario); // advances epoch to effectuate the stake
         // Each staking pool gets 10 SUI of rewards.
         advance_epoch_with_reward_amounts(0, 20, scenario);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let rates = sui_system::pool_exchange_rates(&mut system_state, &pool_id);
-        assert_eq(table::length(rates), 3);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let rates = system_state.pool_exchange_rates(&pool_id);
+        assert_eq(rates.length(), 3);
         assert_exchange_rate_eq(rates, 0, 0, 0);     // no tokens at epoch 0
         assert_exchange_rate_eq(rates, 1, 200, 200); // 200 SUI of self + delegate stake at epoch 1
         assert_exchange_rate_eq(rates, 2, 210, 200); // 10 SUI of rewards at epoch 2
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun assert_exchange_rate_eq(
         rates: &Table<u64, PoolTokenExchangeRate>, epoch: u64, sui_amount: u64, pool_token_amount: u64
     ) {
-        let rate = table::borrow(rates, epoch);
-        assert_eq(staking_pool::sui_amount(rate), sui_amount * MIST_PER_SUI);
-        assert_eq(staking_pool::pool_token_amount(rate), pool_token_amount * MIST_PER_SUI);
+        let rate = &rates[epoch];
+        assert_eq(rate.sui_amount(), sui_amount * MIST_PER_SUI);
+        assert_eq(rate.pool_token_amount(), pool_token_amount * MIST_PER_SUI);
     }
 
     fun set_up_sui_system_state() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validators = vector[
             create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
         ];
         create_sui_system_state_for_testing(validators, 0, 0, ctx);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun set_up_sui_system_state_with_storage_fund() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validators = vector[
             create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
             create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
         ];
         create_sui_system_state_for_testing(validators, 300, 100, ctx);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
@@ -5,7 +5,7 @@
 module sui_system::stake_tests {
     use sui::coin;
     use sui::test_scenario;
-    use sui_system::sui_system::{Self, SuiSystemState};
+    use sui_system::sui_system::SuiSystemState;
     use sui_system::staking_pool::{Self, StakedSui, PoolTokenExchangeRate};
     use sui::test_utils::assert_eq;
     use sui_system::validator_set;
@@ -160,8 +160,9 @@ module sui_system::stake_tests {
             let ctx = scenario.ctx();
 
             // Create a stake to VALIDATOR_ADDR_1.
-            sui_system::request_add_stake(
-                system_state_mut_ref, coin::mint_for_testing(60 * MIST_PER_SUI, ctx), VALIDATOR_ADDR_1, ctx);
+            system_state_mut_ref.request_add_stake(
+                coin::mint_for_testing(60 * MIST_PER_SUI, ctx), VALIDATOR_ADDR_1, ctx
+            );
 
             assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_1) == 100 * MIST_PER_SUI, 101);
             assert!(system_state_mut_ref.validator_stake_amount(VALIDATOR_ADDR_2) == 100 * MIST_PER_SUI, 102);
@@ -249,10 +250,7 @@ module sui_system::stake_tests {
             let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
-            assert!(!validator_set::is_active_validator_by_sui_address(
-                        system_state_mut_ref.validators(),
-                        VALIDATOR_ADDR_1
-                    ), 0);
+            assert!(!system_state_mut_ref.validators().is_active_validator_by_sui_address(VALIDATOR_ADDR_1), 0);
 
             let staked_sui = scenario.take_from_sender<StakedSui>();
             assert_eq(staked_sui.amount(), 100 * MIST_PER_SUI);
@@ -352,10 +350,7 @@ module sui_system::stake_tests {
             let mut system_state = scenario.take_shared<SuiSystemState>();
             let system_state_mut_ref = &mut system_state;
 
-            assert!(!validator_set::is_active_validator_by_sui_address(
-                        system_state_mut_ref.validators(),
-                        VALIDATOR_ADDR_1
-                    ), 0);
+            assert!(!system_state_mut_ref.validators().is_active_validator_by_sui_address(VALIDATOR_ADDR_1), 0);
 
             test_scenario::return_shared(system_state);
         };

--- a/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
+++ b/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
@@ -5,20 +5,15 @@
 module sui_system::governance_test_utils {
     use sui::address;
     use sui::balance;
-    use sui::object;
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
-    use sui_system::staking_pool::{Self, StakedSui, StakingPool};
+    use sui_system::staking_pool::{StakedSui, StakingPool};
     use sui::test_utils::assert_eq;
-    use sui::tx_context::{Self, TxContext};
     use sui_system::validator::{Self, Validator};
     use sui_system::sui_system::{Self, SuiSystemState};
     use sui_system::sui_system_state_inner;
     use sui_system::stake_subsidy;
     use sui::test_scenario::{Self, Scenario};
-    use sui_system::validator_set;
-    use std::option;
-    use std::vector;
     use sui::test_utils;
     use sui::balance::Balance;
 
@@ -54,9 +49,9 @@ module sui_system::governance_test_utils {
     public fun create_validators_with_stakes(stakes: vector<u64>, ctx: &mut TxContext): vector<Validator> {
         let mut i = 0;
         let mut validators = vector[];
-        while (i < vector::length(&stakes)) {
-            let validator = create_validator_for_testing(address::from_u256((i as u256)), *vector::borrow(&stakes, i), ctx);
-            vector::push_back(&mut validators, validator);
+        while (i < stakes.length()) {
+            let validator = create_validator_for_testing(address::from_u256((i as u256)), stakes[i], ctx);
+            validators.push_back(validator);
             i = i + 1
         };
         validators
@@ -98,20 +93,18 @@ module sui_system::governance_test_utils {
     }
 
     public fun set_up_sui_system_state(mut addrs: vector<address>) {
-        let mut scenario_val = test_scenario::begin(@0x0);
-        let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
-        let mut validators = vector::empty();
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let mut validators = vector[];
 
-        while (!vector::is_empty(&addrs)) {
-            vector::push_back(
-                &mut validators,
-                create_validator_for_testing(vector::pop_back(&mut addrs), 100, ctx)
+        while (!addrs.is_empty()) {
+            validators.push_back(
+                create_validator_for_testing(addrs.pop_back(), 100, ctx)
             );
         };
 
         create_sui_system_state_for_testing(validators, 1000, 0, ctx);
-        test_scenario::end(scenario_val);
+        scenario.end();
     }
 
     public fun advance_epoch(scenario: &mut Scenario) {
@@ -121,17 +114,17 @@ module sui_system::governance_test_utils {
     public fun advance_epoch_with_reward_amounts_return_rebate(
         storage_charge: u64, computation_charge: u64, stoarge_rebate: u64, non_refundable_storage_rebate: u64, scenario: &mut Scenario,
     ): Balance<SUI> {
-        test_scenario::next_tx(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario)) + 1;
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(@0x0);
+        let new_epoch = scenario.ctx().epoch() + 1;
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
-        let storage_rebate = sui_system::advance_epoch_for_testing(
-            &mut system_state, new_epoch, 1, storage_charge, computation_charge, stoarge_rebate, non_refundable_storage_rebate, 0, 0, 0, ctx,
+        let storage_rebate = system_state.advance_epoch_for_testing(
+            new_epoch, 1, storage_charge, computation_charge, stoarge_rebate, non_refundable_storage_rebate, 0, 0, 0, ctx,
         );
         test_scenario::return_shared(system_state);
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
         storage_rebate
     }
 
@@ -148,52 +141,51 @@ module sui_system::governance_test_utils {
         reward_slashing_rate: u64,
         scenario: &mut Scenario
     ) {
-        test_scenario::next_tx(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario)) + 1;
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(@0x0);
+        let new_epoch = scenario.ctx().epoch() + 1;
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
-        let storage_rebate = sui_system::advance_epoch_for_testing(
-            &mut system_state, new_epoch, 1, storage_charge * MIST_PER_SUI, computation_charge * MIST_PER_SUI, 0, 0, 0, reward_slashing_rate, 0, ctx
+        let storage_rebate = system_state.advance_epoch_for_testing(
+            new_epoch, 1, storage_charge * MIST_PER_SUI, computation_charge * MIST_PER_SUI, 0, 0, 0, reward_slashing_rate, 0, ctx
         );
         test_utils::destroy(storage_rebate);
         test_scenario::return_shared(system_state);
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
     }
 
     public fun stake_with(
         staker: address, validator: address, amount: u64, scenario: &mut Scenario
     ) {
-        test_scenario::next_tx(scenario, staker);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(staker);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
-        sui_system::request_add_stake(&mut system_state, coin::mint_for_testing(amount * MIST_PER_SUI, ctx), validator, ctx);
+        system_state.request_add_stake(coin::mint_for_testing(amount * MIST_PER_SUI, ctx), validator, ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun unstake(
         staker: address, staked_sui_idx: u64, scenario: &mut Scenario
     ) {
-        test_scenario::next_tx(scenario, staker);
-        let stake_sui_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
-        let staked_sui = test_scenario::take_from_sender_by_id(scenario, *vector::borrow(&stake_sui_ids, staked_sui_idx));
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(staker);
+        let stake_sui_ids = scenario.ids_for_sender<StakedSui>();
+        let staked_sui = scenario.take_from_sender_by_id(stake_sui_ids[staked_sui_idx]);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::request_withdraw_stake(&mut system_state, staked_sui, ctx);
+        let ctx = scenario.ctx();
+        system_state.request_withdraw_stake(staked_sui, ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun add_validator_full_flow(validator: address, name: vector<u8>, net_addr: vector<u8>, init_stake_amount: u64, pubkey: vector<u8>, pop: vector<u8>, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
+        scenario.next_tx(validator);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
 
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        system_state.request_add_validator_candidate(
             pubkey,
             vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
             vector[171, 3, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
@@ -210,18 +202,17 @@ module sui_system::governance_test_utils {
             0,
             ctx
         );
-        sui_system::request_add_stake(&mut system_state, coin::mint_for_testing<SUI>(init_stake_amount * MIST_PER_SUI, ctx), validator, ctx);
-        sui_system::request_add_validator_for_testing(&mut system_state, 0, ctx);
+        system_state.request_add_stake(coin::mint_for_testing<SUI>(init_stake_amount * MIST_PER_SUI, ctx), validator, ctx);
+        system_state.request_add_validator_for_testing(0, ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun add_validator_candidate(validator: address, name: vector<u8>, net_addr: vector<u8>, pubkey: vector<u8>, pop: vector<u8>, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
+        scenario.next_tx(validator);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
 
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        system_state.request_add_validator_candidate(
             pubkey,
             vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
             vector[171, 3, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38],
@@ -242,51 +233,41 @@ module sui_system::governance_test_utils {
     }
 
     public fun remove_validator_candidate(validator: address, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
+        scenario.next_tx(validator);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
 
-        sui_system::request_remove_validator_candidate(
-            &mut system_state,
-            ctx
-        );
+        system_state.request_remove_validator_candidate(ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun add_validator(validator: address, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
+        scenario.next_tx(validator);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
 
-        sui_system::request_add_validator_for_testing(
-            &mut system_state,
-            0,
-            ctx
-        );
+        system_state.request_add_validator_for_testing(0, ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun remove_validator(validator: address, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(validator);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
-        sui_system::request_remove_validator(
-            &mut system_state,
-            ctx
-        );
+        system_state.request_remove_validator(ctx);
         test_scenario::return_shared(system_state);
     }
 
     public fun assert_validator_self_stake_amounts(validator_addrs: vector<address>, stake_amounts: vector<u64>, scenario: &mut Scenario) {
         let mut i = 0;
-        while (i < vector::length(&validator_addrs)) {
-            let validator_addr = *vector::borrow(&validator_addrs, i);
-            let amount = *vector::borrow(&stake_amounts, i);
+        while (i < validator_addrs.length()) {
+            let validator_addr = validator_addrs[i];
+            let amount = stake_amounts[i];
 
-            test_scenario::next_tx(scenario, validator_addr);
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+            scenario.next_tx(validator_addr);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
             let stake_plus_rewards = stake_plus_current_rewards_for_validator(validator_addr, &mut system_state, scenario);
             assert_eq(stake_plus_rewards, amount);
             test_scenario::return_shared(system_state);
@@ -296,13 +277,13 @@ module sui_system::governance_test_utils {
 
     public fun assert_validator_total_stake_amounts(validator_addrs: vector<address>, stake_amounts: vector<u64>, scenario: &mut Scenario) {
         let mut i = 0;
-        while (i < vector::length(&validator_addrs)) {
-            let validator_addr = *vector::borrow(&validator_addrs, i);
-            let amount = *vector::borrow(&stake_amounts, i);
+        while (i < validator_addrs.length()) {
+            let validator_addr = validator_addrs[i];
+            let amount = stake_amounts[i];
 
-            test_scenario::next_tx(scenario, validator_addr);
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-            let validator_amount = sui_system::validator_stake_amount(&mut system_state, validator_addr);
+            scenario.next_tx(validator_addr);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
+            let validator_amount = system_state.validator_stake_amount(validator_addr);
             assert!(validator_amount == amount, validator_amount);
             test_scenario::return_shared(system_state);
             i = i + 1;
@@ -311,12 +292,12 @@ module sui_system::governance_test_utils {
 
     public fun assert_validator_non_self_stake_amounts(validator_addrs: vector<address>, stake_amounts: vector<u64>, scenario: &mut Scenario) {
         let mut i = 0;
-        while (i < vector::length(&validator_addrs)) {
-            let validator_addr = *vector::borrow(&validator_addrs, i);
-            let amount = *vector::borrow(&stake_amounts, i);
-            test_scenario::next_tx(scenario, validator_addr);
-            let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-            let non_self_stake_amount = sui_system::validator_stake_amount(&mut system_state, validator_addr) - stake_plus_current_rewards_for_validator(validator_addr, &mut system_state, scenario);
+        while (i < validator_addrs.length()) {
+            let validator_addr = validator_addrs[i];
+            let amount = stake_amounts[i];
+            scenario.next_tx(validator_addr);
+            let mut system_state = scenario.take_shared<SuiSystemState>();
+            let non_self_stake_amount = system_state.validator_stake_amount(validator_addr) - stake_plus_current_rewards_for_validator(validator_addr, &mut system_state, scenario);
             assert_eq(non_self_stake_amount, amount);
             test_scenario::return_shared(system_state);
             i = i + 1;
@@ -325,35 +306,35 @@ module sui_system::governance_test_utils {
 
     /// Return the rewards for the validator at `addr` in terms of SUI.
     public fun stake_plus_current_rewards_for_validator(addr: address, system_state: &mut SuiSystemState, scenario: &mut Scenario): u64 {
-        let validator_ref = validator_set::get_active_validator_ref(sui_system::validators(system_state), addr);
-        let amount = stake_plus_current_rewards(addr, validator::get_staking_pool_ref(validator_ref), scenario);
+        let validator_ref = system_state.validators().get_active_validator_ref(addr);
+        let amount = stake_plus_current_rewards(addr, validator_ref.get_staking_pool_ref(), scenario);
         amount
     }
 
     public fun stake_plus_current_rewards(addr: address, staking_pool: &StakingPool, scenario: &mut Scenario): u64 {
         let mut sum = 0;
-        test_scenario::next_tx(scenario, addr);
+        scenario.next_tx(addr);
         let mut stake_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
-        let current_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        let current_epoch = scenario.ctx().epoch();
 
-        while (!vector::is_empty(&stake_ids)) {
-            let staked_sui_id = vector::pop_back(&mut stake_ids);
-            let staked_sui = test_scenario::take_from_sender_by_id<StakedSui>(scenario, staked_sui_id);
-            sum = sum + staking_pool::calculate_rewards(staking_pool, &staked_sui, current_epoch);
-            test_scenario::return_to_sender(scenario, staked_sui);
+        while (!stake_ids.is_empty()) {
+            let staked_sui_id = stake_ids.pop_back();
+            let staked_sui = scenario.take_from_sender_by_id<StakedSui>(staked_sui_id);
+            sum = sum + staking_pool.calculate_rewards(&staked_sui, current_epoch);
+            scenario.return_to_sender(staked_sui);
         };
         sum
     }
 
     public fun total_sui_balance(addr: address, scenario: &mut Scenario): u64 {
         let mut sum = 0;
-        test_scenario::next_tx(scenario, addr);
+        scenario.next_tx(addr);
         let coin_ids = test_scenario::ids_for_sender<Coin<SUI>>(scenario);
         let mut i = 0;
-        while (i < vector::length(&coin_ids)) {
-            let coin = test_scenario::take_from_sender_by_id<Coin<SUI>>(scenario, *vector::borrow(&coin_ids, i));
-            sum = sum + coin::value(&coin);
-            test_scenario::return_to_sender(scenario, coin);
+        while (i < coin_ids.length()) {
+            let coin = scenario.take_from_sender_by_id<Coin<SUI>>(coin_ids[i]);
+            sum = sum + coin.value();
+            scenario.return_to_sender(coin);
             i = i + 1;
         };
         sum

--- a/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
+++ b/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
@@ -314,7 +314,7 @@ module sui_system::governance_test_utils {
     public fun stake_plus_current_rewards(addr: address, staking_pool: &StakingPool, scenario: &mut Scenario): u64 {
         let mut sum = 0;
         scenario.next_tx(addr);
-        let mut stake_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
+        let mut stake_ids = scenario.ids_for_sender<StakedSui>();
         let current_epoch = scenario.ctx().epoch();
 
         while (!stake_ids.is_empty()) {
@@ -329,7 +329,7 @@ module sui_system::governance_test_utils {
     public fun total_sui_balance(addr: address, scenario: &mut Scenario): u64 {
         let mut sum = 0;
         scenario.next_tx(addr);
-        let coin_ids = test_scenario::ids_for_sender<Coin<SUI>>(scenario);
+        let coin_ids = scenario.ids_for_sender<Coin<SUI>>();
         let mut i = 0;
         while (i < coin_ids.length()) {
             let coin = scenario.take_from_sender_by_id<Coin<SUI>>(coin_ids[i]);

--- a/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
@@ -4,11 +4,9 @@
 #[test_only]
 module sui_system::rewards_distribution_tests {
     use sui::test_scenario::{Self, Scenario};
-    use sui_system::sui_system::{Self, SuiSystemState};
-
+    use sui_system::sui_system::SuiSystemState;
     use sui_system::validator_cap::UnverifiedValidatorOperationCap;
     use sui_system::governance_test_utils::{
-        Self,
         advance_epoch,
         advance_epoch_with_reward_amounts,
         advance_epoch_with_reward_amounts_and_slashing_rates,
@@ -21,7 +19,6 @@ module sui_system::rewards_distribution_tests {
         total_sui_balance, unstake
     };
     use sui::test_utils::assert_eq;
-    use std::vector;
     use sui::address;
 
     const VALIDATOR_ADDR_1: address = @0x1;
@@ -43,7 +40,7 @@ module sui_system::rewards_distribution_tests {
         let scenario = &mut scenario_val;
 
         // need to advance epoch so validator's staking starts counting
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         advance_epoch_with_reward_amounts(0, 100, scenario);
         assert_validator_total_stake_amounts(
@@ -63,7 +60,7 @@ module sui_system::rewards_distribution_tests {
             vector[150 * MIST_PER_SUI, 970 * MIST_PER_SUI, 350 * MIST_PER_SUI, 450 * MIST_PER_SUI],
             scenario
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -73,11 +70,11 @@ module sui_system::rewards_distribution_tests {
         let scenario = &mut scenario_val;
 
         // need to advance epoch so validator's staking starts counting
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         advance_epoch_with_reward_amounts(0, 100, scenario);
         assert_validator_total_stake_amounts(validator_addrs(), vector[100_000_025 * MIST_PER_SUI, 200_000_025 * MIST_PER_SUI, 300_000_025 * MIST_PER_SUI, 400_000_025 * MIST_PER_SUI], scenario);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -88,7 +85,7 @@ module sui_system::rewards_distribution_tests {
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 200, scenario);
         stake_with(STAKER_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         assert_validator_total_stake_amounts(validator_addrs(), vector[300 * MIST_PER_SUI, 300 * MIST_PER_SUI, 300 * MIST_PER_SUI, 400 * MIST_PER_SUI], scenario);
         assert_validator_self_stake_amounts(validator_addrs(), vector[100 * MIST_PER_SUI, 200 * MIST_PER_SUI, 300 * MIST_PER_SUI, 400 * MIST_PER_SUI], scenario);
@@ -116,7 +113,7 @@ module sui_system::rewards_distribution_tests {
         // that would be about 728 SUI.
         // TODO: Come up with better numbers and clean it up!
         assert_eq(total_sui_balance(STAKER_ADDR_2, scenario), 728108108107);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -128,7 +125,7 @@ module sui_system::rewards_distribution_tests {
         // stake a large amount
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 200000000, scenario);
 
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
 
         advance_epoch_with_reward_amounts(0, 150000, scenario);
 
@@ -141,7 +138,7 @@ module sui_system::rewards_distribution_tests {
 
         // and advance epoch should succeed
         advance_epoch_with_reward_amounts(0, 150, scenario);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -152,7 +149,7 @@ module sui_system::rewards_distribution_tests {
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
         stake_with(STAKER_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
         // V1: 200, V2: 300, V3: 300, V4: 400
 
         set_commission_rate_and_advance_epoch(VALIDATOR_ADDR_2, 2000, scenario); // 50% commission
@@ -175,7 +172,7 @@ module sui_system::rewards_distribution_tests {
         assert_validator_non_self_stake_amounts(validator_addrs(), vector[142 * MIST_PER_SUI, 123709090909, 0, 0], scenario);
         assert_validator_self_stake_amounts(validator_addrs(), vector[148 * MIST_PER_SUI, 266290909091, 390 * MIST_PER_SUI, 490 * MIST_PER_SUI], scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -219,7 +216,7 @@ module sui_system::rewards_distribution_tests {
         // Same analysis as above. Delegator 1 has 3 additional SUI, and 10% of staker 2's rewards are slashed.
         assert!(total_sui_balance(STAKER_ADDR_1, scenario) == 565 * MIST_PER_SUI, 0);
         assert!(total_sui_balance(STAKER_ADDR_2, scenario) == 370 * MIST_PER_SUI, 0);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -260,7 +257,7 @@ module sui_system::rewards_distribution_tests {
         // Same analysis as above. Staker 1 has 150 additional SUI, and since all of staker 2's rewards are slashed she only gets back her principal.
         assert!(total_sui_balance(STAKER_ADDR_1, scenario) == (550 + 150) * MIST_PER_SUI, 0);
         assert!(total_sui_balance(STAKER_ADDR_2, scenario) == 100 * MIST_PER_SUI, 0);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -304,7 +301,7 @@ module sui_system::rewards_distribution_tests {
         // Staker 2 gets 300 * 1/5 * (1 - 20%) = 48 SUI of rewards.
         assert_eq(total_sui_balance(STAKER_ADDR_2, scenario), (100 + 48) * MIST_PER_SUI);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -335,16 +332,16 @@ module sui_system::rewards_distribution_tests {
         // All validators should have 0 rewards added so their stake stays the same.
         assert_validator_self_stake_amounts(validator_addrs(), vector[100 * MIST_PER_SUI, 200 * MIST_PER_SUI, 300 * MIST_PER_SUI, 400 * MIST_PER_SUI], scenario);
 
-        test_scenario::next_tx(scenario, @0x0);
+        scenario.next_tx(@0x0);
         // Storage fund balance should increase by 4000 SUI.
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        assert_eq(sui_system::get_storage_fund_total_balance(&mut system_state), 4000 * MIST_PER_SUI);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        assert_eq(system_state.get_storage_fund_total_balance(), 4000 * MIST_PER_SUI);
 
         // The entire 1000 SUI of storage rewards should go to the object rebate portion of the storage fund.
-        assert_eq(sui_system::get_storage_fund_object_rebates(&mut system_state), 1000 * MIST_PER_SUI);
+        assert_eq(system_state.get_storage_fund_object_rebates(), 1000 * MIST_PER_SUI);
 
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -373,10 +370,10 @@ module sui_system::rewards_distribution_tests {
         // Staker 1 gets 30 SUI, staker 2 gets 40 SUI and staker 3 gets 30 SUI.
         advance_epoch_with_reward_amounts(0, 440, scenario);
 
-        test_scenario::next_tx(scenario, @0x0);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(@0x0);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
         // Check that we have the right amount of SUI in the staking pool.
-        assert_eq(sui_system::validator_stake_amount(&mut system_state, VALIDATOR_ADDR_1), 140 * 23 * MIST_PER_SUI);
+        assert_eq(system_state.validator_stake_amount(VALIDATOR_ADDR_1), 140 * 23 * MIST_PER_SUI);
         test_scenario::return_shared(system_state);
 
         // Withdraw all stakes at once.
@@ -400,12 +397,12 @@ module sui_system::rewards_distribution_tests {
 
         advance_epoch_with_reward_amounts(0, 0, scenario);
 
-        test_scenario::next_tx(scenario, @0x0);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(@0x0);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
         // Since all the stakes are gone the pool is empty except for the validator's original stake.
-        assert_eq(sui_system::validator_stake_amount(&mut system_state, VALIDATOR_ADDR_1), 140 * MIST_PER_SUI);
+        assert_eq(system_state.validator_stake_amount(VALIDATOR_ADDR_1), 140 * MIST_PER_SUI);
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -413,7 +410,7 @@ module sui_system::rewards_distribution_tests {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let mut validators = vector[];
 
         let num_validators = 20;
@@ -422,7 +419,7 @@ module sui_system::rewards_distribution_tests {
         // The stake total sums up to be 481 + 483 + ... + 517 + 519 = 1000 SUI.
         while (i < num_validators) {
             let validator = create_validator_for_testing(address::from_u256((i as u256)), (481 + i * 2), ctx);
-            vector::push_back(&mut validators, validator);
+            validators.push_back(validator);
             i = i + 1;
         };
 
@@ -431,22 +428,22 @@ module sui_system::rewards_distribution_tests {
         advance_epoch_with_reward_amounts(0, 10000, scenario);
 
         let mut i = 0;
-        test_scenario::next_tx(scenario, @0x0);
+        scenario.next_tx(@0x0);
         // Check that each validator has the correct amount of SUI in their stake pool.
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
         while (i < num_validators) {
             let addr = address::from_u256((i as u256));
-            assert_eq(sui_system::validator_stake_amount(&mut system_state, addr), (962 + i * 4) * MIST_PER_SUI);
+            assert_eq(system_state.validator_stake_amount(addr), (962 + i * 4) * MIST_PER_SUI);
             i = i + 1;
         };
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun set_up_sui_system_state() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validators = vector[
             create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx),
@@ -455,13 +452,13 @@ module sui_system::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_4, 400, ctx),
         ];
         create_sui_system_state_for_testing(validators, 1000, 0, ctx);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun set_up_sui_system_state_with_big_amounts() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validators = vector[
             create_validator_for_testing(VALIDATOR_ADDR_1, 100000000, ctx),
@@ -470,7 +467,7 @@ module sui_system::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_4, 400000000, ctx),
         ];
         create_sui_system_state_for_testing(validators, 1000000000, 0, ctx);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun validator_addrs() : vector<address> {
@@ -478,20 +475,20 @@ module sui_system::rewards_distribution_tests {
     }
 
     fun set_commission_rate_and_advance_epoch(addr: address, commission_rate: u64, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::request_set_commission_rate(&mut system_state, commission_rate, ctx);
+        scenario.next_tx(addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
+        system_state.request_set_commission_rate(commission_rate, ctx);
         test_scenario::return_shared(system_state);
-        governance_test_utils::advance_epoch(scenario);
+        advance_epoch(scenario);
     }
 
     fun report_validator(reporter: address, reportee: address, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, reporter);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        sui_system::report_validator(&mut system_state, &cap, reportee);
-        test_scenario::return_to_sender(scenario, cap);
+        scenario.next_tx(reporter);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
+        system_state.report_validator(&cap, reportee);
+        scenario.return_to_sender(cap);
         test_scenario::return_shared(system_state);
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
@@ -10,22 +10,14 @@ module sui_system::sui_system_tests {
     use sui::test_scenario::{Self, Scenario};
     use sui::sui::SUI;
     use sui_system::governance_test_utils::{add_validator_full_flow, advance_epoch, remove_validator, set_up_sui_system_state, create_sui_system_state_for_testing};
-    use sui_system::sui_system::{Self, SuiSystemState};
+    use sui_system::sui_system::SuiSystemState;
     use sui_system::sui_system_state_inner;
     use sui_system::validator::{Self, Validator};
     use sui_system::validator_set;
     use sui_system::validator_cap::UnverifiedValidatorOperationCap;
-    use sui::transfer;
-    use sui::vec_set;
-    use sui::table;
-    use std::vector;
     use sui::balance;
     use sui::test_utils::{assert_eq, destroy};
-    use std::option::Self;
     use sui::url;
-    use std::string;
-    use std::ascii;
-    use sui::tx_context;
 
     #[test]
     fun test_report_validator() {
@@ -67,9 +59,9 @@ module sui_system::sui_system_tests {
         // After 0x1 leaves, both its reports and the reports on its name are gone
         remove_validator(@0x1, scenario);
         advance_epoch(scenario);
-        assert!(vector::is_empty(&get_reporters_of(@0x1, scenario)), 0);
-        assert!(vector::is_empty(&get_reporters_of(@0x2, scenario)), 0);
-        test_scenario::end(scenario_val);
+        assert!(get_reporters_of(@0x1, scenario).is_empty(), 0);
+        assert!(get_reporters_of(@0x2, scenario).is_empty(), 0);
+        scenario_val.end();
     }
 
     #[test]
@@ -80,8 +72,8 @@ module sui_system::sui_system_tests {
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
-        test_scenario::next_tx(scenario, @0x1);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        scenario.next_tx(@0x1);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
         transfer::public_transfer(cap, stakee_address);
 
         // With the cap object in hand, stakee could report validators on behalf of @0x1.
@@ -90,10 +82,10 @@ module sui_system::sui_system_tests {
 
         // stakee could also undo report.
         report_helper(stakee_address, @0x2, true, scenario);
-        assert!(vector::is_empty(&get_reporters_of(@0x2, scenario)), 0);
+        assert!(get_reporters_of(@0x2, scenario).is_empty(), 0);
 
-        test_scenario::next_tx(scenario, stakee_address);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        scenario.next_tx(stakee_address);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
         let new_stakee_address = @0xcafe;
         transfer::public_transfer(cap, new_stakee_address);
 
@@ -106,24 +98,24 @@ module sui_system::sui_system_tests {
 
         // Add a pending validator
         let new_validator_addr = @0x1a4623343cd42be47d67314fce0ad042f3c82685544bc91d8c11d24e74ba7357;
-        test_scenario::next_tx(scenario, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
         let pubkey = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
         let pop = x"8b93fc1b33379e2796d361c4056f0f04ad5aea7f4a8c02eaac57340ff09b6dc158eb1945eece103319167f420daf0cb3";
         add_validator_full_flow(new_validator_addr, b"name1", b"/ip4/127.0.0.1/udp/81", 100, pubkey, pop, scenario);
 
-        test_scenario::next_tx(scenario, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
         // Pending validator could set reference price as well
         set_gas_price_helper(new_validator_addr, 777, scenario);
 
-        test_scenario::next_tx(scenario, new_stakee_address);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let validator = sui_system::active_validator_by_address(&mut system_state, @0x1);
-        assert!(validator::next_epoch_gas_price(validator) == 666, 0);
-        let pending_validator = sui_system::pending_validator_by_address(&mut system_state, new_validator_addr);
-        assert!(validator::next_epoch_gas_price(pending_validator) == 777, 0);
+        scenario.next_tx(new_stakee_address);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let validator = system_state.active_validator_by_address(@0x1);
+        assert!(validator.next_epoch_gas_price() == 666, 0);
+        let pending_validator = system_state.pending_validator_by_address(new_validator_addr);
+        assert!(pending_validator.next_epoch_gas_price() == 777, 0);
         test_scenario::return_shared(system_state);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -135,8 +127,8 @@ module sui_system::sui_system_tests {
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
-        test_scenario::next_tx(scenario, @0x1);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        scenario.next_tx(@0x1);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
         transfer::public_transfer(cap, stakee_address);
 
         report_helper(stakee_address, @0x2, false, scenario);
@@ -149,7 +141,7 @@ module sui_system::sui_system_tests {
         // stakee no longer has permission to report validators, here it aborts.
         report_helper(stakee_address, @0x2, true, scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -161,17 +153,17 @@ module sui_system::sui_system_tests {
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
-        test_scenario::next_tx(scenario, @0x1);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        scenario.next_tx(@0x1);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
         transfer::public_transfer(cap, stakee_address);
 
         // With the cap object in hand, stakee could report validators on behalf of @0x1.
         set_gas_price_helper(stakee_address, 888, scenario);
 
-        test_scenario::next_tx(scenario, stakee_address);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let validator = sui_system::active_validator_by_address(&mut system_state, @0x1);
-        assert!(validator::next_epoch_gas_price(validator) == 888, 0);
+        scenario.next_tx(stakee_address);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let validator = system_state.active_validator_by_address(@0x1);
+        assert!(validator.next_epoch_gas_price() == 888, 0);
         test_scenario::return_shared(system_state);
 
         // @0x1 revokes stakee's permssion by creating a new
@@ -181,7 +173,7 @@ module sui_system::sui_system_tests {
         // stakee no longer has permission to report validators, here it aborts.
         set_gas_price_helper(stakee_address, 888, scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -194,7 +186,7 @@ module sui_system::sui_system_tests {
         // Fails here since the gas price is too high.
         set_gas_price_helper(@0x1, 100_001, scenario);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -204,14 +196,14 @@ module sui_system::sui_system_tests {
         let scenario = &mut scenario_val;
         set_up_sui_system_state(vector[@0x1, @0x2]);
 
-        test_scenario::next_tx(scenario, @0x2);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        scenario.next_tx(@0x2);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
         // Fails here since the commission rate is too high.
-        sui_system::request_set_commission_rate(&mut system_state, 2001, test_scenario::ctx(scenario));
+        system_state.request_set_commission_rate(2001, scenario.ctx());
         test_scenario::return_shared(system_state);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -222,7 +214,7 @@ module sui_system::sui_system_tests {
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x1, @0x42, false, scenario);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -233,7 +225,7 @@ module sui_system::sui_system_tests {
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x1, @0x1, false, scenario);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -244,7 +236,7 @@ module sui_system::sui_system_tests {
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x2, @0x1, true, scenario);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -253,22 +245,22 @@ module sui_system::sui_system_tests {
         let scenario = &mut scenario_val;
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3, @0x4]);
-        test_scenario::next_tx(scenario, @0x1);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let pool_id_1 = sui_system::validator_staking_pool_id(&mut system_state, @0x1);
-        let pool_id_2 = sui_system::validator_staking_pool_id(&mut system_state, @0x2);
-        let pool_id_3 = sui_system::validator_staking_pool_id(&mut system_state, @0x3);
-        let pool_id_4 = sui_system::validator_staking_pool_id(&mut system_state, @0x4);
-        let mut pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
-        assert_eq(table::length(pool_mappings), 4);
-        assert_eq(*table::borrow(pool_mappings, pool_id_1), @0x1);
-        assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
-        assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
-        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
+        scenario.next_tx(@0x1);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let pool_id_1 = system_state.validator_staking_pool_id(@0x1);
+        let pool_id_2 = system_state.validator_staking_pool_id(@0x2);
+        let pool_id_3 = system_state.validator_staking_pool_id(@0x3);
+        let pool_id_4 = system_state.validator_staking_pool_id(@0x4);
+        let mut pool_mappings = system_state.validator_staking_pool_mappings();
+        assert_eq(pool_mappings.length(), 4);
+        assert_eq(pool_mappings[pool_id_1], @0x1);
+        assert_eq(pool_mappings[pool_id_2], @0x2);
+        assert_eq(pool_mappings[pool_id_3], @0x3);
+        assert_eq(pool_mappings[pool_id_4], @0x4);
         test_scenario::return_shared(system_state);
 
         let new_validator_addr = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;
-        test_scenario::next_tx(scenario, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
         // Seed [0; 32]
         let pubkey = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
         // Generated with [fn test_proof_of_possession]
@@ -278,49 +270,49 @@ module sui_system::sui_system_tests {
         add_validator_full_flow(new_validator_addr, b"name2", b"/ip4/127.0.0.1/udp/82", 100, pubkey, pop, scenario);
         advance_epoch(scenario);
 
-        test_scenario::next_tx(scenario, @0x1);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let pool_id_5 = sui_system::validator_staking_pool_id(&mut system_state, new_validator_addr);
-        pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
+        scenario.next_tx(@0x1);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let pool_id_5 = system_state.validator_staking_pool_id(new_validator_addr);
+        pool_mappings = system_state.validator_staking_pool_mappings();
         // Check that the previous mappings didn't change as well.
-        assert_eq(table::length(pool_mappings), 5);
-        assert_eq(*table::borrow(pool_mappings, pool_id_1), @0x1);
-        assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
-        assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
-        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
-        assert_eq(*table::borrow(pool_mappings, pool_id_5), new_validator_addr);
+        assert_eq(pool_mappings.length(), 5);
+        assert_eq(pool_mappings[pool_id_1], @0x1);
+        assert_eq(pool_mappings[pool_id_2], @0x2);
+        assert_eq(pool_mappings[pool_id_3], @0x3);
+        assert_eq(pool_mappings[pool_id_4], @0x4);
+        assert_eq(pool_mappings[pool_id_5], new_validator_addr);
         test_scenario::return_shared(system_state);
 
         // Remove one of the original validators.
         remove_validator(@0x1, scenario);
         advance_epoch(scenario);
 
-        test_scenario::next_tx(scenario, @0x1);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
+        scenario.next_tx(@0x1);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        pool_mappings = system_state.validator_staking_pool_mappings();
         // Check that the previous mappings didn't change as well.
-        assert_eq(table::length(pool_mappings), 4);
-        assert_eq(table::contains(pool_mappings, pool_id_1), false);
-        assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
-        assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
-        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
-        assert_eq(*table::borrow(pool_mappings, pool_id_5), new_validator_addr);
+        assert_eq(pool_mappings.length(), 4);
+        assert_eq(pool_mappings.contains(pool_id_1), false);
+        assert_eq(pool_mappings[pool_id_2], @0x2);
+        assert_eq(pool_mappings[pool_id_3], @0x3);
+        assert_eq(pool_mappings[pool_id_4], @0x4);
+        assert_eq(pool_mappings[pool_id_5], new_validator_addr);
         test_scenario::return_shared(system_state);
 
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun report_helper(sender: address, reported: address, is_undo: bool, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
 
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
         if (is_undo) {
-            sui_system::undo_report_validator(&mut system_state, &cap, reported);
+            system_state.undo_report_validator(&cap, reported);
         } else {
-            sui_system::report_validator(&mut system_state, &cap, reported);
+            system_state.report_validator(&cap, reported);
         };
-        test_scenario::return_to_sender(scenario, cap);
+        scenario.return_to_sender(cap);
         test_scenario::return_shared(system_state);
     }
 
@@ -329,27 +321,27 @@ module sui_system::sui_system_tests {
         new_gas_price: u64,
         scenario: &mut Scenario,
     ) {
-        test_scenario::next_tx(scenario, sender);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        sui_system::request_set_gas_price(&mut system_state, &cap, new_gas_price);
-        test_scenario::return_to_sender(scenario, cap);
+        scenario.next_tx(sender);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        system_state.request_set_gas_price(&cap, new_gas_price);
+        scenario.return_to_sender(cap);
         test_scenario::return_shared(system_state);
     }
 
 
     fun rotate_operation_cap(sender: address, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, sender);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::rotate_operation_cap(&mut system_state, ctx);
+        scenario.next_tx(sender);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let ctx = scenario.ctx();
+        system_state.rotate_operation_cap(ctx);
         test_scenario::return_shared(system_state);
     }
 
     fun get_reporters_of(addr: address, scenario: &mut Scenario): vector<address> {
-        test_scenario::next_tx(scenario, addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let res = vec_set::into_keys(sui_system::get_reporters_of(&mut system_state, addr));
+        scenario.next_tx(addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let res = system_state.get_reporters_of(addr).into_keys();
         test_scenario::return_shared(system_state);
         res
     }
@@ -365,28 +357,27 @@ module sui_system::sui_system_tests {
         commission_rate: u64,
         gas_price: u64,
     ) {
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::update_validator_name(system_state, name, ctx);
-        sui_system::update_validator_description(system_state, b"new_desc", ctx);
-        sui_system::update_validator_image_url(system_state, b"new_image_url", ctx);
-        sui_system::update_validator_project_url(system_state, b"new_project_url", ctx);
-        sui_system::update_candidate_validator_network_address(system_state, network_address, ctx);
-        sui_system::update_candidate_validator_p2p_address(system_state, p2p_address, ctx);
-        sui_system::update_candidate_validator_primary_address(system_state, b"/ip4/127.0.0.1/udp/80", ctx);
-        sui_system::update_candidate_validator_worker_address(system_state, b"/ip4/127.0.0.1/udp/80", ctx);
-        sui_system::update_candidate_validator_protocol_pubkey(
-            system_state,
+        let ctx = scenario.ctx();
+        system_state.update_validator_name(name, ctx);
+        system_state.update_validator_description(b"new_desc", ctx);
+        system_state.update_validator_image_url(b"new_image_url", ctx);
+        system_state.update_validator_project_url(b"new_project_url", ctx);
+        system_state.update_candidate_validator_network_address(network_address, ctx);
+        system_state.update_candidate_validator_p2p_address(p2p_address, ctx);
+        system_state.update_candidate_validator_primary_address(b"/ip4/127.0.0.1/udp/80", ctx);
+        system_state.update_candidate_validator_worker_address(b"/ip4/127.0.0.1/udp/80", ctx);
+        system_state.update_candidate_validator_protocol_pubkey(
             protocol_pub_key,
             pop,
             ctx
         );
-        sui_system::update_candidate_validator_worker_pubkey(system_state, vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25], ctx);
-        sui_system::update_candidate_validator_network_pubkey(system_state, vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62], ctx);
+        system_state.update_candidate_validator_worker_pubkey(vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25], ctx);
+        system_state.update_candidate_validator_network_pubkey(vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62], ctx);
 
-        sui_system::set_candidate_validator_commission_rate(system_state, commission_rate, ctx);
-        let cap = test_scenario::take_from_sender<UnverifiedValidatorOperationCap>(scenario);
-        sui_system::set_candidate_validator_gas_price(system_state, &cap, gas_price);
-        test_scenario::return_to_sender(scenario, cap);
+        system_state.set_candidate_validator_commission_rate(commission_rate, ctx);
+        let cap = scenario.take_from_sender<UnverifiedValidatorOperationCap>();
+        system_state.set_candidate_validator_gas_price(&cap, gas_price);
+        scenario.return_to_sender(cap);
     }
 
 
@@ -413,8 +404,8 @@ module sui_system::sui_system_tests {
             vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
             vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
         );
-        assert!(validator::commission_rate(validator) == commission_rate, 0);
-        assert!(validator::gas_price(validator) == gas_price, 0);
+        assert!(validator.commission_rate() == commission_rate, 0);
+        assert!(validator.gas_price() == gas_price, 0);
 
     }
 
@@ -431,23 +422,22 @@ module sui_system::sui_system_tests {
         network_pubkey: vector<u8>,
         worker_pubkey: vector<u8>,
     ) {
-        let ctx = test_scenario::ctx(scenario);
-        sui_system::update_validator_name(system_state, name, ctx);
-        sui_system::update_validator_description(system_state, b"new_desc", ctx);
-        sui_system::update_validator_image_url(system_state, b"new_image_url", ctx);
-        sui_system::update_validator_project_url(system_state, b"new_project_url", ctx);
-        sui_system::update_validator_next_epoch_network_address(system_state, network_address, ctx);
-        sui_system::update_validator_next_epoch_p2p_address(system_state, p2p_address, ctx);
-        sui_system::update_validator_next_epoch_primary_address(system_state, b"/ip4/168.168.168.168/udp/80", ctx);
-        sui_system::update_validator_next_epoch_worker_address(system_state, b"/ip4/168.168.168.168/udp/80", ctx);
-        sui_system::update_validator_next_epoch_protocol_pubkey(
-            system_state,
+        let ctx = scenario.ctx();
+        system_state.update_validator_name(name, ctx);
+        system_state.update_validator_description(b"new_desc", ctx);
+        system_state.update_validator_image_url(b"new_image_url", ctx);
+        system_state.update_validator_project_url(b"new_project_url", ctx);
+        system_state.update_validator_next_epoch_network_address(network_address, ctx);
+        system_state.update_validator_next_epoch_p2p_address(p2p_address, ctx);
+        system_state.update_validator_next_epoch_primary_address(b"/ip4/168.168.168.168/udp/80", ctx);
+        system_state.update_validator_next_epoch_worker_address(b"/ip4/168.168.168.168/udp/80", ctx);
+        system_state.update_validator_next_epoch_protocol_pubkey(
             protocol_pub_key,
             pop,
             ctx
         );
-        sui_system::update_validator_next_epoch_network_pubkey(system_state, network_pubkey, ctx);
-        sui_system::update_validator_next_epoch_worker_pubkey(system_state, worker_pubkey, ctx);
+        system_state.update_validator_next_epoch_network_pubkey(network_pubkey, ctx);
+        system_state.update_validator_next_epoch_worker_pubkey(worker_pubkey, ctx);
     }
 
     fun verify_metadata(
@@ -481,24 +471,24 @@ module sui_system::sui_system_tests {
         );
 
         // Next epoch
-        assert!(validator::next_epoch_network_address(validator) == &option::some(string::from_ascii(ascii::string(new_network_address))), 0);
-        assert!(validator::next_epoch_p2p_address(validator) == &option::some(string::from_ascii(ascii::string(new_p2p_address))), 0);
-        assert!(validator::next_epoch_primary_address(validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/168.168.168.168/udp/80"))), 0);
-        assert!(validator::next_epoch_worker_address(validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/168.168.168.168/udp/80"))), 0);
+        assert!(validator.next_epoch_network_address() == &option::some(new_network_address.to_string()), 0);
+        assert!(validator.next_epoch_p2p_address() == &option::some(new_p2p_address.to_string()), 0);
+        assert!(validator.next_epoch_primary_address() == &option::some(b"/ip4/168.168.168.168/udp/80".to_string()), 0);
+        assert!(validator.next_epoch_worker_address() == &option::some(b"/ip4/168.168.168.168/udp/80".to_string()), 0);
         assert!(
-            validator::next_epoch_protocol_pubkey_bytes(validator) == &option::some(new_protocol_pub_key),
+            validator.next_epoch_protocol_pubkey_bytes() == &option::some(new_protocol_pub_key),
             0
         );
         assert!(
-            validator::next_epoch_proof_of_possession(validator) == &option::some(new_pop),
+            validator.next_epoch_proof_of_possession() == &option::some(new_pop),
             0
         );
         assert!(
-            validator::next_epoch_worker_pubkey_bytes(validator) == &option::some(new_worker_pubkey),
+            validator.next_epoch_worker_pubkey_bytes() == &option::some(new_worker_pubkey),
             0
         );
         assert!(
-            validator::next_epoch_network_pubkey_bytes(validator) == &option::some(new_network_pubkey),
+            validator.next_epoch_network_pubkey_bytes() == &option::some(new_network_pubkey),
             0
         );
     }
@@ -516,18 +506,18 @@ module sui_system::sui_system_tests {
         worker_pubkey_bytes: vector<u8>,
     ) {
         // Current epoch
-        assert!(validator::name(validator) == &string::from_ascii(ascii::string(name)), 0);
-        assert!(validator::description(validator) == &string::from_ascii(ascii::string(b"new_desc")), 0);
-        assert!(validator::image_url(validator) == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
-        assert!(validator::project_url(validator) == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
-        assert!(validator::network_address(validator) == &string::from_ascii(ascii::string(network_address)), 0);
-        assert!(validator::p2p_address(validator) == &string::from_ascii(ascii::string(p2p_address)), 0);
-        assert!(validator::primary_address(validator) == &string::from_ascii(ascii::string(primary_address)), 0);
-        assert!(validator::worker_address(validator) == &string::from_ascii(ascii::string(worker_address)), 0);
-        assert!(validator::protocol_pubkey_bytes(validator) == &protocol_pub_key, 0);
-        assert!(validator::proof_of_possession(validator) == &pop, 0);
-        assert!(validator::worker_pubkey_bytes(validator) == &worker_pubkey_bytes, 0);
-        assert!(validator::network_pubkey_bytes(validator) == &network_pubkey_bytes, 0);
+        assert!(validator.name() == &name.to_string(), 0);
+        assert!(validator.description() == &b"new_desc".to_string(), 0);
+        assert!(validator.image_url() == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
+        assert!(validator.project_url() == &url::new_unsafe_from_bytes(b"new_project_url"), 0);
+        assert!(validator.network_address() == &network_address.to_string(), 0);
+        assert!(validator.p2p_address() == &p2p_address.to_string(), 0);
+        assert!(validator.primary_address() == &primary_address.to_string(), 0);
+        assert!(validator.worker_address() == &worker_address.to_string(), 0);
+        assert!(validator.protocol_pubkey_bytes() == &protocol_pub_key, 0);
+        assert!(validator.proof_of_possession() == &pop, 0);
+        assert!(validator.worker_pubkey_bytes() == &worker_pubkey_bytes, 0);
+        assert!(validator.network_pubkey_bytes() == &network_pubkey_bytes, 0);
     }
 
 
@@ -556,14 +546,14 @@ module sui_system::sui_system_tests {
         );
 
         // Next epoch
-        assert!(option::is_none(validator::next_epoch_network_address(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_p2p_address(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_primary_address(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_worker_address(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_protocol_pubkey_bytes(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_proof_of_possession(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_worker_pubkey_bytes(validator)), 0);
-        assert!(option::is_none(validator::next_epoch_network_pubkey_bytes(validator)), 0);
+        assert!(validator.next_epoch_network_address().is_none(), 0);
+        assert!(validator.next_epoch_p2p_address().is_none(), 0);
+        assert!(validator.next_epoch_primary_address().is_none(), 0);
+        assert!(validator.next_epoch_worker_address().is_none(), 0);
+        assert!(validator.next_epoch_protocol_pubkey_bytes().is_none(), 0);
+        assert!(validator.next_epoch_proof_of_possession().is_none(), 0);
+        assert!(validator.next_epoch_worker_pubkey_bytes().is_none(), 0);
+        assert!(validator.next_epoch_network_pubkey_bytes().is_none(), 0);
     }
 
     #[test]
@@ -591,8 +581,8 @@ module sui_system::sui_system_tests {
         let scenario = &mut scenario_val;
 
         // Set up SuiSystemState with an active validator
-        let mut validators = vector::empty();
-        let ctx = test_scenario::ctx(scenario);
+        let mut validators = vector[];
+        let ctx = scenario.ctx();
         let validator = validator::new_for_testing(
             validator_addr,
             pubkey,
@@ -613,15 +603,15 @@ module sui_system::sui_system_tests {
             true,
             ctx
         );
-        vector::push_back(&mut validators, validator);
+        validators.push_back(validator);
         create_sui_system_state_for_testing(validators, 1000, 0, ctx);
 
-        test_scenario::next_tx(scenario, validator_addr);
+        scenario.next_tx(validator_addr);
 
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
         // Test active validator metadata changes
-        test_scenario::next_tx(scenario, validator_addr);
+        scenario.next_tx(validator_addr);
         {
             update_metadata(
                 scenario,
@@ -636,8 +626,8 @@ module sui_system::sui_system_tests {
             );
         };
 
-        test_scenario::next_tx(scenario, validator_addr);
-        let validator = sui_system::active_validator_by_address(&mut system_state, validator_addr);
+        scenario.next_tx(validator_addr);
+        let validator = system_state.active_validator_by_address(validator_addr);
         verify_metadata(
             validator,
             b"validator_new_name",
@@ -656,17 +646,16 @@ module sui_system::sui_system_tests {
         );
 
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
 
         // Test pending validator metadata changes
         let mut scenario_val = test_scenario::begin(new_validator_addr);
         let scenario = &mut scenario_val;
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        test_scenario::next_tx(scenario, new_validator_addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        scenario.next_tx(new_validator_addr);
         {
-            let ctx = test_scenario::ctx(scenario);
-            sui_system::request_add_validator_candidate(
-                &mut system_state,
+            let ctx = scenario.ctx();
+            system_state.request_add_validator_candidate(
                 new_pubkey,
                 vector[33, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
                 vector[69, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
@@ -683,10 +672,10 @@ module sui_system::sui_system_tests {
                 0,
                 ctx,
             );
-            sui_system::request_add_validator_for_testing(&mut system_state, 0, ctx);
+            system_state.request_add_validator_for_testing(0, ctx);
         };
 
-        test_scenario::next_tx(scenario, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
         {
             update_metadata(
                 scenario,
@@ -701,8 +690,8 @@ module sui_system::sui_system_tests {
             );
         };
 
-        test_scenario::next_tx(scenario, new_validator_addr);
-        let validator = sui_system::pending_validator_by_address(&mut system_state, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
+        let validator = system_state.pending_validator_by_address(new_validator_addr);
         verify_metadata(
             validator,
             b"new_validator_new_name",
@@ -723,13 +712,13 @@ module sui_system::sui_system_tests {
         test_scenario::return_shared(system_state);
 
         // Advance epoch to effectuate the metadata changes.
-        test_scenario::next_tx(scenario, new_validator_addr);
+        scenario.next_tx(new_validator_addr);
         advance_epoch(scenario);
 
         // Now both validators are active, verify their metadata.
-        test_scenario::next_tx(scenario, new_validator_addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let validator = sui_system::active_validator_by_address(&mut system_state, validator_addr);
+        scenario.next_tx(new_validator_addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let validator = system_state.active_validator_by_address(validator_addr);
         verify_metadata_after_advancing_epoch(
             validator,
             b"validator_new_name",
@@ -741,7 +730,7 @@ module sui_system::sui_system_tests {
             vector[215, 64, 85, 185, 231, 116, 69, 151, 97, 79, 4, 183, 20, 70, 84, 51, 211, 162, 115, 221, 73, 241, 240, 171, 192, 25, 232, 106, 175, 162, 176, 43],
         );
 
-        let validator = sui_system::active_validator_by_address(&mut system_state, new_validator_addr);
+        let validator = system_state.active_validator_by_address(new_validator_addr);
         verify_metadata_after_advancing_epoch(
             validator,
             b"new_validator_new_name",
@@ -754,7 +743,7 @@ module sui_system::sui_system_tests {
         );
 
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
 
@@ -774,12 +763,11 @@ module sui_system::sui_system_tests {
         let scenario = &mut scenario_val;
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
-        test_scenario::next_tx(scenario, validator_addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        test_scenario::next_tx(scenario, validator_addr);
+        scenario.next_tx(validator_addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        scenario.next_tx(validator_addr);
         {
-            sui_system::request_add_validator_candidate_for_testing(
-                &mut system_state,
+            system_state.request_add_validator_candidate_for_testing(
                 pubkey,
                 vector[215, 64, 85, 185, 231, 116, 69, 151, 97, 79, 4, 183, 20, 70, 84, 51, 211, 162, 115, 221, 73, 241, 240, 171, 192, 25, 232, 106, 175, 162, 176, 43],
                 vector[148, 117, 212, 171, 44, 104, 167, 11, 177, 100, 4, 55, 17, 235, 117, 45, 117, 84, 159, 49, 14, 159, 239, 246, 237, 21, 83, 166, 112, 53, 62, 199],
@@ -794,11 +782,11 @@ module sui_system::sui_system_tests {
                 b"/ip4/168.168.168.168/udp/80",
                 1,
                 0,
-                test_scenario::ctx(scenario),
+                scenario.ctx(),
             );
         };
 
-        test_scenario::next_tx(scenario, validator_addr);
+        scenario.next_tx(validator_addr);
         update_candidate(
             scenario,
             &mut system_state,
@@ -811,9 +799,9 @@ module sui_system::sui_system_tests {
             7,
         );
 
-        test_scenario::next_tx(scenario, validator_addr);
+        scenario.next_tx(validator_addr);
 
-        let validator = sui_system::candidate_validator_by_address(&mut system_state, validator_addr);
+        let validator = system_state.candidate_validator_by_address(validator_addr);
         verify_candidate(
             validator,
             b"validator_new_name",
@@ -828,7 +816,7 @@ module sui_system::sui_system_tests {
 
 
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -843,10 +831,9 @@ module sui_system::sui_system_tests {
         let pop = x"83809369ce6572be211512d85621a075ee6a8da57fbb2d867d05e6a395e71f10e4e957796944d68a051381eb91720fba";
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
-        test_scenario::next_tx(scenario, new_validator_addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        scenario.next_tx(new_validator_addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        system_state.request_add_validator_candidate(
             pubkey,
             vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
             vector[42], // invalid
@@ -861,10 +848,10 @@ module sui_system::sui_system_tests {
             b"/ip4/127.0.0.1/udp/80",
             1,
             0,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -877,10 +864,9 @@ module sui_system::sui_system_tests {
         let pop = x"83809369ce6572be211512d85621a075ee6a8da57fbb2d867d05e6a395e71f10e4e957796944d68a051381eb91720fba";
 
         set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
-        test_scenario::next_tx(scenario, new_validator_addr);
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        scenario.next_tx(new_validator_addr);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        system_state.request_add_validator_candidate(
             pubkey,
             vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
             vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
@@ -895,12 +881,11 @@ module sui_system::sui_system_tests {
             b"/ip4/127.0.0.1/udp/80",
             1,
             0,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
 
         // Add the same address as candidate again, should fail this time.
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        system_state.request_add_validator_candidate(
             pubkey,
             vector[32, 219, 38, 23, 242, 109, 116, 235, 225, 192, 219, 45, 40, 124, 162, 25, 33, 68, 52, 41, 123, 9, 98, 11, 184, 150, 214, 62, 60, 210, 121, 62],
             vector[68, 55, 206, 25, 199, 14, 169, 53, 68, 92, 142, 136, 174, 149, 54, 215, 101, 63, 249, 206, 197, 98, 233, 80, 60, 12, 183, 32, 216, 88, 103, 25],
@@ -915,10 +900,10 @@ module sui_system::sui_system_tests {
             b"/ip4/127.0.0.1/udp/80",
             1,
             0,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -938,7 +923,7 @@ module sui_system::sui_system_tests {
         let scenario = &mut scenario_val;
 
         // Set up SuiSystemState with an active validator
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let validator = validator::new_for_testing(
             validator_addr,
             pubkey,
@@ -961,13 +946,12 @@ module sui_system::sui_system_tests {
         );
         create_sui_system_state_for_testing(vector[validator], 1000, 0, ctx);
 
-        test_scenario::next_tx(scenario, new_addr);
+        scenario.next_tx(new_addr);
 
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let mut system_state = scenario.take_shared<SuiSystemState>();
 
         // Add a candidate with the same name. Fails due to duplicating with an already active validator.
-        sui_system::request_add_validator_candidate(
-            &mut system_state,
+        system_state.request_add_validator_candidate(
             new_pubkey,
             vector[115, 220, 238, 151, 134, 159, 173, 41, 80, 2, 66, 196, 61, 17, 191, 76, 103, 39, 246, 127, 171, 85, 19, 235, 210, 106, 97, 97, 116, 48, 244, 191],
             vector[149, 128, 161, 13, 11, 183, 96, 45, 89, 20, 188, 205, 26, 127, 147, 254, 184, 229, 184, 102, 64, 170, 104, 29, 191, 171, 91, 99, 58, 178, 41, 156],
@@ -983,10 +967,10 @@ module sui_system::sui_system_tests {
             b"/ip4/127.0.0.1/udp/80",
             1,
             0,
-            test_scenario::ctx(scenario),
+            scenario.ctx(),
         );
         test_scenario::return_shared(system_state);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -1000,22 +984,22 @@ module sui_system::sui_system_tests {
         advance_epoch_and_check_distribution_counter(scenario, 42, true);
         advance_epoch_and_check_distribution_counter(scenario, 32, false);
         advance_epoch_and_check_distribution_counter(scenario, 52, true);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun advance_epoch_and_check_distribution_counter(scenario: &mut Scenario, epoch_length: u64, should_increment_counter: bool) {
-        test_scenario::next_tx(scenario, @0x0);
-        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario)) + 1;
-        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let prev_epoch_time = sui_system::epoch_start_timestamp_ms(&mut system_state);
-        let prev_counter = sui_system::get_stake_subsidy_distribution_counter(&mut system_state);
+        scenario.next_tx(@0x0);
+        let new_epoch = scenario.ctx().epoch() + 1;
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let prev_epoch_time = system_state.epoch_start_timestamp_ms();
+        let prev_counter = system_state.get_stake_subsidy_distribution_counter();
 
-        let rebate = sui_system::advance_epoch_for_testing(
-            &mut system_state, new_epoch, 1, 0, 0, 0, 0, 0, 0, prev_epoch_time + epoch_length, test_scenario::ctx(scenario)
+        let rebate = system_state.advance_epoch_for_testing(
+            new_epoch, 1, 0, 0, 0, 0, 0, 0, prev_epoch_time + epoch_length, scenario.ctx()
         );
         destroy(rebate);
-        assert_eq(sui_system::get_stake_subsidy_distribution_counter(&mut system_state), prev_counter + (if (should_increment_counter) 1 else 0));
+        assert_eq(system_state.get_stake_subsidy_distribution_counter(), prev_counter + (if (should_increment_counter) 1 else 0));
         test_scenario::return_shared(system_state);
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
@@ -5,16 +5,12 @@
 module sui_system::validator_set_tests {
     use sui::balance;
     use sui::coin;
-    use sui::tx_context::TxContext;
     use sui_system::staking_pool::StakedSui;
     use sui_system::validator::{Self, Validator, staking_pool_id};
     use sui_system::validator_set::{Self, ValidatorSet, active_validator_addresses};
     use sui::test_scenario::{Self, Scenario};
-    use sui::vec_map;
-    use std::ascii;
-    use std::option;
     use sui::test_utils::{Self, assert_eq};
-    use sui::transfer;
+    use sui::vec_map;
 
     const MIST_PER_SUI: u64 = 1_000_000_000; // used internally for stakes.
 
@@ -23,7 +19,7 @@ module sui_system::validator_set_tests {
         // Create 4 validators, with stake 100, 200, 300, 400. Only the first validator is an initial validator.
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
         let validator2 = create_validator(@0x2, 2, 1, false, ctx);
         let validator3 = create_validator(@0x3, 3, 1, false, ctx);
@@ -31,7 +27,7 @@ module sui_system::validator_set_tests {
 
         // Create a validator set with only the first validator in it.
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert!(validator_set::total_stake(&validator_set) == 100 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 100 * MIST_PER_SUI, 0);
 
         // Add the other 3 validators one by one.
         add_and_activate_validator(
@@ -40,29 +36,28 @@ module sui_system::validator_set_tests {
             scenario
         );
         // Adding validator during the epoch should not affect stake and quorum threshold.
-        assert!(validator_set::total_stake(&validator_set) == 100 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 100 * MIST_PER_SUI, 0);
 
         add_and_activate_validator(
             &mut validator_set,
             validator3,
             scenario
         );
-        test_scenario::end(scenario_val);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
         {
-            let ctx1 = test_scenario::ctx(scenario);
-            let stake = validator_set::request_add_stake(
-                &mut validator_set,
+            let ctx1 = scenario.ctx();
+            let stake = validator_set.request_add_stake(
                 @0x1,
-                coin::into_balance(coin::mint_for_testing(500 * MIST_PER_SUI, ctx1)),
+                coin::mint_for_testing(500 * MIST_PER_SUI, ctx1).into_balance(),
                 ctx1,
             );
             transfer::public_transfer(stake, @0x1);
             // Adding stake to existing active validator during the epoch
             // should not change total stake.
-            assert!(validator_set::total_stake(&validator_set) == 100 * MIST_PER_SUI, 0);
+            assert!(validator_set.total_stake() == 100 * MIST_PER_SUI, 0);
         };
 
         add_and_activate_validator(
@@ -73,26 +68,23 @@ module sui_system::validator_set_tests {
 
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
         // Total stake for these should be the starting stake + the 500 staked with validator 1 in addition to the starting stake.
-        assert!(validator_set::total_stake(&validator_set) == 1500 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 1500 * MIST_PER_SUI, 0);
 
-        test_scenario::next_tx(scenario, @0x1);
+        scenario.next_tx(@0x1);
         {
-            let ctx1 = test_scenario::ctx(scenario);
+            let ctx1 = scenario.ctx();
 
-            validator_set::request_remove_validator(
-                &mut validator_set,
-                ctx1,
-            );
+            validator_set.request_remove_validator(ctx1);
         };
 
         // Total validator candidate count changes, but total stake remains during epoch.
-        assert!(validator_set::total_stake(&validator_set) == 1500 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 1500 * MIST_PER_SUI, 0);
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
         // Validator1 is gone. This removes its stake (100) + the 500 staked with it.
-        assert!(validator_set::total_stake(&validator_set) == 900 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 900 * MIST_PER_SUI, 0);
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -100,7 +92,7 @@ module sui_system::validator_set_tests {
         // Create 5 validators with different stakes and different gas prices.
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let v1 = create_validator(@0x1, 1, 45, true, ctx);
         let v2 = create_validator(@0x2, 2, 42, false, ctx);
         let v3 = create_validator(@0x3, 3, 40, false, ctx);
@@ -109,12 +101,12 @@ module sui_system::validator_set_tests {
         // Create a validator set with only the first validator in it.
         let mut validator_set = validator_set::new(vector[v1], ctx);
 
-        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
+        assert_eq(validator_set.derive_reference_gas_price(), 45);
 
         add_and_activate_validator(&mut validator_set, v2, scenario);
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
-        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 45);
+        assert_eq(validator_set.derive_reference_gas_price(), 45);
 
         add_and_activate_validator(
             &mut validator_set,
@@ -123,7 +115,7 @@ module sui_system::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
-        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
+        assert_eq(validator_set.derive_reference_gas_price(), 42);
 
         add_and_activate_validator(
             &mut validator_set,
@@ -132,7 +124,7 @@ module sui_system::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
-        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 42);
+        assert_eq(validator_set.derive_reference_gas_price(), 42);
 
         add_and_activate_validator(
             &mut validator_set,
@@ -141,10 +133,10 @@ module sui_system::validator_set_tests {
         );
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
 
-        assert_eq(validator_set::derive_reference_gas_price(&validator_set), 43);
+        assert_eq(validator_set.derive_reference_gas_price(), 43);
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -152,44 +144,42 @@ module sui_system::validator_set_tests {
     fun test_staking_below_threshold() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
-        test_scenario::end(scenario_val);
+        assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
-        let ctx1 = test_scenario::ctx(scenario);
+        let ctx1 = scenario.ctx();
 
-        let stake = validator_set::request_add_stake(
-            &mut validator_set,
+        let stake = validator_set.request_add_stake(
             @0x1,
             balance::create_for_testing(MIST_PER_SUI - 1), // 1 MIST lower than the threshold
             ctx1,
         );
         transfer::public_transfer(stake, @0x1);
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_staking_min_threshold() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
-        test_scenario::end(scenario_val);
+        assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
-        let ctx1 = test_scenario::ctx(scenario);
-        let stake = validator_set::request_add_stake(
-            &mut validator_set,
+        let ctx1 = scenario.ctx();
+        let stake = validator_set.request_add_stake(
             @0x1,
             balance::create_for_testing(MIST_PER_SUI), // min possible stake
             ctx1,
@@ -197,10 +187,10 @@ module sui_system::validator_set_tests {
         transfer::public_transfer(stake, @0x1);
 
         advance_epoch_with_dummy_rewards(&mut validator_set, scenario);
-        assert!(validator_set::total_stake(&validator_set) == 101 * MIST_PER_SUI, 0);
+        assert!(validator_set.total_stake() == 101 * MIST_PER_SUI, 0);
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -208,7 +198,7 @@ module sui_system::validator_set_tests {
     fun test_add_validator_failure_below_min_stake() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         // Create 2 validators, with stake 100 and 200.
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
@@ -216,41 +206,40 @@ module sui_system::validator_set_tests {
 
         // Create a validator set with only the first validator in it.
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
-        test_scenario::end(scenario_val);
+        assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
-        let ctx1 = test_scenario::ctx(scenario);
-        validator_set::request_add_validator_candidate(&mut validator_set, validator2, ctx1);
+        let ctx1 = scenario.ctx();
+        validator_set.request_add_validator_candidate(validator2, ctx1);
 
-        test_scenario::next_tx(scenario, @0x42);
+        scenario.next_tx(@0x42);
         {
-            let ctx = test_scenario::ctx(scenario);
-            let stake = validator_set::request_add_stake(
-                &mut validator_set,
+            let ctx = scenario.ctx();
+            let stake = validator_set.request_add_stake(
                 @0x2,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
             );
             transfer::public_transfer(stake, @0x42);
             // Adding stake to a preactive validator should not change total stake.
-            assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
+            assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
         };
 
-        test_scenario::next_tx(scenario, @0x2);
+        scenario.next_tx(@0x2);
         // Validator 2 now has 700 SUI in stake but that's not enough because we need 701.
-        validator_set::request_add_validator(&mut validator_set, 701 * MIST_PER_SUI, test_scenario::ctx(scenario));
+        validator_set.request_add_validator(701 * MIST_PER_SUI, scenario.ctx());
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_add_validator_with_nonzero_min_stake() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         // Create 2 validators, with stake 100 and 200.
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
@@ -258,41 +247,40 @@ module sui_system::validator_set_tests {
 
         // Create a validator set with only the first validator in it.
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
-        test_scenario::end(scenario_val);
+        assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
-        let ctx1 = test_scenario::ctx(scenario);
-        validator_set::request_add_validator_candidate(&mut validator_set, validator2, ctx1);
+        let ctx1 = scenario.ctx();
+        validator_set.request_add_validator_candidate(validator2, ctx1);
 
-        test_scenario::next_tx(scenario, @0x42);
+        scenario.next_tx(@0x42);
         {
-            let ctx = test_scenario::ctx(scenario);
-            let stake = validator_set::request_add_stake(
-                &mut validator_set,
+            let ctx = scenario.ctx();
+            let stake = validator_set.request_add_stake(
                 @0x2,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
             );
             transfer::public_transfer(stake, @0x42);
             // Adding stake to a preactive validator should not change total stake.
-            assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
+            assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
         };
 
-        test_scenario::next_tx(scenario, @0x2);
+        scenario.next_tx(@0x2);
         // Validator 2 now has 700 SUI in stake and that's just enough.
-        validator_set::request_add_validator(&mut validator_set, 700 * MIST_PER_SUI, test_scenario::ctx(scenario));
+        validator_set.request_add_validator(700 * MIST_PER_SUI, scenario.ctx());
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_add_candidate_then_remove() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         // Create 2 validators, with stake 100 and 200.
         let validator1 = create_validator(@0x1, 1, 1, true, ctx);
@@ -302,31 +290,31 @@ module sui_system::validator_set_tests {
 
         // Create a validator set with only the first validator in it.
         let mut validator_set = validator_set::new(vector[validator1], ctx);
-        assert_eq(validator_set::total_stake(&validator_set), 100 * MIST_PER_SUI);
-        test_scenario::end(scenario_val);
+        assert_eq(validator_set.total_stake(), 100 * MIST_PER_SUI);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
-        let ctx1 = test_scenario::ctx(scenario);
+        let ctx1 = scenario.ctx();
         // Add the second one as a candidate.
-        validator_set::request_add_validator_candidate(&mut validator_set, validator2, ctx1);
-        assert!(validator_set::is_validator_candidate(&validator_set, @0x2), 0);
+        validator_set.request_add_validator_candidate(validator2, ctx1);
+        assert!(validator_set.is_validator_candidate(@0x2), 0);
 
-        test_scenario::next_tx(scenario, @0x2);
+        scenario.next_tx(@0x2);
         // Then remove its candidacy.
-        validator_set::request_remove_validator_candidate(&mut validator_set, test_scenario::ctx(scenario));
-        assert!(!validator_set::is_validator_candidate(&validator_set, @0x2), 0);
-        assert!(validator_set::is_inactive_validator(&validator_set, pool_id_2), 0);
+        validator_set.request_remove_validator_candidate(scenario.ctx());
+        assert!(!validator_set.is_validator_candidate(@0x2), 0);
+        assert!(validator_set.is_inactive_validator(pool_id_2), 0);
 
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_low_stake_departure() {
         let mut scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         // Create 4 validators.
         let v1 = create_validator(@0x1, 1, 1, true, ctx); // 100 SUI of stake
         let v2 = create_validator(@0x2, 4, 1, true, ctx); // 400 SUI of stake
@@ -334,7 +322,7 @@ module sui_system::validator_set_tests {
         let v4 = create_validator(@0x4, 4, 1, true, ctx); // 400 SUI of stake
 
         let mut validator_set = validator_set::new(vector[v1, v2, v3, v4], ctx);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
 
         let mut scenario_val = test_scenario::begin(@0x1);
         let scenario = &mut scenario_val;
@@ -359,11 +347,10 @@ module sui_system::validator_set_tests {
         assert_eq(active_validator_addresses(&validator_set), vector[@0x2, @0x3, @0x4]);
 
         // Add some stake to @0x4 to get her out of the danger zone.
-        test_scenario::next_tx(scenario, @0x42);
+        scenario.next_tx(@0x42);
         {
-            let ctx = test_scenario::ctx(scenario);
-            let stake = validator_set::request_add_stake(
-                &mut validator_set,
+            let ctx = scenario.ctx();
+            let stake = validator_set.request_add_stake(
                 @0x4,
                 balance::create_for_testing(500 * MIST_PER_SUI),
                 ctx,
@@ -378,16 +365,15 @@ module sui_system::validator_set_tests {
         assert_eq(active_validator_addresses(&validator_set), vector[@0x3, @0x4]);
 
         // Withdraw the stake from @0x4.
-        test_scenario::next_tx(scenario, @0x42);
+        scenario.next_tx(@0x42);
         {
-            let stake = test_scenario::take_from_sender<StakedSui>(scenario);
-            let ctx = test_scenario::ctx(scenario);
-            let withdrawn_balance = validator_set::request_withdraw_stake(
-                &mut validator_set,
+            let stake = scenario.take_from_sender<StakedSui>();
+            let ctx = scenario.ctx();
+            let withdrawn_balance = validator_set.request_withdraw_stake(
                 stake,
                 ctx,
             );
-            transfer::public_transfer(coin::from_balance(withdrawn_balance, ctx), @0x42);
+            transfer::public_transfer(withdrawn_balance.into_coin(ctx), @0x42);
         };
 
         // Now @0x4 gets kicked out after 3 grace days are used at the 4th epoch change.
@@ -409,7 +395,7 @@ module sui_system::validator_set_tests {
         // @0x4 was kicked out.
         assert_eq(active_validator_addresses(&validator_set), vector[@0x3]);
         test_utils::destroy(validator_set);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     fun create_validator(addr: address, hint: u8, gas_price: u64, is_initial_validator: bool, ctx: &mut TxContext): Validator {
@@ -440,16 +426,15 @@ module sui_system::validator_set_tests {
 
     fun hint_to_ascii(hint: u8): vector<u8> {
         let ascii_bytes = vector[hint / 100 + 65, hint % 100 / 10 + 65, hint % 10 + 65];
-        ascii::into_bytes(ascii::string(ascii_bytes))
+        ascii_bytes.to_ascii_string().into_bytes()
     }
 
     fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSet, scenario: &mut Scenario) {
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
         let mut dummy_computation_reward = balance::zero();
         let mut dummy_storage_fund_reward = balance::zero();
 
-        validator_set::advance_epoch(
-            validator_set,
+        validator_set.advance_epoch(
             &mut dummy_computation_reward,
             &mut dummy_storage_fund_reward,
             &mut vec_map::empty(),
@@ -457,11 +442,11 @@ module sui_system::validator_set_tests {
             0, // low_stake_threshold
             0, // very_low_stake_threshold
             0, // low_stake_grace_period
-            test_scenario::ctx(scenario)
+            scenario.ctx()
         );
 
-        balance::destroy_zero(dummy_computation_reward);
-        balance::destroy_zero(dummy_storage_fund_reward);
+        dummy_computation_reward.destroy_zero();
+        dummy_storage_fund_reward.destroy_zero();
     }
 
     fun advance_epoch_with_low_stake_params(
@@ -471,11 +456,10 @@ module sui_system::validator_set_tests {
         low_stake_grace_period: u64,
         scenario: &mut Scenario
     ) {
-        test_scenario::next_epoch(scenario, @0x0);
+        scenario.next_epoch(@0x0);
         let mut dummy_computation_reward = balance::zero();
         let mut dummy_storage_fund_reward = balance::zero();
-        validator_set::advance_epoch(
-            validator_set,
+        validator_set.advance_epoch(
             &mut dummy_computation_reward,
             &mut dummy_storage_fund_reward,
             &mut vec_map::empty(),
@@ -483,17 +467,17 @@ module sui_system::validator_set_tests {
             low_stake_threshold * MIST_PER_SUI,
             very_low_stake_threshold * MIST_PER_SUI,
             low_stake_grace_period,
-            test_scenario::ctx(scenario)
+            scenario.ctx()
         );
 
-        balance::destroy_zero(dummy_computation_reward);
-        balance::destroy_zero(dummy_storage_fund_reward);
+        dummy_computation_reward.destroy_zero();
+        dummy_storage_fund_reward.destroy_zero();
     }
 
     fun add_and_activate_validator(validator_set: &mut ValidatorSet, validator: Validator, scenario: &mut Scenario) {
-        test_scenario::next_tx(scenario, validator::sui_address(&validator));
-        let ctx = test_scenario::ctx(scenario);
-        validator_set::request_add_validator_candidate(validator_set, validator, ctx);
-        validator_set::request_add_validator(validator_set, 0, ctx);
+        scenario.next_tx(validator.sui_address());
+        let ctx = scenario.ctx();
+        validator_set.request_add_validator_candidate(validator, ctx);
+        validator_set.request_add_validator(0, ctx);
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/validator_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_tests.move
@@ -3,21 +3,14 @@
 
 #[test_only]
 module sui_system::validator_tests {
-    use sui::sui::SUI;
     use sui::test_scenario;
     use sui::url;
-    use std::string::Self;
     use sui_system::validator::{Self, Validator};
     use sui::tx_context::TxContext;
-    use std::option;
-    use std::ascii;
-    use sui::coin::{Self, Coin};
-    use sui::balance;
-    use sui_system::staking_pool::{Self, StakedSui};
-    use std::vector;
+    use sui::coin::{Self};
+    use sui_system::staking_pool::StakedSui;
     use sui::test_utils;
     use sui::bag;
-    use sui::transfer;
 
     const VALID_NET_PUBKEY: vector<u8> = vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38];
 
@@ -38,7 +31,7 @@ module sui_system::validator_tests {
 
     #[test_only]
     fun get_test_validator(ctx: &mut TxContext): Validator {
-        let init_stake = coin::into_balance(coin::mint_for_testing(10_000_000_000, ctx));
+        let init_stake = coin::mint_for_testing(10_000_000_000, ctx).into_balance();
         let mut validator = validator::new(
             VALID_ADDRESS,
             VALID_PUBKEY,
@@ -58,14 +51,13 @@ module sui_system::validator_tests {
             ctx
         );
 
-        validator::request_add_stake_at_genesis(
-            &mut validator,
+        validator.request_add_stake_at_genesis(
             init_stake,
             VALID_ADDRESS,
             ctx
         );
 
-        validator::activate(&mut validator, 0);
+        validator.activate(0);
 
         validator
     }
@@ -76,23 +68,23 @@ module sui_system::validator_tests {
         let mut scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
         {
-            let ctx = test_scenario::ctx(scenario);
+            let ctx = scenario.ctx();
 
             let validator = get_test_validator(ctx);
-            assert!(validator::total_stake_amount(&validator) == 10_000_000_000, 0);
-            assert!(validator::sui_address(&validator) == sender, 0);
+            assert!(validator.total_stake_amount() == 10_000_000_000, 0);
+            assert!(validator.sui_address() == sender, 0);
 
             test_utils::destroy(validator);
         };
 
         // Check that after destroy, the original stake still exists.
-         test_scenario::next_tx(scenario, sender);
+         scenario.next_tx(sender);
          {
-             let stake = test_scenario::take_from_sender<StakedSui>(scenario);
-             assert!(staking_pool::staked_sui_amount(&stake) == 10_000_000_000, 0);
-             test_scenario::return_to_sender(scenario, stake);
+             let stake = scenario.take_from_sender<StakedSui>();
+             assert!(stake.amount() == 10_000_000_000, 0);
+             scenario.return_to_sender(stake);
          };
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
@@ -100,267 +92,267 @@ module sui_system::validator_tests {
         let sender = VALID_ADDRESS;
         let mut scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
 
         let mut validator = get_test_validator(ctx);
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
         {
-            let ctx = test_scenario::ctx(scenario);
-            let new_stake = coin::into_balance(coin::mint_for_testing(30_000_000_000, ctx));
-            let stake = validator::request_add_stake(&mut validator, new_stake, sender, ctx);
+            let ctx = scenario.ctx();
+            let new_stake = coin::mint_for_testing(30_000_000_000, ctx).into_balance();
+            let stake = validator.request_add_stake(new_stake, sender, ctx);
             transfer::public_transfer(stake, sender);
 
-            assert!(validator::total_stake(&validator) == 10_000_000_000, 0);
-            assert!(validator::pending_stake_amount(&validator) == 30_000_000_000, 0);
+            assert!(validator.total_stake() == 10_000_000_000, 0);
+            assert!(validator.pending_stake_amount() == 30_000_000_000, 0);
         };
 
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
         {
-            let coin_ids = test_scenario::ids_for_sender<StakedSui>(scenario);
-            let stake = test_scenario::take_from_sender_by_id<StakedSui>(scenario, *vector::borrow(&coin_ids, 0));
-            let ctx = test_scenario::ctx(scenario);
-            let withdrawn_balance = validator::request_withdraw_stake(&mut validator, stake, ctx);
-            transfer::public_transfer(coin::from_balance(withdrawn_balance, ctx), sender);
+            let coin_ids = scenario.ids_for_sender<StakedSui>();
+            let stake = scenario.take_from_sender_by_id<StakedSui>(coin_ids[0]);
+            let ctx = scenario.ctx();
+            let withdrawn_balance = validator.request_withdraw_stake(stake, ctx);
+            transfer::public_transfer(withdrawn_balance.into_coin(ctx), sender);
 
-            assert!(validator::total_stake(&validator) == 10_000_000_000, 0);
-            assert!(validator::pending_stake_amount(&validator) == 30_000_000_000, 0);
-            assert!(validator::pending_stake_withdraw_amount(&validator) == 10_000_000_000, 0);
+            assert!(validator.total_stake() == 10_000_000_000, 0);
+            assert!(validator.pending_stake_amount() == 30_000_000_000, 0);
+            assert!(validator.pending_stake_withdraw_amount() == 10_000_000_000, 0);
 
-            validator::deposit_stake_rewards(&mut validator, balance::zero());
+            validator.deposit_stake_rewards(balance::zero());
 
             // Calling `process_pending_stakes_and_withdraws` will withdraw the coin and transfer to sender.
-            validator::process_pending_stakes_and_withdraws(&mut validator, ctx);
+            validator.process_pending_stakes_and_withdraws(ctx);
 
-            assert!(validator::total_stake(&validator) == 30_000_000_000, 0);
-            assert!(validator::pending_stake_amount(&validator) == 0, 0);
-            assert!(validator::pending_stake_withdraw_amount(&validator) == 0, 0);
+            assert!(validator.total_stake() == 30_000_000_000, 0);
+            assert!(validator.pending_stake_amount() == 0, 0);
+            assert!(validator.pending_stake_withdraw_amount() == 0, 0);
         };
 
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
         {
-            let coin_ids = test_scenario::ids_for_sender<Coin<SUI>>(scenario);
-            let withdraw = test_scenario::take_from_sender_by_id<Coin<SUI>>(scenario, *vector::borrow(&coin_ids, 0));
-            assert!(coin::value(&withdraw) == 10_000_000_000, 0);
-            test_scenario::return_to_sender(scenario, withdraw);
+            let coin_ids = scenario.ids_for_sender<Coin<SUI>>();
+            let withdraw = scenario.take_from_sender_by_id<Coin<SUI>>(coin_ids[0]);
+            assert!(withdraw.value() == 10_000_000_000, 0);
+            scenario.return_to_sender(withdraw);
         };
 
         test_utils::destroy(validator);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     fun test_metadata() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidPubkey)]
     fun test_metadata_invalid_pubkey() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             vector[42],
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidNetPubkey)]
     fun test_metadata_invalid_net_pubkey() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             vector[42],
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidWorkerPubkey)]
     fun test_metadata_invalid_worker_pubkey() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             vector[42],
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidNetAddr)]
     fun test_metadata_invalid_net_addr() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(b"42")),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            b"42".to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidP2pAddr)]
     fun test_metadata_invalid_p2p_addr() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(b"42")),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            b"42".to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidPrimaryAddr)]
     fun test_metadata_invalid_consensus_addr() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(b"42")),
-            string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            b"42".to_string(),
+            VALID_WORKER_ADDR.to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidWorkerAddr)]
     fun test_metadata_invalid_worker_addr() {
         let mut scenario_val = test_scenario::begin(VALID_ADDRESS);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
             PROOF_OF_POSSESSION,
-            string::from_ascii(ascii::string(b"Validator1")),
-            string::from_ascii(ascii::string(b"Validator1")),
+            b"Validator1".to_string(),
+            b"Validator1".to_string(),
             url::new_unsafe_from_bytes(b"image_url1"),
             url::new_unsafe_from_bytes(b"project_url1"),
-            string::from_ascii(ascii::string(VALID_NET_ADDR)),
-            string::from_ascii(ascii::string(VALID_P2P_ADDR)),
-            string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
-            string::from_ascii(ascii::string(b"42")),
+            VALID_NET_ADDR.to_string(),
+            VALID_P2P_ADDR.to_string(),
+            VALID_CONSENSUS_ADDR.to_string(),
+            b"42".to_string(),
             bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
         test_utils::destroy(metadata);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[test, allow(implicit_const_copy)]
@@ -368,7 +360,7 @@ module sui_system::validator_tests {
         let sender = VALID_ADDRESS;
         let mut scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
-        let ctx = test_scenario::ctx(scenario);
+        let ctx = scenario.ctx();
         let new_protocol_pub_key = x"96d19c53f1bee2158c3fcfb5bb2f06d3a8237667529d2d8f0fbb22fe5c3b3e64748420b4103674490476d98530d063271222d2a59b0f7932909cc455a30f00c69380e6885375e94243f7468e9563aad29330aca7ab431927540e9508888f0e1c";
         let new_pop = x"a8a0bcaf04e13565914eb22fa9f27a76f297db04446860ee2b923d10224cedb130b30783fb60b12556e7fc50e5b57a86";
         let new_worker_pub_key = vector[115, 220, 238, 151, 134, 159, 173, 41, 80, 2, 66, 196, 61, 17, 191, 76, 103, 39, 246, 127, 171, 85, 19, 235, 210, 106, 97, 97, 116, 48, 244, 191];
@@ -376,73 +368,63 @@ module sui_system::validator_tests {
 
         let mut validator = get_test_validator(ctx);
 
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_network_address(&mut validator, b"/ip4/192.168.1.1/tcp/80");
-            validator::update_next_epoch_p2p_address(&mut validator, b"/ip4/192.168.1.1/udp/80");
-            validator::update_next_epoch_primary_address(&mut validator, b"/ip4/192.168.1.1/udp/80");
-            validator::update_next_epoch_worker_address(&mut validator, b"/ip4/192.168.1.1/udp/80");
-            validator::update_next_epoch_protocol_pubkey(
-                &mut validator,
-                new_protocol_pub_key,
-                new_pop,
-            );
-            validator::update_next_epoch_worker_pubkey(
-                &mut validator,
-                new_worker_pub_key,
-            );
-            validator::update_next_epoch_network_pubkey(
-                &mut validator,
-                new_network_pub_key,
-            );
+            validator.update_next_epoch_network_address(b"/ip4/192.168.1.1/tcp/80");
+            validator.update_next_epoch_p2p_address(b"/ip4/192.168.1.1/udp/80");
+            validator.update_next_epoch_primary_address(b"/ip4/192.168.1.1/udp/80");
+            validator.update_next_epoch_worker_address(b"/ip4/192.168.1.1/udp/80");
+            validator.update_next_epoch_protocol_pubkey(new_protocol_pub_key, new_pop);
+            validator.update_next_epoch_worker_pubkey( new_worker_pub_key);
+            validator.update_next_epoch_network_pubkey(new_network_pub_key);
 
-            validator::update_name(&mut validator, b"new_name");
-            validator::update_description(&mut validator, b"new_desc");
-            validator::update_image_url(&mut validator, b"new_image_url");
-            validator::update_project_url(&mut validator, b"new_proj_url");
+            validator.update_name(b"new_name");
+            validator.update_description(b"new_desc");
+            validator.update_image_url(b"new_image_url");
+            validator.update_project_url(b"new_proj_url");
         };
 
-        test_scenario::next_tx(scenario, sender);
+        scenario.next_tx(sender);
         {
             // Current epoch
-            assert!(validator::name(&validator) == &string::from_ascii(ascii::string(b"new_name")), 0);
-            assert!(validator::description(&validator) == &string::from_ascii(ascii::string(b"new_desc")), 0);
-            assert!(validator::image_url(&validator) == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
-            assert!(validator::project_url(&validator) == &url::new_unsafe_from_bytes(b"new_proj_url"), 0);
-            assert!(validator::network_address(&validator) == &string::from_ascii(ascii::string(VALID_NET_ADDR)), 0);
-            assert!(validator::p2p_address(&validator) == &string::from_ascii(ascii::string(VALID_P2P_ADDR)), 0);
-            assert!(validator::primary_address(&validator) == &string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)), 0);
-            assert!(validator::worker_address(&validator) == &string::from_ascii(ascii::string(VALID_WORKER_ADDR)), 0);
-            assert!(validator::protocol_pubkey_bytes(&validator) == &VALID_PUBKEY, 0);
-            assert!(validator::proof_of_possession(&validator) == &PROOF_OF_POSSESSION, 0);
-            assert!(validator::network_pubkey_bytes(&validator) == &VALID_NET_PUBKEY, 0);
-            assert!(validator::worker_pubkey_bytes(&validator) == &VALID_WORKER_PUBKEY, 0);
+            assert!(validator.name() == &b"new_name".to_string(), 0);
+            assert!(validator.description() == &b"new_desc".to_string(), 0);
+            assert!(validator.image_url() == &url::new_unsafe_from_bytes(b"new_image_url"), 0);
+            assert!(validator.project_url() == &url::new_unsafe_from_bytes(b"new_proj_url"), 0);
+            assert!(validator.network_address() == &VALID_NET_ADDR.to_string(), 0);
+            assert!(validator.p2p_address() == &VALID_P2P_ADDR.to_string(), 0);
+            assert!(validator.primary_address() == &VALID_CONSENSUS_ADDR.to_string(), 0);
+            assert!(validator.worker_address() == &VALID_WORKER_ADDR.to_string(), 0);
+            assert!(validator.protocol_pubkey_bytes() == &VALID_PUBKEY, 0);
+            assert!(validator.proof_of_possession() == &PROOF_OF_POSSESSION, 0);
+            assert!(validator.network_pubkey_bytes() == &VALID_NET_PUBKEY, 0);
+            assert!(validator.worker_pubkey_bytes() == &VALID_WORKER_PUBKEY, 0);
 
             // Next epoch
-            assert!(validator::next_epoch_network_address(&validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/192.168.1.1/tcp/80"))), 0);
-            assert!(validator::next_epoch_p2p_address(&validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/192.168.1.1/udp/80"))), 0);
-            assert!(validator::next_epoch_primary_address(&validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/192.168.1.1/udp/80"))), 0);
-            assert!(validator::next_epoch_worker_address(&validator) == &option::some(string::from_ascii(ascii::string(b"/ip4/192.168.1.1/udp/80"))), 0);
+            assert!(validator.next_epoch_network_address() == &option::some(b"/ip4/192.168.1.1/tcp/80".to_string()), 0);
+            assert!(validator.next_epoch_p2p_address() == &option::some(b"/ip4/192.168.1.1/udp/80".to_string()), 0);
+            assert!(validator.next_epoch_primary_address() == &option::some(b"/ip4/192.168.1.1/udp/80".to_string()), 0);
+            assert!(validator.next_epoch_worker_address() == &option::some(b"/ip4/192.168.1.1/udp/80".to_string()), 0);
             assert!(
-                validator::next_epoch_protocol_pubkey_bytes(&validator) == &option::some(new_protocol_pub_key),
+                validator.next_epoch_protocol_pubkey_bytes() == &option::some(new_protocol_pub_key),
                 0
             );
             assert!(
-                validator::next_epoch_proof_of_possession(&validator) == &option::some(new_pop),
+                validator.next_epoch_proof_of_possession() == &option::some(new_pop),
                 0
             );
             assert!(
-                validator::next_epoch_worker_pubkey_bytes(&validator) == &option::some(new_worker_pub_key),
+                validator.next_epoch_worker_pubkey_bytes() == &option::some(new_worker_pub_key),
                 0
             );
             assert!(
-                validator::next_epoch_network_pubkey_bytes(&validator) == &option::some(new_network_pub_key),
+                validator.next_epoch_network_pubkey_bytes() == &option::some(new_network_pub_key),
                 0
             );
         };
 
         test_utils::destroy(validator);
-        test_scenario::end(scenario_val);
+        scenario_val.end();
     }
 
     #[expected_failure(abort_code = sui_system::validator::EInvalidProofOfPossession)]
@@ -450,10 +432,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_proof_of_possession() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_protocol_pubkey(
-                &mut validator,
+            validator.update_next_epoch_protocol_pubkey(
                 x"96d19c53f1bee2158c3fcfb5bb2f06d3a8237667529d2d8f0fbb22fe5c3b3e64748420b4103674490476d98530d063271222d2a59b0f7932909cc455a30f00c69380e6885375e94243f7468e9563aad29330aca7ab431927540e9508888f0e1c",
                 // This is an invalid proof of possession, so we abort
                 x"8b9794dfd11b88e16ba8f6a4a2c1e7580738dce2d6910ee594bebd88297b22ae8c34d1ee3f5a081159d68e076ef5d300");
@@ -467,12 +448,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_network_key() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_network_pubkey(
-                &mut validator,
-                x"beef",
-            );
+            validator.update_next_epoch_network_pubkey(x"beef");
         };
 
         tear_down(validator, scenario);
@@ -483,12 +461,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_worker_key() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_worker_pubkey(
-                &mut validator,
-                x"beef",
-            );
+            validator.update_next_epoch_worker_pubkey(x"beef");
         };
 
         tear_down(validator, scenario);
@@ -499,12 +474,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_network_addr() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_network_address(
-                &mut validator,
-                b"beef",
-            );
+            validator.update_next_epoch_network_address(b"beef");
         };
 
         tear_down(validator, scenario);
@@ -515,12 +487,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_primary_addr() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_primary_address(
-                &mut validator,
-                b"beef",
-            );
+            validator.update_next_epoch_primary_address(b"beef");
         };
 
         tear_down(validator, scenario);
@@ -531,12 +500,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_worker_addr() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_worker_address(
-                &mut validator,
-                b"beef",
-            );
+            validator.update_next_epoch_worker_address(b"beef");
         };
 
         tear_down(validator, scenario);
@@ -547,7 +513,7 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_invalid_p2p_address() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
             validator::update_next_epoch_p2p_address(
                 &mut validator,
@@ -563,10 +529,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_primary_address_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_primary_address(
-                &mut validator,
+            validator.update_next_epoch_primary_address(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -580,10 +545,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_net_address_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_network_address(
-                &mut validator,
+            validator.update_next_epoch_network_address(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -597,10 +561,9 @@ module sui_system::validator_tests {
     #[test]
     fun test_validator_update_metadata_worker_address_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_worker_address(
-                &mut validator,
+            validator.update_next_epoch_worker_address(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -614,10 +577,9 @@ module sui_system::validator_tests {
     fun test_validator_update_metadata_p2p_address_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_next_epoch_p2p_address(
-                &mut validator,
+            validator.update_next_epoch_p2p_address(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -631,10 +593,9 @@ module sui_system::validator_tests {
     fun test_validator_update_name_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_name(
-                &mut validator,
+            validator.update_name(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -647,10 +608,9 @@ module sui_system::validator_tests {
     fun test_validator_update_description_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_description(
-                &mut validator,
+            validator.update_description(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -663,10 +623,9 @@ module sui_system::validator_tests {
     fun test_validator_update_project_url_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_project_url(
-                &mut validator,
+            validator.update_project_url(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -679,10 +638,9 @@ module sui_system::validator_tests {
     fun test_validator_update_image_url_too_long() {
         let (sender, mut scenario, mut validator) = set_up();
 
-        test_scenario::next_tx(&mut scenario, sender);
+        scenario.next_tx(sender);
         {
-            validator::update_image_url(
-                &mut validator,
+            validator.update_image_url(
                 // 257 bytes but limit is 256 bytes
                 TOO_LONG_257_BYTES,
             );
@@ -693,13 +651,13 @@ module sui_system::validator_tests {
     fun set_up(): (address, test_scenario::Scenario, validator::Validator) {
         let sender = VALID_ADDRESS;
         let mut scenario_val = test_scenario::begin(sender);
-        let ctx = test_scenario::ctx(&mut scenario_val);
+        let ctx = scenario_val.ctx();
         let validator = get_test_validator(ctx);
         (sender, scenario_val, validator)
     }
 
     fun tear_down(validator: validator::Validator, scenario: test_scenario::Scenario) {
         test_utils::destroy(validator);
-        test_scenario::end(scenario);
+        scenario.end();
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/validator_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_tests.move
@@ -3,14 +3,15 @@
 
 #[test_only]
 module sui_system::validator_tests {
-    use sui::test_scenario;
-    use sui::url;
-    use sui_system::validator::{Self, Validator};
-    use sui::tx_context::TxContext;
-    use sui::coin::{Self};
-    use sui_system::staking_pool::StakedSui;
-    use sui::test_utils;
     use sui::bag;
+    use sui::balance;
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+    use sui::test_scenario;
+    use sui::test_utils;
+    use sui::url;
+    use sui_system::staking_pool::StakedSui;
+    use sui_system::validator::{Self, Validator};
 
     const VALID_NET_PUBKEY: vector<u8> = vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38];
 

--- a/crates/sui-framework/packages/sui-system/tests/voting_power_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/voting_power_tests.move
@@ -8,7 +8,6 @@ module sui_system::voting_power_tests {
     use sui::test_scenario;
     use sui::test_utils;
     use sui::tx_context::TxContext;
-    use std::vector;
     use sui_system::validator::{Self, Validator};
 
     const TOTAL_VOTING_POWER: u64 = 10_000;
@@ -23,7 +22,7 @@ module sui_system::voting_power_tests {
     #[test]
     fun test_small_validator_sets() {
         let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
+        let ctx = scenario.ctx();
         check(vector[1], vector[TOTAL_VOTING_POWER], ctx);
         check(vector[77], vector[TOTAL_VOTING_POWER], ctx);
         check(vector[TOTAL_VOTING_POWER * 93], vector[TOTAL_VOTING_POWER], ctx);
@@ -42,40 +41,40 @@ module sui_system::voting_power_tests {
         // This tests the scenario where we have validators whose stakes are only slightly different.
         // Make sure that the order is preserved correctly and the leftover voting power goes to the right validators.
         check(vector[10000, 10001, 10000], vector[3333, 3334, 3333], ctx);
-        test_scenario::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_medium_validator_sets() {
         let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
+        let ctx = scenario.ctx();
         // >10 validators. now things get a bit more interesting because we can redistribute stake away from the max validators
         check(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[909, 909, 909, 909, 909, 909, 909, 909, 909, 909, 910], ctx);
         check(vector[2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 900, 900, 900, 900, 900, 900, 900, 900, 900, 900], ctx);
         check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 1000, 888, 889, 889, 889, 889, 889, 889, 889, 889], ctx);
         check(vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], vector[522, 674, 826, 978, 1000, 1000, 1000, 1000, 1000, 1000, 1000], ctx);
 
-        test_scenario::end(scenario);
+        scenario.end();
     }
 
     #[test]
     fun test_medium_validator_sets_2() {
         let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
+        let ctx = scenario.ctx();
 
         // more validators, harder to reach max
         check(vector[2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[953, 953, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 476, 477, 477], ctx);
         check(vector[4, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], vector[1000, 951, 951, 951, 639, 639, 639, 325, 325, 325, 325, 325, 325, 325, 325, 326, 326, 326, 326, 326], ctx);
-        test_scenario::end(scenario);
+        scenario.end();
     }
 
     fun get_voting_power(validators: &vector<Validator>): vector<u64> {
         let mut result = vector[];
         let mut i = 0;
-        let len = vector::length(validators);
+        let len = validators.length();
         while (i < len) {
-            let voting_power = validator::voting_power(vector::borrow(validators, i));
-            vector::push_back(&mut result, voting_power);
+            let voting_power = validator::voting_power(&validators[i]);
+            result.push_back(voting_power);
             i = i + 1;
         };
         result

--- a/crates/sui-framework/packages/sui-system/tests/voting_power_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/voting_power_tests.move
@@ -7,7 +7,6 @@ module sui_system::voting_power_tests {
     use sui_system::voting_power;
     use sui::test_scenario;
     use sui::test_utils;
-    use sui::tx_context::TxContext;
     use sui_system::validator::{Self, Validator};
 
     const TOTAL_VOTING_POWER: u64 = 10_000;


### PR DESCRIPTION
## Description 

![image](https://github.com/MystenLabs/sui/assets/1130991/894db607-228e-41b2-90d7-86e2e018de54)

Plus some use funs

## Test Plan 

Tests still pass. Binary diffing is the same, except for `sui_system_tests.move` which differs only in its ascii call usage.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
