### PR TITLE
chore: update protocol config

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1359,7 +1359,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "42",
+              "maxSupportedProtocolVersion": "43",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_zklogin_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -115,6 +115,7 @@ const MAX_PROTOCOL_VERSION: u64 = 43;
 // Version 40:
 // Version 41: Enable group operations native functions in testnet and mainnet (without msm).
 // Version 42: Migrate sui framework and related code to Move 2024
+// Version 43: Introduce the upper bound delta config for a zklogin signature's max epoch. 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 42;
+const MAX_PROTOCOL_VERSION: u64 = 43;
 
 // Record history of protocol version allocations here:
 //
@@ -2059,7 +2059,8 @@ impl ProtocolConfig {
                     cfg.group_ops_bls12381_msm_max_len = Some(32);
                     cfg.group_ops_bls12381_pairing_cost = Some(52);
                 }
-                42 => {
+                42 => {}
+                43 => {
                     cfg.feature_flags.zklogin_max_epoch_upper_bound_delta = Some(30);
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -115,7 +115,7 @@ const MAX_PROTOCOL_VERSION: u64 = 43;
 // Version 40:
 // Version 41: Enable group operations native functions in testnet and mainnet (without msm).
 // Version 42: Migrate sui framework and related code to Move 2024
-// Version 43: Introduce the upper bound delta config for a zklogin signature's max epoch. 
+// Version 43: Introduce the upper bound delta config for a zklogin signature's max epoch.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_42.snap
@@ -41,7 +41,6 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_43.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 42
+version: 43
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -36,13 +36,12 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
-  accept_zklogin_in_multisig: true
-  include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_43.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 42
+version: 43
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -43,6 +43,7 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_42.snap
@@ -46,7 +46,6 @@ feature_flags:
   enable_group_ops_native_functions: true
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
-  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_43.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 42
+version: 43
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  random_beacon: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
@@ -40,9 +41,12 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
+  zklogin_max_epoch_upper_bound_delta: 30
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -217,6 +221,8 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 52
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 10
 group_ops_bls12381_decode_scalar_cost: 52
 group_ops_bls12381_decode_g1_cost: 52
 group_ops_bls12381_decode_g2_cost: 52
@@ -259,6 +265,8 @@ consensus_bad_nodes_stake_threshold: 20
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 1600
+random_beacon_dkg_timeout_round: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
 

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 42
+  protocol_version: 43
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 42
+protocol_version: 43
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x62adcc806020b4f9e7fb7ab1cf0448e0b0ad926d136971d67bb372cfc8475885"
+            id: "0x7a53da1ab16d36835d32fb0b9f069177850468627a0674f43ef00f219775bcbf"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x25e08da45b8c058b43e780186294e035dbfb9d577fb344816bfb88dc02e5fb13"
+      operation_cap_id: "0xa35d51c60b50e3ea9a1d692d8232792bfc31311d0f536cca58a26f8bb2209066"
       gas_price: 1000
       staking_pool:
-        id: "0x36a34b5a3e61721e569b93c83376471739d996323bac81bb62cf692b6d356340"
+        id: "0x0a7ab5fc2d76a32333b1dd2ccc6ae09a0da2d98309ca380aef1a929b6418ff2e"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x3b70ffe10f9a22714e5ec0567fe1dad8e0467aefc280dcb9398991a8a1f6ec9a"
+          id: "0xc8ac4858f8e089c75a9da2bb8adcde10a86c00aeec2e59124eb06e63be6b7d92"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x8a687d88204a80df85c6383bdb4abb685586b464975267a88ea43a06fef5f302"
+            id: "0xb4085c2be8191ebbdc037d5092657951e57d915641a8b5a15b98d7f8d8000193"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xa162660b14cb002551bccdf2ae81c2b200e4e084a93a85e79e6848e1aef0f5bf"
+          id: "0x0b3692d645aeb8ced1102eb4a0b3d3b3953fc9b5b7ed1e6e1c585e215fd4ccff"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x5e122abc785d560c494c783bd1f892cbe48103e843217a9b882a613fb9d189da"
+      id: "0x57b39c7a756ba502c74825ae434e53efa96a69a61da8136960b0095d572600a7"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x2ea44ba530bf36481ba58f8a7a8243dfb09c09e17fa0422df4848a96db2d440e"
+    id: "0xbe0e6b01a2855784335e17ffc04573d079f011d0b1d3ea1fb2851a47742fa9db"
     size: 1
   inactive_validators:
-    id: "0xa1f670083f6cef392b4d0929884ef729f974c751b37f885f736f3eac0f380cd1"
+    id: "0x82452941db36daa9f331fb77efa46dec22865e84578bfbdac397070da05ff800"
     size: 0
   validator_candidates:
-    id: "0x447b9c369379682d1896b52353358f467d4862d6ea1077096f954a86dfcb254d"
+    id: "0xb51d5a837fcaa13b5a711f7a6492c0753d68d73aff97065828a8d499e9c28941"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x64f2da6bfbb4200affb071f702572c37b6cdbd2f2024cb66ad8baae21d8d649e"
+      id: "0x2acd751e7c8905767be429469f5e41e3a2af7d96cc55491b0b6c98a6edb558b2"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x45887eac71d53ee6791b8d4b0e6b6bbe2b441f32f210b7d433a12b4904c8f7d2"
+      id: "0x69219e53cdee9d242c9e46b639100282eecd71458de1bc1cc70c46fd85672d02"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x4e7f9e8c7cd03b5a1ab909968e70b8c4acad298a54077646183e07bbde02a0f2"
+      id: "0xf987d231a4d09efd784ff01da0a7ea8e0a3f5498b12f2b5ca547960a28bf89d2"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc86804d07944a1c0d99e897e22725556a2bff112f2c9f670f977f030cd332666"
+    id: "0x97a70561f28ea5c21824bbed837646e7dc08b9d0d16fad4f7d5c934fbbf8b89b"
   size: 0
+


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test Plan 
```
eugene@eugene-dev ~/code/sui (bump-protocol-config) $ ./scripts/compatibility/check-protocol-compatibility.sh testnet
Found following versions on testnet:
     40 1.22.0-036299745992
     25 1.21.1-5f2bfb15ea0a
     20 1.22.0-0362997459
      8 1.21.1-5f2bfb15ea
      1 1.21.1-cf708afc5fe9

Using most frequent version 1.22.0-036299745992 for compatibility check
Checking protocol compatibility with testnet (036299745992)
Checking out testnet snapshot files
Checking for changes to snapshot files matching *__Testnet_version_*
HEAD is now at b8435cf3b8 chore: update protocol config
Running snapshot tests...
   Compiling syn v2.0.48
   Compiling syn v1.0.107
   Compiling darling_core v0.14.2
   Compiling serde_derive_internals v0.26.0
   Compiling sui-protocol-config-macros v0.1.0 (/home/eugene/code/sui/crates/sui-protocol-config-macros)
   Compiling schemars_derive v0.8.12
   Compiling thiserror-impl v1.0.56
   Compiling serde_derive v1.0.190
   Compiling tracing-attributes v0.1.27
   Compiling clap_derive v4.4.0
   Compiling darling_macro v0.14.2
   Compiling thiserror v1.0.56
   Compiling pest v2.7.2
   Compiling tracing v0.1.40
   Compiling darling v0.14.2
   Compiling serde_with_macros v2.1.0
   Compiling clap v4.4.1
   Compiling pest_meta v2.5.2
   Compiling serde v1.0.190
   Compiling pest_generator v2.5.2
   Compiling pest_derive v2.5.2
   Compiling serde_json v1.0.95
   Compiling insta v1.26.0
   Compiling serde_with v2.1.0
   Compiling schemars v0.8.12
   Compiling sui-protocol-config v0.1.0 (/home/eugene/code/sui/crates/sui-protocol-config)
    Finished test [unoptimized + debuginfo] target(s) in 8.54s
     Running unittests src/lib.rs (target/debug/deps/sui_protocol_config-b2b07029980b4bfd)

running 1 test
test test::snapshot_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.34s
```

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Update protocol config to 43 for max epoch upper bound for zklogin txn. 