### PR TITLE
[CI] use seed specific to commit for Mysticeti simtest

### DIFF
--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -162,9 +162,9 @@ jobs:
         with:
           swap-size-gb: 256
       - name: cargo simtest
-        # Use a different seed per run to avoid unrelated changes stuck on a flaky test.
+        # Use a different seed per commit to avoid unrelated changes stuck on a flaky test.
         run: |
-          MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest --no-fail-fast
+          MSIM_TEST_SEED="$(printf "%lu\n" 0x$(git rev-parse HEAD | cut -c1-16))" scripts/simtest/cargo-simtest simtest --no-fail-fast
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh

--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -29,9 +29,6 @@ env:
   # Enable Mysticeti in tests.
   CONSENSUS: "mysticeti"
 
-  # Reduce logging noise.
-  RUST_LOG: "error"
-
   CARGO_TERM_COLOR: always
   # Disable incremental compilation.
   #

--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -165,8 +165,9 @@ jobs:
         with:
           swap-size-gb: 256
       - name: cargo simtest
+        # Use a different seed per run to avoid unrelated changes stuck on a flaky test.
         run: |
-          scripts/simtest/cargo-simtest simtest --no-fail-fast
+          MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest --no-fail-fast
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,9 +209,8 @@ jobs:
         with:
           swap-size-gb: 256
       - name: cargo simtest
-        # Use a different seed per run to avoid unrelated changes stuck on a flaky test.
         run: |
-          MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest
+          scripts/simtest/cargo-simtest simtest
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,7 +211,7 @@ jobs:
       - name: cargo simtest
         # Use a different seed per run to avoid unrelated changes stuck on a flaky test.
         run: |
-        MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest
+          MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,8 +209,9 @@ jobs:
         with:
           swap-size-gb: 256
       - name: cargo simtest
+        # Use a different seed per run to avoid unrelated changes stuck on a flaky test.
         run: |
-          scripts/simtest/cargo-simtest simtest
+        MSIM_TEST_SEED="$(date +%s)" scripts/simtest/cargo-simtest simtest
       - name: check new tests for flakiness
         run: |
           scripts/simtest/stress-new-tests.sh


### PR DESCRIPTION
## Description 

When a simtest is flaky, unrelated PRs can encounter failures which cannot be easily reproduced locally or in simtest nightly. It doesn't seem productive to block the PR submission in this case.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
