### PR TITLE
Check bridge routes on send token

### DIFF
--- a/crates/sui-framework/docs/bridge/bridge.md
+++ b/crates/sui-framework/docs/bridge/bridge.md
@@ -439,6 +439,15 @@ title: Module `0xb::bridge`
 
 
 
+<a name="0xb_bridge_EInvalidBridgeRoute"></a>
+
+
+
+<pre><code><b>const</b> <a href="bridge.md#0xb_bridge_EInvalidBridgeRoute">EInvalidBridgeRoute</a>: u64 = 16;
+</code></pre>
+
+
+
 <a name="0xb_bridge_EBridgeAlreadyPaused"></a>
 
 
@@ -744,6 +753,7 @@ title: Module `0xb::bridge`
 ) {
     <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
     <b>assert</b>!(!inner.paused, <a href="bridge.md#0xb_bridge_EBridgeUnavailable">EBridgeUnavailable</a>);
+    <b>assert</b>!(<a href="chain_ids.md#0xb_chain_ids_is_valid_route">chain_ids::is_valid_route</a>(inner.chain_id, target_chain), <a href="bridge.md#0xb_bridge_EInvalidBridgeRoute">EInvalidBridgeRoute</a>);
     <b>let</b> amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(<a href="../sui-framework/coin.md#0x2_coin_balance">coin::balance</a>(&token));
 
     <b>let</b> bridge_seq_num = <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(inner, <a href="message_types.md#0xb_message_types_token">message_types::token</a>());

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x7b7944deb3caf4b82bcb3dc2821c79a3c3b4532902c9cf8be3e372d000b2b3eb"
+            id: "0x187f104bf2d652db4d6cac60e73d1f0eee35ed78c32cfed238387ff63bb453b7"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x34c4df87b59cd55bfce99106c884ff91032861f9d68fbb9e18254be53fa06f90"
+      operation_cap_id: "0x6e624be18d130e9760f33b162bd1f74ca45c7d1455bd538ee016e16ea2db88ff"
       gas_price: 1000
       staking_pool:
-        id: "0x3f7473e00fec647ba4f666968fea5b4fd596e1b5cdffa9a4472bbba21e9cfe9d"
+        id: "0x39672c9e746eb31140f646424dbf456cd7eb3efb02da1d6f68b649c97d90ec93"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xd167179392c92d2cdbc3eb4ac4465ee205ad3ed3666671b79cb2716fe5c7fb26"
+          id: "0x0d583a9e07e30d211daf3343e568a132d1bcd90c4be56fc99fdd0905dad24042"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xd409c4a417ef1b7f6fb29eae7104b98f9d29c4968284499897a48ef72f740d6a"
+            id: "0xffa9508e3defcc53a9f4ed2f650dd8902dd044304f6f1979ad93a64468bf5514"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x1df966210499ebdcd6c8763120c6b3fdf3fc0f571ebe031d16721d60d815ec85"
+          id: "0x4690c617477ce06c4e9812b57385027138440e511b1a990ead6023dc64b0bbb2"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x05c0378801204bd28824e2c89acd102b56dc32eb0a49214b4fe6f478ed5c0040"
+      id: "0x845a8843d8af0fc3840fe4aabe90197a69e75863aa51764077135a2e37e3b648"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x3655e9e7d4c9c40f6bcf855400feac0b780afc7df3c394c89ad0675ed8c44c80"
+    id: "0x8e53a960fcd10a5b52dce5e3afbb6ed800ee863e8565f9f43379b8425615633e"
     size: 1
   inactive_validators:
-    id: "0x253b4e34e0506dcd8c7683cac5e4aab682007baceaf2e959103c8b68700e8fc3"
+    id: "0x03a238e9e2328f34a4c66b9b6354b4b096144d4d2f903e6979c516db14bcf865"
     size: 0
   validator_candidates:
-    id: "0x18aa838af70566aadda7bd64592fcea2a6523329bc20e221046a7f5f2926e5e6"
+    id: "0xa2359cd13782f912133450e96045a83a90767f1fa160fd1994770d036812579a"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x1f274bce6f30577325ff1f5e6e5c831295d2ad779fc70f9c9faa56e61d7fd8c5"
+      id: "0x6b08850fa53464592ec898f243808f3fa923b02574b1405ccac58ab613ebb907"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x110f619a3fd20e5e2aa65010c4ecd58028d42dfb0d1ebc54a7bb9ec9aed7b7b9"
+      id: "0x6e4d31876bbc8f743e46950509994d72bcb24dccbcfdd6c3463c0b71adaa9dd0"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x092db3d5616e08c6238d50eab49eaf40b5840a212181af00b0565900b98136e8"
+      id: "0xdcac23daabf1177e9915ce222481d9036197d95126aa82a505e9eb81e7d3f5e5"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x805d8f42450425df7c15963b9f4197ce6582655a5a1e73d6edd9f39549f7cc32"
+    id: "0x7dc4867bf3018e27512ead6361ce7edbf47ae848eb8981a18844941facd3c132"
   size: 0
 


### PR DESCRIPTION
## Description 

Audit found that `send_token` was not checking for valid routes. 
Added the missing check

## Test Plan 

Added unit tests.
Positive tests (no abort) for `send_token` are a bit trickier and will be added when unit test review is done. They were not there so this is not a regression in tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
