### PR TITLE
[move-2024] Generalize name access parsing to handle macros, tyargs

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1722,28 +1722,33 @@ impl<'a> ParsingSymbolicator<'a> {
         }
     }
 
+    fn path_entry_symbols(&mut self, path: &P::PathEntry) {
+        let P::PathEntry { name: _, tyargs, is_macro: _ } = path;
+        if let Some(sp!(_, tyargs)) = tyargs {
+            tyargs.iter().for_each(|t| self.type_symbols(t));
+        }
+    }
+
+    fn root_path_entry_symbols(&mut self, path: &P::RootPathEntry) {
+        let P::RootPathEntry { name: _, tyargs, is_macro: _ } = path;
+        if let Some(sp!(_, tyargs)) = tyargs {
+            tyargs.iter().for_each(|t| self.type_symbols(t));
+        }
+    }
+
     /// Get symbols for an expression
     fn exp_symbols(&mut self, sp!(_, exp): &P::Exp) {
         use P::Exp_ as E;
         match exp {
-            E::Name(chain, vo) => {
+            E::Name(chain) => {
                 self.chain_symbols(chain);
-                if let Some(v) = vo {
-                    v.iter().for_each(|t| self.type_symbols(t));
-                }
             }
-            E::Call(chain, _, vo, v) => {
+            E::Call(chain, v) => {
                 self.chain_symbols(chain);
-                if let Some(v) = vo {
-                    v.iter().for_each(|t| self.type_symbols(t));
-                }
                 v.value.iter().for_each(|e| self.exp_symbols(e));
             }
-            E::Pack(chain, vo, v) => {
+            E::Pack(chain, v) => {
                 self.chain_symbols(chain);
-                if let Some(v) = vo {
-                    v.iter().for_each(|t| self.type_symbols(t));
-                }
                 v.iter().for_each(|(_, e)| self.exp_symbols(e));
             }
             E::Vector(_, vo, v) => {
@@ -1975,9 +1980,8 @@ impl<'a> ParsingSymbolicator<'a> {
     fn type_symbols(&mut self, sp!(_, t): &P::Type) {
         use P::Type_ as T;
         match t {
-            T::Apply(chain, v) => {
+            T::Apply(chain) => {
                 self.chain_symbols(chain);
-                v.iter().for_each(|t| self.type_symbols(t));
             }
             T::Ref(_, t) => self.type_symbols(t),
             T::Fun(v, t) => {
@@ -1993,11 +1997,8 @@ impl<'a> ParsingSymbolicator<'a> {
     fn bind_symbols(&mut self, sp!(_, bind): &P::Bind) {
         use P::Bind_ as B;
         match bind {
-            B::Unpack(chain, vo, bindings) => {
+            B::Unpack(chain, bindings) => {
                 self.chain_symbols(chain);
-                if let Some(v) = vo {
-                    v.iter().for_each(|t| self.type_symbols(t));
-                }
                 match bindings {
                     P::FieldBindings::Named(v) => {
                         v.iter().for_each(|(_, bind)| self.bind_symbols(bind))
@@ -2017,16 +2018,25 @@ impl<'a> ParsingSymbolicator<'a> {
         // record the length of an identifier representing a potentially
         // aliased module, struct or function  name in an access chain,
         let no = match chain {
-            NA::One(n) => Some(*n), // this can be an aliased struct or function
-            NA::Two(leading_name, _) => {
-                // the only thing aliased here coud be a module
-                if let P::LeadingNameAccess_::Name(n) = leading_name.value {
-                    Some(n)
+            NA::Single(entry) => {
+                self.path_entry_symbols(entry);
+                Some(entry.name)
+            },
+            NA::Path(path) => {
+                let P::NamePath { root, entries } = path;
+                self.root_path_entry_symbols(root);
+                entries.iter().for_each(|entry| self.path_entry_symbols(entry));
+                // FIXME: this is a hack that will break when we add enums
+                if entries.len() < 2 {
+                    if let P::LeadingNameAccess_::Name(n) = root.name.value {
+                        Some(n)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
             }
-            NA::Three(..) => None,
         };
         let Some(n) = no else {
             return;

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -184,6 +184,8 @@ codes!(
         InvalidMoveOrCopy: { msg: "invalid 'move' or 'copy'", severity: NonblockingError },
         InvalidLabel: { msg: "invalid expression label", severity: NonblockingError },
         AmbiguousCast: { msg: "ambiguous 'as'", severity: NonblockingError },
+        InvalidName: { msg: "invalid name", severity: BlockingError },
+        InvalidMacro: { msg: "invalid macro invocation", severity: BlockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [
@@ -233,6 +235,7 @@ codes!(
         UnboundLabel: { msg: "unbound label", severity: BlockingError },
         InvalidMut: { msg: "invalid 'mut' declaration", severity: NonblockingError },
         InvalidMacroParameter: { msg: "invalid macro parameter", severity: NonblockingError },
+        InvalidTypeParameter: { msg: "invalid type parameter", severity: NonblockingError },
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [

--- a/external-crates/move/crates/move-compiler/src/expansion/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/mod.rs
@@ -8,5 +8,6 @@ pub mod ast;
 mod byte_string;
 mod hex_string;
 mod legacy_aliases;
+mod path_expander;
 mod primitive_definers;
 pub(crate) mod translate;

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -1,0 +1,1121 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Name access chain (path) resolution. This is driven by the trait PathExpander, which works over
+/// a DefnContext and resolves according to the rules of the selected expander.
+use crate::{
+    diag,
+    diagnostics::Diagnostic,
+    editions::{create_feature_error, Edition, FeatureGate},
+    expansion::{
+        alias_map_builder::{
+            AliasEntry, AliasMapBuilder, NameSpace, ParserExplicitUseFun, UseFunsBuilder,
+        },
+        aliases::{AliasMap, AliasSet},
+        ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_},
+        legacy_aliases,
+        translate::{
+            is_valid_struct_or_constant_name, make_address, module_ident, top_level_address,
+            top_level_address_opt, value, DefnContext,
+        },
+    },
+    ice, ice_assert,
+    parser::{
+        ast::{
+            self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
+            ModuleName, NameAccess, NamePath, PathEntry, RootPathEntry, StructName, Type, Var,
+            ENTRY_MODIFIER, MACRO_MODIFIER, NATIVE_MODIFIER,
+        },
+        syntax::make_loc,
+    },
+    shared::{known_attributes::AttributePosition, unique_map::UniqueMap, *},
+    FullyCompiledProgram,
+};
+use move_command_line_common::parser::{parse_u16, parse_u256, parse_u32};
+use move_core_types::account_address::AccountAddress;
+use move_ir_types::location::*;
+use move_proc_macros::growing_stack;
+use move_symbol_pool::Symbol;
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    iter::IntoIterator,
+    sync::Arc,
+};
+
+use self::known_attributes::DiagnosticAttribute;
+
+//**************************************************************************************************
+// Definitions
+//**************************************************************************************************
+
+pub struct ModuleAccessResult {
+    pub access: E::ModuleAccess,
+    pub ptys_opt: Option<Spanned<Vec<P::Type>>>,
+    pub is_macro: Option<Loc>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Access {
+    Type,
+    ApplyNamed,
+    ApplyPositional,
+    Term,
+    Module, // Just used for errors
+}
+
+// This trait describes the commands available to handle alias scopes and expanding name access
+// chains. This is used to model both legacy and modern path expansion.
+
+pub trait PathExpander {
+    // Push a new innermost alias scope
+    fn push_alias_scope(
+        &mut self,
+        loc: Loc,
+        new_scope: AliasMapBuilder,
+    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>>;
+
+    // Push a number of type parameters onto the alias information in the path expander. They are
+    // never resolved, but are tracked to apply appropriate shadowing.
+    fn push_type_parameters(&mut self, tparams: Vec<&Name>);
+
+    // Pop the innermost alias scope
+    fn pop_alias_scope(&mut self) -> AliasSet;
+
+    fn name_access_chain_to_attribute_value(
+        &mut self,
+        context: &mut DefnContext,
+        attribute_value: P::AttributeValue,
+    ) -> Option<E::AttributeValue>;
+
+    fn name_access_chain_to_module_access(
+        &mut self,
+        context: &mut DefnContext,
+        access: Access,
+        name_chain: P::NameAccessChain,
+    ) -> Option<ModuleAccessResult>;
+
+    fn name_access_chain_to_module_ident(
+        &mut self,
+        context: &mut DefnContext,
+        name_chain: P::NameAccessChain,
+    ) -> Option<E::ModuleIdent>;
+}
+
+pub fn make_access_result(
+    access: E::ModuleAccess,
+    ptys_opt: Option<Spanned<Vec<P::Type>>>,
+    is_macro: Option<Loc>,
+) -> ModuleAccessResult {
+    ModuleAccessResult {
+        access,
+        ptys_opt,
+        is_macro,
+    }
+}
+
+macro_rules! path_entry {
+    ($name:pat, $tyargs:pat, $is_macro:pat) => {
+        PathEntry {
+            name: $name,
+            tyargs: $tyargs,
+            is_macro: $is_macro,
+        }
+    };
+}
+
+macro_rules! single_entry {
+    ($name:pat, $tyargs:pat, $is_macro:pat) => {
+        P::NameAccessChain_::Single(path_entry!($name, $tyargs, $is_macro))
+    };
+}
+
+macro_rules! access_result {
+    ($access:pat, $ptys_opt:pat, $is_macro:pat) => {
+        ModuleAccessResult {
+            access: $access,
+            ptys_opt: $ptys_opt,
+            is_macro: $is_macro,
+        }
+    };
+}
+
+pub(crate) use access_result;
+
+use super::alias_map_builder::UnnecessaryAlias;
+
+//**************************************************************************************************
+// Move 2024 Path Expander
+//**************************************************************************************************
+
+pub struct Move2024PathExpander {
+    aliases: AliasMap,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum AccessChainNameResult {
+    ModuleAccess(Loc, E::ModuleAccess_),
+    Address(Loc, E::Address),
+    ModuleIdent(Loc, E::ModuleIdent),
+    UnresolvedName(Loc, Name),
+    ResolutionFailure(Box<AccessChainNameResult>, AccessChainFailure),
+}
+
+struct AccessChainResult {
+    result: AccessChainNameResult,
+    ptys_opt: Option<Spanned<Vec<P::Type>>>,
+    is_macro: Option<Loc>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum AccessChainFailure {
+    UnresolvedAlias(Name),
+    InvalidKind(String),
+}
+
+macro_rules! chain_result {
+    ($result:pat, $ptys_opt:pat, $is_macro:pat) => {
+        AccessChainResult {
+            result: $result,
+            ptys_opt: $ptys_opt,
+            is_macro: $is_macro,
+        }
+    };
+}
+
+impl Move2024PathExpander {
+    pub(super) fn new() -> Move2024PathExpander {
+        Move2024PathExpander {
+            aliases: AliasMap::new(),
+        }
+    }
+
+    fn resolve_root(
+        &mut self,
+        context: &mut DefnContext,
+        sp!(loc, name): P::LeadingNameAccess,
+    ) -> AccessChainNameResult {
+        use AccessChainFailure as NF;
+        use AccessChainNameResult as NR;
+        use P::LeadingNameAccess_ as LN;
+        match name {
+            LN::AnonymousAddress(address) => NR::Address(loc, E::Address::anonymous(loc, address)),
+            LN::GlobalAddress(name) => {
+                if let Some(address) = context
+                    .named_address_mapping
+                    .expect("ICE no named address mapping")
+                    .get(&name.value)
+                {
+                    NR::Address(loc, make_address(context, name, name.loc, *address))
+                } else {
+                    NR::ResolutionFailure(
+                        Box::new(NR::UnresolvedName(loc, name)),
+                        NF::UnresolvedAlias(name),
+                    )
+                }
+            }
+            LN::Name(name) => match self.resolve_name(context, NameSpace::LeadingAccess, name) {
+                result @ NR::UnresolvedName(_, _) => {
+                    NR::ResolutionFailure(Box::new(result), NF::UnresolvedAlias(name))
+                }
+                other => other,
+            },
+        }
+    }
+
+    fn resolve_name(
+        &mut self,
+        context: &mut DefnContext,
+        namespace: NameSpace,
+        name: Name,
+    ) -> AccessChainNameResult {
+        use AccessChainFailure as NF;
+        use AccessChainNameResult as NR;
+        use E::ModuleAccess_ as EN;
+
+        match self.aliases.resolve(namespace, &name) {
+            Some(AliasEntry::Member(_, mident, sp!(_, mem))) => {
+                // We are preserving the name's original location, rather than referring to where
+                // the alias was defined. The name represents JUST the member name, though, so we do
+                // not change location of the module as we don't have this information.
+                // TODO maybe we should also keep the alias reference (or its location)?
+                NR::ModuleAccess(name.loc, EN::ModuleAccess(mident, sp(name.loc, mem)))
+            }
+            Some(AliasEntry::Module(_, mident)) => {
+                // We are preserving the name's original location, rather than referring to where
+                // the alias was defined. The name represents JUST the module name, though, so we do
+                // not change location of the address as we don't have this information.
+                // TODO maybe we should also keep the alias reference (or its location)?
+                let sp!(
+                    _,
+                    ModuleIdent_ {
+                        address,
+                        module: ModuleName(sp!(_, module))
+                    }
+                ) = mident;
+                let module = ModuleName(sp(name.loc, module));
+                NR::ModuleIdent(name.loc, sp(name.loc, ModuleIdent_ { address, module }))
+            }
+            Some(AliasEntry::Address(_, address)) => {
+                NR::Address(name.loc, make_address(context, name, name.loc, address))
+            }
+            Some(AliasEntry::TypeParam(_)) => {
+                context.env.add_diag(ice!((
+                    name.loc,
+                    "ICE alias map misresolved name as type param"
+                )));
+                NR::UnresolvedName(name.loc, name)
+            }
+            None => {
+                if let Some(entry) = self.aliases.resolve_any_for_error(&name) {
+                    let msg = match namespace {
+                        NameSpace::ModuleMembers => "a type, function, or constant".to_string(),
+                        // we exclude types from this message since it would have been caught in
+                        // the other namespace
+                        NameSpace::LeadingAccess => "an address or module".to_string(),
+                    };
+                    let result = match entry {
+                        AliasEntry::Address(_, address) => {
+                            NR::Address(name.loc, make_address(context, name, name.loc, address))
+                        }
+                        AliasEntry::Module(_, mident) => NR::ModuleIdent(name.loc, mident),
+                        AliasEntry::Member(_, mident, mem) => {
+                            NR::ModuleAccess(name.loc, EN::ModuleAccess(mident, mem))
+                        }
+                        AliasEntry::TypeParam(_) => {
+                            context.env.add_diag(ice!((
+                                name.loc,
+                                "ICE alias map misresolved name as type param"
+                            )));
+                            NR::UnresolvedName(name.loc, name)
+                        }
+                    };
+                    NR::ResolutionFailure(Box::new(result), NF::InvalidKind(msg))
+                } else {
+                    NR::UnresolvedName(name.loc, name)
+                }
+            }
+        }
+    }
+
+    fn resolve_name_access_chain(
+        &mut self,
+        context: &mut DefnContext,
+        access: Access,
+        sp!(loc, chain): P::NameAccessChain,
+    ) -> AccessChainResult {
+        use AccessChainFailure as NF;
+        use AccessChainNameResult as NR;
+        use E::ModuleAccess_ as EN;
+        use P::NameAccessChain_ as PN;
+
+        fn check_tyargs(
+            context: &mut DefnContext,
+            tyargs: &Option<Spanned<Vec<Type>>>,
+            result: &NR,
+        ) {
+            if let NR::Address(_, _) | NR::ModuleIdent(_, _) = result {
+                if let Some(tyargs) = tyargs {
+                    context.env.add_diag(diag!(
+                        NameResolution::InvalidTypeParameter,
+                        (
+                            tyargs.loc,
+                            format!("Cannot use type parameters for {}", result.err_name())
+                        )
+                    ));
+                }
+            }
+        }
+
+        fn check_is_macro(context: &mut DefnContext, is_macro: &Option<Loc>, result: &NR) {
+            if let NR::Address(_, _) | NR::ModuleIdent(_, _) = result {
+                if let Some(loc) = is_macro {
+                    context.env.add_diag(diag!(
+                        NameResolution::InvalidTypeParameter,
+                        (
+                            *loc,
+                            format!("Cannot use {} as a macro invocation", result.err_name())
+                        )
+                    ));
+                }
+            }
+        }
+
+        match chain {
+            PN::Single(path_entry!(name, ptys_opt, is_macro)) => {
+                use crate::naming::ast::BuiltinFunction_;
+                use crate::naming::ast::BuiltinTypeName_;
+                let namespace = match access {
+                    Access::Type | Access::ApplyNamed | Access::ApplyPositional | Access::Term => {
+                        NameSpace::ModuleMembers
+                    }
+                    Access::Module => NameSpace::LeadingAccess,
+                };
+
+                // This is a hack to let `use std::vector` play nicely with `vector`,
+                // plus preserve things like `u64`, etc.
+                let result = if !matches!(access, Access::Module)
+                    && (BuiltinFunction_::all_names().contains(&name.value)
+                        || BuiltinTypeName_::all_names().contains(&name.value))
+                {
+                    NR::UnresolvedName(name.loc, name)
+                } else {
+                    self.resolve_name(context, namespace, name)
+                };
+                AccessChainResult {
+                    result,
+                    ptys_opt,
+                    is_macro,
+                }
+            }
+            PN::Path(path) => {
+                let NamePath { root, entries } = path;
+                let mut result = match self.resolve_root(context, root.name) {
+                    // In Move Legacy, we always treated three-place names as fully-qualified.
+                    // For migration mode, if we could have gotten the correct result doing so,
+                    // we emit a migration change to globally-qualify that path and remediate
+                    // the error.
+                    result @ NR::ModuleIdent(_, _)
+                        if entries.len() == 2
+                            && context.env.edition(context.current_package) == Edition::E2024_MIGRATION
+                            && root.is_macro.is_none()
+                            && root.tyargs.is_none() =>
+                    {
+                        if let Some(address) = top_level_address_opt(context, root.name) {
+                            context.env.add_diag(diag!(
+                                Migration::NeedsGlobalQualification,
+                                (root.name.loc, "Must globally qualify name")
+                            ));
+                            NR::Address(root.name.loc, address)
+                        } else {
+                            NR::ResolutionFailure(
+                                Box::new(result),
+                                NF::InvalidKind("an address".to_string()),
+                            )
+                        }
+                    }
+                    result => result,
+                };
+                let mut ptys_opt = root.tyargs;
+                let mut is_macro = root.is_macro;
+
+                for entry in entries {
+                    check_tyargs(context, &ptys_opt, &result);
+                    check_is_macro(context, &is_macro, &result);
+                    match result {
+                        NR::ModuleAccess(_, _) => {
+                            result = NR::ResolutionFailure(
+                                Box::new(result),
+                                NF::InvalidKind("a module or address".to_string()),
+                            );
+                            break;
+                        }
+                        NR::Address(aloc, address) => {
+                            let loc = make_loc(
+                                aloc.file_hash(),
+                                aloc.start() as usize,
+                                entry.name.loc.end() as usize,
+                            );
+                            result = NR::ModuleIdent(
+                                loc,
+                                sp(loc, ModuleIdent_::new(address, ModuleName(entry.name))),
+                            );
+                            ptys_opt = entry.tyargs;
+                            is_macro = entry.is_macro;
+                        }
+                        NR::ModuleIdent(mloc, mident) => {
+                            let loc = make_loc(
+                                mloc.file_hash(),
+                                mloc.start() as usize,
+                                entry.name.loc.end() as usize,
+                            );
+                            result = NR::ModuleAccess(loc, EN::ModuleAccess(mident, entry.name));
+                            ptys_opt = entry.tyargs;
+                            is_macro = entry.is_macro;
+                        }
+                        NR::UnresolvedName(_, _) => {
+                            context
+                                .env
+                                .add_diag(ice!((loc, "ICE access chain expansion failed")));
+                            break;
+                        }
+                        NR::ResolutionFailure(_, _) => break,
+                    }
+                }
+
+                AccessChainResult {
+                    result,
+                    ptys_opt,
+                    is_macro,
+                }
+            }
+        }
+    }
+}
+
+impl PathExpander for Move2024PathExpander {
+    fn push_alias_scope(
+        &mut self,
+        loc: Loc,
+        new_scope: AliasMapBuilder,
+    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>> {
+        self.aliases.push_alias_scope(loc, new_scope)
+    }
+
+    fn push_type_parameters(&mut self, tparams: Vec<&Name>) {
+        self.aliases.push_type_parameters(tparams)
+    }
+
+    fn pop_alias_scope(&mut self) -> AliasSet {
+        self.aliases.pop_scope()
+    }
+
+    fn name_access_chain_to_attribute_value(
+        &mut self,
+        context: &mut DefnContext,
+        sp!(loc, avalue_): P::AttributeValue,
+    ) -> Option<E::AttributeValue> {
+        use AccessChainNameResult as NR;
+        use E::AttributeValue_ as EV;
+        use P::AttributeValue_ as PV;
+        Some(sp(
+            loc,
+            match avalue_ {
+                PV::Value(v) => EV::Value(value(context, v)?),
+                // A bit strange, but we try to resolve it as a term and a module, and report
+                // an error if they both resolve (to different things)
+                PV::ModuleAccess(access_chain) => {
+                    ice_assert!(
+                        context.env,
+                        access_chain.value.tyargs().is_none(),
+                        loc,
+                        "Found tyargs"
+                    );
+                    ice_assert!(
+                        context.env,
+                        access_chain.value.is_macro().is_none(),
+                        loc,
+                        "Found macro"
+                    );
+                    let chain_result!(term_result, term_tyargs, term_is_macro) =
+                        self.resolve_name_access_chain(context, Access::Term, access_chain.clone());
+                    assert!(term_tyargs.is_none());
+                    assert!(term_is_macro.is_none());
+                    let chain_result!(module_result, module_tyargs, module_is_macro) =
+                        self.resolve_name_access_chain(context, Access::Module, access_chain);
+                    assert!(module_tyargs.is_none());
+                    assert!(module_is_macro.is_none());
+                    let result = match (term_result, module_result) {
+                        (t_res, m_res) if t_res == m_res => t_res,
+                        (NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _), other)
+                        | (other, NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _)) => other,
+                        (t_res, m_res) => {
+                            let msg = format!(
+                                "Ambiguous attribute value. It can resolve to both {} and {}",
+                                t_res.err_name(),
+                                m_res.err_name()
+                            );
+                            context
+                                .env
+                                .add_diag(diag!(Attributes::AmbiguousAttributeValue, (loc, msg)));
+                            return None;
+                        }
+                    };
+                    match result {
+                        NR::ModuleIdent(_, mident) => {
+                            if context.module_members.get(&mident).is_none() {
+                                context.env.add_diag(diag!(
+                                    NameResolution::UnboundModule,
+                                    (loc, format!("Unbound module '{}'", mident))
+                                ));
+                            }
+                            EV::Module(mident)
+                        }
+                        NR::ModuleAccess(loc, access) => EV::ModuleAccess(sp(loc, access)),
+                        NR::UnresolvedName(loc, name) => {
+                            EV::ModuleAccess(sp(loc, E::ModuleAccess_::Name(name)))
+                        }
+                        NR::Address(_, a) => EV::Address(a),
+                        result @ NR::ResolutionFailure(_, _) => {
+                            context.env.add_diag(access_chain_resolution_error(result));
+                            return None;
+                        }
+                    }
+                }
+            },
+        ))
+    }
+
+    fn name_access_chain_to_module_access(
+        &mut self,
+        context: &mut DefnContext,
+        access: Access,
+        chain: P::NameAccessChain,
+    ) -> Option<ModuleAccessResult> {
+        use AccessChainNameResult as NR;
+        use E::ModuleAccess_ as EN;
+        use P::NameAccessChain_ as PN;
+
+        let mut loc = chain.loc;
+
+        let (module_access, tyargs, is_macro) = match access {
+            Access::ApplyPositional | Access::ApplyNamed | Access::Type => {
+                let chain_result!(resolved_name, tyargs, is_macro) =
+                    self.resolve_name_access_chain(context, access, chain.clone());
+                match resolved_name {
+                    NR::UnresolvedName(_, name) => {
+                        loc = name.loc;
+                        (EN::Name(name), tyargs, is_macro)
+                    }
+                    NR::ModuleAccess(_, access) => (access, tyargs, is_macro),
+                    NR::Address(_, _) => {
+                        context.env.add_diag(unexpected_access_error(
+                            resolved_name.loc(),
+                            "address".to_string(),
+                            access,
+                        ));
+                        return None;
+                    }
+                    NR::ModuleIdent(_, sp!(_, ModuleIdent_ { address, module })) => {
+                        let mut diag = unexpected_access_error(
+                            resolved_name.loc(),
+                            "module".to_string(),
+                            access,
+                        );
+                        let base_str = format!("{}", chain);
+                        let realized_str = format!("{}::{}", address, module);
+                        if base_str != realized_str {
+                            diag.add_note(format!(
+                                "Resolved '{}' to module identifier '{}'",
+                                base_str, realized_str
+                            ));
+                        }
+                        context.env.add_diag(diag);
+                        return None;
+                    }
+                    result @ NR::ResolutionFailure(_, _) => {
+                        context.env.add_diag(access_chain_resolution_error(result));
+                        return None;
+                    }
+                }
+            }
+            Access::Term => match chain.value {
+                PN::Single(path_entry!(name, tyargs, is_macro))
+                    if !is_valid_struct_or_constant_name(&name.to_string()) =>
+                {
+                    (EN::Name(name), tyargs, is_macro)
+                }
+                _ => {
+                    let chain_result!(resolved_name, tyargs, is_macro) =
+                        self.resolve_name_access_chain(context, access, chain);
+                    match resolved_name {
+                        NR::UnresolvedName(_, name) => (EN::Name(name), tyargs, is_macro),
+                        NR::ModuleAccess(_, access) => (access, tyargs, is_macro),
+                        NR::Address(_, _) => {
+                            context.env.add_diag(unexpected_access_error(
+                                resolved_name.loc(),
+                                "address".to_string(),
+                                access,
+                            ));
+                            return None;
+                        }
+                        NR::ModuleIdent(_, _) => {
+                            context.env.add_diag(unexpected_access_error(
+                                resolved_name.loc(),
+                                "module".to_string(),
+                                access,
+                            ));
+                            return None;
+                        }
+                        result @ NR::ResolutionFailure(_, _) => {
+                            context.env.add_diag(access_chain_resolution_error(result));
+                            return None;
+                        }
+                    }
+                }
+            },
+            Access::Module => {
+                context.env.add_diag(ice!((
+                    loc,
+                    "ICE module access should never resolve to a module member"
+                )));
+                return None;
+            }
+        };
+        Some(make_access_result(sp(loc, module_access), tyargs, is_macro))
+    }
+
+    fn name_access_chain_to_module_ident(
+        &mut self,
+        context: &mut DefnContext,
+        chain: P::NameAccessChain,
+    ) -> Option<E::ModuleIdent> {
+        use AccessChainNameResult as NR;
+        let chain_result!(resolved_name, tyargs, is_macro) =
+            self.resolve_name_access_chain(context, Access::Module, chain);
+        assert!(tyargs.is_none());
+        assert!(is_macro.is_none());
+        match resolved_name {
+            NR::ModuleIdent(_, mident) => Some(mident),
+            NR::UnresolvedName(_, name) => {
+                context.env.add_diag(unbound_module_error(name));
+                None
+            }
+            NR::Address(_, _) => {
+                context.env.add_diag(unexpected_access_error(
+                    resolved_name.loc(),
+                    "address".to_string(),
+                    Access::Module,
+                ));
+                None
+            }
+            NR::ModuleAccess(_, _) => {
+                context.env.add_diag(unexpected_access_error(
+                    resolved_name.loc(),
+                    "module member".to_string(),
+                    Access::Module,
+                ));
+                None
+            }
+            result @ NR::ResolutionFailure(_, _) => {
+                context.env.add_diag(access_chain_resolution_error(result));
+                None
+            }
+        }
+    }
+}
+
+impl AccessChainNameResult {
+    fn loc(&self) -> Loc {
+        match self {
+            AccessChainNameResult::ModuleAccess(loc, _) => *loc,
+            AccessChainNameResult::Address(loc, _) => *loc,
+            AccessChainNameResult::ModuleIdent(loc, _) => *loc,
+            AccessChainNameResult::UnresolvedName(loc, _) => *loc,
+            AccessChainNameResult::ResolutionFailure(inner, _) => inner.loc(),
+        }
+    }
+
+    fn err_name(&self) -> String {
+        match self {
+            AccessChainNameResult::ModuleAccess(_, _) => "a module member".to_string(),
+            AccessChainNameResult::ModuleIdent(_, _) => "a module".to_string(),
+            AccessChainNameResult::UnresolvedName(_, _) => "a name".to_string(),
+            AccessChainNameResult::Address(_, _) => "an address".to_string(),
+            AccessChainNameResult::ResolutionFailure(inner, _) => inner.err_name(),
+        }
+    }
+}
+
+fn unexpected_access_error(loc: Loc, result: String, access: Access) -> Diagnostic {
+    let case = match access {
+        Access::Type | Access::ApplyNamed => "type",
+        Access::ApplyPositional => "expression",
+        Access::Term => "expression",
+        Access::Module => "module",
+    };
+    let unexpected_msg = if result.starts_with('a') {
+        format!(
+            "Unexpected {0} identifier. An {0} identifier is not a valid {1}",
+            result, case
+        )
+    } else {
+        format!(
+            "Unexpected {0} identifier. A {0} identifier is not a valid {1}",
+            result, case
+        )
+    };
+    diag!(NameResolution::NamePositionMismatch, (loc, unexpected_msg),)
+}
+
+fn unbound_module_error(name: Name) -> Diagnostic {
+    diag!(
+        NameResolution::UnboundModule,
+        (name.loc, format!("Unbound module alias '{}'", name))
+    )
+}
+
+fn access_chain_resolution_error(result: AccessChainNameResult) -> Diagnostic {
+    if let AccessChainNameResult::ResolutionFailure(inner, reason) = result {
+        let loc = inner.loc();
+        let msg = match reason {
+            AccessChainFailure::InvalidKind(kind) => format!(
+                "Expected {} in this position, not {}",
+                kind,
+                inner.err_name()
+            ),
+            AccessChainFailure::UnresolvedAlias(name) => {
+                format!("Could not resolve the name '{}'", name)
+            }
+        };
+        diag!(NameResolution::NamePositionMismatch, (loc, msg))
+    } else {
+        ice!((
+            result.loc(),
+            "ICE compiler miscalled access chain resolution error handler"
+        ))
+    }
+}
+
+//**************************************************************************************************
+// Legacy Path Expander
+//**************************************************************************************************
+
+pub struct LegacyPathExpander {
+    aliases: legacy_aliases::AliasMap,
+    old_alias_maps: Vec<legacy_aliases::OldAliasMap>,
+}
+
+impl LegacyPathExpander {
+    pub fn new() -> LegacyPathExpander {
+        LegacyPathExpander {
+            aliases: legacy_aliases::AliasMap::new(),
+            old_alias_maps: vec![],
+        }
+    }
+}
+
+impl PathExpander for LegacyPathExpander {
+    fn push_alias_scope(
+        &mut self,
+        loc: Loc,
+        new_scope: AliasMapBuilder,
+    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>> {
+        self.old_alias_maps
+            .push(self.aliases.add_and_shadow_all(loc, new_scope)?);
+        Ok(vec![])
+    }
+
+    fn push_type_parameters(&mut self, tparams: Vec<&Name>) {
+        self.old_alias_maps
+            .push(self.aliases.shadow_for_type_parameters(tparams));
+    }
+
+    fn pop_alias_scope(&mut self) -> AliasSet {
+        if let Some(outer_scope) = self.old_alias_maps.pop() {
+            self.aliases.set_to_outer_scope(outer_scope)
+        } else {
+            AliasSet::new()
+        }
+    }
+
+    fn name_access_chain_to_attribute_value(
+        &mut self,
+        context: &mut DefnContext,
+        sp!(loc, avalue_): P::AttributeValue,
+    ) -> Option<E::AttributeValue> {
+        use E::AttributeValue_ as EV;
+        use P::{AttributeValue_ as PV, LeadingNameAccess_ as LN, NameAccessChain_ as PN};
+        Some(sp(
+            loc,
+            match avalue_ {
+                PV::Value(v) => EV::Value(value(context, v)?),
+                // bit wonky, but this is the only spot currently where modules and expressions
+                // exist in the same namespace.
+                // TODO: consider if we want to just force all of these checks into the well-known
+                // attribute setup
+                PV::ModuleAccess(sp!(ident_loc, single_entry!(name, tyargs, is_macro)))
+                    if self.aliases.module_alias_get(&name).is_some() =>
+                {
+                    ice_assert!(context.env, tyargs.is_none(), loc, "Found tyargs");
+                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
+                    let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
+                    let mident = sp(ident_loc, mident_);
+                    if context.module_members.get(&mident).is_none() {
+                        context.env.add_diag(diag!(
+                            NameResolution::UnboundModule,
+                            (ident_loc, format!("Unbound module '{}'", mident))
+                        ));
+                    }
+                    EV::Module(mident)
+                }
+                PV::ModuleAccess(sp!(ident_loc, PN::Path(path))) => {
+                    ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
+                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                    match (&path.root.name, &path.entries[..]) {
+                        (sp!(aloc, LN::AnonymousAddress(a)), [n]) => {
+                            let addr = Address::anonymous(*aloc, *a);
+                            let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n.name)));
+                            if context.module_members.get(&mident).is_none() {
+                                context.env.add_diag(diag!(
+                                    NameResolution::UnboundModule,
+                                    (ident_loc, format!("Unbound module '{}'", mident))
+                                ));
+                            }
+                            EV::Module(mident)
+                        }
+                        (sp!(aloc, LN::GlobalAddress(n1) | LN::Name(n1)), [n2])
+                            if context
+                                .named_address_mapping
+                                .as_ref()
+                                .map(|m| m.contains_key(&n1.value))
+                                .unwrap_or(false) =>
+                        {
+                            let addr = top_level_address(
+                                context,
+                                /* suggest_declaration */ false,
+                                sp(*aloc, LN::Name(*n1)),
+                            );
+                            let mident =
+                                sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
+                            if context.module_members.get(&mident).is_none() {
+                                context.env.add_diag(diag!(
+                                    NameResolution::UnboundModule,
+                                    (ident_loc, format!("Unbound module '{}'", mident))
+                                ));
+                            }
+                            EV::Module(mident)
+                        }
+                        _ => EV::ModuleAccess(
+                            self.name_access_chain_to_module_access(
+                                context,
+                                Access::Type,
+                                sp(ident_loc, PN::Path(path)),
+                            )?
+                            .access,
+                        ),
+                    }
+                }
+                PV::ModuleAccess(ma) => EV::ModuleAccess(
+                    self.name_access_chain_to_module_access(context, Access::Type, ma)?
+                        .access,
+                ),
+            },
+        ))
+    }
+
+    fn name_access_chain_to_module_access(
+        &mut self,
+        context: &mut DefnContext,
+        access: Access,
+        sp!(loc, ptn_): P::NameAccessChain,
+    ) -> Option<ModuleAccessResult> {
+        use E::ModuleAccess_ as EN;
+        use P::{LeadingNameAccess_ as LN, NameAccessChain_ as PN};
+
+        let tn_: ModuleAccessResult = match (access, ptn_) {
+            (
+                Access::ApplyPositional | Access::ApplyNamed | Access::Type,
+                single_entry!(name, tyargs, is_macro),
+            ) => {
+                if access == Access::Type {
+                    ice_assert!(context.env, is_macro.is_none(), loc, "Found macro");
+                }
+                let access = match self.aliases.member_alias_get(&name) {
+                    Some((mident, mem)) => EN::ModuleAccess(mident, mem),
+                    None => EN::Name(name),
+                };
+                make_access_result(sp(name.loc, access), tyargs, is_macro)
+            }
+            (Access::Term, single_entry!(name, tyargs, is_macro))
+                if is_valid_struct_or_constant_name(name.value.as_str()) =>
+            {
+                let access = match self.aliases.member_alias_get(&name) {
+                    Some((mident, mem)) => EN::ModuleAccess(mident, mem),
+                    None => EN::Name(name),
+                };
+                make_access_result(sp(name.loc, access), tyargs, is_macro)
+            }
+            (Access::Term, single_entry!(name, tyargs, is_macro)) => {
+                make_access_result(sp(name.loc, EN::Name(name)), tyargs, is_macro)
+            }
+            (Access::Module, single_entry!(_name, _tyargs, _is_macro)) => {
+                context.env.add_diag(ice!((
+                    loc,
+                    "ICE path resolution produced an impossible path for a module"
+                )));
+                return None;
+            }
+            (_, PN::Path(mut path)) => {
+                if access == Access::Type {
+                    ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                }
+                match (&path.root.name, &path.entries[..]) {
+                    // Error cases
+                    (sp!(aloc, LN::AnonymousAddress(_)), [_]) => {
+                        let diag = unexpected_address_module_error(loc, *aloc, access);
+                        context.env.add_diag(diag);
+                        return None;
+                    }
+                    (sp!(_aloc, LN::GlobalAddress(_)), [_]) => {
+                        let mut diag: Diagnostic = create_feature_error(
+                            context.env.edition(None), // We already know we are failing, so no package.
+                            FeatureGate::Move2024Paths,
+                            loc,
+                        );
+                        diag.add_secondary_label((
+                            loc,
+                            "Paths that start with `::` are not valid in legacy move.",
+                        ));
+                        context.env.add_diag(diag);
+                        return None;
+                    }
+                    // Others
+                    (sp!(_, LN::Name(n1)), [n2]) => match self.aliases.module_alias_get(n1) {
+                        None => {
+                            context.env.add_diag(diag!(
+                                NameResolution::UnboundModule,
+                                (n1.loc, format!("Unbound module alias '{}'", n1))
+                            ));
+                            return None;
+                        }
+                        Some(mident) => {
+                            let n2_name = n2.name.clone();
+                            let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
+                                let mut diag = diag!(
+                                    Syntax::InvalidName,
+                                    (path.tyargs_loc().unwrap(), "Invalid type argument position")
+                                );
+                                diag.add_note(
+                                    "Diagnostics must appear at the end of a name access path",
+                                );
+                                context.env.add_diag(diag);
+                                (None, path.is_macro())
+                            } else {
+                                (path.take_tyargs(), path.is_macro())
+                            };
+                            make_access_result(
+                                sp(loc, EN::ModuleAccess(mident, n2_name)),
+                                tyargs,
+                                is_macro.copied(),
+                            )
+                        }
+                    },
+                    (ln, [n2, n3]) => {
+                        let ident_loc = make_loc(
+                            ln.loc.file_hash(),
+                            ln.loc.start() as usize,
+                            n2.name.loc.end() as usize,
+                        );
+                        let addr =
+                            top_level_address(context, /* suggest_declaration */ false, *ln);
+                        let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
+                        let access = EN::ModuleAccess(mident, n3.name);
+                        let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
+                            let mut diag = diag!(
+                                Syntax::InvalidName,
+                                (path.tyargs_loc().unwrap(), "Invalid type argument position")
+                            );
+                            diag.add_note(
+                                "Diagnostics must appear at the end of a name access path",
+                            );
+                            context.env.add_diag(diag);
+                            (None, path.is_macro())
+                        } else {
+                            (path.take_tyargs(), path.is_macro())
+                        };
+                        make_access_result(sp(loc, access), tyargs, is_macro.copied())
+                    }
+                    _ if path.entries.len() > 2 => {
+                        let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
+                        diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
+                        context.env.add_diag(diag);
+                        return None;
+                    }
+                    _ => {
+                        let diag = diag!(
+                            Syntax::InvalidName,
+                            (loc, "This name has an unexpected format")
+                        );
+                        context.env.add_diag(diag);
+                        return None;
+                    }
+                }
+            }
+        };
+        Some(tn_)
+    }
+
+    fn name_access_chain_to_module_ident(
+        &mut self,
+        context: &mut DefnContext,
+        sp!(loc, pn_): P::NameAccessChain,
+    ) -> Option<E::ModuleIdent> {
+        use P::NameAccessChain_ as PN;
+        match pn_ {
+            PN::Single(single) => {
+                ice_assert!(context.env, single.tyargs.is_none(), loc, "Found tyargs");
+                ice_assert!(context.env, single.is_macro.is_none(), loc, "Found macro");
+                match self.aliases.module_alias_get(&single.name) {
+                    None => {
+                        context.env.add_diag(diag!(
+                            NameResolution::UnboundModule,
+                            (
+                                single.name.loc,
+                                format!("Unbound module alias '{}'", single.name)
+                            ),
+                        ));
+                        None
+                    }
+                    Some(mident) => Some(mident),
+                }
+            }
+            PN::Path(path) => {
+                ice_assert!(context.env, !path.has_tyargs(), loc, "Found tyargs");
+                ice_assert!(context.env, path.is_macro().is_none(), loc, "Found macro");
+                match (&path.root.name, &path.entries[..]) {
+                    (ln, [n]) => {
+                        let pmident_ = P::ModuleIdent_ {
+                            address: *ln,
+                            module: ModuleName(n.name),
+                        };
+                        Some(module_ident(context, sp(loc, pmident_)))
+                    }
+                    // Error cases
+                    (_ln, []) => {
+                        context
+                            .env
+                            .add_diag(ice!((loc, "Found path with no path entries")));
+                        None
+                    }
+                    (ln, [n, m, ..]) => {
+                        let ident_loc = make_loc(
+                            ln.loc.file_hash(),
+                            ln.loc.start() as usize,
+                            n.name.loc.end() as usize,
+                        );
+                        // Process the module ident just for errors
+                        let pmident_ = P::ModuleIdent_ {
+                            address: *ln,
+                            module: ModuleName(n.name),
+                        };
+                        let _ = module_ident(context, sp(ident_loc, pmident_));
+                        context.env.add_diag(diag!(
+                            NameResolution::NamePositionMismatch,
+                                if path.entries.len() < 3 {
+                                    (m.name.loc, "Unexpected module member access. Expected a module identifier only")
+                                } else {
+                                    (loc, "Unexpected access. Expected a module identifier only")
+                                }
+                        ));
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn unexpected_address_module_error(loc: Loc, nloc: Loc, access: Access) -> Diagnostic {
+    let case = match access {
+        Access::Type | Access::ApplyNamed | Access::ApplyPositional => "type",
+        Access::Term => "expression",
+        Access::Module => {
+            return ice!(
+                (
+                    loc,
+                    "ICE expected a module name and got one, but tried to report an error"
+                ),
+                (nloc, "Name location")
+            )
+        }
+    };
+    let unexpected_msg = format!(
+        "Unexpected module identifier. A module identifier is not a valid {}",
+        case
+    );
+    diag!(
+        NameResolution::NamePositionMismatch,
+        (loc, unexpected_msg),
+        (nloc, "Expected a module name".to_owned()),
+    )
+}

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -979,9 +979,7 @@ impl PathExpander for LegacyPathExpander {
                                 Syntax::InvalidName,
                                 (path.tyargs_loc().unwrap(), "Invalid type argument position")
                             );
-                            diag.add_note(
-                                "Type arguments may only be used with module members",
-                            );
+                            diag.add_note("Type arguments may only be used with module members");
                             context.env.add_diag(diag);
                             (None, path.is_macro())
                         } else {
@@ -990,9 +988,7 @@ impl PathExpander for LegacyPathExpander {
                         make_access_result(sp(loc, access), tyargs, is_macro.copied())
                     }
                     (_ln, []) => {
-                        let diag = ice!(
-                            (loc, "Found a root path with no additional entries")
-                        );
+                        let diag = ice!((loc, "Found a root path with no additional entries"));
                         context.env.add_diag(diag);
                         return None;
                     }

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -943,7 +943,7 @@ impl PathExpander for LegacyPathExpander {
                             return None;
                         }
                         Some(mident) => {
-                            let n2_name = n2.name.clone();
+                            let n2_name = n2.name;
                             let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
                                 let mut diag = diag!(
                                     Syntax::InvalidName,

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -8,11 +8,9 @@ use crate::{
     diagnostics::Diagnostic,
     editions::{create_feature_error, Edition, FeatureGate},
     expansion::{
-        alias_map_builder::{
-            AliasEntry, AliasMapBuilder, NameSpace, ParserExplicitUseFun, UseFunsBuilder,
-        },
+        alias_map_builder::{AliasEntry, AliasMapBuilder, NameSpace},
         aliases::{AliasMap, AliasSet},
-        ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_},
+        ast::{self as E, Address, ModuleIdent_},
         legacy_aliases,
         translate::{
             is_valid_struct_or_constant_name, make_address, module_ident, top_level_address,
@@ -21,28 +19,13 @@ use crate::{
     },
     ice, ice_assert,
     parser::{
-        ast::{
-            self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
-            ModuleName, NameAccess, NamePath, PathEntry, RootPathEntry, StructName, Type, Var,
-            ENTRY_MODIFIER, MACRO_MODIFIER, NATIVE_MODIFIER,
-        },
+        ast::{self as P, ModuleName, NameAccess, NamePath, PathEntry, Type},
         syntax::make_loc,
     },
-    shared::{known_attributes::AttributePosition, unique_map::UniqueMap, *},
-    FullyCompiledProgram,
-};
-use move_command_line_common::parser::{parse_u16, parse_u256, parse_u32};
-use move_core_types::account_address::AccountAddress;
-use move_ir_types::location::*;
-use move_proc_macros::growing_stack;
-use move_symbol_pool::Symbol;
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    iter::IntoIterator,
-    sync::Arc,
+    shared::*,
 };
 
-use self::known_attributes::DiagnosticAttribute;
+use move_ir_types::location::*;
 
 //**************************************************************************************************
 // Definitions
@@ -376,7 +359,8 @@ impl Move2024PathExpander {
                     // the error.
                     result @ NR::ModuleIdent(_, _)
                         if entries.len() == 2
-                            && context.env.edition(context.current_package) == Edition::E2024_MIGRATION
+                            && context.env.edition(context.current_package)
+                                == Edition::E2024_MIGRATION
                             && root.is_macro.is_none()
                             && root.tyargs.is_none() =>
                     {

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -950,7 +950,7 @@ impl PathExpander for LegacyPathExpander {
                                     (path.tyargs_loc().unwrap(), "Invalid type argument position")
                                 );
                                 diag.add_note(
-                                    "Diagnostics must appear at the end of a name access path",
+                                    "Type arguments may only be used with module members",
                                 );
                                 context.env.add_diag(diag);
                                 (None, path.is_macro())
@@ -980,7 +980,7 @@ impl PathExpander for LegacyPathExpander {
                                 (path.tyargs_loc().unwrap(), "Invalid type argument position")
                             );
                             diag.add_note(
-                                "Diagnostics must appear at the end of a name access path",
+                                "Type arguments may only be used with module members",
                             );
                             context.env.add_diag(diag);
                             (None, path.is_macro())
@@ -989,17 +989,16 @@ impl PathExpander for LegacyPathExpander {
                         };
                         make_access_result(sp(loc, access), tyargs, is_macro.copied())
                     }
-                    _ if path.entries.len() > 2 => {
-                        let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
-                        diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
+                    (_ln, []) => {
+                        let diag = ice!(
+                            (loc, "Found a root path with no additional entries")
+                        );
                         context.env.add_diag(diag);
                         return None;
                     }
-                    _ => {
-                        let diag = diag!(
-                            Syntax::InvalidName,
-                            (loc, "This name has an unexpected format")
-                        );
+                    (_ln, [_n1, _n2, ..]) => {
+                        let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
+                        diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
                         context.env.add_diag(diag);
                         return None;
                     }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -2186,7 +2186,7 @@ fn types(context: &mut Context, pts: Vec<P::Type>) -> Vec<E::Type> {
 fn sp_types(context: &mut Context, pts_opt: Option<Spanned<Vec<P::Type>>>) -> Vec<E::Type> {
     pts_opt
         .map(|pts| pts.value.into_iter().map(|pt| type_(context, pt)).collect())
-        .unwrap_or(vec![])
+        .unwrap_or_default()
 }
 
 fn optional_sp_types(

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -15,11 +15,18 @@ use crate::{
         ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_},
         byte_string, hex_string, legacy_aliases,
         translate::known_attributes::{DiagnosticAttribute, KnownAttribute},
+        path_expander::{
+            access_result, Access, LegacyPathExpander, Move2024PathExpander, ModuleAccessResult, PathExpander,
+        },
     },
-    ice,
-    parser::ast::{
-        self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
-        ModuleName, StructName, Var, ENTRY_MODIFIER, MACRO_MODIFIER, NATIVE_MODIFIER,
+    ice, ice_assert,
+    parser::{
+        ast::{
+            self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
+            ModuleName, NameAccess, NamePath, StructName, Var, ENTRY_MODIFIER, MACRO_MODIFIER,
+            NATIVE_MODIFIER,
+        },
+        syntax::make_loc,
     },
     shared::{known_attributes::AttributePosition, unique_map::UniqueMap, *},
     FullyCompiledProgram,
@@ -46,12 +53,12 @@ type ModuleMembers = BTreeMap<Name, ModuleMemberKind>;
 // majority of the pass while swapping out how we handle paths and aliases for Move 2024 versus
 // legacy.
 
-struct DefnContext<'env, 'map> {
-    named_address_mapping: Option<&'map NamedAddressMap>,
-    module_members: UniqueMap<ModuleIdent, ModuleMembers>,
-    env: &'env mut CompilationEnv,
-    address_conflicts: BTreeSet<Symbol>,
-    current_package: Option<Symbol>,
+pub(super) struct DefnContext<'env, 'map> {
+    pub(super) named_address_mapping: Option<&'map NamedAddressMap>,
+    pub(super) module_members: UniqueMap<ModuleIdent, ModuleMembers>,
+    pub(super) env: &'env mut CompilationEnv,
+    pub(super) address_conflicts: BTreeSet<Symbol>,
+    pub(super) current_package: Option<Symbol>,
 }
 
 struct Context<'env, 'map> {
@@ -185,7 +192,7 @@ impl<'env, 'map> Context<'env, 'map> {
         &mut self,
         access: Access,
         chain: P::NameAccessChain,
-    ) -> Option<E::ModuleAccess> {
+    ) -> Option<ModuleAccessResult> {
         let Context {
             path_expander,
             defn_context: inner_context,
@@ -582,7 +589,7 @@ fn definition(
 }
 
 // Access a top level address as declared, not affected by any aliasing/shadowing
-fn top_level_address(
+pub(super) fn top_level_address(
     context: &mut DefnContext,
     suggest_declaration: bool,
     ln: P::LeadingNameAccess,
@@ -635,7 +642,10 @@ fn top_level_address_(
     }
 }
 
-fn top_level_address_opt(context: &mut DefnContext, ln: P::LeadingNameAccess) -> Option<Address> {
+pub(super) fn top_level_address_opt(
+    context: &mut DefnContext,
+    ln: P::LeadingNameAccess,
+) -> Option<Address> {
     let name_res = check_valid_address_name(context, &ln);
     let named_address_mapping = context.named_address_mapping.as_ref().unwrap();
     let sp!(loc, ln_) = ln;
@@ -682,7 +692,7 @@ fn address_without_value_error(suggest_declaration: bool, loc: Loc, n: &Name) ->
     diag!(NameResolution::AddressWithoutValue, (loc, msg))
 }
 
-fn make_address(
+pub(super) fn make_address(
     context: &mut DefnContext,
     name: Name,
     loc: Loc,
@@ -695,7 +705,10 @@ fn make_address(
     }
 }
 
-fn module_ident(context: &mut DefnContext, sp!(loc, mident_): P::ModuleIdent) -> ModuleIdent {
+pub(super) fn module_ident(
+    context: &mut DefnContext,
+    sp!(loc, mident_): P::ModuleIdent,
+) -> ModuleIdent {
     let P::ModuleIdent_ {
         address: ln,
         module,
@@ -1313,822 +1326,6 @@ fn prefixed_warning_filters(
 }
 
 //**************************************************************************************************
-// Name Access Chain (Path) Resolution
-//**************************************************************************************************
-
-#[derive(Clone, Copy)]
-enum Access {
-    Type,
-    ApplyNamed,
-    ApplyPositional,
-    Term,
-    Module, // Just used for errors
-}
-
-// This trait describes the commands available to handle alias scopes and expanding name access
-// chains. This is used to model both legacy and modern path expansion.
-
-trait PathExpander {
-    // Push a new innermost alias scope
-    fn push_alias_scope(
-        &mut self,
-        loc: Loc,
-        new_scope: AliasMapBuilder,
-    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>>;
-
-    // Push a number of type parameters onto the alias information in the path expander. They are
-    // never resolved, but are tracked to apply appropriate shadowing.
-    fn push_type_parameters(&mut self, tparams: Vec<&Name>);
-
-    // Pop the innermost alias scope
-    fn pop_alias_scope(&mut self) -> AliasSet;
-
-    fn name_access_chain_to_attribute_value(
-        &mut self,
-        context: &mut DefnContext,
-        attribute_value: P::AttributeValue,
-    ) -> Option<E::AttributeValue>;
-
-    fn name_access_chain_to_module_access(
-        &mut self,
-        context: &mut DefnContext,
-        access: Access,
-        name_chain: P::NameAccessChain,
-    ) -> Option<E::ModuleAccess>;
-
-    fn name_access_chain_to_module_ident(
-        &mut self,
-        context: &mut DefnContext,
-        name_chain: P::NameAccessChain,
-    ) -> Option<E::ModuleIdent>;
-}
-
-// -----------------------------------------------
-// Legacy Implementation
-
-struct LegacyPathExpander {
-    aliases: legacy_aliases::AliasMap,
-    old_alias_maps: Vec<legacy_aliases::OldAliasMap>,
-}
-
-impl LegacyPathExpander {
-    fn new() -> LegacyPathExpander {
-        LegacyPathExpander {
-            aliases: legacy_aliases::AliasMap::new(),
-            old_alias_maps: vec![],
-        }
-    }
-}
-
-impl PathExpander for LegacyPathExpander {
-    fn push_alias_scope(
-        &mut self,
-        loc: Loc,
-        new_scope: AliasMapBuilder,
-    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>> {
-        self.old_alias_maps
-            .push(self.aliases.add_and_shadow_all(loc, new_scope)?);
-        Ok(vec![])
-    }
-
-    fn push_type_parameters(&mut self, tparams: Vec<&Name>) {
-        self.old_alias_maps
-            .push(self.aliases.shadow_for_type_parameters(tparams));
-    }
-
-    fn pop_alias_scope(&mut self) -> AliasSet {
-        if let Some(outer_scope) = self.old_alias_maps.pop() {
-            self.aliases.set_to_outer_scope(outer_scope)
-        } else {
-            AliasSet::new()
-        }
-    }
-
-    fn name_access_chain_to_attribute_value(
-        &mut self,
-        context: &mut DefnContext,
-        sp!(loc, avalue_): P::AttributeValue,
-    ) -> Option<E::AttributeValue> {
-        use E::AttributeValue_ as EV;
-        use P::{AttributeValue_ as PV, LeadingNameAccess_ as LN, NameAccessChain_ as PN};
-        Some(sp(
-            loc,
-            match avalue_ {
-                PV::Value(v) => EV::Value(value(context, v)?),
-                PV::ModuleAccess(
-                    sp!(ident_loc, PN::Two(sp!(aloc, LN::AnonymousAddress(a)), n)),
-                ) => {
-                    let addr = Address::anonymous(aloc, a);
-                    let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n)));
-                    if context.module_members.get(&mident).is_none() {
-                        context.env.add_diag(diag!(
-                            NameResolution::UnboundModule,
-                            (ident_loc, format!("Unbound module '{}'", mident))
-                        ));
-                    }
-                    EV::Module(mident)
-                }
-                // bit wonky, but this is the only spot currently where modules and expressions exist
-                // in the same namespace.
-                // TODO consider if we want to just force all of these checks into the well-known
-                // attribute setup
-                PV::ModuleAccess(sp!(ident_loc, PN::One(n)))
-                    if self.aliases.module_alias_get(&n).is_some() =>
-                {
-                    let sp!(_, mident_) = self.aliases.module_alias_get(&n).unwrap();
-                    let mident = sp(ident_loc, mident_);
-                    if context.module_members.get(&mident).is_none() {
-                        context.env.add_diag(diag!(
-                            NameResolution::UnboundModule,
-                            (ident_loc, format!("Unbound module '{}'", mident))
-                        ));
-                    }
-                    EV::Module(mident)
-                }
-                PV::ModuleAccess(sp!(ident_loc, PN::Two(sp!(aloc, LN::Name(n1)), n2)))
-                    if context
-                        .named_address_mapping
-                        .as_ref()
-                        .map(|m| m.contains_key(&n1.value))
-                        .unwrap_or(false) =>
-                {
-                    let addr = top_level_address(
-                        context,
-                        /* suggest_declaration */ false,
-                        sp(aloc, LN::Name(n1)),
-                    );
-                    let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2)));
-                    if context.module_members.get(&mident).is_none() {
-                        context.env.add_diag(diag!(
-                            NameResolution::UnboundModule,
-                            (ident_loc, format!("Unbound module '{}'", mident))
-                        ));
-                    }
-                    EV::Module(mident)
-                }
-                PV::ModuleAccess(ma) => EV::ModuleAccess(self.name_access_chain_to_module_access(
-                    context,
-                    Access::Type,
-                    ma,
-                )?),
-            },
-        ))
-    }
-
-    fn name_access_chain_to_module_access(
-        &mut self,
-        context: &mut DefnContext,
-        access: Access,
-        sp!(loc, ptn_): P::NameAccessChain,
-    ) -> Option<E::ModuleAccess> {
-        use E::ModuleAccess_ as EN;
-        use P::{LeadingNameAccess_ as LN, NameAccessChain_ as PN};
-
-        let tn_ = match (access, ptn_) {
-            (Access::ApplyPositional, PN::One(n))
-            | (Access::ApplyNamed, PN::One(n))
-            | (Access::Type, PN::One(n)) => match self.aliases.member_alias_get(&n) {
-                Some((mident, mem)) => EN::ModuleAccess(mident, mem),
-                None => EN::Name(n),
-            },
-            (Access::Term, PN::One(n)) if is_valid_struct_or_constant_name(n.value.as_str()) => {
-                match self.aliases.member_alias_get(&n) {
-                    Some((mident, mem)) => EN::ModuleAccess(mident, mem),
-                    None => EN::Name(n),
-                }
-            }
-            (Access::Term, PN::One(n)) => EN::Name(n),
-            (Access::Module, PN::One(_n)) => {
-                context.env.add_diag(ice!((
-                    loc,
-                    "ICE path resolution produced an impossible path for a module"
-                )));
-                return None;
-            }
-            (_, PN::Two(sp!(nloc, LN::AnonymousAddress(_)), _)) => {
-                let diag = unexpected_address_module_error(loc, nloc, access);
-                context.env.add_diag(diag);
-                return None;
-            }
-
-            (_, PN::Two(sp!(_, LN::Name(n1)), n2)) => match self.aliases.module_alias_get(&n1) {
-                None => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundModule,
-                        (n1.loc, format!("Unbound module alias '{}'", n1))
-                    ));
-                    return None;
-                }
-                Some(mident) => EN::ModuleAccess(mident, n2),
-            },
-            (_, PN::Two(sp!(eloc, LN::GlobalAddress(_)), _)) => {
-                let mut diag: Diagnostic = create_feature_error(
-                    context.env.edition(None), // We already know we are failing, so no package.
-                    FeatureGate::Move2024Paths,
-                    eloc,
-                );
-                diag.add_secondary_label((
-                    eloc,
-                    "Paths that start with `::` are not valid in legacy move.",
-                ));
-                context.env.add_diag(diag);
-                return None;
-            }
-            (_, PN::Three(sp!(ident_loc, (ln, n2)), n3)) => {
-                let addr = top_level_address(context, /* suggest_declaration */ false, ln);
-                let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2)));
-                EN::ModuleAccess(mident, n3)
-            }
-        };
-        Some(sp(loc, tn_))
-    }
-
-    fn name_access_chain_to_module_ident(
-        &mut self,
-        context: &mut DefnContext,
-        sp!(loc, pn_): P::NameAccessChain,
-    ) -> Option<E::ModuleIdent> {
-        use P::NameAccessChain_ as PN;
-        match pn_ {
-            PN::One(name) => match self.aliases.module_alias_get(&name) {
-                None => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundModule,
-                        (name.loc, format!("Unbound module alias '{}'", name)),
-                    ));
-                    None
-                }
-                Some(mident) => Some(mident),
-            },
-            PN::Two(ln, n) => {
-                let pmident_ = P::ModuleIdent_ {
-                    address: ln,
-                    module: ModuleName(n),
-                };
-                Some(module_ident(context, sp(loc, pmident_)))
-            }
-            PN::Three(sp!(ident_loc, (ln, n)), mem) => {
-                // Process the module ident just for errors
-                let pmident_ = P::ModuleIdent_ {
-                    address: ln,
-                    module: ModuleName(n),
-                };
-                let _ = module_ident(context, sp(ident_loc, pmident_));
-                context.env.add_diag(diag!(
-                    NameResolution::NamePositionMismatch,
-                    (
-                        mem.loc,
-                        "Unexpected module member access. Expected a module identifier only",
-                    )
-                ));
-                None
-            }
-        }
-    }
-}
-
-fn unexpected_address_module_error(loc: Loc, nloc: Loc, access: Access) -> Diagnostic {
-    let case = match access {
-        Access::Type | Access::ApplyNamed | Access::ApplyPositional => "type",
-        Access::Term => "expression",
-        Access::Module => {
-            return ice!(
-                (
-                    loc,
-                    "ICE expected a module name and got one, but tried to report an error"
-                ),
-                (nloc, "Name location")
-            )
-        }
-    };
-    let unexpected_msg = format!(
-        "Unexpected module identifier. A module identifier is not a valid {}",
-        case
-    );
-    diag!(
-        NameResolution::NamePositionMismatch,
-        (loc, unexpected_msg),
-        (nloc, "Expected a module name".to_owned()),
-    )
-}
-
-// -----------------------------------------------
-// Move 2024 Implementation
-
-struct Move2024PathExpander {
-    aliases: AliasMap,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum AccessChainResult {
-    ModuleAccess(Loc, E::ModuleAccess_),
-    Address(Loc, E::Address),
-    ModuleIdent(Loc, E::ModuleIdent),
-    UnresolvedName(Loc, Name),
-    ResolutionFailure(Box<AccessChainResult>, AccessChainFailure),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum AccessChainFailure {
-    UnresolvedAlias(Name),
-    InvalidKind(String),
-}
-
-impl Move2024PathExpander {
-    fn new() -> Move2024PathExpander {
-        Move2024PathExpander {
-            aliases: AliasMap::new(),
-        }
-    }
-
-    fn resolve_root(
-        &mut self,
-        context: &mut DefnContext,
-        sp!(loc, name): P::LeadingNameAccess,
-    ) -> AccessChainResult {
-        use AccessChainFailure::*;
-        use AccessChainResult::*;
-        use P::LeadingNameAccess_ as LN;
-        match name {
-            LN::AnonymousAddress(address) => Address(loc, E::Address::anonymous(loc, address)),
-            LN::GlobalAddress(name) => {
-                if let Some(address) = context
-                    .named_address_mapping
-                    .expect("ICE no named address mapping")
-                    .get(&name.value)
-                {
-                    Address(loc, make_address(context, name, name.loc, *address))
-                } else {
-                    ResolutionFailure(Box::new(UnresolvedName(loc, name)), UnresolvedAlias(name))
-                }
-            }
-            LN::Name(name) => match self.resolve_name(context, NameSpace::LeadingAccess, name) {
-                result @ UnresolvedName(_, _) => {
-                    ResolutionFailure(Box::new(result), UnresolvedAlias(name))
-                }
-                other => other,
-            },
-        }
-    }
-
-    fn resolve_name(
-        &mut self,
-        context: &mut DefnContext,
-        namespace: NameSpace,
-        name: Name,
-    ) -> AccessChainResult {
-        use AccessChainFailure::*;
-        use AccessChainResult::*;
-        use E::ModuleAccess_ as EN;
-
-        match self.aliases.resolve(namespace, &name) {
-            Some(AliasEntry::Member(_, mident, sp!(_, mem))) => {
-                // We are preserving the name's original location, rather than referring to where
-                // the alias was defined. The name represents JUST the member name, though, so we do
-                // not change location of the module as we don't have this information.
-                // TODO maybe we should also keep the alias reference (or its location)?
-                ModuleAccess(name.loc, EN::ModuleAccess(mident, sp(name.loc, mem)))
-            }
-            Some(AliasEntry::Module(_, mident)) => {
-                // We are preserving the name's original location, rather than referring to where
-                // the alias was defined. The name represents JUST the module name, though, so we do
-                // not change location of the address as we don't have this information.
-                // TODO maybe we should also keep the alias reference (or its location)?
-                let sp!(
-                    _,
-                    ModuleIdent_ {
-                        address,
-                        module: ModuleName(sp!(_, module))
-                    }
-                ) = mident;
-                let module = ModuleName(sp(name.loc, module));
-                ModuleIdent(name.loc, sp(name.loc, ModuleIdent_ { address, module }))
-            }
-            Some(AliasEntry::Address(_, address)) => {
-                Address(name.loc, make_address(context, name, name.loc, address))
-            }
-            Some(AliasEntry::TypeParam(_)) => {
-                context.env.add_diag(ice!((
-                    name.loc,
-                    "ICE alias map misresolved name as type param"
-                )));
-                UnresolvedName(name.loc, name)
-            }
-            None => {
-                if let Some(entry) = self.aliases.resolve_any_for_error(&name) {
-                    let msg = match namespace {
-                        NameSpace::ModuleMembers => "a type, function, or constant".to_string(),
-                        // we exclude types from this message since it would have been caught in
-                        // the other namespace
-                        NameSpace::LeadingAccess => "an address or module".to_string(),
-                    };
-                    let result = match entry {
-                        AliasEntry::Address(_, address) => {
-                            Address(name.loc, make_address(context, name, name.loc, address))
-                        }
-                        AliasEntry::Module(_, mident) => ModuleIdent(name.loc, mident),
-                        AliasEntry::Member(_, mident, mem) => {
-                            ModuleAccess(name.loc, EN::ModuleAccess(mident, mem))
-                        }
-                        AliasEntry::TypeParam(_) => {
-                            context.env.add_diag(ice!((
-                                name.loc,
-                                "ICE alias map misresolved name as type param"
-                            )));
-                            UnresolvedName(name.loc, name)
-                        }
-                    };
-                    ResolutionFailure(Box::new(result), InvalidKind(msg))
-                } else {
-                    UnresolvedName(name.loc, name)
-                }
-            }
-        }
-    }
-
-    fn resolve_name_access_chain(
-        &mut self,
-        context: &mut DefnContext,
-        access: Access,
-        sp!(loc, chain): P::NameAccessChain,
-    ) -> AccessChainResult {
-        use AccessChainFailure::*;
-        use AccessChainResult::*;
-        use E::ModuleAccess_ as EN;
-        use P::NameAccessChain_ as PN;
-
-        match chain {
-            PN::One(name) => {
-                use crate::naming::ast::BuiltinFunction_;
-                use crate::naming::ast::BuiltinTypeName_;
-                let namespace = match access {
-                    Access::Type | Access::ApplyNamed | Access::ApplyPositional | Access::Term => {
-                        NameSpace::ModuleMembers
-                    }
-                    Access::Module => NameSpace::LeadingAccess,
-                };
-
-                // This is a hack to let `use std::vector` play nicely with `vector`,
-                // plus preserve things like `u64`, etc.
-                if !matches!(access, Access::Module)
-                    && (BuiltinFunction_::all_names().contains(&name.value)
-                        || BuiltinTypeName_::all_names().contains(&name.value))
-                {
-                    AccessChainResult::UnresolvedName(name.loc, name)
-                } else {
-                    self.resolve_name(context, namespace, name)
-                }
-            }
-            PN::Two(root_name, name) => match self.resolve_root(context, root_name) {
-                Address(_, address) => {
-                    ModuleIdent(loc, sp(loc, ModuleIdent_::new(address, ModuleName(name))))
-                }
-                ModuleIdent(_, mident) => ModuleAccess(loc, EN::ModuleAccess(mident, name)),
-                result @ ModuleAccess(_, _) => ResolutionFailure(
-                    Box::new(result),
-                    InvalidKind("a module or address".to_string()),
-                ),
-                result @ ResolutionFailure(_, _) => result,
-                result @ UnresolvedName(_, _) => {
-                    context
-                        .env
-                        .add_diag(ice!((loc, "ICE access chain expansion failed")));
-                    result
-                }
-            },
-            PN::Three(sp!(ident_loc, (root_name, next_name)), last_name) => {
-                match self.resolve_root(context, root_name) {
-                    Address(_, address) => {
-                        let mident =
-                            sp(ident_loc, ModuleIdent_::new(address, ModuleName(next_name)));
-                        ModuleAccess(loc, EN::ModuleAccess(mident, last_name))
-                    }
-                    // In Move Legacy, we always treated three-place names as fully-qualified. For
-                    // migration mode, if we could have gotten the correct result doing so, we emit
-                    // a migration change to globally-qualify that path and remediate the error.
-                    result @ ModuleIdent(_, _)
-                        if context.env.edition(context.current_package)
-                            == Edition::E2024_MIGRATION =>
-                    {
-                        if let Some(address) = top_level_address_opt(context, root_name) {
-                            context.env.add_diag(diag!(
-                                Migration::NeedsGlobalQualification,
-                                (root_name.loc, "Must globally qualify name")
-                            ));
-                            let mident =
-                                sp(ident_loc, ModuleIdent_::new(address, ModuleName(next_name)));
-                            ModuleAccess(loc, EN::ModuleAccess(mident, last_name))
-                        } else {
-                            ResolutionFailure(
-                                Box::new(result),
-                                InvalidKind("an address".to_string()),
-                            )
-                        }
-                    }
-                    result @ (ModuleIdent(_, _) | ModuleAccess(_, _)) => {
-                        ResolutionFailure(Box::new(result), InvalidKind("an address".to_string()))
-                    }
-                    result @ ResolutionFailure(_, _) => result,
-                    result @ UnresolvedName(_, _) => {
-                        context
-                            .env
-                            .add_diag(ice!((loc, "ICE access chain expansion failed")));
-                        result
-                    }
-                }
-            }
-        }
-    }
-}
-
-impl PathExpander for Move2024PathExpander {
-    fn push_alias_scope(
-        &mut self,
-        loc: Loc,
-        new_scope: AliasMapBuilder,
-    ) -> Result<Vec<UnnecessaryAlias>, Box<Diagnostic>> {
-        self.aliases.push_alias_scope(loc, new_scope)
-    }
-
-    fn push_type_parameters(&mut self, tparams: Vec<&Name>) {
-        self.aliases.push_type_parameters(tparams)
-    }
-
-    fn pop_alias_scope(&mut self) -> AliasSet {
-        self.aliases.pop_scope()
-    }
-
-    fn name_access_chain_to_attribute_value(
-        &mut self,
-        context: &mut DefnContext,
-        sp!(loc, avalue_): P::AttributeValue,
-    ) -> Option<E::AttributeValue> {
-        use E::AttributeValue_ as EV;
-        use P::AttributeValue_ as PV;
-        Some(sp(
-            loc,
-            match avalue_ {
-                PV::Value(v) => EV::Value(value(context, v)?),
-                // A bit strange, but we try to resolve it as a term and a module, and report
-                // an error if they both resolve (to different things)
-                PV::ModuleAccess(access_chain) => {
-                    let term_result =
-                        self.resolve_name_access_chain(context, Access::Term, access_chain.clone());
-                    let module_result =
-                        self.resolve_name_access_chain(context, Access::Module, access_chain);
-                    let result = match (term_result, module_result) {
-                        (t_res, m_res) if t_res == m_res => t_res,
-                        (
-                            AccessChainResult::ResolutionFailure(_, _)
-                            | AccessChainResult::UnresolvedName(_, _),
-                            other,
-                        )
-                        | (
-                            other,
-                            AccessChainResult::ResolutionFailure(_, _)
-                            | AccessChainResult::UnresolvedName(_, _),
-                        ) => other,
-                        (t_res, m_res) => {
-                            let msg = format!(
-                                "Ambiguous attribute value. It can resolve to both {} and {}",
-                                t_res.err_name(),
-                                m_res.err_name()
-                            );
-                            context
-                                .env
-                                .add_diag(diag!(Attributes::AmbiguousAttributeValue, (loc, msg)));
-                            return None;
-                        }
-                    };
-                    match result {
-                        AccessChainResult::ModuleIdent(_, mident) => {
-                            if context.module_members.get(&mident).is_none() {
-                                context.env.add_diag(diag!(
-                                    NameResolution::UnboundModule,
-                                    (loc, format!("Unbound module '{}'", mident))
-                                ));
-                            }
-                            EV::Module(mident)
-                        }
-                        AccessChainResult::ModuleAccess(loc, access) => {
-                            EV::ModuleAccess(sp(loc, access))
-                        }
-                        AccessChainResult::UnresolvedName(loc, name) => {
-                            EV::ModuleAccess(sp(loc, E::ModuleAccess_::Name(name)))
-                        }
-                        AccessChainResult::Address(_, a) => EV::Address(a),
-                        result @ AccessChainResult::ResolutionFailure(_, _) => {
-                            context.env.add_diag(access_chain_resolution_error(result));
-                            return None;
-                        }
-                    }
-                }
-            },
-        ))
-    }
-
-    fn name_access_chain_to_module_access(
-        &mut self,
-        context: &mut DefnContext,
-        access: Access,
-        chain: P::NameAccessChain,
-    ) -> Option<E::ModuleAccess> {
-        use AccessChainResult::*;
-        use E::ModuleAccess_ as EN;
-        use P::NameAccessChain_ as PN;
-
-        let loc = chain.loc;
-
-        let module_access = match access {
-            Access::ApplyPositional | Access::ApplyNamed | Access::Type => {
-                let resolved_name = self.resolve_name_access_chain(context, access, chain.clone());
-                match resolved_name {
-                    UnresolvedName(_, name) => EN::Name(name),
-                    ModuleAccess(_, access) => access,
-                    Address(_, _) => {
-                        context.env.add_diag(unexpected_access_error(
-                            resolved_name.loc(),
-                            "address".to_string(),
-                            access,
-                        ));
-                        return None;
-                    }
-                    ModuleIdent(_, sp!(_, ModuleIdent_ { address, module })) => {
-                        let mut diag = unexpected_access_error(
-                            resolved_name.loc(),
-                            "module".to_string(),
-                            access,
-                        );
-                        let base_str = format!("{}", chain);
-                        let realized_str = format!("{}::{}", address, module);
-                        if base_str != realized_str {
-                            diag.add_note(format!(
-                                "Resolved '{}' to module identifier '{}'",
-                                base_str, realized_str
-                            ));
-                        }
-                        context.env.add_diag(diag);
-                        return None;
-                    }
-                    result @ ResolutionFailure(_, _) => {
-                        context.env.add_diag(access_chain_resolution_error(result));
-                        return None;
-                    }
-                }
-            }
-            Access::Term => match chain.value {
-                PN::One(name) if !is_valid_struct_or_constant_name(&name.to_string()) => {
-                    EN::Name(name)
-                }
-                _ => {
-                    let resolved_name = self.resolve_name_access_chain(context, access, chain);
-                    match resolved_name {
-                        UnresolvedName(_, name) => EN::Name(name),
-                        ModuleAccess(_, access) => access,
-                        Address(_, _) => {
-                            context.env.add_diag(unexpected_access_error(
-                                resolved_name.loc(),
-                                "address".to_string(),
-                                access,
-                            ));
-                            return None;
-                        }
-                        ModuleIdent(_, _) => {
-                            context.env.add_diag(unexpected_access_error(
-                                resolved_name.loc(),
-                                "module".to_string(),
-                                access,
-                            ));
-                            return None;
-                        }
-                        result @ ResolutionFailure(_, _) => {
-                            context.env.add_diag(access_chain_resolution_error(result));
-                            return None;
-                        }
-                    }
-                }
-            },
-            Access::Module => {
-                context.env.add_diag(ice!((
-                    loc,
-                    "ICE module access should never resolve to a module member"
-                )));
-                return None;
-            }
-        };
-        Some(sp(loc, module_access))
-    }
-
-    fn name_access_chain_to_module_ident(
-        &mut self,
-        context: &mut DefnContext,
-        chain: P::NameAccessChain,
-    ) -> Option<E::ModuleIdent> {
-        use AccessChainResult::*;
-        let resolved_name = self.resolve_name_access_chain(context, Access::Module, chain);
-        match resolved_name {
-            ModuleIdent(_, mident) => Some(mident),
-            UnresolvedName(_, name) => {
-                context.env.add_diag(unbound_module_error(name));
-                None
-            }
-            Address(_, _) => {
-                context.env.add_diag(unexpected_access_error(
-                    resolved_name.loc(),
-                    "address".to_string(),
-                    Access::Module,
-                ));
-                None
-            }
-            ModuleAccess(_, _) => {
-                context.env.add_diag(unexpected_access_error(
-                    resolved_name.loc(),
-                    "module member".to_string(),
-                    Access::Module,
-                ));
-                None
-            }
-            result @ ResolutionFailure(_, _) => {
-                context.env.add_diag(access_chain_resolution_error(result));
-                None
-            }
-        }
-    }
-}
-
-impl AccessChainResult {
-    fn loc(&self) -> Loc {
-        match self {
-            AccessChainResult::ModuleAccess(loc, _) => *loc,
-            AccessChainResult::Address(loc, _) => *loc,
-            AccessChainResult::ModuleIdent(loc, _) => *loc,
-            AccessChainResult::UnresolvedName(loc, _) => *loc,
-            AccessChainResult::ResolutionFailure(inner, _) => inner.loc(),
-        }
-    }
-
-    fn err_name(&self) -> String {
-        match self {
-            AccessChainResult::ModuleAccess(_, _) => "a module member".to_string(),
-            AccessChainResult::ModuleIdent(_, _) => "a module".to_string(),
-            AccessChainResult::UnresolvedName(_, _) => "a name".to_string(),
-            AccessChainResult::Address(_, _) => "an address".to_string(),
-            AccessChainResult::ResolutionFailure(inner, _) => inner.err_name(),
-        }
-    }
-}
-
-fn unexpected_access_error(loc: Loc, result: String, access: Access) -> Diagnostic {
-    let case = match access {
-        Access::Type | Access::ApplyNamed => "type",
-        Access::ApplyPositional => "expression",
-        Access::Term => "expression",
-        Access::Module => "module",
-    };
-    let unexpected_msg = if result.starts_with('a') {
-        format!(
-            "Unexpected {0} identifier. An {0} identifier is not a valid {1}",
-            result, case
-        )
-    } else {
-        format!(
-            "Unexpected {0} identifier. A {0} identifier is not a valid {1}",
-            result, case
-        )
-    };
-    diag!(NameResolution::NamePositionMismatch, (loc, unexpected_msg),)
-}
-
-fn unbound_module_error(name: Name) -> Diagnostic {
-    diag!(
-        NameResolution::UnboundModule,
-        (name.loc, format!("Unbound module alias '{}'", name))
-    )
-}
-
-fn access_chain_resolution_error(result: AccessChainResult) -> Diagnostic {
-    if let AccessChainResult::ResolutionFailure(inner, reason) = result {
-        let loc = inner.loc();
-        let msg = match reason {
-            AccessChainFailure::InvalidKind(kind) => format!(
-                "Expected {} in this position, not {}",
-                kind,
-                inner.err_name()
-            ),
-            AccessChainFailure::UnresolvedAlias(name) => {
-                format!("Could not resolve the name '{}'", name)
-            }
-        };
-        diag!(NameResolution::NamePositionMismatch, (loc, msg))
-    } else {
-        ice!((
-            result.loc(),
-            "ICE compiler miscalled access chain resolution error handler"
-        ))
-    }
-}
-
-//**************************************************************************************************
 // Aliases
 //**************************************************************************************************
 
@@ -2499,9 +1696,34 @@ fn explicit_use_fun(
         ty,
         method,
     } = pexplicit;
-    let function =
+    let access_result!(function, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::ApplyPositional, *function)?;
-    let ty = context.name_access_chain_to_module_access(Access::Type, *ty)?;
+    ice_assert!(
+        context.env(),
+        tyargs.is_none(),
+        loc,
+        "'use fun' with tyargs"
+    );
+    ice_assert!(
+        context.env(),
+        is_macro.is_none(),
+        loc,
+        "Found a 'use fun' as a macro"
+    );
+    let access_result!(ty, tyargs, is_macro) =
+        context.name_access_chain_to_module_access(Access::Type, *ty)?;
+    ice_assert!(
+        context.env(),
+        tyargs.is_none(),
+        loc,
+        "'use fun' with tyargs"
+    );
+    ice_assert!(
+        context.env(),
+        is_macro.is_none(),
+        loc,
+        "Found a 'use fun' as a macro"
+    );
     Some(E::ExplicitUseFun {
         loc,
         attributes,
@@ -2944,16 +2166,13 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
     let t_ = match pt_ {
         PT::Unit => ET::Unit,
         PT::Multiple(ts) => ET::Multiple(types(context, ts)),
-        PT::Apply(pn, ptyargs) => {
-            let tyargs = types(context, ptyargs);
-            match context.name_access_chain_to_module_access(Access::Type, *pn) {
-                None => {
-                    assert!(context.env().has_errors());
-                    ET::UnresolvedError
-                }
-                Some(n) => ET::Apply(n, tyargs),
+        PT::Apply(pn) => match context.name_access_chain_to_module_access(Access::Type, *pn) {
+            None => {
+                assert!(context.env().has_errors());
+                ET::UnresolvedError
             }
-        }
+            Some(access_result!(n, ptyargs, _)) => ET::Apply(n, sp_types(context, ptyargs)),
+        },
         PT::Ref(mut_, inner) => ET::Ref(mut_, Box::new(type_(context, *inner))),
         PT::Fun(args, result) => {
             let args = types(context, args);
@@ -2966,6 +2185,19 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
 
 fn types(context: &mut Context, pts: Vec<P::Type>) -> Vec<E::Type> {
     pts.into_iter().map(|pt| type_(context, pt)).collect()
+}
+
+fn sp_types(context: &mut Context, pts_opt: Option<Spanned<Vec<P::Type>>>) -> Vec<E::Type> {
+    pts_opt
+        .map(|pts| pts.value.into_iter().map(|pt| type_(context, pt)).collect())
+        .unwrap_or(vec![])
+}
+
+fn optional_sp_types(
+    context: &mut Context,
+    pts_opt: Option<Spanned<Vec<P::Type>>>,
+) -> Option<Vec<E::Type>> {
+    pts_opt.map(|pts| pts.value.into_iter().map(|pt| type_(context, pt)).collect())
 }
 
 fn optional_types(context: &mut Context, pts_opt: Option<Vec<P::Type>>) -> Option<Vec<E::Type>> {
@@ -3062,6 +2294,24 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
             }
         };
     }
+    macro_rules! bind_access_result {
+        ($rhs:expr => $lhs:pat in $body:expr ) => {
+            if let $lhs = $rhs {
+                $body
+            } else {
+                assert!(context.env().has_errors());
+                EE::UnresolvedError
+            }
+        };
+        ($rhs:expr => $lhs:pat in $body:block ) => {
+            if let $lhs = $rhs {
+                $body
+            } else {
+                assert!(context.env().has_errors());
+                EE::UnresolvedError
+            }
+        };
+    }
     let e_ = match pe_ {
         PE::Unit => EE::Unit { trailing: false },
         PE::Parens(pe) => {
@@ -3074,7 +2324,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
             }
         }
         PE::Value(pv) => unwrap_or_error_exp!(value(&mut context.defn_context, pv).map(EE::Value)),
-        PE::Name(_, Some(_)) => {
+        PE::Name(pn) if pn.value.has_tyargs() => {
             let msg = "Expected name to be followed by a brace-enclosed list of field expressions \
                 or a parenthesized list of arguments for a function call";
             context
@@ -3082,26 +2332,39 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
                 .add_diag(diag!(NameResolution::NamePositionMismatch, (loc, msg)));
             EE::UnresolvedError
         }
-        PE::Name(pn, ptys_opt) => {
-            let en_opt = context.name_access_chain_to_module_access(Access::Term, pn);
-            let tys_opt = optional_types(context, ptys_opt);
-            unwrap_or_error_exp!(en_opt.map(|en| EE::Name(en, tys_opt)))
+        PE::Name(pn) => {
+            bind_access_result!(
+                context.name_access_chain_to_module_access(Access::Term, pn) =>
+                    Some(access_result!(name, ptys_opt, is_macro)) in {
+                        assert!(ptys_opt.is_none());
+                        assert!(is_macro.is_none());
+                        EE::Name(name, None)
+                    }
+            )
         }
-        PE::Call(pn, is_macro, ptys_opt, sp!(rloc, prs)) => {
-            let tys_opt = optional_types(context, ptys_opt);
-            let ers = sp(rloc, exps(context, prs));
+        PE::Call(pn, sp!(rloc, prs)) => {
             let en_opt = context.name_access_chain_to_module_access(Access::ApplyPositional, pn);
-            unwrap_or_error_exp!(en_opt.map(|en| EE::Call(en, is_macro, tys_opt, ers)))
+            let ers = sp(rloc, exps(context, prs));
+            bind_access_result!(
+                en_opt =>
+                    Some(access_result!(name, ptys_opt, is_macro))
+                    in EE::Call(name, is_macro, optional_sp_types(context, ptys_opt), ers)
+            )
         }
-        PE::Pack(pn, ptys_opt, pfields) => {
+        PE::Pack(pn, pfields) => {
             let en_opt = context.name_access_chain_to_module_access(Access::ApplyNamed, pn);
-            let tys_opt = optional_types(context, ptys_opt);
             let efields_vec = pfields
                 .into_iter()
                 .map(|(f, pe)| (f, *exp(context, Box::new(pe))))
                 .collect();
             let efields = named_fields(context, loc, "construction", "argument", efields_vec);
-            unwrap_or_error_exp!(en_opt.map(|en| EE::Pack(en, tys_opt, efields)))
+            bind_access_result!(
+                en_opt =>
+                    Some(access_result!(name, ptys_opt, is_macro)) in {
+                        assert!(is_macro.is_none());
+                        EE::Pack(name, optional_sp_types(context, ptys_opt), efields)
+                    }
+            )
         }
         PE::Vector(vec_loc, ptys_opt, sp!(args_loc, pargs_)) => {
             let tys_opt = optional_types(context, ptys_opt);
@@ -3282,9 +2545,9 @@ fn exp_cast(context: &mut Context, in_parens: bool, plhs: Box<P::Exp>, pty: P::T
             PE::Value(_)
             | PE::Move(_, _)
             | PE::Copy(_, _)
-            | PE::Name(_, _)
-            | PE::Call(_, _, _, _)
-            | PE::Pack(_, _, _)
+            | PE::Name(_)
+            | PE::Call(_, _)
+            | PE::Pack(_, _)
             | PE::Vector(_, _, _)
             | PE::Block(_)
             | PE::ExpList(_)
@@ -3470,7 +2733,7 @@ fn exp_dotted(context: &mut Context, pdotted: Box<P::Exp>) -> Option<Box<E::ExpD
     Some(Box::new(sp(loc, edotted_)))
 }
 
-fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> Option<E::Value> {
+pub(super) fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> Option<E::Value> {
     use E::Value_ as EV;
     use P::Value_ as PV;
     let value_ = match pvalue_ {
@@ -3611,9 +2874,11 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
             check_valid_local_name(context, &v);
             EL::Var(Some(emut), sp(loc, E::ModuleAccess_::Name(v.0)), None)
         }
-        PB::Unpack(ptn, ptys_opt, pfields) => {
-            let tn = context.name_access_chain_to_module_access(Access::ApplyNamed, *ptn)?;
-            let tys_opt = optional_types(context, ptys_opt);
+        PB::Unpack(ptn, pfields) => {
+            let access_result!(name, ptys_opt, is_macro) =
+                context.name_access_chain_to_module_access(Access::ApplyNamed, *ptn)?;
+            ice_assert!(context.env(), is_macro.is_none(), loc, "Found macro in lhs");
+            let tys_opt = optional_sp_types(context, ptys_opt);
             let fields = match pfields {
                 FieldBindings::Named(named_bindings) => {
                     let vfields: Option<Vec<(Field, E::LValue)>> = named_bindings
@@ -3632,7 +2897,7 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
                     E::FieldBindings::Positional(fields?)
                 }
             };
-            EL::Unpack(tn, tys_opt, fields)
+            EL::Unpack(name, tys_opt, fields)
         }
     };
     Some(sp(loc, b_))
@@ -3698,11 +2963,9 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
     use E::ModuleAccess_ as M;
     use P::Exp_ as PE;
     match e_ {
-        PE::Name(name, ptys_opt) => {
-            let resolved_name =
-                context.name_access_chain_to_module_access(Access::Term, name.clone());
-            match resolved_name {
-                Some(sp!(_, M::Name(_))) if ptys_opt.is_some() => {
+        PE::Name(name) => {
+            match context.name_access_chain_to_module_access(Access::Term, name.clone()) {
+                Some(access_result!(sp!(_, name @ M::Name(_)), Some(_), _is_macro)) => {
                     let msg = "Unexpected assignment of instantiated type without fields";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note(format!(
@@ -3712,7 +2975,17 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                     context.env().add_diag(diag);
                     None
                 }
-                Some(sp!(_, M::ModuleAccess(_, _))) => {
+                Some(access_result!(_, _ptys_opt, Some(_))) => {
+                    let msg = "Unexpected assignment of name with macro invocation";
+                    let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
+                    diag.add_note("Macro invocation '!' must appear on an invocation");
+                    context.env().add_diag(diag);
+                    None
+                }
+                Some(access_result!(sp!(_, name @ M::Name(_)), None, None)) => {
+                    Some(sp(loc, EL::Var(None, sp(loc, name), None)))
+                }
+                Some(access_result!(sp!(_, M::ModuleAccess(_, _)), _ptys_opt, _is_macro)) => {
                     let msg = "Unexpected assignment of module access without fields";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note(format!(
@@ -3722,32 +2995,43 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                     context.env().add_diag(diag);
                     None
                 }
-                Some(sp!(_, name @ M::Name(_))) => {
-                    Some(sp(loc, EL::Var(None, sp(loc, name), None)))
-                }
                 None => None,
             }
         }
-        PE::Pack(pn, ptys_opt, pfields) => {
-            let en = context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            let tys_opt = optional_types(context, ptys_opt);
+        PE::Pack(pn, pfields) => {
+            let access_result!(name, ptys_opt, is_macro) =
+                context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
+            ice_assert!(
+                context.env(),
+                is_macro.is_none(),
+                loc,
+                "Marked a bind as a macro"
+            );
+            let tys_opt = optional_sp_types(context, ptys_opt);
             let efields = assign_unpack_fields(context, loc, pfields)?;
             Some(sp(
                 loc,
-                EL::Unpack(en, tys_opt, E::FieldBindings::Named(efields)),
+                EL::Unpack(name, tys_opt, E::FieldBindings::Named(efields)),
             ))
         }
-        PE::Call(pn, None, ptys_opt, sp!(_, exprs)) => {
+        PE::Call(pn, sp!(_, exprs)) => {
             let pkg = context.current_package();
             context
                 .env()
                 .check_feature(pkg, FeatureGate::PositionalFields, loc);
-            let en = context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
-            let tys_opt = optional_types(context, ptys_opt);
+            let access_result!(name, ptys_opt, is_macro) =
+                context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
+            ice_assert!(
+                context.env(),
+                is_macro.is_none(),
+                loc,
+                "Marked a bind as a macro"
+            );
+            let tys_opt = optional_sp_types(context, ptys_opt);
             let pfields: Option<_> = exprs.into_iter().map(|e| assign(context, e)).collect();
             Some(sp(
                 loc,
-                EL::Unpack(en, tys_opt, E::FieldBindings::Positional(pfields?)),
+                EL::Unpack(name, tys_opt, E::FieldBindings::Positional(pfields?)),
             ))
         }
         _ => {

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -5,28 +5,24 @@
 use crate::{
     diag,
     diagnostics::{codes::WarningFilter, Diagnostic, WarningFilters},
-    editions::{self, create_feature_error, Edition, FeatureGate, Flavor},
+    editions::{self, Edition, FeatureGate, Flavor},
     expansion::{
         alias_map_builder::{
-            AliasEntry, AliasMapBuilder, NameSpace, ParserExplicitUseFun, UnnecessaryAlias,
-            UseFunsBuilder,
+            AliasEntry, AliasMapBuilder, ParserExplicitUseFun, UnnecessaryAlias, UseFunsBuilder,
         },
-        aliases::{AliasMap, AliasSet},
+        aliases::AliasSet,
         ast::{self as E, Address, Fields, ModuleIdent, ModuleIdent_},
-        byte_string, hex_string, legacy_aliases,
-        translate::known_attributes::{DiagnosticAttribute, KnownAttribute},
+        byte_string, hex_string,
         path_expander::{
-            access_result, Access, LegacyPathExpander, Move2024PathExpander, ModuleAccessResult, PathExpander,
+            access_result, Access, LegacyPathExpander, ModuleAccessResult, Move2024PathExpander,
+            PathExpander,
         },
+        translate::known_attributes::{DiagnosticAttribute, KnownAttribute},
     },
     ice, ice_assert,
-    parser::{
-        ast::{
-            self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
-            ModuleName, NameAccess, NamePath, StructName, Var, ENTRY_MODIFIER, MACRO_MODIFIER,
-            NATIVE_MODIFIER,
-        },
-        syntax::make_loc,
+    parser::ast::{
+        self as P, Ability, BlockLabel, ConstantName, Field, FieldBindings, FunctionName,
+        ModuleName, NameAccess, StructName, Var, ENTRY_MODIFIER, MACRO_MODIFIER, NATIVE_MODIFIER,
     },
     shared::{known_attributes::AttributePosition, unique_map::UniqueMap, *},
     FullyCompiledProgram,

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -358,7 +358,6 @@ pub enum Type_ {
     // N
     // N<t1, ... , tn>
     Apply(Box<NameAccessChain>),
-    // Apply(Box<NameAccessChain>, Vec<Type>),
     // &t
     // &mut t
     Ref(bool, Box<Type>),
@@ -397,7 +396,6 @@ pub enum Bind_ {
     // T ( b1, ... bn )
     // T<t1, ... , tn> ( b1, ... bn )
     Unpack(Box<NameAccessChain>, FieldBindings),
-    // Unpack(Box<NameAccessChain>, Option<Vec<Type>>, FieldBindings),
 }
 pub type Bind = Spanned<Bind_>;
 // b1, ..., bn
@@ -510,15 +508,12 @@ pub enum Exp_ {
     // f!(earg,*)
     Call(
         NameAccessChain,
-        // Option<Loc>,
-        // Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
     ),
 
     // tn {f1: e1, ... , f_n: e_n }
     Pack(
         NameAccessChain,
-        // Option<Vec<Type>>,
         Vec<(Field, Exp)>,
     ),
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -743,6 +743,8 @@ impl NamePath {
     }
 }
 
+// Possibly move this trait out of `ast.rs`?
+#[allow(clippy::len_without_is_empty)]
 pub trait NameAccess {
     fn is_macro(&self) -> Option<&Loc>;
     fn tyargs(&self) -> Option<&Spanned<Vec<Type>>>;
@@ -890,10 +892,8 @@ impl NameAccess for NamePath {
             true
         } else if let Some(last) = self.entries.last() {
             last.tyargs.is_some()
-        } else if self.entries.len() == 0 && self.root.tyargs.is_some() {
-            true
         } else {
-            false
+            self.entries.is_empty() && self.root.tyargs.is_some()
         }
     }
 

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -505,16 +505,10 @@ pub enum Exp_ {
 
     // f(earg,*)
     // f!(earg,*)
-    Call(
-        NameAccessChain,
-        Spanned<Vec<Exp>>,
-    ),
+    Call(NameAccessChain, Spanned<Vec<Exp>>),
 
     // tn {f1: e1, ... , f_n: e_n }
-    Pack(
-        NameAccessChain,
-        Vec<(Field, Exp)>,
-    ),
+    Pack(NameAccessChain, Vec<(Field, Exp)>),
 
     // vector [ e1, ..., e_n ]
     // vector<t> [e1, ..., en ]

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -502,7 +502,6 @@ pub enum Exp_ {
     Copy(Loc, Box<Exp>),
     // [m::]n[<t1, .., tn>]
     Name(NameAccessChain),
-    // Name(NameAccessChain, Option<Vec<Type>>),
 
     // f(earg,*)
     // f!(earg,*)

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -303,28 +303,8 @@ pub struct Constant {
 }
 
 //**************************************************************************************************
-// Types
+// Names
 //**************************************************************************************************
-
-// MName = Name <TyArgs>
-//       | Leading <TyArgs> :: Name
-//       | Leading :: Name <TyArgs>
-//       | Leading :: Name <TyArgs> :: Name
-//       | Leading :: Name :: Name <TyArgs>
-//       | Leading :: Name :: Name <TyArgs> :: Name
-//
-// VName = MName <TyArgs> :: Name
-
-// A ModuleAccess references a local or global name or something from a module,
-// either a struct type or a function.
-// The boolean flag indicates if a name was pushed on after tyarg parsing, which we use in
-// expansion to determine if the variant form was valid.
-// FIXME(cswords): We should eventually rewrite all of this to be `NamePath`s that hold tyargs:
-//    pub enum NamePath {
-//        Base { name: Name, tyargs: Option<Vec<Type>> },
-//        Leading { name: LeadingNameAccess },
-//        Ext { base: Box<NamePath>, name: Name, tyargs: Option<Vec<Type>> },
-//    }
 
 // A single name with optional type arguments that may be a macro call.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -335,7 +315,7 @@ pub struct PathEntry {
 }
 
 // A path root.
-// For now these should hever have tyargs or macro call set (though the type arguments will be
+// For now these should never have tyargs or macro call set (though the type arguments will be
 // used for enums).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootPathEntry {
@@ -357,16 +337,12 @@ pub struct NamePath {
 pub enum NameAccessChain_ {
     Single(PathEntry),
     Path(NamePath),
-    // // <Name>
-    // One(Name),
-    // // (<Name>|<Num>)::<Name>, bool indicates last name was pushed on
-    // Two(LeadingNameAccess, Name, bool),
-    // // (<Name>|<Num>)::<Name>::<Name>, bool indicates last name was pushed on
-    // Three(Spanned<(LeadingNameAccess, Name)>, Name, bool),
-    // // (<Name>|<Num>)::<Name>::<Name>::<Name>, bool indicates last name was pushed on
-    // Four(Spanned<(LeadingNameAccess, Name)>, Name, Name, bool),
 }
 pub type NameAccessChain = Spanned<NameAccessChain_>;
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum Ability_ {

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -776,19 +776,17 @@ impl NameAccess for PathEntry {
 
 impl NameAccess for NamePath {
     fn is_macro(&self) -> Option<&Loc> {
-        self.root.is_macro.as_ref().or_else(|| self.entries.iter().find_map(|e| e.is_macro.as_ref()))
+        self.root
+            .is_macro
+            .as_ref()
+            .or_else(|| self.entries.iter().find_map(|e| e.is_macro.as_ref()))
     }
 
     fn tyargs(&self) -> Option<&Spanned<Vec<Type>>> {
-        if let Some(tyargs) = &self.root.tyargs {
-            return Some(tyargs);
-        }
-        for entry in self.entries.iter() {
-            if let Some(tyargs) = &entry.tyargs {
-                return Some(tyargs);
-            }
-        }
-        None
+        self.root
+            .tyargs
+            .as_ref()
+            .or_else(|| self.entries.iter().find_map(|e| e.tyargs.as_ref()))
     }
 
     fn push_path_entry(
@@ -866,15 +864,7 @@ impl NameAccess for NamePath {
     }
 
     fn tyargs_loc(&self) -> Option<Loc> {
-        if let Some(sp!(loc, _)) = self.root.tyargs {
-            return Some(loc);
-        }
-        for entry in self.entries.iter() {
-            if let Some(sp!(loc, _)) = entry.tyargs {
-                return Some(loc);
-            }
-        }
-        None
+        self.tyargs().map(|tyarg_ref| tyarg_ref.loc)
     }
 
     fn len(&self) -> usize {

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -2,9 +2,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{
-    ast_debug::*, Identifier, Name, NamedAddressMap, NamedAddressMapIndex, NamedAddressMaps,
-    NumericalAddress, TName,
+use crate::{
+    diag,
+    diagnostics::Diagnostic,
+    ice,
+    shared::{
+        ast_debug::*, Identifier, Name, NamedAddressMap, NamedAddressMapIndex, NamedAddressMaps,
+        NumericalAddress, TName,
+    },
 };
 use move_command_line_common::files::FileHash;
 use move_ir_types::location::*;
@@ -301,16 +306,65 @@ pub struct Constant {
 // Types
 //**************************************************************************************************
 
+// MName = Name <TyArgs>
+//       | Leading <TyArgs> :: Name
+//       | Leading :: Name <TyArgs>
+//       | Leading :: Name <TyArgs> :: Name
+//       | Leading :: Name :: Name <TyArgs>
+//       | Leading :: Name :: Name <TyArgs> :: Name
+//
+// VName = MName <TyArgs> :: Name
+
 // A ModuleAccess references a local or global name or something from a module,
 // either a struct type or a function.
+// The boolean flag indicates if a name was pushed on after tyarg parsing, which we use in
+// expansion to determine if the variant form was valid.
+// FIXME(cswords): We should eventually rewrite all of this to be `NamePath`s that hold tyargs:
+//    pub enum NamePath {
+//        Base { name: Name, tyargs: Option<Vec<Type>> },
+//        Leading { name: LeadingNameAccess },
+//        Ext { base: Box<NamePath>, name: Name, tyargs: Option<Vec<Type>> },
+//    }
+
+// A single name with optional type arguments that may be a macro call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathEntry {
+    pub name: Name,
+    pub tyargs: Option<Spanned<Vec<Type>>>,
+    pub is_macro: Option<Loc>,
+}
+
+// A path root.
+// For now these should hever have tyargs or macro call set (though the type arguments will be
+// used for enums).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootPathEntry {
+    pub name: LeadingNameAccess,
+    pub tyargs: Option<Spanned<Vec<Type>>>,
+    pub is_macro: Option<Loc>,
+}
+
+// INVARIANT: entries should be non-zero, or this should be converted to a `SingleName`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamePath {
+    pub root: RootPathEntry,
+    pub entries: Vec<PathEntry>,
+}
+
+// See the NameAccess trait below for usage.
+// INVARIANT: never push onto a Single. A Single is a final form, demoted from a Path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NameAccessChain_ {
-    // <Name>
-    One(Name),
-    // (<Name>|<Num>)::<Name>
-    Two(LeadingNameAccess, Name),
-    // (<Name>|<Num>)::<Name>::<Name>
-    Three(Spanned<(LeadingNameAccess, Name)>, Name),
+    Single(PathEntry),
+    Path(NamePath),
+    // // <Name>
+    // One(Name),
+    // // (<Name>|<Num>)::<Name>, bool indicates last name was pushed on
+    // Two(LeadingNameAccess, Name, bool),
+    // // (<Name>|<Num>)::<Name>::<Name>, bool indicates last name was pushed on
+    // Three(Spanned<(LeadingNameAccess, Name)>, Name, bool),
+    // // (<Name>|<Num>)::<Name>::<Name>::<Name>, bool indicates last name was pushed on
+    // Four(Spanned<(LeadingNameAccess, Name)>, Name, Name, bool),
 }
 pub type NameAccessChain = Spanned<NameAccessChain_>;
 
@@ -327,7 +381,8 @@ pub type Ability = Spanned<Ability_>;
 pub enum Type_ {
     // N
     // N<t1, ... , tn>
-    Apply(Box<NameAccessChain>, Vec<Type>),
+    Apply(Box<NameAccessChain>),
+    // Apply(Box<NameAccessChain>, Vec<Type>),
     // &t
     // &mut t
     Ref(bool, Box<Type>),
@@ -365,7 +420,8 @@ pub enum Bind_ {
     // T<t1, ... , tn> { f1: b1, ... fn: bn }
     // T ( b1, ... bn )
     // T<t1, ... , tn> ( b1, ... bn )
-    Unpack(Box<NameAccessChain>, Option<Vec<Type>>, FieldBindings),
+    Unpack(Box<NameAccessChain>, FieldBindings),
+    // Unpack(Box<NameAccessChain>, Option<Vec<Type>>, FieldBindings),
 }
 pub type Bind = Spanned<Bind_>;
 // b1, ..., bn
@@ -471,19 +527,24 @@ pub enum Exp_ {
     // copy e
     Copy(Loc, Box<Exp>),
     // [m::]n[<t1, .., tn>]
-    Name(NameAccessChain, Option<Vec<Type>>),
+    Name(NameAccessChain),
+    // Name(NameAccessChain, Option<Vec<Type>>),
 
     // f(earg,*)
     // f!(earg,*)
     Call(
         NameAccessChain,
-        Option<Loc>,
-        Option<Vec<Type>>,
+        // Option<Loc>,
+        // Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
     ),
 
     // tn {f1: e1, ... , f_n: e_n }
-    Pack(NameAccessChain, Option<Vec<Type>>, Vec<(Field, Exp)>),
+    Pack(
+        NameAccessChain,
+        // Option<Vec<Type>>,
+        Vec<(Field, Exp)>,
+    ),
 
     // vector [ e1, ..., e_n ]
     // vector<t> [e1, ..., en ]
@@ -647,6 +708,253 @@ impl fmt::Debug for LeadingNameAccess_ {
 impl LeadingNameAccess_ {
     pub const fn anonymous(address: NumericalAddress) -> Self {
         Self::AnonymousAddress(address)
+    }
+}
+
+impl NameAccessChain_ {
+    pub fn single(name: Name) -> Self {
+        NameAccessChain_::Single(PathEntry {
+            name,
+            tyargs: None,
+            is_macro: None,
+        })
+    }
+
+    pub fn path(root: RootPathEntry) -> NamePath {
+        NamePath {
+            root,
+            entries: vec![],
+        }
+    }
+}
+
+impl NamePath {
+    /// Destructively take the type arguments, if any.
+    pub(crate) fn take_tyargs(&mut self) -> Option<Spanned<Vec<Type>>> {
+        if self.root.tyargs.is_some() {
+            return std::mem::take(&mut self.root.tyargs);
+        }
+        for entry in self.entries.iter_mut() {
+            if entry.tyargs.is_some() {
+                return std::mem::take(&mut entry.tyargs);
+            }
+        }
+        None
+    }
+}
+
+pub trait NameAccess {
+    fn is_macro(&self) -> Option<&Loc>;
+    fn tyargs(&self) -> Option<&Spanned<Vec<Type>>>;
+
+    fn push_path_entry(
+        &mut self,
+        name: Name,
+        tyargs: Option<Spanned<Vec<Type>>>,
+        is_macro: Option<Loc>,
+    ) -> Vec<Diagnostic>;
+
+    fn has_tyargs(&self) -> bool;
+    fn tyargs_loc(&self) -> Option<Loc>;
+    fn has_tyargs_last(&self) -> bool;
+    fn len(&self) -> usize;
+}
+
+impl NameAccess for PathEntry {
+    fn is_macro(&self) -> Option<&Loc> {
+        self.is_macro.as_ref()
+    }
+
+    fn tyargs(&self) -> Option<&Spanned<Vec<Type>>> {
+        self.tyargs.as_ref()
+    }
+
+    fn push_path_entry(
+        &mut self,
+        name: Name,
+        _tyargs: Option<Spanned<Vec<Type>>>,
+        _is_macro: Option<Loc>,
+    ) -> Vec<Diagnostic> {
+        let diag = ice!((name.loc, "Tried adding this name to a Single chain"));
+        vec![diag]
+    }
+
+    fn has_tyargs(&self) -> bool {
+        self.tyargs.is_some()
+    }
+
+    fn has_tyargs_last(&self) -> bool {
+        true
+    }
+
+    fn tyargs_loc(&self) -> Option<Loc> {
+        self.tyargs.as_ref().map(|sp!(loc, _)| *loc)
+    }
+
+    fn len(&self) -> usize {
+        1
+    }
+}
+
+impl NameAccess for NamePath {
+    fn is_macro(&self) -> Option<&Loc> {
+        if let Some(loc) = &self.root.is_macro {
+            return Some(loc);
+        }
+        for entry in self.entries.iter() {
+            if let Some(loc) = &entry.is_macro {
+                return Some(loc);
+            }
+        }
+        None
+    }
+
+    fn tyargs(&self) -> Option<&Spanned<Vec<Type>>> {
+        if let Some(tyargs) = &self.root.tyargs {
+            return Some(tyargs);
+        }
+        for entry in self.entries.iter() {
+            if let Some(tyargs) = &entry.tyargs {
+                return Some(tyargs);
+            }
+        }
+        None
+    }
+
+    fn push_path_entry(
+        &mut self,
+        name: Name,
+        tyargs: Option<Spanned<Vec<Type>>>,
+        is_macro: Option<Loc>,
+    ) -> Vec<Diagnostic> {
+        let mut diags: Vec<Diagnostic> = vec![];
+
+        let mut final_tyargs = tyargs;
+
+        if let (Some(prev_loc), Some(sp!(new_loc, _))) = (self.tyargs_loc(), &final_tyargs) {
+            let mut diag = diag!(
+                Syntax::InvalidName,
+                (
+                    *new_loc,
+                    "Paths cannot include type arguments more than once"
+                ),
+                (prev_loc, "Previous type arguments appeared here")
+            );
+            diag.add_note("Type arguments should only appear on module members");
+            diags.push(diag);
+            // If we already had tyargs, remove these.
+            final_tyargs = None;
+        }
+
+        if let Some(prev_loc) = self.is_macro() {
+            let diag = diag!(
+                Syntax::InvalidName,
+                (
+                    name.loc,
+                    "A macro call cannot have name access entries after it"
+                ),
+                (*prev_loc, "Macro invocation given here")
+            );
+            diags.push(diag);
+            // If this is a macro, remove previous `!` usages.
+            self.root.is_macro = None;
+            for entry in self.entries.iter_mut() {
+                entry.is_macro = None;
+            }
+        }
+
+        if self.len() > 3 {
+            let diag = diag!(
+                Syntax::InvalidName,
+                (name.loc, "Paths cannot have length greater than four")
+            );
+            diags.push(diag);
+        } else {
+            let path_entry = PathEntry {
+                name,
+                tyargs: final_tyargs,
+                is_macro,
+            };
+            self.entries.push(path_entry);
+        }
+        diags
+    }
+
+    fn has_tyargs(&self) -> bool {
+        self.root.tyargs.is_some() || self.entries.iter().any(|entry| entry.tyargs.is_some())
+    }
+
+    fn has_tyargs_last(&self) -> bool {
+        if !self.has_tyargs() {
+            // Tyargs are last vacuously
+            true
+        } else if let Some(last) = self.entries.last() {
+            last.tyargs.is_some()
+        } else if self.entries.len() == 0 && self.root.tyargs.is_some() {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn tyargs_loc(&self) -> Option<Loc> {
+        if let Some(sp!(loc, _)) = self.root.tyargs {
+            return Some(loc);
+        }
+        for entry in self.entries.iter() {
+            if let Some(sp!(loc, _)) = entry.tyargs {
+                return Some(loc);
+            }
+        }
+        None
+    }
+
+    fn len(&self) -> usize {
+        1 + self.entries.len()
+    }
+}
+
+macro_rules! forward_name_access {
+    ($self:ident.$call:ident($($args:ident),*)) => {
+        match $self {
+            NameAccessChain_::Single(entry) => entry.$call($($args),*),
+            NameAccessChain_::Path(entry) => entry.$call($($args),*),
+        }
+    }
+}
+
+impl NameAccess for NameAccessChain_ {
+    fn is_macro(&self) -> Option<&Loc> {
+        forward_name_access!(self.is_macro())
+    }
+
+    fn tyargs(&self) -> Option<&Spanned<Vec<Type>>> {
+        forward_name_access!(self.tyargs())
+    }
+
+    fn push_path_entry(
+        &mut self,
+        name: Name,
+        tyargs: Option<Spanned<Vec<Type>>>,
+        is_macro: Option<Loc>,
+    ) -> Vec<Diagnostic> {
+        forward_name_access!(self.push_path_entry(name, tyargs, is_macro))
+    }
+
+    fn has_tyargs(&self) -> bool {
+        forward_name_access!(self.has_tyargs())
+    }
+
+    fn has_tyargs_last(&self) -> bool {
+        forward_name_access!(self.has_tyargs_last())
+    }
+
+    fn tyargs_loc(&self) -> Option<Loc> {
+        forward_name_access!(self.tyargs_loc())
+    }
+
+    fn len(&self) -> usize {
+        forward_name_access!(self.len())
     }
 }
 
@@ -865,12 +1173,33 @@ impl fmt::Display for ModuleIdent_ {
     }
 }
 
+impl fmt::Display for RootPathEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl fmt::Display for PathEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl fmt::Display for NamePath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.root)?;
+        for entry in self.entries.iter() {
+            write!(f, "::{}", entry.name)?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for NameAccessChain_ {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         match self {
-            NameAccessChain_::One(n) => write!(f, "{}", n),
-            NameAccessChain_::Two(ln, n2) => write!(f, "{}::{}", ln, n2),
-            NameAccessChain_::Three(sp!(_, (ln, n2)), n3) => write!(f, "{}::{}::{}", ln, n2, n3),
+            NameAccessChain_::Single(entry) => entry.fmt(f),
+            NameAccessChain_::Path(entry) => entry.fmt(f),
         }
     }
 }
@@ -1347,13 +1676,8 @@ impl AstDebug for Type_ {
                 ss.ast_debug(w);
                 w.write(")")
             }
-            Type_::Apply(m, ss) => {
+            Type_::Apply(m) => {
                 m.ast_debug(w);
-                if !ss.is_empty() {
-                    w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
-                }
             }
             Type_::Ref(mut_, s) => {
                 w.write("&");
@@ -1378,9 +1702,61 @@ impl AstDebug for Vec<Type> {
     }
 }
 
+impl AstDebug for RootPathEntry {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let RootPathEntry {
+            name,
+            tyargs,
+            is_macro,
+        } = self;
+        w.write(format!("{}", name));
+        if is_macro.is_some() {
+            w.write("!");
+        }
+        if let Some(ts) = tyargs {
+            w.write("<");
+            ts.ast_debug(w);
+            w.write(">");
+        }
+    }
+}
+
+impl AstDebug for PathEntry {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let PathEntry {
+            name,
+            tyargs,
+            is_macro,
+        } = self;
+        w.write(format!("{}", name));
+        if is_macro.is_some() {
+            w.write("!");
+        }
+        if let Some(ts) = tyargs {
+            w.write("<");
+            ts.ast_debug(w);
+            w.write(">");
+        }
+    }
+}
+
+impl AstDebug for NamePath {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let NamePath { root, entries } = self;
+        w.write(format!("{}::", root));
+        w.list(entries, "::", |w, e| {
+            e.ast_debug(w);
+            false
+        });
+    }
+}
+
 impl AstDebug for NameAccessChain_ {
     fn ast_debug(&self, w: &mut AstWriter) {
-        w.write(&format!("{}", self))
+        match self {
+            NameAccessChain_::Single(entry) => entry.ast_debug(w),
+            NameAccessChain_::Path(entry) => entry.ast_debug(w),
+        }
     }
 }
 
@@ -1452,35 +1828,17 @@ impl AstDebug for Exp_ {
                 w.write("copy ");
                 e.ast_debug(w);
             }
-            E::Name(ma, tys_opt) => {
+            E::Name(ma) => {
                 ma.ast_debug(w);
-                if let Some(ss) = tys_opt {
-                    w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
-                }
             }
-            E::Call(ma, is_macro, tys_opt, sp!(_, rhs)) => {
+            E::Call(ma, sp!(_, rhs)) => {
                 ma.ast_debug(w);
-                if is_macro.is_some() {
-                    w.write("!");
-                }
-                if let Some(ss) = tys_opt {
-                    w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
-                }
                 w.write("(");
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            E::Pack(ma, tys_opt, fields) => {
+            E::Pack(ma, fields) => {
                 ma.ast_debug(w);
-                if let Some(ss) = tys_opt {
-                    w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
-                }
                 w.write("{");
                 w.comma(fields, |w, (f, e)| {
                     w.write(&format!("{}: ", f));
@@ -1605,16 +1963,16 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
                 w.write(&format!(".{}", n));
             }
-            E::DotCall(e, n, is_macro, tys_opt, sp!(_, rhs)) => {
+            E::DotCall(e, n, is_macro, tyargs, sp!(_, rhs)) => {
                 e.ast_debug(w);
                 w.write(&format!(".{}", n));
                 if is_macro.is_some() {
                     w.write("!");
                 }
-                if let Some(ss) = tys_opt {
+                if let Some(ts) = tyargs {
                     w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
+                    ts.ast_debug(w);
+                    w.write("<");
                 }
                 w.write("(");
                 w.comma(rhs, |w, e| e.ast_debug(w));
@@ -1738,13 +2096,8 @@ impl AstDebug for Bind_ {
                 }
                 w.write(&format!("{}", v))
             }
-            B::Unpack(ma, tys_opt, fields) => {
+            B::Unpack(ma, fields) => {
                 ma.ast_debug(w);
-                if let Some(ss) = tys_opt {
-                    w.write("<");
-                    ss.ast_debug(w);
-                    w.write(">");
-                }
                 fields.ast_debug(w);
             }
         }

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -776,15 +776,7 @@ impl NameAccess for PathEntry {
 
 impl NameAccess for NamePath {
     fn is_macro(&self) -> Option<&Loc> {
-        if let Some(loc) = &self.root.is_macro {
-            return Some(loc);
-        }
-        for entry in self.entries.iter() {
-            if let Some(loc) = &entry.is_macro {
-                return Some(loc);
-            }
-        }
-        None
+        self.root.is_macro.as_ref().or_else(|| self.entries.iter().find_map(|e| e.is_macro.as_ref()))
     }
 
     fn tyargs(&self) -> Option<&Spanned<Vec<Type>>> {

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -210,6 +210,10 @@ impl<'input> Lexer<'input> {
         self.token
     }
 
+    pub fn remaining(&self) -> &'input str {
+        &self.text[self.cur_start..]
+    }
+
     pub fn content(&self) -> &'input str {
         &self.text[self.cur_start..self.cur_end]
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -567,7 +567,10 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
                 Syntax::InvalidName,
                 (
                     *loc,
-                    format!("Macro invocation are disallowed here. Expected {}", item_description())
+                    format!(
+                        "Macro invocation are disallowed here. Expected {}",
+                        item_description()
+                    )
                 )
             ));
             is_macro = None;
@@ -579,7 +582,10 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
                 Syntax::InvalidName,
                 (
                     ty_loc,
-                    format!("Type arguments are disallowed here. Expected {}", item_description())
+                    format!(
+                        "Type arguments are disallowed here. Expected {}",
+                        item_description()
+                    )
                 )
             ));
             tys = None;
@@ -686,7 +692,7 @@ fn parse_macro_opt_and_tyargs_opt(
     // If there is no whitespace after the name or if a macro call has been started,
     //   treat it as the start of a list of type arguments.
     // Otherwise, assume that the '<' is a boolean operator.
-    let start_loc = context.tokens.start_loc();
+    let _start_loc = context.tokens.start_loc();
     if context.tokens.peek() == Tok::Less && (context.at_end(end_loc) || is_macro.is_some()) {
         let start_loc = context.tokens.start_loc();
         let loc = make_loc(context.tokens.file_hash(), start_loc, start_loc);
@@ -2316,7 +2322,7 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
 
 fn parse_type_(
     context: &mut Context,
-    whitespace_sensitive_ty_args: bool,
+    _whitespace_sensitive_ty_args: bool,
 ) -> Result<Type, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
     let t = match context.tokens.peek() {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -38,6 +38,10 @@ impl<'env, 'lexer, 'input> Context<'env, 'lexer, 'input> {
             tokens,
         }
     }
+
+    fn at_end(&self, prev: Loc) -> bool {
+        prev.end() as usize == self.tokens.start_loc()
+    }
 }
 
 //**************************************************************************************************
@@ -336,6 +340,29 @@ where
     }
 }
 
+// Helper for location blocks
+
+macro_rules! ok_with_loc {
+    ($context:expr, $body:block) => {{
+        let start_loc = $context.tokens.start_loc();
+        let result = $body;
+        let end_loc = $context.tokens.previous_end_loc();
+        Ok(sp(
+            make_loc($context.tokens.file_hash(), start_loc, end_loc),
+            result,
+        ))
+    }};
+    ($context:expr, $body:expr) => {{
+        let start_loc = $context.tokens.start_loc();
+        let result = $body;
+        let end_loc = $context.tokens.previous_end_loc();
+        Ok(sp(
+            make_loc($context.tokens.file_hash(), start_loc, end_loc),
+            result,
+        ))
+    }};
+}
+
 //**************************************************************************************************
 // Identifiers, Addresses, and Names
 //**************************************************************************************************
@@ -419,14 +446,14 @@ fn parse_address_bytes(
 // Parse the beginning of an access, either an address or an identifier:
 //      LeadingNameAccess = <NumericalAddress> | <Identifier> | <SyntaxIdentifier>
 fn parse_leading_name_access(context: &mut Context) -> Result<LeadingNameAccess, Box<Diagnostic>> {
-    parse_leading_name_access_(context, false, || "an address or an identifier")
+    parse_leading_name_access_(context, false, &|| "an address or an identifier")
 }
 
 // Parse the beginning of an access, either an address or an identifier with a specific description
-fn parse_leading_name_access_<'a, F: FnOnce() -> &'a str>(
+fn parse_leading_name_access_<'a, F: Fn() -> &'a str>(
     context: &mut Context,
     global_name: bool,
-    item_description: F,
+    item_description: &F,
 ) -> Result<LeadingNameAccess, Box<Diagnostic>> {
     match context.tokens.peek() {
         Tok::RestrictedIdentifier | Tok::Identifier => {
@@ -491,83 +518,188 @@ fn parse_module_name(context: &mut Context) -> Result<ModuleName, Box<Diagnostic
     Ok(ModuleName(parse_identifier(context)?))
 }
 
-// Parse a module identifier:
-//      ModuleIdent = <LeadingNameAccess> "::" <ModuleName>
-//                  | "::" <LeadingNameAccess> "::" <ModuleName>
-
 // Parse a module access (a variable, struct type, or function):
-//      NameAccessChain = <LeadingNameAccess> ( "::" <Identifier> ( "::" <Identifier> )? )?
-fn parse_name_access_chain<'a, F: FnOnce() -> &'a str>(
+//      NameAccessChain =
+//          <LeadingNameAccess> <OptionalTypeArgs>
+//              ( "::" <Identifier> <OptionalTypeArgs> )^n
+//
+//  (n in {0,1,2})
+//  Returns a name and an indicator if we parsed a macro. Note that if `n > 2`, this parses those
+//  and reports errors.
+fn parse_name_access_chain<'a, F: Fn() -> &'a str>(
     context: &mut Context,
+    macros_allowed: bool,
+    tyargs_allowed: bool,
     item_description: F,
 ) -> Result<NameAccessChain, Box<Diagnostic>> {
-    let start_loc = context.tokens.start_loc();
-    let access = if context.tokens.peek() == Tok::ColonColon {
-        context.tokens.advance()?;
-        parse_name_access_chain_(context, true, item_description)?
-    } else {
-        parse_name_access_chain_(context, false, item_description)?
-    };
-    let end_loc = context.tokens.previous_end_loc();
-    Ok(spanned(
-        context.tokens.file_hash(),
-        start_loc,
-        end_loc,
-        access,
-    ))
+    ok_with_loc!(context, {
+        let global_name = if context.tokens.peek() == Tok::ColonColon {
+            context.tokens.advance()?;
+            true
+        } else {
+            false
+        };
+        parse_name_access_chain_(
+            context,
+            macros_allowed,
+            tyargs_allowed,
+            global_name,
+            item_description,
+        )?
+    })
 }
 
 // Parse a module access with a specific description
-fn parse_name_access_chain_<'a, F: FnOnce() -> &'a str>(
+fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
     context: &mut Context,
+    macros_allowed: bool,
+    tyargs_allowed: bool,
     global_name: bool,
     item_description: F,
 ) -> Result<NameAccessChain_, Box<Diagnostic>> {
-    let start_loc = context.tokens.start_loc();
-    let ln = parse_leading_name_access_(context, global_name, item_description)?;
+    use LeadingNameAccess_ as LN;
+    let ln = parse_leading_name_access_(context, global_name, &item_description)?;
+
+    let (mut is_macro, mut tys) = parse_macro_opt_and_tyargs_opt(context, ln.loc)?;
+    if let Some(loc) = &is_macro {
+        if !macros_allowed {
+            context.env.add_diag(diag!(
+                Syntax::InvalidName,
+                (
+                    *loc,
+                    format!("Macro invocation are disallowed here. Expected {}", item_description())
+                )
+            ));
+            is_macro = None;
+        }
+    }
+    if let Some(sp!(ty_loc, _)) = tys {
+        if !tyargs_allowed {
+            context.env.add_diag(diag!(
+                Syntax::InvalidName,
+                (
+                    ty_loc,
+                    format!("Type arguments are disallowed here. Expected {}", item_description())
+                )
+            ));
+            tys = None;
+        }
+    }
+
     let ln = match ln {
         // A name by itself is a valid access chain
-        sp!(_, LeadingNameAccess_::Name(n1)) if context.tokens.peek() != Tok::ColonColon => {
-            return Ok(NameAccessChain_::One(n1))
+        sp!(_, LN::Name(n1)) if context.tokens.peek() != Tok::ColonColon => {
+            let single = PathEntry {
+                name: n1,
+                tyargs: tys,
+                is_macro,
+            };
+            return Ok(NameAccessChain_::Single(single));
         }
         ln => ln,
     };
 
-    if matches!(ln, sp!(_, LeadingNameAccess_::GlobalAddress(_)))
+    if matches!(ln.value, LN::GlobalAddress(_) | LN::AnonymousAddress(_))
         && context.tokens.peek() != Tok::ColonColon
     {
+        let addr_msg = match &ln.value {
+            LN::AnonymousAddress(_) => "anonymous",
+            LN::GlobalAddress(_) => "global",
+            LN::Name(_) => "named",
+        };
         let mut diag = diag!(
             Syntax::UnexpectedToken,
             (
                 ln.loc,
-                "Expected '::' after the address in this module access chain"
+                format!(
+                    "Expected '::' after the {} address in this module access chain",
+                    addr_msg
+                )
             )
         );
-        diag.add_note(
-            "Access chains that start with '::' must be one of the following forms: \
-            \n  '::<address>::<module>', '::<address>::<module>::<member>'",
-        );
+        diag.add_note("Access chains that start with '::' must be multi-part");
         return Err(Box::new(diag));
     }
 
-    consume_token_(
-        context.tokens,
-        Tok::ColonColon,
-        start_loc,
-        " after an address in a module access chain",
-    )?;
-    let n2 = parse_identifier(context)?;
-    if context.tokens.peek() != Tok::ColonColon {
-        return Ok(NameAccessChain_::Two(ln, n2));
+    let root = RootPathEntry {
+        name: ln,
+        tyargs: tys,
+        is_macro,
+    };
+
+    let mut path = NameAccessChain_::path(root);
+    while context.tokens.peek() == Tok::ColonColon {
+        consume_token_(
+            context.tokens,
+            Tok::ColonColon,
+            context.tokens.start_loc(),
+            " after an address in a module access chain",
+        )?;
+        let name = parse_identifier(context)?;
+        let (mut is_macro, mut tys) = parse_macro_opt_and_tyargs_opt(context, name.loc)?;
+        if let Some(loc) = &is_macro {
+            if !macros_allowed {
+                context.env.add_diag(diag!(
+                    Syntax::InvalidName,
+                    (
+                        *loc,
+                        format!("Cannot use macro invocation '!' in {}", item_description())
+                    )
+                ));
+                is_macro = None;
+            }
+        }
+        if let Some(sp!(ty_loc, _)) = tys {
+            if !tyargs_allowed {
+                context.env.add_diag(diag!(
+                    Syntax::InvalidName,
+                    (
+                        ty_loc,
+                        format!("Cannot use type arguments in {}", item_description())
+                    )
+                ));
+                tys = None;
+            }
+        }
+
+        path.push_path_entry(name, tys, is_macro)
+            .into_iter()
+            .for_each(|diag| context.env.add_diag(diag));
     }
-    let ln_n2_loc = make_loc(
-        context.tokens.file_hash(),
-        start_loc,
-        context.tokens.previous_end_loc(),
-    );
-    consume_token(context.tokens, Tok::ColonColon)?;
-    let n3 = parse_identifier(context)?;
-    Ok(NameAccessChain_::Three(sp(ln_n2_loc, (ln, n2)), n3))
+    Ok(NameAccessChain_::Path(path))
+}
+
+fn parse_macro_opt_and_tyargs_opt(
+    context: &mut Context,
+    end_loc: Loc,
+) -> Result<(Option<Loc>, Option<Spanned<Vec<Type>>>), Box<Diagnostic>> {
+    let mut is_macro = None;
+    let mut tyargs = None;
+
+    if let Tok::Exclaim = context.tokens.peek() {
+        let loc = current_token_loc(context.tokens);
+        context.tokens.advance()?;
+        is_macro = Some(loc);
+    }
+
+    // There's an ambiguity if the name is followed by a '<'.
+    // If there is no whitespace after the name or if a macro call has been started,
+    //   treat it as the start of a list of type arguments.
+    // Otherwise, assume that the '<' is a boolean operator.
+    let start_loc = context.tokens.start_loc();
+    if context.tokens.peek() == Tok::Less && (context.at_end(end_loc) || is_macro.is_some()) {
+        let start_loc = context.tokens.start_loc();
+        let loc = make_loc(context.tokens.file_hash(), start_loc, start_loc);
+        let tys_ = parse_optional_type_args(context)
+            .map_err(|diag| add_type_args_ambiguity_label(loc, diag))?;
+        let ty_loc = make_loc(
+            context.tokens.file_hash(),
+            start_loc,
+            context.tokens.previous_end_loc(),
+        );
+        tyargs = tys_.map(|tys| sp(ty_loc, tys));
+    }
+    Ok((is_macro, tyargs))
 }
 
 //**************************************************************************************************
@@ -725,7 +857,12 @@ fn parse_attribute_value(context: &mut Context) -> Result<AttributeValue, Box<Di
         return Ok(sp(v.loc, AttributeValue_::Value(v)));
     }
 
-    let ma = parse_name_access_chain(context, || "attribute name value")?;
+    let ma = parse_name_access_chain(
+        context,
+        /* macros */ false,
+        /* tyargs */ false,
+        || "attribute name value",
+    )?;
     Ok(sp(ma.loc, AttributeValue_::ModuleAccess(ma)))
 }
 
@@ -834,7 +971,7 @@ fn parse_exp_field(context: &mut Context) -> Result<(Field, Exp), Box<Diagnostic
     } else {
         sp(
             f.loc(),
-            Exp_::Name(sp(f.loc(), NameAccessChain_::One(f.0)), None),
+            Exp_::Name(sp(f.loc(), NameAccessChain_::single(f.0))),
         )
     };
     Ok((f, arg))
@@ -902,8 +1039,12 @@ fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
     // The item description specified here should include the special case above for
     // variable names, because if the current context cannot be parsed as a struct name
     // it is possible that the user intention was to use a variable name.
-    let ty = parse_name_access_chain(context, || "a variable or struct name")?;
-    let ty_args = parse_optional_type_args(context)?;
+    let ty = parse_name_access_chain(
+        context,
+        /* macros */ false,
+        /* tyargs */ true,
+        || "a variable or struct name",
+    )?;
     let args = if context.tokens.peek() == Tok::LParen {
         let current_loc = current_token_loc(context.tokens);
         context.env.check_feature(
@@ -930,7 +1071,7 @@ fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
         FieldBindings::Named(args)
     };
     let end_loc = context.tokens.previous_end_loc();
-    let unpack = Bind_::Unpack(Box::new(ty), ty_args, args);
+    let unpack = Bind_::Unpack(Box::new(ty), args);
     Ok(spanned(
         context.tokens.file_hash(),
         start_loc,
@@ -1506,37 +1647,18 @@ fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnosti
 //          | <NameAccessChain> "!" <OptionalTypeArgs> "(" Comma<Exp> ")"
 //          | <NameAccessChain> <OptionalTypeArgs>
 fn parse_name_exp(context: &mut Context) -> Result<Exp_, Box<Diagnostic>> {
-    let name = parse_name_access_chain(context, || {
-        panic!("parse_name_exp with something other than a ModuleAccess")
-    })?;
-
-    let is_macro = if let Tok::Exclaim = context.tokens.peek() {
-        let loc = current_token_loc(context.tokens);
-        context.tokens.advance()?;
-        Some(loc)
-    } else {
-        None
-    };
-
-    // There's an ambiguity if the name is followed by a '<'.
-    // If there is no whitespace after the name or if a macro call has been started,
-    //   treat it as the start of a list of type arguments.
-    // Otherwise, assume that the '<' is a boolean operator.
-    let mut tys = None;
-    let start_loc = context.tokens.start_loc();
-    if context.tokens.peek() == Tok::Less
-        && (name.loc.end() as usize == start_loc || is_macro.is_some())
-    {
-        let loc = make_loc(context.tokens.file_hash(), start_loc, start_loc);
-        tys = parse_optional_type_args(context)
-            .map_err(|diag| add_type_args_ambiguity_label(loc, diag))?;
-    }
+    let name = parse_name_access_chain(
+        context,
+        /* macros */ true,
+        /* tyargs */ true,
+        || panic!("parse_name_exp with something other than a ModuleAccess"),
+    )?;
 
     match context.tokens.peek() {
-        _ if is_macro.is_some() => {
+        _ if name.value.is_macro().is_some() => {
             // if in a macro, we must have a call
             let rhs = parse_call_args(context)?;
-            Ok(Exp_::Call(name, is_macro, tys, rhs))
+            Ok(Exp_::Call(name, rhs))
         }
 
         // Pack: "{" Comma<ExpField> "}"
@@ -1548,18 +1670,18 @@ fn parse_name_exp(context: &mut Context) -> Result<Exp_, Box<Diagnostic>> {
                 parse_exp_field,
                 "a field expression",
             )?;
-            Ok(Exp_::Pack(name, tys, fs))
+            Ok(Exp_::Pack(name, fs))
         }
 
         // Call: "(" Comma<Exp> ")"
         Tok::LParen => {
-            debug_assert!(is_macro.is_none());
+            debug_assert!(name.value.is_macro().is_none());
             let rhs = parse_call_args(context)?;
-            Ok(Exp_::Call(name, None, tys, rhs))
+            Ok(Exp_::Call(name, rhs))
         }
 
         // Other name reference...
-        _ => Ok(Exp_::Name(name, tys)),
+        _ => Ok(Exp_::Name(name)),
     }
 }
 
@@ -1998,9 +2120,8 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
 // to determine if we should parse the type arguments and args following a name. Otherwise, we will
 // parse a field access
 fn is_start_of_call_after_function_name(context: &Context, n: &Name) -> bool {
-    let call_start = context.tokens.start_loc();
     let peeked = context.tokens.peek();
-    (peeked == Tok::Less && n.loc.end() as usize == call_start)
+    (peeked == Tok::Less && context.at_end(n.loc))
         || peeked == Tok::LParen
         || peeked == Tok::Exclaim
 }
@@ -2157,7 +2278,7 @@ fn parse_quant_binding(context: &mut Context) -> Result<Spanned<(Bind, Exp)>, Bo
         // Built `domain<ty>()` expression.
         context.tokens.advance()?;
         let ty = parse_type(context)?;
-        make_builtin_call(ty.loc, symbol!("$spec_domain"), Some(vec![ty]), vec![])
+        make_builtin_call(ty.loc, symbol!("$spec_domain"), vec![])
     } else {
         // This is a quantifier over a value, like a vector or a range.
         consume_identifier(context.tokens, "in")?;
@@ -2172,9 +2293,9 @@ fn parse_quant_binding(context: &mut Context) -> Result<Spanned<(Bind, Exp)>, Bo
     ))
 }
 
-fn make_builtin_call(loc: Loc, name: Symbol, type_args: Option<Vec<Type>>, args: Vec<Exp>) -> Exp {
-    let maccess = sp(loc, NameAccessChain_::One(sp(loc, name)));
-    sp(loc, Exp_::Call(maccess, None, type_args, sp(loc, args)))
+fn make_builtin_call(loc: Loc, name: Symbol, args: Vec<Exp>) -> Exp {
+    let maccess = sp(loc, NameAccessChain_::single(sp(loc, name)));
+    sp(loc, Exp_::Call(maccess, sp(loc, args)))
 }
 
 //**************************************************************************************************
@@ -2254,16 +2375,13 @@ fn parse_type_(
             ));
         }
         _ => {
-            let tn = parse_name_access_chain(context, || "a type name")?;
-            let start_loc = context.tokens.start_loc();
-            let tys = if context.tokens.peek() == Tok::Less
-                && (!whitespace_sensitive_ty_args || tn.loc.end() as usize == start_loc)
-            {
-                parse_comma_list(context, Tok::Less, Tok::Greater, parse_type, "a type")?
-            } else {
-                vec![]
-            };
-            Type_::Apply(Box::new(tn), tys)
+            let tn = parse_name_access_chain(
+                context,
+                /* macros */ false,
+                /* tyargs */ true,
+                || "a type name",
+            )?;
+            Type_::Apply(Box::new(tn))
         }
     };
     let end_loc = context.tokens.previous_end_loc();
@@ -2461,15 +2579,21 @@ fn parse_function_decl(
         sp(name.loc(), Type_::Unit)
     };
 
+    // FIXME: we don't use these
     // ("acquires" (<NameAccessChain> ",")* <NameAccessChain> ","?
     let mut acquires = vec![];
     if match_token(context.tokens, Tok::Acquires)? {
         let follows_acquire = |tok| matches!(tok, Tok::Semicolon | Tok::LBrace);
         loop {
-            acquires.push(parse_name_access_chain(context, || {
-                "a resource struct name"
-            })?);
+            let an = parse_name_access_chain(
+                context,
+                /* macros */ false,
+                /* tyargs */ false,
+                || "a resource struct name",
+            )?;
+            acquires.push(an);
             if follows_acquire(context.tokens.peek()) {
+                println!("breaking");
                 break;
             }
             consume_token(context.tokens, Tok::Comma)?;
@@ -2977,7 +3101,18 @@ fn parse_friend_decl(
 ) -> Result<FriendDecl, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
     consume_token(context.tokens, Tok::Friend)?;
-    let friend = parse_name_access_chain(context, || "a friend declaration")?;
+    let friend = parse_name_access_chain(
+        context,
+        /* macros */ false,
+        /* tyargs */ false,
+        || "a friend declaration",
+    )?;
+    if friend.value.is_macro().is_some() || friend.value.has_tyargs() {
+        context.env.add_diag(diag!(
+            Syntax::InvalidName,
+            (friend.loc, "Invalid 'friend' name")
+        ))
+    }
     consume_token(context.tokens, Tok::Semicolon)?;
     let loc = make_loc(
         context.tokens.file_hash(),
@@ -3019,9 +3154,19 @@ fn parse_use_decl(
     let use_ = match context.tokens.peek() {
         Tok::Fun => {
             consume_token(context.tokens, Tok::Fun).unwrap();
-            let function = parse_name_access_chain(context, || "a function name")?;
+            let function = parse_name_access_chain(
+                context,
+                /* macros */ false,
+                /* tyargs */ false,
+                || "a function name",
+            )?;
             consume_token(context.tokens, Tok::As)?;
-            let ty = parse_name_access_chain(context, || "a type name")?;
+            let ty = parse_name_access_chain(
+                context,
+                /* macros */ false,
+                /* tyargs */ false,
+                || "a type name with no type arguments",
+            )?;
             consume_token(context.tokens, Tok::Period)?;
             let method = parse_identifier(context)?;
             Use::Fun {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -554,16 +554,13 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
     let (mut is_macro, mut tys) = parse_macro_opt_and_tyargs_opt(context, ln.loc)?;
     if let Some(loc) = &is_macro {
         if !macros_allowed {
-            context.env.add_diag(diag!(
-                Syntax::InvalidName,
-                (
-                    *loc,
-                    format!(
-                        "Macro invocation are disallowed here. Expected {}",
-                        item_description()
-                    )
-                )
-            ));
+            let msg = format!(
+                "Macro invocation are disallowed here. Expected {}",
+                item_description()
+            );
+            context
+                .env
+                .add_diag(diag!(Syntax::InvalidName, (*loc, msg)));
             is_macro = None;
         }
     }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2541,7 +2541,6 @@ fn parse_struct_type_parameters(
 //          "fun"
 //          <FunctionDefName> "(" Comma<Parameter> ")"
 //          (":" <Type>)?
-//          ("acquires" <NameAccessChain> ("," <NameAccessChain>)*)?
 //          ("{" <Sequence> "}" | ";")
 //
 fn parse_function_decl(
@@ -2577,30 +2576,6 @@ fn parse_function_decl(
     } else {
         sp(name.loc(), Type_::Unit)
     };
-
-    // FIXME: we don't use these
-    // ("acquires" (<NameAccessChain> ",")* <NameAccessChain> ","?
-    let mut acquires = vec![];
-    if match_token(context.tokens, Tok::Acquires)? {
-        let follows_acquire = |tok| matches!(tok, Tok::Semicolon | Tok::LBrace);
-        loop {
-            let an = parse_name_access_chain(
-                context,
-                /* macros */ false,
-                /* tyargs */ false,
-                || "a resource struct name",
-            )?;
-            acquires.push(an);
-            if follows_acquire(context.tokens.peek()) {
-                println!("breaking");
-                break;
-            }
-            consume_token(context.tokens, Tok::Comma)?;
-            if follows_acquire(context.tokens.peek()) {
-                break;
-            }
-        }
-    }
 
     let body = match native {
         Some(loc) => {

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -343,15 +343,6 @@ where
 // Helper for location blocks
 
 macro_rules! ok_with_loc {
-    ($context:expr, $body:block) => {{
-        let start_loc = $context.tokens.start_loc();
-        let result = $body;
-        let end_loc = $context.tokens.previous_end_loc();
-        Ok(sp(
-            make_loc($context.tokens.file_hash(), start_loc, end_loc),
-            result,
-        ))
-    }};
     ($context:expr, $body:expr) => {{
         let start_loc = $context.tokens.start_loc();
         let result = $body;
@@ -623,7 +614,9 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
                 )
             )
         );
-        diag.add_note("Access chains that start with '::' must be multi-part");
+        if matches!(ln.value, LN::GlobalAddress(_)) {
+            diag.add_note("Access chains that start with '::' must be multi-part");
+        }
         return Err(Box::new(diag));
     }
 

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -8,7 +8,7 @@ use move_symbol_pool::Symbol;
 use crate::{
     diag,
     parser::{
-        ast as P,
+        ast::{self as P, NamePath, PathEntry},
         filter::{filter_program, FilterContext},
     },
     shared::{known_attributes, CompilationEnv},
@@ -159,16 +159,32 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
     );
 
     let mod_name = sp(mloc, UNIT_TEST_MODULE_NAME);
-    let mod_addr_name = sp(mloc, (leading_name_access, mod_name));
     let fn_name = sp(mloc, "create_signers_for_testing".into());
+    let name_path = NamePath {
+        root: P::RootPathEntry {
+            name: leading_name_access,
+            tyargs: None,
+            is_macro: None,
+        },
+        entries: vec![
+            PathEntry {
+                name: mod_name,
+                tyargs: None,
+                is_macro: None,
+            },
+            PathEntry {
+                name: fn_name,
+                tyargs: None,
+                is_macro: None,
+            },
+        ],
+    };
     let args_ = vec![sp(
         mloc,
         P::Exp_::Value(sp(mloc, P::Value_::Num("0".into()))),
     )];
     let nop_call = P::Exp_::Call(
-        sp(mloc, P::NameAccessChain_::Three(mod_addr_name, fn_name)),
-        None,
-        None,
+        sp(mloc, P::NameAccessChain_::Path(name_path)),
         sp(mloc, args_),
     );
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_module_name.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/use_module_name.move
@@ -1,0 +1,25 @@
+module a::vector {
+    public fun borrow<T>(_v: &vector<T>, _n: u64): &T { abort 0 }
+    public fun length<T>(_v: &vector<T>): u64 { abort 0 }
+    public fun singleton<T>(_t: T): vector<T> { abort 0 }
+}
+
+module a::vector_tests {
+    use a::vector as V;
+
+    public struct R has store { }
+    public struct Droppable has drop {}
+    public struct NotDroppable {}
+
+    fun test_singleton_contains() {
+        assert!(*V::borrow(&V::singleton(0), 0) == 0, 0);
+        assert!(*V::borrow(&V::singleton(true), 0) == true, 0);
+        assert!(*V::borrow(&V::singleton(@0x1), 0) == @0x1, 0);
+    }
+
+    fun test_singleton_len() {
+        assert!(V::length(&V::singleton(0)) == 1, 0);
+        assert!(V::length(&V::singleton(true)) == 1, 0);
+        assert!(V::length(&V::singleton(@0x1)) == 1, 0);
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_exists_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_exists_invalid.exp
@@ -16,8 +16,7 @@ error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/global_access_exists_invalid.move:13:26
    │
 13 │         let _ : bool = ::exists<Self::R>(0x0);
-   │                          ^^^^^^ Expected '::' after the address in this module access chain
+   │                          ^^^^^^ Expected '::' after the global address in this module access chain
    │
-   = Access chains that start with '::' must be one of the following forms: 
-       '::<address>::<module>', '::<address>::<module>::<member>'
+   = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_exists_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_exists_invalid.move
@@ -8,7 +8,7 @@ module 0x42::M {
     fun move_from(): u64 { 0 }
     fun freeze(): u64 { 0 }
 
-    fun t(account: &signer) acquires Self::R {
+    fun t(account: &signer) {
         let _ : u64 = exists();
         let _ : bool = ::exists<Self::R>(0x0);
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_pack_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_pack_invalid.exp
@@ -2,8 +2,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/global_access_pack_invalid.move:3:11
   │
 3 │         ::S { }
-  │           ^ Expected '::' after the address in this module access chain
+  │           ^ Expected '::' after the global address in this module access chain
   │
-  = Access chains that start with '::' must be one of the following forms: 
-      '::<address>::<module>', '::<address>::<module>::<member>'
+  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_value_invalid.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/global_access_value_invalid.exp
@@ -2,8 +2,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_2024/parser/global_access_value_invalid.move:3:15
   │
 3 │         1 + ::global_value
-  │               ^^^^^^^^^^^^ Expected '::' after the address in this module access chain
+  │               ^^^^^^^^^^^^ Expected '::' after the global address in this module access chain
   │
-  = Access chains that start with '::' must be one of the following forms: 
-      '::<address>::<module>', '::<address>::<module>::<member>'
+  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.exp
@@ -1,36 +1,73 @@
-error[E03004]: unbound type
-  ┌─ tests/move_2024/parser/invalid_macro_locs.move:5:37
+error[E04001]: restricted visibility
+  ┌─ tests/move_2024/parser/invalid_macro_locs.move:6:9
   │
-5 │     public macro fun make_s<$T>($u: T): S<T> {
-  │                                     ^ Unbound type 'T' in current scope
+6 │         S{ u: $u }
+  │         ^^^^^^^^^^ Invalid instantiation of 'a::m::S'.
+All structs can only be constructed in the module in which they are declared
 
-error[E03004]: unbound type
-  ┌─ tests/move_2024/parser/invalid_macro_locs.move:5:43
-  │
-5 │     public macro fun make_s<$T>($u: T): S<T> {
-  │                                           ^ Unbound type 'T' in current scope
-
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:10:11
+error[E04029]: invalid function call
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:13:9
    │
- 1 │ module a::m {
-   │           - Module previously defined here, with 'a::m'
+ 5 │     public macro fun make_s<$T>($u: $T): S<$T> {
+   │            ----- 'macro' function is declared here
    ·
-10 │ module a::m {
-   │           ^ Duplicate definition for module 'a::m'
+13 │         a!::m::make_s<u64>(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ 'make_s' is a macro function and must be called with a `!`. Try replacing with 'make_s!'
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:13:13
+   │
+13 │         a!::m::make_s<u64>(0u64)
+   │          -  ^ A macro call cannot have name access entries after it
+   │          │   
+   │          Macro invocation given here
+
+error[E04029]: invalid function call
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:17:9
+   │
+ 5 │     public macro fun make_s<$T>($u: $T): S<$T> {
+   │            ----- 'macro' function is declared here
+   ·
+17 │         a::m!::make_s<u64>(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ 'make_s' is a macro function and must be called with a `!`. Try replacing with 'make_s!'
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:17:16
+   │
+17 │         a::m!::make_s<u64>(0u64)
+   │             -  ^^^^^^ A macro call cannot have name access entries after it
+   │             │   
+   │             Macro invocation given here
+
+error[E04029]: invalid function call
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:21:9
+   │
+ 5 │     public macro fun make_s<$T>($u: $T): S<$T> {
+   │            ----- 'macro' function is declared here
+   ·
+21 │         a!::m!::make_s<u64>(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ 'make_s' is a macro function and must be called with a `!`. Try replacing with 'make_s!'
 
 error[E01016]: invalid name
    ┌─ tests/move_2024/parser/invalid_macro_locs.move:21:13
    │
-21 │         a!::m::make_s<u64>(0u64)
+21 │         a!::m!::make_s<u64>(0u64)
    │          -  ^ A macro call cannot have name access entries after it
    │          │   
    │          Macro invocation given here
 
 error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:21:17
+   │
+21 │         a!::m!::make_s<u64>(0u64)
+   │              -  ^^^^^^ A macro call cannot have name access entries after it
+   │              │   
+   │              Macro invocation given here
+
+error[E01016]: invalid name
    ┌─ tests/move_2024/parser/invalid_macro_locs.move:25:16
    │
-25 │         a::m!::make_s<u64>(0u64)
+25 │         a::m!::make_s!<u64>(0u64)
    │             -  ^^^^^^ A macro call cannot have name access entries after it
    │             │   
    │             Macro invocation given here
@@ -38,7 +75,7 @@ error[E01016]: invalid name
 error[E01016]: invalid name
    ┌─ tests/move_2024/parser/invalid_macro_locs.move:29:13
    │
-29 │         a!::m!::make_s<u64>(0u64)
+29 │         a!::m!::make_s!<u64>(0u64)
    │          -  ^ A macro call cannot have name access entries after it
    │          │   
    │          Macro invocation given here
@@ -46,91 +83,65 @@ error[E01016]: invalid name
 error[E01016]: invalid name
    ┌─ tests/move_2024/parser/invalid_macro_locs.move:29:17
    │
-29 │         a!::m!::make_s<u64>(0u64)
+29 │         a!::m!::make_s!<u64>(0u64)
    │              -  ^^^^^^ A macro call cannot have name access entries after it
    │              │   
    │              Macro invocation given here
-
-error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:32:23
-   │
-32 │     fun test04(): a::m<u64>::S {
-   │                       ^^^^^ Cannot use type parameters for a module
-
-error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:33:13
-   │
-33 │         a!::m!::make_s!<u64>(0u64)
-   │          -  ^ A macro call cannot have name access entries after it
-   │          │   
-   │          Macro invocation given here
-
-error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:33:17
-   │
-33 │         a!::m!::make_s!<u64>(0u64)
-   │              -  ^^^^^^ A macro call cannot have name access entries after it
-   │              │   
-   │              Macro invocation given here
-
-error[E03004]: unbound type
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:42:37
-   │
-42 │     public macro fun make_s<$T>($u: T): S<T> {
-   │                                     ^ Unbound type 'T' in current scope
-
-error[E03004]: unbound type
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:42:43
-   │
-42 │     public macro fun make_s<$T>($u: T): S<T> {
-   │                                           ^ Unbound type 'T' in current scope
 
 error[E04001]: restricted visibility
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:43:9
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:39:9
    │
-43 │         S{ u: $u }
+39 │         S{ u: $u }
    │         ^^^^^^^^^^ Invalid instantiation of '0x42::m::S'.
 All structs can only be constructed in the module in which they are declared
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:58:13
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:46:13
    │
-58 │         0x42!::m::make_s<u64>(0u64)
+46 │         0x42!::m::make_s<u64>(0u64)
    │             ^
    │             │
    │             Unexpected '!'
    │             Expected ';'
 
 error[E04029]: invalid function call
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:62:9
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:50:9
    │
-42 │     public macro fun make_s<$T>($u: T): S<T> {
+38 │     public macro fun make_s<$T>($u: $T): S<$T> {
    │            ----- 'macro' function is declared here
    ·
-62 │         0x42::m!::make_s<u64>(0u64)
+50 │         0x42::m!::make_s<u64>(0u64)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'make_s' is a macro function and must be called with a `!`. Try replacing with 'make_s!'
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:62:19
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:50:19
    │
-62 │         0x42::m!::make_s<u64>(0u64)
+50 │         0x42::m!::make_s<u64>(0u64)
    │                -  ^^^^^^ A macro call cannot have name access entries after it
    │                │   
    │                Macro invocation given here
 
 error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:66:13
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:54:13
    │
-66 │         0x42!::m!::make_s<u64>(0u64)
+54 │         0x42!::m!::make_s<u64>(0u64)
    │             ^
    │             │
    │             Unexpected '!'
    │             Expected ';'
 
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/invalid_macro_locs.move:70:13
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:58:19
    │
-70 │         0x42!::m!::make_s!<u64>(0u64)
+58 │         0x42::m!::make_s!<u64>(0u64)
+   │                -  ^^^^^^ A macro call cannot have name access entries after it
+   │                │   
+   │                Macro invocation given here
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:62:13
+   │
+62 │         0x42!::m!::make_s!<u64>(0u64)
    │             ^
    │             │
    │             Unexpected '!'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.exp
@@ -1,0 +1,138 @@
+error[E03004]: unbound type
+  ┌─ tests/move_2024/parser/invalid_macro_locs.move:5:37
+  │
+5 │     public macro fun make_s<$T>($u: T): S<T> {
+  │                                     ^ Unbound type 'T' in current scope
+
+error[E03004]: unbound type
+  ┌─ tests/move_2024/parser/invalid_macro_locs.move:5:43
+  │
+5 │     public macro fun make_s<$T>($u: T): S<T> {
+  │                                           ^ Unbound type 'T' in current scope
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:10:11
+   │
+ 1 │ module a::m {
+   │           - Module previously defined here, with 'a::m'
+   ·
+10 │ module a::m {
+   │           ^ Duplicate definition for module 'a::m'
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:21:13
+   │
+21 │         a!::m::make_s<u64>(0u64)
+   │          -  ^ A macro call cannot have name access entries after it
+   │          │   
+   │          Macro invocation given here
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:25:16
+   │
+25 │         a::m!::make_s<u64>(0u64)
+   │             -  ^^^^^^ A macro call cannot have name access entries after it
+   │             │   
+   │             Macro invocation given here
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:29:13
+   │
+29 │         a!::m!::make_s<u64>(0u64)
+   │          -  ^ A macro call cannot have name access entries after it
+   │          │   
+   │          Macro invocation given here
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:29:17
+   │
+29 │         a!::m!::make_s<u64>(0u64)
+   │              -  ^^^^^^ A macro call cannot have name access entries after it
+   │              │   
+   │              Macro invocation given here
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:32:23
+   │
+32 │     fun test04(): a::m<u64>::S {
+   │                       ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:33:13
+   │
+33 │         a!::m!::make_s!<u64>(0u64)
+   │          -  ^ A macro call cannot have name access entries after it
+   │          │   
+   │          Macro invocation given here
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:33:17
+   │
+33 │         a!::m!::make_s!<u64>(0u64)
+   │              -  ^^^^^^ A macro call cannot have name access entries after it
+   │              │   
+   │              Macro invocation given here
+
+error[E03004]: unbound type
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:42:37
+   │
+42 │     public macro fun make_s<$T>($u: T): S<T> {
+   │                                     ^ Unbound type 'T' in current scope
+
+error[E03004]: unbound type
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:42:43
+   │
+42 │     public macro fun make_s<$T>($u: T): S<T> {
+   │                                           ^ Unbound type 'T' in current scope
+
+error[E04001]: restricted visibility
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:43:9
+   │
+43 │         S{ u: $u }
+   │         ^^^^^^^^^^ Invalid instantiation of '0x42::m::S'.
+All structs can only be constructed in the module in which they are declared
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:58:13
+   │
+58 │         0x42!::m::make_s<u64>(0u64)
+   │             ^
+   │             │
+   │             Unexpected '!'
+   │             Expected ';'
+
+error[E04029]: invalid function call
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:62:9
+   │
+42 │     public macro fun make_s<$T>($u: T): S<T> {
+   │            ----- 'macro' function is declared here
+   ·
+62 │         0x42::m!::make_s<u64>(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 'make_s' is a macro function and must be called with a `!`. Try replacing with 'make_s!'
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:62:19
+   │
+62 │         0x42::m!::make_s<u64>(0u64)
+   │                -  ^^^^^^ A macro call cannot have name access entries after it
+   │                │   
+   │                Macro invocation given here
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:66:13
+   │
+66 │         0x42!::m!::make_s<u64>(0u64)
+   │             ^
+   │             │
+   │             Unexpected '!'
+   │             Expected ';'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/invalid_macro_locs.move:70:13
+   │
+70 │         0x42!::m!::make_s!<u64>(0u64)
+   │             ^
+   │             │
+   │             Unexpected '!'
+   │             Expected ';'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
@@ -2,12 +2,12 @@ module a::m {
 
     public struct S<T> { u: T }
 
-    public macro fun make_s<$T>($u: T): S<T> {
+    public macro fun make_s<$T>($u: $T): S<$T> {
         S{ u: $u }
     }
 }
 
-module a::m {
+module a::n {
 
     fun valid(): a::m::S<u64> {
         a::m::make_s!<u64>(0u64)
@@ -39,7 +39,7 @@ module 0x42::m {
 
     public struct S<T> { u: T }
 
-    public macro fun make_s<$T>($u: T): S<T> {
+    public macro fun make_s<$T>($u: $T): S<$T> {
         S{ u: $u }
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
@@ -1,0 +1,73 @@
+module a::m {
+
+    public struct S<T> { u: T }
+
+    public macro fun make_s<$T>($u: T): S<T> {
+        S{ u: $u }
+    }
+}
+
+module a::m {
+
+    fun valid(): a::m::S<u64> {
+        a::m::make_s!<u64>(0u64)
+    }
+
+    fun test00(): a::m::S<u64> {
+        a::m::make_s!<u64>(0u64)
+    }
+
+    fun test01(): a::m::S<u64> {
+        a!::m::make_s<u64>(0u64)
+    }
+
+    fun test02(): a::m::S<u64> {
+        a::m!::make_s<u64>(0u64)
+    }
+
+    fun test03(): a::m::S<u64> {
+        a!::m!::make_s<u64>(0u64)
+    }
+
+    fun test04(): a::m<u64>::S {
+        a!::m!::make_s!<u64>(0u64)
+    }
+
+}
+
+module 0x42::m {
+
+    public struct S<T> { u: T }
+
+    public macro fun make_s<$T>($u: T): S<T> {
+        S{ u: $u }
+    }
+}
+
+module 0x42::n {
+
+    fun valid(): 0x42::m::S<u64> {
+        0x42::m::make_s!<u64>(0u64)
+    }
+
+    fun test00(): 0x42::m::S<u64> {
+        0x42::m::make_s!<u64>(0u64)
+    }
+
+    fun test01(): 0x42::m::S<u64> {
+        0x42!::m::make_s<u64>(0u64)
+    }
+
+    fun test02(): 0x42::m::S<u64> {
+        0x42::m!::make_s<u64>(0u64)
+    }
+
+    fun test03(): 0x42::m::S<u64> {
+        0x42!::m!::make_s<u64>(0u64)
+    }
+
+    fun test04(): 0x42::m<u64>::S {
+        0x42!::m!::make_s!<u64>(0u64)
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_macro_locs.move
@@ -9,27 +9,23 @@ module a::m {
 
 module a::n {
 
-    fun valid(): a::m::S<u64> {
-        a::m::make_s!<u64>(0u64)
-    }
-
     fun test00(): a::m::S<u64> {
-        a::m::make_s!<u64>(0u64)
-    }
-
-    fun test01(): a::m::S<u64> {
         a!::m::make_s<u64>(0u64)
     }
 
-    fun test02(): a::m::S<u64> {
+    fun test01(): a::m::S<u64> {
         a::m!::make_s<u64>(0u64)
     }
 
-    fun test03(): a::m::S<u64> {
+    fun test02(): a::m::S<u64> {
         a!::m!::make_s<u64>(0u64)
     }
 
-    fun test04(): a::m<u64>::S {
+    fun test03(): a::m::S<u64> {
+        a::m!::make_s!<u64>(0u64)
+    }
+
+    fun test04(): a::m::S<u64> {
         a!::m!::make_s!<u64>(0u64)
     }
 
@@ -46,27 +42,23 @@ module 0x42::m {
 
 module 0x42::n {
 
-    fun valid(): 0x42::m::S<u64> {
-        0x42::m::make_s!<u64>(0u64)
-    }
-
     fun test00(): 0x42::m::S<u64> {
-        0x42::m::make_s!<u64>(0u64)
-    }
-
-    fun test01(): 0x42::m::S<u64> {
         0x42!::m::make_s<u64>(0u64)
     }
 
-    fun test02(): 0x42::m::S<u64> {
+    fun test01(): 0x42::m::S<u64> {
         0x42::m!::make_s<u64>(0u64)
     }
 
-    fun test03(): 0x42::m::S<u64> {
+    fun test02(): 0x42::m::S<u64> {
         0x42!::m!::make_s<u64>(0u64)
     }
 
-    fun test04(): 0x42::m<u64>::S {
+    fun test03(): 0x42::m::S<u64> {
+        0x42::m!::make_s!<u64>(0u64)
+    }
+
+    fun test04(): 0x42::m::S<u64> {
         0x42!::m!::make_s!<u64>(0u64)
     }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.exp
@@ -1,46 +1,55 @@
-error[E02001]: duplicate declaration, item, or annotation
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:10:11
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:12:19
    │
- 1 │ module a::m {
-   │           - Module previously defined here, with 'a::m'
-   ·
-10 │ module a::m {
-   │           ^ Duplicate definition for module 'a::m'
+12 │     fun test00(): a::m<u64>::S {
+   │                   ^^^^^^^^^^^^ Invalid instantiation of 'a::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:16:23
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:12:23
    │
-16 │     fun test00(): a::m<u64>::S {
+12 │     fun test00(): a::m<u64>::S {
    │                       ^^^^^ Cannot use type parameters for a module
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:17:13
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:13:13
    │
-17 │         a::m<u64>::make_s(0u64)
+13 │         a::m<u64>::make_s(0u64)
    │             ^^^^^ Cannot use type parameters for a module
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:16:19
+   │
+16 │     fun test01(): a<u64>::m::S {
+   │                   ^^^^^^^^^^^^ Invalid instantiation of 'a::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:16:20
+   │
+16 │     fun test01(): a<u64>::m::S {
+   │                    ^^^^^ Cannot use type parameters for an address
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:17:10
+   │
+17 │         a<u64>::m::make_s(0u64)
+   │          ^^^^^ Cannot use type parameters for an address
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:20:19
+   │
+20 │     fun test02(): a<u64>::m<u64>::S {
+   │                   ^^^^^^^^^^^^^^^^^ Invalid instantiation of 'a::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
    ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:20:20
    │
-20 │     fun test01(): a<u64>::m::S {
-   │                    ^^^^^ Cannot use type parameters for an address
-
-error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:21:10
-   │
-21 │         a<u64>::m::make_s(0u64)
-   │          ^^^^^ Cannot use type parameters for an address
-
-error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:20
-   │
-24 │     fun test02(): a<u64>::m<u64>::S {
+20 │     fun test02(): a<u64>::m<u64>::S {
    │                    ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:28
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:20:28
    │
-24 │     fun test02(): a<u64>::m<u64>::S {
+20 │     fun test02(): a<u64>::m<u64>::S {
    │                    -----   ^^^^^ Paths cannot include type arguments more than once
    │                    │        
    │                    Previous type arguments appeared here
@@ -48,31 +57,37 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:10
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:21:10
    │
-25 │         a<u64>::m<u64>::make_s(0u64)
+21 │         a<u64>::m<u64>::make_s(0u64)
    │          ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:18
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:21:18
    │
-25 │         a<u64>::m<u64>::make_s(0u64)
+21 │         a<u64>::m<u64>::make_s(0u64)
    │          -----   ^^^^^ Paths cannot include type arguments more than once
    │          │        
    │          Previous type arguments appeared here
    │
    = Type arguments should only appear on module members
 
-error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:23
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:19
    │
-28 │     fun test03(): a::m<u64>::S<u64> {
+24 │     fun test03(): a::m<u64>::S<u64> {
+   │                   ^^^^^^^^^^^^^^^^^ Invalid instantiation of 'a::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:23
+   │
+24 │     fun test03(): a::m<u64>::S<u64> {
    │                       ^^^^^ Cannot use type parameters for a module
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:31
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:31
    │
-28 │     fun test03(): a::m<u64>::S<u64> {
+24 │     fun test03(): a::m<u64>::S<u64> {
    │                       -----   ^^^^^ Paths cannot include type arguments more than once
    │                       │        
    │                       Previous type arguments appeared here
@@ -80,47 +95,63 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:13
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:13
    │
-29 │         a::m<u64>::make_s<u64>(0u64)
+25 │         a::m<u64>::make_s<u64>(0u64)
    │             ^^^^^ Cannot use type parameters for a module
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:26
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:26
    │
-29 │         a::m<u64>::make_s<u64>(0u64)
+25 │         a::m<u64>::make_s<u64>(0u64)
    │             -----        ^^^^^ Paths cannot include type arguments more than once
    │             │             
    │             Previous type arguments appeared here
    │
    = Type arguments should only appear on module members
 
-error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:32:23
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:19
    │
-32 │     fun test04(): a::m<u64>::S<u64> {
-   │                       ^^^^^ Cannot use type parameters for a module
+28 │     fun test04(): a<u64>::m<u64>::S<u64> {
+   │                   ^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of 'a::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:20
+   │
+28 │     fun test04(): a<u64>::m<u64>::S<u64> {
+   │                    ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:32:31
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:28
    │
-32 │     fun test04(): a::m<u64>::S<u64> {
-   │                       -----   ^^^^^ Paths cannot include type arguments more than once
-   │                       │        
-   │                       Previous type arguments appeared here
+28 │     fun test04(): a<u64>::m<u64>::S<u64> {
+   │                    -----   ^^^^^ Paths cannot include type arguments more than once
+   │                    │        
+   │                    Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:36
+   │
+28 │     fun test04(): a<u64>::m<u64>::S<u64> {
+   │                    -----           ^^^^^ Paths cannot include type arguments more than once
+   │                    │                
+   │                    Previous type arguments appeared here
    │
    = Type arguments should only appear on module members
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:10
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:10
    │
-33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+29 │         a<u64>::m<u64>::make_s<u64>(0u64)
    │          ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:18
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:18
    │
-33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+29 │         a<u64>::m<u64>::make_s<u64>(0u64)
    │          -----   ^^^^^ Paths cannot include type arguments more than once
    │          │        
    │          Previous type arguments appeared here
@@ -128,9 +159,9 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:31
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:31
    │
-33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+29 │         a<u64>::m<u64>::make_s<u64>(0u64)
    │          -----                ^^^^^ Paths cannot include type arguments more than once
    │          │                     
    │          Previous type arguments appeared here
@@ -138,91 +169,91 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E03008]: too few type arguments
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:19
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:46:19
    │
-54 │     fun test00(): 0x42::m<u64>::S {
+46 │     fun test00(): 0x42::m<u64>::S {
    │                   ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:26
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:46:26
    │
-54 │     fun test00(): 0x42::m<u64>::S {
+46 │     fun test00(): 0x42::m<u64>::S {
    │                          ^^^^^ Cannot use type parameters for a module
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:16
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:47:16
    │
-55 │         0x42::m<u64>::make_s(0u64)
+47 │         0x42::m<u64>::make_s(0u64)
    │                ^^^^^ Cannot use type parameters for a module
 
 error[E03008]: too few type arguments
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:19
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:50:19
    │
-58 │     fun test01(): 0x42<u64>::m::S {
+50 │     fun test01(): 0x42<u64>::m::S {
    │                   ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:23
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:50:23
    │
-58 │     fun test01(): 0x42<u64>::m::S {
+50 │     fun test01(): 0x42<u64>::m::S {
    │                       ^^^^^ Cannot use type parameters for an address
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:51:9
    │
-59 │         0x42<u64>::m::make_s(0u64)
+51 │         0x42<u64>::m::make_s(0u64)
    │         ^^^^^^^^
    │         │
    │         Invalid argument to '>'
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:51:9
    │
-58 │     fun test01(): 0x42<u64>::m::S {
+50 │     fun test01(): 0x42<u64>::m::S {
    │                   --------------- Expected: '0x42::m::S<_>'
-59 │         0x42<u64>::m::make_s(0u64)
+51 │         0x42<u64>::m::make_s(0u64)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │
    │         Invalid return expression
    │         Given: 'bool'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:14
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:51:14
    │
-59 │         0x42<u64>::m::make_s(0u64)
+51 │         0x42<u64>::m::make_s(0u64)
    │              ^^^ Unbound variable 'u64'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:18
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:51:18
    │
-59 │         0x42<u64>::m::make_s(0u64)
+51 │         0x42<u64>::m::make_s(0u64)
    │         -------- ^^^^^^^^^^^^^^^^^ Invalid argument to '>'
    │         │         
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:20
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:51:20
    │
-59 │         0x42<u64>::m::make_s(0u64)
+51 │         0x42<u64>::m::make_s(0u64)
    │                    ^ Could not resolve the name 'm'
 
 error[E03008]: too few type arguments
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:19
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:19
    │
-62 │     fun test02(): 0x42<u64>::m<u64>::S {
+54 │     fun test02(): 0x42<u64>::m<u64>::S {
    │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:23
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:23
    │
-62 │     fun test02(): 0x42<u64>::m<u64>::S {
+54 │     fun test02(): 0x42<u64>::m<u64>::S {
    │                       ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:31
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:31
    │
-62 │     fun test02(): 0x42<u64>::m<u64>::S {
+54 │     fun test02(): 0x42<u64>::m<u64>::S {
    │                       -----   ^^^^^ Paths cannot include type arguments more than once
    │                       │        
    │                       Previous type arguments appeared here
@@ -230,61 +261,61 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:9
    │
-63 │         0x42<u64>::m<u64>::make_s(0u64)
+55 │         0x42<u64>::m<u64>::make_s(0u64)
    │         ^^^^^^^^
    │         │
    │         Invalid argument to '>'
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:9
    │
-62 │     fun test02(): 0x42<u64>::m<u64>::S {
+54 │     fun test02(): 0x42<u64>::m<u64>::S {
    │                   -------------------- Expected: '0x42::m::S<_>'
-63 │         0x42<u64>::m<u64>::make_s(0u64)
+55 │         0x42<u64>::m<u64>::make_s(0u64)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │
    │         Invalid return expression
    │         Given: 'bool'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:14
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:14
    │
-63 │         0x42<u64>::m<u64>::make_s(0u64)
+55 │         0x42<u64>::m<u64>::make_s(0u64)
    │              ^^^ Unbound variable 'u64'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:18
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:18
    │
-63 │         0x42<u64>::m<u64>::make_s(0u64)
+55 │         0x42<u64>::m<u64>::make_s(0u64)
    │         -------- ^^^^^^^^^^^^^^^^^^^^^^ Invalid argument to '>'
    │         │         
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:20
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:20
    │
-63 │         0x42<u64>::m<u64>::make_s(0u64)
+55 │         0x42<u64>::m<u64>::make_s(0u64)
    │                    ^ Could not resolve the name 'm'
 
 error[E03008]: too few type arguments
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:19
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:19
    │
-66 │     fun test03(): 0x42::m<u64>::S<u64> {
+58 │     fun test03(): 0x42::m<u64>::S<u64> {
    │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:26
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:26
    │
-66 │     fun test03(): 0x42::m<u64>::S<u64> {
+58 │     fun test03(): 0x42::m<u64>::S<u64> {
    │                          ^^^^^ Cannot use type parameters for a module
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:34
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:34
    │
-66 │     fun test03(): 0x42::m<u64>::S<u64> {
+58 │     fun test03(): 0x42::m<u64>::S<u64> {
    │                          -----   ^^^^^ Paths cannot include type arguments more than once
    │                          │        
    │                          Previous type arguments appeared here
@@ -292,15 +323,15 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:67:16
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:16
    │
-67 │         0x42::m<u64>::make_s<u64>(0u64)
+59 │         0x42::m<u64>::make_s<u64>(0u64)
    │                ^^^^^ Cannot use type parameters for a module
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:67:29
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:29
    │
-67 │         0x42::m<u64>::make_s<u64>(0u64)
+59 │         0x42::m<u64>::make_s<u64>(0u64)
    │                -----        ^^^^^ Paths cannot include type arguments more than once
    │                │             
    │                Previous type arguments appeared here
@@ -308,71 +339,81 @@ error[E01016]: invalid name
    = Type arguments should only appear on module members
 
 error[E03008]: too few type arguments
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:19
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:19
    │
-70 │     fun test04(): 0x42::m<u64>::S<u64> {
-   │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+62 │     fun test04(): 0x42<u64>::m<u64>::S<u64> {
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
 
 error[E03018]: invalid type parameter
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:26
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:23
    │
-70 │     fun test04(): 0x42::m<u64>::S<u64> {
-   │                          ^^^^^ Cannot use type parameters for a module
+62 │     fun test04(): 0x42<u64>::m<u64>::S<u64> {
+   │                       ^^^^^ Cannot use type parameters for an address
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:34
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:31
    │
-70 │     fun test04(): 0x42::m<u64>::S<u64> {
-   │                          -----   ^^^^^ Paths cannot include type arguments more than once
-   │                          │        
-   │                          Previous type arguments appeared here
+62 │     fun test04(): 0x42<u64>::m<u64>::S<u64> {
+   │                       -----   ^^^^^ Paths cannot include type arguments more than once
+   │                       │        
+   │                       Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:39
+   │
+62 │     fun test04(): 0x42<u64>::m<u64>::S<u64> {
+   │                       -----           ^^^^^ Paths cannot include type arguments more than once
+   │                       │                
+   │                       Previous type arguments appeared here
    │
    = Type arguments should only appear on module members
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
    │
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │         ^^^^^^^^
    │         │
    │         Invalid argument to '>'
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:9
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
    │
-70 │     fun test04(): 0x42::m<u64>::S<u64> {
-   │                   -------------------- Expected: '0x42::m::S<_>'
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+62 │     fun test04(): 0x42<u64>::m<u64>::S<u64> {
+   │                   ------------------------- Expected: '0x42::m::S<_>'
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │
    │         Invalid return expression
    │         Given: 'bool'
 
 error[E03009]: unbound variable
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:14
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:14
    │
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │              ^^^ Unbound variable 'u64'
 
 error[E04003]: built-in operation not supported
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:18
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:18
    │
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │         -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid argument to '>'
    │         │         
    │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E03006]: unexpected name in this position
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:20
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:20
    │
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │                    ^ Could not resolve the name 'm'
 
 error[E01016]: invalid name
-   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:34
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:34
    │
-71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+63 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
    │                     -----        ^^^^^ Paths cannot include type arguments more than once
    │                     │             
    │                     Previous type arguments appeared here

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.exp
@@ -1,0 +1,381 @@
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:10:11
+   │
+ 1 │ module a::m {
+   │           - Module previously defined here, with 'a::m'
+   ·
+10 │ module a::m {
+   │           ^ Duplicate definition for module 'a::m'
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:16:23
+   │
+16 │     fun test00(): a::m<u64>::S {
+   │                       ^^^^^ Cannot use type parameters for a module
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:17:13
+   │
+17 │         a::m<u64>::make_s(0u64)
+   │             ^^^^^ Cannot use type parameters for a module
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:20:20
+   │
+20 │     fun test01(): a<u64>::m::S {
+   │                    ^^^^^ Cannot use type parameters for an address
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:21:10
+   │
+21 │         a<u64>::m::make_s(0u64)
+   │          ^^^^^ Cannot use type parameters for an address
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:20
+   │
+24 │     fun test02(): a<u64>::m<u64>::S {
+   │                    ^^^^^ Cannot use type parameters for an address
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:24:28
+   │
+24 │     fun test02(): a<u64>::m<u64>::S {
+   │                    -----   ^^^^^ Paths cannot include type arguments more than once
+   │                    │        
+   │                    Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:10
+   │
+25 │         a<u64>::m<u64>::make_s(0u64)
+   │          ^^^^^ Cannot use type parameters for an address
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:25:18
+   │
+25 │         a<u64>::m<u64>::make_s(0u64)
+   │          -----   ^^^^^ Paths cannot include type arguments more than once
+   │          │        
+   │          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:23
+   │
+28 │     fun test03(): a::m<u64>::S<u64> {
+   │                       ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:28:31
+   │
+28 │     fun test03(): a::m<u64>::S<u64> {
+   │                       -----   ^^^^^ Paths cannot include type arguments more than once
+   │                       │        
+   │                       Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:13
+   │
+29 │         a::m<u64>::make_s<u64>(0u64)
+   │             ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:29:26
+   │
+29 │         a::m<u64>::make_s<u64>(0u64)
+   │             -----        ^^^^^ Paths cannot include type arguments more than once
+   │             │             
+   │             Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:32:23
+   │
+32 │     fun test04(): a::m<u64>::S<u64> {
+   │                       ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:32:31
+   │
+32 │     fun test04(): a::m<u64>::S<u64> {
+   │                       -----   ^^^^^ Paths cannot include type arguments more than once
+   │                       │        
+   │                       Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:10
+   │
+33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+   │          ^^^^^ Cannot use type parameters for an address
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:18
+   │
+33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+   │          -----   ^^^^^ Paths cannot include type arguments more than once
+   │          │        
+   │          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:33:31
+   │
+33 │         a<u64>::m<u64>::make_s<u64>(0u64)
+   │          -----                ^^^^^ Paths cannot include type arguments more than once
+   │          │                     
+   │          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:19
+   │
+54 │     fun test00(): 0x42::m<u64>::S {
+   │                   ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:54:26
+   │
+54 │     fun test00(): 0x42::m<u64>::S {
+   │                          ^^^^^ Cannot use type parameters for a module
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:55:16
+   │
+55 │         0x42::m<u64>::make_s(0u64)
+   │                ^^^^^ Cannot use type parameters for a module
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:19
+   │
+58 │     fun test01(): 0x42<u64>::m::S {
+   │                   ^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:58:23
+   │
+58 │     fun test01(): 0x42<u64>::m::S {
+   │                       ^^^^^ Cannot use type parameters for an address
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:9
+   │
+59 │         0x42<u64>::m::make_s(0u64)
+   │         ^^^^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:9
+   │
+58 │     fun test01(): 0x42<u64>::m::S {
+   │                   --------------- Expected: '0x42::m::S<_>'
+59 │         0x42<u64>::m::make_s(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given: 'bool'
+
+error[E03009]: unbound variable
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:14
+   │
+59 │         0x42<u64>::m::make_s(0u64)
+   │              ^^^ Unbound variable 'u64'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:18
+   │
+59 │         0x42<u64>::m::make_s(0u64)
+   │         -------- ^^^^^^^^^^^^^^^^^ Invalid argument to '>'
+   │         │         
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:59:20
+   │
+59 │         0x42<u64>::m::make_s(0u64)
+   │                    ^ Could not resolve the name 'm'
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:19
+   │
+62 │     fun test02(): 0x42<u64>::m<u64>::S {
+   │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:23
+   │
+62 │     fun test02(): 0x42<u64>::m<u64>::S {
+   │                       ^^^^^ Cannot use type parameters for an address
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:62:31
+   │
+62 │     fun test02(): 0x42<u64>::m<u64>::S {
+   │                       -----   ^^^^^ Paths cannot include type arguments more than once
+   │                       │        
+   │                       Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
+   │
+63 │         0x42<u64>::m<u64>::make_s(0u64)
+   │         ^^^^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:9
+   │
+62 │     fun test02(): 0x42<u64>::m<u64>::S {
+   │                   -------------------- Expected: '0x42::m::S<_>'
+63 │         0x42<u64>::m<u64>::make_s(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given: 'bool'
+
+error[E03009]: unbound variable
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:14
+   │
+63 │         0x42<u64>::m<u64>::make_s(0u64)
+   │              ^^^ Unbound variable 'u64'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:18
+   │
+63 │         0x42<u64>::m<u64>::make_s(0u64)
+   │         -------- ^^^^^^^^^^^^^^^^^^^^^^ Invalid argument to '>'
+   │         │         
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:63:20
+   │
+63 │         0x42<u64>::m<u64>::make_s(0u64)
+   │                    ^ Could not resolve the name 'm'
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:19
+   │
+66 │     fun test03(): 0x42::m<u64>::S<u64> {
+   │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:26
+   │
+66 │     fun test03(): 0x42::m<u64>::S<u64> {
+   │                          ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:66:34
+   │
+66 │     fun test03(): 0x42::m<u64>::S<u64> {
+   │                          -----   ^^^^^ Paths cannot include type arguments more than once
+   │                          │        
+   │                          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:67:16
+   │
+67 │         0x42::m<u64>::make_s<u64>(0u64)
+   │                ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:67:29
+   │
+67 │         0x42::m<u64>::make_s<u64>(0u64)
+   │                -----        ^^^^^ Paths cannot include type arguments more than once
+   │                │             
+   │                Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E03008]: too few type arguments
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:19
+   │
+70 │     fun test04(): 0x42::m<u64>::S<u64> {
+   │                   ^^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x42::m::S'. Expected 1 type argument(s) but got 0
+
+error[E03018]: invalid type parameter
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:26
+   │
+70 │     fun test04(): 0x42::m<u64>::S<u64> {
+   │                          ^^^^^ Cannot use type parameters for a module
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:70:34
+   │
+70 │     fun test04(): 0x42::m<u64>::S<u64> {
+   │                          -----   ^^^^^ Paths cannot include type arguments more than once
+   │                          │        
+   │                          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:9
+   │
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │         ^^^^^^^^
+   │         │
+   │         Invalid argument to '>'
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:9
+   │
+70 │     fun test04(): 0x42::m<u64>::S<u64> {
+   │                   -------------------- Expected: '0x42::m::S<_>'
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │
+   │         Invalid return expression
+   │         Given: 'bool'
+
+error[E03009]: unbound variable
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:14
+   │
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │              ^^^ Unbound variable 'u64'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:18
+   │
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │         -------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid argument to '>'
+   │         │         
+   │         Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:20
+   │
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │                    ^ Could not resolve the name 'm'
+
+error[E01016]: invalid name
+   ┌─ tests/move_2024/parser/invalid_tyarg_locs.move:71:34
+   │
+71 │         0x42<u64>::m<u64>::make_s<u64>(0u64)
+   │                     -----        ^^^^^ Paths cannot include type arguments more than once
+   │                     │             
+   │                     Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.move
@@ -1,0 +1,74 @@
+module a::m {
+
+    public struct S<T> { u: T }
+
+    public fun make_s<T>(u: T): S<T> {
+        S{ u }
+    }
+}
+
+module a::m {
+
+    fun valid(): a::m::S<u64> {
+        a::m::make_s<u64>(0u64)
+    }
+
+    fun test00(): a::m<u64>::S {
+        a::m<u64>::make_s(0u64)
+    }
+
+    fun test01(): a<u64>::m::S {
+        a<u64>::m::make_s(0u64)
+    }
+
+    fun test02(): a<u64>::m<u64>::S {
+        a<u64>::m<u64>::make_s(0u64)
+    }
+
+    fun test03(): a::m<u64>::S<u64> {
+        a::m<u64>::make_s<u64>(0u64)
+    }
+
+    fun test04(): a::m<u64>::S<u64> {
+        a<u64>::m<u64>::make_s<u64>(0u64)
+    }
+
+}
+
+module 0x42::m {
+
+    public struct S<T> { u: T }
+
+    public fun make_s<T>(u: T): S<T> {
+        S{ u }
+    }
+
+}
+
+module 0x42::n {
+
+    fun valid(): 0x42::m::S<u64> {
+        0x42::m::make_s<u64>(0u64)
+    }
+
+    fun test00(): 0x42::m<u64>::S {
+        0x42::m<u64>::make_s(0u64)
+    }
+
+    fun test01(): 0x42<u64>::m::S {
+        0x42<u64>::m::make_s(0u64)
+    }
+
+    fun test02(): 0x42<u64>::m<u64>::S {
+        0x42<u64>::m<u64>::make_s(0u64)
+    }
+
+    fun test03(): 0x42::m<u64>::S<u64> {
+        0x42::m<u64>::make_s<u64>(0u64)
+    }
+
+    fun test04(): 0x42::m<u64>::S<u64> {
+        0x42<u64>::m<u64>::make_s<u64>(0u64)
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/invalid_tyarg_locs.move
@@ -7,11 +7,7 @@ module a::m {
     }
 }
 
-module a::m {
-
-    fun valid(): a::m::S<u64> {
-        a::m::make_s<u64>(0u64)
-    }
+module a::n {
 
     fun test00(): a::m<u64>::S {
         a::m<u64>::make_s(0u64)
@@ -29,7 +25,7 @@ module a::m {
         a::m<u64>::make_s<u64>(0u64)
     }
 
-    fun test04(): a::m<u64>::S<u64> {
+    fun test04(): a<u64>::m<u64>::S<u64> {
         a<u64>::m<u64>::make_s<u64>(0u64)
     }
 
@@ -47,10 +43,6 @@ module 0x42::m {
 
 module 0x42::n {
 
-    fun valid(): 0x42::m::S<u64> {
-        0x42::m::make_s<u64>(0u64)
-    }
-
     fun test00(): 0x42::m<u64>::S {
         0x42::m<u64>::make_s(0u64)
     }
@@ -67,7 +59,7 @@ module 0x42::n {
         0x42::m<u64>::make_s<u64>(0u64)
     }
 
-    fun test04(): 0x42::m<u64>::S<u64> {
+    fun test04(): 0x42<u64>::m<u64>::S<u64> {
         0x42<u64>::m<u64>::make_s<u64>(0u64)
     }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/long_path.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/long_path.exp
@@ -1,0 +1,24 @@
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_2024/parser/long_path.move:7:26
+  │
+7 │     public struct A { y: 0x42::m::X::Y }
+  │                          ^^^^^^^^^^ Expected a module or address in this position, not a module member
+
+error[E03006]: unexpected name in this position
+  ┌─ tests/move_2024/parser/long_path.move:8:26
+  │
+8 │     public struct B { x: 0x42::m::X::X }
+  │                          ^^^^^^^^^^ Expected a module or address in this position, not a module member
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/parser/long_path.move:10:27
+   │
+10 │     fun foo(): 0x42::m::X<042::m::Y::Y> {
+   │                           ^^^^^^^^^ Expected a module or address in this position, not a module member
+
+error[E03006]: unexpected name in this position
+   ┌─ tests/move_2024/parser/long_path.move:11:9
+   │
+11 │         0x42::m::X<u64>::X { t: abort 0 }
+   │         ^^^^^^^^^^ Expected a module or address in this position, not a module member
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/long_path.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/long_path.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+    public struct X<T> { t: T }
+    public struct Y<T> { t: T }
+}
+
+module 0x42::n {
+    public struct A { y: 0x42::m::X::Y }
+    public struct B { x: 0x42::m::X::X }
+
+    fun foo(): 0x42::m::X<042::m::Y::Y> {
+        0x42::m::X<u64>::X { t: abort 0 }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.exp
@@ -1,9 +1,0 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_2024/parser/match_keyword.move:2:9
-  │
-2 │     fun match(_: u64): bool { false }
-  │         ^^^^^
-  │         │
-  │         Unexpected 'match'
-  │         Expected an identifier
-

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_2024/parser/match_keyword.move:2:9
+  │
+2 │     fun match(_: u64): bool { false }
+  │         ^^^^^
+  │         │
+  │         Unexpected 'match'
+  │         Expected an identifier
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.move
@@ -1,0 +1,3 @@
+module a::m {
+    fun match(_: u64): bool { false }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/match_keyword.move
@@ -1,3 +1,0 @@
-module a::m {
-    fun match(_: u64): bool { false }
-}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
@@ -1,3 +1,12 @@
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:11:17
+   │
+11 │         let Foo <u64>(_) = Foo(0);
+   │                 ^
+   │                 │
+   │                 Unexpected '<'
+   │                 Expected '{'
+
 error[E03003]: unbound module member
    ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:17
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_multi.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_multi.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │                    ^
   │                    │
   │                    Unexpected '('
-  │                    Expected a type name
+  │                    Expected a type name with no type arguments
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_ref.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_ref.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │                    ^
   │                    │
   │                    Unexpected '&'
-  │                    Expected a type name
+  │                    Expected a type name with no type arguments
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_type_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_type_args.exp
@@ -1,9 +1,24 @@
-error[E01002]: unexpected token
+warning[W09001]: unused alias
+  ┌─ tests/move_2024/parser/use_fun_type_args.move:3:5
+  │
+3 │     use fun foo as X<u64>.foo;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unused 'use fun' of 'a::m::X.foo'. Consider removing it
+  │
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E01016]: invalid name
   ┌─ tests/move_2024/parser/use_fun_type_args.move:3:21
   │
 3 │     use fun foo as X<u64>.foo;
-  │                     ^
-  │                     │
-  │                     Unexpected '<'
-  │                     Expected '.'
+  │                     ^^^^^ Type arguments are disallowed here. Expected a type name with no type arguments
+
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_2024/parser/use_fun_type_args.move:4:9
+  │
+3 │     use fun foo as X<u64>.foo;
+  │                           --- Previously declared here
+4 │     fun foo<T>(_: X<T>) { abort 0 }
+  │         ^^^       ---- Function declarations create an implicit 'use fun' when their first argument is a type defined in the same module
+  │         │          
+  │         Duplicate 'use fun' for 'a::m::X.foo'
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_unit.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/use_fun_unit.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │                    ^
   │                    │
   │                    Unexpected '('
-  │                    Expected a type name
+  │                    Expected a type name with no type arguments
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/expected_failure_constants_shadowed_module_invalid.unit_test.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/expected_failure_constants_shadowed_module_invalid.unit_test.exp
@@ -2,5 +2,5 @@ error[E03006]: unexpected name in this position
    ┌─ tests/move_2024/unit_test/expected_failure_constants_shadowed_module_invalid.move:10:35
    │
 10 │     #[expected_failure(abort_code=a::a::C)]
-   │                                   ^ Expected an address in this position, not a module
+   │                                   ^^^^ Expected a module or address in this position, not a module member
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.exp
@@ -1,9 +1,6 @@
-error[E01002]: unexpected token
+error[E01016]: invalid name
   ┌─ tests/move_check/parser/acquires_list_generic.move:6:25
   │
 6 │     fun foo() acquires B<CupC<R>> {
-  │                         ^
-  │                         │
-  │                         Unexpected '<'
-  │                         Expected ','
+  │                         ^^^^^^^^^ Type arguments are disallowed here. Expected a resource struct name
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.exp
@@ -1,6 +1,0 @@
-error[E01016]: invalid name
-  ┌─ tests/move_check/parser/acquires_list_generic.move:6:25
-  │
-6 │     fun foo() acquires B<CupC<R>> {
-  │                         ^^^^^^^^^ Type arguments are disallowed here. Expected a resource struct name
-

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/acquires_list_generic.move
@@ -1,9 +1,0 @@
-module 0x42::M {
-    struct CupC<phantom T: drop> {}
-    struct R {}
-    struct B<phantom T> {}
-
-    fun foo() acquires B<CupC<R>> {
-        abort 0
-    }
-}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/friend_decl_address_only.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/friend_decl_address_only.exp
@@ -1,8 +1,8 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/friend_decl_address_only.move:3:16
+  ┌─ tests/move_check/parser/friend_decl_address_only.move:3:12
   │
 3 │     friend 0x42;
-  │            ----^ Unexpected ';'
-  │            │    
-  │            Expected '::' after an address in a module access chain
+  │            ^^^^ Expected '::' after the anonymous address in this module access chain
+  │
+  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/friend_decl_address_only.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/friend_decl_address_only.exp
@@ -3,6 +3,4 @@ error[E01002]: unexpected token
   │
 3 │     friend 0x42;
   │            ^^^^ Expected '::' after the anonymous address in this module access chain
-  │
-  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_bad_name.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_bad_name.exp
@@ -1,9 +1,0 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/function_acquires_bad_name.move:3:22
-  │
-3 │     fun f() acquires {
-  │                      ^
-  │                      │
-  │                      Unexpected '{'
-  │                      Expected a resource struct name
-

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_bad_name.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_bad_name.move
@@ -1,5 +1,0 @@
-module 0x42::M {
-    // Test for an invalid (i.e., missing) resource name
-    fun f() acquires {
-    }
-}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_missing_comma.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_missing_comma.exp
@@ -1,9 +1,0 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/function_acquires_missing_comma.move:5:25
-  │
-5 │     fun f() acquires X1 X2 {
-  │                         ^^
-  │                         │
-  │                         Unexpected 'X2'
-  │                         Expected ','
-

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_missing_comma.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/function_acquires_missing_comma.move
@@ -1,9 +1,0 @@
-module 0x42::M {
-    struct X1 {}
-    struct X2 {}
-    // Test a missing comma in the acquires list.
-    fun f() acquires X1 X2 {
-        borrow_global_mut<X1>(0x1);
-        borrow_global_mut<X2>(0x1);
-    }
-}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/global_access.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/global_access.move
@@ -8,7 +8,7 @@ module 0x42::M {
     fun move_from(): u64 { 0 }
     fun freeze(): u64 { 0 }
 
-    fun t(account: &signer) acquires Self::R {
+    fun t(account: &signer) {
         let _ : u64 = exists();
         let _ : bool = ::exists<Self::R>(0x0);
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.exp
@@ -4,7 +4,7 @@ error[E01016]: invalid name
 6 │         a<u64>::m::S { u: 0 }
   │          ^^^^^ Invalid type argument position
   │
-  = Diagnostics must appear at the end of a name access path
+  = Type arguments may only be used with module members
 
 error[E01016]: invalid name
    ┌─ tests/move_check/parser/invalid_tyarg_locs.move:10:13
@@ -12,7 +12,7 @@ error[E01016]: invalid name
 10 │         a::m<u64>::S { u: 0 }
    │             ^^^^^ Invalid type argument position
    │
-   = Diagnostics must appear at the end of a name access path
+   = Type arguments may only be used with module members
 
 error[E01016]: invalid name
    ┌─ tests/move_check/parser/invalid_tyarg_locs.move:14:10
@@ -20,7 +20,7 @@ error[E01016]: invalid name
 14 │         a<u64>::m<u64>::S { u: 0 }
    │          ^^^^^ Invalid type argument position
    │
-   = Diagnostics must appear at the end of a name access path
+   = Type arguments may only be used with module members
 
 error[E01016]: invalid name
    ┌─ tests/move_check/parser/invalid_tyarg_locs.move:14:18
@@ -47,7 +47,7 @@ error[E01016]: invalid name
 28 │         0x42::m<u64>::S { u: 0 }
    │                ^^^^^ Invalid type argument position
    │
-   = Diagnostics must appear at the end of a name access path
+   = Type arguments may only be used with module members
 
 error[E01002]: unexpected token
    ┌─ tests/move_check/parser/invalid_tyarg_locs.move:32:18

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.exp
@@ -1,0 +1,60 @@
+error[E01016]: invalid name
+  ┌─ tests/move_check/parser/invalid_tyarg_locs.move:6:10
+  │
+6 │         a<u64>::m::S { u: 0 }
+  │          ^^^^^ Invalid type argument position
+  │
+  = Diagnostics must appear at the end of a name access path
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:10:13
+   │
+10 │         a::m<u64>::S { u: 0 }
+   │             ^^^^^ Invalid type argument position
+   │
+   = Diagnostics must appear at the end of a name access path
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:14:10
+   │
+14 │         a<u64>::m<u64>::S { u: 0 }
+   │          ^^^^^ Invalid type argument position
+   │
+   = Diagnostics must appear at the end of a name access path
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:14:18
+   │
+14 │         a<u64>::m<u64>::S { u: 0 }
+   │          -----   ^^^^^ Paths cannot include type arguments more than once
+   │          │        
+   │          Previous type arguments appeared here
+   │
+   = Type arguments should only appear on module members
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:24:18
+   │
+24 │         0x42<u64>::m::S { u: 0 }
+   │                  ^^
+   │                  │
+   │                  Unexpected '::'
+   │                  Expected an expression term
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:28:16
+   │
+28 │         0x42::m<u64>::S { u: 0 }
+   │                ^^^^^ Invalid type argument position
+   │
+   = Diagnostics must appear at the end of a name access path
+
+error[E01002]: unexpected token
+   ┌─ tests/move_check/parser/invalid_tyarg_locs.move:32:18
+   │
+32 │         0x42<u64>::m<u64>::S { u: 0 }
+   │                  ^^
+   │                  │
+   │                  Unexpected '::'
+   │                  Expected an expression term
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_tyarg_locs.move
@@ -1,0 +1,35 @@
+module a::m {
+
+    struct S<T> { u: T }
+
+    fun test00(): a::m::S<u64> {
+        a<u64>::m::S { u: 0 }
+    }
+
+    fun test01(): a::m::S<u64> {
+        a::m<u64>::S { u: 0 }
+    }
+
+    fun test02(): a::m::S<u64> {
+        a<u64>::m<u64>::S { u: 0 }
+    }
+
+}
+
+module 0x42::m {
+
+    struct S<T> { u: T }
+
+    fun test00(): S<u64> {
+        0x42<u64>::m::S { u: 0 }
+    }
+
+    fun test01(): S<u64> {
+        0x42::m<u64>::S { u: 0 }
+    }
+
+    fun test02(): S<u64> {
+        0x42<u64>::m<u64>::S { u: 0 }
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/less_than_space.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/less_than_space.exp
@@ -1,9 +1,10 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/less_than_space.move:5:18
+  ┌─ tests/move_check/parser/less_than_space.move:5:16
   │
 5 │         if (v< 10) return v;
-  │              - --^ Unexpected ')'
-  │              │ │  
-  │              │ Expected '::' after an address in a module access chain
+  │              - ^^ Expected '::' after the anonymous address in this module access chain
+  │              │  
   │              Perhaps you need a blank space before this '<' operator?
+  │
+  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/less_than_space.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/less_than_space.exp
@@ -5,6 +5,4 @@ error[E01002]: unexpected token
   │              - ^^ Expected '::' after the anonymous address in this module access chain
   │              │  
   │              Perhaps you need a blank space before this '<' operator?
-  │
-  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/long_path.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/long_path.exp
@@ -1,0 +1,32 @@
+error[E01016]: invalid name
+  ┌─ tests/move_check/parser/long_path.move:7:19
+  │
+7 │     struct A { y: 0x42::m::X::Y }
+  │                   ^^^^^^^^^^^^^ Too many name segments
+  │
+  = Names may only have 0, 1, or 2 segments separated by '::'
+
+error[E01016]: invalid name
+  ┌─ tests/move_check/parser/long_path.move:8:19
+  │
+8 │     struct B { x: 0x42::m::X::X }
+  │                   ^^^^^^^^^^^^^ Too many name segments
+  │
+  = Names may only have 0, 1, or 2 segments separated by '::'
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/long_path.move:10:27
+   │
+10 │     fun foo(): 0x42::m::X<042::m::Y::Y> {
+   │                           ^^^^^^^^^^^^ Too many name segments
+   │
+   = Names may only have 0, 1, or 2 segments separated by '::'
+
+error[E01016]: invalid name
+   ┌─ tests/move_check/parser/long_path.move:11:9
+   │
+11 │         0x42::m::X<u64>::X { t: abort 0 }
+   │         ^^^^^^^^^^^^^^^^^^ Too many name segments
+   │
+   = Names may only have 0, 1, or 2 segments separated by '::'
+

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/long_path.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/long_path.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+    struct X<T> { t: T }
+    struct Y<T> { t: T }
+}
+
+module 0x42::n {
+    struct A { y: 0x42::m::X::Y }
+    struct B { x: 0x42::m::X::X }
+
+    fun foo(): 0x42::m::X<042::m::Y::Y> {
+        0x42::m::X<u64>::X { t: abort 0 }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/struct.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    struct X { n : u64 }
+
+    struct Y<X> { x : X }
+
+    struct Z<X> { x : Y<X> }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_space_after_less.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_space_after_less.exp
@@ -1,9 +1,10 @@
 error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/vector_space_after_less.move:4:29
+  ┌─ tests/move_check/parser/vector_space_after_less.move:4:26
   │
 4 │         let a = vector < 100;
-  │                        - ---^ Unexpected ';'
-  │                        │ │   
-  │                        │ Expected '::' after an address in a module access chain
+  │                        - ^^^ Expected '::' after the anonymous address in this module access chain
+  │                        │  
   │                        Perhaps you need a blank space before this '<' operator?
+  │
+  = Access chains that start with '::' must be multi-part
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_space_after_less.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/vector_space_after_less.exp
@@ -5,6 +5,4 @@ error[E01002]: unexpected token
   │                        - ^^^ Expected '::' after the anonymous address in this module access chain
   │                        │  
   │                        Perhaps you need a blank space before this '<' operator?
-  │
-  = Access chains that start with '::' must be multi-part
 


### PR DESCRIPTION
## Description 

This generalizes name access chains in parsing to handle tyargs, toward allowing `Option<Int>::Some` in enums. Macros weren't part of the goal, but since macros are `foo::bar!<args>(...)`, it became necessary.

## Test Plan 

A few new tests, plus everything works (with a few shifted expected outputs, hopefully for the better).

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
