### PR TITLE
[test-cluster] Randomize committee size

### DIFF
--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -14,7 +14,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn basic_checkpoints_integration_test() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_random_num_validators()
+        .build()
+        .await;
     let tx = make_transfer_sui_transaction(&test_cluster.wallet, None, None).await;
     let digest = *tx.digest();
     test_cluster.execute_transaction(tx).await;

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -127,7 +127,10 @@ async fn test_transaction_expiration() {
 // may not always be tested.
 #[sim_test]
 async fn reconfig_with_revert_end_to_end_test() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_random_num_validators()
+        .build()
+        .await;
     let authorities = test_cluster.swarm.validator_node_handles();
     let rgp = test_cluster.get_reference_gas_price().await;
     let (sender, mut gas_objects) = test_cluster.wallet.get_one_account().await.unwrap();

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -5,6 +5,7 @@ use futures::{future::join_all, StreamExt};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::WsClient;
 use jsonrpsee::ws_client::WsClientBuilder;
+use rand::Rng;
 use rand::{distributions::*, rngs::OsRng, seq::SliceRandom};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -816,6 +817,11 @@ impl TestClusterBuilder {
 
     pub fn with_num_validators(mut self, num: usize) -> Self {
         self.num_validators = Some(num);
+        self
+    }
+
+    pub fn with_random_num_validators(mut self) -> Self {
+        self.num_validators = Some(rand::thread_rng().gen_range(1..=NUM_VALIDATOR));
         self
     }
 


### PR DESCRIPTION
## Description 

We get interesting test behavior for different values of `num_validators` in the range `[1, 4]`.

Notably, below 4, we test the regime where we have no fault tolerance. 

## Test Plan 

Existing simtests, and probably try and run this in the simtest nightly to see what happens

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
