### PR TITLE
[zkLogin] Check that bigints fit into the field for extra safety

### DIFF
--- a/.changeset/cuddly-days-wash.md
+++ b/.changeset/cuddly-days-wash.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zklogin': patch
+---
+
+Additional check for bigints

--- a/sdk/zklogin/src/poseidon.ts
+++ b/sdk/zklogin/src/poseidon.ts
@@ -39,7 +39,16 @@ const poseidonNumToHashFN = [
 	poseidon16,
 ];
 
+export const BN254_FIELD_SIZE = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+
 export function poseidonHash(inputs: (number | bigint | string)[]): bigint {
+	inputs.forEach(x => {
+		const b = BigInt(x);
+		if (b < 0 || b >= BN254_FIELD_SIZE) {
+			throw new Error(`Element ${b} not in the BN254 field`);
+		}
+	});
+
 	const hashFN = poseidonNumToHashFN[inputs.length - 1];
 
 	if (hashFN) {

--- a/sdk/zklogin/src/poseidon.ts
+++ b/sdk/zklogin/src/poseidon.ts
@@ -39,10 +39,11 @@ const poseidonNumToHashFN = [
 	poseidon16,
 ];
 
-export const BN254_FIELD_SIZE = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+export const BN254_FIELD_SIZE =
+	21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
 export function poseidonHash(inputs: (number | bigint | string)[]): bigint {
-	inputs.forEach(x => {
+	inputs.forEach((x) => {
 		const b = BigInt(x);
 		if (b < 0 || b >= BN254_FIELD_SIZE) {
 			throw new Error(`Element ${b} not in the BN254 field`);

--- a/sdk/zklogin/test/poseidon.test.ts
+++ b/sdk/zklogin/test/poseidon.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { BN254_FIELD_SIZE, poseidonHash } from '../src/poseidon';
+
+test('can hash single input', () => {
+	const result = poseidonHash([123]);
+	expect(result).toBeTypeOf('bigint');
+});
+
+test('can hash multiple inputs', () => {
+	const result = poseidonHash([1, 2, 3, 4, 5]);
+	expect(result).toBeTypeOf('bigint');
+});
+
+test('throws error for invalid input', () => {
+	expect(() => poseidonHash([-1])).toThrowError('Element -1 not in the BN254 field');
+});
+
+test('throws error for invalid input greater than BN254_FIELD_SIZE', () => {
+	expect(() => poseidonHash([BN254_FIELD_SIZE])).toThrowError('Element 21888242871839275222246405745257275088548364400416034343698204186575808495617 not in the BN254 field');
+});

--- a/sdk/zklogin/test/poseidon.test.ts
+++ b/sdk/zklogin/test/poseidon.test.ts
@@ -1,4 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 import { expect, test } from 'vitest';
+
 import { BN254_FIELD_SIZE, poseidonHash } from '../src/poseidon';
 
 test('can hash single input', () => {
@@ -16,5 +19,7 @@ test('throws error for invalid input', () => {
 });
 
 test('throws error for invalid input greater than BN254_FIELD_SIZE', () => {
-	expect(() => poseidonHash([BN254_FIELD_SIZE])).toThrowError('Element 21888242871839275222246405745257275088548364400416034343698204186575808495617 not in the BN254 field');
+	expect(() => poseidonHash([BN254_FIELD_SIZE])).toThrowError(
+		'Element 21888242871839275222246405745257275088548364400416034343698204186575808495617 not in the BN254 field',
+	);
 });


### PR DESCRIPTION
## Description 

Turns out we don't check anywhere that the inputs fit into the field and neither does the poseidon-lite library (it just truncates elements and fits them into the field). 

Instrumenting poseidon seems like the simplest way to do this. The other option (which I have not taken) is to instrument as soon as we receive some inputs..

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
