### PR TITLE
[formal-snapshots] Introduce strict verification

### DIFF
--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -706,21 +706,3 @@ impl StateAccumulatorV2 {
         accumulate_effects(&*self.store, effects, protocol_config)
     }
 }
-
-pub fn accumulate_live_object_iter(iter: Box<dyn Iterator<Item = LiveObject> + '_>) -> Accumulator {
-    let mut acc = Accumulator::default();
-    for live_object in iter {
-        match live_object {
-            LiveObject::Normal(object) => {
-                acc.insert(object.compute_object_reference().2);
-            }
-            LiveObject::Wrapped(key) => {
-                acc.insert(
-                    bcs::to_bytes(&WrappedObject::new(key.0, key.1))
-                        .expect("Failed to serialize WrappedObject"),
-                );
-            }
-        }
-    }
-    acc
-}

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -706,3 +706,21 @@ impl StateAccumulatorV2 {
         accumulate_effects(&*self.store, effects, protocol_config)
     }
 }
+
+pub fn accumulate_live_object_iter(iter: Box<dyn Iterator<Item = LiveObject> + '_>) -> Accumulator {
+    let mut acc = Accumulator::default();
+    for live_object in iter {
+        match live_object {
+            LiveObject::Normal(object) => {
+                acc.insert(object.compute_object_reference().2);
+            }
+            LiveObject::Wrapped(key) => {
+                acc.insert(
+                    bcs::to_bytes(&WrappedObject::new(key.0, key.1))
+                        .expect("Failed to serialize WrappedObject"),
+                );
+            }
+        }
+    }
+    acc
+}

--- a/crates/sui-snapshot/src/lib.rs
+++ b/crates/sui-snapshot/src/lib.rs
@@ -10,6 +10,7 @@ pub mod uploader;
 mod writer;
 
 use anyhow::Result;
+use fastcrypto::hash::MultisetHash;
 use num_enum::IntoPrimitive;
 use num_enum::TryFromPrimitive;
 use object_store::path::Path;
@@ -21,13 +22,17 @@ use sui_core::authority::epoch_start_configuration::EpochFlag;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
 use sui_core::checkpoints::CheckpointStore;
 use sui_core::epoch::committee_store::CommitteeStore;
+use sui_core::state_accumulator::accumulate_live_object_iter;
+use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_storage::object_store::util::path_to_filesystem;
 use sui_storage::{compute_sha3_checksum, FileCompression, SHA3_BYTES};
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::ObjectID;
+use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::sui_system_state::SuiSystemStateTrait;
+use tracing::info;
 
 /// The following describes the format of an object file (*.obj) used for persisting live sui objects.
 /// The maximum size per .obj file is 128MB. State snapshot will be taken at the end of every epoch.
@@ -218,12 +223,16 @@ pub async fn setup_db_state(
     perpetual_db: Arc<AuthorityPerpetualTables>,
     checkpoint_store: Arc<CheckpointStore>,
     committee_store: Arc<CommitteeStore>,
+    chain: Chain,
+    verify: bool,
 ) -> Result<()> {
     // This function should be called once state accumulator based hash verification
     // is complete and live object set state is downloaded to local store
     let system_state_object = get_sui_system_state(&perpetual_db)?;
     let new_epoch_start_state = system_state_object.into_epoch_start_state();
+    let protocol_version = new_epoch_start_state.protocol_version();
     let next_epoch_committee = new_epoch_start_state.get_sui_committee();
+    let root_digest: ECMHLiveObjectSetDigest = accumulator.digest().into();
     let last_checkpoint = checkpoint_store
         .get_epoch_last_checkpoint(epoch)
         .expect("Error loading last checkpoint for current epoch")
@@ -241,6 +250,60 @@ pub async fn setup_db_state(
     perpetual_db.set_highest_pruned_checkpoint_without_wb(last_checkpoint.sequence_number)?;
     committee_store.insert_new_committee(&next_epoch_committee)?;
     checkpoint_store.update_highest_executed_checkpoint(&last_checkpoint)?;
+
+    // TODO add progress bar
+    if verify {
+        eprintln!(
+            "Beginning DB live object state verification. This may take a while, \
+            and currently does not provide progress updates..."
+        );
+        // NB: this is technically incorrect as below we get the protocol config
+        // from the system state object, which at this point contains protocol version
+        // information for the next epoch (epoch the validator was preparing to
+        // reconfigure into at the time the root state hash was computed). This means
+        // that the protocol config is for the next epoch. The protocol config is relevant
+        // for us to determine if tombstones are included in the live object set digest.
+        // Incorrectly considering tombstones may cause the verification to fail. The correct
+        // thing to do would be to get the previous epoch's system state object, but this is
+        // not in the live object set. For now, we optimistically assume this protocol config
+        // parameter is not affected by the off-by-one. If verification fails, we re-fetch the
+        // protocol config for the previous protocol version. Iff the tombstone parameter value
+        // differs between the two protocol configs, we re-verify using this value.
+        let protocol_config = ProtocolConfig::get_for_version(protocol_version, chain);
+        let include_tombstones = !protocol_config.simplified_unwrap_then_delete();
+        let iter = perpetual_db.iter_live_object_set(include_tombstones);
+        let local_digest =
+            ECMHLiveObjectSetDigest::from(accumulate_live_object_iter(Box::new(iter)).digest());
+        let verification_succeeded = if root_digest == local_digest {
+            true
+        } else {
+            let prev_protocol_config = ProtocolConfig::get_for_version(protocol_version - 1, chain);
+            let prev_include_tombstones = !prev_protocol_config.simplified_unwrap_then_delete();
+
+            // check for protocol config edge case
+            if include_tombstones == prev_include_tombstones {
+                false
+            } else {
+                info!(
+                    "Retrying verification for protocol version {:?} with include_tombstones = {}",
+                    protocol_version - 1,
+                    prev_include_tombstones
+                );
+                let iter = perpetual_db.iter_live_object_set(prev_include_tombstones);
+                let local_digest = ECMHLiveObjectSetDigest::from(
+                    accumulate_live_object_iter(Box::new(iter)).digest(),
+                );
+                root_digest == local_digest
+            }
+        };
+        assert!(
+            verification_succeeded,
+            "End of epoch {} root state digest {} does not match \
+                local root state hash {} after restoring db from formal snapshot",
+            epoch, root_digest.digest, local_digest.digest,
+        );
+        eprintln!("DB live object state verification completed successfully!");
+    }
 
     Ok(())
 }

--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -170,7 +170,7 @@ impl StateSnapshotReaderV1 {
         &mut self,
         perpetual_db: &AuthorityPerpetualTables,
         abort_registration: AbortRegistration,
-        sender: Option<tokio::sync::mpsc::Sender<Accumulator>>,
+        sender: Option<tokio::sync::mpsc::Sender<(Accumulator, u64)>>,
     ) -> Result<()> {
         // This computes and stores the sha3 digest of object references in REFERENCE file for each
         // bucket partition. When downloading objects, we will match sha3 digest of object references
@@ -239,7 +239,7 @@ impl StateSnapshotReaderV1 {
 
     fn spawn_accumulation_tasks(
         &self,
-        sender: tokio::sync::mpsc::Sender<Accumulator>,
+        sender: tokio::sync::mpsc::Sender<(Accumulator, u64)>,
         num_part_files: usize,
     ) -> JoinHandle<()> {
         // Spawn accumulation progress bar
@@ -249,7 +249,7 @@ impl StateSnapshotReaderV1 {
         let accum_progress_bar = self.m.add(
              ProgressBar::new(num_part_files as u64).with_style(
                  ProgressStyle::with_template(
-                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated ({msg})",
+                     "[{elapsed_precise}] {wide_bar} {pos} out of {len} ref files accumulated from snapshot ({msg})",
                  )
                  .unwrap(),
              ),
@@ -306,9 +306,10 @@ impl StateSnapshotReaderV1 {
                         let sender_clone = sender.clone();
                         tokio::spawn(async move {
                             let mut partial_acc = Accumulator::default();
+                            let num_objects = obj_digests.len();
                             partial_acc.insert_all(obj_digests);
                             sender_clone
-                                .send(partial_acc)
+                                .send((partial_acc, num_objects as u64))
                                 .await
                                 .expect("Unable to send accumulator from snapshot reader");
                         })

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -6,8 +6,9 @@ use crate::{
     db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand},
     download_db_snapshot, download_formal_snapshot, dump_checkpoints_from_archive,
     get_latest_available_epoch, get_object, get_transaction_block, make_clients, pkg_dump,
-    restore_from_db_checkpoint, verify_archive, verify_archive_by_checksum, ConciseObjectOutput,
-    GroupedObjectOutput, VerboseObjectOutput,
+    restore_from_db_checkpoint, verify_archive, verify_archive_by_checksum, 
+    ConciseObjectOutput, GroupedObjectOutput, SnapshotVerifyMode,
+    VerboseObjectOutput,
 };
 use anyhow::Result;
 use futures::{future::join_all, StreamExt};
@@ -323,10 +324,9 @@ pub enum ToolCommand {
         /// value based on number of available logical cores.
         #[clap(long = "num-parallel-downloads")]
         num_parallel_downloads: Option<usize>,
-        /// If true, perform snapshot and checkpoint summary verification.
-        /// Defaults to true.
-        #[clap(long = "verify")]
-        verify: Option<bool>,
+        /// Verification mode to employ.
+        #[clap(long = "verify", default_value = "normal")]
+        verify: Option<SnapshotVerifyMode>,
         /// Network to download snapshot for. Defaults to "mainnet".
         /// If `--snapshot-bucket` or `--archive-bucket` is not specified,
         /// the value of this flag is used to construct default bucket names.
@@ -908,7 +908,7 @@ impl ToolCommand {
                     );
                 }
 
-                let verify = verify.unwrap_or(true);
+                let verify = verify.unwrap_or_default();
                 download_formal_snapshot(
                     &path,
                     epoch_to_download,

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -6,9 +6,8 @@ use crate::{
     db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand},
     download_db_snapshot, download_formal_snapshot, dump_checkpoints_from_archive,
     get_latest_available_epoch, get_object, get_transaction_block, make_clients, pkg_dump,
-    restore_from_db_checkpoint, verify_archive, verify_archive_by_checksum, 
-    ConciseObjectOutput, GroupedObjectOutput, SnapshotVerifyMode,
-    VerboseObjectOutput,
+    restore_from_db_checkpoint, verify_archive, verify_archive_by_checksum, ConciseObjectOutput,
+    GroupedObjectOutput, SnapshotVerifyMode, VerboseObjectOutput,
 };
 use anyhow::Result;
 use futures::{future::join_all, StreamExt};

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -38,11 +38,13 @@ use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use anyhow::anyhow;
+use clap::ValueEnum;
 use eyre::ContextCompat;
 use fastcrypto::hash::MultisetHash;
 use futures::{StreamExt, TryStreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use prometheus::Registry;
+use serde::{Deserialize, Serialize};
 use sui_archival::reader::{ArchiveReader, ArchiveReaderMetrics};
 use sui_archival::{verify_archive_with_checksums, verify_archive_with_genesis_config};
 use sui_config::node::ArchiveReaderConfig;
@@ -70,6 +72,19 @@ use typed_store::rocks::MetricConf;
 pub mod commands;
 pub mod db_tool;
 pub mod pkg_dump;
+
+#[derive(
+    Clone, Serialize, Deserialize, Debug, PartialEq, Copy, PartialOrd, Ord, Eq, ValueEnum, Default,
+)]
+pub enum SnapshotVerifyMode {
+    /// verification of both db state and checkpoint chain is skipped.
+    None,
+    /// verify snapshot state during download, but no post-restore db verification.
+    #[default]
+    Normal,
+    /// verify db state post-restore against the end of epoch state root commitment.
+    Strict,
+}
 
 // This functions requires at least one of genesis or fullnode_rpc to be `Some`.
 async fn make_clients(
@@ -843,7 +858,7 @@ pub async fn download_formal_snapshot(
     archive_store_config: ObjectStoreConfig,
     num_parallel_downloads: usize,
     network: Chain,
-    verify: bool,
+    verify: SnapshotVerifyMode,
 ) -> Result<(), anyhow::Error> {
     eprintln!(
         "Beginning formal snapshot restore to end of epoch {}, network: {:?}",
@@ -878,7 +893,7 @@ pub async fn download_formal_snapshot(
         archive_store_config.clone(),
         epoch,
         num_parallel_downloads,
-        verify,
+        verify != SnapshotVerifyMode::None,
     );
     let (_abort_handle, abort_registration) = AbortHandle::new_pair();
     let perpetual_db_clone = perpetual_db.clone();
@@ -928,7 +943,7 @@ pub async fn download_formal_snapshot(
         .expect("Expected nonempty checkpoint store");
 
     // Perform snapshot state verification
-    if verify {
+    if verify != SnapshotVerifyMode::None {
         assert_eq!(
             last_checkpoint.epoch(),
             epoch,
@@ -955,7 +970,7 @@ pub async fn download_formal_snapshot(
                 assert_eq!(
                     *consensus_digest, local_digest,
                     "End of epoch {} root state digest {} does not match \
-                    local root state hash {} after restoring from formal snapshot",
+                    local root state hash {} computed from snapshot data",
                     epoch, consensus_digest.digest, local_digest.digest,
                 );
                 eprintln!("Formal snapshot state verification completed successfully!");
@@ -981,10 +996,12 @@ pub async fn download_formal_snapshot(
 
     setup_db_state(
         epoch,
-        root_accumulator,
-        perpetual_db,
+        root_accumulator.clone(),
+        perpetual_db.clone(),
         checkpoint_store,
         committee_store,
+        network,
+        verify == SnapshotVerifyMode::Strict,
     )
     .await?;
 


### PR DESCRIPTION
## Description 

`--verify strict` adds an additional level of verification by verifying the live object set of the db after restore, rather than simply the contents of the snapshot itself. These two are not equivalent in cases where the restore process inadvertently adds objects to the live object set from a source other than the downloaded snapshot itself. One such example could be inserting genesis objects.

## Test Plan 

```
target/release/sui-tool download-formal-snapshot --network mainnet --latest --path /opt/sui/db/authorities_db --genesis /opt/sui/mainnet/config/genesis.blob --no-sign-request --verify strict
Beginning formal snapshot restore to end of epoch 419, network: Mainnet with verification mode Strict
[00:25:02] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 35942088/35942088(Checkpoint summary sync is complete)
[00:07:42] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 453 out of 453 .ref files done
(ref files download complete)
[00:00:42] ████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 453 out of 453 ref files checksummed (Checksumming complete)
[00:02:17] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 453 out of 453 ref files accumulated from snapshot (Accumulation complete)
[00:30:33] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 453 out of 453 .obj files done
(Objects download complete)
[00:40:30] ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 35942088/35942088(Checkpoint summary verification is complete)
[00:40:02] ██████████████████████████████████████████████████████████████████████████████████████░ 257689825 out of 257775627 ref files accumulated from db (live obj accumulations per sec: 107250.80399722935)DB live object state verification completed successfully!
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
