### PR TITLE
[CLI] Add ability to run verifier on an individual module

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -662,16 +662,16 @@ pub enum SuiClientCommands {
     #[clap(name = "verify-bytecode-meter")]
     VerifyBytecodeMeter {
         /// Path to directory containing a Move package, (defaults to the current directory)
-        #[clap(name = "package", long, short, global = true)]
+        #[clap(name = "package", long, global = true)]
         package_path: Option<PathBuf>,
 
         /// Protocol version to use for the bytecode verifier (defaults to the latest protocol
         /// version)
-        #[clap(name = "protocol-version", long, short = 'P')]
+        #[clap(name = "protocol-version", long)]
         protocol_version: Option<u64>,
 
         /// Path to specific pre-compiled module bytecode to verify (instead of an entire package)
-        #[clap(name = "module", long, short, global = true)]
+        #[clap(name = "module", long, global = true)]
         module_path: Option<PathBuf>,
 
         /// Package build options

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -5,6 +5,7 @@ use crate::client_ptb::ptb::PTB;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::{Debug, Display, Formatter, Write},
+    fs,
     path::PathBuf,
     str::FromStr,
     sync::Arc,
@@ -19,13 +20,14 @@ use fastcrypto::{
     traits::ToFromBytes,
 };
 
+use move_binary_format::CompiledModule;
 use move_core_types::language_storage::TypeTag;
 use move_package::BuildConfig as MoveBuildConfig;
 use prometheus::Registry;
 use serde::Serialize;
 use serde_json::{json, Value};
 use sui_move::build::resolve_lock_file_path;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
 use shared_crypto::intent::Intent;
@@ -659,9 +661,18 @@ pub enum SuiClientCommands {
     /// Run the bytecode verifier on the package
     #[clap(name = "verify-bytecode-meter")]
     VerifyBytecodeMeter {
-        /// Path to directory containing a Move package
-        #[clap(name = "package_path", global = true, default_value = ".")]
-        package_path: PathBuf,
+        /// Path to directory containing a Move package, (defaults to the current directory)
+        #[clap(name = "package", long, short, global = true)]
+        package_path: Option<PathBuf>,
+
+        /// Protocol version to use for the bytecode verifier (defaults to the latest protocol
+        /// version)
+        #[clap(name = "protocol-version", long, short = 'P')]
+        protocol_version: Option<u64>,
+
+        /// Path to specific pre-compiled module bytecode to verify (instead of an entire package)
+        #[clap(name = "module", long, short, global = true)]
+        module_path: Option<PathBuf>,
 
         /// Package build options
         #[clap(flatten)]
@@ -1056,20 +1067,49 @@ impl SuiClientCommands {
             }
 
             SuiClientCommands::VerifyBytecodeMeter {
+                protocol_version,
+                module_path,
                 package_path,
                 build_config,
             } => {
-                let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+                let protocol_version =
+                    protocol_version.map_or(ProtocolVersion::MAX, ProtocolVersion::new);
+                let protocol_config =
+                    ProtocolConfig::get_for_version(protocol_version, Chain::Unknown);
+
                 let registry = &Registry::new();
                 let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
 
-                let package = compile_package_simple(build_config, package_path)?;
-                let modules: Vec<_> = package.get_modules().cloned().collect();
+                let modules = match (module_path, package_path) {
+                    (Some(_), Some(_)) => {
+                        bail!("Cannot specify both a module path and a package path")
+                    }
+
+                    (Some(module_path), None) => {
+                        let module_bytes =
+                            fs::read(module_path).context("Failed to read module file")?;
+                        let module = CompiledModule::deserialize_with_defaults(&module_bytes)
+                            .context("Failed to deserialize module")?;
+                        vec![module]
+                    }
+
+                    (None, package_path) => {
+                        let package_path = package_path.unwrap_or_else(|| PathBuf::from("."));
+                        let package = compile_package_simple(build_config, package_path)?;
+                        package.get_modules().cloned().collect()
+                    }
+                };
 
                 let mut verifier =
                     sui_execution::verifier(&protocol_config, true, &bytecode_verifier_metrics);
                 let overrides = VerifierOverrides::new(None, None);
-                println!("Running bytecode verifier for {} modules", modules.len());
+
+                println!(
+                    "Running bytecode verifier for {} module{}",
+                    modules.len(),
+                    if modules.len() != 1 { "s" } else { "" },
+                );
+
                 let verifier_values = verifier.meter_compiled_modules_with_overrides(
                     &modules,
                     &protocol_config,


### PR DESCRIPTION
## Description

Adding a couple of features to the `verify-bytecode-meter` command:

- Specify a `--module` (as bytecode) to verify.
- Specify a protocol version to verify at.

Also switches the `--package` path from a positional parameter to a flag, for symmetry with the new `--module` flag.

## Test Plan

```
sui-framework/deepbook$ cargo run --bin sui -- \
  client verify-bytecode-meter
sui-framework/deepbook$ cargo run --bin sui -- \
  client verify-bytecode-meter --package .
sui-framework/deepbook$ cargo run --bin sui -- \
  move build
sui-framework/deepbook$ cargo run --bin sui -- \
  client verify-bytecode-meter --module build/DeepBook/bytecode_modules/clob.mv
sui-framework/deepbook$ cargo run --bin sui -- \ # Errors
  client verify-bytecode-meter --package '.'   \
  --module build/DeepBook/bytecode_modules/clob.mv
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
 - Adds a `--module`/`-m` flag to `sui client bytecode-verify-meter` to verify some module bytecode.
 - Replaces the positional, optional package path parameter for this command with `--package`/`-p`.