### PR TITLE
[move] Visitor trait for annotated Move values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6712,6 +6712,7 @@ dependencies = [
  "enum-compat-util",
  "ethnum",
  "hex",
+ "leb128",
  "move-proc-macros",
  "num",
  "once_cell",
@@ -6722,6 +6723,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "thiserror",
  "uint",
 ]
 

--- a/crates/data-transform/src/main.rs
+++ b/crates/data-transform/src/main.rs
@@ -9,9 +9,9 @@ use once_cell::sync::Lazy;
 use std::process::exit;
 use std::str::FromStr;
 use std::sync::Arc;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 
 use move_bytecode_utils::module_cache::SyncModuleCache;
-use move_core_types::annotated_value::MoveStruct;
 use sui_types::object::MoveObject;
 
 use self::models::*;
@@ -286,7 +286,7 @@ fn main() {
 
                 match layout {
                     Ok(l) => {
-                        let move_object = MoveStruct::simple_deserialize(&event.event_bcs, &l)
+                        let move_object = BoundedVisitor::deserialize_struct(&event.event_bcs, &l)
                             .map_err(|e| IndexerError::SerdeError(e.to_string()));
 
                         match move_object {

--- a/crates/sui-analytics-indexer/src/handlers/mod.rs
+++ b/crates/sui-analytics-indexer/src/handlers/mod.rs
@@ -12,6 +12,7 @@ use sui_package_resolver::{PackageStore, Resolver};
 use sui_types::base_types::ObjectID;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::object::{Object, Owner};
 use sui_types::transaction::TransactionData;
 use sui_types::transaction::TransactionDataAPI;
@@ -174,7 +175,7 @@ async fn get_move_struct<T: PackageStore>(
         .await?
     {
         MoveTypeLayout::Struct(move_struct_layout) => {
-            MoveStruct::simple_deserialize(contents, &move_struct_layout)
+            BoundedVisitor::deserialize_struct(contents, &move_struct_layout)
         }
         _ => Err(anyhow!("Object is not a move struct")),
     }?;

--- a/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
+++ b/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
@@ -5,7 +5,7 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 
 use move_core_types::{
-    annotated_value::{MoveFieldLayout, MoveStruct, MoveStructLayout, MoveTypeLayout},
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     ident_str,
     language_storage::StructTag,
 };
@@ -17,6 +17,7 @@ use sui_json_rpc_types::SuiMoveStruct;
 
 use sui_types::base_types::ObjectID;
 use sui_types::gas_coin::GasCoin;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::{MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 
 #[test]
@@ -33,7 +34,7 @@ fn test_to_json_value() {
     };
     let event_bytes = bcs::to_bytes(&move_event).unwrap();
     let sui_move_struct: SuiMoveStruct =
-        MoveStruct::simple_deserialize(&event_bytes, &TestEvent::layout())
+        BoundedVisitor::deserialize_struct(&event_bytes, &TestEvent::layout())
             .unwrap()
             .into();
     let json_value = sui_move_struct.to_json_value();

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -41,6 +41,7 @@ use sui_indexer::schema::{objects, objects_history, objects_snapshot};
 use sui_indexer::types::ObjectStatus as NativeObjectStatus;
 use sui_indexer::types::OwnerType;
 use sui_package_resolver::Resolver;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::object::{
     MoveObject as NativeMoveObject, Object as NativeObject, Owner as NativeOwner,
 };
@@ -1352,7 +1353,9 @@ pub(crate) async fn deserialize_move_struct(
         return Err(Error::Internal("Object is not a move struct".to_string()));
     };
 
-    let move_struct = MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
+    // TODO (annotated-visitor): Use custom visitors for extracting a dynamic field, and for
+    // creating a GraphQL MoveValue directly (not via an annotated visitor).
+    let move_struct = BoundedVisitor::deserialize_struct(contents, &layout).map_err(|e| {
         Error::Internal(format!(
             "Error deserializing move struct for type {}: {e}",
             struct_tag.to_canonical_string(/* with_prefix */ true)

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -5,13 +5,13 @@ use std::str::FromStr;
 
 use diesel::prelude::*;
 use move_bytecode_utils::module_cache::GetModule;
-use move_core_types::annotated_value::MoveStruct;
 use move_core_types::identifier::Identifier;
 
 use sui_json_rpc_types::{SuiEvent, SuiMoveStruct};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::digests::TransactionDigest;
 use sui_types::event::EventID;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::object::MoveObject;
 use sui_types::parse_sui_struct_tag;
 
@@ -108,7 +108,7 @@ impl StoredEvent {
         let type_ = parse_sui_struct_tag(&self.event_type)?;
 
         let layout = MoveObject::get_layout_from_struct_tag(type_.clone(), module_cache)?;
-        let move_object = MoveStruct::simple_deserialize(&self.bcs, &layout)
+        let move_object = BoundedVisitor::deserialize_struct(&self.bcs, &layout)
             .map_err(|e| IndexerError::SerdeError(e.to_string()))?;
         let parsed_json = SuiMoveStruct::from(move_object).to_json_value();
         let tx_digest =

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -35,6 +35,7 @@ use sui_types::base_types::{
 };
 use sui_types::id::{ID, RESOLVED_SUI_ID};
 use sui_types::move_package::MovePackage;
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::transfer::RESOLVED_RECEIVING_STRUCT;
 use sui_types::MOVE_STDLIB_ADDRESS;
 
@@ -154,7 +155,7 @@ impl SuiJsonValue {
             if let Some(s) = try_parse_string(layout, bytes) {
                 json!(s)
             } else {
-                let result = bcs::from_bytes_seed(layout, bytes).map_or_else(
+                let result = BoundedVisitor::deserialize_value(bytes, layout).map_or_else(
                     |_| {
                         // fallback to array[u8] if fail to convert to json.
                         JsonValue::Array(

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -26,7 +26,6 @@ use move_compiler::{
 use move_core_types::ident_str;
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::MoveStruct,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
 };
@@ -69,6 +68,7 @@ use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionE
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
 };
+use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::storage::ObjectStore;
 use sui_types::storage::ReadStore;
 use sui_types::transaction::Command;
@@ -648,7 +648,8 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter {
                     object::Data::Move(move_obj) => {
                         let layout = move_obj.get_layout(&&*self).unwrap();
                         let move_struct =
-                            MoveStruct::simple_deserialize(move_obj.contents(), &layout).unwrap();
+                            BoundedVisitor::deserialize_struct(move_obj.contents(), &layout)
+                                .unwrap();
 
                         self.stabilize_str(format!(
                             "Owner: {}\nVersion: {}\nContents: {}",

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -19,6 +19,7 @@ use serde_with::Bytes;
 
 use crate::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use crate::error::{SuiError, SuiResult};
+use crate::object::bounded_visitor::BoundedVisitor;
 use crate::sui_serde::BigInt;
 use crate::sui_serde::Readable;
 use crate::SUI_SYSTEM_ADDRESS;
@@ -128,7 +129,7 @@ impl Event {
         contents: &[u8],
         layout: MoveStructLayout,
     ) -> SuiResult<MoveStruct> {
-        MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
+        BoundedVisitor::deserialize_struct(contents, &layout).map_err(|e| {
             SuiError::ObjectSerializationError {
                 error: e.to_string(),
             }

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -1,0 +1,295 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use move_core_types::{
+    annotated_visitor::{self, StructDriver, Traversal},
+    language_storage::{StructTag, TypeTag},
+};
+
+use crate::balance::Balance;
+
+/// Traversal to gather the total balances of all coin types visited.
+#[derive(Default)]
+pub(crate) struct BalanceTraversal {
+    balances: BTreeMap<TypeTag, u64>,
+}
+
+/// Helper traversal to accumulate the values of all u64s visited. Used by `BalanceTraversal` to
+/// get the value of a `Balance` struct's field.
+#[derive(Default)]
+struct Accumulator {
+    total: u64,
+}
+
+impl BalanceTraversal {
+    /// Consume the traversal to get at its balance mapping.
+    pub(crate) fn finish(self) -> BTreeMap<TypeTag, u64> {
+        self.balances
+    }
+}
+
+impl Traversal for BalanceTraversal {
+    type Error = annotated_visitor::Error;
+
+    fn traverse_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, '_, '_>,
+    ) -> Result<(), Self::Error> {
+        let Some(coin_type) = is_balance(&driver.struct_layout().type_) else {
+            // Not a balance, search recursively for balances among fields.
+            while driver.next_field(self)?.is_some() {}
+            return Ok(());
+        };
+
+        let mut acc = Accumulator::default();
+        while driver.next_field(&mut acc)?.is_some() {}
+        *self.balances.entry(coin_type).or_default() += acc.total;
+        Ok(())
+    }
+}
+
+impl Traversal for Accumulator {
+    type Error = annotated_visitor::Error;
+    fn traverse_u64(&mut self, value: u64) -> Result<(), Self::Error> {
+        self.total += value;
+        Ok(())
+    }
+}
+
+/// Returns `Some(T)` if the struct is a `sui::balance::Balance<T>`, and `None` otherwise.
+fn is_balance(s: &StructTag) -> Option<TypeTag> {
+    (Balance::is_balance(s) && s.type_params.len() == 1).then(|| s.type_params[0].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::id::UID;
+
+    use super::*;
+
+    use move_core_types::{
+        account_address::AccountAddress, annotated_value as A, identifier::Identifier,
+        language_storage::StructTag,
+    };
+
+    #[test]
+    fn test_traverse_balance() {
+        let layout = bal_t("0x42::foo::Bar");
+        let value = bal_v("0x42::foo::Bar", 42);
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BalanceTraversal::default();
+        A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        let balances = visitor.finish();
+
+        assert_eq!(balances, BTreeMap::from([(type_("0x42::foo::Bar"), 42)]));
+    }
+
+    #[test]
+    fn test_traverse_coin() {
+        let layout = coin_t("0x42::foo::Bar");
+        let value = coin_v("0x42::foo::Bar", "0x101", 42);
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BalanceTraversal::default();
+        A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        let balances = visitor.finish();
+
+        assert_eq!(balances, BTreeMap::from([(type_("0x42::foo::Bar"), 42)]));
+    }
+
+    #[test]
+    fn test_traverse_nested() {
+        use A::MoveTypeLayout as T;
+
+        let layout = layout_(
+            "0xa::foo::Bar",
+            vec![
+                ("b", bal_t("0x42::baz::Qux")),
+                ("c", coin_t("0x42::baz::Qux")),
+                ("d", T::Vector(Box::new(coin_t("0x42::quy::Frob")))),
+            ],
+        );
+
+        let value = value_(
+            "0xa::foo::Bar",
+            vec![
+                ("b", bal_v("0x42::baz::Qux", 42)),
+                ("c", coin_v("0x42::baz::Qux", "0x101", 43)),
+                (
+                    "d",
+                    A::MoveValue::Vector(vec![
+                        coin_v("0x42::quy::Frob", "0x102", 44),
+                        coin_v("0x42::quy::Frob", "0x103", 45),
+                    ]),
+                ),
+            ],
+        );
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BalanceTraversal::default();
+        A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        let balances = visitor.finish();
+
+        assert_eq!(
+            balances,
+            BTreeMap::from([
+                (type_("0x42::baz::Qux"), 42 + 43),
+                (type_("0x42::quy::Frob"), 44 + 45),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_traverse_primitive() {
+        use A::MoveTypeLayout as T;
+
+        let layout = T::U64;
+        let value = A::MoveValue::U64(42);
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BalanceTraversal::default();
+        A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        let balances = visitor.finish();
+
+        assert_eq!(balances, BTreeMap::from([]));
+    }
+
+    #[test]
+    fn test_traverse_fake_balance() {
+        use A::MoveTypeLayout as T;
+
+        let layout = layout_(
+            "0xa::foo::Bar",
+            vec![
+                ("b", bal_t("0x42::baz::Qux")),
+                ("c", coin_t("0x42::baz::Qux")),
+                (
+                    "d",
+                    layout_(
+                        // Fake balance
+                        "0x3::balance::Balance<0x42::baz::Qux>",
+                        vec![("value", T::U64)],
+                    ),
+                ),
+            ],
+        );
+
+        let value = value_(
+            "0xa::foo::Bar",
+            vec![
+                ("b", bal_v("0x42::baz::Qux", 42)),
+                ("c", coin_v("0x42::baz::Qux", "0x101", 43)),
+                (
+                    "d",
+                    value_(
+                        "0x3::balance::Balance<0x42::baz::Qux>",
+                        vec![("value", A::MoveValue::U64(44))],
+                    ),
+                ),
+            ],
+        );
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BalanceTraversal::default();
+        A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        let balances = visitor.finish();
+
+        assert_eq!(
+            balances,
+            BTreeMap::from([(type_("0x42::baz::Qux"), 42 + 43),])
+        );
+    }
+
+    /// Create a UID Move Value for test purposes.
+    fn uid_(addr: &str) -> A::MoveValue {
+        value_(
+            "0x2::object::UID",
+            vec![(
+                "id",
+                value_(
+                    "0x2::object::ID",
+                    vec![(
+                        "bytes",
+                        A::MoveValue::Address(AccountAddress::from_str(addr).unwrap()),
+                    )],
+                ),
+            )],
+        )
+    }
+
+    /// Create a Balance value for testing purposes.
+    fn bal_v(tag: &str, value: u64) -> A::MoveValue {
+        value_(
+            &format!("0x2::balance::Balance<{tag}>"),
+            vec![("value", A::MoveValue::U64(value))],
+        )
+    }
+
+    /// Create a Coin value for testing purposes.
+    fn coin_v(tag: &str, id: &str, value: u64) -> A::MoveValue {
+        value_(
+            &format!("0x2::coin::Coin<{tag}>"),
+            vec![("id", uid_(id)), ("balance", bal_v(tag, value))],
+        )
+    }
+
+    /// Create a Balance layout for testing purposes.
+    fn bal_t(tag: &str) -> A::MoveTypeLayout {
+        layout_(
+            &format!("0x2::balance::Balance<{tag}>"),
+            vec![("value", A::MoveTypeLayout::U64)],
+        )
+    }
+
+    /// Create a Coin layout for testing purposes.
+    fn coin_t(tag: &str) -> A::MoveTypeLayout {
+        layout_(
+            &format!("0x2::coin::Coin<{tag}>"),
+            vec![
+                ("id", A::MoveTypeLayout::Struct(UID::layout())),
+                ("balance", bal_t(tag)),
+            ],
+        )
+    }
+
+    /// Create a struct value for test purposes.
+    fn value_(rep: &str, fields: Vec<(&str, A::MoveValue)>) -> A::MoveValue {
+        let type_ = StructTag::from_str(rep).unwrap();
+        let fields = fields
+            .into_iter()
+            .map(|(name, value)| (Identifier::new(name).unwrap(), value))
+            .collect();
+
+        A::MoveValue::Struct(A::MoveStruct::new(type_, fields))
+    }
+
+    // Create a type tag for test purposes.
+    fn type_(rep: &str) -> TypeTag {
+        TypeTag::from_str(rep).unwrap()
+    }
+
+    /// Create a struct layout for test purposes.
+    fn layout_(rep: &str, fields: Vec<(&str, A::MoveTypeLayout)>) -> A::MoveTypeLayout {
+        let type_ = StructTag::from_str(rep).unwrap();
+        let fields = fields
+            .into_iter()
+            .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
+            .collect();
+
+        A::MoveTypeLayout::Struct(A::MoveStructLayout { type_, fields })
+    }
+
+    /// BCS encode Move value.
+    fn serialize(value: A::MoveValue) -> Vec<u8> {
+        value.clone().undecorate().simple_serialize().unwrap()
+    }
+}

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -1,0 +1,359 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::bail;
+use move_core_types::{
+    account_address::AccountAddress,
+    annotated_value as A,
+    annotated_visitor::{self, StructDriver, VecDriver, Visitor},
+    language_storage::TypeTag,
+    u256::U256,
+};
+
+/// Visitor to deserialize annotated values or structs, bounding the size budgeted for types and
+/// field names in the output. The visitor does not bound the size of values, because they are
+/// assumed to already be bounded by execution.
+pub struct BoundedVisitor {
+    /// Budget left to spend on field names and types.
+    bound: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Visitor(#[from] annotated_visitor::Error),
+
+    #[error("Deserialized value too large")]
+    OutOfBudget,
+}
+
+/// Initial budget for deserialization -- we're okay to spend an extra ~100KiB on types and field
+/// information per value.
+///
+/// Bounded deserialization is intended for use outside of the validator, and so uses a fixed bound,
+/// rather than one that is configured as part of the protocol.
+const MAX_BOUND: usize = 100 * 1024;
+
+impl BoundedVisitor {
+    fn new(bound: usize) -> Self {
+        Self { bound }
+    }
+
+    /// Deserialize `bytes` as a `MoveValue` with layout `layout`. Can fail if the bytes do not
+    /// represent a value with this layout, or if the deserialized value exceeds the field/type size
+    /// budget.
+    pub fn deserialize_value(
+        bytes: &[u8],
+        layout: &A::MoveTypeLayout,
+    ) -> anyhow::Result<A::MoveValue> {
+        let mut visitor = Self::default();
+        A::MoveValue::visit_deserialize(bytes, layout, &mut visitor)
+    }
+
+    /// Deserialize `bytes` as a `MoveStruct` with layout `layout`. Can fail if the bytes do not
+    /// represent a struct with this layout, or if the deserialized struct exceeds the field/type
+    /// size budget.
+    pub fn deserialize_struct(
+        bytes: &[u8],
+        layout: &A::MoveStructLayout,
+    ) -> anyhow::Result<A::MoveStruct> {
+        let mut visitor = Self::default();
+        let A::MoveValue::Struct(struct_) =
+            A::MoveStruct::visit_deserialize(bytes, layout, &mut visitor)?
+        else {
+            bail!("Expected to deserialize a struct");
+        };
+        Ok(struct_)
+    }
+
+    /// Deduct `size` from the overall budget. Errors if `size` exceeds the current budget.
+    fn debit(&mut self, size: usize) -> Result<(), Error> {
+        if self.bound < size {
+            Err(Error::OutOfBudget)
+        } else {
+            self.bound -= size;
+            Ok(())
+        }
+    }
+
+    /// Deduct the estimated size of `tag` from the overall budget. Errors if its size exceeds the
+    /// current budget. The estimated size is proportional to the representation of that type in
+    /// memory, but does not match its exact size.
+    fn debit_type_size(&mut self, tag: &TypeTag) -> Result<(), Error> {
+        use TypeTag as TT;
+        let mut frontier = vec![tag];
+        while let Some(tag) = frontier.pop() {
+            match tag {
+                TT::Bool
+                | TT::U8
+                | TT::U16
+                | TT::U32
+                | TT::U64
+                | TT::U128
+                | TT::U256
+                | TT::Address
+                | TT::Signer => self.debit(8)?,
+
+                TT::Vector(inner) => {
+                    self.debit(8)?;
+                    frontier.push(inner);
+                }
+
+                TT::Struct(tag) => {
+                    self.debit(8 + AccountAddress::LENGTH + tag.module.len() + tag.name.len())?;
+                    frontier.extend(tag.type_params.iter());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Visitor for BoundedVisitor {
+    type Value = A::MoveValue;
+    type Error = Error;
+
+    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U8(value))
+    }
+
+    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U16(value))
+    }
+
+    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U32(value))
+    }
+
+    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U64(value))
+    }
+
+    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U128(value))
+    }
+
+    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::U256(value))
+    }
+
+    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::Bool(value))
+    }
+
+    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::Address(value))
+    }
+
+    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        Ok(A::MoveValue::Signer(value))
+    }
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error> {
+        let mut elems = vec![];
+        while let Some(elem) = driver.next_element(self)? {
+            elems.push(elem);
+        }
+
+        Ok(A::MoveValue::Vector(elems))
+    }
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error> {
+        let tag = driver.struct_layout().type_.clone().into();
+
+        self.debit_type_size(&tag)?;
+        for field in &driver.struct_layout().fields {
+            self.debit(field.name.len())?;
+        }
+
+        let mut fields = vec![];
+        while let Some((field, elem)) = driver.next_field(self)? {
+            fields.push((field.name.clone(), elem));
+        }
+
+        let TypeTag::Struct(type_) = tag else {
+            unreachable!("SAFETY: tag was derived from a StructTag.");
+        };
+
+        Ok(A::MoveValue::Struct(A::MoveStruct {
+            type_: *type_,
+            fields,
+        }))
+    }
+}
+
+impl Default for BoundedVisitor {
+    fn default() -> Self {
+        Self::new(MAX_BOUND)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    use expect_test::expect;
+    use move_core_types::{identifier::Identifier, language_storage::StructTag};
+
+    #[test]
+    fn test_success() {
+        use A::MoveTypeLayout as T;
+        use A::MoveValue as V;
+
+        let type_layout = layout_(
+            "0x0::foo::Bar",
+            vec![
+                ("a", T::U64),
+                ("b", T::Vector(Box::new(T::U64))),
+                ("c", layout_("0x0::foo::Baz", vec![("d", T::U64)])),
+            ],
+        );
+
+        let value = value_(
+            "0x0::foo::Bar",
+            vec![
+                ("a", V::U64(42)),
+                ("b", V::Vector(vec![V::U64(43)])),
+                ("c", value_("0x0::foo::Baz", vec![("d", V::U64(44))])),
+            ],
+        );
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BoundedVisitor::new(1000);
+        let deser = A::MoveValue::visit_deserialize(&bytes, &type_layout, &mut visitor).unwrap();
+        assert_eq!(value, deser);
+    }
+
+    #[test]
+    fn test_too_deep() {
+        use A::MoveTypeLayout as T;
+        use A::MoveValue as V;
+
+        let mut layout = T::U64;
+        let mut value = V::U64(42);
+
+        const DEPTH: usize = 10;
+        for _ in 0..DEPTH {
+            layout = layout_("0x0::foo::Bar", vec![("f", layout)]);
+            value = value_("0x0::foo::Bar", vec![("f", value)]);
+        }
+
+        let bound = DEPTH * (8 + 32 + "foo".len() + "Bar".len() + "f".len());
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BoundedVisitor::new(bound);
+        let deser = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        assert_eq!(deser, value);
+
+        let mut visitor = BoundedVisitor::new(bound - 1);
+        let err = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap_err();
+
+        let expect = expect!["Deserialized value too large"];
+        expect.assert_eq(&err.to_string());
+    }
+
+    #[test]
+    fn test_too_wide() {
+        use A::MoveTypeLayout as T;
+        use A::MoveValue as V;
+
+        const WIDTH: usize = 10;
+        let mut idents = vec![];
+        let mut fields = vec![];
+        let mut values = vec![];
+
+        for i in 0..WIDTH {
+            idents.push(format!("f{}", i));
+        }
+
+        for (i, id) in idents.iter().enumerate() {
+            let layout = layout_("0x0::foo::Baz", vec![("f", T::U64)]);
+            let value = value_("0x0::foo::Baz", vec![("f", V::U64(i as u64))]);
+
+            fields.push((id.as_str(), layout));
+            values.push((id.as_str(), value));
+        }
+
+        let layout = layout_("0x0::foo::Bar", fields);
+        let value = value_("0x0::foo::Bar", values);
+
+        let outer = 8 + 32 + "foo".len() + "Bar".len();
+        let inner = WIDTH * ("fx".len() + 8 + 32 + "foo".len() + "Baz".len() + "f".len());
+        let bound = outer + inner;
+
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BoundedVisitor::new(bound);
+        let deser = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        assert_eq!(deser, value);
+
+        let mut visitor = BoundedVisitor::new(bound - 1);
+        let err = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap_err();
+
+        let expect = expect!["Deserialized value too large"];
+        expect.assert_eq(&err.to_string());
+    }
+
+    #[test]
+    fn test_big_types() {
+        use A::MoveTypeLayout as T;
+        use A::MoveValue as V;
+
+        let big_mod_ = "m".repeat(128);
+        let big_name = "T".repeat(128);
+        let big_type = format!("0x0::{big_mod_}::{big_name}");
+
+        let layout = layout_(big_type.as_str(), vec![("f", T::U64)]);
+        let value = value_(big_type.as_str(), vec![("f", V::U64(42))]);
+
+        let bound = 8 + 32 + big_mod_.len() + big_name.len() + "f".len();
+        let bytes = serialize(value.clone());
+
+        let mut visitor = BoundedVisitor::new(bound);
+        let deser = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap();
+        assert_eq!(deser, value);
+
+        let mut visitor = BoundedVisitor::new(bound - 1);
+        let err = A::MoveValue::visit_deserialize(&bytes, &layout, &mut visitor).unwrap_err();
+
+        let expect = expect!["Deserialized value too large"];
+        expect.assert_eq(&err.to_string());
+    }
+
+    /// Create a struct value for test purposes.
+    fn value_(rep: &str, fields: Vec<(&str, A::MoveValue)>) -> A::MoveValue {
+        let type_ = StructTag::from_str(rep).unwrap();
+        let fields = fields
+            .into_iter()
+            .map(|(name, value)| (Identifier::new(name).unwrap(), value))
+            .collect();
+
+        A::MoveValue::Struct(A::MoveStruct::new(type_, fields))
+    }
+
+    /// Create a struct layout for test purposes.
+    fn layout_(rep: &str, fields: Vec<(&str, A::MoveTypeLayout)>) -> A::MoveTypeLayout {
+        let type_ = StructTag::from_str(rep).unwrap();
+        let fields = fields
+            .into_iter()
+            .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
+            .collect();
+
+        A::MoveTypeLayout::Struct(A::MoveStructLayout { type_, fields })
+    }
+
+    /// BCS encode Move value.
+    fn serialize(value: A::MoveValue) -> Vec<u8> {
+        value.clone().undecorate().simple_serialize().unwrap()
+    }
+}

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1330,6 +1330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1705,7 @@ dependencies = [
  "enum-compat-util",
  "ethnum",
  "hex",
+ "leb128",
  "move-proc-macros",
  "num",
  "once_cell",
@@ -1711,6 +1718,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "thiserror",
  "uint",
 ]
 

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -47,6 +47,7 @@ hkdf = "0.10.0"
 im = "15.1.0"
 internment = { version = "0.5.0", features = [ "arc"] }
 itertools = "0.10.0"
+leb128 = "0.2.5"
 libfuzzer-sys = "0.4"
 log = { version = "0.4.14", features = ["serde"] }
 lsp-server = "0.5.1"

--- a/external-crates/move/crates/move-core-types/Cargo.toml
+++ b/external-crates/move/crates/move-core-types/Cargo.toml
@@ -27,6 +27,8 @@ arbitrary = { workspace = true, optional = true }
 enum-compat-util.workspace = true
 move-proc-macros.workspace = true
 bcs.workspace = true
+leb128.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     account_address::AccountAddress,
+    annotated_visitor::{visit_struct, visit_value, Error as VError, Visitor},
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
     runtime_value as R, u256,
@@ -98,8 +99,44 @@ pub enum MoveTypeLayout {
 }
 
 impl MoveValue {
+    /// TODO (annotated-visitor): Port legacy uses of this method to `BoundedVisitor`.
     pub fn simple_deserialize(blob: &[u8], ty: &MoveTypeLayout) -> AResult<Self> {
         Ok(bcs::from_bytes_seed(ty, blob)?)
+    }
+
+    /// Deserialize `blob` as a Move value with the given `ty`-pe layout, and visit its
+    /// sub-structure with the given `visitor`. The visitor dictates the return value that is built
+    /// up during deserialization.
+    ///
+    /// # Nested deserialization
+    ///
+    /// Vectors and structs are nested structures that can be met during deserialization. Visitors
+    /// are passed a driver (`VecDriver` or `StructDriver` correspondingly) which controls how
+    /// nested elements or fields are visited including whether a given nested element/field is
+    /// explored, which visitor to use (the visitor can pass `self` to recursively explore them) and
+    /// whether a given element is visited or skipped.
+    ///
+    /// The visitor may leave elements unvisited at the end of the vector or struct, which
+    /// implicitly skips them.
+    ///
+    /// # Errors
+    ///
+    /// Deserialization can fail because of an issue in the serialized format (data doesn't match
+    /// layout, unexpected bytes or trailing bytes), or a custom error expressed by the visitor.
+    pub fn visit_deserialize<V: Visitor>(
+        mut blob: &[u8],
+        ty: &MoveTypeLayout,
+        visitor: &mut V,
+    ) -> AResult<V::Value>
+    where
+        V::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let res = visit_value(&mut blob, ty, visitor)?;
+        if blob.is_empty() {
+            Ok(res)
+        } else {
+            Err(VError::TrailingBytes(blob.len()).into())
+        }
     }
 
     pub fn simple_serialize(&self) -> Option<Vec<u8>> {
@@ -142,8 +179,28 @@ impl MoveStruct {
         Self { type_, fields }
     }
 
+    /// TODO (annotated-visitor): Port legacy uses of this method to `BoundedVisitor`.
     pub fn simple_deserialize(blob: &[u8], ty: &MoveStructLayout) -> AResult<Self> {
         Ok(bcs::from_bytes_seed(ty, blob)?)
+    }
+
+    /// Like `MoveValue::visit_deserialize` (see for details), but specialized to visiting a struct
+    /// (the `blob` is known to be a serialized Move struct, and the layout is a
+    /// `MoveStructLayout`).
+    pub fn visit_deserialize<V: Visitor>(
+        mut blob: &[u8],
+        ty: &MoveStructLayout,
+        visitor: &mut V,
+    ) -> AResult<V::Value>
+    where
+        V::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let res = visit_struct(&mut blob, ty, visitor)?;
+        if blob.is_empty() {
+            Ok(res)
+        } else {
+            Err(VError::TrailingBytes(blob.len()).into())
+        }
     }
 
     pub fn into_fields(self) -> Vec<MoveValue> {

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -1,0 +1,371 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+
+use crate::{
+    account_address::AccountAddress,
+    annotated_value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+    u256::U256,
+};
+
+/// Visitors can be used for building values out of a serialized Move struct or value.
+pub trait Visitor {
+    type Value;
+
+    /// Visitors can return any error as long as it can represent an error from the visitor itself.
+    /// The easiest way to achieve this is to use `thiserror`:
+    ///
+    /// ```rust,no_doc
+    /// #[derive(thiserror::Error)]
+    /// enum Error {
+    ///     #[error(transparent)]
+    ///     Visitor(#[from] annotated_visitor::Error)
+    ///
+    ///     // Custom error variants ...
+    /// }
+    /// ```
+    type Error: From<Error>;
+
+    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error>;
+    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error>;
+    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error>;
+    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error>;
+    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error>;
+    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error>;
+    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error>;
+    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error>;
+    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error>;
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error>;
+}
+
+/// A traversal is a special kind of visitor that doesn't return any values. The trait comes with
+/// default implementations for every variant that do nothing, allowing an implementor to focus on
+/// only the cases they care about.
+///
+/// Note that the default implementation for structs and vectors recurse down into their elements. A
+/// traversal that doesn't want to look inside structs and vectors needs to provide a custom
+/// implementation with an empty body:
+///
+/// ```rust,no_run
+/// fn traverse_vector(&mut self, _: &mut VecDriver) -> Result<(), Self::Error> {
+///     Ok(())
+/// }
+/// ```
+pub trait Traversal {
+    type Error: From<Error>;
+
+    fn traverse_u8(&mut self, _value: u8) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u16(&mut self, _value: u16) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u32(&mut self, _value: u32) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u64(&mut self, _value: u64) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u128(&mut self, _value: u128) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u256(&mut self, _value: U256) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_bool(&mut self, _value: bool) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_address(&mut self, _value: AccountAddress) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_signer(&mut self, _value: AccountAddress) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_vector(&mut self, driver: &mut VecDriver<'_, '_, '_>) -> Result<(), Self::Error> {
+        while driver.next_element(self)?.is_some() {}
+        Ok(())
+    }
+
+    fn traverse_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, '_, '_>,
+    ) -> Result<(), Self::Error> {
+        while driver.next_field(self)?.is_some() {}
+        Ok(())
+    }
+}
+
+/// Default implementation converting any traversal into a visitor.
+impl<T: Traversal + ?Sized> Visitor for T {
+    type Value = ();
+    type Error = T::Error;
+
+    fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
+        self.traverse_u8(value)
+    }
+
+    fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
+        self.traverse_u16(value)
+    }
+
+    fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+        self.traverse_u32(value)
+    }
+
+    fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+        self.traverse_u64(value)
+    }
+
+    fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
+        self.traverse_u128(value)
+    }
+
+    fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
+        self.traverse_u256(value)
+    }
+
+    fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+        self.traverse_bool(value)
+    }
+
+    fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        self.traverse_address(value)
+    }
+
+    fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+        self.traverse_signer(value)
+    }
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_vector(driver)
+    }
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, '_, '_>,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_struct(driver)
+    }
+}
+
+/// Exposes information about a vector being visited (the element layout) to a visitor
+/// implementation, and allows that visitor to progress the traversal (by visiting or skipping
+/// elements).
+pub struct VecDriver<'r, 'b, 'l> {
+    bytes: &'r mut &'b [u8],
+    layout: &'l MoveTypeLayout,
+    len: u64,
+    off: u64,
+}
+
+/// Exposes information about a struct being visited (its layout, details about the next field to be
+/// visited) to a visitor implementation, and allows that visitor to progress the traversal (by
+/// visiting or skipping fields).
+pub struct StructDriver<'r, 'b, 'l> {
+    bytes: &'r mut &'b [u8],
+    layout: &'l MoveStructLayout,
+    off: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("unexpected end of input")]
+    UnexpectedEof,
+
+    #[error("unexpected byte: {0}")]
+    UnexpectedByte(u8),
+
+    #[error("trailing {0} byte(s) at the end of input")]
+    TrailingBytes(usize),
+}
+
+/// The null traversal implements `Traversal` and `Visitor` but without doing anything (does not
+/// return a value, and does not modify any state). This is useful for skipping over parts of the
+/// value structure.
+pub struct NullTraversal;
+
+impl Traversal for NullTraversal {
+    type Error = Error;
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<'r, 'b, 'l> VecDriver<'r, 'b, 'l> {
+    fn new(bytes: &'r mut &'b [u8], layout: &'l MoveTypeLayout, len: u64) -> Self {
+        Self {
+            bytes,
+            layout,
+            len,
+            off: 0,
+        }
+    }
+
+    /// Type layout for the vector's inner type.
+    pub fn element_layout(&self) -> &'l MoveTypeLayout {
+        self.layout
+    }
+
+    /// The number of elements in this vector
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Returns whether or not there are more elements to visit in this vector.
+    pub fn has_element(&self) -> bool {
+        self.off < self.len
+    }
+
+    /// Visit the next element in the vector. The driver accepts a visitor to use for this element,
+    /// allowing the visitor to be changed on recursive calls or even between elements in the same
+    /// vector.
+    ///
+    /// Returns `Ok(None)` if there are no more elements in the vector, `Ok(v)` if there was an
+    /// element and it was successfully visited (where `v` is the value returned by the visitor) or
+    /// an error if there was an underlying deserialization error, or an error during visitation.
+    pub fn next_element<V: Visitor + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<Option<V::Value>, V::Error> {
+        Ok(if self.off >= self.len {
+            None
+        } else {
+            let res = visit_value(self.bytes, self.layout, visitor)?;
+            self.off += 1;
+            Some(res)
+        })
+    }
+
+    /// Skip the next element in this vector. Returns whether there was an element to skip or not on
+    /// success, or an error if there was an underlying deserialization error.
+    pub fn skip_element(&mut self) -> Result<bool, Error> {
+        self.next_element(&mut NullTraversal).map(|v| v.is_some())
+    }
+}
+
+impl<'r, 'b, 'l> StructDriver<'r, 'b, 'l> {
+    fn new(bytes: &'r mut &'b [u8], layout: &'l MoveStructLayout) -> Self {
+        Self {
+            bytes,
+            layout,
+            off: 0,
+        }
+    }
+
+    /// The layout of the struct being visited.
+    pub fn struct_layout(&self) -> &'l MoveStructLayout {
+        self.layout
+    }
+
+    /// The layout of the next field to be visited (if there is one), or `None` otherwise.
+    pub fn peek_field(&self) -> Option<&'l MoveFieldLayout> {
+        self.layout.fields.get(self.off)
+    }
+
+    /// Visit the next field in the struct. The driver accepts a visitor to use for this field,
+    /// allowing the visitor to be changed on recursive calls or even between fields in the same
+    /// struct.
+    ///
+    /// Returns `Ok(None)` if there are no more fields in the struct, `Ok((f, v))` if there was an
+    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
+    /// `f` is the layout of the field that was visited) or an error if there was an underlying
+    /// deserialization error, or an error during visitation.
+    pub fn next_field<V: Visitor + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<Option<(&'l MoveFieldLayout, V::Value)>, V::Error> {
+        let Some(field) = self.peek_field() else {
+            return Ok(None);
+        };
+
+        let res = visit_value(self.bytes, &field.layout, visitor)?;
+        self.off += 1;
+        Ok(Some((field, res)))
+    }
+
+    /// Skip the next field. Returns the layout of the field that was visited if there was one, or
+    /// `None` if there was none. Can return an error if there was a deserialization error.
+    pub fn skip_field(&mut self) -> Result<Option<&'l MoveFieldLayout>, Error> {
+        self.next_field(&mut NullTraversal)
+            .map(|res| res.map(|(f, _)| f))
+    }
+}
+
+/// Visit a serialized Move value with the provided `layout`, held in `bytes`, using the provided
+/// visitor to build a value out of it. See `annoted_value::MoveValue::visit_deserialize` for
+/// details.
+pub(crate) fn visit_value<V: Visitor + ?Sized>(
+    bytes: &mut &[u8],
+    layout: &MoveTypeLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    use MoveTypeLayout as L;
+
+    match layout {
+        L::Bool => match read_exact::<1>(bytes)? {
+            [0] => visitor.visit_bool(false),
+            [1] => visitor.visit_bool(true),
+            [b] => Err(Error::UnexpectedByte(b).into()),
+        },
+
+        L::U8 => visitor.visit_u8(u8::from_le_bytes(read_exact::<1>(bytes)?)),
+        L::U16 => visitor.visit_u16(u16::from_le_bytes(read_exact::<2>(bytes)?)),
+        L::U32 => visitor.visit_u32(u32::from_le_bytes(read_exact::<4>(bytes)?)),
+        L::U64 => visitor.visit_u64(u64::from_le_bytes(read_exact::<8>(bytes)?)),
+        L::U128 => visitor.visit_u128(u128::from_le_bytes(read_exact::<16>(bytes)?)),
+        L::U256 => visitor.visit_u256(U256::from_le_bytes(&read_exact::<32>(bytes)?)),
+        L::Address => visitor.visit_address(AccountAddress::new(read_exact::<32>(bytes)?)),
+        L::Signer => visitor.visit_signer(AccountAddress::new(read_exact::<32>(bytes)?)),
+
+        L::Vector(l) => {
+            let len = leb128::read::unsigned(bytes).map_err(|_| Error::UnexpectedEof)?;
+            let mut driver = VecDriver::new(bytes, l.as_ref(), len);
+            let res = visitor.visit_vector(&mut driver)?;
+            while driver.skip_element()? {}
+            Ok(res)
+        }
+
+        L::Struct(l) => visit_struct(bytes, l, visitor),
+    }
+}
+
+/// Like `visit_value` but specialized to visiting a struct (where the `bytes` is known to be a
+/// serialized move struct), and the layout is a struct layout.
+pub(crate) fn visit_struct<V: Visitor + ?Sized>(
+    bytes: &mut &[u8],
+    layout: &MoveStructLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    let mut driver = StructDriver::new(bytes, layout);
+    let res = visitor.visit_struct(&mut driver)?;
+    while driver.skip_field()?.is_some() {}
+    Ok(res)
+}
+
+fn read_exact<const N: usize>(bytes: &mut &[u8]) -> Result<[u8; N], Error> {
+    let mut buf = [0u8; N];
+    bytes
+        .read_exact(&mut buf)
+        .map_err(|_| Error::UnexpectedEof)?;
+    Ok(buf)
+}

--- a/external-crates/move/crates/move-core-types/src/lib.rs
+++ b/external-crates/move/crates/move-core-types/src/lib.rs
@@ -9,6 +9,7 @@ use std::fmt;
 pub mod abi;
 pub mod account_address;
 pub mod annotated_value;
+pub mod annotated_visitor;
 pub mod effects;
 pub mod errmap;
 pub mod gas_algebra;

--- a/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
@@ -5,3 +5,4 @@
 mod identifier_test;
 mod language_storage_test;
 mod value_test;
+mod visitor_test;

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -1,0 +1,537 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt::Write, str::FromStr};
+
+use crate::{
+    account_address::AccountAddress,
+    annotated_value::{MoveFieldLayout, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+    annotated_visitor::{self, NullTraversal, StructDriver, Traversal, VecDriver, Visitor},
+    identifier::Identifier,
+    language_storage::StructTag,
+    u256::U256,
+};
+
+#[test]
+fn traversal() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    #[derive(Default)]
+    struct CountingTraversal(usize);
+
+    impl Traversal for CountingTraversal {
+        type Error = annotated_visitor::Error;
+
+        fn traverse_u8(&mut self, _: u8) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_u16(&mut self, _: u16) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_u32(&mut self, _: u32) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_u64(&mut self, _: u64) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_u128(&mut self, _: u128) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_u256(&mut self, _: U256) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_bool(&mut self, _: bool) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_address(&mut self, _: AccountAddress) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_signer(&mut self, _: AccountAddress) -> Result<(), Self::Error> {
+            self.0 += 1;
+            Ok(())
+        }
+
+        fn traverse_vector(
+            &mut self,
+            driver: &mut VecDriver<'_, '_, '_>,
+        ) -> Result<(), Self::Error> {
+            self.0 += 1;
+            while driver.next_element(self)?.is_some() {}
+            Ok(())
+        }
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, '_, '_>,
+        ) -> Result<(), Self::Error> {
+            self.0 += 1;
+            while driver.next_field(self)?.is_some() {}
+            Ok(())
+        }
+    }
+
+    let type_layout = layout_(
+        "0x0::foo::Bar",
+        vec![
+            ("a", T::U8),
+            ("b", T::U16),
+            ("c", T::U32),
+            ("d", T::U64),
+            ("e", T::U128),
+            ("f", T::U256),
+            ("g", T::Bool),
+            ("h", T::Address),
+            ("i", T::Signer),
+            ("j", T::Vector(Box::new(T::U8))),
+            ("k", layout_("0x0::foo::Baz", vec![("l", T::U8)])),
+        ],
+    );
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = value_(
+        "0x0::foo::Bar",
+        vec![
+            ("a", V::U8(1)),
+            ("b", V::U16(2)),
+            ("c", V::U32(3)),
+            ("d", V::U64(4)),
+            ("e", V::U128(5)),
+            ("f", V::U256(6u32.into())),
+            ("g", V::Bool(true)),
+            ("h", V::Address(AccountAddress::ZERO)),
+            ("i", V::Signer(AccountAddress::ZERO)),
+            ("j", V::Vector(vec![V::U8(7), V::U8(8), V::U8(9)])),
+            ("k", value_("0x0::foo::Baz", vec![("l", V::U8(10))])),
+        ],
+    );
+
+    let bytes = serialize(value);
+
+    let mut value_traversal = CountingTraversal::default();
+    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_traversal).unwrap();
+
+    let mut struct_traversal = CountingTraversal::default();
+    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_traversal).unwrap();
+
+    assert_eq!(16, value_traversal.0);
+    assert_eq!(16, struct_traversal.0);
+}
+
+#[test]
+fn unexpected_eof() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let type_layout = layout_("0x0::foo::Bar", vec![("a", T::U64)]);
+    let value = value_("0x0::foo::Bar", vec![("a", V::U64(42))]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let mut bytes = serialize(value);
+
+    // Oops, dropped a byte
+    bytes.pop();
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn bad_bool_byte() {
+    use MoveTypeLayout as T;
+    assert_eq!(
+        "unexpected byte: 42",
+        MoveValue::visit_deserialize(&[42], &T::Bool, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn bad_vector_length() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let layout = T::Vector(Box::new(T::U8));
+    let value = V::Vector(vec![V::U8(1), V::U8(2), V::U8(3)]);
+
+    let mut bytes = serialize(value);
+
+    // Oops, dropped a byte
+    bytes.pop();
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn trailing_bytes() {
+    use MoveTypeLayout as T;
+    assert_eq!(
+        "trailing 1 byte(s) at the end of input",
+        MoveValue::visit_deserialize(&[42, 42], &T::U8, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn nested_typed_struct_visit() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    #[derive(Default)]
+    struct PrintVisitor {
+        depth: usize,
+        output: String,
+    }
+
+    impl Visitor for PrintVisitor {
+        type Value = MoveValue;
+        type Error = annotated_visitor::Error;
+
+        fn visit_u8(&mut self, value: u8) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u8", self.depth).unwrap();
+            Ok(V::U8(value))
+        }
+
+        fn visit_u16(&mut self, value: u16) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u16", self.depth).unwrap();
+            Ok(V::U16(value))
+        }
+
+        fn visit_u32(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u32", self.depth).unwrap();
+            Ok(V::U32(value))
+        }
+
+        fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u64", self.depth).unwrap();
+            Ok(V::U64(value))
+        }
+
+        fn visit_u128(&mut self, value: u128) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u128", self.depth).unwrap();
+            Ok(V::U128(value))
+        }
+
+        fn visit_u256(&mut self, value: U256) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: u256", self.depth).unwrap();
+            Ok(V::U256(value))
+        }
+
+        fn visit_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: bool", self.depth).unwrap();
+            Ok(V::Bool(value))
+        }
+
+        fn visit_address(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: address", self.depth).unwrap();
+            Ok(V::Address(value))
+        }
+
+        fn visit_signer(&mut self, value: AccountAddress) -> Result<Self::Value, Self::Error> {
+            write!(self.output, "\n[{}] {value}: signer", self.depth).unwrap();
+            Ok(V::Signer(value))
+        }
+
+        fn visit_vector(
+            &mut self,
+            driver: &mut VecDriver<'_, '_, '_>,
+        ) -> Result<Self::Value, Self::Error> {
+            let layout = driver.element_layout();
+            write!(self.output, "\n[{}] vector<{layout:#}>", self.depth).unwrap();
+
+            let mut elems = vec![];
+            let mut elem_visitor = Self {
+                depth: self.depth + 1,
+                output: std::mem::take(&mut self.output),
+            };
+
+            while let Some(elem) = driver.next_element(&mut elem_visitor)? {
+                elems.push(elem)
+            }
+
+            self.output = elem_visitor.output;
+            Ok(V::Vector(elems))
+        }
+
+        fn visit_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, '_, '_>,
+        ) -> Result<Self::Value, Self::Error> {
+            let layout = driver.struct_layout();
+            write!(self.output, "\n[{}] {layout:#}", self.depth).unwrap();
+
+            let mut fields = vec![];
+            let mut field_visitor = Self {
+                depth: self.depth + 1,
+                output: std::mem::take(&mut self.output),
+            };
+
+            while let Some((field, value)) = driver.next_field(&mut field_visitor)? {
+                fields.push((field.name.clone(), value));
+            }
+
+            self.output = field_visitor.output;
+            let type_ = driver.struct_layout().type_.clone();
+            Ok(V::Struct(MoveStruct { type_, fields }))
+        }
+    }
+
+    let type_layout = layout_(
+        "0x0::foo::Bar",
+        vec![(
+            "inner",
+            layout_(
+                "0x0::baz::Qux",
+                vec![("f", T::U64), ("g", T::Vector(Box::new(T::U32)))],
+            ),
+        )],
+    );
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = value_(
+        "0x0::foo::Bar",
+        vec![(
+            "inner",
+            value_(
+                "0x0::baz::Qux",
+                vec![
+                    ("f", V::U64(7)),
+                    ("g", V::Vector(vec![V::U32(1), V::U32(2), V::U32(3)])),
+                ],
+            ),
+        )],
+    );
+
+    let bytes = serialize(value.clone());
+
+    let mut value_visitor = PrintVisitor::default();
+    let from_value =
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+
+    let mut struct_visitor = PrintVisitor::default();
+    let from_struct =
+        MoveStruct::visit_deserialize(&bytes, &struct_layout, &mut struct_visitor).unwrap();
+
+    let expected_output = r#"
+[0] struct 0x0::foo::Bar {
+    inner: struct 0x0::baz::Qux {
+        f: u64,
+        g: vector<u32>,
+    },
+}
+[1] struct 0x0::baz::Qux {
+    f: u64,
+    g: vector<u32>,
+}
+[2] 7: u64
+[2] vector<u32>
+[3] 1: u32
+[3] 2: u32
+[3] 3: u32"#;
+
+    // This is a little strange -- even though we are deserializing a struct, we still get a value.
+    // This is because the return type comes from the visitor, not the deserializer.
+    assert_eq!(value, from_value);
+    assert_eq!(value, from_struct);
+
+    assert_eq!(value_visitor.output, expected_output);
+    assert_eq!(struct_visitor.output, expected_output);
+}
+
+#[test]
+fn peek_field_test() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    struct PeekU64Visitor<'f> {
+        fields: &'f [&'f str],
+    }
+
+    impl<'f> Visitor for PeekU64Visitor<'f> {
+        type Value = Option<u64>;
+        type Error = annotated_visitor::Error;
+
+        fn visit_u64(&mut self, value: u64) -> Result<Self::Value, Self::Error> {
+            Ok(self.fields.is_empty().then_some(value))
+        }
+
+        fn visit_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, '_, '_>,
+        ) -> Result<Self::Value, Self::Error> {
+            let [field, fields @ ..] = self.fields else {
+                return Ok(None);
+            };
+
+            while let Some(layout) = driver.peek_field() {
+                if layout.name.as_str() == *field {
+                    return driver
+                        .next_field(&mut Self { fields })
+                        .map(|value| value.and_then(|(_, v)| v));
+                } else {
+                    driver.skip_field()?;
+                }
+            }
+
+            Ok(None)
+        }
+
+        // === Empty/default cases ===
+
+        fn visit_u8(&mut self, _: u8) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u16(&mut self, _: u16) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u32(&mut self, _: u32) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u128(&mut self, _: u128) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u256(&mut self, _: U256) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_bool(&mut self, _: bool) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_address(&mut self, _: AccountAddress) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_signer(&mut self, _: AccountAddress) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        /// Field specifier doesn't support vectors, so we know we won't find the field we want
+        /// under here.
+        fn visit_vector(
+            &mut self,
+            _: &mut VecDriver<'_, '_, '_>,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    let type_layout = layout_(
+        "0x0::foo::Bar",
+        vec![
+            ("a", T::U64),
+            ("b", T::U32),
+            ("c", T::Vector(Box::new(T::U64))),
+            ("d", layout_("0x0::foo::Baz", vec![("e", T::U64)])),
+        ],
+    );
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = value_(
+        "0x0::foo::Bar",
+        vec![
+            ("a", V::U64(42)),
+            ("b", V::U32(43)),
+            ("c", V::Vector(vec![V::U64(44)])),
+            ("d", value_("0x0::foo::Baz", vec![("e", V::U64(45))])),
+        ],
+    );
+
+    let bytes = serialize(value);
+
+    let visit_value = |fields| {
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
+    };
+
+    let visit_struct = |fields| {
+        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut PeekU64Visitor { fields })
+            .unwrap()
+    };
+
+    assert_eq!(visit_value(&["a"]), Some(42));
+    assert_eq!(visit_value(&["b"]), None);
+    assert_eq!(visit_value(&["c"]), None);
+    assert_eq!(visit_value(&["d", "e"]), Some(45));
+
+    assert_eq!(visit_struct(&["a"]), Some(42));
+    assert_eq!(visit_struct(&["b"]), None);
+    assert_eq!(visit_struct(&["c"]), None);
+    assert_eq!(visit_struct(&["d", "e"]), Some(45));
+}
+
+/// Create a struct value for test purposes.
+fn value_(rep: &str, fields: Vec<(&str, MoveValue)>) -> MoveValue {
+    let type_ = StructTag::from_str(rep).unwrap();
+    let fields = fields
+        .into_iter()
+        .map(|(name, value)| (Identifier::new(name).unwrap(), value))
+        .collect();
+
+    MoveValue::Struct(MoveStruct::new(type_, fields))
+}
+
+/// Create a struct layout for test purposes.
+fn layout_(rep: &str, fields: Vec<(&str, MoveTypeLayout)>) -> MoveTypeLayout {
+    let type_ = StructTag::from_str(rep).unwrap();
+    let fields = fields
+        .into_iter()
+        .map(|(name, layout)| MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
+        .collect();
+
+    MoveTypeLayout::Struct(MoveStructLayout { type_, fields })
+}
+
+/// BCS encode Move value.
+fn serialize(value: MoveValue) -> Vec<u8> {
+    value.clone().undecorate().simple_serialize().unwrap()
+}

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -11,7 +11,8 @@ use indexmap::set::IndexSet;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::{MoveStruct, MoveTypeLayout, MoveValue},
+    annotated_value::{MoveTypeLayout, MoveValue},
+    annotated_visitor as AV,
     effects::Op,
     language_storage::StructTag,
     runtime_value as R,
@@ -628,7 +629,6 @@ fn check_circular_ownership(
     Ok(())
 }
 
-// TODO use a custom DeserializerSeed and improve this performance
 /// WARNING! This function assumes that the bcs bytes have already been validated,
 /// and it will give an invariant violation otherwise.
 /// In short, we are relying on the invariant that the bytes are valid for objects
@@ -639,40 +639,35 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
-    let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
-        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
-    get_all_uids_in_value(&mut ids, &v)?;
-    Ok(ids)
-}
+    struct UIDTraversalV2<'i>(&'i mut BTreeSet<ObjectID>);
+    struct UIDCollectorV2<'i>(&'i mut BTreeSet<ObjectID>);
 
-fn get_all_uids_in_value(
-    acc: &mut BTreeSet<ObjectID>,
-    v: &MoveValue,
-) -> Result<(), /* invariant violation */ String> {
-    let mut stack = vec![v];
-    while let Some(cur) = stack.pop() {
-        let s = match cur {
-            MoveValue::Struct(s) => s,
-            MoveValue::Vector(vec) => {
-                stack.extend(vec);
-                continue;
+    impl<'i> AV::Traversal for UIDTraversalV2<'i> {
+        type Error = AV::Error;
+
+        fn traverse_struct(&mut self, driver: &mut AV::StructDriver) -> Result<(), Self::Error> {
+            if driver.struct_layout().type_ == UID::type_() {
+                while driver.next_field(&mut UIDCollectorV2(self.0))?.is_some() {}
+            } else {
+                while driver.next_field(self)?.is_some() {}
             }
-            _ => continue,
-        };
-
-        let MoveStruct { type_, fields } = s;
-        if type_ == &UID::type_() {
-            let inner = match &fields[0].1 {
-                MoveValue::Struct(MoveStruct { fields, .. }) => fields,
-                v => return Err(format!("Unexpected UID layout. {v:?}")),
-            };
-            match &inner[0].1 {
-                MoveValue::Address(id) => acc.insert((*id).into()),
-                v => return Err(format!("Unexpected ID layout. {v:?}")),
-            };
-        } else {
-            stack.extend(fields.iter().map(|(_, v)| v));
+            Ok(())
         }
     }
-    Ok(())
+
+    impl<'i> AV::Traversal for UIDCollectorV2<'i> {
+        type Error = AV::Error;
+        fn traverse_address(&mut self, value: AccountAddress) -> Result<(), Self::Error> {
+            self.0.insert(value.into());
+            Ok(())
+        }
+    }
+
+    MoveValue::visit_deserialize(
+        bcs_bytes,
+        fully_annotated_layout,
+        &mut UIDTraversalV2(&mut ids),
+    )
+    .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    Ok(ids)
 }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -653,6 +653,7 @@ fn find_all_wrapped_objects<'a>(
             }
         };
         let blob = value.borrow().simple_serialize(&layout).unwrap();
+        // TODO (annotated-visitor): Replace with a custom visitor.
         let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
         let uid = UID::type_();
         visit_structs(&move_value, |depth, tag, fields| {

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -619,6 +619,7 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
+    // TODO (annotated-visitor): Replace with a custom visitor
     let v = A::MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
         .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
     get_all_uids_in_value(&mut ids, &v)?;

--- a/sui-execution/v0/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v0/sui-move-natives/src/test_scenario.rs
@@ -656,6 +656,7 @@ fn find_all_wrapped_objects<'a>(
             }
         };
         let blob = value.borrow().simple_serialize(&layout).unwrap();
+        // TODO (annotated-visitor): Replace with a custom visitor.
         let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
         let uid = UID::type_();
         visit_structs(&move_value, |depth, tag, fields| {

--- a/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v1/sui-move-natives/src/object_runtime/mod.rs
@@ -671,6 +671,7 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
+    // TODO (annotated-visitor): Replace with a custom visitor
     let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
         .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
     get_all_uids_in_value(&mut ids, &v)?;

--- a/sui-execution/v1/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v1/sui-move-natives/src/test_scenario.rs
@@ -651,6 +651,7 @@ fn find_all_wrapped_objects<'a>(
             }
         };
         let blob = value.borrow().simple_serialize(&layout).unwrap();
+        // TODO (annotated-visitor): Replace with a custom visitor.
         let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
         let uid = UID::type_();
         visit_structs(&move_value, |depth, tag, fields| {

--- a/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v2/sui-move-natives/src/object_runtime/mod.rs
@@ -639,6 +639,7 @@ pub fn get_all_uids(
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
+    // TODO (annotated-visitor): Replace with a custom visitor
     let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
         .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
     get_all_uids_in_value(&mut ids, &v)?;

--- a/sui-execution/v2/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v2/sui-move-natives/src/test_scenario.rs
@@ -653,6 +653,7 @@ fn find_all_wrapped_objects<'a>(
             }
         };
         let blob = value.borrow().simple_serialize(&layout).unwrap();
+        // TODO (annotated-visitor): Replace with a custom visitor.
         let move_value = MoveValue::simple_deserialize(&blob, &annotated_layout).unwrap();
         let uid = UID::type_();
         visit_structs(&move_value, |depth, tag, fields| {


### PR DESCRIPTION
## Description 

Adds a visitor for annotated Move values (finally!) 🙂 

## Test Plan 

Added additional tests + make sure CI passes. 

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
