### PR TITLE
unblock sui-tool download-db-snapshot

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -866,6 +866,8 @@ impl ToolCommand {
                                 "GCS_SNAPSHOT_SERVICE_ACCOUNT_FILE_PATH",
                             )
                             .ok(),
+                            google_project_id: env::var("GCS_SNAPSHOT_SERVICE_ACCOUNT_PROJECT_ID")
+                                .ok(),
                             object_store_connection_limit: 200,
                             no_sign_request,
                             ..Default::default()


### PR DESCRIPTION
## Description 

@tharbert noticed `sui-tool download-db-snapshot` doesn't currently work against our requester pays bucket. this fixes the problem.

I'll cherry-pick this fix so it's included in the next release and doesn't break @tharbert's statefulset


