### PR TITLE
[suiop] fix cargo configuration to work for sui repo and externally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "clap",
  "mysten-network",
  "rand 0.8.5",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
 ]
 
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
@@ -1535,6 +1535,7 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "base64 0.21.2",
  "bitflags 1.3.2",
  "bytes",
@@ -1597,6 +1598,18 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2611,7 +2624,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "mockall",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "parking_lot 0.12.1",
  "prometheus",
@@ -2623,7 +2636,7 @@ dependencies = [
  "shared-crypto",
  "sui-protocol-config",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7375,7 +7388,27 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "prometheus",
- "prometheus-closure-metric",
+ "prometheus-closure-metric 0.1.0",
+ "scopeguard",
+ "tap",
+ "tokio",
+ "tracing",
+ "uuid 1.2.2",
+]
+
+[[package]]
+name = "mysten-metrics"
+version = "0.7.0"
+source = "git+https://github.com/mystenlabs/sui.git?branch=main#9b991637c51417e4b3c644d56ed674c4ae37972f"
+dependencies = [
+ "async-trait",
+ "axum",
+ "dashmap",
+ "futures",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "prometheus-closure-metric 0.1.0 (git+https://github.com/mystenlabs/sui.git?branch=main)",
  "scopeguard",
  "tap",
  "tokio",
@@ -7412,13 +7445,28 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "prometheus",
  "serde",
  "serde_json",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tower",
+ "tracing",
+]
+
+[[package]]
+name = "mysten-service"
+version = "0.0.1"
+source = "git+https://github.com/mystenlabs/sui.git?branch=main#9b991637c51417e4b3c644d56ed674c4ae37972f"
+dependencies = [
+ "anyhow",
+ "axum",
+ "mysten-metrics 0.7.0 (git+https://github.com/mystenlabs/sui.git?branch=main)",
+ "prometheus",
+ "serde",
+ "telemetry-subscribers 0.2.0 (git+https://github.com/mystenlabs/sui.git?branch=main)",
+ "tokio",
  "tracing",
 ]
 
@@ -7428,7 +7476,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",
- "mysten-service",
+ "mysten-service 0.0.1 (git+https://github.com/mystenlabs/sui.git?branch=main)",
  "prometheus",
  "serde",
  "tokio",
@@ -7530,7 +7578,7 @@ dependencies = [
  "futures",
  "indexmap 2.1.0",
  "mockall",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "narwhal-config",
  "narwhal-crypto",
  "narwhal-network",
@@ -7542,7 +7590,7 @@ dependencies = [
  "prometheus",
  "serde",
  "sui-protocol-config",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7567,7 +7615,7 @@ dependencies = [
  "dashmap",
  "futures",
  "mysten-common",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "narwhal-crypto",
  "narwhal-test-utils",
  "narwhal-types",
@@ -7595,7 +7643,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -7615,7 +7663,7 @@ dependencies = [
  "sui-keys",
  "sui-protocol-config",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -7647,7 +7695,7 @@ dependencies = [
  "itertools 0.10.5",
  "mockall",
  "mysten-common",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -7667,7 +7715,7 @@ dependencies = [
  "sui-macros",
  "sui-protocol-config",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7708,7 +7756,7 @@ dependencies = [
  "fdlimit",
  "indexmap 2.1.0",
  "itertools 0.10.5",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -7723,7 +7771,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "sui-protocol-config",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tonic 0.11.0",
@@ -7749,7 +7797,7 @@ dependencies = [
  "indexmap 2.1.0",
  "mockall",
  "mysten-common",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "mysten-util-mem",
  "narwhal-config",
@@ -7793,7 +7841,7 @@ dependencies = [
  "futures",
  "governor",
  "itertools 0.10.5",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -7808,7 +7856,7 @@ dependencies = [
  "reqwest",
  "sui-protocol-config",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -9285,6 +9333,16 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "prometheus-closure-metric"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/sui.git?branch=main#9b991637c51417e4b3c644d56ed674c4ae37972f"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -11576,7 +11634,7 @@ dependencies = [
  "sui-types",
  "tabled",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -11719,7 +11777,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "num_enum 0.6.1",
  "object_store 0.7.0",
  "parquet",
@@ -11740,7 +11798,7 @@ dependencies = [
  "sui-storage",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -11787,7 +11845,7 @@ dependencies = [
  "sui-storage",
  "sui-swarm-config",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -11798,7 +11856,7 @@ name = "sui-authority-aggregation"
 version = "0.1.0"
 dependencies = [
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "sui-types",
  "tokio",
  "tracing",
@@ -11818,7 +11876,7 @@ dependencies = [
  "crossterm",
  "eyre",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "narwhal-config",
  "prettytable-rs",
  "prometheus-parse",
@@ -11851,7 +11909,7 @@ dependencies = [
  "indicatif",
  "itertools 0.10.5",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "narwhal-node",
  "prometheus",
  "rand 0.8.5",
@@ -11877,7 +11935,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-types",
  "sysinfo",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "tokio",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11905,7 +11963,7 @@ dependencies = [
  "hex-literal 0.3.4",
  "lru 0.10.0",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "num_enum 0.6.1",
  "once_cell",
  "prometheus",
@@ -11923,7 +11981,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -11964,7 +12022,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -11977,7 +12035,7 @@ name = "sui-common"
 version = "0.1.0"
 dependencies = [
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "sui-types",
  "tokio",
  "tracing",
@@ -12050,7 +12108,7 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "mysten-common",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -12098,7 +12156,7 @@ dependencies = [
  "sui-transaction-checks",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "test-fuzz",
@@ -12150,7 +12208,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "notify",
  "object_store 0.7.0",
  "prometheus",
@@ -12162,7 +12220,7 @@ dependencies = [
  "sui-data-ingestion-core",
  "sui-storage",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -12177,7 +12235,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "notify",
  "object_store 0.7.0",
  "prometheus",
@@ -12187,7 +12245,7 @@ dependencies = [
  "sui-storage",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -12214,7 +12272,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-package",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -12240,7 +12298,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-tool",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -12311,7 +12369,7 @@ dependencies = [
  "eyre",
  "futures",
  "http",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "parking_lot 0.12.1",
  "prometheus",
  "rocksdb",
@@ -12325,7 +12383,7 @@ dependencies = [
  "sui-sdk",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -12462,7 +12520,7 @@ dependencies = [
  "move-core-types",
  "move-disassembler",
  "move-ir-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "once_cell",
  "prometheus",
@@ -12490,7 +12548,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "thiserror",
  "tokio",
@@ -12545,7 +12603,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "ntest",
  "prometheus",
  "rayon",
@@ -12569,7 +12627,7 @@ dependencies = [
  "sui-transaction-builder",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "thiserror",
  "tokio",
@@ -12619,7 +12677,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "prometheus",
  "serde",
@@ -12637,7 +12695,7 @@ dependencies = [
  "sui-transaction-builder",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "thiserror",
  "tokio",
  "tower",
@@ -12653,7 +12711,7 @@ dependencies = [
  "anyhow",
  "fastcrypto",
  "jsonrpsee",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "prometheus",
  "sui-json",
@@ -12695,7 +12753,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "tokio",
  "tracing",
@@ -12715,7 +12773,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "schemars",
  "serde",
  "serde_json",
@@ -12798,7 +12856,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.9.21",
  "strum_macros 0.24.3",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tracing",
 ]
@@ -12825,7 +12883,7 @@ dependencies = [
  "move-prover",
  "move-unit-test",
  "move-vm-runtime",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -12839,7 +12897,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-simulator",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -12965,7 +13023,7 @@ dependencies = [
  "fastcrypto-tbls",
  "futures",
  "governor",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "prometheus",
  "rand 0.8.5",
@@ -12976,7 +13034,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tonic 0.11.0",
@@ -13003,7 +13061,7 @@ dependencies = [
  "humantime",
  "move-vm-profiler",
  "mysten-common",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-network",
  "narwhal-worker",
@@ -13027,7 +13085,7 @@ dependencies = [
  "sui-tls",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tower",
  "tracing",
@@ -13081,7 +13139,7 @@ dependencies = [
  "clap",
  "dirs 4.0.0",
  "jsonpath_lib",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -13096,7 +13154,7 @@ dependencies = [
  "sui-sdk",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tracing",
 ]
@@ -13176,7 +13234,7 @@ dependencies = [
  "itertools 0.10.5",
  "mime",
  "multiaddr",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "prometheus",
  "prost 0.12.3",
@@ -13193,7 +13251,7 @@ dependencies = [
  "snap",
  "sui-tls",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tower",
  "tower-http",
@@ -13280,7 +13338,7 @@ dependencies = [
  "futures",
  "hyper",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "once_cell",
  "rand 0.8.5",
  "reqwest",
@@ -13298,7 +13356,7 @@ dependencies = [
  "sui-sdk",
  "sui-swarm-config",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -13329,7 +13387,7 @@ dependencies = [
  "sui-keys",
  "sui-sdk",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "tokio",
  "tonic 0.11.0",
@@ -13388,7 +13446,7 @@ dependencies = [
  "sui-framework",
  "sui-move-build",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tower",
  "tracing",
@@ -13423,7 +13481,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-transaction-checks",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tracing",
 ]
@@ -13504,7 +13562,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-symbol-pool",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "prometheus",
  "reqwest",
  "serde",
@@ -13514,7 +13572,7 @@ dependencies = [
  "sui-move-build",
  "sui-sdk",
  "sui-source-validation",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -13551,7 +13609,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "num_cpus",
  "num_enum 0.6.1",
  "object_store 0.7.0",
@@ -13572,7 +13630,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -13604,7 +13662,7 @@ dependencies = [
  "sui-simulator",
  "sui-swarm-config",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "test-cluster",
  "tokio",
  "tracing",
@@ -13616,7 +13674,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "prometheus",
  "rand 0.8.5",
@@ -13628,7 +13686,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-types",
  "tap",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tonic-health",
@@ -13695,7 +13753,7 @@ dependencies = [
  "http",
  "sui-cluster-test",
  "sui-faucet",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tokio",
  "tower",
  "tower-http",
@@ -13766,7 +13824,7 @@ dependencies = [
  "sui-snapshot",
  "sui-storage",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -13845,7 +13903,7 @@ dependencies = [
  "sui-storage",
  "sui-swarm-config",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "typed-store",
@@ -13883,7 +13941,7 @@ dependencies = [
  "move-vm-profiler",
  "move-vm-test-utils",
  "move-vm-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",
@@ -14008,7 +14066,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "move-core-types",
- "mysten-metrics",
+ "mysten-metrics 0.7.0",
  "notify",
  "object_store 0.7.0",
  "prometheus",
@@ -14020,7 +14078,7 @@ dependencies = [
  "sui-json-rpc",
  "sui-storage",
  "sui-types",
- "telemetry-subscribers",
+ "telemetry-subscribers 0.2.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -14259,6 +14317,32 @@ dependencies = [
  "camino",
  "clap",
  "console-subscriber",
+ "crossterm",
+ "futures",
+ "once_cell",
+ "opentelemetry 0.20.0",
+ "opentelemetry-otlp",
+ "opentelemetry-proto",
+ "opentelemetry_api 0.20.0",
+ "prometheus",
+ "prost 0.11.9",
+ "tokio",
+ "tonic 0.9.2",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "telemetry-subscribers"
+version = "0.2.0"
+source = "git+https://github.com/mystenlabs/sui.git?branch=main#9b991637c51417e4b3c644d56ed674c4ae37972f"
+dependencies = [
+ "atomic_float",
+ "bytes",
+ "bytes-varint",
+ "clap",
  "crossterm",
  "futures",
  "once_cell",
@@ -14983,11 +15067,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -15007,13 +15090,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/crates/mysten-service-boilerplate/Cargo-sui.toml
+++ b/crates/mysten-service-boilerplate/Cargo-sui.toml
@@ -6,10 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-workspace.anyhow = true
-workspace.axum = true
-workspace.mysten-service = true
-workspace.prometheus = true
-workspace.tracing = true
+anyhow.workspace = true
+axum.workspace = true
+mysten-service.workspace = true
+prometheus.workspace = true
+tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/mysten-service-boilerplate/Cargo-sui.toml
+++ b/crates/mysten-service-boilerplate/Cargo-sui.toml
@@ -10,6 +10,6 @@ workspace.anyhow = true
 workspace.axum = true
 workspace.mysten-service = true
 workspace.prometheus = true
-workspace.serde = true
-workspace.tokio = true
 workspace.tracing = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }

--- a/crates/mysten-service-boilerplate/Cargo.toml
+++ b/crates/mysten-service-boilerplate/Cargo.toml
@@ -7,10 +7,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-anyhow.workspace = true
-mysten-service.workspace = true
-prometheus.workspace = true
-tracing.workspace = true
-axum.workspace = true
-serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
+anyhow = "1.0.79"
+axum = { version = "0.6.6", features = ["macros"] }
+mysten-service = { git = "https://github.com/mystenlabs/sui.git", branch = "main", package = "mysten-service" }
+prometheus = "0.13.3"
+tracing = "0.1.40"
+serde = { version = "1.0.188", features = ["derive"] }
+tokio = { version = "1.32.0", features = ["full"] }

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -107,9 +107,9 @@ fn create_rust_service(path: &Path) -> Result<()> {
         .contains("sui/crates");
     debug!("sui service: {:?}", is_sui_service);
     let cargo_toml_path = if is_sui_service {
-        "Cargo.toml"
+        "Cargo-sui.toml"
     } else {
-        "Cargo-external.toml"
+        "Cargo.toml"
     };
     let cargo_toml = PROJECT_DIR.get_file(cargo_toml_path).unwrap();
     let main_rs = PROJECT_DIR.get_file("src/main.rs").unwrap();


### PR DESCRIPTION
## Description 

cargo-sui is for the sui repo, the base cargo.toml is for external use

## Test Plan 

functions as expected

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
