### PR TITLE
Re-execute locally built checkpoints at startup

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2790,6 +2790,15 @@ impl AuthorityState {
             .enqueue_certificates(certs, epoch_store)
     }
 
+    pub(crate) fn enqueue_with_expected_effects_digest(
+        &self,
+        certs: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
+        epoch_store: &AuthorityPerEpochStore,
+    ) {
+        self.transaction_manager
+            .enqueue_with_expected_effects_digest(certs, epoch_store)
+    }
+
     fn create_owner_index_if_empty(
         &self,
         genesis_objects: &[Object],

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -957,6 +957,23 @@ impl AuthorityStore {
         Ok(())
     }
 
+    /// Commits transactions only to the db. Called by checkpoint builder. See
+    /// ExecutionCache::commit_transactions for more info
+    pub(crate) fn commit_transactions(
+        &self,
+        transactions: &[(TransactionDigest, VerifiedTransaction)],
+    ) -> SuiResult {
+        let mut batch = self.perpetual_tables.transactions.batch();
+        batch.insert_batch(
+            &self.perpetual_tables.transactions,
+            transactions
+                .iter()
+                .map(|(digest, tx)| (*digest, tx.serializable_ref())),
+        )?;
+        batch.write()?;
+        Ok(())
+    }
+
     pub(crate) async fn acquire_transaction_locks(
         &self,
         epoch_store: &AuthorityPerEpochStore,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -361,6 +361,11 @@ impl CheckpointExecutor {
             .await
             .expect("commit_transaction_outputs cannot fail");
 
+        // pending_execution stores transactions received from consensus which may not have
+        // been executed yet. At this point, they have been committed to the db durably and
+        // can be removed.
+        // After end-to-end quarantining, we will not need pending_execution since the consensus
+        // log itself will be used for recovery.
         epoch_store
             .multi_remove_pending_execution(all_tx_digests)
             .expect("cannot fail");

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -361,6 +361,10 @@ impl CheckpointExecutor {
             .await
             .expect("commit_transaction_outputs cannot fail");
 
+        epoch_store
+            .multi_remove_pending_execution(all_tx_digests)
+            .expect("cannot fail");
+
         if !checkpoint.is_last_checkpoint_of_epoch() {
             self.bump_highest_executed_checkpoint(checkpoint);
         }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1048,7 +1048,7 @@ impl CheckpointBuilder {
         // and pending_consensus_transactions, and this method can be removed.
         self.state
             .get_cache_commit()
-            .commit_transactions(&all_tx_digests)
+            .persist_transactions(&all_tx_digests)
             .await?;
 
         batch.write()?;

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1036,6 +1036,16 @@ impl CheckpointBuilder {
             )?;
         }
 
+        // Durably commit transactions (but not their outputs) to the database.
+        // Called before writing a locally built checkpoint to the CheckpointStore, so that
+        // the inputs of the checkpoint cannot be lost.
+        // These transactions are guaranteed to be final unless this validator
+        // forks (i.e. constructs a checkpoint which will never be certified). In this case
+        // some non-final transactions could be left in the database.
+        //
+        // This is an intermediate solution until we delay commits to the epoch db. After
+        // we have done that, crash recovery will be done by re-processing consensus commits
+        // and pending_consensus_transactions, and this method can be removed.
         self.state
             .get_cache_commit()
             .commit_transactions(&all_tx_digests)

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -83,7 +83,7 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// This is an intermediate solution until we delay commits to the epoch db. After
     /// we have done that, crash recovery will be done by re-processing consensus commits
     /// and pending_consensus_transactions, and this method can be removed.
-    fn commit_transactions<'a>(
+    fn persist_transactions<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, SuiResult>;

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -70,7 +70,22 @@ pub trait ExecutionCacheCommit: Send + Sync {
     fn commit_transaction_outputs<'a>(
         &'a self,
         epoch: EpochId,
-        digest: &'a [TransactionDigest],
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, SuiResult>;
+
+    /// Durably commit transactions (but not their outputs) to the database.
+    /// Called before writing a locally built checkpoint to the CheckpointStore, so that
+    /// the inputs of the checkpoint cannot be lost.
+    /// These transactions are guaranteed to be final unless this validator
+    /// forks (i.e. constructs a checkpoint which will never be certified). In this case
+    /// some non-final transactions could be left in the database.
+    ///
+    /// This is an intermediate solution until we delay commits to the epoch db. After
+    /// we have done that, crash recovery will be done by re-processing consensus commits
+    /// and pending_consensus_transactions, and this method can be removed.
+    fn commit_transactions<'a>(
+        &'a self,
+        digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, SuiResult>;
 }
 

--- a/crates/sui-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/sui-core/src/execution_cache/passthrough_cache.rs
@@ -369,7 +369,7 @@ impl ExecutionCacheCommit for PassthroughCache {
         async { Ok(()) }.boxed()
     }
 
-    fn commit_transactions(&self, _digests: &[TransactionDigest]) -> BoxFuture<'_, SuiResult> {
+    fn persist_transactions(&self, _digests: &[TransactionDigest]) -> BoxFuture<'_, SuiResult> {
         // Nothing needs to be done since they were already committed in write_transaction_outputs
         async { Ok(()) }.boxed()
     }

--- a/crates/sui-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/sui-core/src/execution_cache/passthrough_cache.rs
@@ -368,6 +368,11 @@ impl ExecutionCacheCommit for PassthroughCache {
         // Nothing needs to be done since they were already committed in write_transaction_outputs
         async { Ok(()) }.boxed()
     }
+
+    fn commit_transactions(&self, _digests: &[TransactionDigest]) -> BoxFuture<'_, SuiResult> {
+        // Nothing needs to be done since they were already committed in write_transaction_outputs
+        async { Ok(()) }.boxed()
+    }
 }
 
 implement_passthrough_traits!(PassthroughCache);

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -768,7 +768,7 @@ impl WritebackCache {
         }
     }
 
-    async fn commit_transactions(&self, digests: &[TransactionDigest]) -> SuiResult {
+    async fn persist_transactions(&self, digests: &[TransactionDigest]) -> SuiResult {
         let mut txns = Vec::with_capacity(digests.len());
         for tx_digest in digests {
             let Some(tx) = self
@@ -922,11 +922,11 @@ impl ExecutionCacheCommit for WritebackCache {
         WritebackCache::commit_transaction_outputs(self, epoch, digests).boxed()
     }
 
-    fn commit_transactions<'a>(
+    fn persist_transactions<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, SuiResult> {
-        WritebackCache::commit_transactions(self, digests).boxed()
+        WritebackCache::persist_transactions(self, digests).boxed()
     }
 }
 

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -783,7 +783,9 @@ impl WritebackCache {
                     .get_transaction_block(tx_digest)
                     .unwrap()
                     .is_some());
-                // if the transaction is not in dirty, it either does not exist or does not need to be committed.
+                // If the transaction is not in dirty, it does not need to be committed.
+                // This situation can happen if we build a checkpoint locally which was just executed
+                // via state sync.
                 continue;
             };
 

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -768,6 +768,31 @@ impl WritebackCache {
         }
     }
 
+    async fn commit_transactions(&self, digests: &[TransactionDigest]) -> SuiResult {
+        let mut txns = Vec::with_capacity(digests.len());
+        for tx_digest in digests {
+            let Some(tx) = self
+                .dirty
+                .pending_transaction_writes
+                .get(tx_digest)
+                .map(|o| o.transaction.clone())
+            else {
+                // tx should exist in the db if it is not in dirty set.
+                debug_assert!(self
+                    .store
+                    .get_transaction_block(tx_digest)
+                    .unwrap()
+                    .is_some());
+                // if the transaction is not in dirty, it either does not exist or does not need to be committed.
+                continue;
+            };
+
+            txns.push((*tx_digest, (*tx).clone()));
+        }
+
+        self.store.commit_transactions(&txns)
+    }
+
     // Move the oldest/least entry from the dirty queue to the cache queue.
     // This is called after the entry is committed to the db.
     fn move_version_from_dirty_to_cache<K, V>(
@@ -893,6 +918,13 @@ impl ExecutionCacheCommit for WritebackCache {
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, SuiResult> {
         WritebackCache::commit_transaction_outputs(self, epoch, digests).boxed()
+    }
+
+    fn commit_transactions<'a>(
+        &'a self,
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, SuiResult> {
+        WritebackCache::commit_transactions(self, digests).boxed()
     }
 }
 

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -412,12 +412,6 @@ impl TransactionManager {
                         panic!("Failed to check if tx is already executed: {:?}", err)
                     })
                 {
-                    // also ensure the transaction will not be retried after restart.
-                    epoch_store
-                        .remove_pending_execution(&digest)
-                        .unwrap_or_else(|err| {
-                            panic!("remove_pending_execution should not fail: {:?}", err)
-                        });
                     self.metrics
                         .transaction_manager_num_enqueued_certificates
                         .with_label_values(&["already_executed"])
@@ -559,12 +553,6 @@ impl TransactionManager {
                     "Ignoring enqueued certificate from wrong epoch. Expected={} Certificate={:?}",
                     inner.epoch, pending_cert.certificate
                 );
-                // also ensure the transaction will not be retried after restart.
-                epoch_store
-                    .remove_pending_execution(&digest)
-                    .unwrap_or_else(|err| {
-                        panic!("remove_pending_execution should not fail: {:?}", err)
-                    });
                 continue;
             }
 
@@ -590,10 +578,6 @@ impl TransactionManager {
                 .is_tx_already_executed(&digest)
                 .expect("Check if tx is already executed should not fail");
             if is_tx_already_executed {
-                // also ensure the transaction will not be retried after restart.
-                epoch_store
-                    .remove_pending_execution(&digest)
-                    .expect("remove_pending_execution should not fail");
                 self.metrics
                     .transaction_manager_num_enqueued_certificates
                     .with_label_values(&["already_executed"])
@@ -749,8 +733,6 @@ impl TransactionManager {
 
             inner.maybe_shrink_capacity();
         }
-
-        let _ = epoch_store.remove_pending_execution(digest);
     }
 
     /// Sends the ready certificate for execution.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -641,6 +641,10 @@ impl SuiNode {
                 .unwrap();
         }
 
+        checkpoint_store
+            .reexecute_local_checkpoints(&state, &epoch_store)
+            .await;
+
         // Start the loop that receives new randomness and generates transactions for it.
         RandomnessRoundReceiver::spawn(state.clone(), randomness_rx);
 


### PR DESCRIPTION
This will be necessary for the WritebackCache, and unnecessary but harmless otherwise.

Until built checkpoints are re-executed, the validator is an in inconsistent state, since
every locally checkpointed transaction should have effects locally available. Without this change, we hit this case https://github.com/MystenLabs/sui/blob/59168f73ffd71023de6427186e5dac206cf4698e/crates/sui-core/src/storage.rs#L172 when we shouldn't.

This is a temporary measure. Once we cache and quarantine consensus output, we will simply re-process any consensus commits which have not yet resulted in a certified checkpoint, so we won't have this edge case anymore.
