### PR TITLE
[bridge 65/n] change tokenId from enum to u8, to prepare for the add token flow

### DIFF
--- a/crates/sui-bridge/src/abi.rs
+++ b/crates/sui-bridge/src/abi.rs
@@ -21,7 +21,7 @@ use ethers::{
 };
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::SuiAddress;
-use sui_types::bridge::{BridgeChainId, TokenId};
+use sui_types::bridge::BridgeChainId;
 
 // TODO: write a macro to handle variants
 
@@ -139,7 +139,7 @@ pub struct EthToSuiTokenBridgeV1 {
     pub eth_chain_id: BridgeChainId,
     pub sui_address: SuiAddress,
     pub eth_address: EthAddress,
-    pub token_id: TokenId,
+    pub token_id: u8,
     pub sui_adjusted_amount: u64,
 }
 
@@ -152,7 +152,7 @@ impl TryFrom<&TokensDepositedFilter> for EthToSuiTokenBridgeV1 {
             eth_chain_id: BridgeChainId::try_from(event.source_chain_id)?,
             sui_address: SuiAddress::from_bytes(event.recipient_address.as_ref())?,
             eth_address: event.sender_address,
-            token_id: TokenId::try_from(event.token_id)?,
+            token_id: event.token_id,
             sui_adjusted_amount: event.sui_adjusted_amount,
         })
     }
@@ -232,7 +232,7 @@ mod tests {
         types::{BlocklistType, EmergencyActionType},
     };
     use fastcrypto::encoding::{Encoding, Hex};
-    use sui_types::crypto::ToFromBytes;
+    use sui_types::{bridge::TOKEN_ID_ETH, crypto::ToFromBytes};
 
     #[test]
     fn test_eth_message_conversion_emergency_action_regression() -> anyhow::Result<()> {
@@ -316,7 +316,7 @@ mod tests {
         let action = AssetPriceUpdateAction {
             nonce: 2,
             chain_id: BridgeChainId::EthSepolia,
-            token_id: TokenId::ETH,
+            token_id: TOKEN_ID_ETH,
             new_usd_price: 80000000,
         };
         let message: eth_bridge_limiter::Message = action.into();

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -89,7 +89,7 @@ impl BridgeClient {
             BridgeAction::AssetPriceUpdateAction(a) => {
                 let chain_id = (a.chain_id as u8).to_string();
                 let nonce = a.nonce.to_string();
-                let token_id = (a.token_id as u8).to_string();
+                let token_id = a.token_id.to_string();
                 let new_usd_price = a.new_usd_price.to_string();
                 format!("sign/update_asset_price/{chain_id}/{nonce}/{token_id}/{new_usd_price}")
             }
@@ -182,7 +182,7 @@ mod tests {
     use fastcrypto::hash::{HashFunction, Keccak256};
     use fastcrypto::traits::KeyPair;
     use prometheus::Registry;
-    use sui_types::bridge::{BridgeChainId, TokenId};
+    use sui_types::bridge::{BridgeChainId, TOKEN_ID_BTC, TOKEN_ID_USDT};
     use sui_types::{base_types::SuiAddress, crypto::get_key_pair, digests::TransactionDigest};
 
     #[tokio::test]
@@ -378,7 +378,7 @@ mod tests {
                 sui_address: SuiAddress::random_for_testing_only(),
                 eth_chain_id: BridgeChainId::EthSepolia,
                 eth_address: EthAddress::random(),
-                token_id: TokenId::USDT,
+                token_id: TOKEN_ID_USDT,
                 amount_sui_adjusted: 1,
             },
         });
@@ -401,7 +401,7 @@ mod tests {
                 eth_address: EthAddress::random(),
                 sui_chain_id: BridgeChainId::SuiDevnet,
                 sui_address: SuiAddress::random_for_testing_only(),
-                token_id: TokenId::USDT,
+                token_id: TOKEN_ID_USDT,
                 sui_adjusted_amount: 1,
             },
         });
@@ -473,7 +473,7 @@ mod tests {
         let action = BridgeAction::AssetPriceUpdateAction(crate::types::AssetPriceUpdateAction {
             chain_id: BridgeChainId::SuiDevnet,
             nonce: 8,
-            token_id: TokenId::BTC,
+            token_id: TOKEN_ID_BTC,
             new_usd_price: 100_000_000,
         });
         assert_eq!(

--- a/crates/sui-bridge/src/crypto.rs
+++ b/crates/sui-bridge/src/crypto.rs
@@ -190,7 +190,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
     use sui_types::base_types::SuiAddress;
-    use sui_types::bridge::{BridgeChainId, TokenId};
+    use sui_types::bridge::{BridgeChainId, TOKEN_ID_ETH};
     use sui_types::crypto::get_key_pair;
     use sui_types::digests::TransactionDigest;
 
@@ -342,7 +342,7 @@ mod tests {
                 eth_chain_id: BridgeChainId::EthSepolia,
                 eth_address: EthAddress::from_str("0xb18f79Fe671db47393315fFDB377Da4Ea1B7AF96")
                     .unwrap(),
-                token_id: TokenId::ETH,
+                token_id: TOKEN_ID_ETH,
                 amount_sui_adjusted: 100000u64,
             },
         });

--- a/crates/sui-bridge/src/e2e_tests/basic.rs
+++ b/crates/sui-bridge/src/e2e_tests/basic.rs
@@ -28,7 +28,7 @@ use sui_sdk::wallet_context::WalletContext;
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::bridge::{
-    BridgeChainId, MoveTypeBridgeMessageKey, MoveTypeBridgeRecord, TokenId, BRIDGE_MODULE_NAME,
+    BridgeChainId, MoveTypeBridgeMessageKey, MoveTypeBridgeRecord, BRIDGE_MODULE_NAME, TOKEN_ID_ETH,
 };
 use sui_types::collection_types::LinkedTableNode;
 use sui_types::committee::TOTAL_VOTING_POWER;
@@ -139,7 +139,7 @@ async fn test_bridge_from_eth_to_sui_to_eth() {
         sui_chain_id,
         amount,
         sui_amount,
-        TokenId::ETH,
+        TOKEN_ID_ETH,
         0,
     )
     .await;
@@ -529,7 +529,7 @@ async fn deposit_eth_to_sui_package(
         BRIDGE_PACKAGE_ID,
         BRIDGE_MODULE_NAME.to_owned(),
         ident_str!("send_token").to_owned(),
-        vec![get_sui_token_type_tag(TokenId::ETH)],
+        vec![get_sui_token_type_tag(TOKEN_ID_ETH).unwrap()],
         vec![arg_bridge, arg_target_chain, arg_target_address, arg_token],
     );
 
@@ -587,7 +587,7 @@ async fn init_eth_to_sui_bridge(
     sui_chain_id: u8,
     amount: u64,
     sui_amount: u64,
-    token_id: TokenId,
+    token_id: u8,
     nonce: u64,
 ) {
     let eth_tx = deposit_native_eth_to_sol_contract(
@@ -615,7 +615,7 @@ async fn init_eth_to_sui_bridge(
     assert_eq!(eth_bridge_event.source_chain_id, eth_chain_id);
     assert_eq!(eth_bridge_event.nonce, nonce);
     assert_eq!(eth_bridge_event.destination_chain_id, sui_chain_id);
-    assert_eq!(eth_bridge_event.token_id, token_id as u8);
+    assert_eq!(eth_bridge_event.token_id, token_id);
     assert_eq!(eth_bridge_event.sui_adjusted_amount, sui_amount);
     assert_eq!(eth_bridge_event.sender_address, eth_address);
     assert_eq!(eth_bridge_event.recipient_address, sui_address.to_vec());
@@ -670,7 +670,7 @@ async fn init_sui_to_eth_bridge(
     );
     assert_eq!(bridge_event.sui_bridge_event.sui_address, sui_address);
     assert_eq!(bridge_event.sui_bridge_event.eth_address, eth_address);
-    assert_eq!(bridge_event.sui_bridge_event.token_id, TokenId::ETH);
+    assert_eq!(bridge_event.sui_bridge_event.token_id, TOKEN_ID_ETH);
     assert_eq!(
         bridge_event.sui_bridge_event.amount_sui_adjusted,
         sui_amount

--- a/crates/sui-bridge/src/encoding.rs
+++ b/crates/sui-bridge/src/encoding.rs
@@ -72,7 +72,7 @@ impl BridgeMessageEncoding for SuiToEthBridgeAction {
         bytes.extend_from_slice(e.eth_address.as_bytes());
 
         // Add token id
-        bytes.push(e.token_id as u8);
+        bytes.push(e.token_id);
 
         // Add token amount
         bytes.extend_from_slice(&e.amount_sui_adjusted.to_be_bytes());
@@ -116,7 +116,7 @@ impl BridgeMessageEncoding for EthToSuiBridgeAction {
         bytes.extend_from_slice(&e.sui_address.to_vec());
 
         // Add token id
-        bytes.push(e.token_id as u8);
+        bytes.push(e.token_id);
 
         // Add token amount
         bytes.extend_from_slice(&e.sui_adjusted_amount.to_be_bytes());
@@ -239,7 +239,7 @@ impl BridgeMessageEncoding for AssetPriceUpdateAction {
     fn as_payload_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         // Add token id
-        bytes.push(self.token_id as u8);
+        bytes.push(self.token_id);
         // Add new usd limit
         bytes.extend_from_slice(&self.new_usd_price.to_be_bytes());
         bytes
@@ -302,11 +302,10 @@ mod tests {
     use fastcrypto::traits::ToFromBytes;
     use prometheus::Registry;
     use std::str::FromStr;
+    use sui_types::base_types::{SuiAddress, TransactionDigest};
     use sui_types::bridge::BridgeChainId;
-    use sui_types::{
-        base_types::{SuiAddress, TransactionDigest},
-        bridge::TokenId,
-    };
+    use sui_types::bridge::TOKEN_ID_BTC;
+    use sui_types::bridge::TOKEN_ID_USDC;
 
     use super::*;
 
@@ -322,7 +321,7 @@ mod tests {
         let eth_chain_id = BridgeChainId::EthSepolia;
         let sui_address = SuiAddress::random_for_testing_only();
         let eth_address = EthAddress::random();
-        let token_id = TokenId::USDC;
+        let token_id = TOKEN_ID_USDC;
         let amount_sui_adjusted = 1_000_000;
 
         let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
@@ -355,7 +354,7 @@ mod tests {
         let eth_address_length_bytes = vec![EthAddress::len_bytes() as u8]; // len: 1
         let eth_address_bytes = eth_address.as_bytes().to_vec(); // len: 20
 
-        let token_id_bytes = vec![token_id as u8]; // len: 1
+        let token_id_bytes = vec![token_id]; // len: 1
         let token_amount_bytes = amount_sui_adjusted.to_be_bytes().to_vec(); // len: 8
 
         let mut combined_bytes = Vec::new();
@@ -401,7 +400,7 @@ mod tests {
         .unwrap();
         let eth_address =
             EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
-        let token_id = TokenId::USDC;
+        let token_id = TOKEN_ID_USDC;
         let amount_sui_adjusted = 12345;
 
         let sui_bridge_event = EmittedSuiToEthTokenBridgeV1 {
@@ -610,7 +609,7 @@ mod tests {
         let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
             nonce: 266,
             chain_id: BridgeChainId::SuiLocalTest,
-            token_id: TokenId::BTC,
+            token_id: TOKEN_ID_BTC,
             new_usd_price: 100_000 * USD_MULTIPLIER, // $100k USD
         });
         let bytes = action.to_bytes();
@@ -774,7 +773,7 @@ mod tests {
         .unwrap();
         let eth_address =
             EthAddress::from_str("0x00000000000000000000000000000000000000c8").unwrap();
-        let token_id = TokenId::USDC;
+        let token_id = TOKEN_ID_USDC;
         let sui_adjusted_amount = 12345;
 
         let eth_bridge_event = EthToSuiTokenBridgeV1 {

--- a/crates/sui-bridge/src/error.rs
+++ b/crates/sui-bridge/src/error.rs
@@ -33,6 +33,8 @@ pub enum BridgeError {
     TransientProviderError(String),
     // Ethereum provider error
     ProviderError(String),
+    // TokenId is unknown
+    UnknownTokenId(u8),
     // Invalid BridgeCommittee
     InvalidBridgeCommittee(String),
     // Invalid Bridge authority signature

--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -21,7 +21,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use sui_json_rpc_types::SuiEvent;
 use sui_types::base_types::SuiAddress;
-use sui_types::bridge::{BridgeChainId, TokenId};
+use sui_types::bridge::BridgeChainId;
 
 use sui_types::digests::TransactionDigest;
 use sui_types::BRIDGE_PACKAGE_ID;
@@ -47,7 +47,7 @@ pub struct EmittedSuiToEthTokenBridgeV1 {
     pub eth_chain_id: BridgeChainId,
     pub sui_address: SuiAddress,
     pub eth_address: EthAddress,
-    pub token_id: TokenId,
+    pub token_id: u8,
     // The amount of tokens deposited with decimal points on Sui side
     pub amount_sui_adjusted: u64,
 }
@@ -63,13 +63,7 @@ impl TryFrom<MoveTokenBridgeEvent> for EmittedSuiToEthTokenBridgeV1 {
                 event.message_type
             )));
         }
-        let token_id = TokenId::try_from(event.token_type).map_err(|_e| {
-            BridgeError::Generic(format!(
-                "Failed to convert MoveTokenBridgeEvent to EmittedSuiToEthTokenBridgeV1. Failed to convert token type {} to TokenId",
-                event.token_type,
-            ))
-        })?;
-
+        let token_id = event.token_type;
         let sui_chain_id = BridgeChainId::try_from(event.source_chain).map_err(|_e| {
             BridgeError::Generic(format!(
                 "Failed to convert MoveTokenBridgeEvent to EmittedSuiToEthTokenBridgeV1. Failed to convert source chain {} to BridgeChainId",
@@ -204,7 +198,8 @@ pub mod tests {
     use sui_json_rpc_types::SuiEvent;
     use sui_types::base_types::ObjectID;
     use sui_types::base_types::SuiAddress;
-    use sui_types::bridge::{BridgeChainId, TokenId};
+    use sui_types::bridge::BridgeChainId;
+    use sui_types::bridge::TOKEN_ID_SUI;
     use sui_types::digests::TransactionDigest;
     use sui_types::event::EventID;
     use sui_types::Identifier;
@@ -217,7 +212,7 @@ pub mod tests {
             sui_address: SuiAddress::random_for_testing_only(),
             eth_chain_id: BridgeChainId::EthSepolia,
             eth_address: EthAddress::random(),
-            token_id: TokenId::Sui,
+            token_id: TOKEN_ID_SUI,
             amount_sui_adjusted: 100,
         };
         let emitted_event = MoveTokenBridgeEvent {
@@ -227,7 +222,7 @@ pub mod tests {
             sender_address: sanitized_event.sui_address.to_vec(),
             target_chain: sanitized_event.eth_chain_id as u8,
             target_address: sanitized_event.eth_address.as_bytes().to_vec(),
-            token_type: sanitized_event.token_id as u8,
+            token_type: sanitized_event.token_id,
             amount_sui_adjusted: sanitized_event.amount_sui_adjusted,
         };
 

--- a/crates/sui-bridge/src/server/handler.rs
+++ b/crates/sui-bridge/src/server/handler.rs
@@ -332,7 +332,7 @@ mod tests {
     };
     use ethers::types::{Address as EthAddress, TransactionReceipt};
     use sui_json_rpc_types::SuiEvent;
-    use sui_types::bridge::{BridgeChainId, TokenId};
+    use sui_types::bridge::{BridgeChainId, TOKEN_ID_USDC};
     use sui_types::{base_types::SuiAddress, crypto::get_key_pair};
 
     #[tokio::test]
@@ -419,7 +419,7 @@ mod tests {
             sender_address: SuiAddress::random_for_testing_only().to_vec(),
             target_chain: BridgeChainId::EthLocalTest as u8,
             target_address: EthAddress::random().as_bytes().to_vec(),
-            token_type: TokenId::USDC as u8,
+            token_type: TOKEN_ID_USDC,
             amount_sui_adjusted: 12345,
         };
 

--- a/crates/sui-bridge/src/server/mod.rs
+++ b/crates/sui-bridge/src/server/mod.rs
@@ -25,7 +25,7 @@ use fastcrypto::{
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
-use sui_types::bridge::{BridgeChainId, TokenId};
+use sui_types::bridge::BridgeChainId;
 
 pub mod governance_verifier;
 pub mod handler;
@@ -200,9 +200,6 @@ async fn handle_asset_price_update_action(
     let chain_id = BridgeChainId::try_from(chain_id).map_err(|err| {
         BridgeError::InvalidBridgeClientRequest(format!("Invalid chain id: {:?}", err))
     })?;
-    let token_id = TokenId::try_from(token_id).map_err(|err| {
-        BridgeError::InvalidBridgeClientRequest(format!("Invalid token id: {:?}", err))
-    })?;
     let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
         chain_id,
         nonce,
@@ -265,6 +262,8 @@ async fn handle_evm_contract_upgrade(
 
 #[cfg(test)]
 mod tests {
+    use sui_types::bridge::TOKEN_ID_BTC;
+
     use super::*;
     use crate::client::bridge_client::BridgeClient;
     use crate::server::mock_handler::BridgeRequestMockHandler;
@@ -321,7 +320,7 @@ mod tests {
         let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
             nonce: 266,
             chain_id: BridgeChainId::SuiLocalTest,
-            token_id: TokenId::BTC,
+            token_id: TOKEN_ID_BTC,
             new_usd_price: 100_000_0000, // $100k USD
         });
         client.request_sign_bridge_action(action).await.unwrap();

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -480,7 +480,7 @@ mod tests {
     use std::{collections::HashSet, str::FromStr};
     use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
     use sui_sdk::wallet_context;
-    use sui_types::bridge::{BridgeChainId, TokenId};
+    use sui_types::bridge::{BridgeChainId, TOKEN_ID_SUI, TOKEN_ID_USDC};
     use test_cluster::TestClusterBuilder;
 
     use super::*;
@@ -505,7 +505,7 @@ mod tests {
             sui_address: SuiAddress::random_for_testing_only(),
             eth_chain_id: BridgeChainId::EthSepolia,
             eth_address: Address::random(),
-            token_id: TokenId::Sui,
+            token_id: TOKEN_ID_SUI,
             amount_sui_adjusted: 100,
         };
         let emitted_event_1 = MoveTokenBridgeEvent {
@@ -515,7 +515,7 @@ mod tests {
             sender_address: sanitized_event_1.sui_address.to_vec(),
             target_chain: sanitized_event_1.eth_chain_id as u8,
             target_address: sanitized_event_1.eth_address.as_bytes().to_vec(),
-            token_type: sanitized_event_1.token_id as u8,
+            token_type: sanitized_event_1.token_id,
             amount_sui_adjusted: sanitized_event_1.amount_sui_adjusted,
         };
 
@@ -663,7 +663,7 @@ mod tests {
             context,
             eth_recv_address,
             usdc_object_ref,
-            TokenId::USDC,
+            TOKEN_ID_USDC,
             bridge_object_arg,
         )
         .await;
@@ -672,7 +672,7 @@ mod tests {
         assert_eq!(bridge_event.eth_chain_id, BridgeChainId::EthLocalTest);
         assert_eq!(bridge_event.eth_address, eth_recv_address);
         assert_eq!(bridge_event.sui_address, sender);
-        assert_eq!(bridge_event.token_id, TokenId::USDC);
+        assert_eq!(bridge_event.token_id, TOKEN_ID_USDC);
         assert_eq!(bridge_event.amount_sui_adjusted, usdc_amount);
 
         let action = get_test_sui_to_eth_bridge_action(
@@ -682,7 +682,7 @@ mod tests {
             Some(bridge_event.amount_sui_adjusted),
             Some(bridge_event.sui_address),
             Some(bridge_event.eth_address),
-            Some(TokenId::USDC),
+            Some(TOKEN_ID_USDC),
         );
         let status = sui_client
             .inner

--- a/crates/sui-bridge/src/tools/mod.rs
+++ b/crates/sui-bridge/src/tools/mod.rs
@@ -19,7 +19,7 @@ use sui_config::Config;
 use sui_sdk::SuiClientBuilder;
 use sui_types::base_types::ObjectRef;
 use sui_types::base_types::SuiAddress;
-use sui_types::bridge::{BridgeChainId, TokenId};
+use sui_types::bridge::BridgeChainId;
 use sui_types::crypto::SuiKeyPair;
 
 use crate::types::BridgeAction;
@@ -137,15 +137,12 @@ pub fn make_action(chain_id: BridgeChainId, cmd: &GovernanceClientCommands) -> B
             nonce,
             token_id,
             new_usd_price,
-        } => {
-            let token_id = TokenId::try_from(*token_id).expect("Invalid token id");
-            BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
-                nonce: *nonce,
-                chain_id,
-                token_id,
-                new_usd_price: *new_usd_price,
-            })
-        }
+        } => BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
+            nonce: *nonce,
+            chain_id,
+            token_id: *token_id,
+            new_usd_price: *new_usd_price,
+        }),
     }
 }
 

--- a/crates/sui-bridge/src/types.rs
+++ b/crates/sui-bridge/src/types.rs
@@ -21,7 +21,6 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use shared_crypto::intent::IntentScope;
 use std::collections::{BTreeMap, BTreeSet};
-use sui_types::bridge::TokenId;
 use sui_types::bridge::{
     BridgeChainId, BRIDGE_COMMITTEE_MAXIMAL_VOTING_POWER, BRIDGE_COMMITTEE_MINIMAL_VOTING_POWER,
 };
@@ -271,7 +270,7 @@ pub struct LimitUpdateAction {
 pub struct AssetPriceUpdateAction {
     pub nonce: u64,
     pub chain_id: BridgeChainId,
-    pub token_id: TokenId,
+    pub token_id: u8,
     pub new_usd_price: u64,
 }
 
@@ -439,7 +438,8 @@ mod tests {
     use ethers::types::Address as EthAddress;
     use fastcrypto::traits::KeyPair;
     use std::collections::HashSet;
-    use sui_types::{bridge::TokenId, crypto::get_key_pair};
+    use sui_types::bridge::TOKEN_ID_BTC;
+    use sui_types::crypto::get_key_pair;
 
     use super::*;
 
@@ -547,7 +547,7 @@ mod tests {
         let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
             nonce: 266,
             chain_id: BridgeChainId::SuiLocalTest,
-            token_id: TokenId::BTC,
+            token_id: TOKEN_ID_BTC,
             new_usd_price: 100_000 * USD_MULTIPLIER,
         });
         assert_eq!(action.approval_threshold(), 5001);

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -51,6 +51,13 @@ pub const APPROVAL_THRESHOLD_LIMIT_UPDATE: u64 = 5001;
 pub const APPROVAL_THRESHOLD_ASSET_PRICE_UPDATE: u64 = 5001;
 pub const APPROVAL_THRESHOLD_EVM_CONTRACT_UPGRADE: u64 = 5001;
 
+// const for initial token ids for convenience
+pub const TOKEN_ID_SUI: u8 = 0;
+pub const TOKEN_ID_BTC: u8 = 1;
+pub const TOKEN_ID_ETH: u8 = 2;
+pub const TOKEN_ID_USDC: u8 = 3;
+pub const TOKEN_ID_USDT: u8 = 4;
+
 #[derive(
     Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, TryFromPrimitive, JsonSchema, Hash,
 )]
@@ -76,29 +83,6 @@ impl BridgeChainId {
                 | BridgeChainId::SuiLocalTest
         )
     }
-}
-
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    TryFromPrimitive,
-    Hash,
-    Ord,
-    PartialOrd,
-    JsonSchema,
-)]
-#[repr(u8)]
-pub enum TokenId {
-    Sui = 0,
-    BTC = 1,
-    ETH = 2,
-    USDC = 3,
-    USDT = 4,
 }
 
 pub fn get_bridge_obj_initial_shared_version(
@@ -282,13 +266,7 @@ impl BridgeTrait for BridgeInnerV1 {
             .notional_values
             .contents
             .into_iter()
-            .map(|e| {
-                let token_id =
-                    TokenId::try_from(e.key).map_err(|_e| SuiError::GenericBridgeError {
-                        error: format!("Unrecognized oken id: {}", e.key),
-                    })?;
-                Ok((token_id, e.value))
-            })
+            .map(|e| Ok((e.key, e.value)))
             .collect::<SuiResult<Vec<_>>>()?;
         let transfer_records = self
             .limiter
@@ -386,7 +364,8 @@ pub struct BridgeCommitteeSummary {
 #[serde(rename_all = "camelCase")]
 pub struct BridgeLimiterSummary {
     pub transfer_limit: Vec<(BridgeChainId, BridgeChainId, u64)>,
-    pub notional_values: Vec<(TokenId, u64)>,
+    // mapping from token id to notional value
+    pub notional_values: Vec<(u8, u64)>,
     pub transfer_records: Vec<(BridgeChainId, BridgeChainId, MoveTypeBridgeTransferRecord)>,
 }
 


### PR DESCRIPTION
## Description 

To unblock token flow, in this PR we change the usage of TokenID enum to u8.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
