### PR TITLE
Add multi_get_object_info_for_tx_building to fullnode rpc

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -233,11 +233,11 @@ impl IndexerReader {
         object_id: &ObjectID,
         version: Option<VersionNumber>,
     ) -> Result<Option<Object>, IndexerError> {
-        let Some(stored_package) = self.get_object_from_db(object_id, version)? else {
+        let Some(stored_object) = self.get_object_from_db(object_id, version)? else {
             return Ok(None);
         };
 
-        let object = stored_package.try_into()?;
+        let object = stored_object.try_into()?;
         Ok(Some(object))
     }
 
@@ -849,7 +849,7 @@ impl IndexerReader {
                     ),
                     (None, Some(_)) => {
                         return Err(IndexerError::InvalidArgumentError(
-                            "Function cannot be present wihtout Module.".into(),
+                            "Function cannot be present without Module.".into(),
                         ));
                     }
                     (None, None) => (

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -139,7 +139,7 @@ pub async fn build_json_rpc_server(
     builder.register_module(TransactionBuilderApi::new(reader.clone()))?;
     builder.register_module(MoveUtilsApi::new(reader.clone()))?;
     builder.register_module(GovernanceReadApi::new(reader.clone()))?;
-    builder.register_module(ReadApi::new(reader.clone()))?;
+    builder.register_module(ReadApi::new(reader.clone(), http_client.clone()))?;
     builder.register_module(CoinReadApi::new(reader.clone()))?;
     builder.register_module(ExtendedApi::new(reader.clone()))?;
 

--- a/crates/sui-json-rpc-api/src/read.rs
+++ b/crates/sui-json-rpc-api/src/read.rs
@@ -7,7 +7,7 @@ use jsonrpsee::proc_macros::rpc;
 use sui_json_rpc_types::{
     Checkpoint, CheckpointId, CheckpointPage, SuiEvent, SuiGetPastObjectRequest,
     SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseOptions,
+    SuiTransactionBlockResponseOptions, SuiTxObjectInfo,
 };
 use sui_json_rpc_types::{ProtocolConfigResponse, SuiLoadedChildObjectsResponse};
 use sui_open_rpc_macros::open_rpc;
@@ -58,6 +58,20 @@ pub trait ReadApi {
         /// options for specifying the content to be returned
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiObjectResponse>>;
+
+    /// Given a list of object IDs, return the information of each object needed for transaction building.
+    /// If any object does not exist, it will return an error.
+    /// If any object is an object-owned object, which cannot be used as transaction input, it will return an error.
+    /// If an object exists, the corresponding entry will be an enum of object information.
+    /// For shared object, the entry will contain the init shared version;
+    /// For owned object, the entry will contain the latest version, digest and owner address.
+    /// For immutable object, the entry will contain the latest version and digest.
+    /// It is guaranteed that the returned list will have the same length as the input list.
+    #[method(name = "multiGetObjectInfoForTxBuilding")]
+    async fn multi_get_object_info_for_tx_building(
+        &self,
+        object_ids: Vec<ObjectID>,
+    ) -> RpcResult<Vec<SuiTxObjectInfo>>;
 
     /// Note there is no software-level guarantee/SLA that objects with past versions
     /// can be retrieved by this API, even if the object and version exists/existed.

--- a/crates/sui-json-rpc-api/src/read.rs
+++ b/crates/sui-json-rpc-api/src/read.rs
@@ -61,10 +61,10 @@ pub trait ReadApi {
 
     /// Given a list of object IDs, return the information of each object needed for transaction building.
     /// If any object does not exist, it will return an error.
-    /// If any object is an object-owned object, which cannot be used as transaction input, it will return an error.
+    /// If any object is a child object, which cannot be used as transaction input, it will return an error.
     /// If an object exists, the corresponding entry will be an enum of object information.
     /// For shared object, the entry will contain the init shared version;
-    /// For owned object, the entry will contain the latest version, digest and owner address.
+    /// For address owned object (including receiving objects), the entry will contain the latest version, digest and owner address.
     /// For immutable object, the entry will contain the latest version and digest.
     /// It is guaranteed that the returned list will have the same length as the input list.
     #[method(name = "multiGetObjectInfoForTxBuilding")]

--- a/crates/sui-json-rpc-tests/tests/transaction_building_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_building_tests.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_json_rpc::error::SuiRpcInputError;
+use sui_json_rpc_api::ReadApiClient;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiTxObjectInfo};
+use sui_macros::sim_test;
+use sui_types::base_types::ObjectID;
+use sui_types::error::UserInputError;
+use sui_types::object::{Object, Owner};
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn test_multi_get_object_info_for_tx_building() {
+    let shared_object = Object::shared_for_testing();
+    let initial_shared_version = match shared_object.owner {
+        Owner::Shared {
+            initial_shared_version,
+            ..
+        } => initial_shared_version,
+        _ => panic!("Expected shared object"),
+    };
+    let owned_object = Object::new_gas_for_testing();
+    let immutable_object = Object::immutable_for_testing();
+    let cluster = TestClusterBuilder::new()
+        .with_objects(
+            [
+                shared_object.clone(),
+                owned_object.clone(),
+                immutable_object.clone(),
+            ]
+            .into_iter(),
+        )
+        .build()
+        .await;
+    let http_client = cluster.rpc_client();
+    let mut objects = http_client
+        .multi_get_objects(
+            vec![owned_object.id(), immutable_object.id()],
+            Some(SuiObjectDataOptions::new().with_owner()),
+        )
+        .await
+        .unwrap();
+    let imm_obj = objects.pop().unwrap().data.unwrap();
+    let owned_obj = objects.pop().unwrap().data.unwrap();
+    let results = http_client
+        .multi_get_object_info_for_tx_building(vec![
+            shared_object.id(),
+            owned_object.id(),
+            immutable_object.id(),
+        ])
+        .await
+        .unwrap();
+    assert_eq!(
+        results,
+        vec![
+            SuiTxObjectInfo::Shared {
+                initial_shared_version,
+            },
+            SuiTxObjectInfo::AddressOwned {
+                version: owned_obj.version,
+                digest: owned_obj.digest,
+                owner: owned_obj
+                    .owner
+                    .unwrap()
+                    .get_address_owner_address()
+                    .unwrap(),
+            },
+            SuiTxObjectInfo::Immutable {
+                version: imm_obj.version,
+                digest: imm_obj.digest,
+            }
+        ]
+    )
+}
+
+#[sim_test]
+async fn test_multi_get_object_info_for_tx_building_invalid_object() {
+    let owned_object = Object::new_gas_for_testing();
+    let child_object = Object::with_object_owner_for_testing(ObjectID::random(), owned_object.id());
+    let cluster = TestClusterBuilder::new()
+        .with_objects([owned_object.clone(), child_object.clone()].into_iter())
+        .build()
+        .await;
+    let http_client = cluster.rpc_client();
+    let results = http_client
+        .multi_get_object_info_for_tx_building(vec![child_object.id()])
+        .await;
+    assert!(results.unwrap_err().to_string().contains(
+        &UserInputError::InvalidChildObjectArgument {
+            child_id: child_object.id(),
+            parent_id: owned_object.id(),
+        }
+        .to_string()
+    ));
+    let random_id = ObjectID::random();
+    let results = http_client
+        .multi_get_object_info_for_tx_building(vec![random_id])
+        .await;
+    assert!(results.unwrap_err().to_string().contains(
+        &UserInputError::ObjectNotFound {
+            object_id: random_id,
+            version: None,
+        }
+        .to_string()
+    ));
+}
+
+#[sim_test]
+async fn test_multi_get_object_info_for_tx_building_limit() {
+    let owned_object = Object::new_gas_for_testing();
+    let cluster = TestClusterBuilder::new()
+        .with_objects([owned_object.clone()])
+        .build()
+        .await;
+    let http_client = cluster.rpc_client();
+    let results = http_client
+        .multi_get_object_info_for_tx_building(
+            (0..2048).map(|_| owned_object.id()).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2048);
+    let results = http_client
+        .multi_get_object_info_for_tx_building(
+            (0..2049).map(|_| owned_object.id()).collect::<Vec<_>>(),
+        )
+        .await;
+    assert!(results
+        .unwrap_err()
+        .to_string()
+        .contains(&SuiRpcInputError::SizeLimitExceeded(2048.to_string()).to_string()));
+}

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -1246,3 +1246,29 @@ impl SuiObjectResponseQuery {
         }
     }
 }
+
+/// A struct that contains basic information of an input object of a transaction.
+/// This is needed when building a transaction, returned by multi_get_object_info_for_tx_building RPC call.
+#[serde_as]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq)]
+#[serde(rename = "ObjectInfo", rename_all = "camelCase")]
+pub enum SuiTxObjectInfo {
+    AddressOwned {
+        #[schemars(with = "AsSequenceNumber")]
+        #[serde_as(as = "AsSequenceNumber")]
+        version: SequenceNumber,
+        digest: ObjectDigest,
+        owner: SuiAddress,
+    },
+    Immutable {
+        #[schemars(with = "AsSequenceNumber")]
+        #[serde_as(as = "AsSequenceNumber")]
+        version: SequenceNumber,
+        digest: ObjectDigest,
+    },
+    Shared {
+        #[schemars(with = "AsSequenceNumber")]
+        #[serde_as(as = "AsSequenceNumber")]
+        initial_shared_version: SequenceNumber,
+    },
+}

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -593,10 +593,9 @@ impl ReadApiServer for ReadApi {
             if object_ids.len() > MAX_OBJECT_IDS {
                 return Err(SuiRpcInputError::SizeLimitExceeded(MAX_OBJECT_IDS.to_string()).into());
             }
-            let state = self.state.clone();
             let mut results = vec![];
             for object_id in &object_ids {
-                let object = state.get_object(object_id).await?;
+                let object = self.state.get_object(object_id).await?;
                 let Some(object) = object else {
                     return Err(
                         SuiRpcInputError::UserInputError(UserInputError::ObjectNotFound {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2160,7 +2160,7 @@
           "name": "Read API"
         }
       ],
-      "description": "Given a list of object IDs, return the information of each object needed for transaction building. If any object does not exist, it will return an error. If any object is an object-owned object, which cannot be used as transaction input, it will return an error. If an object exists, the corresponding entry will be an enum of object information. For shared object, the entry will contain the init shared version; For owned object, the entry will contain the latest version, digest and owner address. For immutable object, the entry will contain the latest version and digest. It is guaranteed that the returned list will have the same length as the input list.",
+      "description": "Given a list of object IDs, return the information of each object needed for transaction building. If any object does not exist, it will return an error. If any object is a child object, which cannot be used as transaction input, it will return an error. If an object exists, the corresponding entry will be an enum of object information. For shared object, the entry will contain the init shared version; For address owned object (including receiving objects), the entry will contain the latest version, digest and owner address. For immutable object, the entry will contain the latest version and digest. It is guaranteed that the returned list will have the same length as the input list.",
       "params": [
         {
           "name": "object_ids",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2154,6 +2154,37 @@
       ]
     },
     {
+      "name": "sui_multiGetObjectInfoForTxBuilding",
+      "tags": [
+        {
+          "name": "Read API"
+        }
+      ],
+      "description": "Given a list of object IDs, return the information of each object needed for transaction building. If any object does not exist, it will return an error. If any object is an object-owned object, which cannot be used as transaction input, it will return an error. If an object exists, the corresponding entry will be an enum of object information. For shared object, the entry will contain the init shared version; For owned object, the entry will contain the latest version, digest and owner address. For immutable object, the entry will contain the latest version and digest. It is guaranteed that the returned list will have the same length as the input list.",
+      "params": [
+        {
+          "name": "object_ids",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<SuiTxObjectInfo>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/ObjectInfo"
+          }
+        }
+      }
+    },
+    {
       "name": "sui_multiGetObjects",
       "tags": [
         {
@@ -7250,6 +7281,83 @@
       },
       "ObjectID": {
         "$ref": "#/components/schemas/Hex"
+      },
+      "ObjectInfo": {
+        "description": "A struct that contains basic information of an input object of a transaction. This is needed when building a transaction, returned by multi_get_object_info_for_tx_building RPC call.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "addressOwned"
+            ],
+            "properties": {
+              "addressOwned": {
+                "type": "object",
+                "required": [
+                  "digest",
+                  "owner",
+                  "version"
+                ],
+                "properties": {
+                  "digest": {
+                    "$ref": "#/components/schemas/ObjectDigest"
+                  },
+                  "owner": {
+                    "$ref": "#/components/schemas/SuiAddress"
+                  },
+                  "version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "immutable"
+            ],
+            "properties": {
+              "immutable": {
+                "type": "object",
+                "required": [
+                  "digest",
+                  "version"
+                ],
+                "properties": {
+                  "digest": {
+                    "$ref": "#/components/schemas/ObjectDigest"
+                  },
+                  "version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "shared"
+            ],
+            "properties": {
+              "shared": {
+                "type": "object",
+                "required": [
+                  "initial_shared_version"
+                ],
+                "properties": {
+                  "initial_shared_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "ObjectRead": {
         "oneOf": [


### PR DESCRIPTION
## Description 

Add a more lightweight interface to get the latest version and digest of a given list of object ids.
This will save network egress because we do not return objects but just the version and digests.
Setting the limit to be 2048 because that's the limit of the number of input objects one can use in a transaction. It is generally annoying to have to use multiple queries for one transaction.
This is affordable because very soon we will be using writeback cache on fullnodes, and latest versions of objects are most likely in the cache, so it is cheap without much db access.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Introduced a new RPC API `multi_get_object_info_for_tx_building` that can query the object informationfor a given list of object IDs for the purpose of transaction building. For owned objects we return the latest version and digest; for shared objects we return the initial shared version. The limit per query for this API is 2048, which is consistent with the input object number limit on transactions.
