### PR TITLE
indexer fix: cursor should be exclusive (#16925)

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -759,9 +759,9 @@ impl IndexerReader {
         // Translate transaction digest cursor to tx sequence number
         if let Some(cursor_tx_seq) = cursor_tx_seq {
             if is_descending {
-                query = query.filter(transactions::dsl::tx_sequence_number.le(cursor_tx_seq));
+                query = query.filter(transactions::dsl::tx_sequence_number.lt(cursor_tx_seq));
             } else {
-                query = query.filter(transactions::dsl::tx_sequence_number.ge(cursor_tx_seq));
+                query = query.filter(transactions::dsl::tx_sequence_number.gt(cursor_tx_seq));
             }
         }
         if is_descending {
@@ -1326,7 +1326,7 @@ impl IndexerReader {
                 .limit(limit as i64)
                 .into_boxed();
             if let Some(object_cursor) = cursor {
-                query = query.filter(objects::dsl::object_id.ge(object_cursor.to_vec()));
+                query = query.filter(objects::dsl::object_id.gt(object_cursor.to_vec()));
             }
             query.load::<StoredObject>(conn)
         })?;


### PR DESCRIPTION
## Description 

indexer cursor should always be exclusive so that when the iteration reaches the end, it can keep retrying with the same cursor until new items arrive and no duplicate items will be returned.

Pavlos found this on the DF fields method and I searched the indexer_reader file and made sure that we do not have `.ge(` or `.le(` any more.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
