### PR TITLE
Implement caching for transactions, effects, and events

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -282,6 +282,7 @@ mod test {
             },
         );
         register_fail_point_async("narwhal-delay", || delay_failpoint(10..20, 0.001));
+        register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
 
         test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -13,12 +13,15 @@ use std::{
 use sui_framework::BuiltInFramework;
 use sui_macros::{register_fail_point_async, sim_test};
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::effects::TestEffectsBuilder;
 use sui_types::{
     base_types::{random_object_ref, SuiAddress},
     crypto::{deterministic_random_account_key, get_key_pair_from_rng, AccountKeyPair},
     object::{MoveObject, Owner, OBJECT_START_VERSION},
     storage::ChildObjectResolver,
+};
+use sui_types::{
+    effects::{TestEffectsBuilder, TransactionEffectsAPI},
+    event::Event,
 };
 use tempfile::tempdir;
 
@@ -162,12 +165,16 @@ impl Scenario {
             .build_and_sign(&keypair);
 
         let tx = VerifiedTransaction::new_unchecked(tx);
-        let effects = TestEffectsBuilder::new(tx.inner()).build();
+        let events: TransactionEvents = Default::default();
+
+        let effects = TestEffectsBuilder::new(tx.inner())
+            .with_events_digest(events.digest())
+            .build();
 
         TransactionOutputs {
             transaction: Arc::new(tx),
             effects,
-            events: Default::default(),
+            events,
             markers: Default::default(),
             wrapped: Default::default(),
             deleted: Default::default(),
@@ -248,6 +255,17 @@ impl Scenario {
             self.outputs.written.insert(id, object.clone());
             self.objects.insert(id, object).assert_inserted();
         }
+    }
+
+    fn with_events(&mut self) {
+        let mut events: TransactionEvents = Default::default();
+        events.data.push(Event::random_for_testing());
+
+        let effects = TestEffectsBuilder::new(self.outputs.transaction.inner())
+            .with_events_digest(events.digest())
+            .build();
+        self.outputs.events = events;
+        self.outputs.effects = effects;
     }
 
     fn with_packages(&mut self, short_ids: &[u32]) {
@@ -614,6 +632,61 @@ async fn test_received() {
 
         s.assert_received(&[1]);
         s.assert_live(&[1, 2]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_extra_outputs() {
+    telemetry_subscribers::init_for_testing();
+    Scenario::iterate(|mut s| async move {
+        // make sure that events, effects, transactions are all
+        // returned correctly no matter the cache state.
+        s.with_created(&[1, 2]);
+        s.with_events();
+
+        let tx = s.do_tx().await;
+
+        s.cache.get_transaction_block(&tx).unwrap().unwrap();
+        let fx = s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        let events_digest = fx.events_digest().unwrap();
+        s.cache.get_events(events_digest).unwrap().unwrap();
+
+        s.commit(tx).await.unwrap();
+
+        s.cache.get_transaction_block(&tx).unwrap().unwrap();
+        s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        s.cache.get_events(events_digest).unwrap().unwrap();
+
+        // clear cache
+        s.reset_cache();
+
+        s.cache.get_transaction_block(&tx).unwrap().unwrap();
+        s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        s.cache.get_events(events_digest).unwrap().unwrap();
+
+        s.with_created(&[3]);
+        let tx = s.do_tx().await;
+
+        // when Events is empty, it should be treated as None
+        let fx = s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        let events_digest = fx.events_digest().unwrap();
+        assert!(
+            s.cache.get_events(events_digest).unwrap().is_none(),
+            "empty events should be none"
+        );
+
+        s.commit(tx).await.unwrap();
+        assert!(
+            s.cache.get_events(events_digest).unwrap().is_none(),
+            "empty events should be none"
+        );
+
+        s.reset_cache();
+        assert!(
+            s.cache.get_events(events_digest).unwrap().is_none(),
+            "empty events should be none"
+        );
     })
     .await;
 }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -199,6 +199,9 @@ impl UncommittedData {
     }
 }
 
+// TODO: set this via the config
+static MAX_CACHE_SIZE: u64 = 10000;
+
 /// CachedData stores data that has been committed to the db, but is likely to be read soon.
 struct CachedCommittedData {
     // See module level comment for an explanation of caching strategy.
@@ -223,32 +226,32 @@ struct CachedCommittedData {
 impl CachedCommittedData {
     fn new() -> Self {
         let object_cache = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let marker_cache = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let transactions = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let transaction_effects = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let transaction_events = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let executed_effects_digests = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         let transaction_objects = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
 
         Self {
@@ -317,8 +320,8 @@ macro_rules! check_cache_entry_by_latest {
 impl WritebackCache {
     fn new(store: Arc<AuthorityStore>, metrics: Arc<ExecutionCacheMetrics>) -> Self {
         let packages = MokaCache::builder()
-            .max_capacity(10000)
-            .initial_capacity(10000)
+            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(MAX_CACHE_SIZE)
             .build();
         Self {
             dirty: UncommittedData::new(),
@@ -610,6 +613,8 @@ impl WritebackCache {
         epoch: EpochId,
         digest: TransactionDigest,
     ) -> SuiResult {
+        fail_point_async!("writeback-cache-commit");
+
         let DashMapEntry::Occupied(occupied) = self.dirty.pending_transaction_writes.entry(digest)
         else {
             panic!("Attempt to commit unknown transaction {:?}", digest);

--- a/crates/sui-types/src/effects/test_effects_builder.rs
+++ b/crates/sui-types/src/effects/test_effects_builder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{ObjectID, SequenceNumber};
-use crate::digests::ObjectDigest;
+use crate::digests::{ObjectDigest, TransactionEventsDigest};
 use crate::effects::{EffectsObjectChange, IDOperation, ObjectIn, ObjectOut, TransactionEffects};
 use crate::execution::SharedInput;
 use crate::execution_status::ExecutionStatus;
@@ -18,6 +18,7 @@ pub struct TestEffectsBuilder {
     status: Option<ExecutionStatus>,
     /// Provide the assigned versions for all shared objects.
     shared_input_versions: BTreeMap<ObjectID, SequenceNumber>,
+    events_digest: Option<TransactionEventsDigest>,
 }
 
 impl TestEffectsBuilder {
@@ -26,6 +27,7 @@ impl TestEffectsBuilder {
             transaction: transaction.clone(),
             status: None,
             shared_input_versions: BTreeMap::new(),
+            events_digest: None,
         }
     }
 
@@ -40,6 +42,11 @@ impl TestEffectsBuilder {
     ) -> Self {
         assert!(self.shared_input_versions.is_empty());
         self.shared_input_versions = versions;
+        self
+    }
+
+    pub fn with_events_digest(mut self, digest: TransactionEventsDigest) -> Self {
+        self.events_digest = Some(digest);
         self
     }
 
@@ -125,7 +132,7 @@ impl TestEffectsBuilder {
             })
             .collect();
         let gas_object_id = self.transaction.transaction_data().gas()[0].0;
-        let event_digest = None;
+        let event_digest = self.events_digest;
         let dependencies = vec![];
         TransactionEffects::new_from_execution_v2(
             status,


### PR DESCRIPTION
Adds caching for the rest of the non-object transaction outputs