### PR TITLE
indexer fetcher: configurable interval and set default to 0.5s

### DIFF
--- a/crates/sui-indexer/src/framework/fetcher.rs
+++ b/crates/sui-indexer/src/framework/fetcher.rs
@@ -22,7 +22,7 @@ pub struct CheckpointFetcher {
 }
 
 impl CheckpointFetcher {
-    const INTERVAL_PERIOD: std::time::Duration = std::time::Duration::from_secs(5);
+    const INTERVAL_MS: usize = 500;
     const CHECKPOINT_DOWNLOAD_CONCURRENCY: usize = 100;
 
     pub fn new(
@@ -41,7 +41,12 @@ impl CheckpointFetcher {
     }
 
     pub async fn run(mut self) {
-        let mut interval = tokio::time::interval(Self::INTERVAL_PERIOD);
+        let interval_ms = std::env::var("CHECKPOINT_FETCH_INTERVAL_MS")
+            .unwrap_or_else(|_| Self::INTERVAL_MS.to_string())
+            .parse::<u64>()
+            .expect("Invalid interval");
+        let interval_duration = std::time::Duration::from_millis(interval_ms);
+        let mut interval = tokio::time::interval(interval_duration);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         info!("CheckpointFetcher started");


### PR DESCRIPTION
## Description 

this was found in incident inc_mainnet_wallet_latencies_2058 and patching this PR reduced the FN -> indexer lagging from ~10s to near realtime, more details can be found in the incident channel.

## Test Plan 

CI and incident deployment

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
