### PR TITLE
[move-ide] Added support for building and testing

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -35,6 +35,16 @@
 				"command": "move.serverVersion",
 				"title": "Show Server Version",
 				"category": "Move"
+			},
+			{
+				"command": "move.build",
+				"title": "Build a Move package",
+				"category": "Move"
+			},
+			{
+				"command": "move.test",
+				"title": "Test a Move package",
+				"category": "Move"
 			}
 		],
 		"configuration": {
@@ -54,6 +64,15 @@
                     "scope": "machine-overridable",
                     "default": null,
                     "markdownDescription": "Path to rust-analyzer executable (points to `~/.sui/bin/move-analyzer` by default)."
+				},
+				"move.sui.path": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "scope": "machine-overridable",
+                    "default": null,
+                    "markdownDescription": "Path to Sui executable (by default assumes that `sui` is on the systems path)."
 				},
 				"move.trace.server": {
 					"type": "string",
@@ -89,7 +108,13 @@
 		"menus": {
 			"commandPalette": [
 				{
-					"command": "move.serverVersion"
+					"command": "sui.serverVersion"
+				},
+				{
+					"command": "sui.build"
+				},
+				{
+					"command": "sui.test"
 				}
 			]
 		}

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -4,7 +4,7 @@
 
 import * as os from 'os';
 import * as vscode from 'vscode';
-import * as Path from 'path';
+import * as path from 'path';
 import { log } from './log';
 import { assert } from 'console';
 
@@ -49,7 +49,20 @@ export class Configuration {
         if (serverPath.startsWith('~/')) {
             return os.homedir() + serverPath.slice('~'.length);
         }
-        return Path.resolve(serverPath);
+        return path.resolve(serverPath);
+    }
+
+    /** The path to the Sui binary. */
+    get suiPath(): string {
+        const suiBin = 'sui';
+        const suiPath = this.configuration.get<string | null >('sui.path') ?? suiBin;
+        if (suiPath === suiBin) {
+            return suiPath;
+        }
+        if (suiPath.startsWith('~/')) {
+            return os.homedir() + suiPath.slice('~'.length);
+        }
+        return path.resolve(suiPath);
     }
 
     /**

--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -8,6 +8,8 @@ import { Extension } from './extension';
 import { log } from './log';
 
 import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import * as commands from './commands';
 
@@ -32,6 +34,73 @@ async function serverVersion(context: Readonly<Context>): Promise<void> {
         );
     }
 }
+
+async function findPkgRoot(): Promise<string | undefined> {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+        await vscode.window.showErrorMessage('Cannot find package manifest (no active editor window)');
+        return undefined;
+    }
+
+    const containsManifest = (dir: string): boolean => {
+        const filesInDir = fs.readdirSync(dir);
+        return filesInDir.includes('Move.toml');
+    };
+
+    const activeFileDir = path.dirname(activeEditor.document.uri.fsPath);
+    let currentDir = activeFileDir;
+    while (currentDir !== path.parse(currentDir).root) {
+        if (containsManifest(currentDir)) {
+            return currentDir;
+        }
+        currentDir = path.resolve(currentDir, '..');
+    }
+
+    if (containsManifest(currentDir)) {
+        return currentDir;
+    }
+
+    await vscode.window.showErrorMessage(`Cannot find package manifest for file in '${activeFileDir}' directory`);
+    return undefined;
+}
+
+async function suiMoveCmd(context: Readonly<Context>, cmd: string): Promise<void> {
+    const version = childProcess.spawnSync(
+        context.configuration.suiPath, ['--version'], { encoding: 'utf8' },
+    );
+    if (version.stdout) {
+        const pkgRoot = await findPkgRoot();
+        if (pkgRoot !== undefined) {
+            const terminalName = `sui move`;
+            let terminal = vscode.window.terminals.find(t => t.name === terminalName);
+            if (!terminal) {
+                terminal = vscode.window.createTerminal(terminalName);
+            }
+            terminal.show(true);
+            terminal.sendText('cd ' + pkgRoot, true);
+            terminal.sendText(`sui move ${cmd}`, true);
+        }
+    } else {
+        await vscode.window.showErrorMessage(
+            `A problem occurred when executing the Sui command: '${context.configuration.suiPath}'`,
+        );
+    }
+}
+
+/**
+ * An extension command that that builds the current Move project.
+ */
+async function buildProject(context: Readonly<Context>): Promise<void> {
+    return suiMoveCmd(context, 'build');
+}
+
+/**
+ * An extension command that that builds the current Move project.
+ */
+async function testProject(context: Readonly<Context>): Promise<void> {
+    return suiMoveCmd(context, 'test');
+}
+
 
 /**
  * The entry point to this VS Code extension.
@@ -111,6 +180,8 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
 
     // Register handlers for VS Code commands that the user explicitly issues.
     context.registerCommand('serverVersion', serverVersion);
+    context.registerCommand('build', buildProject);
+    context.registerCommand('test', testProject);
 
     // Configure other language features.
     context.configureLanguage();


### PR DESCRIPTION
## Description 

This PR adds support for building and locally testing Move code using Command Palette.

## Test Plan 

Tested manually that the build and test commands work.
