### PR TITLE
Implement accumulate_cached_live_object_set_for_testing

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -666,6 +666,7 @@ impl AuthorityStore {
     }
 
     /// This function should only be used for initializing genesis and should remain private.
+    #[instrument(level = "debug", skip_all)]
     pub(crate) fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> SuiResult<()> {
         let mut batch = self.perpetual_tables.objects.batch();
         let ref_and_objects: Vec<_> = objects
@@ -1385,7 +1386,7 @@ impl AuthorityStore {
     /// TODO: implement GC for transactions that are no longer needed.
     pub fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
         let Some(effects) = self.get_executed_effects(tx_digest)? else {
-            debug!("Not reverting {:?} as it was not executed", tx_digest);
+            info!("Not reverting {:?} as it was not executed", tx_digest);
             return Ok(());
         };
 

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -93,7 +93,8 @@ pub async fn execute_certificate_with_execution_error(
         .epoch_store_for_testing()
         .protocol_config()
         .simplified_unwrap_then_delete();
-    let mut state = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
+    let mut state =
+        state_acc.accumulate_cached_live_object_set_for_testing(include_wrapped_tombstone);
 
     if with_shared {
         send_consensus(authority, &certificate).await;
@@ -105,7 +106,8 @@ pub async fn execute_certificate_with_execution_error(
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
     // we unfortunately don't get a very descriptive error message, but we can at least see that something went wrong inside the VM
     let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
-    let state_after = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
+    let state_after =
+        state_acc.accumulate_cached_live_object_set_for_testing(include_wrapped_tombstone);
     let effects_acc = state_acc.accumulate_effects(
         vec![result.inner().data().clone()],
         epoch_store.protocol_config(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -215,6 +215,7 @@ impl CheckpointExecutor {
                     "Pending checkpoint execution buffer should be empty after processing last checkpoint of epoch",
                 );
                 fail_point_async!("crash");
+                debug!(epoch = epoch_store.epoch(), "finished epoch");
                 return StopReason::EpochComplete;
             }
 
@@ -1179,7 +1180,7 @@ async fn execute_transactions(
     Ok(())
 }
 
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "info", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
 async fn finalize_checkpoint(
     state: &AuthorityState,
     cache_reader: &dyn ExecutionCacheRead,
@@ -1191,6 +1192,7 @@ async fn finalize_checkpoint(
     effects: Vec<TransactionEffects>,
     data_ingestion_dir: Option<PathBuf>,
 ) -> SuiResult {
+    debug!("finalizing checkpoint");
     if epoch_store.per_epoch_finalized_txns_enabled() {
         epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
     }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -60,7 +60,7 @@ use moka::sync::Cache as MokaCache;
 use mysten_common::sync::notify_read::NotifyRead;
 use parking_lot::Mutex;
 use prometheus::Registry;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 use std::sync::Arc;
 use sui_config::node::AuthorityStorePruningConfig;
@@ -196,6 +196,20 @@ impl UncommittedData {
         self.executed_effects_digests.clear();
         self.pending_transaction_writes.clear();
         self.transaction_events.clear();
+    }
+
+    fn is_empty(&self) -> bool {
+        let empty = self.pending_transaction_writes.is_empty();
+        if empty && cfg!(debug_assertions) {
+            assert!(
+                self.objects.is_empty()
+                    && self.markers.is_empty()
+                    && self.transaction_effects.is_empty()
+                    && self.executed_effects_digests.is_empty()
+                    && self.transaction_events.is_empty()
+            );
+        }
+        empty
     }
 }
 
@@ -1379,6 +1393,50 @@ impl AccumulatorStore for WritebackCache {
         // The only time it is safe to iterate the live object set is at an epoch boundary,
         // at which point the db is consistent and the dirty cache is empty. So this does
         // read the cache
+        assert!(
+            self.dirty.is_empty(),
+            "cannot iterate live object set with dirty data"
+        );
         self.store.iter_live_object_set(include_wrapped_tombstone)
+    }
+
+    // A version of iter_live_object_set that reads the cache. Only use for testing. If used
+    // on a live validator, can cause the server to block for as long as it takes to iterate
+    // the entire live object set.
+    fn iter_cached_live_object_set_for_testing(
+        &self,
+        include_wrapped_tombstone: bool,
+    ) -> Box<dyn Iterator<Item = LiveObject> + '_> {
+        // hold iter until we are finished to prevent any concurrent inserts/deletes
+        let iter = self.dirty.objects.iter();
+        let mut dirty_objects = BTreeMap::new();
+
+        // add everything from the store
+        for obj in self.store.iter_live_object_set(include_wrapped_tombstone) {
+            dirty_objects.insert(obj.object_id(), obj);
+        }
+
+        // add everything from the cache, but also remove deletions
+        for entry in iter {
+            let id = *entry.key();
+            let value = entry.value();
+            match value.get_highest().unwrap() {
+                (_, ObjectEntry::Object(object)) => {
+                    dirty_objects.insert(id, LiveObject::Normal(object.clone()));
+                }
+                (version, ObjectEntry::Wrapped) => {
+                    if include_wrapped_tombstone {
+                        dirty_objects.insert(id, LiveObject::Wrapped(ObjectKey(id, *version)));
+                    } else {
+                        dirty_objects.remove(&id);
+                    }
+                }
+                (_, ObjectEntry::Deleted) => {
+                    dirty_objects.remove(&id);
+                }
+            }
+        }
+
+        Box::new(dirty_objects.into_values())
     }
 }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -363,7 +363,7 @@ impl WritebackCache {
         version: SequenceNumber,
         object: ObjectEntry,
     ) {
-        tracing::trace!("inserting object entry {:?}: {:?}", object_id, version);
+        debug!("inserting object entry {:?}: {:?}", object_id, version);
         fail_point_async!("write_object_entry");
         self.dirty
             .objects
@@ -894,6 +894,10 @@ impl ExecutionCacheRead for WritebackCache {
         if let Some(p) = ExecutionCacheRead::get_object(self, package_id)? {
             if p.is_package() {
                 let p = PackageObject::new(p);
+                tracing::trace!(
+                    "caching package: {:?}",
+                    p.object().compute_object_reference()
+                );
                 self.packages.insert(*package_id, p.clone());
                 Ok(Some(p))
             } else {

--- a/crates/sui-e2e-tests/tests/object_deletion_tests.rs
+++ b/crates/sui-e2e-tests/tests/object_deletion_tests.rs
@@ -315,7 +315,7 @@ mod sim_only_tests {
     fn count_wrapped_tombstone(node: &SuiNode) -> usize {
         let store = node.state().get_execution_cache();
         store
-            .iter_live_object_set(true)
+            .iter_cached_live_object_set_for_testing(true)
             .filter(|o| matches!(o, LiveObject::Wrapped(_)))
             .count()
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -606,7 +606,7 @@ impl SuiNode {
             secret,
             config.supported_protocol_versions.unwrap(),
             store.clone(),
-            execution_cache,
+            execution_cache.clone(),
             epoch_store.clone(),
             committee_store.clone(),
             index_store.clone(),
@@ -684,7 +684,7 @@ impl SuiNode {
             software_version,
         )?;
 
-        let accumulator = Arc::new(StateAccumulator::new(store));
+        let accumulator = Arc::new(StateAccumulator::new(execution_cache));
 
         let authority_names_to_peer_ids = epoch_store
             .epoch_start_state()

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -268,7 +268,7 @@ impl SingleValidator {
         let objects: HashMap<_, _> = self
             .get_validator()
             .get_execution_cache()
-            .iter_live_object_set(false)
+            .iter_cached_live_object_set_for_testing(false)
             .map(|o| match o {
                 LiveObject::Normal(object) => (object.id(), object),
                 LiveObject::Wrapped(_) => unreachable!(),


### PR DESCRIPTION
Add accumulate_cached_live_object_set_for_testing, because there are many tests that rely on the ability to iterate the live objects mid-epoch