### PR TITLE
[pruner] add smoothing option

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -569,6 +569,8 @@ pub struct AuthorityStorePruningConfig {
     /// disables object tombstone pruning. We don't serialize it if it is the default value, false.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub killswitch_tombstone_pruning: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub smooth: bool,
 }
 
 fn default_num_latest_epoch_dbs_to_retain() -> usize {
@@ -599,6 +601,7 @@ impl Default for AuthorityStorePruningConfig {
             periodic_compaction_threshold_days: None,
             num_epochs_to_retain_for_checkpoints: if cfg!(msim) { Some(2) } else { None },
             killswitch_tombstone_pruning: false,
+            smooth: false,
         }
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -133,7 +133,9 @@ use typed_store::TypedStoreError;
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
 use crate::authority::authority_store::{ExecutionLockReadGuard, ObjectLockStatus};
-use crate::authority::authority_store_pruner::AuthorityStorePruner;
+use crate::authority::authority_store_pruner::{
+    AuthorityStorePruner, EPOCH_DURATION_MS_FOR_TESTING,
+};
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::checkpoints::checkpoint_executor::CheckpointExecutor;
@@ -2724,6 +2726,7 @@ impl AuthorityState {
             metrics,
             config.indirect_objects_threshold,
             archive_readers,
+            EPOCH_DURATION_MS_FOR_TESTING,
         )
         .await
     }

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -50,6 +50,7 @@ static PERIODIC_PRUNING_TABLES: Lazy<BTreeSet<String>> = Lazy::new(|| {
     .map(|cf| cf.to_string())
     .collect()
 });
+pub const EPOCH_DURATION_MS_FOR_TESTING: u64 = 24 * 60 * 60 * 1000;
 pub struct AuthorityStorePruner {
     _objects_pruner_cancel_handle: oneshot::Sender<()>,
 }
@@ -307,12 +308,20 @@ impl AuthorityStorePruner {
         config: AuthorityStorePruningConfig,
         metrics: Arc<AuthorityStorePruningMetrics>,
         indirect_objects_threshold: usize,
+        epoch_duration_ms: u64,
     ) -> anyhow::Result<()> {
-        let max_eligible_checkpoint_number = checkpoint_store
+        let mut max_eligible_checkpoint_number = checkpoint_store
             .get_highest_executed_checkpoint()?
             .map(|c| *c.sequence_number())
             .unwrap_or_default();
         let pruned_checkpoint_number = perpetual_db.get_highest_pruned_checkpoint()?;
+        if config.smooth && config.num_epochs_to_retain > 0 {
+            max_eligible_checkpoint_number = Self::smoothed_max_eligible_checkpoint_number(
+                pruned_checkpoint_number,
+                max_eligible_checkpoint_number,
+                epoch_duration_ms,
+            );
+        }
         Self::prune_for_eligible_epochs(
             perpetual_db,
             checkpoint_store,
@@ -336,6 +345,7 @@ impl AuthorityStorePruner {
         metrics: Arc<AuthorityStorePruningMetrics>,
         indirect_objects_threshold: usize,
         archive_readers: ArchiveReaderBalancer,
+        epoch_duration_ms: u64,
     ) -> anyhow::Result<()> {
         let pruned_checkpoint_number =
             checkpoint_store.get_highest_pruned_checkpoint_seq_number()?;
@@ -343,7 +353,7 @@ impl AuthorityStorePruner {
             .get_archive_watermark()
             .await?
             .unwrap_or(u64::MAX);
-        let max_eligible_checkpoint = if config.num_epochs_to_retain != u64::MAX {
+        let mut max_eligible_checkpoint = if config.num_epochs_to_retain != u64::MAX {
             min(
                 perpetual_db.get_highest_pruned_checkpoint()?,
                 latest_archived_checkpoint,
@@ -351,6 +361,13 @@ impl AuthorityStorePruner {
         } else {
             latest_archived_checkpoint
         };
+        if config.smooth {
+            max_eligible_checkpoint = Self::smoothed_max_eligible_checkpoint_number(
+                pruned_checkpoint_number,
+                max_eligible_checkpoint,
+                epoch_duration_ms,
+            );
+        }
         debug!("Max eligible checkpoint {}", max_eligible_checkpoint);
         Self::prune_for_eligible_epochs(
             perpetual_db,
@@ -535,6 +552,29 @@ impl AuthorityStorePruner {
         Ok(Some(sst_file))
     }
 
+    fn pruning_tick_duration_ms(epoch_duration_ms: u64) -> u64 {
+        min(epoch_duration_ms / 2, 60 * 1000)
+    }
+
+    fn smoothed_max_eligible_checkpoint_number(
+        pruned_checkpoint: CheckpointSequenceNumber,
+        max_eligible_checkpoint: CheckpointSequenceNumber,
+        epoch_duration_ms: u64,
+    ) -> CheckpointSequenceNumber {
+        if max_eligible_checkpoint == 0 {
+            return max_eligible_checkpoint;
+        }
+        let num_intervals = epoch_duration_ms
+            .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
+            .unwrap_or(1);
+        let delta = max_eligible_checkpoint
+            .checked_sub(pruned_checkpoint)
+            .unwrap_or_default()
+            .checked_div(num_intervals)
+            .unwrap_or(1);
+        pruned_checkpoint + delta
+    }
+
     fn setup_pruning(
         config: AuthorityStorePruningConfig,
         epoch_duration_ms: u64,
@@ -551,7 +591,8 @@ impl AuthorityStorePruner {
             config.num_epochs_to_retain
         );
 
-        let tick_duration = Duration::from_millis(min(epoch_duration_ms / 2, 60 * 1000));
+        let tick_duration =
+            Duration::from_millis(Self::pruning_tick_duration_ms(epoch_duration_ms));
         let pruning_initial_delay = if cfg!(msim) {
             Duration::from_millis(1)
         } else {
@@ -600,12 +641,12 @@ impl AuthorityStorePruner {
             loop {
                 tokio::select! {
                     _ = objects_prune_interval.tick(), if config.num_epochs_to_retain != u64::MAX => {
-                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, &objects_lock_table, config, metrics.clone(), indirect_objects_threshold).await {
+                        if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, &objects_lock_table, config, metrics.clone(), indirect_objects_threshold, epoch_duration_ms).await {
                             error!("Failed to prune objects: {:?}", err);
                         }
                     },
                     _ = checkpoints_prune_interval.tick(), if !matches!(config.num_epochs_to_retain_for_checkpoints(), None | Some(u64::MAX) | Some(0)) => {
-                        if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, &objects_lock_table, config, metrics.clone(), indirect_objects_threshold, archive_readers.clone()).await {
+                        if let Err(err) = Self::prune_checkpoints_for_eligible_epochs(&perpetual_db, &checkpoint_store, &objects_lock_table, config, metrics.clone(), indirect_objects_threshold, archive_readers.clone(), epoch_duration_ms).await {
                             error!("Failed to prune checkpoints: {:?}", err);
                         }
                     },

--- a/crates/sui-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/sui-core/src/execution_cache/passthrough_cache.rs
@@ -4,7 +4,7 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store::{ExecutionLockWriteGuard, SuiLockResult};
 use crate::authority::authority_store_pruner::{
-    AuthorityStorePruner, AuthorityStorePruningMetrics,
+    AuthorityStorePruner, AuthorityStorePruningMetrics, EPOCH_DURATION_MS_FOR_TESTING,
 };
 use crate::authority::epoch_start_configuration::EpochFlag;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
@@ -91,6 +91,7 @@ impl PassthroughCache {
             pruning_config,
             AuthorityStorePruningMetrics::new_for_test(),
             usize::MAX,
+            EPOCH_DURATION_MS_FOR_TESTING,
         )
         .await;
         let _ = AuthorityStorePruner::compact(&self.store.perpetual_tables);

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -40,7 +40,7 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::authority_store::{ExecutionLockWriteGuard, SuiLockResult};
 use crate::authority::authority_store_pruner::{
-    AuthorityStorePruner, AuthorityStorePruningMetrics,
+    AuthorityStorePruner, AuthorityStorePruningMetrics, EPOCH_DURATION_MS_FOR_TESTING,
 };
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
@@ -723,6 +723,7 @@ impl WritebackCache {
             pruning_config,
             AuthorityStorePruningMetrics::new_for_test(),
             usize::MAX,
+            EPOCH_DURATION_MS_FOR_TESTING,
         )
         .await;
         let _ = AuthorityStorePruner::compact(&self.store.perpetual_tables);

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -15,7 +15,7 @@ use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_core::authority::authority_per_epoch_store::AuthorityEpochTables;
 use sui_core::authority::authority_store_pruner::{
-    AuthorityStorePruner, AuthorityStorePruningMetrics,
+    AuthorityStorePruner, AuthorityStorePruningMetrics, EPOCH_DURATION_MS_FOR_TESTING,
 };
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::authority::authority_store_types::{StoreData, StoreObject};
@@ -222,6 +222,7 @@ pub async fn prune_objects(db_path: PathBuf) -> anyhow::Result<()> {
         pruning_config,
         metrics,
         usize::MAX,
+        EPOCH_DURATION_MS_FOR_TESTING,
     )
     .await?;
     Ok(())
@@ -252,6 +253,7 @@ pub async fn prune_checkpoints(db_path: PathBuf) -> anyhow::Result<()> {
         metrics,
         usize::MAX,
         archive_readers,
+        EPOCH_DURATION_MS_FOR_TESTING,
     )
     .await?;
     Ok(())


### PR DESCRIPTION
The PR adds a smoothing option to the objects pruner. 
The implementation is very basic: the pruner aims to clear the backlog over the course of one epoch. 
On every tick (which is around 1 minute by default), it calculates the appropriate delta to prune. 
The delta is calculated as 
`(last_executed_checkpoint - last_pruned_checkpoint) / number_of_tick_intervals_per_epoch`






