### PR TITLE
[move] Make error message for invalid field access nicer

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2086,9 +2086,8 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
         sp!(_, Apply(_, sp!(_, ModuleType(m, n)), targs)) => {
             if !context.is_current_module(&m) {
                 let msg = format!(
-                    "Invalid access of field '{}' on '{}::{}'. Fields can only be accessed inside \
-                     the struct's module",
-                    field, &m, &n
+                    "Invalid access of field '{field}' on the struct '{m}::{n}'. The field '{field}' can only \
+                    be accessed within the module '{m}' since it defines '{n}'"
                 );
                 context
                     .env

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/dot_call_private_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/dot_call_private_field.exp
@@ -2,5 +2,5 @@ error[E04001]: restricted visibility
    ┌─ tests/move_2024/typing/dot_call_private_field.move:13:5
    │
 13 │     y.x.f()
-   │     ^^^ Invalid access of field 'x' on '0x42::t::Y'. Fields can only be accessed inside the struct's module
+   │     ^^^ Invalid access of field 'x' on the struct '0x42::t::Y'. The field 'x' can only be accessed within the module '0x42::t' since it defines 'Y'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/borrow_field_internal.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/borrow_field_internal.exp
@@ -2,11 +2,11 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/borrow_field_internal.move:13:11
    │
 13 │         (&X::s().f: &u64);
-   │           ^^^^^^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │           ^^^^^^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 
 error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/borrow_field_internal.move:15:11
    │
 15 │         (&s.f: &u64);
-   │           ^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │           ^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/implicit_deref_borrow_field_internal.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/implicit_deref_borrow_field_internal.exp
@@ -2,11 +2,11 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/implicit_deref_borrow_field_internal.move:13:10
    │
 13 │         (X::s().f: u64);
-   │          ^^^^^^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │          ^^^^^^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 
 error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/implicit_deref_borrow_field_internal.move:15:10
    │
 15 │         (s.f: u64);
-   │          ^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │          ^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/mutate_field_internal.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/mutate_field_internal.exp
@@ -2,11 +2,11 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/mutate_field_internal.move:13:9
    │
 13 │         X::s().f = 0;
-   │         ^^^^^^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │         ^^^^^^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 
 error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/mutate_field_internal.move:15:9
    │
 15 │         s.f = 0;
-   │         ^^^ Invalid access of field 'f' on '0x2::X::S'. Fields can only be accessed inside the struct's module
+   │         ^^^ Invalid access of field 'f' on the struct '0x2::X::S'. The field 'f' can only be accessed within the module '0x2::X' since it defines 'S'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/native_structs_pack_unpack.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/native_structs_pack_unpack.exp
@@ -34,7 +34,7 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/native_structs_pack_unpack.move:15:18
    │
 15 │         let _f = c.f;
-   │                  ^^^ Invalid access of field 'f' on '0x42::C::T'. Fields can only be accessed inside the struct's module
+   │                  ^^^ Invalid access of field 'f' on the struct '0x42::C::T'. The field 'f' can only be accessed within the module '0x42::C' since it defines 'T'
 
 error[E03010]: unbound field
    ┌─ tests/move_check/typing/native_structs_pack_unpack.move:15:18

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/unused_struct_field.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/unused_struct_field.exp
@@ -2,5 +2,5 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/unused_struct_field.move:63:57
    │
 63 │     public fun flaky(x: 0x42::private_struct::S): u64 { x.f }
-   │                                                         ^^^ Invalid access of field 'f' on '0x42::private_struct::S'. Fields can only be accessed inside the struct's module
+   │                                                         ^^^ Invalid access of field 'f' on the struct '0x42::private_struct::S'. The field 'f' can only be accessed within the module '0x42::private_struct' since it defines 'S'
 

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/unused_struct_field.unused.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/unused_struct_field.unused.exp
@@ -26,5 +26,5 @@ error[E04001]: restricted visibility
    ┌─ tests/move_check/typing/unused_struct_field.move:63:57
    │
 63 │     public fun flaky(x: 0x42::private_struct::S): u64 { x.f }
-   │                                                         ^^^ Invalid access of field 'f' on '0x42::private_struct::S'. Fields can only be accessed inside the struct's module
+   │                                                         ^^^ Invalid access of field 'f' on the struct '0x42::private_struct::S'. The field 'f' can only be accessed within the module '0x42::private_struct' since it defines 'S'
 


### PR DESCRIPTION
## Description 

Attempts to make the error message for an invalid field access (outside of the declaring module) a bit nicer and easier to understand.

## Test Plan 

Updated existing tests.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Made error messages for accessing struct fields outside of the declaring module nicer.
