### PR TITLE
indexer easy: index data limit config

### DIFF
--- a/crates/sui-indexer/src/framework/runner.rs
+++ b/crates/sui-indexer/src/framework/runner.rs
@@ -7,9 +7,9 @@ use super::fetcher::CheckpointDownloadData;
 use super::interface::Handler;
 
 // Limit indexing parallelism on big checkpoints to avoid OOM,
-// by limiting the total size of batch checkpoints to ~50MB.
+// by limiting the total size of batch checkpoints to ~20MB.
 // On testnet, most checkpoints are < 200KB, some can go up to 50MB.
-const CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT: usize = 50000000;
+const CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT: usize = 20000000;
 const CHECKPOINT_PROCESSING_BATCH_SIZE: usize = 100;
 
 pub async fn run<S>(stream: S, mut handlers: Vec<Box<dyn Handler>>, metrics: IndexerMetrics)
@@ -17,9 +17,12 @@ where
     S: futures::Stream<Item = CheckpointDownloadData> + std::marker::Unpin,
 {
     use futures::StreamExt;
-
     let batch_size = std::env::var("CHECKPOINT_PROCESSING_BATCH_SIZE")
         .unwrap_or(CHECKPOINT_PROCESSING_BATCH_SIZE.to_string())
+        .parse::<usize>()
+        .unwrap();
+    let data_limit = std::env::var("CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT")
+        .unwrap_or(CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT.to_string())
         .parse::<usize>()
         .unwrap();
     tracing::info!("Indexer runner is starting with {batch_size}");
@@ -31,7 +34,7 @@ where
         for checkpoint in checkpoints.iter() {
             cp_batch_total_size += checkpoint.size;
             cp_batch.push(checkpoint.data.clone());
-            if cp_batch_total_size >= CHECKPOINT_PROCESSING_BATCH_DATA_LIMIT {
+            if cp_batch_total_size >= data_limit {
                 futures::future::join_all(handlers.iter_mut().map(|handler| async {
                     handler.process_checkpoints(&cp_batch).await.unwrap()
                 }))


### PR DESCRIPTION
## Description 

title, to tune the data limit for oom experiment.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
