### PR TITLE
[Verifier] verify-bytecode-meter accepts multiple modules

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -676,9 +676,11 @@ pub enum SuiClientCommands {
         #[clap(name = "protocol-version", long)]
         protocol_version: Option<u64>,
 
-        /// Path to specific pre-compiled module bytecode to verify (instead of an entire package)
-        #[clap(name = "module", long, global = true)]
-        module_path: Option<PathBuf>,
+        /// Paths to specific pre-compiled module bytecode to verify (instead of an entire package).
+        /// Multiple modules can be verified by passing multiple --module flags. They will be
+        /// treated as if they were one package (subject to the overall package limit).
+        #[clap(name = "module", long, action = clap::ArgAction::Append, global = true)]
+        module_paths: Vec<PathBuf>,
 
         /// Package build options
         #[clap(flatten)]
@@ -1074,7 +1076,7 @@ impl SuiClientCommands {
 
             SuiClientCommands::VerifyBytecodeMeter {
                 protocol_version,
-                module_path,
+                module_paths,
                 package_path,
                 build_config,
             } => {
@@ -1086,20 +1088,24 @@ impl SuiClientCommands {
                 let registry = &Registry::new();
                 let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
 
-                let (pkg_name, modules) = match (module_path, package_path) {
-                    (Some(_), Some(_)) => {
+                let (pkg_name, modules) = match (module_paths, package_path) {
+                    (paths, Some(_)) if paths.len() > 0 => {
                         bail!("Cannot specify both a module path and a package path")
                     }
 
-                    (Some(module_path), None) => {
-                        let module_bytes =
-                            fs::read(module_path).context("Failed to read module file")?;
-                        let module = CompiledModule::deserialize_with_defaults(&module_bytes)
-                            .context("Failed to deserialize module")?;
-                        ("<unknown>".to_string(), vec![module])
+                    (paths, None) if paths.len() > 0 => {
+                        let mut modules = Vec::with_capacity(paths.len());
+                        for path in paths {
+                            let module_bytes =
+                                fs::read(path).context("Failed to read module file")?;
+                            let module = CompiledModule::deserialize_with_defaults(&module_bytes)
+                                .context("Failed to deserialize module")?;
+                            modules.push(module);
+                        }
+                        ("<unknown>".to_string(), modules)
                     }
 
-                    (None, package_path) => {
+                    (_, package_path) => {
                         let package_path = package_path.unwrap_or_else(|| PathBuf::from("."));
                         let package = compile_package_simple(build_config, package_path)?;
                         let name = package


### PR DESCRIPTION
When passing modules to `sui client verify-bytecode-meter`, support passing multiple `--modules` to be treated as a single package.

## Test Plan

```
deepbook$ cargo run --bin sui -p sui               \
  -- client verify-bytecode-meter                  \
  --module build/DeepBook/bytecode_modules/math.mv \
  --module build/DeepBook/bytecode_modules/clob.mv

Running bytecode verifier for 2 modules
╭──────────────────────────────────────────────────╮
│ Package will pass metering check!                │
├──────────────────────────────────────────────────┤
│ Limits                                           │
├─────────────────────────────────────┬────────────┤
│ packages                            │ 16,000,000 │
│   modules                           │ 16,000,000 │
│     functions                       │ 16,000,000 │
├─────────────────────────────────────┴────────────┤
│ Ticks Used                                       │
├─────────────────────────────────────┬────────────┤
│ <unknown>                           │  1,859,140 │
│   math                              │     41,915 │
│     unsafe_mul                      │      1,225 │
│     unsafe_mul_round                │      5,675 │
│     mul                             │      2,410 │
│     mul_round                       │      2,905 │
│     unsafe_div                      │      1,225 │
│     unsafe_div_round                │      6,085 │
│     div_round                       │      2,905 │
│     count_leading_zeros             │     19,485 │
│   clob                              │  1,817,225 │
│     destroy_empty_level             │      1,205 │
│     create_account                  │        360 │
│     create_pool                     │        480 │
│     deposit_base                    │      5,490 │
│     deposit_quote                   │      5,490 │
│     withdraw_base                   │      6,500 │
│     withdraw_quote                  │      6,500 │
│     swap_exact_base_for_quote       │     20,805 │
│     swap_exact_quote_for_base       │     18,590 │
│     match_bid_with_quote_quantity   │    383,275 │
│     match_bid                       │    310,200 │
│     match_ask                       │    316,500 │
│     place_market_order              │     37,615 │
│     inject_limit_order              │     70,195 │
│     place_limit_order               │    184,740 │
│     order_is_bid                    │        540 │
│     emit_order_canceled             │      4,905 │
│     emit_order_filled               │      8,335 │
│     cancel_order                    │     57,890 │
│     remove_order                    │     20,095 │
│     cancel_all_orders               │     64,425 │
│     batch_cancel_order              │    102,405 │
│     list_open_orders                │     57,300 │
│     account_balance                 │      6,620 │
│     get_market_price                │      3,265 │
│     get_level2_book_status_bid_side │     39,785 │
│     get_level2_book_status_ask_side │     39,785 │
│     get_level2_book_status          │     23,545 │
│     get_order_status                │     20,385 │
├─────────────────────────────────────┴────────────┤
│ Package will pass metering check!                │
╰──────────────────────────────────────────────────╯
```

## Stack

- #16903 
- #16941 
- #16945 
- #16963 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

`sui client verify-bytecode-meter` supports passing multiple `--module` flags to verify multiple compiled modules together as if they were one package.