### PR TITLE
WritebackCache bugfixes

### DIFF
--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -703,7 +703,7 @@ async fn test_missing_reverts_panic() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "transaction must exist")]
+#[should_panic(expected = "attempt to revert committed transaction")]
 async fn test_revert_committed_tx_panics() {
     telemetry_subscribers::init_for_testing();
     Scenario::iterate(|mut s| async move {
@@ -711,6 +711,21 @@ async fn test_revert_committed_tx_panics() {
         let tx1 = s.do_tx().await;
         s.commit(tx1).await.unwrap();
         s.cache().revert_state_update(&tx1).unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_revert_unexecuted_tx() {
+    telemetry_subscribers::init_for_testing();
+    Scenario::iterate(|mut s| async move {
+        s.with_created(&[1]);
+        let tx1 = s.do_tx().await;
+        s.commit(tx1).await.unwrap();
+        let random_digest = TransactionDigest::random();
+        // must not panic - pending_consensus_transactions is a super set of
+        // executed but un-checkpointed transactions
+        s.cache().revert_state_update(&random_digest).unwrap();
     })
     .await;
 }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -748,11 +748,14 @@ impl WritebackCache {
     fn revert_state_update_impl(&self, tx: &TransactionDigest) -> SuiResult {
         // TODO: remove revert_state_update_impl entirely, and simply drop all dirty
         // state when clear_state_end_of_epoch_impl is called.
-        let (_, outputs) = self
-            .dirty
-            .pending_transaction_writes
-            .remove(tx)
-            .expect("transaction must exist");
+        // Futher, once we do this, we can delay the insertion of the transaction into
+        // pending_consensus_transactions until after the transaction has executed.
+        let Some((_, outputs)) = self.dirty.pending_transaction_writes.remove(tx) else {
+            // A transaction can be inserted into pending_consensus_transactions, but then reconfiguration
+            // can happen before the transaction executes.
+            info!("Not reverting {:?} as it was not executed", tx);
+            return Ok(());
+        };
 
         for (object_id, object) in outputs.written.iter() {
             if object.is_package() {
@@ -821,20 +824,9 @@ impl ExecutionCacheRead for WritebackCache {
         }
     }
 
-    // TOOO: we may not need this function now that all writes go through the cache
-    fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]) {
-        for package_id in system_package_ids {
-            if let Some(p) = self
-                .store
-                .get_object(package_id)
-                .expect("Failed to update system packages")
-            {
-                assert!(p.is_package());
-                self.packages.insert(*package_id, PackageObject::new(p));
-            }
-            // It's possible that a package is not found if it's newly added system package ID
-            // that hasn't got created yet. This should be very very rare though.
-        }
+    fn force_reload_system_packages(&self, _system_package_ids: &[ObjectID]) {
+        // This is a no-op because all writes go through the cache, therefore it can never
+        // be incoherent
     }
 
     // get_object and variants.

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -751,6 +751,11 @@ impl WritebackCache {
         // Futher, once we do this, we can delay the insertion of the transaction into
         // pending_consensus_transactions until after the transaction has executed.
         let Some((_, outputs)) = self.dirty.pending_transaction_writes.remove(tx) else {
+            assert!(
+                !self.is_tx_already_executed(tx).expect("read cannot fail"),
+                "attempt to revert committed transaction"
+            );
+
             // A transaction can be inserted into pending_consensus_transactions, but then reconfiguration
             // can happen before the transaction executes.
             info!("Not reverting {:?} as it was not executed", tx);
@@ -764,6 +769,7 @@ impl WritebackCache {
             }
         }
 
+        // Note: individual object entries are removed when clear_state_end_of_epoch_impl is called
         Ok(())
     }
 

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -112,6 +112,12 @@ impl BenchmarkContext {
             .await;
         let mut new_gas_objects = HashMap::new();
         for effects in results {
+            self.validator()
+                .get_validator()
+                .get_cache_commit()
+                .commit_transaction_outputs(effects.executed_epoch(), effects.transaction_digest())
+                .await
+                .unwrap();
             let (owner, root_object) = effects
                 .created()
                 .into_iter()


### PR DESCRIPTION
- revert_state_update may be called for transactions that have not been
  executed
- force_reload_system_packages was not only unnecessary, but harmful, as
  it reloaded stale state from the db
