### PR TITLE
Stefan/win support

### DIFF
--- a/crates/suiop-cli/build.rs
+++ b/crates/suiop-cli/build.rs
@@ -1,0 +1,17 @@
+//! `build.rs`
+
+fn main() {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut project_path = std::path::PathBuf::from(&manifest);
+    project_path.push("boilerplate");
+
+    if project_path.exists() && project_path.is_file() {
+        std::fs::remove_file(project_path.as_path()).unwrap();
+        std::fs::create_dir_all(project_path.as_path()).unwrap();
+        return;
+    }
+
+    if !project_path.exists() {
+        std::fs::create_dir_all(project_path.as_path()).unwrap();
+    }
+}

--- a/crates/suiop-cli/build.rs
+++ b/crates/suiop-cli/build.rs
@@ -4,14 +4,15 @@ fn main() {
     let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let mut project_path = std::path::PathBuf::from(&manifest);
     project_path.push("boilerplate");
+    let project_path = project_path.as_path();
 
     if project_path.exists() && project_path.is_file() {
-        std::fs::remove_file(project_path.as_path()).unwrap();
-        std::fs::create_dir_all(project_path.as_path()).unwrap();
+        std::fs::remove_file(project_path).unwrap();
+        std::fs::create_dir_all(project_path).unwrap();
         return;
     }
 
     if !project_path.exists() {
-        std::fs::create_dir_all(project_path.as_path()).unwrap();
+        std::fs::create_dir_all(project_path).unwrap();
     }
 }

--- a/crates/suiop-cli/build.rs
+++ b/crates/suiop-cli/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! `build.rs`
 
 fn main() {

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use tracing::debug;
 use tracing::info;
 
+// include the boilerplate code in this binary
 static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/boilerplate");
 
 #[derive(ValueEnum, Parser, Debug, Clone)]

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -14,7 +14,6 @@ use std::path::Path;
 use tracing::debug;
 use tracing::info;
 
-// include the boilerplate code in this binary
 static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/boilerplate");
 
 #[derive(ValueEnum, Parser, Debug, Clone)]


### PR DESCRIPTION
## Description 

On Windows we have reports (+ repro locally) that `cargo build` fails at `suiop-cli` boilerplate code. In the repo, there is a file, so presumably, when the repo is cloned, the file is copied as well. The `include_dir!` macro expects a directory, but in the end it is a file, which leads to an error. 

@after-ephemera would appreciate your feedback on this one such that we can get it to compile on Windows. Thanks!

## Test Plan 

Existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
