### PR TITLE
[Consensus 2.0] Refactor synchronizer 

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -241,6 +241,7 @@ where
             context.clone(),
             core_dispatcher.clone(),
             block_verifier.clone(),
+            dag_state.clone(),
         );
 
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -428,6 +429,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -502,6 +504,7 @@ mod tests {
             context.clone(),
             core_dispatcher.clone(),
             block_verifier.clone(),
+            dag_state.clone(),
         );
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -250,6 +250,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             return Err(ConsensusError::TooManyFetchBlocksRequested(peer));
         }
 
+        if !highest_accepted_rounds.is_empty()
+            && highest_accepted_rounds.len() != self.context.committee.size()
+        {
+            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
+                highest_accepted_rounds.len(),
+                self.context.committee.size(),
+            ));
+        }
+
         // Some quick validation of the requested block refs
         for block in &block_refs {
             if !self.context.committee.is_valid_index(block.author) {
@@ -267,36 +276,29 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let blocks = self.dag_state.read().get_blocks(&block_refs);
 
         // Now check if an ancestor's round is higher than the one that the peer has. If yes, then serve
-        // that ancestor blocks up to 10
-        let all_ancestors = blocks
-            .iter()
-            .flatten()
-            .flat_map(|block| block.ancestors().to_vec())
-            .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
-            .take(MAX_ADDITIONAL_BLOCKS)
-            .collect::<Vec<_>>();
-
+        // that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
         let mut ancestor_blocks = vec![];
-        if !all_ancestors.is_empty() {
-            ancestor_blocks = self.dag_state.read().get_blocks(&all_ancestors);
+        if !highest_accepted_rounds.is_empty() {
+            let all_ancestors = blocks
+                .iter()
+                .flatten()
+                .flat_map(|block| block.ancestors().to_vec())
+                .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
+                .take(MAX_ADDITIONAL_BLOCKS)
+                .collect::<Vec<_>>();
+
+            if !all_ancestors.is_empty() {
+                ancestor_blocks = self.dag_state.read().get_blocks(&all_ancestors);
+            }
         }
 
         // Return the serialised blocks & the ancestor blocks
-        let mut result = blocks
+        let result = blocks
             .into_iter()
+            .chain(ancestor_blocks)
             .flatten()
             .map(|block| block.serialized().clone())
             .collect::<Vec<_>>();
-
-        let result_ancestors = ancestor_blocks
-            .into_iter()
-            .flatten()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-
-        // Use as a separator empty Bytes. Any blocks after the empty Bytes should be the result ancestors
-        result.push(Bytes::new());
-        result.extend(result_ancestors);
 
         Ok(result)
     }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -243,7 +243,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
     ) -> ConsensusResult<Vec<Bytes>> {
+        const MAX_ADDITIONAL_BLOCKS: usize = 10;
         if block_refs.len() > self.context.parameters.max_blocks_per_fetch {
             return Err(ConsensusError::TooManyFetchBlocksRequested(peer));
         }
@@ -264,12 +266,37 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // For now ask dag state directly
         let blocks = self.dag_state.read().get_blocks(&block_refs);
 
-        // Return the serialised blocks
-        let result = blocks
+        // Now check if an ancestor's round is higher than the one that the peer has. If yes, then serve
+        // that ancestor blocks up to 10
+        let all_ancestors = blocks
+            .iter()
+            .flatten()
+            .flat_map(|block| block.ancestors().to_vec())
+            .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
+            .take(MAX_ADDITIONAL_BLOCKS)
+            .collect::<Vec<_>>();
+
+        let mut ancestor_blocks = vec![];
+        if !all_ancestors.is_empty() {
+            ancestor_blocks = self.dag_state.read().get_blocks(&all_ancestors);
+        }
+
+        // Return the serialised blocks & the ancestor blocks
+        let mut result = blocks
             .into_iter()
             .flatten()
             .map(|block| block.serialized().clone())
             .collect::<Vec<_>>();
+
+        let result_ancestors = ancestor_blocks
+            .into_iter()
+            .flatten()
+            .map(|block| block.serialized().clone())
+            .collect::<Vec<_>>();
+
+        // Use as a separator empty Bytes. Any blocks after the empty Bytes should be the result ancestors
+        result.push(Bytes::new());
+        result.extend(result_ancestors);
 
         Ok(result)
     }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::time::Instant;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
@@ -13,7 +13,6 @@ use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use tracing::{debug, warn};
 
-use crate::block::{timestamp_utc_ms, BlockTimestampMs};
 use crate::{
     block::{BlockAPI, BlockRef, VerifiedBlock},
     block_verifier::BlockVerifier,
@@ -24,7 +23,7 @@ use crate::{
 struct SuspendedBlock {
     block: VerifiedBlock,
     missing_ancestors: BTreeSet<BlockRef>,
-    timestamp: BlockTimestampMs,
+    timestamp: Instant,
 }
 
 impl SuspendedBlock {
@@ -32,7 +31,7 @@ impl SuspendedBlock {
         Self {
             block,
             missing_ancestors,
-            timestamp: timestamp_utc_ms(),
+            timestamp: Instant::now(),
         }
     }
 }
@@ -276,7 +275,7 @@ impl BlockManager {
             }
         }
 
-        let now = timestamp_utc_ms();
+        let now = Instant::now();
 
         // Report the unsuspended blocks
         for block in &unsuspended_blocks {
@@ -297,7 +296,7 @@ impl BlockManager {
                 .node_metrics
                 .suspended_block_time
                 .with_label_values(&[hostname])
-                .observe(Duration::from_millis(now.saturating_sub(block.timestamp)).as_secs_f64());
+                .observe(now.saturating_duration_since(block.timestamp).as_secs_f64());
         }
 
         unsuspended_blocks

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -95,72 +95,77 @@ impl BlockManager {
         let mut missing_blocks = BTreeSet::new();
 
         for block in blocks {
-            let (block, blocks_to_fetch) = self.try_accept_one_block(block);
-            missing_blocks.extend(&blocks_to_fetch);
+            // Try to accept the input block.
+            let block = match self.try_accept_one_block(block) {
+                TryAcceptResult::Accepted(block) => block,
+                TryAcceptResult::Suspended(ancestors_to_fetch) => {
+                    missing_blocks.extend(ancestors_to_fetch);
+                    continue;
+                }
+                TryAcceptResult::Processed => continue,
+            };
 
-            if let Some(block) = block {
-                // Try to unsuspend any children blocks.
-                let unsuspended_blocks = self.try_unsuspend_children_blocks(&block);
+            // If the block is accepted, try to unsuspend its children blocks if any.
+            let unsuspended_blocks = self.try_unsuspend_children_blocks(&block);
 
-                // Try to verify the block with ancestor blocks.
-                let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-                let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-                {
-                    'block: for b in iter::once(block).chain(unsuspended_blocks) {
-                        let ancestors = self.dag_state.read().get_blocks(b.ancestors());
-                        assert_eq!(b.ancestors().len(), ancestors.len());
-                        let mut ancestor_blocks = vec![];
-                        'ancestor: for (ancestor_ref, found) in
-                            b.ancestors().iter().zip(ancestors.into_iter())
-                        {
-                            if let Some(found_block) = found {
-                                // This invariant should be guaranteed by DagState.
-                                assert_eq!(ancestor_ref, &found_block.reference());
-                                ancestor_blocks.push(found_block);
-                                continue 'ancestor;
-                            }
-                            // blocks_to_accept have not been added to DagState yet, but they
-                            // can appear in ancestors.
-                            if blocks_to_accept.contains_key(ancestor_ref) {
-                                ancestor_blocks.push(blocks_to_accept[ancestor_ref].clone());
-                                continue 'ancestor;
-                            }
-                            // If an ancestor is already rejected, reject this block as well.
-                            if blocks_to_reject.contains_key(ancestor_ref) {
-                                blocks_to_reject.insert(b.reference(), b);
-                                continue 'block;
-                            }
-                            panic!("Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}", b, ancestor_ref);
+            // Try to verify the block and its children for timestamp, with ancestor blocks.
+            let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+            let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+            {
+                'block: for b in iter::once(block).chain(unsuspended_blocks) {
+                    let ancestors = self.dag_state.read().get_blocks(b.ancestors());
+                    assert_eq!(b.ancestors().len(), ancestors.len());
+                    let mut ancestor_blocks = vec![];
+                    'ancestor: for (ancestor_ref, found) in
+                        b.ancestors().iter().zip(ancestors.into_iter())
+                    {
+                        if let Some(found_block) = found {
+                            // This invariant should be guaranteed by DagState.
+                            assert_eq!(ancestor_ref, &found_block.reference());
+                            ancestor_blocks.push(found_block);
+                            continue 'ancestor;
                         }
-                        if let Err(e) = self.block_verifier.check_ancestors(&b, &ancestor_blocks) {
-                            warn!("Block {:?} failed to verify ancestors: {}", b, e);
+                        // blocks_to_accept have not been added to DagState yet, but they
+                        // can appear in ancestors.
+                        if blocks_to_accept.contains_key(ancestor_ref) {
+                            ancestor_blocks.push(blocks_to_accept[ancestor_ref].clone());
+                            continue 'ancestor;
+                        }
+                        // If an ancestor is already rejected, reject this block as well.
+                        if blocks_to_reject.contains_key(ancestor_ref) {
                             blocks_to_reject.insert(b.reference(), b);
-                        } else {
-                            blocks_to_accept.insert(b.reference(), b);
+                            continue 'block;
                         }
+                        panic!("Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}", b, ancestor_ref);
+                    }
+                    if let Err(e) = self.block_verifier.check_ancestors(&b, &ancestor_blocks) {
+                        warn!("Block {:?} failed to verify ancestors: {}", b, e);
+                        blocks_to_reject.insert(b.reference(), b);
+                    } else {
+                        blocks_to_accept.insert(b.reference(), b);
                     }
                 }
-                for (block_ref, block) in blocks_to_reject {
-                    self.context
-                        .metrics
-                        .node_metrics
-                        .invalid_blocks
-                        .with_label_values(&[&block_ref.author.to_string(), "accept_block"])
-                        .inc();
-                    warn!("Invalid block {:?} is rejected", block);
-                }
-
-                // TODO: report blocks_to_reject to peers.
-
-                // Insert the accepted blocks into DAG state so future blocks including them as
-                // ancestors do not get suspended.
-                let blocks_to_accept: Vec<_> = blocks_to_accept.into_values().collect();
-                self.dag_state
-                    .write()
-                    .accept_blocks(blocks_to_accept.clone());
-
-                accepted_blocks.extend(blocks_to_accept);
             }
+            for (block_ref, block) in blocks_to_reject {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_blocks
+                    .with_label_values(&[&block_ref.author.to_string(), "accept_block"])
+                    .inc();
+                warn!("Invalid block {:?} is rejected", block);
+            }
+
+            // TODO: report blocks_to_reject to peers.
+
+            // Insert the accepted blocks into DAG state so future blocks including them as
+            // ancestors do not get suspended.
+            let blocks_to_accept: Vec<_> = blocks_to_accept.into_values().collect();
+            self.dag_state
+                .write()
+                .accept_blocks(blocks_to_accept.clone());
+
+            accepted_blocks.extend(blocks_to_accept);
         }
 
         let metrics = &self.context.metrics.node_metrics;
@@ -184,10 +189,7 @@ impl BlockManager {
     /// Tries to accept the provided block. To accept a block its ancestors must have been already successfully accepted. If
     /// block is accepted then Some result is returned. None is returned when either the block is suspended or the block
     /// has been already accepted before.
-    fn try_accept_one_block(
-        &mut self,
-        block: VerifiedBlock,
-    ) -> (Option<VerifiedBlock>, BTreeSet<BlockRef>) {
+    fn try_accept_one_block(&mut self, block: VerifiedBlock) -> TryAcceptResult {
         let block_ref = block.reference();
         let mut missing_ancestors = BTreeSet::new();
         let mut ancestors_to_fetch = BTreeSet::new();
@@ -195,7 +197,7 @@ impl BlockManager {
 
         // If block has been already received and suspended, or already processed and stored, or is a genesis block, then skip it.
         if self.suspended_blocks.contains_key(&block_ref) || dag_state.contains_block(&block_ref) {
-            return (None, ancestors_to_fetch);
+            return TryAcceptResult::Processed;
         }
 
         let ancestors = block.ancestors();
@@ -243,10 +245,10 @@ impl BlockManager {
                 .inc();
             self.suspended_blocks
                 .insert(block_ref, SuspendedBlock::new(block, missing_ancestors));
-            return (None, ancestors_to_fetch);
+            return TryAcceptResult::Suspended(ancestors_to_fetch);
         }
 
-        (Some(block), ancestors_to_fetch)
+        TryAcceptResult::Accepted(block)
     }
 
     /// Given an accepted block `accepted_block` it attempts to accept all the suspended children blocks assuming such exist.
@@ -349,6 +351,16 @@ impl BlockManager {
             && self.missing_ancestors.is_empty()
             && self.missing_blocks.is_empty()
     }
+}
+
+// Result of trying to accept one block.
+enum TryAcceptResult {
+    // The block is accepted. Wraps the block itself.
+    Accepted(VerifiedBlock),
+    // The block is suspended. Wraps ancestors to be fetched.
+    Suspended(BTreeSet<BlockRef>),
+    // The block has been processed and exists in BlockManager or DagState.
+    Processed,
 }
 
 #[cfg(test)]

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
@@ -12,6 +13,7 @@ use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use tracing::{debug, warn};
 
+use crate::block::{timestamp_utc_ms, BlockTimestampMs};
 use crate::{
     block::{BlockAPI, BlockRef, VerifiedBlock},
     block_verifier::BlockVerifier,
@@ -22,6 +24,7 @@ use crate::{
 struct SuspendedBlock {
     block: VerifiedBlock,
     missing_ancestors: BTreeSet<BlockRef>,
+    timestamp: BlockTimestampMs,
 }
 
 impl SuspendedBlock {
@@ -29,6 +32,7 @@ impl SuspendedBlock {
         Self {
             block,
             missing_ancestors,
+            timestamp: timestamp_utc_ms(),
         }
     }
 }
@@ -74,7 +78,7 @@ impl BlockManager {
 
     /// Tries to accept the provided blocks assuming that all their causal history exists. The method
     /// returns all the blocks that have been successfully processed in round ascending order, that includes also previously
-    /// suspended blocks that have now been able to get accepted. Method also returns a set with the new missing ancestor blocks.
+    /// suspended blocks that have now been able to get accepted. Method also returns a set with the missing ancestor blocks.
     pub(crate) fn try_accept_blocks(
         &mut self,
         mut blocks: Vec<VerifiedBlock>,
@@ -88,10 +92,13 @@ impl BlockManager {
         );
 
         let mut accepted_blocks = vec![];
-        let missing_blocks_before = self.missing_blocks.clone();
+        let mut missing_blocks = BTreeSet::new();
 
         for block in blocks {
-            if let Some(block) = self.try_accept_one_block(block) {
+            let (block, blocks_to_fetch) = self.try_accept_one_block(block);
+            missing_blocks.extend(&blocks_to_fetch);
+
+            if let Some(block) = block {
                 // Try to unsuspend any children blocks.
                 let unsuspended_blocks = self.try_unsuspend_children_blocks(&block);
 
@@ -156,19 +163,10 @@ impl BlockManager {
             }
         }
 
-        // Newly missed blocks
-        // TODO: make sure that the computation here is bounded either in the byzantine or node fall
-        // back scenario.
-        let missing_blocks_after = self
-            .missing_blocks
-            .difference(&missing_blocks_before)
-            .cloned()
-            .collect::<BTreeSet<_>>();
-
         let metrics = &self.context.metrics.node_metrics;
         metrics
             .missing_blocks_total
-            .set(missing_blocks_after.len() as i64);
+            .inc_by(missing_blocks.len() as u64);
         metrics
             .block_manager_suspended_blocks
             .set(self.suspended_blocks.len() as i64);
@@ -180,20 +178,24 @@ impl BlockManager {
             .set(self.missing_blocks.len() as i64);
 
         // Figure out the new missing blocks
-        (accepted_blocks, missing_blocks_after)
+        (accepted_blocks, missing_blocks)
     }
 
     /// Tries to accept the provided block. To accept a block its ancestors must have been already successfully accepted. If
     /// block is accepted then Some result is returned. None is returned when either the block is suspended or the block
     /// has been already accepted before.
-    fn try_accept_one_block(&mut self, block: VerifiedBlock) -> Option<VerifiedBlock> {
+    fn try_accept_one_block(
+        &mut self,
+        block: VerifiedBlock,
+    ) -> (Option<VerifiedBlock>, BTreeSet<BlockRef>) {
         let block_ref = block.reference();
         let mut missing_ancestors = BTreeSet::new();
+        let mut ancestors_to_fetch = BTreeSet::new();
         let dag_state = self.dag_state.read();
 
         // If block has been already received and suspended, or already processed and stored, or is a genesis block, then skip it.
         if self.suspended_blocks.contains_key(&block_ref) || dag_state.contains_block(&block_ref) {
-            return None;
+            return (None, ancestors_to_fetch);
         }
 
         let ancestors = block.ancestors();
@@ -217,6 +219,7 @@ impl BlockManager {
                 // that we already have its payload.
                 if !self.suspended_blocks.contains_key(ancestor) {
                     self.missing_blocks.insert(*ancestor);
+                    ancestors_to_fetch.insert(*ancestor);
                 }
             }
         }
@@ -240,10 +243,10 @@ impl BlockManager {
                 .inc();
             self.suspended_blocks
                 .insert(block_ref, SuspendedBlock::new(block, missing_ancestors));
-            return None;
+            return (None, ancestors_to_fetch);
         }
 
-        Some(block)
+        (Some(block), ancestors_to_fetch)
     }
 
     /// Given an accepted block `accepted_block` it attempts to accept all the suspended children blocks assuming such exist.
@@ -264,19 +267,21 @@ impl BlockManager {
                     // For each dependency try to unsuspend it. If that's successful then we add it to the queue so
                     // we can recursively try to unsuspend its children.
                     if let Some(block) = self.try_unsuspend_block(&r, &block.reference()) {
-                        unsuspended_blocks.push(block.block.clone());
-                        to_process_blocks.push(block.block);
+                        to_process_blocks.push(block.block.clone());
+                        unsuspended_blocks.push(block);
                     }
                 }
             }
         }
+
+        let now = timestamp_utc_ms();
 
         // Report the unsuspended blocks
         for block in &unsuspended_blocks {
             let hostname = self
                 .context
                 .committee
-                .authority(block.author())
+                .authority(block.block.author())
                 .hostname
                 .as_str();
             self.context
@@ -285,9 +290,18 @@ impl BlockManager {
                 .block_unsuspensions
                 .with_label_values(&[hostname])
                 .inc();
+            self.context
+                .metrics
+                .node_metrics
+                .suspended_block_time
+                .with_label_values(&[hostname])
+                .observe(Duration::from_millis(now.saturating_sub(block.timestamp)).as_secs_f64());
         }
 
         unsuspended_blocks
+            .into_iter()
+            .map(|block| block.block)
+            .collect()
     }
 
     /// Attempts to unsuspend a block by checking its ancestors and removing the `accepted_dependency` by its local set.
@@ -400,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn try_accept_block_returns_missing_blocks_once() {
+    fn try_accept_block_returns_missing_blocks() {
         let (context, _key_pairs) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -414,11 +428,10 @@ mod tests {
 
         // Take the blocks from round 4 up to 2 (included). Only the first block of each round should return missing
         // ancestors when try to accept
-        for (i, block) in all_blocks
+        for block in all_blocks
             .into_iter()
             .rev()
             .take_while(|block| block.round() >= 2)
-            .enumerate()
         {
             // WHEN
             let (accepted_blocks, missing) = block_manager.try_accept_blocks(vec![block.clone()]);
@@ -426,13 +439,8 @@ mod tests {
             // THEN
             assert!(accepted_blocks.is_empty());
 
-            // Only the first block for each round should return missing blocks. Every other shouldn't
-            if i % 4 == 0 {
-                let block_ancestors = block.ancestors().iter().cloned().collect::<BTreeSet<_>>();
-                assert_eq!(missing, block_ancestors);
-            } else {
-                assert!(missing.is_empty());
-            }
+            let block_ancestors = block.ancestors().iter().cloned().collect::<BTreeSet<_>>();
+            assert_eq!(missing, block_ancestors);
         }
     }
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -358,7 +358,8 @@ enum TryAcceptResult {
     Accepted(VerifiedBlock),
     // The block is suspended. Wraps ancestors to be fetched.
     Suspended(BTreeSet<BlockRef>),
-    // The block has been processed and exists in BlockManager or DagState.
+    // The block has been processed before and already exists in BlockManager (and is suspended) or
+    // in DagState (so has been already accepted). No further processing has been done at this point.
     Processed,
 }
 

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -250,6 +250,7 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
@@ -142,7 +143,7 @@ impl CommitObserver {
                 .metrics
                 .node_metrics
                 .block_commit_latency
-                .observe(latency_ms as f64);
+                .observe(Duration::from_millis(latency_ms).as_secs_f64());
             self.context
                 .metrics
                 .node_metrics

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -398,6 +398,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         .fetch_blocks(
                             target_authority,
                             request_block_refs.to_vec(),
+                            vec![],
                             FETCH_BLOCKS_TIMEOUT,
                         )
                         .await?;

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -57,6 +57,9 @@ pub enum ConsensusError {
     #[error("Too many blocks have been requested from authority {0}")]
     TooManyFetchBlocksRequested(AuthorityIndex),
 
+    #[error("Provided size of highest accepted rounds parameter, {0}, is different than committee size, {1}")]
+    InvalidSizeOfHighestAcceptedRounds(usize, usize),
+
     #[error("Invalid authority index: {index} > {max}")]
     InvalidAuthorityIndex { index: AuthorityIndex, max: usize },
 

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -153,6 +153,9 @@ pub enum ConsensusError {
     #[error("Network error: {0:?}")]
     NetworkError(String),
 
+    #[error("Request timeout: {0:?}")]
+    NetworkRequestTimeout(String),
+
     #[error("Consensus has shut down!")]
     Shutdown,
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -79,7 +79,9 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
 
     // TODO: add a parameter for maximum total size of blocks returned.
     /// Fetches serialized `SignedBlock`s from a peer. It also might return additional ancestor blocks
-    /// of the requested blocks according to the provided `highest_accepted_rounds`.
+    /// of the requested blocks according to the provided `highest_accepted_rounds`. The `highest_accepted_rounds`
+    /// length should be equal to the committee size. If `highest_accepted_rounds` is empty then it will
+    /// be simply ignored.
     async fn fetch_blocks(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -77,12 +77,14 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
         timeout: Duration,
     ) -> ConsensusResult<BlockStream>;
 
-    /// Fetches serialized `SignedBlock`s from a peer.
     // TODO: add a parameter for maximum total size of blocks returned.
+    /// Fetches serialized `SignedBlock`s from a peer. It also might return additional ancestor blocks
+    /// of the requested blocks according to the provided `highest_accepted_rounds`.
     async fn fetch_blocks(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 
@@ -123,6 +125,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
     ) -> ConsensusResult<Vec<Bytes>>;
 
     // Handles the request to fetch commits by index range from the peer.

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -68,6 +68,7 @@ impl NetworkService for Mutex<TestService> {
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
+        _highest_accepted_rounds: Vec<Round>,
     ) -> ConsensusResult<Vec<Bytes>> {
         self.lock().handle_fetch_blocks.push((peer, block_refs));
         Ok(vec![])

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -240,6 +240,7 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -482,9 +482,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 .join(","),
         );
 
-        // now release all the locked blocks as they have been fetched and verified
-        drop(requested_blocks_guard);
-
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want
         // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
         // will take care of that.
@@ -492,6 +489,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .add_blocks(blocks)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
+
+        // now release all the locked blocks as they have been fetched, verified & processed
+        drop(requested_blocks_guard);
 
         // kick off immediately the scheduled synchronizer
         if !missing_blocks.is_empty() {

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -50,11 +50,11 @@ impl Drop for BlocksGuard {
 }
 
 // Keeps a mapping between the missing blocks that have been instructed to be fetched and the authorities
-// that are currently fetching them. The `inner` map value is another map that is keeping the concurrent number
-// of requests to fetch the corresponding block by an authority. It is allowed to concurrently fetch a block multiple times
-// from an authority and the map here does the accounting.
+// that are currently fetching them. For a block ref there is a maximum number of authorities that can
+// concurrently fetch it. The authority ids that are currently fetching a block are set on the corresponding
+// `BTreeSet` and basically they act as "locks".
 struct InflightBlocksMap {
-    inner: Mutex<HashMap<BlockRef, BTreeMap<AuthorityIndex, u32>>>,
+    inner: Mutex<HashMap<BlockRef, BTreeSet<AuthorityIndex>>>,
 }
 
 impl InflightBlocksMap {
@@ -69,14 +69,10 @@ impl InflightBlocksMap {
     /// per block by attempting to lock per block. If a block is already fetched by the maximum allowed
     /// number of authorities, then the block ref will not be included in the returned set. The method
     /// returns all the block refs that have been successfully locked and allowed to be fetched.
-    /// If `skip_checks = true` then no checks are made against the max authorities to fetch per block or
-    /// same peer already fetching the same block. This is currently used only from the scheduler to
-    /// allow us attempt fetching the blocks concurrently.
     fn lock_blocks(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,
         peer: AuthorityIndex,
-        skip_checks: bool,
     ) -> Option<BlocksGuard> {
         let mut blocks = BTreeSet::new();
         let mut inner = self.inner.lock();
@@ -85,11 +81,10 @@ impl InflightBlocksMap {
             // check that the number of authorities that are already instructed to fetch the block is not
             // higher than the allowed and the `peer_index` has not already been instructed to do that.
             let authorities = inner.entry(block_ref).or_default();
-            if skip_checks
-                || (authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK
-                    && authorities.get(&peer).is_none())
+            if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK
+                && authorities.get(&peer).is_none()
             {
-                authorities.entry(peer).and_modify(|c| *c += 1).or_insert(1);
+                assert!(authorities.insert(peer));
                 blocks.insert(block_ref);
             }
         }
@@ -115,17 +110,8 @@ impl InflightBlocksMap {
             let authorities = blocks_to_fetch
                 .get_mut(block_ref)
                 .expect("Should have found a non empty map");
-            let count = authorities
-                .get_mut(&peer)
-                .expect("Should have found a peer entry");
-            assert!(*count > 0, "Counter for active peers can not be zero");
 
-            *count = count.saturating_sub(1);
-
-            // if there is none pending anymore to fetch from this peer, then just remove completely the peer map
-            if *count == 0 {
-                authorities.remove(&peer);
-            }
+            assert!(authorities.remove(&peer), "Peer index should be present!");
 
             // if the last one then just clean up
             if authorities.is_empty() {
@@ -135,7 +121,8 @@ impl InflightBlocksMap {
     }
 
     /// Drops the provided `blocks_guard` which will force to unlock the blocks, and lock now again the
-    /// referenced block refs. This method will acquire the new locks by skipping any checks.
+    /// referenced block refs. The swap is best effort and there is no guarantee that the `peer` will
+    /// be able to acquire the new locks.
     fn swap_locks(
         self: &Arc<Self>,
         blocks_guard: BlocksGuard,
@@ -147,7 +134,7 @@ impl InflightBlocksMap {
         drop(blocks_guard);
 
         // Now create new guard
-        self.lock_blocks(block_refs, peer, false)
+        self.lock_blocks(block_refs, peer)
     }
 
     #[cfg(test)]
@@ -289,7 +276,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 .take(self.context.parameters.max_blocks_per_fetch)
                                 .collect();
 
-                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer_index, false);
+                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer_index);
                             let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;
@@ -725,8 +712,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             let block_refs = blocks.iter().cloned().collect::<BTreeSet<_>>();
 
             // lock the blocks to be fetched. If no lock can be acquired for any of the blocks then don't bother
-            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer, false)
-            {
+            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer) {
                 request_futures.push(Self::fetch_blocks_request(
                     network_client.clone(),
                     peer,
@@ -759,9 +745,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             // try again if there is any peer left
                             if let Some(next_peer) = peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
-                                let blocks_guard = inflight_blocks.swap_locks(blocks_guard, next_peer);
-
-                                if let Some(blocks_guard) = blocks_guard {
+                                if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer) {
                                     request_futures.push(Self::fetch_blocks_request(
                                         network_client.clone(),
                                         next_peer,
@@ -771,7 +755,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                         1,
                                     ));
                                 } else {
-                                    // try to fetch them from others
+                                    debug!("Couldn't acquire locks to fetch blocks from peer {next_peer}.")
                                 }
                             } else {
                                 debug!("No more peers left to fetch blocks");
@@ -949,7 +933,7 @@ mod tests {
         ];
         let missing_block_refs = some_block_refs.iter().cloned().collect::<BTreeSet<_>>();
 
-        // Do not skip checks
+        // Lock & unlock blocks
         {
             let mut all_guards = Vec::new();
 
@@ -957,27 +941,27 @@ mod tests {
             for i in 1..=2 {
                 let authority = AuthorityIndex::new_for_test(i);
 
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
+                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
                 let guard = guard.expect("Guard should be created");
                 assert_eq!(guard.block_refs.len(), 4);
 
                 all_guards.push(guard);
 
                 // trying to acquire any of them again will not succeed
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
+                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
                 assert!(guard.is_none());
             }
 
             // Trying to acquire for authority 3 it will fail - as we have maxed out the number of allowed peers
             let authority_3 = AuthorityIndex::new_for_test(3);
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3, false);
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
             assert!(guard.is_none());
 
             // Explicitly drop the guard of authority 1 and try for authority 3 again - it will now succeed
             drop(all_guards.remove(0));
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3, false);
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
             let guard = guard.expect("Guard should be successfully acquired");
 
             assert_eq!(guard.block_refs, missing_block_refs);
@@ -989,35 +973,12 @@ mod tests {
             assert_eq!(map.num_of_locked_blocks(), 0);
         }
 
-        // Skip checks
-        {
-            let mut all_guards = Vec::new();
-            let authority = AuthorityIndex::new_for_test(1);
-
-            // Try to acquire the block locks for authority 1 multiple times
-            for _i in 0..5 {
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority, true);
-                let guard = guard.expect("Guard should be created");
-                assert_eq!(guard.block_refs.len(), 4);
-
-                all_guards.push(guard);
-            }
-
-            // Now try to acquire locks without skipping checks
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
-            assert!(guard.is_none());
-
-            drop(all_guards);
-
-            assert_eq!(map.num_of_locked_blocks(), 0);
-        }
-
         // Swap locks
         {
             // acquire a lock for authority 1
             let authority_1 = AuthorityIndex::new_for_test(1);
             let guard = map
-                .lock_blocks(missing_block_refs.clone(), authority_1, false)
+                .lock_blocks(missing_block_refs.clone(), authority_1)
                 .unwrap();
 
             // Now swap the locks for authority 2

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -4,28 +4,28 @@
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt as _;
-use itertools::Itertools as _;
 use mysten_metrics::{monitored_future, monitored_scope};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 #[cfg(not(test))]
-use rand::{rngs::ThreadRng, seq::SliceRandom};
-use std::collections::{BTreeMap, BTreeSet};
+use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
-use tokio::time::{error::Elapsed, sleep, sleep_until, timeout, Instant};
+use tokio::time::{sleep, sleep_until, timeout, Instant};
 use tracing::{debug, info, warn};
 
 use crate::block::{timestamp_utc_ms, BlockRef, SignedBlock, VerifiedBlock};
 use crate::block_verifier::BlockVerifier;
 use crate::context::Context;
 use crate::core_thread::CoreThreadDispatcher;
+use crate::dag_state::DagState;
 use crate::error::{ConsensusError, ConsensusResult};
 use crate::network::NetworkClient;
-use crate::BlockAPI;
+use crate::{BlockAPI, Round};
 use consensus_config::AuthorityIndex;
 
 /// The number of concurrent fetch blocks requests per authority
@@ -35,12 +35,135 @@ const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2_000);
 
 const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 
+const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 2;
+
+struct BlocksGuard {
+    map: Arc<InflightBlocksMap>,
+    block_refs: BTreeSet<BlockRef>,
+    peer: AuthorityIndex,
+}
+
+impl Drop for BlocksGuard {
+    fn drop(&mut self) {
+        self.map.unlock_blocks(&self.block_refs, self.peer);
+    }
+}
+
+// Keeps a mapping between the missing blocks that have been instructed to be fetched and the authorities
+// that are currently fetching them. The `inner` map value is another map that is keeping the concurrent number
+// of requests to fetch the corresponding block by an authority. It is allowed to concurrently fetch a block multiple times
+// from an authority and the map here does the accounting.
+struct InflightBlocksMap {
+    inner: Mutex<HashMap<BlockRef, BTreeMap<AuthorityIndex, u32>>>,
+}
+
+impl InflightBlocksMap {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Locks the blocks to be fetched for the assigned `peer_index`. We want to avoid re-fetching the
+    /// missing blocks from too many authorities at the same time, thus we limit the concurrency
+    /// per block by attempting to lock per block. If a block is already fetched by the maximum allowed
+    /// number of authorities, then the block ref will not be included in the returned set. The method
+    /// returns all the block refs that have been successfully locked and allowed to be fetched.
+    /// If `skip_checks = true` then no checks are made against the max authorities to fetch per block or
+    /// same peer already fetching the same block. This is currently used only from the scheduler to
+    /// allow us attempt fetching the blocks concurrently.
+    fn lock_blocks(
+        self: &Arc<Self>,
+        missing_block_refs: BTreeSet<BlockRef>,
+        peer: AuthorityIndex,
+        skip_checks: bool,
+    ) -> Option<BlocksGuard> {
+        let mut blocks = BTreeSet::new();
+        let mut inner = self.inner.lock();
+
+        for block_ref in missing_block_refs {
+            // check that the number of authorities that are already instructed to fetch the block is not
+            // higher than the allowed and the `peer_index` has not already been instructed to do that.
+            let authorities = inner.entry(block_ref).or_default();
+            if skip_checks
+                || (authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK
+                    && authorities.get(&peer).is_none())
+            {
+                authorities.entry(peer).and_modify(|c| *c += 1).or_insert(1);
+                blocks.insert(block_ref);
+            }
+        }
+
+        if blocks.is_empty() {
+            None
+        } else {
+            Some(BlocksGuard {
+                map: self.clone(),
+                block_refs: blocks,
+                peer,
+            })
+        }
+    }
+
+    /// Unlocks the provided block references for the given `peer`. The unlocking is strict, meaning that
+    /// if this method is called for a specific block ref and peer more times than the corresponding lock
+    /// has been called, it will panic.
+    fn unlock_blocks(self: &Arc<Self>, block_refs: &BTreeSet<BlockRef>, peer: AuthorityIndex) {
+        // Now mark all the blocks as fetched from the map
+        let mut blocks_to_fetch = self.inner.lock();
+        for block_ref in block_refs {
+            let authorities = blocks_to_fetch
+                .get_mut(block_ref)
+                .expect("Should have found a non empty map");
+            let count = authorities
+                .get_mut(&peer)
+                .expect("Should have found a peer entry");
+            assert!(*count > 0, "Counter for active peers can not be zero");
+
+            *count = count.saturating_sub(1);
+
+            // if there is none pending anymore to fetch from this peer, then just remove completely the peer map
+            if *count == 0 {
+                authorities.remove(&peer);
+            }
+
+            // if the last one then just clean up
+            if authorities.is_empty() {
+                blocks_to_fetch.remove(block_ref);
+            }
+        }
+    }
+
+    /// Drops the provided `blocks_guard` which will force to unlock the blocks, and lock now again the
+    /// referenced block refs. This method will acquire the new locks by skipping any checks.
+    fn swap_locks(
+        self: &Arc<Self>,
+        blocks_guard: BlocksGuard,
+        peer: AuthorityIndex,
+    ) -> Option<BlocksGuard> {
+        let block_refs = blocks_guard.block_refs.clone();
+
+        // Explicitly drop the guard
+        drop(blocks_guard);
+
+        // Now create new guard
+        self.lock_blocks(block_refs, peer, false)
+    }
+
+    #[cfg(test)]
+    fn num_of_locked_blocks(self: &Arc<Self>) -> usize {
+        let inner = self.inner.lock();
+        inner.len()
+    }
+}
+
 enum Command {
     FetchBlocks {
         missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
+    KickOffScheduler,
 }
 
 pub(crate) struct SynchronizerHandle {
@@ -53,13 +176,13 @@ impl SynchronizerHandle {
     /// the peer authority.
     pub(crate) async fn fetch_blocks(
         &self,
-        block_refs: BTreeSet<BlockRef>,
+        missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
     ) -> ConsensusResult<()> {
         let (sender, receiver) = oneshot::channel();
         self.commands_sender
             .send(Command::FetchBlocks {
-                missing_block_refs: block_refs,
+                missing_block_refs,
                 peer_index,
                 result: sender,
             })
@@ -77,11 +200,14 @@ impl SynchronizerHandle {
 pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,
-    fetch_block_senders: BTreeMap<AuthorityIndex, Sender<BTreeSet<BlockRef>>>,
+    fetch_block_senders: BTreeMap<AuthorityIndex, Sender<BlocksGuard>>,
     core_dispatcher: Arc<D>,
+    dag_state: Arc<RwLock<DagState>>,
     fetch_blocks_scheduler_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
+    inflight_blocks_map: Arc<InflightBlocksMap>,
+    commands_sender: Sender<Command>,
 }
 
 impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C, V, D> {
@@ -90,8 +216,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
+        dag_state: Arc<RwLock<DagState>>,
     ) -> Arc<SynchronizerHandle> {
         let (commands_sender, commands_receiver) = channel(1_000);
+        let inflight_blocks_map = InflightBlocksMap::new();
 
         // Spawn the tasks to fetch the blocks from the others
         let mut fetch_block_senders = BTreeMap::new();
@@ -107,10 +235,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 block_verifier.clone(),
                 context.clone(),
                 core_dispatcher.clone(),
+                dag_state.clone(),
                 receiver,
+                commands_sender.clone(),
             ));
             fetch_block_senders.insert(index, sender);
         }
+
+        let commands_sender_clone = commands_sender.clone();
 
         // Spawn the task to listen to the requests & periodic runs
         tasks.spawn(async {
@@ -122,6 +254,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 fetch_blocks_scheduler_task: JoinSet::new(),
                 network_client,
                 block_verifier,
+                inflight_blocks_map,
+                commands_sender: commands_sender_clone,
+                dag_state,
             };
             s.run().await;
         });
@@ -147,20 +282,48 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         Command::FetchBlocks{ missing_block_refs, peer_index, result } => {
                             assert_ne!(peer_index, self.context.own_index, "We should never attempt to fetch blocks from our own node");
 
-                            if missing_block_refs.is_empty() {
+                            // Keep only the max allowed blocks to request. It is ok to reduce here as the scheduler
+                            // task will take care syncing whatever is leftover.
+                            let missing_block_refs = missing_block_refs
+                                .into_iter()
+                                .take(self.context.parameters.max_blocks_per_fetch)
+                                .collect();
+
+                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer_index, false);
+                            let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;
-                            }
+                            };
 
                             // We don't block if the corresponding peer task is saturated - but we rather drop the request. That's ok as the periodic
                             // synchronization task will handle any still missing blocks in next run.
-                            let r = self.fetch_block_senders.get(&peer_index).expect("Fatal error, sender should be present").try_send(missing_block_refs).map_err(|err| {
-                                match err {
-                                    TrySendError::Full(_) => ConsensusError::SynchronizerSaturated(peer_index),
-                                    TrySendError::Closed(_) => ConsensusError::Shutdown
-                                }
-                            });
+                            let r = self
+                                .fetch_block_senders
+                                .get(&peer_index)
+                                .expect("Fatal error, sender should be present")
+                                .try_send(blocks_guard)
+                                .map_err(|err| {
+                                    match err {
+                                        TrySendError::Full(_) => ConsensusError::SynchronizerSaturated(peer_index),
+                                        TrySendError::Closed(_) => ConsensusError::Shutdown
+                                    }
+                                });
+
                             result.send(r).ok();
+                        },
+                        Command::KickOffScheduler => {
+                            // just reset the scheduler timeout timer to run immediately if not already running.
+                            // If the scheduler is already running then just reduce the remaining time to run.
+                            let timeout = if self.fetch_blocks_scheduler_task.is_empty() {
+                                Instant::now()
+                            } else {
+                                Instant::now() + SYNCHRONIZER_TIMEOUT.checked_div(2).unwrap()
+                            };
+
+                            // only reset if it is earlier than the next deadline
+                            if timeout < scheduler_timeout.deadline() {
+                                scheduler_timeout.as_mut().reset(timeout);
+                            }
                         }
                     }
                 },
@@ -187,8 +350,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     }
 
                     scheduler_timeout
-                    .as_mut()
-                    .reset(Instant::now() + SYNCHRONIZER_TIMEOUT);
+                        .as_mut()
+                        .reset(Instant::now() + SYNCHRONIZER_TIMEOUT);
                 }
             }
         }
@@ -200,7 +363,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         block_verifier: Arc<V>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
-        mut receiver: Receiver<BTreeSet<BlockRef>>,
+        dag_state: Arc<RwLock<DagState>>,
+        mut receiver: Receiver<BlocksGuard>,
+        commands_sender: Sender<Command>,
     ) {
         const MAX_RETRIES: u32 = 5;
 
@@ -208,12 +373,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         loop {
             tokio::select! {
-                Some(block_refs) = receiver.recv(), if requests.len() < FETCH_BLOCKS_CONCURRENCY => {
-                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, block_refs, FETCH_REQUEST_TIMEOUT, 1))
+                Some(blocks_guard) = receiver.recv(), if requests.len() < FETCH_BLOCKS_CONCURRENCY => {
+                    // get the highest accepted rounds
+                    let highest_rounds = Self::get_highest_accepted_rounds(dag_state.clone(), &context);
+
+                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, 1))
                 },
-                Some((response, block_refs, retries, _peer)) = requests.next() => {
+                Some((response, blocks_guard, retries, _peer, highest_rounds)) = requests.next() => {
                     match response {
-                        Ok(Ok(blocks)) => {
+                        Ok(blocks) => {
                             let peer_hostname = &context.committee.authority(peer_index).hostname;
                             context
                                 .metrics
@@ -222,18 +390,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
                             if let Err(err) = Self::process_fetched_blocks(blocks,
                                 peer_index,
-                                block_refs,
+                                blocks_guard,
                                 core_dispatcher.clone(),
                                 block_verifier.clone(),
-                                context.clone()).await {
+                                context.clone(),
+                                commands_sender.clone()).await {
                                 warn!("Error while processing fetched blocks from peer {peer_index}: {err}");
                             }
                         },
-                        Ok(Err(_)) | Err(Elapsed {..}) => {
+                        Err(_) => {
                             if retries <= MAX_RETRIES {
-                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, block_refs, FETCH_REQUEST_TIMEOUT, retries))
+                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
                                 warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_index}.");
+                                // we don't necessarily need to do, but dropping the guard here to unlock the blocks
+                                drop(blocks_guard);
                             }
                         }
                     }
@@ -251,16 +422,118 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     async fn process_fetched_blocks(
         serialized_blocks: Vec<Bytes>,
         peer_index: AuthorityIndex,
-        requested_block_refs: BTreeSet<BlockRef>,
+        requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
         context: Arc<Context>,
+        commands_sender: Sender<Command>,
     ) -> ConsensusResult<()> {
-        let mut verified_blocks = Vec::new();
+        // The maximum number of blocks that can be additionally fetched from the one requested - those
+        // are potentially missing ancestors.
+        const MAX_ADDITIONAL_BLOCKS: usize = 10;
 
-        if serialized_blocks.len() > requested_block_refs.len() {
+        // Split the number of blocks to the requested and additional ones
+        let at = serialized_blocks
+            .iter()
+            .position(|b| b.is_empty())
+            .unwrap_or(serialized_blocks.len());
+        let (serialized_blocks, mut ancestor_serialized_blocks) = serialized_blocks.split_at(at);
+
+        // remove the separator (empty bytes element) from the `ancestor_serialized_blocks` if not empty
+        if !ancestor_serialized_blocks.is_empty() {
+            ancestor_serialized_blocks = &ancestor_serialized_blocks[1..];
+        }
+
+        if serialized_blocks.len() > requested_blocks_guard.block_refs.len()
+            || ancestor_serialized_blocks.len() > MAX_ADDITIONAL_BLOCKS
+        {
             return Err(ConsensusError::TooManyFetchedBlocksReturned(peer_index));
         }
+
+        // Verify the requested blocks
+        let mut blocks = Self::verify_blocks(
+            serialized_blocks.to_vec(),
+            requested_blocks_guard.block_refs.clone(),
+            block_verifier.clone(),
+            context.clone(),
+            peer_index,
+        )?;
+
+        // Now verify any additional ancestor blocks. We need to verify that the ancestor blocks are indeed ancestors of the requested blocks
+        let ancestors = blocks
+            .iter()
+            .flat_map(|b| b.ancestors().to_vec())
+            .collect::<BTreeSet<BlockRef>>();
+        let ancestor_blocks = Self::verify_blocks(
+            ancestor_serialized_blocks.to_vec(),
+            ancestors,
+            block_verifier.clone(),
+            context.clone(),
+            peer_index,
+        )?;
+
+        blocks.extend(ancestor_blocks);
+
+        debug!(
+            "Synced missing ancestor blocks {} from peer {peer_index}",
+            blocks
+                .iter()
+                .map(|b| b.reference().to_string())
+                .join(","),
+        );
+
+        // now release all the locked blocks as they have been fetched and verified
+        drop(requested_blocks_guard);
+
+        // Now send them to core for processing. Ignore the returned missing blocks as we don't want
+        // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
+        // will take care of that.
+        let missing_blocks = core_dispatcher
+            .add_blocks(blocks)
+            .await
+            .map_err(|_| ConsensusError::Shutdown)?;
+
+        // kick off immediately the scheduled synchronizer
+        if !missing_blocks.is_empty() {
+            // do not block here, so we avoid any possible cycles.
+            if let Err(TrySendError::Full(_)) = commands_sender.try_send(Command::KickOffScheduler)
+            {
+                warn!("Commands channel is full")
+            }
+        }
+
+        context
+            .metrics
+            .node_metrics
+            .missing_blocks_after_fetch_total
+            .inc_by(missing_blocks.len() as u64);
+
+        Ok(())
+    }
+
+    fn get_highest_accepted_rounds(
+        dag_state: Arc<RwLock<DagState>>,
+        context: &Arc<Context>,
+    ) -> Vec<Round> {
+        let blocks = dag_state
+            .read()
+            .get_last_cached_block_per_authority(Round::MAX);
+        assert_eq!(blocks.len(), context.committee.size());
+
+        blocks
+            .into_iter()
+            .map(|block| block.round())
+            .collect::<Vec<_>>()
+    }
+
+    fn verify_blocks(
+        serialized_blocks: Vec<Bytes>,
+        valid_block_refs: BTreeSet<BlockRef>,
+        block_verifier: Arc<V>,
+        context: Arc<Context>,
+        peer_index: AuthorityIndex,
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
+        let mut verified_blocks = Vec::new();
 
         for serialized_block in serialized_blocks {
             let signed_block: SignedBlock =
@@ -281,8 +554,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             }
             let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
 
-            // we want the peer to only respond with blocks that we have asked for.
-            if !requested_block_refs.contains(&verified_block.reference()) {
+            if !valid_block_refs.contains(&verified_block.reference()) {
                 return Err(ConsensusError::UnexpectedFetchedBlock {
                     index: peer_index,
                     block_ref: verified_block.reference(),
@@ -304,55 +576,55 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
             verified_blocks.push(verified_block);
         }
-        debug!(
-            "Synced missing ancestor blocks {} from peer {peer_index}",
-            verified_blocks
-                .iter()
-                .map(|b| b.reference().to_string())
-                .join(","),
-        );
 
-        // Now send them to core for processing. Ignore the returned missing blocks as we don't want
-        // this mechanism to keep feedback looping on fetching more blocks. The periodic synchronization
-        // will take care of that.
-        let _missing_blocks = core_dispatcher
-            .add_blocks(verified_blocks)
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
-
-        Ok(())
+        Ok(verified_blocks)
     }
 
     async fn fetch_blocks_request(
         network_client: Arc<C>,
         peer: AuthorityIndex,
-        block_refs: BTreeSet<BlockRef>,
+        blocks_guard: BlocksGuard,
+        highest_rounds: Vec<Round>,
         request_timeout: Duration,
         mut retries: u32,
     ) -> (
-        Result<ConsensusResult<Vec<Bytes>>, Elapsed>,
-        BTreeSet<BlockRef>,
+        ConsensusResult<Vec<Bytes>>,
+        BlocksGuard,
         u32,
         AuthorityIndex,
+        Vec<Round>,
     ) {
         let start = Instant::now();
         let resp = timeout(
             request_timeout,
             network_client.fetch_blocks(
                 peer,
-                block_refs.clone().into_iter().collect::<Vec<_>>(),
+                blocks_guard
+                    .block_refs
+                    .clone()
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+                highest_rounds.clone().into_iter().collect::<Vec<_>>(),
                 request_timeout,
             ),
         )
         .await;
 
-        if matches!(resp, Ok(Err(_))) {
-            // Add a delay before retrying - if that is needed. If request has timed out then eventually
-            // this will be a no-op.
-            sleep_until(start + request_timeout).await;
-            retries += 1;
-        }
-        (resp, block_refs, retries, peer)
+        let resp = match resp {
+            Ok(Err(err)) => {
+                // Add a delay before retrying - if that is needed. If request has timed out then eventually
+                // this will be a no-op.
+                sleep_until(start + request_timeout).await;
+                retries += 1;
+                Err(err)
+            } // network error
+            Err(err) => {
+                // timeout
+                Err(ConsensusError::NetworkRequestTimeout(err.to_string()))
+            }
+            Ok(result) => result,
+        };
+        (resp, blocks_guard, retries, peer, highest_rounds)
     }
 
     async fn start_fetch_missing_blocks_task(&mut self) -> ConsensusResult<()> {
@@ -371,18 +643,18 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let network_client = self.network_client.clone();
         let block_verifier = self.block_verifier.clone();
         let core_dispatcher = self.core_dispatcher.clone();
+        let blocks_to_fetch = self.inflight_blocks_map.clone();
+        let commands_sender = self.commands_sender.clone();
+        let dag_state = self.dag_state.clone();
 
         self.fetch_blocks_scheduler_task
             .spawn(monitored_future!(async move {
                 let _scope = monitored_scope("FetchMissingBlocksScheduler");
-
                 context.metrics.node_metrics.fetch_blocks_scheduler_inflight.inc();
-
                 let total_requested = missing_blocks.len();
 
                 // Fetch blocks from peers
-                let results = Self::fetch_blocks_from_authorities(context.clone(), network_client, missing_blocks).await;
-
+                let results = Self::fetch_blocks_from_authorities(context.clone(), blocks_to_fetch.clone(), network_client, missing_blocks, core_dispatcher.clone(), dag_state).await;
                 if results.is_empty() {
                     warn!("No results returned while requesting missing blocks");
                     return;
@@ -390,31 +662,33 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
                 // Now process the returned results
                 let mut total_fetched = 0;
-                for (requested_block_refs, fetched_blocks, peer) in results {
+                for (blocks_guard, fetched_blocks, peer) in results {
                     total_fetched += fetched_blocks.len();
                     let peer_hostname = &context.committee.authority(peer).hostname;
                     context.metrics.node_metrics.fetched_blocks.with_label_values(&[peer_hostname, "periodic"]).inc_by(fetched_blocks.len() as u64);
 
-                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, requested_block_refs, core_dispatcher.clone(), block_verifier.clone(), context.clone()).await {
+                    if let Err(err) = Self::process_fetched_blocks(fetched_blocks, peer, blocks_guard, core_dispatcher.clone(), block_verifier.clone(), context.clone(), commands_sender.clone()).await {
                         warn!("Error occurred while processing fetched blocks from peer {peer}: {err}");
                     }
                 }
 
                 context.metrics.node_metrics.fetch_blocks_scheduler_inflight.dec();
-
                 debug!("Total blocks requested to fetch: {}, total fetched: {}", total_requested, total_fetched);
             }));
         Ok(())
     }
 
     /// Fetches the `missing_blocks` from available peers. The method will attempt to split the load amongst multiple (random) peers.
-    /// The method returns a vector with the fetched blocks from each peer that successfully responded. Each element of the vector
-    /// is a tuple which contains the requested missing block refs, the returned blocks and the peer authority index.
+    /// The method returns a vector with the fetched blocks from each peer that successfully responded and any corresponding additional ancestor blocks.
+    /// Each element of the vector is a tuple which contains the requested missing block refs, the returned blocks and the peer authority index.
     async fn fetch_blocks_from_authorities(
         context: Arc<Context>,
+        inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<C>,
         missing_blocks: BTreeSet<BlockRef>,
-    ) -> Vec<(BTreeSet<BlockRef>, Vec<Bytes>, AuthorityIndex)> {
+        _core_dispatcher: Arc<D>,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
         const MAX_PEERS: usize = 3;
 
         // Attempt to fetch only up to a max of blocks
@@ -439,8 +713,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
 
         let mut peers = peers.into_iter();
-
         let mut request_futures = FuturesUnordered::new();
+
+        let highest_rounds = Self::get_highest_accepted_rounds(dag_state, &context);
 
         // Send the initial requests
         for blocks in missing_blocks.chunks(context.parameters.max_blocks_per_fetch) {
@@ -449,13 +724,18 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 .expect("Possible misconfiguration as a peer should be found");
             let block_refs = blocks.iter().cloned().collect::<BTreeSet<_>>();
 
-            request_futures.push(Self::fetch_blocks_request(
-                network_client.clone(),
-                peer,
-                block_refs,
-                FETCH_REQUEST_TIMEOUT,
-                1,
-            ));
+            // lock the blocks to be fetched. If no lock can be acquired for any of the blocks then don't bother
+            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer, false)
+            {
+                request_futures.push(Self::fetch_blocks_request(
+                    network_client.clone(),
+                    peer,
+                    blocks_guard,
+                    highest_rounds.clone(),
+                    FETCH_REQUEST_TIMEOUT,
+                    1,
+                ));
+            }
         }
 
         let mut results = Vec::new();
@@ -465,26 +745,34 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         loop {
             tokio::select! {
-                Some((response, requested_block_refs, _retries, peer_index)) = request_futures.next() =>
+                Some((response, blocks_guard, _retries, peer_index, highest_rounds)) = request_futures.next() =>
                     match response {
-                        Ok(Ok(fetched_blocks)) => {
-                            results.push((requested_block_refs, fetched_blocks, peer_index));
+                        Ok(fetched_blocks) => {
+                            results.push((blocks_guard, fetched_blocks, peer_index));
 
                             // no more pending requests are left, just break the loop
                             if request_futures.is_empty() {
                                 break;
                             }
                         },
-                        Ok(Err(_)) | Err(Elapsed {..}) => {
+                        Err(_) => {
                             // try again if there is any peer left
                             if let Some(next_peer) = peers.next() {
-                                request_futures.push(Self::fetch_blocks_request(
-                                    network_client.clone(),
-                                    next_peer,
-                                    requested_block_refs,
-                                    FETCH_REQUEST_TIMEOUT,
-                                    1,
-                                ));
+                                // do best effort to lock guards. If we can't lock then don't bother at this run.
+                                let blocks_guard = inflight_blocks.swap_locks(blocks_guard, next_peer);
+
+                                if let Some(blocks_guard) = blocks_guard {
+                                    request_futures.push(Self::fetch_blocks_request(
+                                        network_client.clone(),
+                                        next_peer,
+                                        blocks_guard,
+                                        highest_rounds,
+                                        FETCH_REQUEST_TIMEOUT,
+                                        1,
+                                    ));
+                                } else {
+                                    // try to fetch them from others
+                                }
                             } else {
                                 debug!("No more peers left to fetch blocks");
                             }
@@ -503,16 +791,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
 #[cfg(test)]
 mod tests {
-    use crate::block::{BlockRef, Round, TestBlock, VerifiedBlock};
+    use crate::block::{BlockDigest, BlockRef, Round, TestBlock, VerifiedBlock};
     use crate::block_verifier::NoopBlockVerifier;
     use crate::context::Context;
     use crate::core_thread::{CoreError, CoreThreadDispatcher};
+    use crate::dag_state::DagState;
     use crate::error::{ConsensusError, ConsensusResult};
     use crate::network::{BlockStream, NetworkClient};
-    use crate::synchronizer::{Synchronizer, FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT};
+    use crate::storage::mem_store::MemStore;
+    use crate::synchronizer::{
+        InflightBlocksMap, Synchronizer, FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT,
+    };
     use async_trait::async_trait;
     use bytes::Bytes;
     use consensus_config::AuthorityIndex;
+    use parking_lot::RwLock;
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
     use std::time::Duration;
@@ -610,6 +903,7 @@ mod tests {
             &self,
             peer: AuthorityIndex,
             block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             let mut lock = self.fetch_blocks_requests.lock().await;
@@ -643,6 +937,97 @@ mod tests {
         }
     }
 
+    #[test]
+    fn inflight_blocks_map() {
+        // GIVEN
+        let map = InflightBlocksMap::new();
+        let some_block_refs = [
+            BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            BlockRef::new(12, AuthorityIndex::new_for_test(3), BlockDigest::MIN),
+            BlockRef::new(15, AuthorityIndex::new_for_test(2), BlockDigest::MIN),
+        ];
+        let missing_block_refs = some_block_refs.iter().cloned().collect::<BTreeSet<_>>();
+
+        // Do not skip checks
+        {
+            let mut all_guards = Vec::new();
+
+            // Try to acquire the block locks for authorities 1 & 2
+            for i in 1..=2 {
+                let authority = AuthorityIndex::new_for_test(i);
+
+                let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
+                let guard = guard.expect("Guard should be created");
+                assert_eq!(guard.block_refs.len(), 4);
+
+                all_guards.push(guard);
+
+                // trying to acquire any of them again will not succeed
+                let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
+                assert!(guard.is_none());
+            }
+
+            // Trying to acquire for authority 3 it will fail - as we have maxed out the number of allowed peers
+            let authority_3 = AuthorityIndex::new_for_test(3);
+
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3, false);
+            assert!(guard.is_none());
+
+            // Explicitly drop the guard of authority 1 and try for authority 3 again - it will now succeed
+            drop(all_guards.remove(0));
+
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3, false);
+            let guard = guard.expect("Guard should be successfully acquired");
+
+            assert_eq!(guard.block_refs, missing_block_refs);
+
+            // Dropping all guards should unlock on the block refs
+            drop(guard);
+            drop(all_guards);
+
+            assert_eq!(map.num_of_locked_blocks(), 0);
+        }
+
+        // Skip checks
+        {
+            let mut all_guards = Vec::new();
+            let authority = AuthorityIndex::new_for_test(1);
+
+            // Try to acquire the block locks for authority 1 multiple times
+            for _i in 0..5 {
+                let guard = map.lock_blocks(missing_block_refs.clone(), authority, true);
+                let guard = guard.expect("Guard should be created");
+                assert_eq!(guard.block_refs.len(), 4);
+
+                all_guards.push(guard);
+            }
+
+            // Now try to acquire locks without skipping checks
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority, false);
+            assert!(guard.is_none());
+
+            drop(all_guards);
+
+            assert_eq!(map.num_of_locked_blocks(), 0);
+        }
+
+        // Swap locks
+        {
+            // acquire a lock for authority 1
+            let authority_1 = AuthorityIndex::new_for_test(1);
+            let guard = map
+                .lock_blocks(missing_block_refs.clone(), authority_1, false)
+                .unwrap();
+
+            // Now swap the locks for authority 2
+            let authority_2 = AuthorityIndex::new_for_test(2);
+            let guard = map.swap_locks(guard, authority_2);
+
+            assert_eq!(guard.unwrap().block_refs, missing_block_refs);
+        }
+    }
+
     #[tokio::test]
     async fn successful_fetch_blocks_from_peer() {
         // GIVEN
@@ -651,12 +1036,15 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let handle = Synchronizer::start(
             network_client.clone(),
             context,
             core_dispatcher.clone(),
             block_verifier,
+            dag_state,
         );
 
         // Create some test blocks
@@ -693,12 +1081,15 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         let handle = Synchronizer::start(
             network_client.clone(),
             context,
             core_dispatcher.clone(),
             block_verifier,
+            dag_state,
         );
 
         // Create some test blocks
@@ -746,6 +1137,8 @@ mod tests {
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let network_client = Arc::new(MockNetworkClient::default());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
 
         // Create some test blocks
         let expected_blocks = (0..10)
@@ -785,6 +1178,7 @@ mod tests {
             context,
             core_dispatcher.clone(),
             block_verifier,
+            dag_state,
         );
 
         sleep(2 * FETCH_REQUEST_TIMEOUT).await;

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt as _;
+use itertools::Itertools as _;
 use mysten_metrics::{monitored_future, monitored_scope};
 use parking_lot::{Mutex, RwLock};
 #[cfg(not(test))]
@@ -473,10 +473,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         debug!(
             "Synced missing ancestor blocks {} from peer {peer_index}",
-            blocks
-                .iter()
-                .map(|b| b.reference().to_string())
-                .join(","),
+            blocks.iter().map(|b| b.reference().to_string()).join(","),
         );
 
         // Now send them to core for processing. Ignore the returned missing blocks as we don't want


### PR DESCRIPTION
## Description 

This PR is introducing the following changes to the synchronizer & block_manager

1. `BlockManager` will not return any more the missing blocks only once during block acceptance , but every time
2. `Synchronizer` during live synchronization will allow a block to be fetched from up to two different peers. Those peers are basically block authors who used the missing peers as ancestors (the info we basically get from the block manager) thus allowing is to make more informed decisions and make the synchronization more intensive
3. `Synchronizer` will attempt to kick off the scheduler immediately if after fetching missing blocks and try to accept them, we still have more missing ancestors 
4. The highest accepted rounds are provided as part of the `FetchBlocksRequest` to allow the other peer making a decision sending to the requestor a few more blocks that might be missing ancestors.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
