### PR TITLE
[cli][easy] Add serialize-signed-transaction and serialize-unsigned transaction flags for sui client ptb command

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -81,6 +81,7 @@ use crate::key_identity::{get_identity_address, KeyIdentity};
 #[cfg(test)]
 mod profiler_tests;
 
+#[macro_export]
 macro_rules! serialize_or_execute {
     ($tx_data:expr, $serialize_unsigned:expr, $serialize_signed:expr, $context:expr, $result_variant:ident) => {{
         assert!(

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -31,6 +31,8 @@ pub const GAS_BUDGET: &str = "gas-budget";
 pub const SUMMARY: &str = "summary";
 pub const GAS_COIN: &str = "gas-coin";
 pub const JSON: &str = "json";
+pub const SERIALIZE_UNSIGNED: &str = "serialize-unsigned-transaction";
+pub const SERIALIZE_SIGNED: &str = "serialize-signed-transaction";
 
 // Types
 pub const U8: &str = "u8";
@@ -67,6 +69,8 @@ pub const COMMANDS: &[&str] = &[
     SUMMARY,
     GAS_COIN,
     JSON,
+    SERIALIZE_UNSIGNED,
+    SERIALIZE_SIGNED,
 ];
 
 pub fn is_keyword(s: &str) -> bool {
@@ -97,6 +101,8 @@ pub struct Program {
 pub struct ProgramMetadata {
     pub preview_set: bool,
     pub summary_set: bool,
+    pub serialize_unsigned_set: bool,
+    pub serialize_signed_set: bool,
     pub gas_object_id: Option<Spanned<ObjectID>>,
     pub json_set: bool,
     pub gas_budget: Spanned<u64>,

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -37,6 +37,8 @@ struct ProgramParsingState {
     preview_set: bool,
     summary_set: bool,
     warn_shadows_set: bool,
+    serialize_unsigned_set: bool,
+    serialize_signed_set: bool,
     json_set: bool,
     gas_object_id: Option<Spanned<ObjectID>>,
     gas_budget: Option<Spanned<u64>>,
@@ -56,6 +58,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 preview_set: false,
                 summary_set: false,
                 warn_shadows_set: false,
+                serialize_unsigned_set: false,
+                serialize_signed_set: false,
                 json_set: false,
                 gas_object_id: None,
                 gas_budget: None,
@@ -99,6 +103,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
             }
 
             match lexeme {
+                L(T::Command, A::SERIALIZE_UNSIGNED) => flag!(serialize_unsigned_set),
+                L(T::Command, A::SERIALIZE_SIGNED) => flag!(serialize_signed_set),
                 L(T::Command, A::SUMMARY) => flag!(summary_set),
                 L(T::Command, A::JSON) => flag!(json_set),
                 L(T::Command, A::PREVIEW) => flag!(preview_set),
@@ -201,6 +207,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 A::ProgramMetadata {
                     preview_set: self.state.preview_set,
                     summary_set: self.state.summary_set,
+                    serialize_unsigned_set: self.state.serialize_unsigned_set,
+                    serialize_signed_set: self.state.serialize_signed_set,
                     gas_object_id: self.state.gas_object_id,
                     json_set: self.state.json_set,
                     gas_budget,

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    client_commands::SuiClientCommandResult,
     client_ptb::{
         ast::{ParsedProgram, Program},
         builder::PTBBuilder,
@@ -12,6 +13,8 @@ use crate::{
     sp,
 };
 
+use super::{ast::ProgramMetadata, lexer::Lexer, parser::ProgramParser};
+use crate::serialize_or_execute;
 use anyhow::{anyhow, Error};
 use clap::{arg, Args, ValueHint};
 use move_core_types::account_address::AccountAddress;
@@ -27,10 +30,10 @@ use sui_types::{
     digests::TransactionDigest,
     gas::GasCostSummary,
     quorum_driver_types::ExecuteTransactionRequestType,
-    transaction::{ProgrammableTransaction, Transaction, TransactionData},
+    transaction::{
+        ProgrammableTransaction, SenderSignedData, Transaction, TransactionData, TransactionDataAPI,
+    },
 };
-
-use super::{ast::ProgramMetadata, lexer::Lexer, parser::ProgramParser};
 
 #[derive(Clone, Debug, Args)]
 #[clap(disable_help_flag = true)]
@@ -87,6 +90,10 @@ impl PTB {
             }
             Ok(parsed) => parsed,
         };
+
+        if program_metadata.serialize_unsigned_set && program_metadata.serialize_signed_set {
+            anyhow::bail!("Cannot serialize both signed and unsigned PTBs");
+        }
 
         if program_metadata.preview_set {
             println!(
@@ -157,6 +164,17 @@ impl PTB {
             program_metadata.gas_budget.value,
             gas_price,
         );
+
+        if program_metadata.serialize_unsigned_set {
+            serialize_or_execute!(tx_data, true, false, context, PTB).print(true);
+            return Ok(());
+        }
+
+        if program_metadata.serialize_signed_set {
+            serialize_or_execute!(tx_data, false, true, context, PTB).print(true);
+            return Ok(());
+        }
+
         // sign the tx
         let signature =
             context
@@ -386,6 +404,16 @@ pub fn ptb_description() -> clap::Command {
             --"summary"
             "Show only a short summary (digest, execution status, gas cost). \
             Do not use this flag when you need all the transaction data and the execution effects."
+        ))
+        .arg(arg!(
+            --"serialize-unsigned-transaction"
+            "4Instead of executing the transaction, serialize the bcs bytes of the unsigned \
+            transaction data (TransactionData) using base64 encoding."
+        ))
+        .arg(arg!(
+            --"serialize-signed-transaction"
+            "Instead of executing the transaction, serialize the bcs bytes of the signed \
+            transaction data (Transaction) using base64 encoding."
         ))
         .arg(arg!(
             --"warn-shadows"

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -401,19 +401,19 @@ pub fn ptb_description() -> clap::Command {
             "Preview the list of PTB transactions instead of executing them."
         ))
         .arg(arg!(
-            --"summary"
-            "Show only a short summary (digest, execution status, gas cost). \
-            Do not use this flag when you need all the transaction data and the execution effects."
-        ))
-        .arg(arg!(
             --"serialize-unsigned-transaction"
-            "4Instead of executing the transaction, serialize the bcs bytes of the unsigned \
-            transaction data (TransactionData) using base64 encoding."
+            "Instead of executing the transaction, serialize the bcs bytes of the unsigned \
+            transaction data using base64 encoding."
         ))
         .arg(arg!(
             --"serialize-signed-transaction"
             "Instead of executing the transaction, serialize the bcs bytes of the signed \
-            transaction data (Transaction) using base64 encoding."
+            transaction data using base64 encoding."
+        ))
+        .arg(arg!(
+            --"summary"
+            "Show only a short summary (digest, execution status, gas cost). \
+            Do not use this flag when you need all the transaction data and the execution effects."
         ))
         .arg(arg!(
             --"warn-shadows"

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
@@ -27,6 +27,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -62,6 +64,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -106,6 +110,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -169,6 +175,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -223,6 +231,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -292,6 +302,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -355,6 +367,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -409,6 +423,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -472,6 +488,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -526,6 +544,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -568,6 +588,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -629,6 +651,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -737,6 +761,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -822,6 +848,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -907,6 +935,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -943,6 +973,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1004,6 +1036,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1050,6 +1084,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1096,6 +1132,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1170,6 +1208,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1222,6 +1262,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1278,6 +1320,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1297,6 +1341,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: Some(
                 Spanned {
                     span: Span {
@@ -1324,6 +1370,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: true,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1343,6 +1391,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: true,
             gas_budget: Spanned {
@@ -1362,6 +1412,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: true,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -1381,6 +1433,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
@@ -27,6 +27,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {
@@ -62,6 +64,8 @@ expression: parsed
         ProgramMetadata {
             preview_set: false,
             summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
             gas_object_id: None,
             json_set: false,
             gas_budget: Spanned {

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod client_commands;
+#[macro_use]
 pub mod client_ptb;
 pub mod console;
 pub mod fire_drill;


### PR DESCRIPTION
## Description 

Add support for the `serialize-signed-transaction` and `serialize-unsigned-transaction` flags that output transaction bytes instead of executing the transaction for the `sui client ptb` command.

## Test Plan 

Existing tests as this uses the `serialize-or-execute` macro.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Added support for the `serialize-signed-transaction` and `serialize-unsigned-transaction` flags that output transaction bytes instead of executing the transaction for the `sui client ptb` command.