### PR TITLE
[Consensus] block stream subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.11.0",
  "tonic-build",
  "tower",

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -43,6 +43,10 @@ pub struct Parameters {
     /// Anemo network settings.
     #[serde(default = "AnemoParameters::default")]
     pub anemo: AnemoParameters,
+
+    /// Tonic network settings.
+    #[serde(default = "TonicParameters::default")]
+    pub tonic: TonicParameters,
 }
 
 impl Parameters {
@@ -55,7 +59,13 @@ impl Parameters {
     }
 
     pub fn default_min_round_delay() -> Duration {
-        Duration::from_millis(50)
+        if cfg!(msim) {
+            // Checkpoint building and execution cannot keep up with high commit rate in simtests,
+            // leading to long reconfiguration delays.
+            Duration::from_millis(200)
+        } else {
+            Duration::from_millis(50)
+        }
     }
 
     pub fn default_max_forward_time_drift() -> Duration {
@@ -82,6 +92,7 @@ impl Default for Parameters {
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
             db_path: None,
             anemo: AnemoParameters::default(),
+            tonic: TonicParameters::default(),
         }
     }
 }
@@ -93,7 +104,13 @@ pub struct AnemoParameters {
     ///
     /// If unspecified, this will default to 8 MiB.
     #[serde(default = "AnemoParameters::default_excessive_message_size")]
-    excessive_message_size: usize,
+    pub excessive_message_size: usize,
+}
+
+impl AnemoParameters {
+    fn default_excessive_message_size() -> usize {
+        8 << 20
+    }
 }
 
 impl Default for AnemoParameters {
@@ -104,12 +121,36 @@ impl Default for AnemoParameters {
     }
 }
 
-impl AnemoParameters {
-    pub fn excessive_message_size(&self) -> usize {
-        self.excessive_message_size
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TonicParameters {
+    /// Keepalive interval and timeouts for both client and server, tcp and http2.
+    ///
+    /// If unspecified, this will default to 10s.
+    #[serde(default = "TonicParameters::default_keepalive_interval")]
+    pub keepalive_interval: Duration,
+
+    /// Message size limits for both requests and responses.
+    ///
+    /// If unspecified, this will default to 8MiB.
+    #[serde(default = "TonicParameters::default_message_size_limit")]
+    pub message_size_limit: usize,
+}
+
+impl TonicParameters {
+    fn default_keepalive_interval() -> Duration {
+        Duration::from_secs(10)
     }
 
-    fn default_excessive_message_size() -> usize {
+    fn default_message_size_limit() -> usize {
         8 << 20
+    }
+}
+
+impl Default for TonicParameters {
+    fn default() -> Self {
+        Self {
+            keepalive_interval: TonicParameters::default_keepalive_interval(),
+            message_size_limit: TonicParameters::default_message_size_limit(),
+        }
     }
 }

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -61,7 +61,8 @@ impl Parameters {
     pub fn default_min_round_delay() -> Duration {
         if cfg!(msim) {
             // Checkpoint building and execution cannot keep up with high commit rate in simtests,
-            // leading to long reconfiguration delays.
+            // leading to long reconfiguration delays. This is because simtest is single threaded,
+            // and spending too much time in consensus can lead to starvation elsewhere.
             Duration::from_millis(200)
         } else {
             Duration::from_millis(50)
@@ -123,9 +124,9 @@ impl Default for AnemoParameters {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TonicParameters {
-    /// Keepalive interval and timeouts for both client and server, tcp and http2.
+    /// Keepalive interval and timeouts for both client and server.
     ///
-    /// If unspecified, this will default to 10s.
+    /// If unspecified, this will default to 5s.
     #[serde(default = "TonicParameters::default_keepalive_interval")]
     pub keepalive_interval: Duration,
 
@@ -138,7 +139,7 @@ pub struct TonicParameters {
 
 impl TonicParameters {
     fn default_keepalive_interval() -> Duration {
-        Duration::from_secs(10)
+        Duration::from_secs(5)
     }
 
     fn default_message_size_limit() -> usize {

--- a/consensus/config/tests/parameters_test.rs
+++ b/consensus/config/tests/parameters_test.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use consensus_config::Parameters;
-use insta::assert_yaml_snapshot;
-
 #[test]
+#[cfg(not(msim))]
 fn parameters_snapshot_matches() {
-    let parameters = Parameters::default();
-    assert_yaml_snapshot!("parameters", parameters)
+    let parameters = consensus_config::Parameters::default();
+    insta::assert_yaml_snapshot!("parameters", parameters)
 }

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -15,4 +15,8 @@ max_forward_time_drift:
 db_path: ~
 anemo:
   excessive_message_size: 8388608
-
+tonic:
+  keepalive_interval:
+    secs: 10
+    nanos: 0
+  message_size_limit: 8388608

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -17,6 +17,6 @@ anemo:
   excessive_message_size: 8388608
 tonic:
   keepalive_interval:
-    secs: 10
+    secs: 5
     nanos: 0
   message_size_limit: 8388608

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -36,6 +36,7 @@ tap.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -1,18 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    pin::{pin, Pin},
-    sync::Arc,
-    time::Duration,
-};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::AuthorityIndex;
-use futures::{ready, stream, task, Future as _, Stream, StreamExt};
+use futures::{ready, stream, task, Stream, StreamExt};
 use parking_lot::RwLock;
 use tokio::{sync::broadcast, time::sleep};
+use tokio_util::sync::ReusableBoxFuture;
 use tracing::{info, warn};
 
 use crate::{
@@ -33,7 +30,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     block_verifier: Arc<dyn BlockVerifier>,
     synchronizer: Arc<SynchronizerHandle>,
     core_dispatcher: Arc<C>,
-    tx_block_broadcaster: broadcast::Sender<VerifiedBlock>,
+    rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
     dag_state: Arc<RwLock<DagState>>,
 }
 
@@ -43,7 +40,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         block_verifier: Arc<dyn BlockVerifier>,
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
-        tx_block_broadcaster: broadcast::Sender<VerifiedBlock>,
+        rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         Self {
@@ -51,17 +48,21 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             block_verifier,
             synchronizer,
             core_dispatcher,
-            tx_block_broadcaster,
+            rx_block_broadcaster,
             dag_state,
         }
     }
+}
 
-    /// Handling the block sent from the peer via either unicast RPC or subscription stream.
-    pub(crate) async fn handle_received_block(
+#[async_trait]
+impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
+    async fn handle_send_block(
         &self,
         peer: AuthorityIndex,
         serialized_block: Bytes,
     ) -> ConsensusResult<()> {
+        let peer_hostname = &self.context.committee.authority(peer).hostname;
+
         // TODO: dedup block verifications, here and with fetched blocks.
         let signed_block: SignedBlock =
             bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
@@ -72,12 +73,14 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[&peer.to_string(), "send_block"])
+                .with_label_values(&[peer_hostname, "send_block"])
                 .inc();
             let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
             info!("Block with wrong authority from {}: {}", peer, e);
             return Err(e);
         }
+        // Specified peer can be trusted to be a valid authority index.
+        let peer_hostname = &self.context.committee.authority(peer).hostname;
 
         // Reject blocks failing validations.
         if let Err(e) = self.block_verifier.verify(&signed_block) {
@@ -85,7 +88,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[&peer.to_string(), "send_block"])
+                .with_label_values(&[peer_hostname, "send_block"])
                 .inc();
             info!("Invalid block from {}: {}", peer, e);
             return Err(e);
@@ -99,6 +102,12 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .saturating_sub(timestamp_utc_ms()),
         );
         if forward_time_drift > self.context.parameters.max_forward_time_drift {
+            self.context
+                .metrics
+                .node_metrics
+                .rejected_future_blocks
+                .with_label_values(&[&peer_hostname])
+                .inc();
             return Err(ConsensusError::BlockTooFarInFuture {
                 block_timestamp: verified_block.timestamp_ms(),
                 forward_time_drift,
@@ -111,17 +120,23 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .block_timestamp_drift_wait_ms
-                .with_label_values(&[&peer.to_string()])
+                .with_label_values(&[peer_hostname])
                 .inc_by(forward_time_drift.as_millis() as u64);
             sleep(forward_time_drift).await;
         }
+
+        self.context
+            .metrics
+            .node_metrics
+            .verified_blocks
+            .with_label_values(&[&peer_hostname])
+            .inc();
 
         let missing_ancestors = self
             .core_dispatcher
             .add_blocks(vec![verified_block])
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
-
         if !missing_ancestors.is_empty() {
             // schedule the fetching of them from this peer
             if let Err(err) = self
@@ -134,17 +149,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         }
 
         Ok(())
-    }
-}
-
-#[async_trait]
-impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
-    async fn handle_send_block(
-        &self,
-        peer: AuthorityIndex,
-        serialized_block: Bytes,
-    ) -> ConsensusResult<()> {
-        self.handle_received_block(peer, serialized_block).await
     }
 
     async fn handle_subscribe_blocks(
@@ -162,11 +166,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .into_iter()
                 .map(|block| block.serialized().clone()),
         );
-        let broadcasted_blocks = BroadcastedBlockStream {
-            peer,
-            receiver: self.tx_block_broadcaster.subscribe(),
-        };
-        Ok(Box::pin(missed_blocks.chain(broadcasted_blocks)))
+        let broadcasted_blocks =
+            BroadcastedBlockStream::new(peer, self.rx_block_broadcaster.resubscribe());
+        // Return a stream of blocks that first yields missed blocks as requested, then new blocks.
+        Ok(Box::pin(missed_blocks.chain(
+            broadcasted_blocks.map(|block| block.serialized().clone()),
+        )))
     }
 
     async fn handle_fetch_blocks(
@@ -208,36 +213,70 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 }
 
 /// Each broadcasted block stream wraps a broadcast receiver for blocks.
-/// It yields serialized blocks that are broadcasted after the stream is created.
-struct BroadcastedBlockStream {
+/// It yields blocks that are broadcasted after the stream is created.
+pub(crate) type BroadcastedBlockStream = BroadcastStream<VerifiedBlock>;
+
+/// Adapted from `tokio_stream::wrappers::BroadcastStream`. The main difference is that
+/// this tolerates lags with only logging, without yielding errors.
+pub(crate) struct BroadcastStream<T> {
     peer: AuthorityIndex,
-    receiver: broadcast::Receiver<VerifiedBlock>,
+    // Stores the receiver across poll_next() calls.
+    inner: ReusableBoxFuture<
+        'static,
+        (
+            Result<T, broadcast::error::RecvError>,
+            broadcast::Receiver<T>,
+        ),
+    >,
 }
 
-impl Stream for BroadcastedBlockStream {
-    type Item = Bytes;
+impl<T: 'static + Clone + Send> BroadcastStream<T> {
+    pub fn new(peer: AuthorityIndex, rx: broadcast::Receiver<T>) -> Self {
+        Self {
+            peer,
+            inner: ReusableBoxFuture::new(make_recv_future(rx)),
+        }
+    }
+}
+
+impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
+    type Item = T;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
     ) -> task::Poll<Option<Self::Item>> {
         let peer = self.peer;
-        loop {
-            let block = match ready!(pin!(self.receiver.recv()).poll(cx)) {
-                Ok(block) => Some(block.serialized().clone()),
+        let maybe_item = loop {
+            let (result, rx) = ready!(self.inner.poll(cx));
+            self.inner.set(make_recv_future(rx));
+            match result {
+                Ok(item) => break Some(item),
                 Err(broadcast::error::RecvError::Closed) => {
                     info!("Block BroadcastedBlockStream {} closed", peer);
-                    None
+                    break None;
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
-                    info!(
-                        "Block BroadcastedBlockStream {} lagged by {n} messages",
-                        peer
+                    warn!(
+                        "Block BroadcastedBlockStream {} lagged by {} messages",
+                        peer, n
                     );
                     continue;
                 }
-            };
-            return task::Poll::Ready(block);
-        }
+            }
+        };
+        task::Poll::Ready(maybe_item)
     }
 }
+
+async fn make_recv_future<T: Clone>(
+    mut rx: broadcast::Receiver<T>,
+) -> (
+    Result<T, broadcast::error::RecvError>,
+    broadcast::Receiver<T>,
+) {
+    let result = rx.recv().await;
+    (result, rx)
+}
+
+// TODO: add a unit test for BroadcastStream.

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -79,7 +79,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             info!("Block with wrong authority from {}: {}", peer, e);
             return Err(e);
         }
-        // Specified peer can be trusted to be a valid authority index.
         let peer_hostname = &self.context.committee.authority(peer).hostname;
 
         // Reject blocks failing validations.

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -77,7 +77,7 @@ impl Broadcaster {
         mut rx_block_broadcast: broadcast::Receiver<VerifiedBlock>,
         peer: AuthorityIndex,
     ) {
-        let peer_hostname = context.committee.authority(peer).hostname.clone();
+        let peer_hostname = &context.committee.authority(peer).hostname;
 
         // Record the last block to be broadcasted, to retry in case no new block is produced for awhile.
         // Even if the peer has acknowledged the last block, the block might have been dropped afterwards
@@ -179,7 +179,7 @@ impl Broadcaster {
                 .metrics
                 .node_metrics
                 .broadcaster_rtt_estimate_ms
-                .with_label_values(&[&peer_hostname])
+                .with_label_values(&[peer_hostname])
                 .set(rtt_estimate.as_millis() as i64);
         }
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -328,6 +328,7 @@ impl DagState {
 
     /// Returns cached recent blocks from the specified authority.
     /// Blocks returned is limited by both the `start` round, and if the blocks are cached.
+    /// NOTE: caller should not assume returned blocks are always chained.
     pub(crate) fn get_cached_blocks(
         &self,
         authority: AuthorityIndex,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -327,8 +327,10 @@ impl DagState {
     }
 
     /// Returns cached recent blocks from the specified authority.
-    /// Blocks returned is limited by both the `start` round, and if the blocks are cached.
+    /// Blocks returned are limited to round >= `start`, and cached.
     /// NOTE: caller should not assume returned blocks are always chained.
+    /// "Disconnected" blocks can be returned when there are byzantine blocks,
+    /// or when received blocks are not deduped.
     pub(crate) fn get_cached_blocks(
         &self,
         authority: AuthorityIndex,

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -22,6 +22,7 @@ mod metrics;
 mod network;
 mod stake_aggregator;
 mod storage;
+mod subscriber;
 mod synchronizer;
 #[cfg(test)]
 mod test_dag;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -88,6 +88,8 @@ pub(crate) struct NodeMetrics {
     pub fetch_blocks_scheduler_inflight: IntGauge,
     pub fetched_blocks: IntCounterVec,
     pub invalid_blocks: IntCounterVec,
+    pub rejected_future_blocks: IntCounterVec,
+    pub verified_blocks: IntCounterVec,
     pub committed_leaders_total: IntCounterVec,
     pub last_committed_leader_round: IntGauge,
     pub commit_round_advancement_interval: Histogram,
@@ -100,6 +102,8 @@ pub(crate) struct NodeMetrics {
     pub suspended_blocks: IntCounterVec,
     pub threshold_clock_round: IntGauge,
     pub unsuspended_blocks: IntCounterVec,
+    pub subscriber_connection_attempts: IntCounterVec,
+    pub subscriber_connections: IntGaugeVec,
     pub uptime: Histogram,
 }
 
@@ -189,6 +193,18 @@ impl NodeMetrics {
                 &["authority", "source"],
                 registry,
             ).unwrap(),
+            rejected_future_blocks: register_int_counter_vec_with_registry!(
+                "rejected_future_blocks",
+                "Number of blocks rejected because their timestamp is too far in the future",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            verified_blocks: register_int_counter_vec_with_registry!(
+                "verified_blocks",
+                "Number of blocks received from each peer that are verified",
+                &["authority"],
+                registry,
+            ).unwrap(),
             committed_leaders_total: register_int_counter_vec_with_registry!(
                 "committed_leaders_total",
                 "Total number of (direct or indirect) committed leaders per authority",
@@ -252,6 +268,18 @@ impl NodeMetrics {
             unsuspended_blocks: register_int_counter_vec_with_registry!(
                 "unsuspended_blocks",
                 "The number of unsuspended blocks",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            subscriber_connection_attempts: register_int_counter_vec_with_registry!(
+                "subscriber_connection_attempts",
+                "The number of connection attempts per peer",
+                &["authority", "status"],
+                registry,
+            ).unwrap(),
+            subscriber_connections: register_int_gauge_vec_with_registry!(
+                "subscriber_connections",
+                "The number of block stream connections breaking down by peer",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use consensus_config::AuthorityIndex;
+use futures::stream;
+use parking_lot::Mutex;
+
+use crate::{
+    block::BlockRef,
+    error::ConsensusResult,
+    network::{BlockStream, NetworkService},
+    Round,
+};
+
+pub(crate) struct TestService {
+    pub(crate) handle_send_block: Vec<(AuthorityIndex, Bytes)>,
+    pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+    pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
+    pub(crate) own_blocks: Vec<Bytes>,
+}
+
+impl TestService {
+    pub(crate) fn new() -> Self {
+        Self {
+            handle_send_block: Vec::new(),
+            handle_fetch_blocks: Vec::new(),
+            handle_subscribe_blocks: Vec::new(),
+            own_blocks: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_own_blocks(&mut self, blocks: Vec<Bytes>) {
+        self.own_blocks.extend(blocks);
+    }
+}
+
+#[async_trait]
+impl NetworkService for Mutex<TestService> {
+    async fn handle_send_block(&self, peer: AuthorityIndex, block: Bytes) -> ConsensusResult<()> {
+        let mut state = self.lock();
+        state.handle_send_block.push((peer, block));
+        Ok(())
+    }
+
+    async fn handle_subscribe_blocks(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+    ) -> ConsensusResult<BlockStream> {
+        let mut state = self.lock();
+        state.handle_subscribe_blocks.push((peer, last_received));
+        let own_blocks = state
+            .own_blocks
+            .iter()
+            // Let index in own_blocks be the round, and skip blocks <= last_received round.
+            .skip(last_received as usize + 1)
+            .cloned()
+            .collect::<Vec<_>>();
+        Ok(Box::pin(stream::iter(own_blocks)))
+    }
+
+    async fn handle_fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        self.lock().handle_fetch_blocks.push((peer, block_refs));
+        Ok(vec![])
+    }
+}

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -1,0 +1,285 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use consensus_config::AuthorityIndex;
+use futures::StreamExt;
+use mysten_metrics::spawn_monitored_task;
+use parking_lot::{Mutex, RwLock};
+use tokio::{task::JoinHandle, time::sleep};
+use tracing::{debug, error, info};
+
+use crate::{
+    block::BlockAPI as _,
+    context::Context,
+    dag_state::DagState,
+    network::{NetworkClient, NetworkService},
+    Round,
+};
+
+/// Subscriber manages the block stream subscriptions to other peers, taking care of retrying
+/// when subscription streams break. Blocks returned from the peer are sent to the authority
+/// service for processing.
+/// Currently subscription management for individual peer is not exposed, but it could become
+/// useful in future.
+pub(crate) struct Subscriber<C: NetworkClient, S: NetworkService> {
+    context: Arc<Context>,
+    network_client: Arc<C>,
+    authority_service: Arc<S>,
+    dag_state: Arc<RwLock<DagState>>,
+    subscriptions: Arc<Mutex<Box<[Option<JoinHandle<()>>]>>>,
+}
+
+impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        network_client: Arc<C>,
+        authority_service: Arc<S>,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> Self {
+        let subscriptions = (0..context.committee.size())
+            .map(|_| None)
+            .collect::<Vec<_>>();
+        Self {
+            context,
+            network_client,
+            authority_service,
+            dag_state,
+            subscriptions: Arc::new(Mutex::new(subscriptions.into_boxed_slice())),
+        }
+    }
+
+    pub(crate) fn subscribe(&self, peer: AuthorityIndex) {
+        if peer == self.context.own_index {
+            error!("Attempt to subscribe to own validator {peer} is ignored!");
+            return;
+        }
+        let context = self.context.clone();
+        let network_client = self.network_client.clone();
+        let authority_service = self.authority_service.clone();
+        let last_received = self
+            .dag_state
+            .read()
+            .get_last_block_for_authority(peer)
+            .round();
+
+        let mut subscriptions = self.subscriptions.lock();
+        self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
+        subscriptions[peer.value()] = Some(spawn_monitored_task!(Self::subscription_loop(
+            context,
+            network_client,
+            authority_service,
+            peer,
+            last_received,
+        )));
+        let peer_hostname = &self.context.committee.authority(peer).hostname;
+        self.context
+            .metrics
+            .node_metrics
+            .subscriber_connections
+            .with_label_values(&[peer_hostname])
+            .set(1);
+    }
+
+    pub(crate) fn stop(&self) {
+        let mut subscriptions = self.subscriptions.lock();
+        for (peer, _) in self.context.committee.authorities() {
+            self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);
+        }
+    }
+
+    fn unsubscribe_locked(&self, peer: AuthorityIndex, subscription: &mut Option<JoinHandle<()>>) {
+        let peer_hostname = &self.context.committee.authority(peer).hostname;
+        self.context
+            .metrics
+            .node_metrics
+            .subscriber_connections
+            .with_label_values(&[peer_hostname])
+            .set(0);
+        if let Some(subscription) = subscription.take() {
+            subscription.abort();
+        }
+    }
+
+    async fn subscription_loop(
+        context: Arc<Context>,
+        network_client: Arc<C>,
+        authority_service: Arc<S>,
+        peer: AuthorityIndex,
+        last_received: Round,
+    ) {
+        const IMMEDIATE_RETRIES: i64 = 3;
+        const INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+        const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+        const RETRY_INTERVAL_MULTIPLIER: f32 = 1.2;
+        let peer_hostname = &context.committee.authority(peer).hostname;
+        let mut retries: i64 = 0;
+        let mut delay = INITIAL_RETRY_INTERVAL;
+        'subscription: loop {
+            if retries > IMMEDIATE_RETRIES {
+                // When not immediately retrying, delay retries from 100ms and to 10s.
+                debug!(
+                    "Delaying retry {} to subscribe to blocks from peer {} in {} seconds",
+                    retries,
+                    peer,
+                    delay.as_secs_f32(),
+                );
+                sleep(delay).await;
+                delay = delay
+                    .mul_f32(RETRY_INTERVAL_MULTIPLIER)
+                    .min(MAX_RETRY_INTERVAL);
+            } else if retries > 0 {
+                // Retry immediately, but still yield to avoid monopolizing the thread.
+                tokio::task::yield_now().await;
+            } else {
+                // First attempt, reset delay for next retries but no waiting.
+                delay = INITIAL_RETRY_INTERVAL;
+            }
+            let mut blocks = match network_client
+                .subscribe_blocks(peer, last_received, MAX_RETRY_INTERVAL)
+                .await
+            {
+                Ok(blocks) => {
+                    context
+                        .metrics
+                        .node_metrics
+                        .subscriber_connection_attempts
+                        .with_label_values(&[&peer_hostname, "success"])
+                        .inc();
+                    blocks
+                }
+                Err(e) => {
+                    debug!("Failed to subscribe to blocks from peer {}: {}", peer, e);
+                    context
+                        .metrics
+                        .node_metrics
+                        .subscriber_connection_attempts
+                        .with_label_values(&[&peer_hostname, "failure"])
+                        .inc();
+                    retries += 1;
+                    continue 'subscription;
+                }
+            };
+            'stream: loop {
+                match blocks.next().await {
+                    Some(block) => {
+                        let result = authority_service
+                            .handle_send_block(peer, block.clone())
+                            .await;
+                        if let Err(e) = result {
+                            info!(
+                                "Failed to process block from peer {}: {}. Block: {:?}",
+                                peer, e, block,
+                            );
+                        }
+                        // Reset retries when a block is received.
+                        retries = 0;
+                    }
+                    None => {
+                        debug!("Subscription to blocks from peer {} ended", peer);
+                        retries += 1;
+                        break 'stream;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use anemo::async_trait;
+    use bytes::Bytes;
+    use futures::stream;
+
+    use super::*;
+    use crate::{
+        block::{BlockRef, VerifiedBlock},
+        error::ConsensusResult,
+        network::{test_network::TestService, BlockStream},
+        storage::mem_store::MemStore,
+    };
+
+    struct SubscriberTestClient {}
+
+    impl SubscriberTestClient {
+        fn new() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl NetworkClient for SubscriberTestClient {
+        const SUPPORT_STREAMING: bool = true;
+
+        async fn send_block(
+            &self,
+            _peer: AuthorityIndex,
+            _block: &VerifiedBlock,
+            _timeout: Duration,
+        ) -> ConsensusResult<()> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn subscribe_blocks(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockStream> {
+            let block_stream = stream::unfold((), |_| async {
+                sleep(Duration::from_millis(1)).await;
+                Some((Bytes::from(vec![1u8; 8]), ()))
+            })
+            .take(10);
+            Ok(Box::pin(block_stream))
+        }
+
+        async fn fetch_blocks(
+            &self,
+            _peer: AuthorityIndex,
+            _block_refs: Vec<BlockRef>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!("Unimplemented")
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn subscriber_retries() {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let authority_service = Arc::new(Mutex::new(TestService::new()));
+        let network_client = Arc::new(SubscriberTestClient::new());
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let subscriber = Subscriber::new(
+            context.clone(),
+            network_client,
+            authority_service.clone(),
+            dag_state,
+        );
+
+        let peer = context.committee.to_authority_index(2).unwrap();
+        subscriber.subscribe(peer);
+
+        // Wait for enough blocks received.
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let service = authority_service.lock();
+            if service.handle_send_block.len() >= 100 {
+                break;
+            }
+        }
+
+        // Even if the stream ends after 10 blocks, the subscriber should retry and get enough
+        // blocks eventually.
+        let service = authority_service.lock();
+        assert!(service.handle_send_block.len() >= 100);
+        for (p, block) in service.handle_send_block.iter() {
+            assert_eq!(*p, peer);
+            assert_eq!(*block, Bytes::from(vec![1u8; 8]));
+        }
+    }
+}

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -92,13 +92,11 @@ impl ConsensusManagerTrait for MysticetiManager {
         let epoch = epoch_store.epoch();
         let protocol_config = epoch_store.protocol_config();
         let network_type = match std::env::var("CONSENSUS_NETWORK") {
-            Ok(type_str) => {
-                if type_str.to_lowercase() == "tonic" {
-                    NetworkType::Tonic
-                } else {
-                    NetworkType::Anemo
-                }
-            }
+            Ok(type_str) => match type_str.to_lowercase().as_str() {
+                "tonic" => NetworkType::Tonic,
+                "anemo" => NetworkType::Anemo,
+                _ => NetworkType::Anemo,
+            },
             Err(_) => NetworkType::Anemo,
         };
 


### PR DESCRIPTION
## Description 

Implements block subscription with stream block responses via tonic.
From experiments, this is shown to reduce latency jitters, especially between hosts in different continents.

Also, enable keepalive and message size limits in tonic.

## Test Plan 

CI
Private testnet

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
