### PR TITLE
[formal-snasphots] Verify on write

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -825,18 +825,7 @@ impl AuthorityState {
         &self,
         epoch: EpochId,
     ) -> SuiResult<Option<Vec<CheckpointCommitment>>> {
-        let commitments =
-            self.checkpoint_store
-                .get_epoch_last_checkpoint(epoch)?
-                .map(|checkpoint| {
-                    checkpoint
-                        .end_of_epoch_data
-                        .as_ref()
-                        .expect("Last checkpoint of epoch expected to have EndOfEpochData")
-                        .epoch_commitments
-                        .clone()
-                });
-        Ok(commitments)
+        self.checkpoint_store.get_epoch_state_commitments(epoch)
     }
 
     /// This is a private method and should be kept that way. It doesn't check whether

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -602,6 +602,10 @@ impl CheckpointExecutor {
                     .await
                     .expect("Finalizing checkpoint cannot fail");
 
+                    self.checkpoint_store
+                        .insert_epoch_last_checkpoint(cur_epoch, checkpoint)
+                        .expect("Failed to insert epoch last checkpoint");
+
                     self.accumulator
                         .accumulate_epoch(
                             &cur_epoch,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use sui_macros::fail_point;
 use sui_network::default_mysten_network_config;
 use sui_types::base_types::ConciseableName;
+use sui_types::messages_checkpoint::CheckpointCommitment;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
@@ -671,6 +672,21 @@ impl CheckpointStore {
         self.epoch_last_checkpoint_map
             .insert(&epoch_id, checkpoint.sequence_number())?;
         Ok(())
+    }
+
+    pub fn get_epoch_state_commitments(
+        &self,
+        epoch: EpochId,
+    ) -> SuiResult<Option<Vec<CheckpointCommitment>>> {
+        let commitments = self.get_epoch_last_checkpoint(epoch)?.map(|checkpoint| {
+            checkpoint
+                .end_of_epoch_data
+                .as_ref()
+                .expect("Last checkpoint of epoch expected to have EndOfEpochData")
+                .epoch_commitments
+                .clone()
+        });
+        Ok(commitments)
     }
 
     /// Given the epoch ID, and the last checkpoint of the epoch, derive a few statistics of the epoch.

--- a/crates/sui-snapshot/src/tests.rs
+++ b/crates/sui-snapshot/src/tests.rs
@@ -4,6 +4,7 @@
 use crate::reader::StateSnapshotReaderV1;
 use crate::writer::StateSnapshotWriterV1;
 use crate::FileCompression;
+use fastcrypto::hash::MultisetHash;
 use futures::future::AbortHandle;
 use indicatif::MultiProgress;
 use std::collections::HashSet;
@@ -11,8 +12,11 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
+use sui_core::state_accumulator::StateAccumulator;
 use sui_protocol_config::ProtocolConfig;
+use sui_types::accumulator::Accumulator;
 use sui_types::base_types::ObjectID;
+use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Object;
 use tempfile::tempdir;
 
@@ -51,6 +55,19 @@ fn compare_live_objects(
     Ok(())
 }
 
+fn accumulate_live_object_set(
+    perpetual_db: &AuthorityPerpetualTables,
+    include_wrapped_tombstone: bool,
+) -> Accumulator {
+    let mut acc = Accumulator::default();
+    perpetual_db
+        .iter_live_object_set(include_wrapped_tombstone)
+        .for_each(|live_object| {
+            StateAccumulator::accumulate_live_object(&mut acc, &live_object);
+        });
+    acc
+}
+
 #[tokio::test]
 async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
     let db_path = temp_dir();
@@ -78,8 +95,10 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
     .await?;
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&db_path, None));
     insert_keys(&perpetual_db, 1000)?;
+    let root_accumulator =
+        ECMHLiveObjectSetDigest::from(accumulate_live_object_set(&perpetual_db, true).digest());
     snapshot_writer
-        .write_internal(0, true, perpetual_db.clone())
+        .write_internal(0, true, perpetual_db.clone(), root_accumulator)
         .await?;
     let local_store_restore_config = ObjectStoreConfig {
         object_store: Some(ObjectStoreType::File),
@@ -131,8 +150,10 @@ async fn test_snapshot_empty_db() -> Result<(), anyhow::Error> {
     )
     .await?;
     let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&db_path, None));
+    let root_accumulator =
+        ECMHLiveObjectSetDigest::from(accumulate_live_object_set(&perpetual_db, true).digest());
     snapshot_writer
-        .write_internal(0, true, perpetual_db.clone())
+        .write_internal(0, true, perpetual_db.clone(), root_accumulator)
         .await?;
     let local_store_restore_config = ObjectStoreConfig {
         object_store: Some(ObjectStoreType::File),

--- a/crates/sui-snapshot/src/uploader.rs
+++ b/crates/sui-snapshot/src/uploader.rs
@@ -12,13 +12,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
+use sui_core::checkpoints::CheckpointStore;
 use sui_core::db_checkpoint_handler::{STATE_SNAPSHOT_COMPLETED_MARKER, SUCCESS_MARKER};
 use sui_storage::object_store::util::{
     find_all_dirs_with_epoch_prefix, find_missing_epochs_dirs, path_to_filesystem, put,
     run_manifest_update_loop,
 };
-
 use sui_storage::FileCompression;
+use sui_types::messages_checkpoint::CheckpointCommitment::ECMHLiveObjectSetDigest;
 use tracing::{debug, error, info};
 
 pub struct StateSnapshotUploaderMetrics {
@@ -44,6 +45,8 @@ pub struct StateSnapshotUploader {
     db_checkpoint_path: PathBuf,
     /// Store on local disk where db checkpoints are written to
     db_checkpoint_store: Arc<DynObjectStore>,
+    /// Checkpoint store; needed to fetch epoch state commitments for verification
+    checkpoint_store: Arc<CheckpointStore>,
     /// Directory path on local disk where state snapshots are staged for upload
     staging_path: PathBuf,
     /// Store on local disk where state snapshots are staged for upload
@@ -62,6 +65,7 @@ impl StateSnapshotUploader {
         snapshot_store_config: ObjectStoreConfig,
         interval_s: u64,
         registry: &Registry,
+        checkpoint_store: Arc<CheckpointStore>,
     ) -> Result<Arc<Self>> {
         let db_checkpoint_store_config = ObjectStoreConfig {
             object_store: Some(ObjectStoreType::File),
@@ -76,6 +80,7 @@ impl StateSnapshotUploader {
         Ok(Arc::new(StateSnapshotUploader {
             db_checkpoint_path: db_checkpoint_path.to_path_buf(),
             db_checkpoint_store: db_checkpoint_store_config.make()?,
+            checkpoint_store,
             staging_path: staging_path.to_path_buf(),
             staging_store: staging_store_config.make()?,
             snapshot_store: snapshot_store_config.make()?,
@@ -115,7 +120,18 @@ impl StateSnapshotUploader {
                     &path_to_filesystem(self.db_checkpoint_path.clone(), &db_path.child("store"))?,
                     None,
                 ));
-                state_snapshot_writer.write(*epoch, db).await?;
+                let commitments = self
+                    .checkpoint_store
+                    .get_epoch_state_commitments(*epoch)
+                    .expect("Expected last checkpoint of epoch to have end of epoch data")
+                    .expect("Expected end of epoch data to be present");
+                let ECMHLiveObjectSetDigest(state_hash_commitment) = commitments
+                    .last()
+                    .expect("Expected at least one commitment")
+                    .clone();
+                state_snapshot_writer
+                    .write(*epoch, db, state_hash_commitment)
+                    .await?;
                 info!("State snapshot creation successful for epoch: {}", *epoch);
                 // Drop marker in the output directory that upload completed successfully
                 let bytes = Bytes::from_static(b"success");


### PR DESCRIPTION
## Description 

During snapshot write, we iterate through the live object set. Later, a reader downloads and verifies. If there is an inconsistency in the write path, we will learn about it too late, so let's verify during the write stage.

## Test Plan 

Running https://github.com/MystenLabs/sui/pull/16914/commits against R2 mainnet snapshot writer. [This workflow run](https://github.com/MystenLabs/sui-operations/actions/runs/8474730636) shows that the snapshot exists and we were able to restore from it

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
