### PR TITLE
[RFC] Add support for zero gas price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11736,6 +11736,7 @@ dependencies = [
  "sui-indexer",
  "sui-json-rpc-types",
  "sui-package-resolver",
+ "sui-protocol-config",
  "sui-rest-api",
  "sui-storage",
  "sui-types",

--- a/crates/sui-analytics-indexer/Cargo.toml
+++ b/crates/sui-analytics-indexer/Cargo.toml
@@ -50,10 +50,11 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 sui-json-rpc-types.workspace = true
 sui-package-resolver.workspace = true
+sui-protocol-config.workspace = true
 simulacrum.workspace = true
-arrow = { version = "50.0.0"}
+arrow = { version = "50.0.0" }
 gcp-bigquery-client = "0.18.0"
-snowflake-api = { version = "0.6.0"  }
+snowflake-api = { version = "0.6.0" }
 tap = { version = "1.0.1", features = [] }
 
 [dev-dependencies]

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -8,6 +8,7 @@ use fastcrypto::encoding::{Base64, Encoding};
 use tracing::error;
 
 use sui_indexer::framework::Handler;
+use sui_protocol_config::ZeroGasPriceOverride;
 use sui_rest_api::{CheckpointData, CheckpointTransaction};
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
@@ -164,7 +165,7 @@ impl TransactionHandler {
             storage_rebate: gas_summary.storage_rebate,
             non_refundable_storage_fee: gas_summary.non_refundable_storage_fee,
 
-            gas_price: txn_data.gas_price(),
+            gas_price: txn_data.gas_price(ZeroGasPriceOverride::NoOverride),
 
             raw_transaction: Base64::encode(bcs::to_bytes(&txn_data).unwrap()),
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2397,14 +2397,19 @@ impl AuthorityPerEpochStore {
             })
             .collect();
 
+        let zero_gas_price_override = self
+            .protocol_config
+            .get_zero_tx_gas_price_override(self.reference_gas_price());
         // We always order transactions using randomness last.
         PostConsensusTxReorder::reorder(
             &mut sequenced_transactions,
             self.protocol_config.consensus_transaction_ordering(),
+            zero_gas_price_override,
         );
         PostConsensusTxReorder::reorder(
             &mut sequenced_randomness_transactions,
             self.protocol_config.consensus_transaction_ordering(),
+            zero_gas_price_override,
         );
         let consensus_transactions: Vec<_> = system_transactions
             .into_iter()

--- a/crates/sui-core/src/post_consensus_tx_reorder.rs
+++ b/crates/sui-core/src/post_consensus_tx_reorder.rs
@@ -5,8 +5,9 @@ use crate::consensus_handler::{
     SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
 };
 use mysten_metrics::monitored_scope;
-use sui_protocol_config::ConsensusTransactionOrdering;
+use sui_protocol_config::{ConsensusTransactionOrdering, ZeroGasPriceOverride};
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
+use sui_types::transaction::TransactionDataAPI;
 
 pub struct PostConsensusTxReorder {}
 
@@ -14,17 +15,23 @@ impl PostConsensusTxReorder {
     pub fn reorder(
         transactions: &mut [VerifiedSequencedConsensusTransaction],
         kind: ConsensusTransactionOrdering,
+        zero_gas_price_override: ZeroGasPriceOverride,
     ) {
         // TODO: make the reordering algorithm richer and depend on object hotness as well.
         // Order transactions based on their gas prices. System transactions without gas price
         // are put to the beginning of the sequenced_transactions vector.
         match kind {
-            ConsensusTransactionOrdering::ByGasPrice => Self::order_by_gas_price(transactions),
+            ConsensusTransactionOrdering::ByGasPrice => {
+                Self::order_by_gas_price(transactions, zero_gas_price_override)
+            }
             ConsensusTransactionOrdering::None => (),
         }
     }
 
-    fn order_by_gas_price(transactions: &mut [VerifiedSequencedConsensusTransaction]) {
+    fn order_by_gas_price(
+        transactions: &mut [VerifiedSequencedConsensusTransaction],
+        zero_gas_price_override: ZeroGasPriceOverride,
+    ) {
         let _scope = monitored_scope("HandleConsensusOutput::order_by_gas_price");
         transactions.sort_by_key(|txn| {
             // Reverse order, so that transactions with higher gas price are put to the beginning.
@@ -33,7 +40,7 @@ impl PostConsensusTxReorder {
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         tracking_id: _,
                         kind: ConsensusTransactionKind::UserTransaction(cert),
-                    }) => cert.gas_price(),
+                    }) => cert.transaction_data().gas_price(zero_gas_price_override),
                     // Non-user transactions are considered to have gas price of MAX u64 and are
                     // put to the beginning.
                     _ => u64::MAX,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -252,7 +252,7 @@ async fn test_dry_run_transaction_block() {
         txn_data.sender(),
         vec![],
         txn_data.gas_budget(),
-        txn_data.gas_price(),
+        txn_data.gas_price(ZeroGasPriceOverride::NoOverride),
     );
     let (response, _, _, _) = fullnode
         .dry_exec_transaction(txn_data, transaction_digest)

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -8,6 +8,7 @@ use fastcrypto::encoding::{Base64, Encoding};
 use move_core_types::account_address::AccountAddress;
 use serde::de::DeserializeOwned;
 use sui_json_rpc_types::DevInspectArgs;
+use sui_protocol_config::ZeroGasPriceOverride;
 use sui_sdk::SuiClient;
 use sui_types::transaction::{TransactionData, TransactionKind};
 use sui_types::{gas_coin::GAS, transaction::TransactionDataAPI, TypeTag};
@@ -157,7 +158,7 @@ impl Query {
                 (
                     tx_data.sender(),
                     tx_data.clone().into_kind(),
-                    Some(tx_data.gas_price().into()),
+                    Some(tx_data.gas_price(ZeroGasPriceOverride::NoOverride).into()),
                     Some(tx_data.gas_owner()),
                     Some(tx_data.gas_budget().into()),
                     Some(tx_data.gas().to_vec()),

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::fmt::{self, Display, Formatter, Write};
 use sui_json::{primitive_type, SuiJsonValue};
+use sui_protocol_config::ZeroGasPriceOverride;
 use sui_types::authenticator_state::ActiveJwk;
 use sui_types::base_types::{
     EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
@@ -1314,7 +1315,7 @@ impl SuiTransactionBlockData {
                 .map(|obj_ref| SuiObjectRef::from(*obj_ref))
                 .collect(),
             owner: data.gas_owner(),
-            price: data.gas_price(),
+            price: data.gas_price(ZeroGasPriceOverride::NoOverride),
             budget: data.gas_budget(),
         };
         let transaction = SuiTransactionBlockKind::try_from(data.into_kind(), module_cache)?;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1359,7 +1359,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "42",
+              "maxSupportedProtocolVersion": "43",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,
@@ -1378,6 +1378,7 @@
                 "enable_group_ops_native_functions": false,
                 "enable_jwk_consensus_updates": false,
                 "enable_poseidon": false,
+                "enable_zero_tx_gas_price": false,
                 "end_of_epoch_transaction_supported": false,
                 "hardened_otw_check": false,
                 "include_consensus_digest_in_prologue": false,

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 42
+  protocol_version: 43
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 42
+protocol_version: 43
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x62adcc806020b4f9e7fb7ab1cf0448e0b0ad926d136971d67bb372cfc8475885"
+            id: "0x7a53da1ab16d36835d32fb0b9f069177850468627a0674f43ef00f219775bcbf"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x25e08da45b8c058b43e780186294e035dbfb9d577fb344816bfb88dc02e5fb13"
+      operation_cap_id: "0xa35d51c60b50e3ea9a1d692d8232792bfc31311d0f536cca58a26f8bb2209066"
       gas_price: 1000
       staking_pool:
-        id: "0x36a34b5a3e61721e569b93c83376471739d996323bac81bb62cf692b6d356340"
+        id: "0x0a7ab5fc2d76a32333b1dd2ccc6ae09a0da2d98309ca380aef1a929b6418ff2e"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x3b70ffe10f9a22714e5ec0567fe1dad8e0467aefc280dcb9398991a8a1f6ec9a"
+          id: "0xc8ac4858f8e089c75a9da2bb8adcde10a86c00aeec2e59124eb06e63be6b7d92"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x8a687d88204a80df85c6383bdb4abb685586b464975267a88ea43a06fef5f302"
+            id: "0xb4085c2be8191ebbdc037d5092657951e57d915641a8b5a15b98d7f8d8000193"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xa162660b14cb002551bccdf2ae81c2b200e4e084a93a85e79e6848e1aef0f5bf"
+          id: "0x0b3692d645aeb8ced1102eb4a0b3d3b3953fc9b5b7ed1e6e1c585e215fd4ccff"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x5e122abc785d560c494c783bd1f892cbe48103e843217a9b882a613fb9d189da"
+      id: "0x57b39c7a756ba502c74825ae434e53efa96a69a61da8136960b0095d572600a7"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x2ea44ba530bf36481ba58f8a7a8243dfb09c09e17fa0422df4848a96db2d440e"
+    id: "0xbe0e6b01a2855784335e17ffc04573d079f011d0b1d3ea1fb2851a47742fa9db"
     size: 1
   inactive_validators:
-    id: "0xa1f670083f6cef392b4d0929884ef729f974c751b37f885f736f3eac0f380cd1"
+    id: "0x82452941db36daa9f331fb77efa46dec22865e84578bfbdac397070da05ff800"
     size: 0
   validator_candidates:
-    id: "0x447b9c369379682d1896b52353358f467d4862d6ea1077096f954a86dfcb254d"
+    id: "0xb51d5a837fcaa13b5a711f7a6492c0753d68d73aff97065828a8d499e9c28941"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x64f2da6bfbb4200affb071f702572c37b6cdbd2f2024cb66ad8baae21d8d649e"
+      id: "0x2acd751e7c8905767be429469f5e41e3a2af7d96cc55491b0b6c98a6edb558b2"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x45887eac71d53ee6791b8d4b0e6b6bbe2b441f32f210b7d433a12b4904c8f7d2"
+      id: "0x69219e53cdee9d242c9e46b639100282eecd71458de1bc1cc70c46fd85672d02"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x4e7f9e8c7cd03b5a1ab909968e70b8c4acad298a54077646183e07bbde02a0f2"
+      id: "0xf987d231a4d09efd784ff01da0a7ea8e0a3f5498b12f2b5ca547960a28bf89d2"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc86804d07944a1c0d99e897e22725556a2bff112f2c9f670f977f030cd332666"
+    id: "0x97a70561f28ea5c21824bbed837646e7dc08b9d0d16fad4f7d5c934fbbf8b89b"
   size: 0
+

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -54,13 +54,15 @@ mod checked {
         reference_gas_price: u64,
         transaction: &TransactionData,
     ) -> SuiResult<SuiGasStatus> {
+        let zero_gas_price_override =
+            protocol_config.get_zero_tx_gas_price_override(reference_gas_price);
         check_gas(
             objects,
             protocol_config,
             reference_gas_price,
             gas,
             transaction.gas_budget(),
-            transaction.gas_price(),
+            transaction.gas_price(zero_gas_price_override),
             transaction.kind(),
         )
     }


### PR DESCRIPTION
## Description 

This PR adds the support to specify gas_price = 0 to indicate that we will use reference gas price for the transaction.
To make sure that I safely guard all use cases of gas_price() on a transaction, I updated the API to take in an explicit enum that indicates whether we want to override the gas price when it's 0.
This allows me to discover all cases and decide whether an override is needed. There are two cases where we need to override it, one is execution, and another is when we order transactions by gas price.

## Test Plan 

Added a few tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [X ] protocol change
- [X ] user-visible impact
- [ ] breaking change for a client SDKs
- [X ] breaking change for FNs (FN binary must upgrade)
- [X ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR allows a transaction to use 0 as gas_price, which will tell the system to use the network reference gas price. This makes it convenient for builders to construct transactions who don't want to worry about gas prices or congestion, and can save a call to RPC nodes just to get the gas price. It also makes the execution more reliable when transactions are sent at epoch boundary: we don't need to worry about the case when system reference gas price suddenly increased and transaction becomes invalid.