### PR TITLE
[sui-framework][cleanup] Remove unnecessary parens around `as`

### DIFF
--- a/crates/sui-framework/docs/deepbook/critbit.md
+++ b/crates/sui-framework/docs/deepbook/critbit.md
@@ -575,7 +575,7 @@ title: Module `0xdee9::critbit`
     <b>assert</b>!(closest_key != key, <a href="critbit.md#0xdee9_critbit_EKeyAlreadyExist">EKeyAlreadyExist</a>);
 
     // Note that we reserve count_leading_zeros of form u128 for future <b>use</b>
-    <b>let</b> <a href="critbit.md#0xdee9_critbit">critbit</a> = 64 - (count_leading_zeros(((closest_key ^ key) <b>as</b> u128) ) -64);
+    <b>let</b> <a href="critbit.md#0xdee9_critbit">critbit</a> = 64 - (count_leading_zeros((closest_key ^ key) <b>as</b> u128) - 64);
     <b>let</b> new_mask = 1u64 &lt;&lt; (<a href="critbit.md#0xdee9_critbit">critbit</a> - 1);
 
     <b>let</b> new_internal_node= <a href="critbit.md#0xdee9_critbit_InternalNode">InternalNode</a> {

--- a/crates/sui-framework/docs/deepbook/math.md
+++ b/crates/sui-framework/docs/deepbook/math.md
@@ -94,11 +94,11 @@ scaling setting for float
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="math.md#0xdee9_math_unsafe_mul_round">unsafe_mul_round</a>(x: u64, y: u64): (bool, u64) {
-    <b>let</b> x = (x <b>as</b> u128);
-    <b>let</b> y = (y <b>as</b> u128);
+    <b>let</b> x = x <b>as</b> u128;
+    <b>let</b> y = y <b>as</b> u128;
     <b>let</b> <b>mut</b> is_round_down = <b>true</b>;
     <b>if</b> ((x * y) % <a href="math.md#0xdee9_math_FLOAT_SCALING_U128">FLOAT_SCALING_U128</a> == 0) is_round_down = <b>false</b>;
-    (is_round_down, ((x * y / <a href="math.md#0xdee9_math_FLOAT_SCALING_U128">FLOAT_SCALING_U128</a>) <b>as</b> u64))
+    (is_round_down, (x * y / <a href="math.md#0xdee9_math_FLOAT_SCALING_U128">FLOAT_SCALING_U128</a>) <b>as</b> u64)
 }
 </code></pre>
 
@@ -199,11 +199,11 @@ scaling setting for float
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="math.md#0xdee9_math_unsafe_div_round">unsafe_div_round</a>(x: u64, y: u64): (bool, u64) {
-    <b>let</b> x = (x <b>as</b> u128);
-    <b>let</b> y = (y <b>as</b> u128);
+    <b>let</b> x = x <b>as</b> u128;
+    <b>let</b> y = y <b>as</b> u128;
     <b>let</b> <b>mut</b> is_round_down = <b>true</b>;
     <b>if</b> ((x * (<a href="math.md#0xdee9_math_FLOAT_SCALING">FLOAT_SCALING</a> <b>as</b> u128) % y) == 0) is_round_down = <b>false</b>;
-    (is_round_down, ((x * (<a href="math.md#0xdee9_math_FLOAT_SCALING">FLOAT_SCALING</a> <b>as</b> u128) / y) <b>as</b> u64))
+    (is_round_down, (x * (<a href="math.md#0xdee9_math_FLOAT_SCALING">FLOAT_SCALING</a> <b>as</b> u128) / y) <b>as</b> u64)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-framework/bcs.md
+++ b/crates/sui-framework/docs/sui-framework/bcs.md
@@ -325,7 +325,7 @@ Read <code>u64</code> value from bcs-serialized bytes.
 
     <b>let</b> (<b>mut</b> value, <b>mut</b> i) = (0u64, 0u8);
     <b>while</b> (i &lt; 64) {
-        <b>let</b> byte = (<a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u64);
+        <b>let</b> byte = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u64;
         value = value + (byte &lt;&lt; i);
         i = i + 8;
     };
@@ -359,7 +359,7 @@ Read <code>u128</code> value from bcs-serialized bytes.
 
     <b>let</b> (<b>mut</b> value, <b>mut</b> i) = (0u128, 0u8);
     <b>while</b> (i &lt; 128) {
-        <b>let</b> byte = (<a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u128);
+        <b>let</b> byte = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u128;
         value = value + (byte &lt;&lt; i);
         i = i + 8;
     };
@@ -393,7 +393,7 @@ Read <code>u256</code> value from bcs-serialized bytes.
 
     <b>let</b> (<b>mut</b> value, <b>mut</b> i) = (0u256, 0u16);
     <b>while</b> (i &lt; 256) {
-        <b>let</b> byte = (<a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u256);
+        <b>let</b> byte = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u256;
         value = value + (byte &lt;&lt; (i <b>as</b> u8));
         i = i + 8;
     };
@@ -430,7 +430,7 @@ See more here: https://en.wikipedia.org/wiki/LEB128
     <b>let</b> (<b>mut</b> total, <b>mut</b> shift, <b>mut</b> len) = (0u64, 0, 0);
     <b>while</b> (<b>true</b>) {
         <b>assert</b>!(len &lt;= 4, <a href="bcs.md#0x2_bcs_ELenOutOfRange">ELenOutOfRange</a>);
-        <b>let</b> byte = (<a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u64);
+        <b>let</b> byte = <a href="../move-stdlib/bcs.md#0x1_bcs">bcs</a>.bytes.pop_back() <b>as</b> u64;
         len = len + 1;
         total = total | ((byte & 0x7f) &lt;&lt; shift);
         <b>if</b> ((byte & 0x80) == 0) {

--- a/crates/sui-framework/docs/sui-framework/hex.md
+++ b/crates/sui-framework/docs/sui-framework/hex.md
@@ -70,7 +70,7 @@ Encode <code>bytes</code> in lowercase hex
     <b>let</b> (<b>mut</b> i, <b>mut</b> r, l) = (0, <a href="../move-stdlib/vector.md#0x1_vector">vector</a>[], bytes.length());
     <b>let</b> hex_vector = <a href="../sui-framework/hex.md#0x2_hex_HEX">HEX</a>;
     <b>while</b> (i &lt; l) {
-        r.append(hex_vector[(bytes[i] <b>as</b> u64)]);
+        r.append(hex_vector[bytes[i] <b>as</b> u64]);
         i = i + 1;
     };
     r

--- a/crates/sui-framework/docs/sui-framework/math.md
+++ b/crates/sui-framework/docs/sui-framework/math.md
@@ -185,7 +185,7 @@ math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/math.md#0x2_math_sqrt">sqrt</a>(x: u64): u64 {
     <b>let</b> <b>mut</b> bit = 1u128 &lt;&lt; 64;
     <b>let</b> <b>mut</b> res = 0u128;
-    <b>let</b> <b>mut</b> x = (x <b>as</b> u128);
+    <b>let</b> <b>mut</b> x = x <b>as</b> u128;
 
     <b>while</b> (bit != 0) {
         <b>if</b> (x &gt;= res + bit) {
@@ -197,7 +197,7 @@ math::sqrt(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
         bit = bit &gt;&gt; 2;
     };
 
-    (res <b>as</b> u64)
+    res <b>as</b> u64
 }
 </code></pre>
 
@@ -248,7 +248,7 @@ math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/math.md#0x2_math_sqrt_u128">sqrt_u128</a>(x: u128): u128 {
     <b>let</b> <b>mut</b> bit = 1u256 &lt;&lt; 128;
     <b>let</b> <b>mut</b> res = 0u256;
-    <b>let</b> <b>mut</b> x = (x <b>as</b> u256);
+    <b>let</b> <b>mut</b> x = x <b>as</b> u256;
 
     <b>while</b> (bit != 0) {
         <b>if</b> (x &gt;= res + bit) {
@@ -260,7 +260,7 @@ math::sqrt_u128(8 * 1000000) => 2828; // same as above, 2828 / 1000 (2.828)
         bit = bit &gt;&gt; 2;
     };
 
-    (res <b>as</b> u128)
+    res <b>as</b> u128
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-framework/random.md
+++ b/crates/sui-framework/docs/sui-framework/random.md
@@ -508,7 +508,7 @@ Generate n random bytes.
         num_of_blocks = num_of_blocks - 1;
     };
     // Fill the generator's buffer <b>if</b> needed.
-    <b>let</b> num_of_bytes = (num_of_bytes <b>as</b> u64);
+    <b>let</b> num_of_bytes = num_of_bytes <b>as</b> u64;
     <b>if</b> (<a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&g.buffer) &lt; (num_of_bytes - <a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&result))) {
         <a href="../sui-framework/random.md#0x2_random_fill_buffer">fill_buffer</a>(g);
     };
@@ -540,7 +540,7 @@ Generate n random bytes.
 
 
 <pre><code><b>fun</b> <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>, num_of_bytes: u8): u256 {
-    <b>if</b> (<a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&g.buffer) &lt; (num_of_bytes <b>as</b> u64)) {
+    <b>if</b> (<a href="../move-stdlib/vector.md#0x1_vector_length">vector::length</a>(&g.buffer) &lt; num_of_bytes <b>as</b> u64) {
         <a href="../sui-framework/random.md#0x2_random_fill_buffer">fill_buffer</a>(g);
     };
     <b>let</b> <b>mut</b> result: u256 = 0;
@@ -600,7 +600,7 @@ Generate a u128.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u128">generate_u128</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>): u128 {
-    (<a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 16) <b>as</b> u128)
+    <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 16) <b>as</b> u128
 }
 </code></pre>
 
@@ -625,7 +625,7 @@ Generate a u64.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u64">generate_u64</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>): u64 {
-    (<a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 8) <b>as</b> u64)
+    <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 8) <b>as</b> u64
 }
 </code></pre>
 
@@ -650,7 +650,7 @@ Generate a u32.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u32">generate_u32</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>): u32 {
-    (<a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 4) <b>as</b> u32)
+    <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 4) <b>as</b> u32
 }
 </code></pre>
 
@@ -675,7 +675,7 @@ Generate a u16.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u16">generate_u16</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>): u16 {
-    (<a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 2) <b>as</b> u16)
+    <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 2) <b>as</b> u16
 }
 </code></pre>
 
@@ -700,7 +700,7 @@ Generate a u8.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u8">generate_u8</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>): u8 {
-    (<a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 1) <b>as</b> u8)
+    <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, 1) <b>as</b> u8
 }
 </code></pre>
 
@@ -756,9 +756,9 @@ Generate a boolean.
     // Pick a <a href="../sui-framework/random.md#0x2_random">random</a> number in [0, max - <b>min</b>] by generating a <a href="../sui-framework/random.md#0x2_random">random</a> number that is larger than max-<b>min</b>, and taking
     // the modulo of the <a href="../sui-framework/random.md#0x2_random">random</a> number by the range size. Then add the <b>min</b> <b>to</b> the result <b>to</b> get a number in
     // [<b>min</b>, max].
-    <b>let</b> range_size = ((max - <b>min</b>) <b>as</b> u256) + 1;
+    <b>let</b> range_size = (max - <b>min</b>) <b>as</b> u256 + 1;
     <b>let</b> rand = <a href="../sui-framework/random.md#0x2_random_u256_from_bytes">u256_from_bytes</a>(g, num_of_bytes);
-    <b>min</b> + ((rand % range_size) <b>as</b> u128)
+    <b>min</b> + (rand % range_size <b>as</b> u128)
 }
 </code></pre>
 
@@ -807,7 +807,7 @@ Generate a random u128 in [min, max] (with a bias of 2^{-64}).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u64_in_range">generate_u64_in_range</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>, <b>min</b>: u64, max: u64): u64 {
-    (<a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, (<b>min</b> <b>as</b> u128), (max <b>as</b> u128), 16) <b>as</b> u64)
+    <a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, <b>min</b> <b>as</b> u128, max <b>as</b> u128, 16) <b>as</b> u64
 }
 </code></pre>
 
@@ -832,7 +832,7 @@ Generate a random u32 in [min, max] (with a bias of 2^{-64}).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u32_in_range">generate_u32_in_range</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>, <b>min</b>: u32, max: u32): u32 {
-    (<a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, (<b>min</b> <b>as</b> u128), (max <b>as</b> u128), 12) <b>as</b> u32)
+    <a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, <b>min</b> <b>as</b> u128, max <b>as</b> u128, 12) <b>as</b> u32
 }
 </code></pre>
 
@@ -857,7 +857,7 @@ Generate a random u16 in [min, max] (with a bias of 2^{-64}).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u16_in_range">generate_u16_in_range</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>, <b>min</b>: u16, max: u16): u16 {
-    (<a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, (<b>min</b> <b>as</b> u128), (max <b>as</b> u128), 10) <b>as</b> u16)
+    <a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, <b>min</b> <b>as</b> u128, max <b>as</b> u128, 10) <b>as</b> u16
 }
 </code></pre>
 
@@ -882,7 +882,7 @@ Generate a random u8 in [min, max] (with a bias of 2^{-64}).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui-framework/random.md#0x2_random_generate_u8_in_range">generate_u8_in_range</a>(g: &<b>mut</b> <a href="../sui-framework/random.md#0x2_random_RandomGenerator">RandomGenerator</a>, <b>min</b>: u8, max: u8): u8 {
-    (<a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, (<b>min</b> <b>as</b> u128), (max <b>as</b> u128), 9) <b>as</b> u8)
+    <a href="../sui-framework/random.md#0x2_random_u128_in_range">u128_in_range</a>(g, <b>min</b> <b>as</b> u128, max <b>as</b> u128, 9) <b>as</b> u8
 }
 </code></pre>
 
@@ -912,12 +912,12 @@ Shuffle a vector using the random generator (Fisher–Yates/Knuth shuffle).
         <b>return</b>
     };
     <b>assert</b>!(n &lt;= <a href="../sui-framework/random.md#0x2_random_U16_MAX">U16_MAX</a>, <a href="../sui-framework/random.md#0x2_random_EInvalidLength">EInvalidLength</a>);
-    <b>let</b> n = (n <b>as</b> u16);
+    <b>let</b> n = n <b>as</b> u16;
     <b>let</b> <b>mut</b> i: u16 = 0;
     <b>let</b> end = n - 1;
     <b>while</b> (i &lt; end) {
         <b>let</b> j = <a href="../sui-framework/random.md#0x2_random_generate_u16_in_range">generate_u16_in_range</a>(g, i, end);
-        <a href="../move-stdlib/vector.md#0x1_vector_swap">vector::swap</a>(v, (i <b>as</b> u64), (j <b>as</b> u64));
+        <a href="../move-stdlib/vector.md#0x1_vector_swap">vector::swap</a>(v, i <b>as</b> u64, j <b>as</b> u64);
         i = i + 1;
     };
 }

--- a/crates/sui-framework/docs/sui-system/stake_subsidy.md
+++ b/crates/sui-framework/docs/sui-system/stake_subsidy.md
@@ -127,7 +127,7 @@ title: Module `0x3::stake_subsidy`
 ): <a href="stake_subsidy.md#0x3_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
     // Rate can't be higher than 100%.
     <b>assert</b>!(
-        stake_subsidy_decrease_rate &lt;= (<a href="stake_subsidy.md#0x3_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u16),
+        stake_subsidy_decrease_rate &lt;= <a href="stake_subsidy.md#0x3_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u16,
         <a href="stake_subsidy.md#0x3_stake_subsidy_ESubsidyDecreaseRateTooLarge">ESubsidyDecreaseRateTooLarge</a>,
     );
 
@@ -175,7 +175,7 @@ Advance the epoch counter and draw down the subsidy for the epoch.
 
     // Decrease the subsidy amount only when the current period ends.
     <b>if</b> (self.distribution_counter % self.stake_subsidy_period_length == 0) {
-        <b>let</b> decrease_amount = (self.current_distribution_amount <b>as</b> u128)
+        <b>let</b> decrease_amount = self.current_distribution_amount <b>as</b> u128
             * (self.stake_subsidy_decrease_rate <b>as</b> u128) / <a href="stake_subsidy.md#0x3_stake_subsidy_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
         self.current_distribution_amount = self.current_distribution_amount - (decrease_amount <b>as</b> u64)
     };

--- a/crates/sui-framework/docs/sui-system/staking_pool.md
+++ b/crates/sui-framework/docs/sui-system/staking_pool.md
@@ -1317,10 +1317,10 @@ Returns true if the provided staking pool is preactive at the provided epoch.
     <b>if</b> (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {
         <b>return</b> token_amount
     };
-    <b>let</b> res = (exchange_rate.sui_amount <b>as</b> u128)
+    <b>let</b> res = exchange_rate.sui_amount <b>as</b> u128
             * (token_amount <b>as</b> u128)
             / (exchange_rate.pool_token_amount <b>as</b> u128);
-    (res <b>as</b> u64)
+    res <b>as</b> u64
 }
 </code></pre>
 
@@ -1349,10 +1349,10 @@ Returns true if the provided staking pool is preactive at the provided epoch.
     <b>if</b> (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {
         <b>return</b> sui_amount
     };
-    <b>let</b> res = (exchange_rate.pool_token_amount <b>as</b> u128)
+    <b>let</b> res = exchange_rate.pool_token_amount <b>as</b> u128
             * (sui_amount <b>as</b> u128)
             / (exchange_rate.sui_amount <b>as</b> u128);
-    (res <b>as</b> u64)
+    res <b>as</b> u64
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui-system/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui-system/sui_system_state_inner.md
@@ -2087,7 +2087,7 @@ gas coins.
     <b>let</b> prev_epoch_start_timestamp = self.epoch_start_timestamp_ms;
     self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
 
-    <b>let</b> bps_denominator_u64 = (<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u64);
+    <b>let</b> bps_denominator_u64 = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u64;
     // Rates can't be higher than 100%.
     <b>assert</b>!(
         storage_fund_reinvest_rate &lt;= bps_denominator_u64
@@ -2132,15 +2132,15 @@ gas coins.
     <b>let</b> stake_subsidy_amount = <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>.value();
     computation_reward.join(<a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>);
 
-    <b>let</b> total_stake_u128 = (total_stake <b>as</b> u128);
-    <b>let</b> computation_charge_u128 = (computation_charge <b>as</b> u128);
+    <b>let</b> total_stake_u128 = total_stake <b>as</b> u128;
+    <b>let</b> computation_charge_u128 = computation_charge <b>as</b> u128;
 
-    <b>let</b> storage_fund_reward_amount = (storage_fund_balance <b>as</b> u128) * computation_charge_u128 / total_stake_u128;
-    <b>let</b> <b>mut</b> storage_fund_reward = computation_reward.split((storage_fund_reward_amount <b>as</b> u64));
+    <b>let</b> storage_fund_reward_amount = storage_fund_balance <b>as</b> u128 * computation_charge_u128 / total_stake_u128;
+    <b>let</b> <b>mut</b> storage_fund_reward = computation_reward.split(storage_fund_reward_amount <b>as</b> u64);
     <b>let</b> storage_fund_reinvestment_amount =
         storage_fund_reward_amount * (storage_fund_reinvest_rate <b>as</b> u128) / <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
     <b>let</b> storage_fund_reinvestment = storage_fund_reward.split(
-        (storage_fund_reinvestment_amount <b>as</b> u64),
+        storage_fund_reinvestment_amount <b>as</b> u64,
     );
 
     self.epoch = self.epoch + 1;
@@ -2195,7 +2195,7 @@ gas coins.
             reference_gas_price: self.reference_gas_price,
             total_stake: new_total_stake,
             storage_charge,
-            storage_fund_reinvestment: (storage_fund_reinvestment_amount <b>as</b> u64),
+            storage_fund_reinvestment: storage_fund_reinvestment_amount <b>as</b> u64,
             storage_rebate: storage_rebate_amount,
             storage_fund_balance: self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.total_balance(),
             stake_subsidy_amount,

--- a/crates/sui-framework/docs/sui-system/validator_set.md
+++ b/crates/sui-framework/docs/sui-system/validator_set.md
@@ -2422,19 +2422,19 @@ as well as storage fund rewards.
         // Use the slashing rate <b>to</b> compute the amount of staking rewards slashed from this punished <a href="validator.md#0x3_validator">validator</a>.
         <b>let</b> unadjusted_staking_reward = unadjusted_staking_reward_amounts[validator_index];
         <b>let</b> staking_reward_adjustment_u128 =
-            (unadjusted_staking_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
+            unadjusted_staking_reward <b>as</b> u128 * (reward_slashing_rate <b>as</b> u128)
             / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
 
         // Insert into individual mapping and record into the total adjustment sum.
-        individual_staking_reward_adjustments.insert(validator_index, (staking_reward_adjustment_u128 <b>as</b> u64));
+        individual_staking_reward_adjustments.insert(validator_index, staking_reward_adjustment_u128 <b>as</b> u64);
         total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 <b>as</b> u64);
 
         // Do the same thing for storage fund rewards.
         <b>let</b> unadjusted_storage_fund_reward = unadjusted_storage_fund_reward_amounts[validator_index];
         <b>let</b> storage_fund_reward_adjustment_u128 =
-            (unadjusted_storage_fund_reward <b>as</b> u128) * (reward_slashing_rate <b>as</b> u128)
+            unadjusted_storage_fund_reward <b>as</b> u128 * (reward_slashing_rate <b>as</b> u128)
             / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
-        individual_storage_fund_reward_adjustments.insert(validator_index, (storage_fund_reward_adjustment_u128 <b>as</b> u64));
+        individual_storage_fund_reward_adjustments.insert(validator_index, storage_fund_reward_adjustment_u128 <b>as</b> u64);
         total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 <b>as</b> u64);
     };
 
@@ -2527,9 +2527,9 @@ Returns the unadjusted amounts of staking reward and storage fund reward for eac
         // Integer divisions will truncate the results. Because of this, we expect that at the end
         // there will be some reward remaining in `total_staking_reward`.
         // Use u128 <b>to</b> avoid multiplication overflow.
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = <a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128;
         <b>let</b> reward_amount = <a href="voting_power.md#0x3_voting_power">voting_power</a> * (total_staking_reward <b>as</b> u128) / (total_voting_power <b>as</b> u128);
-        staking_reward_amounts.push_back((reward_amount <b>as</b> u64));
+        staking_reward_amounts.push_back(reward_amount <b>as</b> u64);
         // Storage fund's share of the rewards are equally distributed among validators.
         storage_fund_reward_amounts.push_back(storage_fund_reward_per_validator);
         i = i + 1;
@@ -2584,7 +2584,7 @@ The staking rewards are shared with the stakers while the storage fund ones are 
         // Integer divisions will truncate the results. Because of this, we expect that at the end
         // there will be some reward remaining in `total_reward`.
         // Use u128 <b>to</b> avoid multiplication overflow.
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a>: u128 = (<a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = <a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power">voting_power</a>() <b>as</b> u128;
 
         // Compute adjusted staking reward.
         <b>let</b> unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
@@ -2596,7 +2596,7 @@ The staking rewards are shared with the stakers while the storage fund ones are 
             } <b>else</b> {
                 // Otherwise the slashed rewards should be distributed among the unslashed
                 // validators so add the corresponding adjustment.
-                <b>let</b> adjustment = (total_staking_reward_adjustment <b>as</b> u128) * <a href="voting_power.md#0x3_voting_power">voting_power</a>
+                <b>let</b> adjustment = total_staking_reward_adjustment <b>as</b> u128 * <a href="voting_power.md#0x3_voting_power">voting_power</a>
                                / (total_unslashed_validator_voting_power <b>as</b> u128);
                 unadjusted_staking_reward_amount + (adjustment <b>as</b> u64)
             };
@@ -2662,7 +2662,7 @@ The staking rewards are shared with the stakers while the storage fund ones are 
         <b>let</b> validator_commission_amount = (staking_reward_amount <b>as</b> u128) * (<a href="validator.md#0x3_validator">validator</a>.commission_rate() <b>as</b> u128) / <a href="validator_set.md#0x3_validator_set_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a>;
 
         // The <a href="validator.md#0x3_validator">validator</a> reward = storage_fund_reward + commission.
-        <b>let</b> <b>mut</b> validator_reward = staker_reward.split((validator_commission_amount <b>as</b> u64));
+        <b>let</b> <b>mut</b> validator_reward = staker_reward.split(validator_commission_amount <b>as</b> u64);
 
         // Add storage fund rewards <b>to</b> the <a href="validator.md#0x3_validator">validator</a>'s reward.
         validator_reward.join(

--- a/crates/sui-framework/docs/sui-system/voting_power.md
+++ b/crates/sui-framework/docs/sui-system/voting_power.md
@@ -241,8 +241,8 @@ Anything beyond the threshold is added to the remaining_power, which is also ret
     <b>while</b> (i &lt; len) {
         <b>let</b> <a href="validator.md#0x3_validator">validator</a> = &validators[i];
         <b>let</b> stake = <a href="validator.md#0x3_validator">validator</a>.<a href="voting_power.md#0x3_voting_power_total_stake">total_stake</a>();
-        <b>let</b> adjusted_stake = (stake <b>as</b> u128) * (<a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a> <b>as</b> u128) / (total_stake <b>as</b> u128);
-        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>((adjusted_stake <b>as</b> u64), threshold);
+        <b>let</b> adjusted_stake = stake <b>as</b> u128 * (<a href="voting_power.md#0x3_voting_power_TOTAL_VOTING_POWER">TOTAL_VOTING_POWER</a> <b>as</b> u128) / (total_stake <b>as</b> u128);
+        <b>let</b> <a href="voting_power.md#0x3_voting_power">voting_power</a> = <a href="../sui-framework/math.md#0x2_math_min">math::min</a>(adjusted_stake <b>as</b> u64, threshold);
         <b>let</b> info = <a href="voting_power.md#0x3_voting_power_VotingPowerInfoV2">VotingPowerInfoV2</a> {
             validator_index: i,
             <a href="voting_power.md#0x3_voting_power">voting_power</a>,

--- a/crates/sui-framework/packages/deepbook/sources/clob.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob.move
@@ -63,9 +63,9 @@ module deepbook::clob {
     const MIN_BID_ORDER_ID: u64 = 1;
     const MIN_ASK_ORDER_ID: u64 = 1 << 63;
     const MIN_PRICE: u64 = 0;
-    const MAX_PRICE: u64 = ((1u128 << 64 - 1) as u64);
+    const MAX_PRICE: u64 = (1u128 << 64 - 1) as u64;
     #[test_only]
-    const TIMESTAMP_INF: u64 = ((1u128 << 64 - 1) as u64);
+    const TIMESTAMP_INF: u64 = (1u128 << 64 - 1) as u64;
     #[test_only]
     const FEE_AMOUNT_FOR_CREATE_POOL: u64 = 100 * 1_000_000_000; // 100 SUI
 

--- a/crates/sui-framework/packages/deepbook/sources/clob_v2.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob_v2.move
@@ -64,9 +64,9 @@ module deepbook::clob_v2 {
     const MIN_BID_ORDER_ID: u64 = 1;
     const MIN_ASK_ORDER_ID: u64 = 1 << 63;
     const MIN_PRICE: u64 = 0;
-    const MAX_PRICE: u64 = ((1u128 << 64 - 1) as u64);
+    const MAX_PRICE: u64 = (1u128 << 64 - 1) as u64;
     #[test_only]
-    const TIMESTAMP_INF: u64 = ((1u128 << 64 - 1) as u64);
+    const TIMESTAMP_INF: u64 = (1u128 << 64 - 1) as u64;
     const REFERENCE_TAKER_FEE_RATE: u64 = 2_500_000;
     const REFERENCE_MAKER_REBATE_RATE: u64 = 1_500_000;
     const FEE_AMOUNT_FOR_CREATE_POOL: u64 = 100 * 1_000_000_000; // 100 SUI
@@ -2146,14 +2146,14 @@ module deepbook::clob_v2 {
         matched_order_metadata: &MatchedOrderMetadata<BaseAsset, QuoteAsset>
     ) : ( ID, u64, bool, address, address, u64, u64, u64, u64) {
         (
-            matched_order_metadata.pool_id, 
+            matched_order_metadata.pool_id,
             matched_order_metadata.order_id,
-            matched_order_metadata.is_bid, 
+            matched_order_metadata.is_bid,
             matched_order_metadata.taker_address,
-            matched_order_metadata.maker_address, 
+            matched_order_metadata.maker_address,
             matched_order_metadata.base_asset_quantity_filled,
-            matched_order_metadata.price, 
-            matched_order_metadata.taker_commission, 
+            matched_order_metadata.price,
+            matched_order_metadata.taker_commission,
             matched_order_metadata.maker_rebates
         )
     }

--- a/crates/sui-framework/packages/deepbook/sources/critbit.move
+++ b/crates/sui-framework/packages/deepbook/sources/critbit.move
@@ -172,7 +172,7 @@ module deepbook::critbit {
         assert!(closest_key != key, EKeyAlreadyExist);
 
         // Note that we reserve count_leading_zeros of form u128 for future use
-        let critbit = 64 - (count_leading_zeros(((closest_key ^ key) as u128) ) -64);
+        let critbit = 64 - (count_leading_zeros((closest_key ^ key) as u128) - 64);
         let new_mask = 1u64 << (critbit - 1);
 
         let new_internal_node= InternalNode {

--- a/crates/sui-framework/packages/deepbook/sources/math.move
+++ b/crates/sui-framework/packages/deepbook/sources/math.move
@@ -23,11 +23,11 @@ module deepbook::math {
     // multiply two floating numbers
     // also returns whether the result is rounded down
     public(package) fun unsafe_mul_round(x: u64, y: u64): (bool, u64) {
-        let x = (x as u128);
-        let y = (y as u128);
+        let x = x as u128;
+        let y = y as u128;
         let mut is_round_down = true;
         if ((x * y) % FLOAT_SCALING_U128 == 0) is_round_down = false;
-        (is_round_down, ((x * y / FLOAT_SCALING_U128) as u64))
+        (is_round_down, (x * y / FLOAT_SCALING_U128) as u64)
     }
 
     // multiply two floating numbers and assert the result is non zero
@@ -55,11 +55,11 @@ module deepbook::math {
     // divide two floating numbers
     // also returns whether the result is rounded down
     public(package) fun unsafe_div_round(x: u64, y: u64): (bool, u64) {
-        let x = (x as u128);
-        let y = (y as u128);
+        let x = x as u128;
+        let y = y as u128;
         let mut is_round_down = true;
         if ((x * (FLOAT_SCALING as u128) % y) == 0) is_round_down = false;
-        (is_round_down, ((x * (FLOAT_SCALING as u128) / y) as u64))
+        (is_round_down, (x * (FLOAT_SCALING as u128) / y) as u64)
     }
 
     // divide two floating numbers and assert the result is non zero
@@ -134,12 +134,12 @@ module deepbook::math {
     fun test_count_leading_zeros() {
         let mut i: u8 = 0;
         while (i <= 127) {
-            assert_eq(count_leading_zeros((pow(2, i) as u128)), 128 - i - 1);
+            assert_eq(count_leading_zeros(pow(2, i) as u128), 128 - i - 1);
             i = i + 1;
         };
 
         while (i <= 127) {
-            assert_eq(count_leading_zeros((pow(2, i) as u128) + 1), 128 - i - 1);
+            assert_eq(count_leading_zeros(pow(2, i) as u128 + 1), 128 - i - 1);
             i = i + 1;
         };
         assert_eq(count_leading_zeros(0), 128);

--- a/crates/sui-framework/packages/deepbook/tests/clob_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/clob_tests.move
@@ -18,10 +18,10 @@ module deepbook::clob_test {
     use std::option;
 
     const MIN_PRICE: u64 = 0;
-    const MAX_PRICE: u64 = ((1u128 << 64 - 1) as u64);
+    const MAX_PRICE: u64 = (1u128 << 64 - 1) as u64;
     const MIN_ASK_ORDER_ID: u64 = 1 << 63;
     const FLOAT_SCALING: u64 = 1000000000;
-    const TIMESTAMP_INF: u64 = ((1u128 << 64 - 1) as u64);
+    const TIMESTAMP_INF: u64 = (1u128 << 64 - 1) as u64;
     const FILL_OR_KILL: u8 = 2;
     const POST_OR_ABORT: u8 = 3;
     const CLIENT_ID_ALICE: u64 = 0;

--- a/crates/sui-framework/packages/deepbook/tests/order_query_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/order_query_tests.move
@@ -22,7 +22,7 @@ module deepbook::order_query_tests {
     const CLIENT_ID_ALICE: u64 = 0;
     const FLOAT_SCALING: u64 = 1000000000;
     const CANCEL_OLDEST: u8 = 0;
-    const TIMESTAMP_INF: u64 = ((1u128 << 64 - 1) as u64);
+    const TIMESTAMP_INF: u64 = (1u128 << 64 - 1) as u64;
 
     const OWNER: address = @0xf;
     const ALICE: address = @0xBEEF;

--- a/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
@@ -38,13 +38,13 @@ module std::fixed_point32 {
         // The product of two 64 bit values has 128 bits, so perform the
         // multiplication with u128 types and keep the full 128 bit product
         // to avoid losing accuracy.
-        let unscaled_product = (val as u128) * (multiplier.value as u128);
+        let unscaled_product = val as u128 * (multiplier.value as u128);
         // The unscaled product has 32 fractional bits (from the multiplier)
         // so rescale it by shifting away the low bits.
         let product = unscaled_product >> 32;
         // Check whether the value is too large.
         assert!(product <= MAX_U64, EMULTIPLICATION);
-        (product as u64)
+        product as u64
     }
 
     /// Divide a u64 integer by a fixed-point number, truncating any
@@ -55,13 +55,13 @@ module std::fixed_point32 {
         assert!(divisor.value != 0, EDIVISION_BY_ZERO);
         // First convert to 128 bits and then shift left to
         // add 32 fractional zero bits to the dividend.
-        let scaled_value = (val as u128) << 32;
+        let scaled_value = val as u128 << 32;
         let quotient = scaled_value / (divisor.value as u128);
         // Check whether the value is too large.
         assert!(quotient <= MAX_U64, EDIVISION);
         // the value may be too large, which will cause the cast to fail
         // with an arithmetic error.
-        (quotient as u64)
+        quotient as u64
     }
 
     /// Create a fixed-point value from a rational number specified by its
@@ -79,15 +79,15 @@ module std::fixed_point32 {
         // Scale the numerator to have 64 fractional bits and the denominator
         // to have 32 fractional bits, so that the quotient will have 32
         // fractional bits.
-        let scaled_numerator = (numerator as u128) << 64;
-        let scaled_denominator = (denominator as u128) << 32;
+        let scaled_numerator = numerator as u128 << 64;
+        let scaled_denominator = denominator as u128 << 32;
         assert!(scaled_denominator != 0, EDENOMINATOR);
         let quotient = scaled_numerator / scaled_denominator;
         assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
         // Return the quotient as a fixed-point number. We first need to check whether the cast
         // can succeed.
         assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
-        FixedPoint32 { value: (quotient as u64) }
+        FixedPoint32 { value: quotient as u64 }
     }
 
     /// Create a fixedpoint value from a raw value.

--- a/crates/sui-framework/packages/sui-framework/sources/bcs.move
+++ b/crates/sui-framework/packages/sui-framework/sources/bcs.move
@@ -106,7 +106,7 @@ module sui::bcs {
 
         let (mut value, mut i) = (0u64, 0u8);
         while (i < 64) {
-            let byte = (bcs.bytes.pop_back() as u64);
+            let byte = bcs.bytes.pop_back() as u64;
             value = value + (byte << i);
             i = i + 8;
         };
@@ -120,7 +120,7 @@ module sui::bcs {
 
         let (mut value, mut i) = (0u128, 0u8);
         while (i < 128) {
-            let byte = (bcs.bytes.pop_back() as u128);
+            let byte = bcs.bytes.pop_back() as u128;
             value = value + (byte << i);
             i = i + 8;
         };
@@ -134,7 +134,7 @@ module sui::bcs {
 
         let (mut value, mut i) = (0u256, 0u16);
         while (i < 256) {
-            let byte = (bcs.bytes.pop_back() as u256);
+            let byte = bcs.bytes.pop_back() as u256;
             value = value + (byte << (i as u8));
             i = i + 8;
         };
@@ -153,7 +153,7 @@ module sui::bcs {
         let (mut total, mut shift, mut len) = (0u64, 0, 0);
         while (true) {
             assert!(len <= 4, ELenOutOfRange);
-            let byte = (bcs.bytes.pop_back() as u64);
+            let byte = bcs.bytes.pop_back() as u64;
             len = len + 1;
             total = total | ((byte & 0x7f) << shift);
             if ((byte & 0x80) == 0) {

--- a/crates/sui-framework/packages/sui-framework/sources/hex.move
+++ b/crates/sui-framework/packages/sui-framework/sources/hex.move
@@ -17,7 +17,7 @@ module sui::hex {
         let (mut i, mut r, l) = (0, vector[], bytes.length());
         let hex_vector = HEX;
         while (i < l) {
-            r.append(hex_vector[(bytes[i] as u64)]);
+            r.append(hex_vector[bytes[i] as u64]);
             i = i + 1;
         };
         r

--- a/crates/sui-framework/packages/sui-framework/sources/math.move
+++ b/crates/sui-framework/packages/sui-framework/sources/math.move
@@ -75,7 +75,7 @@ module sui::math {
     public fun sqrt(x: u64): u64 {
         let mut bit = 1u128 << 64;
         let mut res = 0u128;
-        let mut x = (x as u128);
+        let mut x = x as u128;
 
         while (bit != 0) {
             if (x >= res + bit) {
@@ -87,7 +87,7 @@ module sui::math {
             bit = bit >> 2;
         };
 
-        (res as u64)
+        res as u64
     }
 
     /// Similar to math::sqrt, but for u128 numbers. Get a nearest lower integer Square Root for `x`. Given that this
@@ -118,7 +118,7 @@ module sui::math {
     public fun sqrt_u128(x: u128): u128 {
         let mut bit = 1u256 << 128;
         let mut res = 0u256;
-        let mut x = (x as u256);
+        let mut x = x as u256;
 
         while (bit != 0) {
             if (x >= res + bit) {
@@ -130,7 +130,7 @@ module sui::math {
             bit = bit >> 2;
         };
 
-        (res as u128)
+        res as u128
     }
 
     /// Calculate x / y, but round up the result.

--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -171,7 +171,7 @@ module sui::random {
             num_of_blocks = num_of_blocks - 1;
         };
         // Fill the generator's buffer if needed.
-        let num_of_bytes = (num_of_bytes as u64);
+        let num_of_bytes = num_of_bytes as u64;
         if (vector::length(&g.buffer) < (num_of_bytes - vector::length(&result))) {
             fill_buffer(g);
         };
@@ -186,7 +186,7 @@ module sui::random {
     // Assumes that the caller has already checked that num_of_bytes is valid.
     // TODO: Replace with a macro when we have support for it.
     fun u256_from_bytes(g: &mut RandomGenerator, num_of_bytes: u8): u256 {
-        if (vector::length(&g.buffer) < (num_of_bytes as u64)) {
+        if (vector::length(&g.buffer) < num_of_bytes as u64) {
             fill_buffer(g);
         };
         let mut result: u256 = 0;
@@ -206,27 +206,27 @@ module sui::random {
 
     /// Generate a u128.
     public fun generate_u128(g: &mut RandomGenerator): u128 {
-        (u256_from_bytes(g, 16) as u128)
+        u256_from_bytes(g, 16) as u128
     }
 
     /// Generate a u64.
     public fun generate_u64(g: &mut RandomGenerator): u64 {
-        (u256_from_bytes(g, 8) as u64)
+        u256_from_bytes(g, 8) as u64
     }
 
     /// Generate a u32.
     public fun generate_u32(g: &mut RandomGenerator): u32 {
-        (u256_from_bytes(g, 4) as u32)
+        u256_from_bytes(g, 4) as u32
     }
 
     /// Generate a u16.
     public fun generate_u16(g: &mut RandomGenerator): u16 {
-        (u256_from_bytes(g, 2) as u16)
+        u256_from_bytes(g, 2) as u16
     }
 
     /// Generate a u8.
     public fun generate_u8(g: &mut RandomGenerator): u8 {
-        (u256_from_bytes(g, 1) as u8)
+        u256_from_bytes(g, 1) as u8
     }
 
     /// Generate a boolean.
@@ -246,9 +246,9 @@ module sui::random {
         // Pick a random number in [0, max - min] by generating a random number that is larger than max-min, and taking
         // the modulo of the random number by the range size. Then add the min to the result to get a number in
         // [min, max].
-        let range_size = ((max - min) as u256) + 1;
+        let range_size = (max - min) as u256 + 1;
         let rand = u256_from_bytes(g, num_of_bytes);
-        min + ((rand % range_size) as u128)
+        min + (rand % range_size as u128)
     }
 
     /// Generate a random u128 in [min, max] (with a bias of 2^{-64}).
@@ -258,22 +258,22 @@ module sui::random {
 
     //// Generate a random u64 in [min, max] (with a bias of 2^{-64}).
     public fun generate_u64_in_range(g: &mut RandomGenerator, min: u64, max: u64): u64 {
-        (u128_in_range(g, (min as u128), (max as u128), 16) as u64)
+        u128_in_range(g, min as u128, max as u128, 16) as u64
     }
 
     /// Generate a random u32 in [min, max] (with a bias of 2^{-64}).
     public fun generate_u32_in_range(g: &mut RandomGenerator, min: u32, max: u32): u32 {
-        (u128_in_range(g, (min as u128), (max as u128), 12) as u32)
+        u128_in_range(g, min as u128, max as u128, 12) as u32
     }
 
     /// Generate a random u16 in [min, max] (with a bias of 2^{-64}).
     public fun generate_u16_in_range(g: &mut RandomGenerator, min: u16, max: u16): u16 {
-        (u128_in_range(g, (min as u128), (max as u128), 10) as u16)
+        u128_in_range(g, min as u128, max as u128, 10) as u16
     }
 
     /// Generate a random u8 in [min, max] (with a bias of 2^{-64}).
     public fun generate_u8_in_range(g: &mut RandomGenerator, min: u8, max: u8): u8 {
-        (u128_in_range(g, (min as u128), (max as u128), 9) as u8)
+        u128_in_range(g, min as u128, max as u128, 9) as u8
     }
 
     /// Shuffle a vector using the random generator (Fisher–Yates/Knuth shuffle).
@@ -283,12 +283,12 @@ module sui::random {
             return
         };
         assert!(n <= U16_MAX, EInvalidLength);
-        let n = (n as u16);
+        let n = n as u16;
         let mut i: u16 = 0;
         let end = n - 1;
         while (i < end) {
             let j = generate_u16_in_range(g, i, end);
-            vector::swap(v, (i as u64), (j as u64));
+            vector::swap(v, i as u64, j as u64);
             i = i + 1;
         };
     }

--- a/crates/sui-framework/packages/sui-framework/sources/test/test_random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_random.move
@@ -56,7 +56,7 @@ module sui::test_random {
         let mut bytes = next_digest(random);
         let (mut value, mut i) = (0u256, 0u8);
         while (i < 32) {
-            let byte = (bytes.pop_back() as u256);
+            let byte = bytes.pop_back() as u256;
             value = value + (byte << 8*i);
             i = i + 1;
         };
@@ -73,7 +73,7 @@ module sui::test_random {
 
     /// Use the given pseudorandom generator to generate a random `u128` integer.
     public fun next_u128(random: &mut Random): u128 {
-        (next_u256_in_range(random, 1 << 128) as u128)
+        next_u256_in_range(random, 1 << 128) as u128
     }
 
     /// Use the given pseudo-random generator and a non-zero `upper_bound` to generate a
@@ -86,7 +86,7 @@ module sui::test_random {
 
     /// Use the given pseudorandom generator to generate a random `u64` integer.
     public fun next_u64(random: &mut Random): u64 {
-        (next_u256_in_range(random, 1 << 64) as u64)
+        next_u256_in_range(random, 1 << 64) as u64
     }
 
     /// Use the given pseudo-random generator and a non-zero `upper_bound` to generate a
@@ -99,7 +99,7 @@ module sui::test_random {
 
     /// Use the given pseudorandom generator to generate a random `u32`.
     public fun next_u32(random: &mut Random): u32 {
-        (next_u256_in_range(random, 1 << 32) as u32)
+        next_u256_in_range(random, 1 << 32) as u32
     }
 
     /// Use the given pseudo-random generator and a non-zero `upper_bound` to generate a
@@ -112,7 +112,7 @@ module sui::test_random {
 
     /// Use the given pseudorandom generator to generate a random `u16`.
     public fun next_u16(random: &mut Random): u16 {
-        (next_u256_in_range(random, 1 << 16) as u16)
+        next_u256_in_range(random, 1 << 16) as u16
     }
 
     /// Use the given pseudo-random generator and a non-zero `upper_bound` to generate a

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/bls12381_tests.move
@@ -101,7 +101,7 @@ module sui::bls12381_tests {
         while (i > 0) {
             let curr_byte = round % 0x100;
             let curr_element = &mut round_bytes[i];
-            *curr_element = (curr_byte as u8);
+            *curr_element = curr_byte as u8;
             round = round >> 8;
             i = i - 1;
         };

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/royalty_policy.test.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/policies/royalty_policy.test.move
@@ -48,7 +48,7 @@ module sui::royalty_policy {
     ) {
         let config: &Config = policy::get_rule(Rule {}, policy);
         let paid = policy::paid(request);
-        let amount = (((paid as u128) * (config.amount_bp as u128) / 10_000) as u64);
+        let amount = (paid as u128 * (config.amount_bp as u128) / 10_000) as u64;
 
         assert!(coin::value(payment) >= amount, EInsufficientAmount);
 

--- a/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
+++ b/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
@@ -49,7 +49,7 @@ module sui_system::stake_subsidy {
     ): StakeSubsidy {
         // Rate can't be higher than 100%.
         assert!(
-            stake_subsidy_decrease_rate <= (BASIS_POINT_DENOMINATOR as u16),
+            stake_subsidy_decrease_rate <= BASIS_POINT_DENOMINATOR as u16,
             ESubsidyDecreaseRateTooLarge,
         );
 
@@ -77,7 +77,7 @@ module sui_system::stake_subsidy {
 
         // Decrease the subsidy amount only when the current period ends.
         if (self.distribution_counter % self.stake_subsidy_period_length == 0) {
-            let decrease_amount = (self.current_distribution_amount as u128)
+            let decrease_amount = self.current_distribution_amount as u128
                 * (self.stake_subsidy_decrease_rate as u128) / BASIS_POINT_DENOMINATOR;
             self.current_distribution_amount = self.current_distribution_amount - (decrease_amount as u64)
         };

--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -413,10 +413,10 @@ module sui_system::staking_pool {
         if (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {
             return token_amount
         };
-        let res = (exchange_rate.sui_amount as u128)
+        let res = exchange_rate.sui_amount as u128
                 * (token_amount as u128)
                 / (exchange_rate.pool_token_amount as u128);
-        (res as u64)
+        res as u64
     }
 
     fun get_token_amount(exchange_rate: &PoolTokenExchangeRate, sui_amount: u64): u64 {
@@ -425,10 +425,10 @@ module sui_system::staking_pool {
         if (exchange_rate.sui_amount == 0 || exchange_rate.pool_token_amount == 0) {
             return sui_amount
         };
-        let res = (exchange_rate.pool_token_amount as u128)
+        let res = exchange_rate.pool_token_amount as u128
                 * (sui_amount as u128)
                 / (exchange_rate.sui_amount as u128);
-        (res as u64)
+        res as u64
     }
 
     fun initial_exchange_rate(): PoolTokenExchangeRate {

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -831,7 +831,7 @@ module sui_system::sui_system_state_inner {
         let prev_epoch_start_timestamp = self.epoch_start_timestamp_ms;
         self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
 
-        let bps_denominator_u64 = (BASIS_POINT_DENOMINATOR as u64);
+        let bps_denominator_u64 = BASIS_POINT_DENOMINATOR as u64;
         // Rates can't be higher than 100%.
         assert!(
             storage_fund_reinvest_rate <= bps_denominator_u64
@@ -876,15 +876,15 @@ module sui_system::sui_system_state_inner {
         let stake_subsidy_amount = stake_subsidy.value();
         computation_reward.join(stake_subsidy);
 
-        let total_stake_u128 = (total_stake as u128);
-        let computation_charge_u128 = (computation_charge as u128);
+        let total_stake_u128 = total_stake as u128;
+        let computation_charge_u128 = computation_charge as u128;
 
-        let storage_fund_reward_amount = (storage_fund_balance as u128) * computation_charge_u128 / total_stake_u128;
-        let mut storage_fund_reward = computation_reward.split((storage_fund_reward_amount as u64));
+        let storage_fund_reward_amount = storage_fund_balance as u128 * computation_charge_u128 / total_stake_u128;
+        let mut storage_fund_reward = computation_reward.split(storage_fund_reward_amount as u64);
         let storage_fund_reinvestment_amount =
             storage_fund_reward_amount * (storage_fund_reinvest_rate as u128) / BASIS_POINT_DENOMINATOR;
         let storage_fund_reinvestment = storage_fund_reward.split(
-            (storage_fund_reinvestment_amount as u64),
+            storage_fund_reinvestment_amount as u64,
         );
 
         self.epoch = self.epoch + 1;
@@ -939,7 +939,7 @@ module sui_system::sui_system_state_inner {
                 reference_gas_price: self.reference_gas_price,
                 total_stake: new_total_stake,
                 storage_charge,
-                storage_fund_reinvestment: (storage_fund_reinvestment_amount as u64),
+                storage_fund_reinvestment: storage_fund_reinvestment_amount as u64,
                 storage_rebate: storage_rebate_amount,
                 storage_fund_balance: self.storage_fund.total_balance(),
                 stake_subsidy_amount,

--- a/crates/sui-framework/packages/sui-system/sources/validator_set.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_set.move
@@ -993,19 +993,19 @@ module sui_system::validator_set {
             // Use the slashing rate to compute the amount of staking rewards slashed from this punished validator.
             let unadjusted_staking_reward = unadjusted_staking_reward_amounts[validator_index];
             let staking_reward_adjustment_u128 =
-                (unadjusted_staking_reward as u128) * (reward_slashing_rate as u128)
+                unadjusted_staking_reward as u128 * (reward_slashing_rate as u128)
                 / BASIS_POINT_DENOMINATOR;
 
             // Insert into individual mapping and record into the total adjustment sum.
-            individual_staking_reward_adjustments.insert(validator_index, (staking_reward_adjustment_u128 as u64));
+            individual_staking_reward_adjustments.insert(validator_index, staking_reward_adjustment_u128 as u64);
             total_staking_reward_adjustment = total_staking_reward_adjustment + (staking_reward_adjustment_u128 as u64);
 
             // Do the same thing for storage fund rewards.
             let unadjusted_storage_fund_reward = unadjusted_storage_fund_reward_amounts[validator_index];
             let storage_fund_reward_adjustment_u128 =
-                (unadjusted_storage_fund_reward as u128) * (reward_slashing_rate as u128)
+                unadjusted_storage_fund_reward as u128 * (reward_slashing_rate as u128)
                 / BASIS_POINT_DENOMINATOR;
-            individual_storage_fund_reward_adjustments.insert(validator_index, (storage_fund_reward_adjustment_u128 as u64));
+            individual_storage_fund_reward_adjustments.insert(validator_index, storage_fund_reward_adjustment_u128 as u64);
             total_storage_fund_reward_adjustment = total_storage_fund_reward_adjustment + (storage_fund_reward_adjustment_u128 as u64);
         };
 
@@ -1058,9 +1058,9 @@ module sui_system::validator_set {
             // Integer divisions will truncate the results. Because of this, we expect that at the end
             // there will be some reward remaining in `total_staking_reward`.
             // Use u128 to avoid multiplication overflow.
-            let voting_power: u128 = (validator.voting_power() as u128);
+            let voting_power: u128 = validator.voting_power() as u128;
             let reward_amount = voting_power * (total_staking_reward as u128) / (total_voting_power as u128);
-            staking_reward_amounts.push_back((reward_amount as u64));
+            staking_reward_amounts.push_back(reward_amount as u64);
             // Storage fund's share of the rewards are equally distributed among validators.
             storage_fund_reward_amounts.push_back(storage_fund_reward_per_validator);
             i = i + 1;
@@ -1095,7 +1095,7 @@ module sui_system::validator_set {
             // Integer divisions will truncate the results. Because of this, we expect that at the end
             // there will be some reward remaining in `total_reward`.
             // Use u128 to avoid multiplication overflow.
-            let voting_power: u128 = (validator.voting_power() as u128);
+            let voting_power = validator.voting_power() as u128;
 
             // Compute adjusted staking reward.
             let unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
@@ -1107,7 +1107,7 @@ module sui_system::validator_set {
                 } else {
                     // Otherwise the slashed rewards should be distributed among the unslashed
                     // validators so add the corresponding adjustment.
-                    let adjustment = (total_staking_reward_adjustment as u128) * voting_power
+                    let adjustment = total_staking_reward_adjustment as u128 * voting_power
                                    / (total_unslashed_validator_voting_power as u128);
                     unadjusted_staking_reward_amount + (adjustment as u64)
                 };
@@ -1153,7 +1153,7 @@ module sui_system::validator_set {
             let validator_commission_amount = (staking_reward_amount as u128) * (validator.commission_rate() as u128) / BASIS_POINT_DENOMINATOR;
 
             // The validator reward = storage_fund_reward + commission.
-            let mut validator_reward = staker_reward.split((validator_commission_amount as u64));
+            let mut validator_reward = staker_reward.split(validator_commission_amount as u64);
 
             // Add storage fund rewards to the validator's reward.
             validator_reward.join(

--- a/crates/sui-framework/packages/sui-system/sources/voting_power.move
+++ b/crates/sui-framework/packages/sui-system/sources/voting_power.move
@@ -76,8 +76,8 @@ module sui_system::voting_power {
         while (i < len) {
             let validator = &validators[i];
             let stake = validator.total_stake();
-            let adjusted_stake = (stake as u128) * (TOTAL_VOTING_POWER as u128) / (total_stake as u128);
-            let voting_power = math::min((adjusted_stake as u64), threshold);
+            let adjusted_stake = stake as u128 * (TOTAL_VOTING_POWER as u128) / (total_stake as u128);
+            let voting_power = math::min(adjusted_stake as u64, threshold);
             let info = VotingPowerInfoV2 {
                 validator_index: i,
                 voting_power,

--- a/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
+++ b/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
@@ -50,7 +50,7 @@ module sui_system::governance_test_utils {
         let mut i = 0;
         let mut validators = vector[];
         while (i < stakes.length()) {
-            let validator = create_validator_for_testing(address::from_u256((i as u256)), stakes[i], ctx);
+            let validator = create_validator_for_testing(address::from_u256(i as u256), stakes[i], ctx);
             validators.push_back(validator);
             i = i + 1
         };

--- a/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
@@ -418,7 +418,7 @@ module sui_system::rewards_distribution_tests {
         // Create a set of 20 validators, each with 481 + i * 2 SUI of stake.
         // The stake total sums up to be 481 + 483 + ... + 517 + 519 = 1000 SUI.
         while (i < num_validators) {
-            let validator = create_validator_for_testing(address::from_u256((i as u256)), (481 + i * 2), ctx);
+            let validator = create_validator_for_testing(address::from_u256(i as u256), (481 + i * 2), ctx);
             validators.push_back(validator);
             i = i + 1;
         };
@@ -432,7 +432,7 @@ module sui_system::rewards_distribution_tests {
         // Check that each validator has the correct amount of SUI in their stake pool.
         let mut system_state = scenario.take_shared<SuiSystemState>();
         while (i < num_validators) {
-            let addr = address::from_u256((i as u256));
+            let addr = address::from_u256(i as u256);
             assert_eq(system_state.validator_stake_amount(addr), (962 + i * 4) * MIST_PER_SUI);
             i = i + 1;
         };

--- a/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/validator_set_tests.move
@@ -399,7 +399,7 @@ module sui_system::validator_set_tests {
     }
 
     fun create_validator(addr: address, hint: u8, gas_price: u64, is_initial_validator: bool, ctx: &mut TxContext): Validator {
-        let stake_value = (hint as u64) * 100 * MIST_PER_SUI;
+        let stake_value = hint as u64 * 100 * MIST_PER_SUI;
         let name = hint_to_ascii(hint);
         let validator = validator::new_for_testing(
             addr,


### PR DESCRIPTION
## Description 

- Cleanup after #16830

## Test Plan 

- 👀 
- Disassembled each file before and after the change. Diff'd the output, no change

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
