### PR TITLE
Fix audit feedback on committee creation

### DIFF
--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x701ac4809c3d65a372ced26ff4a5520373b63e7cf6ac08ac07ba142c732a8247"
+            id: "0x7b7944deb3caf4b82bcb3dc2821c79a3c3b4532902c9cf8be3e372d000b2b3eb"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x5802f48504ea51ea7ce2a8f9226f3fcf027b5db1adf7adf6c3bc87d052f929e4"
+      operation_cap_id: "0x34c4df87b59cd55bfce99106c884ff91032861f9d68fbb9e18254be53fa06f90"
       gas_price: 1000
       staking_pool:
-        id: "0x349866c7009a99ebfc99be42eff40906666118904a5be0a671eef5d73091d72e"
+        id: "0x3f7473e00fec647ba4f666968fea5b4fd596e1b5cdffa9a4472bbba21e9cfe9d"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x5fc18f40e1209cd5ec096a651081d10ce93ad65f23786ca905fe1e7ceac4da57"
+          id: "0xd167179392c92d2cdbc3eb4ac4465ee205ad3ed3666671b79cb2716fe5c7fb26"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x7a8a87cface7881fafa03b017c7e692bcd609315dce0dba98b39fec8a097ffbb"
+            id: "0xd409c4a417ef1b7f6fb29eae7104b98f9d29c4968284499897a48ef72f740d6a"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x4437781f452524b5d39f2fc24b68c6743391ca70e2a5df9e19f68ac0d8fc8b56"
+          id: "0x1df966210499ebdcd6c8763120c6b3fdf3fc0f571ebe031d16721d60d815ec85"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x1a202a8572fcf7d00a2e5be5e77fee570ea8343b687e4dfba6e8c3632fb9f85f"
+      id: "0x05c0378801204bd28824e2c89acd102b56dc32eb0a49214b4fe6f478ed5c0040"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x0833cd18096dc13d9c1df0077fd08c48b4e8e6c8478f1524cf90d8654f5b7220"
+    id: "0x3655e9e7d4c9c40f6bcf855400feac0b780afc7df3c394c89ad0675ed8c44c80"
     size: 1
   inactive_validators:
-    id: "0xd8d2cc1f506d65f6dc04dfcf1412f5c5443af1c64ff19acbd8dd3df0040474d3"
+    id: "0x253b4e34e0506dcd8c7683cac5e4aab682007baceaf2e959103c8b68700e8fc3"
     size: 0
   validator_candidates:
-    id: "0xfbb82a96e6920edeea2918848424b85622a21c2e2d9f6a0145b31dd137c3bbb8"
+    id: "0x18aa838af70566aadda7bd64592fcea2a6523329bc20e221046a7f5f2926e5e6"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xf9dc3f2f527183fbbb98e41001f75ec93fe3766494b7b6854c17f6f0ef5c6821"
+      id: "0x1f274bce6f30577325ff1f5e6e5c831295d2ad779fc70f9c9faa56e61d7fd8c5"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x7c022b2cf106e306c3c6835dde188705b95cc299b6c5e58a6daa7708f4062eb8"
+      id: "0x110f619a3fd20e5e2aa65010c4ecd58028d42dfb0d1ebc54a7bb9ec9aed7b7b9"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xf85e7f36432988398479faeffd45cbdb4ecdeff4ce4b7db4523c1cae1ad1a015"
+      id: "0x092db3d5616e08c6238d50eab49eaf40b5840a212181af00b0565900b98136e8"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x66f9ba05fd8b9724e007311222054bf9c9b7d08fb3c95e4615e115d22acbbe7b"
+    id: "0x805d8f42450425df7c15963b9f4197ce6582655a5a1e73d6edd9f39549f7cc32"
   size: 0
 


### PR DESCRIPTION
## Description 

As reported by audit if a validator registers with an already used pubkey for the bridge (whether maliciously or not) the creation of the committee will fail and as such an end of epoch would fail attempting to create the committee.
Moreover there is no way at the moment to flush the proposed committee (in that respect, should we have an API for it?) and it would require an emergency release to take care of the problem.
This should prevent the problem from happeing.

## Test Plan 

Added unit test

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
