### PR TITLE
[Consensus] add streaming support to tonic network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic 0.11.0",
  "tonic-build",
  "tower",

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -35,6 +35,7 @@ sui-protocol-config.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -37,6 +37,17 @@ fn build_tonic_services(out_dir: &Path) {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("subscribe_blocks")
+                .route_name("SubscribeBlocks")
+                .input_type("crate::network::tonic_network::SubscribeBlocksRequest")
+                .output_type("crate::network::tonic_network::SubscribeBlocksResponse")
+                .codec_path(codec_path)
+                .server_streaming()
+                .client_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("fetch_blocks")
                 .route_name("FetchBlocks")
                 .input_type("crate::network::tonic_network::FetchBlocksRequest")

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -42,6 +42,7 @@ fn build_tonic_services(out_dir: &Path) {
                 .input_type("crate::network::tonic_network::FetchBlocksRequest")
                 .output_type("crate::network::tonic_network::FetchBlocksResponse")
                 .codec_path(codec_path)
+                .server_streaming()
                 .build(),
         )
         .build();

--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -30,8 +30,8 @@ fn build_tonic_services(out_dir: &Path) {
             tonic_build::manual::Method::builder()
                 .name("send_block")
                 .route_name("SendBlock")
-                .input_type("crate::network::SendBlockRequest")
-                .output_type("crate::network::SendBlockResponse")
+                .input_type("crate::network::tonic_network::SendBlockRequest")
+                .output_type("crate::network::tonic_network::SendBlockResponse")
                 .codec_path(codec_path)
                 .build(),
         )
@@ -39,8 +39,8 @@ fn build_tonic_services(out_dir: &Path) {
             tonic_build::manual::Method::builder()
                 .name("fetch_blocks")
                 .route_name("FetchBlocks")
-                .input_type("crate::network::FetchBlocksRequest")
-                .output_type("crate::network::FetchBlocksResponse")
+                .input_type("crate::network::tonic_network::FetchBlocksRequest")
+                .output_type("crate::network::tonic_network::FetchBlocksResponse")
                 .codec_path(codec_path)
                 .build(),
         )
@@ -65,8 +65,8 @@ fn build_anemo_services(out_dir: &Path) {
             anemo_build::manual::Method::builder()
                 .name("send_block")
                 .route_name("SendBlock")
-                .request_type("crate::network::SendBlockRequest")
-                .response_type("crate::network::SendBlockResponse")
+                .request_type("crate::network::anemo_network::SendBlockRequest")
+                .response_type("crate::network::anemo_network::SendBlockResponse")
                 .codec_path(codec_path)
                 .build(),
         )
@@ -74,8 +74,8 @@ fn build_anemo_services(out_dir: &Path) {
             anemo_build::manual::Method::builder()
                 .name("fetch_blocks")
                 .route_name("FetchBlocks")
-                .request_type("crate::network::FetchBlocksRequest")
-                .response_type("crate::network::FetchBlocksResponse")
+                .request_type("crate::network::anemo_network::FetchBlocksRequest")
+                .response_type("crate::network::anemo_network::FetchBlocksResponse")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -458,12 +458,18 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
+        const BLOCK_SUBSCRIPTION: bool = false;
+
         async fn send_block(
             &self,
             _peer: AuthorityIndex,
             _block: &VerifiedBlock,
             _timeout: Duration,
         ) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
+        }
+
+        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
             unimplemented!("Unimplemented")
         }
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -355,6 +355,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
+            _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -172,7 +172,7 @@ where
         let network_client = network_manager.client();
 
         // REQUIRED: Broadcaster must be created before Core, to start listen on block broadcasts.
-        let broadcaster = if N::Client::BLOCK_STREAMING {
+        let broadcaster = if N::Client::SUPPORT_STREAMING {
             None
         } else {
             Some(Broadcaster::new(
@@ -340,7 +340,7 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
-        const BLOCK_STREAMING: bool = false;
+        const SUPPORT_STREAMING: bool = false;
 
         async fn send_block(
             &self,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -21,10 +21,7 @@ use crate::{
     dag_state::DagState,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
-    network::{
-        anemo_network::AnemoManager, tonic_network::TonicManager, NetworkClient as _,
-        NetworkManager,
-    },
+    network::{anemo_network::AnemoManager, tonic_network::TonicManager, NetworkManager},
     storage::rocksdb_store::RocksDBStore,
     synchronizer::{Synchronizer, SynchronizerHandle},
     transaction::{TransactionClient, TransactionConsumer, TransactionVerifier},
@@ -126,7 +123,7 @@ where
     synchronizer: Arc<SynchronizerHandle>,
     leader_timeout_handle: LeaderTimeoutTaskHandle,
     core_thread_handle: CoreThreadHandle,
-    // Not started when using block streaming.
+    // Not created when using block streaming.
     broadcaster: Option<Broadcaster>,
     network_manager: N,
 }
@@ -172,15 +169,11 @@ where
         let network_client = network_manager.client();
 
         // REQUIRED: Broadcaster must be created before Core, to start listen on block broadcasts.
-        let broadcaster = if N::Client::SUPPORT_STREAMING {
-            None
-        } else {
-            Some(Broadcaster::new(
-                context.clone(),
-                network_client.clone(),
-                &signals_receivers,
-            ))
-        };
+        let broadcaster = Some(Broadcaster::new(
+            context.clone(),
+            network_client.clone(),
+            &signals_receivers,
+        ));
 
         let store = Arc::new(RocksDBStore::new(&context.parameters.db_path_str_unsafe()));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -480,7 +480,15 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
+        async fn subscribe_block_stream(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+        ) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
             unimplemented!("Unimplemented")
         }
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -1,37 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-    vec,
-};
+use std::{sync::Arc, time::Instant};
 
-use async_trait::async_trait;
-use bytes::Bytes;
 use consensus_config::{AuthorityIndex, Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
 use parking_lot::RwLock;
 use prometheus::Registry;
 use sui_protocol_config::ProtocolConfig;
-use tokio::time::sleep;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{
-    block::{timestamp_utc_ms, BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
+    authority_service::AuthorityService,
     block_manager::BlockManager,
-    block_verifier::{BlockVerifier, SignedBlockVerifier},
+    block_verifier::SignedBlockVerifier,
     broadcaster::Broadcaster,
     commit_observer::CommitObserver,
     context::Context,
     core::{Core, CoreSignals},
-    core_thread::{ChannelCoreThreadDispatcher, CoreThreadDispatcher, CoreThreadHandle},
+    core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
-    error::{ConsensusError, ConsensusResult},
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
     network::{
         anemo_network::AnemoManager, tonic_network::TonicManager, NetworkClient as _,
-        NetworkManager, NetworkService,
+        NetworkManager,
     },
     storage::rocksdb_store::RocksDBStore,
     synchronizer::{Synchronizer, SynchronizerHandle},
@@ -226,13 +218,13 @@ where
             block_verifier.clone(),
         );
 
-        let network_service = Arc::new(AuthorityService {
-            context: context.clone(),
+        let network_service = Arc::new(AuthorityService::new(
+            context.clone(),
             block_verifier,
             core_dispatcher,
-            synchronizer: synchronizer.clone(),
+            synchronizer.clone(),
             dag_state,
-        });
+        ));
         network_manager
             .install_service(network_keypair, network_service)
             .await;
@@ -275,139 +267,12 @@ where
     }
 }
 
-/// Authority's network interface.
-pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
-    context: Arc<Context>,
-    block_verifier: Arc<dyn BlockVerifier>,
-    core_dispatcher: Arc<C>,
-    synchronizer: Arc<SynchronizerHandle>,
-    dag_state: Arc<RwLock<DagState>>,
-}
-
-#[async_trait]
-impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
-    async fn handle_send_block(
-        &self,
-        peer: AuthorityIndex,
-        serialized_block: Bytes,
-    ) -> ConsensusResult<()> {
-        // TODO: dedup block verifications, here and with fetched blocks.
-        let signed_block: SignedBlock =
-            bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
-
-        // Reject blocks not produced by the peer.
-        if peer != signed_block.author() {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_blocks
-                .with_label_values(&[&peer.to_string(), "send_block"])
-                .inc();
-            let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
-            info!("Block with wrong authority from {}: {}", peer, e);
-            return Err(e);
-        }
-
-        // Reject blocks failing validations.
-        if let Err(e) = self.block_verifier.verify(&signed_block) {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_blocks
-                .with_label_values(&[&peer.to_string(), "send_block"])
-                .inc();
-            info!("Invalid block from {}: {}", peer, e);
-            return Err(e);
-        }
-        let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
-
-        // Reject block with timestamp too far in the future.
-        let forward_time_drift = Duration::from_millis(
-            verified_block
-                .timestamp_ms()
-                .saturating_sub(timestamp_utc_ms()),
-        );
-        if forward_time_drift > self.context.parameters.max_forward_time_drift {
-            return Err(ConsensusError::BlockTooFarInFuture {
-                block_timestamp: verified_block.timestamp_ms(),
-                forward_time_drift,
-            });
-        }
-
-        // Wait until the block's timestamp is current.
-        if forward_time_drift > Duration::ZERO {
-            self.context
-                .metrics
-                .node_metrics
-                .block_timestamp_drift_wait_ms
-                .with_label_values(&[&peer.to_string()])
-                .inc_by(forward_time_drift.as_millis() as u64);
-            sleep(forward_time_drift).await;
-        }
-
-        let missing_ancestors = self
-            .core_dispatcher
-            .add_blocks(vec![verified_block])
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
-
-        if !missing_ancestors.is_empty() {
-            // schedule the fetching of them from this peer
-            if let Err(err) = self
-                .synchronizer
-                .fetch_blocks(missing_ancestors, peer)
-                .await
-            {
-                warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn handle_fetch_blocks(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        const MAX_ALLOWED_FETCH_BLOCKS: usize = 200;
-
-        if block_refs.len() > MAX_ALLOWED_FETCH_BLOCKS {
-            return Err(ConsensusError::TooManyFetchBlocksRequested(peer));
-        }
-
-        // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == 0 {
-                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
-            }
-        }
-
-        // For now ask dag state directly
-        let blocks = self.dag_state.read().get_blocks(&block_refs);
-
-        // Return the serialised blocks
-        let result = blocks
-            .into_iter()
-            .flatten()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-
-        Ok(result)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc};
+    use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
     use async_trait::async_trait;
+    use bytes::Bytes;
     use consensus_config::{local_committee_and_keys, Parameters};
     use parking_lot::Mutex;
     use prometheus::Registry;
@@ -419,10 +284,11 @@ mod tests {
     use super::*;
     use crate::{
         authority_node::AuthorityService,
-        block::{timestamp_utc_ms, BlockRef, Round, TestBlock, VerifiedBlock},
+        block::{timestamp_utc_ms, BlockAPI as _, BlockRef, Round, TestBlock, VerifiedBlock},
         block_verifier::NoopBlockVerifier,
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
+        error::ConsensusResult,
         network::NetworkClient,
         storage::mem_store::MemStore,
         transaction::NoopTransactionVerifier,
@@ -560,13 +426,13 @@ mod tests {
             core_dispatcher.clone(),
             block_verifier.clone(),
         );
-        let authority_service = Arc::new(AuthorityService {
-            context: context.clone(),
+        let authority_service = Arc::new(AuthorityService::new(
+            context.clone(),
             block_verifier,
-            core_dispatcher: core_dispatcher.clone(),
+            core_dispatcher.clone(),
             synchronizer,
             dag_state,
-        });
+        ));
 
         // Test delaying blocks with time drift.
         let now = timestamp_utc_ms();
@@ -581,7 +447,7 @@ mod tests {
         let serialized = input_block.serialized().clone();
         tokio::spawn(async move {
             service
-                .handle_send_block(context.committee.to_authority_index(0).unwrap(), serialized)
+                .handle_received_block(context.committee.to_authority_index(0).unwrap(), serialized)
                 .await
                 .unwrap();
         });

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -168,7 +168,7 @@ where
         let (core_signals, signals_receivers) = CoreSignals::new(context.clone());
         let tx_block_broadcast = core_signals.block_broadcast_sender();
 
-        let mut network_manager = N::new(context.clone(), core_signals.block_broadcast_sender());
+        let mut network_manager = N::new(context.clone());
         let network_client = network_manager.client();
 
         // REQUIRED: Broadcaster must be created before Core, to start listen on block broadcasts.

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use consensus_config::AuthorityIndex;
+use parking_lot::RwLock;
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+use crate::{
+    block::{timestamp_utc_ms, BlockAPI as _, BlockRef, SignedBlock, VerifiedBlock},
+    block_verifier::BlockVerifier,
+    context::Context,
+    core_thread::CoreThreadDispatcher,
+    dag_state::DagState,
+    error::{ConsensusError, ConsensusResult},
+    network::NetworkService,
+    synchronizer::SynchronizerHandle,
+};
+
+/// Authority's network interface.
+pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
+    context: Arc<Context>,
+    block_verifier: Arc<dyn BlockVerifier>,
+    core_dispatcher: Arc<C>,
+    synchronizer: Arc<SynchronizerHandle>,
+    dag_state: Arc<RwLock<DagState>>,
+}
+
+impl<C: CoreThreadDispatcher> AuthorityService<C> {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        block_verifier: Arc<dyn BlockVerifier>,
+        core_dispatcher: Arc<C>,
+        synchronizer: Arc<SynchronizerHandle>,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> Self {
+        Self {
+            context,
+            block_verifier,
+            core_dispatcher,
+            synchronizer,
+            dag_state,
+        }
+    }
+
+    pub(crate) async fn handle_received_block(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block: Bytes,
+    ) -> ConsensusResult<()> {
+        // TODO: dedup block verifications, here and with fetched blocks.
+        let signed_block: SignedBlock =
+            bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
+
+        // Reject blocks not produced by the peer.
+        if peer != signed_block.author() {
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[&peer.to_string(), "send_block"])
+                .inc();
+            let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
+            info!("Block with wrong authority from {}: {}", peer, e);
+            return Err(e);
+        }
+
+        // Reject blocks failing validations.
+        if let Err(e) = self.block_verifier.verify(&signed_block) {
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[&peer.to_string(), "send_block"])
+                .inc();
+            info!("Invalid block from {}: {}", peer, e);
+            return Err(e);
+        }
+        let verified_block = VerifiedBlock::new_verified(signed_block, serialized_block);
+
+        // Reject block with timestamp too far in the future.
+        let forward_time_drift = Duration::from_millis(
+            verified_block
+                .timestamp_ms()
+                .saturating_sub(timestamp_utc_ms()),
+        );
+        if forward_time_drift > self.context.parameters.max_forward_time_drift {
+            return Err(ConsensusError::BlockTooFarInFuture {
+                block_timestamp: verified_block.timestamp_ms(),
+                forward_time_drift,
+            });
+        }
+
+        // Wait until the block's timestamp is current.
+        if forward_time_drift > Duration::ZERO {
+            self.context
+                .metrics
+                .node_metrics
+                .block_timestamp_drift_wait_ms
+                .with_label_values(&[&peer.to_string()])
+                .inc_by(forward_time_drift.as_millis() as u64);
+            sleep(forward_time_drift).await;
+        }
+
+        let missing_ancestors = self
+            .core_dispatcher
+            .add_blocks(vec![verified_block])
+            .await
+            .map_err(|_| ConsensusError::Shutdown)?;
+
+        if !missing_ancestors.is_empty() {
+            // schedule the fetching of them from this peer
+            if let Err(err) = self
+                .synchronizer
+                .fetch_blocks(missing_ancestors, peer)
+                .await
+            {
+                warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
+    async fn handle_send_block(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block: Bytes,
+    ) -> ConsensusResult<()> {
+        self.handle_received_block(peer, serialized_block).await
+    }
+
+    async fn handle_fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        const MAX_ALLOWED_FETCH_BLOCKS: usize = 200;
+
+        if block_refs.len() > MAX_ALLOWED_FETCH_BLOCKS {
+            return Err(ConsensusError::TooManyFetchBlocksRequested(peer));
+        }
+
+        // Some quick validation of the requested block refs
+        for block in &block_refs {
+            if !self.context.committee.is_valid_index(block.author) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: block.author,
+                    max: self.context.committee.size(),
+                });
+            }
+            if block.round == 0 {
+                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
+            }
+        }
+
+        // For now ask dag state directly
+        let blocks = self.dag_state.read().get_blocks(&block_refs);
+
+        // Return the serialised blocks
+        let result = blocks
+            .into_iter()
+            .flatten()
+            .map(|block| block.serialized().clone())
+            .collect::<Vec<_>>();
+
+        Ok(result)
+    }
+}

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -241,6 +241,7 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
+            _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -198,6 +198,7 @@ mod test {
     use crate::{
         block::{BlockRef, TestBlock},
         core::CoreSignals,
+        network::BlockStream,
         Round,
     };
 
@@ -236,15 +237,11 @@ mod test {
             Ok(())
         }
 
-        async fn subscribe_block_stream(
+        async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
+        ) -> ConsensusResult<BlockStream> {
             unimplemented!("Unimplemented")
         }
 

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -221,6 +221,8 @@ mod test {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
+        const BLOCK_SUBSCRIPTION: bool = false;
+
         async fn send_block(
             &self,
             peer: AuthorityIndex,
@@ -231,6 +233,10 @@ mod test {
             let blocks = blocks_sent.entry(peer).or_default();
             blocks.push(block.serialized().clone());
             Ok(())
+        }
+
+        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
         }
 
         async fn fetch_blocks(

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -221,7 +221,7 @@ mod test {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
-        const BLOCK_SUBSCRIPTION: bool = false;
+        const BLOCK_STREAMING: bool = false;
 
         async fn send_block(
             &self,

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -198,6 +198,7 @@ mod test {
     use crate::{
         block::{BlockRef, TestBlock},
         core::CoreSignals,
+        Round,
     };
 
     struct FakeNetworkClient {
@@ -235,7 +236,15 @@ mod test {
             Ok(())
         }
 
-        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
+        async fn subscribe_block_stream(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+        ) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
             unimplemented!("Unimplemented")
         }
 

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -223,7 +223,7 @@ mod test {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
-        const BLOCK_STREAMING: bool = false;
+        const SUPPORT_STREAMING: bool = false;
 
         async fn send_block(
             &self,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -526,7 +526,7 @@ impl CoreSignals {
 
     /// Sends a signal to all the waiters that a new block has been produced. The method will return
     /// true if block has reached even one subscriber, false otherwise.
-    pub fn new_block(&self, block: VerifiedBlock) -> ConsensusResult<()> {
+    pub(crate) fn new_block(&self, block: VerifiedBlock) -> ConsensusResult<()> {
         // When there is only one authority in committee, it is unnecessary to broadcast
         // the block which will fail anyway without subscribers to the signal.
         if self.context.committee.size() > 1 {
@@ -542,8 +542,13 @@ impl CoreSignals {
 
     /// Sends a signal that threshold clock has advanced to new round. The `round_number` is the round at which the
     /// threshold clock has advanced to.
-    pub fn new_round(&mut self, round_number: Round) {
+    pub(crate) fn new_round(&mut self, round_number: Round) {
         let _ = self.new_round_sender.send_replace(round_number);
+    }
+
+    /// Returns the channel to broadcast new blocks.
+    pub(crate) fn block_broadcast_sender(&self) -> broadcast::Sender<VerifiedBlock> {
+        self.tx_block_broadcast.clone()
     }
 }
 

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -326,6 +326,31 @@ impl DagState {
         genesis_block.clone()
     }
 
+    /// Returns cached recent blocks from the input authority, starting from round `start`,
+    /// and up to `max_count` of blocks.
+    pub(crate) fn get_cached_blocks(
+        &self,
+        authority: AuthorityIndex,
+        start: Round,
+        max_count: usize,
+    ) -> Vec<VerifiedBlock> {
+        let mut blocks = vec![];
+        for block_ref in self.recent_refs[authority].range((
+            Included(BlockRef::new(start, authority, BlockDigest::MIN)),
+            Unbounded,
+        )) {
+            if blocks.len() >= max_count {
+                break;
+            }
+            let block = self
+                .recent_blocks
+                .get(block_ref)
+                .expect("Block should exist in recent blocks");
+            blocks.push(block.clone());
+        }
+        blocks
+    }
+
     /// Returns the last block proposed per authority with `round < end_round`.
     /// The method is guaranteed to return results only when the `end_round` is not earlier of the
     /// available cached data for each authority, otherwise the method will panic - it's the caller's

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -326,8 +326,8 @@ impl DagState {
         genesis_block.clone()
     }
 
-    /// Returns cached recent blocks from the input authority, starting from round `start`.
-    /// Number of blocks returned is limited by the number of blocks cached.
+    /// Returns cached recent blocks from the specified authority.
+    /// Blocks returned is limited by both the `start` round, and if the blocks are cached.
     pub(crate) fn get_cached_blocks(
         &self,
         authority: AuthorityIndex,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -326,22 +326,18 @@ impl DagState {
         genesis_block.clone()
     }
 
-    /// Returns cached recent blocks from the input authority, starting from round `start`,
-    /// and up to `max_count` of blocks.
+    /// Returns cached recent blocks from the input authority, starting from round `start`.
+    /// Number of blocks returned is limited by the number of blocks cached.
     pub(crate) fn get_cached_blocks(
         &self,
         authority: AuthorityIndex,
         start: Round,
-        max_count: usize,
     ) -> Vec<VerifiedBlock> {
         let mut blocks = vec![];
         for block_ref in self.recent_refs[authority].range((
             Included(BlockRef::new(start, authority, BlockDigest::MIN)),
             Unbounded,
         )) {
-            if blocks.len() >= max_count {
-                break;
-            }
             let block = self
                 .recent_blocks
                 .get(block_ref)
@@ -1265,6 +1261,61 @@ mod test {
     }
 
     #[test]
+    fn test_get_cached_blocks() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = 5;
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create no blocks for authority 0
+        // Create one block (round 10) for authority 1
+        // Create two blocks (rounds 10,11) for authority 2
+        // Create three blocks (rounds 10,11,12) for authority 3
+        let mut all_blocks = Vec::new();
+        for author in 1..=3 {
+            for round in 10..(10 + author) {
+                let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
+                all_blocks.push(block.clone());
+                dag_state.accept_block(block);
+            }
+        }
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(0).unwrap(), 0);
+        assert!(cached_blocks.is_empty());
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(1).unwrap(), 10);
+        assert_eq!(cached_blocks.len(), 1);
+        assert_eq!(cached_blocks[0].round(), 10);
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(2).unwrap(), 10);
+        assert_eq!(cached_blocks.len(), 2);
+        assert_eq!(cached_blocks[0].round(), 10);
+        assert_eq!(cached_blocks[1].round(), 11);
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(2).unwrap(), 11);
+        assert_eq!(cached_blocks.len(), 1);
+        assert_eq!(cached_blocks[0].round(), 11);
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(3).unwrap(), 10);
+        assert_eq!(cached_blocks.len(), 3);
+        assert_eq!(cached_blocks[0].round(), 10);
+        assert_eq!(cached_blocks[1].round(), 11);
+        assert_eq!(cached_blocks[2].round(), 12);
+
+        let cached_blocks =
+            dag_state.get_cached_blocks(context.committee.to_authority_index(3).unwrap(), 12);
+        assert_eq!(cached_blocks.len(), 1);
+        assert_eq!(cached_blocks[0].round(), 12);
+    }
+
+    #[test]
     fn test_get_cached_last_block_per_authority() {
         // GIVEN
         const CACHED_ROUNDS: Round = 2;
@@ -1287,16 +1338,6 @@ mod test {
                 dag_state.accept_block(block);
             }
         }
-
-        dag_state.add_commit(TrustedCommit::new_for_test(
-            1 as CommitIndex,
-            CommitDigest::MIN,
-            all_blocks.last().unwrap().reference(),
-            all_blocks
-                .into_iter()
-                .map(|block| block.reference())
-                .collect::<Vec<_>>(),
-        ));
 
         // WHEN search for the latest blocks
         let end_round = 4;

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -22,11 +22,13 @@ mod network;
 mod stake_aggregator;
 mod storage;
 mod synchronizer;
-#[cfg(test)]
-mod test_dag;
 mod threshold_clock;
 mod transaction;
 mod universal_committer;
+
+mod authority_service;
+#[cfg(test)]
+mod test_dag;
 
 pub use authority_node::{ConsensusAuthority, NetworkType};
 pub use block::{BlockAPI, Round};

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod authority_node;
+mod authority_service;
 mod base_committer;
 mod block;
 mod block_manager;
@@ -22,13 +23,11 @@ mod network;
 mod stake_aggregator;
 mod storage;
 mod synchronizer;
+#[cfg(test)]
+mod test_dag;
 mod threshold_clock;
 mod transaction;
 mod universal_committer;
-
-mod authority_service;
-#[cfg(test)]
-mod test_dag;
 
 pub use authority_node::{ConsensusAuthority, NetworkType};
 pub use block::{BlockAPI, Round};

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -123,7 +123,7 @@ impl AnemoClient {
 
 #[async_trait]
 impl NetworkClient for AnemoClient {
-    const BLOCK_STREAMING: bool = false;
+    const SUPPORT_STREAMING: bool = false;
 
     async fn send_block(
         &self,

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -122,6 +122,8 @@ impl AnemoClient {
 
 #[async_trait]
 impl NetworkClient for AnemoClient {
+    const BLOCK_SUBSCRIPTION: bool = false;
+
     async fn send_block(
         &self,
         peer: AuthorityIndex,
@@ -137,6 +139,10 @@ impl NetworkClient for AnemoClient {
             .await
             .map_err(|e| ConsensusError::NetworkError(format!("send_block failed: {e:?}")))?;
         Ok(())
+    }
+
+    fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
+        unimplemented!("broadcast_block() is not implemented for AnemoClient!");
     }
 
     async fn fetch_blocks(

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -33,7 +33,7 @@ use super::{
     connection_monitor::{AnemoConnectionMonitor, ConnectionMonitorHandle},
     epoch_filter::{AllowedEpoch, EPOCH_HEADER_KEY},
     metrics::NetworkRouteMetrics,
-    NetworkClient, NetworkManager, NetworkService,
+    BlockStream, NetworkClient, NetworkManager, NetworkService,
 };
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -142,15 +142,11 @@ impl NetworkClient for AnemoClient {
         Ok(())
     }
 
-    async fn subscribe_block_stream(
+    async fn subscribe_blocks(
         &self,
         _peer: AuthorityIndex,
         _last_received: Round,
-    ) -> ConsensusResult<()> {
-        unimplemented!("Unimplemented")
-    }
-
-    async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
+    ) -> ConsensusResult<BlockStream> {
         unimplemented!("Unimplemented")
     }
 
@@ -650,7 +646,10 @@ mod test {
         block::{BlockRef, TestBlock, VerifiedBlock},
         context::Context,
         error::ConsensusResult,
-        network::{anemo_network::AnemoManager, NetworkClient, NetworkManager, NetworkService},
+        network::{
+            anemo_network::AnemoManager, BlockStream, NetworkClient, NetworkManager, NetworkService,
+        },
+        Round,
     };
 
     struct TestService {
@@ -676,6 +675,14 @@ mod test {
         ) -> ConsensusResult<()> {
             self.lock().handle_send_block.push((peer, block));
             Ok(())
+        }
+
+        async fn handle_subscribe_blocks(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+        ) -> ConsensusResult<BlockStream> {
+            unimplemented!()
         }
 
         async fn handle_fetch_blocks(

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -697,7 +697,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn anemo_basics() {
+    async fn anemo_send_block() {
         let (context, keys) = Context::new_for_test(4);
 
         let context_0 = Arc::new(

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -146,6 +146,7 @@ impl NetworkClient for AnemoClient {
         &self,
         _peer: AuthorityIndex,
         _last_received: Round,
+        _timeout: Duration,
     ) -> ConsensusResult<BlockStream> {
         unimplemented!("Unimplemented")
     }

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -39,6 +39,7 @@ use crate::{
     block::{BlockRef, VerifiedBlock},
     context::Context,
     error::{ConsensusError, ConsensusResult},
+    Round,
 };
 
 /// Implements Anemo RPC client for Consensus.
@@ -141,8 +142,16 @@ impl NetworkClient for AnemoClient {
         Ok(())
     }
 
-    fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
-        unimplemented!("broadcast_block() is not implemented for AnemoClient!");
+    async fn subscribe_block_stream(
+        &self,
+        _peer: AuthorityIndex,
+        _last_received: Round,
+    ) -> ConsensusResult<()> {
+        unimplemented!("Unimplemented")
+    }
+
+    async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
+        unimplemented!("Unimplemented")
     }
 
     async fn fetch_blocks(

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -22,7 +22,7 @@ use cfg_if::cfg_if;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
 use prometheus::HistogramTimer;
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast::{self, error::RecvError};
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, warn};
 
 use super::{
@@ -298,7 +298,7 @@ impl AnemoManager {
 impl<S: NetworkService> NetworkManager<S> for AnemoManager {
     type Client = AnemoClient;
 
-    fn new(context: Arc<Context>, _tx_block_broadcast: broadcast::Sender<VerifiedBlock>) -> Self {
+    fn new(context: Arc<Context>) -> Self {
         AnemoManager::new(context)
     }
 

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -21,6 +21,7 @@ use bytes::Bytes;
 use cfg_if::cfg_if;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
 use prometheus::HistogramTimer;
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, warn};
 
@@ -32,8 +33,7 @@ use super::{
     connection_monitor::{AnemoConnectionMonitor, ConnectionMonitorHandle},
     epoch_filter::{AllowedEpoch, EPOCH_HEADER_KEY},
     metrics::NetworkRouteMetrics,
-    FetchBlocksRequest, FetchBlocksResponse, NetworkClient, NetworkManager, NetworkService,
-    SendBlockRequest, SendBlockResponse,
+    NetworkClient, NetworkManager, NetworkService,
 };
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -486,6 +486,27 @@ impl<S: NetworkService> NetworkManager<S> for AnemoManager {
             .with_label_values(&["anemo"])
             .set(0);
     }
+}
+
+/// Network message types.
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct SendBlockRequest {
+    // Serialized SignedBlock.
+    block: Bytes,
+}
+
+#[derive(Clone, Serialize, Deserialize, prost::Message)]
+pub(crate) struct SendBlockResponse {}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct FetchBlocksRequest {
+    block_refs: Vec<Vec<u8>>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct FetchBlocksResponse {
+    // Serialized SignedBlock.
+    blocks: Vec<Bytes>,
 }
 
 #[derive(Clone)]

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -22,7 +22,7 @@ use cfg_if::cfg_if;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
 use prometheus::HistogramTimer;
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::{self, error::RecvError};
 use tracing::{debug, error, warn};
 
 use super::{
@@ -122,7 +122,7 @@ impl AnemoClient {
 
 #[async_trait]
 impl NetworkClient for AnemoClient {
-    const BLOCK_SUBSCRIPTION: bool = false;
+    const BLOCK_STREAMING: bool = false;
 
     async fn send_block(
         &self,
@@ -292,7 +292,7 @@ impl AnemoManager {
 impl<S: NetworkService> NetworkManager<S> for AnemoManager {
     type Client = AnemoClient;
 
-    fn new(context: Arc<Context>) -> Self {
+    fn new(context: Arc<Context>, _tx_block_broadcast: broadcast::Sender<VerifiedBlock>) -> Self {
         AnemoManager::new(context)
     }
 

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod metrics;
 pub(crate) mod tonic_network;
 
 /// A stream of serialized blocks returned over the network.
-pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send + Sync>>;
+pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
 
 /// Network client for communicating with peers.
 ///
@@ -57,6 +57,7 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
         last_received: Round,
+        timeout: Duration,
     ) -> ConsensusResult<BlockStream>;
 
     /// Fetches serialized `SignedBlock`s from a peer.

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -35,6 +35,9 @@ pub(crate) mod tonic_network;
 /// - To bound server resources, server should implement own timeout for incoming requests.
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + 'static {
+    // Whether the network client streams blocks to subscribed peers.
+    const BLOCK_SUBSCRIPTION: bool;
+
     /// Sends a serialized SignedBlock to a peer.
     async fn send_block(
         &self,
@@ -42,6 +45,9 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
         block: &VerifiedBlock,
         timeout: Duration,
     ) -> ConsensusResult<()>;
+
+    /// Broadcasts a serialized SignedBlock to all subscribed peers.
+    fn broadcast_block(&self, block: &VerifiedBlock) -> ConsensusResult<()>;
 
     /// Fetches serialized `SignedBlock`s from a peer.
     async fn fetch_blocks(

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -1,6 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module defines the network interface, and provides network implementations for the
+//! consensus protocol.
+//!
+//! Having an abstract network interface allows
+//! - simplying the semantics of sending data and serving requests over the network
+//! - hiding implementation specific types and semantics from the consensus protocol
+//! - allowing easy swapping of network implementations, for better performance or testing
+//!
+//! When modifying the client and server interfaces, the principle is to keep the interfaces
+//! low level, close to underlying implementations in semantics. For example, the client interface
+//! exposes sending messages to a specific peer, instead of broadcasting to all peers. Subscribing
+//! to a stream of blocks gets back the stream via response, instead of delivering the stream
+//! directly to the server. This keeps the logic agnostics to the underlying network outside of
+//! this module, so they can be reused easily across network implementations.
+
 use std::{pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
@@ -60,6 +75,7 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
     ) -> ConsensusResult<BlockStream>;
 
     /// Fetches serialized `SignedBlock`s from a peer.
+    // TODO: add a parameter for maximum total size of blocks returned.
     async fn fetch_blocks(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -6,7 +6,6 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
-use serde::{Deserialize, Serialize};
 
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -85,28 +84,4 @@ where
 
     /// Stops the network service.
     async fn stop(&mut self);
-}
-
-/// Network message types.
-#[derive(Clone, Serialize, Deserialize, prost::Message)]
-pub(crate) struct SendBlockRequest {
-    // Serialized SignedBlock.
-    #[prost(bytes = "bytes", tag = "1")]
-    block: Bytes,
-}
-
-#[derive(Clone, Serialize, Deserialize, prost::Message)]
-pub(crate) struct SendBlockResponse {}
-
-#[derive(Clone, Serialize, Deserialize, prost::Message)]
-pub(crate) struct FetchBlocksRequest {
-    #[prost(bytes = "vec", repeated, tag = "1")]
-    block_refs: Vec<Vec<u8>>,
-}
-
-#[derive(Clone, Serialize, Deserialize, prost::Message)]
-pub(crate) struct FetchBlocksResponse {
-    // Serialized SignedBlock.
-    #[prost(bytes = "bytes", repeated, tag = "1")]
-    blocks: Vec<Bytes>,
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -41,7 +41,7 @@ pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + 'static {
     // Whether the network client streams blocks to subscribed peers.
-    const BLOCK_STREAMING: bool;
+    const SUPPORT_STREAMING: bool;
 
     /// Sends a serialized SignedBlock to a peer.
     async fn send_block(

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -6,6 +6,7 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
+use tokio::sync::broadcast;
 
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -36,7 +37,7 @@ pub(crate) mod tonic_network;
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + 'static {
     // Whether the network client streams blocks to subscribed peers.
-    const BLOCK_SUBSCRIPTION: bool;
+    const BLOCK_STREAMING: bool;
 
     /// Sends a serialized SignedBlock to a peer.
     async fn send_block(
@@ -80,7 +81,7 @@ where
     type Client: NetworkClient;
 
     /// Creates a new network manager.
-    fn new(context: Arc<Context>) -> Self;
+    fn new(context: Arc<Context>, tx_block_broadcast: broadcast::Sender<VerifiedBlock>) -> Self;
 
     /// Returns the network client.
     fn client(&self) -> Arc<Self::Client>;

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair};
 use futures::Stream;
-use tokio::sync::broadcast;
 
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -96,7 +95,7 @@ where
     type Client: NetworkClient;
 
     /// Creates a new network manager.
-    fn new(context: Arc<Context>, tx_block_broadcast: broadcast::Sender<VerifiedBlock>) -> Self;
+    fn new(context: Arc<Context>) -> Self;
 
     /// Returns the network client.
     fn client(&self) -> Arc<Self::Client>;

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     block::{BlockRef, VerifiedBlock},
     context::Context,
     error::ConsensusResult,
+    Round,
 };
 
 // Anemo generated stubs for RPCs.
@@ -47,8 +48,15 @@ pub(crate) trait NetworkClient: Send + Sync + 'static {
         timeout: Duration,
     ) -> ConsensusResult<()>;
 
-    /// Broadcasts a serialized SignedBlock to all subscribed peers.
-    fn broadcast_block(&self, block: &VerifiedBlock) -> ConsensusResult<()>;
+    /// Subscribes to blocks from a peer after last_received round.
+    async fn subscribe_block_stream(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+    ) -> ConsensusResult<()>;
+
+    /// Unsubscribe the block stream from a peer.
+    async fn unsubscribe_block_stream(&self, peer: AuthorityIndex) -> ConsensusResult<()>;
 
     /// Fetches serialized `SignedBlock`s from a peer.
     async fn fetch_blocks(

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -77,7 +77,7 @@ impl TonicClient {
 
 #[async_trait]
 impl NetworkClient for TonicClient {
-    const BLOCK_STREAMING: bool = true;
+    const SUPPORT_STREAMING: bool = false;
 
     async fn send_block(
         &self,

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -29,8 +29,7 @@ use super::{
         consensus_service_client::ConsensusServiceClient,
         consensus_service_server::ConsensusService,
     },
-    FetchBlocksRequest, FetchBlocksResponse, NetworkClient, NetworkManager, NetworkService,
-    SendBlockRequest, SendBlockResponse,
+    NetworkClient, NetworkManager, NetworkService,
 };
 use crate::{
     block::{BlockRef, VerifiedBlock},
@@ -402,6 +401,30 @@ fn to_socket_addr(addr: &Multiaddr) -> Result<SocketAddr, &'static str> {
             Err("invalid address")
         }
     }
+}
+
+/// Network message types.
+#[derive(Clone, prost::Message)]
+pub(crate) struct SendBlockRequest {
+    // Serialized SignedBlock.
+    #[prost(bytes = "bytes", tag = "1")]
+    block: Bytes,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct SendBlockResponse {}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchBlocksRequest {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    block_refs: Vec<Vec<u8>>,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchBlocksResponse {
+    // Serialized SignedBlock.
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    blocks: Vec<Bytes>,
 }
 
 // TODO: after supporting peer authentication, using rtest to share the test case with anemo_network.rs

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -45,6 +45,7 @@ use crate::{
 const AUTHORITY_INDEX_METADATA_KEY: &str = "authority-index";
 
 // Maximum bytes size in a single fetch_blocks()response.
+// TODO: put max RPC response size in protocol config.
 const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
 // Maximum total bytes fetched in a single fetch_blocks() call, after combining the responses.

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -23,7 +23,7 @@ use tokio::{
         broadcast,
         oneshot::{self, Sender},
     },
-    task::{JoinHandle, JoinSet},
+    task::JoinSet,
 };
 use tokio_stream::{iter, Iter};
 use tonic::{
@@ -280,7 +280,10 @@ impl Stream for BroadcastedBlockStream {
                     return task::Poll::Ready(None);
                 }
                 task::Poll::Ready(Err(broadcast::error::RecvError::Lagged(n))) => {
-                    info!("Block BroadcastedBlockStream {} lagged by {n} messages", peer);
+                    info!(
+                        "Block BroadcastedBlockStream {} lagged by {n} messages",
+                        peer
+                    );
                     continue;
                 }
                 task::Poll::Pending => {

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -565,12 +565,18 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
+        const BLOCK_SUBSCRIPTION: bool = false;
+
         async fn send_block(
             &self,
             _peer: AuthorityIndex,
             _serialized_block: &VerifiedBlock,
             _timeout: Duration,
         ) -> ConsensusResult<()> {
+            todo!()
+        }
+
+        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
             todo!()
         }
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -565,7 +565,7 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
-        const BLOCK_SUBSCRIPTION: bool = false;
+        const BLOCK_STREAMING: bool = false;
 
         async fn send_block(
             &self,

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -565,7 +565,7 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
-        const BLOCK_STREAMING: bool = false;
+        const SUPPORT_STREAMING: bool = false;
 
         async fn send_block(
             &self,

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -580,6 +580,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
+            _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -573,11 +573,19 @@ mod tests {
             _serialized_block: &VerifiedBlock,
             _timeout: Duration,
         ) -> ConsensusResult<()> {
-            todo!()
+            unimplemented!("Unimplemented")
         }
 
-        fn broadcast_block(&self, _block: &VerifiedBlock) -> ConsensusResult<()> {
-            todo!()
+        async fn subscribe_block_stream(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+        ) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
         }
 
         async fn fetch_blocks(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -487,7 +487,7 @@ mod tests {
     use crate::context::Context;
     use crate::core_thread::{CoreError, CoreThreadDispatcher};
     use crate::error::{ConsensusError, ConsensusResult};
-    use crate::network::NetworkClient;
+    use crate::network::{BlockStream, NetworkClient};
     use crate::synchronizer::{Synchronizer, FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT};
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -576,15 +576,11 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn subscribe_block_stream(
+        async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn unsubscribe_block_stream(&self, _peer: AuthorityIndex) -> ConsensusResult<()> {
+        ) -> ConsensusResult<BlockStream> {
             unimplemented!("Unimplemented")
         }
 


### PR DESCRIPTION
## Description 

This is the first PR of the streaming implementation. Tonic streaming, and streaming support in `AuthorityService` are implemented.

But block propagation with tonic is still using unary RPC. It will switch to use streaming after adding client side logic for block subscription in future.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
