### PR TITLE
[bridge 66/n] resume pending actions when node restarts

### DIFF
--- a/crates/sui-bridge/src/action_executor.rs
+++ b/crates/sui-bridge/src/action_executor.rs
@@ -524,7 +524,7 @@ mod tests {
 
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -535,7 +535,7 @@ mod tests {
 
         // Expect to see the transaction to be requested and successfully executed hence removed from WAL
         tx_subscription.recv().await.unwrap();
-        assert!(store.get_all_pending_actions().unwrap().is_empty());
+        assert!(store.get_all_pending_actions().is_empty());
 
         /////////////////////////////////////////////////////////////////////////////////////////////////
         ////////////////////////////////////// Test execution failure ///////////////////////////////////
@@ -569,7 +569,7 @@ mod tests {
 
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -582,7 +582,7 @@ mod tests {
         tx_subscription.recv().await.unwrap();
         // The action is not removed from WAL because the transaction failed
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -614,7 +614,7 @@ mod tests {
 
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -630,7 +630,6 @@ mod tests {
         // The retry is still going on, action still in WAL
         assert!(store
             .get_all_pending_actions()
-            .unwrap()
             .contains_key(&action.digest()));
 
         // Now let it succeed
@@ -646,7 +645,6 @@ mod tests {
         // The action is successful and should be removed from WAL now
         assert!(!store
             .get_all_pending_actions()
-            .unwrap()
             .contains_key(&action.digest()));
     }
 
@@ -697,7 +695,7 @@ mod tests {
 
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -722,7 +720,7 @@ mod tests {
         );
         // Still in WAL
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -761,7 +759,6 @@ mod tests {
         // The action is removed from WAL
         assert!(!store
             .get_all_pending_actions()
-            .unwrap()
             .contains_key(&action.digest()));
     }
 
@@ -802,7 +799,7 @@ mod tests {
         );
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -816,20 +813,13 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         tx_subscription.try_recv().unwrap_err();
         // And the action is still in WAL
-        assert!(store
-            .get_all_pending_actions()
-            .unwrap()
-            .contains_key(&action_digest));
+        assert!(store.get_all_pending_actions().contains_key(&action_digest));
 
         sui_client_mock.set_action_onchain_status(&action, BridgeActionStatus::Approved);
 
         // The next retry will see the action is already processed on chain and remove it from WAL
         let now = std::time::Instant::now();
-        while store
-            .get_all_pending_actions()
-            .unwrap()
-            .contains_key(&action_digest)
-        {
+        while store.get_all_pending_actions().contains_key(&action_digest) {
             if now.elapsed().as_secs() > 10 {
                 panic!("Timeout waiting for action to be removed from WAL");
             }
@@ -890,7 +880,7 @@ mod tests {
 
         store.insert_pending_actions(&[action.clone()]).unwrap();
         assert_eq!(
-            store.get_all_pending_actions().unwrap()[&action.digest()],
+            store.get_all_pending_actions()[&action.digest()],
             action.clone()
         );
 
@@ -909,11 +899,7 @@ mod tests {
         // The next retry will see the action is already processed on chain and remove it from WAL
         let now = std::time::Instant::now();
         let action_digest = action.digest();
-        while store
-            .get_all_pending_actions()
-            .unwrap()
-            .contains_key(&action_digest)
-        {
+        while store.get_all_pending_actions().contains_key(&action_digest) {
             if now.elapsed().as_secs() > 10 {
                 panic!("Timeout waiting for action to be removed from WAL");
             }

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -153,7 +153,7 @@ async fn start_client_components(
     let orchestrator =
         BridgeOrchestrator::new(sui_client, sui_events_rx, eth_events_rx, store.clone());
 
-    all_handles.extend(orchestrator.run(bridge_action_executor));
+    all_handles.extend(orchestrator.run(bridge_action_executor).await);
     Ok(all_handles)
 }
 

--- a/crates/sui-bridge/src/orchestrator.rs
+++ b/crates/sui-bridge/src/orchestrator.rs
@@ -48,7 +48,7 @@ where
         }
     }
 
-    pub fn run(
+    pub async fn run(
         self,
         bridge_action_executor: impl BridgeActionExecutorTrait,
     ) -> Vec<JoinHandle<()>> {
@@ -66,11 +66,24 @@ where
             self.sui_events_rx,
         )));
         let store_clone = self.store.clone();
+
+        // Re-submit pending actions to executor
+        let actions = store_clone
+            .get_all_pending_actions()
+            .into_values()
+            .collect::<Vec<_>>();
+        for action in actions {
+            submit_to_executor(&executor_sender, action)
+                .await
+                .expect("Submit to executor should not fail");
+        }
+
         task_handles.push(spawn_logged_monitored_task!(Self::run_eth_watcher(
             store_clone,
             executor_sender,
             self.eth_events_rx,
         )));
+
         // TODO: spawn bridge committee change watcher task
         task_handles
     }
@@ -197,12 +210,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_utils::get_test_log_and_action, types::BridgeActionDigest};
+    use crate::{
+        test_utils::{get_test_eth_to_sui_bridge_action, get_test_log_and_action},
+        types::BridgeActionDigest,
+    };
     use ethers::types::{Address as EthAddress, TxHash};
     use prometheus::Registry;
     use std::str::FromStr;
 
     use super::*;
+    use crate::test_utils::get_test_sui_to_eth_bridge_action;
     use crate::{events::tests::get_test_sui_event_and_action, sui_mock_client::SuiMockClient};
 
     #[tokio::test]
@@ -221,7 +238,8 @@ mod tests {
             eth_events_rx,
             store.clone(),
         )
-        .run(executor);
+        .run(executor)
+        .await;
 
         let identifier = Identifier::from_str("test_sui_watcher_task").unwrap();
         let (sui_event, bridge_action) = get_test_sui_event_and_action(identifier.clone());
@@ -237,7 +255,7 @@ mod tests {
             bridge_action.digest()
         );
         loop {
-            let actions = store.get_all_pending_actions().unwrap();
+            let actions = store.get_all_pending_actions();
             if actions.is_empty() {
                 if start.elapsed().as_secs() > 5 {
                     panic!("Timed out waiting for action to be written to WAL");
@@ -272,7 +290,8 @@ mod tests {
             eth_events_rx,
             store.clone(),
         )
-        .run(executor);
+        .run(executor)
+        .await;
         let address = EthAddress::random();
         let (log, bridge_action) = get_test_log_and_action(address, TxHash::random(), 10);
         let log_index_in_tx = 10;
@@ -297,7 +316,7 @@ mod tests {
         );
         let start = std::time::Instant::now();
         loop {
-            let actions = store.get_all_pending_actions().unwrap();
+            let actions = store.get_all_pending_actions();
             if actions.is_empty() {
                 if start.elapsed().as_secs() > 5 {
                     panic!("Timed out waiting for action to be written to WAL");
@@ -314,6 +333,47 @@ mod tests {
             );
             break;
         }
+    }
+
+    #[tokio::test]
+    /// Test that when orchestrator starts, all pending actions are sent to executor
+    async fn test_resume_actions_in_pending_logs() {
+        let (_sui_events_tx, sui_events_rx, _eth_events_tx, eth_events_rx, sui_client, store) =
+            setup();
+        let (executor, mut executor_requested_action_rx) = MockExecutor::new();
+
+        let action1 = get_test_sui_to_eth_bridge_action(
+            None,
+            Some(0),
+            Some(99),
+            Some(10000),
+            None,
+            None,
+            None,
+        );
+
+        let action2 = get_test_eth_to_sui_bridge_action(None, None, None);
+        store
+            .insert_pending_actions(&vec![action1.clone(), action2.clone()])
+            .unwrap();
+
+        // start orchestrator
+        let _handles = BridgeOrchestrator::new(
+            Arc::new(sui_client),
+            sui_events_rx,
+            eth_events_rx,
+            store.clone(),
+        )
+        .run(executor)
+        .await;
+
+        // Executor should have received the action
+        let mut digests = std::collections::HashSet::new();
+        digests.insert(executor_requested_action_rx.recv().await.unwrap());
+        digests.insert(executor_requested_action_rx.recv().await.unwrap());
+        assert!(digests.contains(&action1.digest()));
+        assert!(digests.contains(&action2.digest()));
+        assert_eq!(digests.len(), 2);
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/sui-bridge/src/storage.rs
+++ b/crates/sui-bridge/src/storage.rs
@@ -108,10 +108,8 @@ impl BridgeOrchestratorTables {
             .map_err(|e| BridgeError::StorageError(format!("Couldn't write batch: {:?}", e)))
     }
 
-    pub fn get_all_pending_actions(
-        &self,
-    ) -> BridgeResult<HashMap<BridgeActionDigest, BridgeAction>> {
-        Ok(self.pending_actions.unbounded_iter().collect())
+    pub fn get_all_pending_actions(&self) -> HashMap<BridgeActionDigest, BridgeAction> {
+        self.pending_actions.unbounded_iter().collect()
     }
 
     pub fn get_sui_event_cursors(
@@ -172,7 +170,7 @@ mod tests {
         );
 
         // in the beginning it's empty
-        let actions = store.get_all_pending_actions().unwrap();
+        let actions = store.get_all_pending_actions();
         assert!(actions.is_empty());
 
         // remove non existing entry is ok
@@ -182,7 +180,7 @@ mod tests {
             .insert_pending_actions(&vec![action1.clone(), action2.clone()])
             .unwrap();
 
-        let actions = store.get_all_pending_actions().unwrap();
+        let actions = store.get_all_pending_actions();
         assert_eq!(
             actions,
             HashMap::from_iter(vec![
@@ -193,7 +191,7 @@ mod tests {
 
         // insert an existing action is ok
         store.insert_pending_actions(&[action1.clone()]).unwrap();
-        let actions = store.get_all_pending_actions().unwrap();
+        let actions = store.get_all_pending_actions();
         assert_eq!(
             actions,
             HashMap::from_iter(vec![
@@ -204,7 +202,7 @@ mod tests {
 
         // remove action 2
         store.remove_pending_actions(&[action2.digest()]).unwrap();
-        let actions = store.get_all_pending_actions().unwrap();
+        let actions = store.get_all_pending_actions();
         assert_eq!(
             actions,
             HashMap::from_iter(vec![(action1.digest(), action1.clone())])
@@ -212,7 +210,7 @@ mod tests {
 
         // remove action 1
         store.remove_pending_actions(&[action1.digest()]).unwrap();
-        let actions = store.get_all_pending_actions().unwrap();
+        let actions = store.get_all_pending_actions();
         assert!(actions.is_empty());
 
         // update eth event cursor


### PR DESCRIPTION
## Description 

When the node restarts, we read pending actions from DB and send to executor to resume them.

meat is in `crates/sui-bridge/src/orchestrator.rs`


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
