### PR TITLE
[bridge 69/n] add pub function `get_token_transfer_action_signatures` to get signatures in one call

### DIFF
--- a/crates/sui-bridge/src/sui_mock_client.rs
+++ b/crates/sui-bridge/src/sui_mock_client.rs
@@ -216,6 +216,15 @@ impl SuiClientInner for SuiMockClient {
             .unwrap_or(BridgeActionStatus::Pending))
     }
 
+    async fn get_token_transfer_action_onchain_signatures(
+        &self,
+        _bridge_object_arg: ObjectArg,
+        _source_chain_id: u8,
+        _seq_number: u64,
+    ) -> Result<Option<Vec<Vec<u8>>>, BridgeError> {
+        unimplemented!()
+    }
+
     async fn execute_transaction_block_with_effects(
         &self,
         tx: Transaction,

--- a/crates/sui-framework/docs/bridge/bridge.md
+++ b/crates/sui-framework/docs/bridge/bridge.md
@@ -33,6 +33,7 @@ title: Module `0xb::bridge`
 -  [Function `execute_add_tokens_on_sui`](#0xb_bridge_execute_add_tokens_on_sui)
 -  [Function `get_current_seq_num_and_increment`](#0xb_bridge_get_current_seq_num_and_increment)
 -  [Function `get_token_transfer_action_status`](#0xb_bridge_get_token_transfer_action_status)
+-  [Function `get_token_transfer_action_signatures`](#0xb_bridge_get_token_transfer_action_signatures)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/ascii.md#0x1_ascii">0x1::ascii</a>;
@@ -1393,6 +1394,46 @@ title: Module `0xb::bridge`
     };
 
     <a href="bridge.md#0xb_bridge_TRANSFER_STATUS_PENDING">TRANSFER_STATUS_PENDING</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0xb_bridge_get_token_transfer_action_signatures"></a>
+
+## Function `get_token_transfer_action_signatures`
+
+
+
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_signatures">get_token_transfer_action_signatures</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_signatures">get_token_transfer_action_signatures</a>(
+    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    source_chain: u8,
+    bridge_seq_num: u64,
+): Option&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;&gt; {
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
+        source_chain,
+        <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
+        bridge_seq_num
+    );
+
+    <b>if</b> (!inner.token_transfer_records.contains(key)) {
+        <b>return</b> <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>()
+    };
+
+    <b>let</b> record = &inner.token_transfer_records[key];
+    record.verified_signatures
 }
 </code></pre>
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x4b1d4e0eca57e141ccacbb29350cfdca55065b70174451993a876f76a8b69020"
+            id: "0xbb68a06870c759ae2d77bc48f6f3f641c10e686b1406d616d7117e082bdb796e"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x8aec2438e5a34d4c5f4730d8b64a85ecb862828ff3f21a6d3b7e4712db921b9e"
+      operation_cap_id: "0xeb4d10ddf8ac4f73a180b5dec2041d435dd5666e376df923cd62b798a5eade42"
       gas_price: 1000
       staking_pool:
-        id: "0x126850b494874d72681f34bdcdf6d321ad9b99c3c9640c2676043e99ba920703"
+        id: "0xd472a59712598a2e3d3a6aafbe9cd0a302fc04ef0a7c9d3b6a330a6e88101256"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xe8fa727c4a67eb2494e78c18cc754b11334e9bd6d8a217580223510e7a157d79"
+          id: "0xcf55096ddc16c7457f15dc3b946941b82a0fcfce591971bf09d1dc357b2af1b2"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x6f1768dcd588b5d9e347a6dcd144d3e30b60a18a5790d93a97f3b2e56824fef6"
+            id: "0x0dff41c827fda3f2fa023735cb8a1cd1feee5fbc2d5abb1591b3e82bc2d56960"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x98c4d0e68fe268142de542227ac9c80abe046ff9fd3fa238894a5fc73175f2e2"
+          id: "0x43ae86a9f6a4f9711300f8a878c149b447b95ee102fb4f7d7d77b8afe284c9a9"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x8a1bfc178dad6e409047be40cf6189d66c92b5b8521100ea0ee1d9740f691626"
+      id: "0xde36b1332a5fe8356dea42d497a516f74e18ee709c86ee789464bee8ef2554d8"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x2fb067022f4bbf978bffb6560dc47a2f376b9865aa88f9ea73b1ff597309a3f1"
+    id: "0xb5dde421a4791a266b2e9b33c145b54da48dfc4dda23335078037c75d985518a"
     size: 1
   inactive_validators:
-    id: "0xb1b228f5c070bd1ca7ec4b26bed11a0c08495081714b7a122f44fcdc2d1ea800"
+    id: "0xdd05aead93d8c347cba2620764e4433800e70ab50111f6ebbf0d19a7e5ad5705"
     size: 0
   validator_candidates:
-    id: "0xba3504ab17724e03b31cd46ac7582651a800cf07c45839d2d391652f0aca9a8a"
+    id: "0x0a3a36a1d61ab20798394c51f7e7d316175737c2fdc4be31085e8e200d86a089"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x9e3cb04cd023b1742aae8e9b03c148190335fb9260f9a76e1e26778b4517ed05"
+      id: "0x480539d9f64a8270edb9c52da24e02e3620b358fc04de5bb949ad76e0d1fc232"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x9bfafc8febddfdab28fc38f8e8f4756a90492e8150c883743800cf22dc2a0d1c"
+      id: "0x194da01a9b47eef6aaa30918cc7d1e92ba1c041e93dcdaf8871e38e90a158cf4"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xa480b7043e4e1c97f9db41aca677f74b90eee4609ce39ebafba8d28f9958755d"
+      id: "0x8e634d3b3357cbb45d6bf45a49078eb01924014615ca01ea69ee33996767ee9a"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xfc3819a52bc84e358da619621478c139493208533d3bbe8f7978f6283ed1f0fb"
+    id: "0x672f9e3dde05b3a86f67dff42c6d3979af0c983ba462af0d5bbba58d3adeadf7"
   size: 0
 


### PR DESCRIPTION
## Description 

Combining it with `DevInspectResults` we can get signatures for a recorded transfer action.

Before this i have to do multiple calls to retrieves sigs. See the red lines replaced with `get_token_transfer_action_onchain_signatures_until_success`  call  in `basic.rs`. This will also make front end's life easier when getting sigs.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
