### PR TITLE
[BUGFIX][CLI] verify-bytecode-meter returns module ticks

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -662,16 +662,16 @@ pub enum SuiClientCommands {
     #[clap(name = "verify-bytecode-meter")]
     VerifyBytecodeMeter {
         /// Path to directory containing a Move package, (defaults to the current directory)
-        #[clap(name = "package", long, short, global = true)]
+        #[clap(name = "package", long, global = true)]
         package_path: Option<PathBuf>,
 
         /// Protocol version to use for the bytecode verifier (defaults to the latest protocol
         /// version)
-        #[clap(name = "protocol-version", long, short = 'P')]
+        #[clap(name = "protocol-version", long)]
         protocol_version: Option<u64>,
 
         /// Path to specific pre-compiled module bytecode to verify (instead of an entire package)
-        #[clap(name = "module", long, short, global = true)]
+        #[clap(name = "module", long, global = true)]
         module_path: Option<PathBuf>,
 
         /// Package build options

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -5,6 +5,7 @@ use crate::client_ptb::ptb::PTB;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::{Debug, Display, Formatter, Write},
+    fs,
     path::PathBuf,
     str::FromStr,
     sync::Arc,
@@ -19,13 +20,14 @@ use fastcrypto::{
     traits::ToFromBytes,
 };
 
+use move_binary_format::CompiledModule;
 use move_core_types::language_storage::TypeTag;
 use move_package::BuildConfig as MoveBuildConfig;
 use prometheus::Registry;
 use serde::Serialize;
 use serde_json::{json, Value};
 use sui_move::build::resolve_lock_file_path;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
 
 use shared_crypto::intent::Intent;
@@ -659,9 +661,18 @@ pub enum SuiClientCommands {
     /// Run the bytecode verifier on the package
     #[clap(name = "verify-bytecode-meter")]
     VerifyBytecodeMeter {
-        /// Path to directory containing a Move package
-        #[clap(name = "package_path", global = true, default_value = ".")]
-        package_path: PathBuf,
+        /// Path to directory containing a Move package, (defaults to the current directory)
+        #[clap(name = "package", long, short, global = true)]
+        package_path: Option<PathBuf>,
+
+        /// Protocol version to use for the bytecode verifier (defaults to the latest protocol
+        /// version)
+        #[clap(name = "protocol-version", long, short = 'P')]
+        protocol_version: Option<u64>,
+
+        /// Path to specific pre-compiled module bytecode to verify (instead of an entire package)
+        #[clap(name = "module", long, short, global = true)]
+        module_path: Option<PathBuf>,
 
         /// Package build options
         #[clap(flatten)]
@@ -1056,20 +1067,49 @@ impl SuiClientCommands {
             }
 
             SuiClientCommands::VerifyBytecodeMeter {
+                protocol_version,
+                module_path,
                 package_path,
                 build_config,
             } => {
-                let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+                let protocol_version =
+                    protocol_version.map_or(ProtocolVersion::MAX, ProtocolVersion::new);
+                let protocol_config =
+                    ProtocolConfig::get_for_version(protocol_version, Chain::Unknown);
+
                 let registry = &Registry::new();
                 let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
 
-                let package = compile_package_simple(build_config, package_path)?;
-                let modules: Vec<_> = package.get_modules().cloned().collect();
+                let modules = match (module_path, package_path) {
+                    (Some(_), Some(_)) => {
+                        bail!("Cannot specify both a module path and a package path")
+                    }
+
+                    (Some(module_path), None) => {
+                        let module_bytes =
+                            fs::read(module_path).context("Failed to read module file")?;
+                        let module = CompiledModule::deserialize_with_defaults(&module_bytes)
+                            .context("Failed to deserialize module")?;
+                        vec![module]
+                    }
+
+                    (None, package_path) => {
+                        let package_path = package_path.unwrap_or_else(|| PathBuf::from("."));
+                        let package = compile_package_simple(build_config, package_path)?;
+                        package.get_modules().cloned().collect()
+                    }
+                };
 
                 let mut verifier =
                     sui_execution::verifier(&protocol_config, true, &bytecode_verifier_metrics);
                 let overrides = VerifierOverrides::new(None, None);
-                println!("Running bytecode verifier for {} modules", modules.len());
+
+                println!(
+                    "Running bytecode verifier for {} module{}",
+                    modules.len(),
+                    if modules.len() != 1 { "s" } else { "" },
+                );
+
                 let verifier_values = verifier.meter_compiled_modules_with_overrides(
                     &modules,
                     &protocol_config,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -224,7 +224,7 @@ impl<'m> verifier::Verifier for Verifier<'m> {
         config.max_per_mod_meter_units = config_overrides.max_per_mod_meter_units;
         run_metered_move_bytecode_verifier(modules, &config, &mut self.meter, self.metrics)?;
         let fun_meter_units_result = self.meter.get_usage(Scope::Function);
-        let mod_meter_units_result = self.meter.get_usage(Scope::Function);
+        let mod_meter_units_result = self.meter.get_usage(Scope::Module);
         Ok(VerifierMeteredValues::new(
             max_per_fun_meter_current,
             max_per_mod_meter_current,

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -238,7 +238,7 @@ impl<'m> verifier::Verifier for Verifier<'m> {
             self.metrics,
         )?;
         let fun_meter_units_result = self.meter.get_usage(Scope::Function);
-        let mod_meter_units_result = self.meter.get_usage(Scope::Function);
+        let mod_meter_units_result = self.meter.get_usage(Scope::Module);
         Ok(VerifierMeteredValues::new(
             max_per_fun_meter_current,
             max_per_mod_meter_current,

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -226,7 +226,7 @@ impl<'m> verifier::Verifier for Verifier<'m> {
         config.max_per_mod_meter_units = config_overrides.max_per_mod_meter_units;
         run_metered_move_bytecode_verifier(modules, &config, &mut self.meter, self.metrics)?;
         let fun_meter_units_result = self.meter.get_usage(Scope::Function);
-        let mod_meter_units_result = self.meter.get_usage(Scope::Function);
+        let mod_meter_units_result = self.meter.get_usage(Scope::Module);
         Ok(VerifierMeteredValues::new(
             max_per_fun_meter_current,
             max_per_mod_meter_current,

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -224,7 +224,7 @@ impl<'m> verifier::Verifier for Verifier<'m> {
         config.max_per_mod_meter_units = config_overrides.max_per_mod_meter_units;
         run_metered_move_bytecode_verifier(modules, &config, &mut self.meter, self.metrics)?;
         let fun_meter_units_result = self.meter.get_usage(Scope::Function);
-        let mod_meter_units_result = self.meter.get_usage(Scope::Function);
+        let mod_meter_units_result = self.meter.get_usage(Scope::Module);
         Ok(VerifierMeteredValues::new(
             max_per_fun_meter_current,
             max_per_mod_meter_current,


### PR DESCRIPTION
## Description

We were returning the ticks used for the last function as the verifier ticks, which is not correct.  Returning the ticks used for the last function is also not particularly useful, but I will fix that in a follow-up PR.

## Test Plan

```
sui-framework/deepbook$ cargo run --bin sui -- \
  client verify-bytecode-meter
Total number of linter warnings suppressed: 3 (filtered categories: 2)
Running bytecode verifier for 7 modules
╭──────────────────────────────────╮
│ Module will pass metering check! │
├────────┬────────────┬────────────┤
│        │ Module     │ Function   │
│ Max    │ 16000000   │ 16000000   │
│ Used   │ 5869980    │ 7040       │
╰────────┴────────────┴────────────╯
```

## Stack

- #16899 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixes a bug where `sui client verify-bytecode-meter` incorrectly returned the ticks used by the last function to be verified as the ticks used by the last module verified.