### PR TITLE
[consensus] Add LeaderSwapTable & ReputationScores

### DIFF
--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -80,6 +80,15 @@ impl Committee {
         self.authorities[authority_index].stake
     }
 
+    pub fn authority_index(&self, authority: &Authority) -> AuthorityIndex {
+        AuthorityIndex(
+            self.authorities
+                .iter()
+                .position(|a| a == authority)
+                .expect("Authority not found in the committee!") as u32,
+        )
+    }
+
     pub fn authority(&self, authority_index: AuthorityIndex) -> &Authority {
         &self.authorities[authority_index]
     }
@@ -129,7 +138,7 @@ impl Committee {
 ///
 /// NOTE: this is intentionally un-cloneable, to encourage only copying relevant fields.
 /// AuthorityIndex should be used to reference an authority instead.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Authority {
     /// Voting power of the authority in the committee.
     pub stake: Stake,

--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -80,15 +80,6 @@ impl Committee {
         self.authorities[authority_index].stake
     }
 
-    pub fn authority_index(&self, authority: &Authority) -> AuthorityIndex {
-        AuthorityIndex(
-            self.authorities
-                .iter()
-                .position(|a| a == authority)
-                .expect("Authority not found in the committee!") as u32,
-        )
-    }
-
     pub fn authority(&self, authority_index: AuthorityIndex) -> &Authority {
         &self.authorities[authority_index]
     }
@@ -138,7 +129,7 @@ impl Committee {
 ///
 /// NOTE: this is intentionally un-cloneable, to encourage only copying relevant fields.
 /// AuthorityIndex should be used to reference an authority instead.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Authority {
     /// Voting power of the authority in the committee.
     pub stake: Stake,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -20,6 +20,7 @@ use crate::{
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
     network::{
@@ -213,8 +214,14 @@ where
             store.clone(),
         );
 
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+
         let core = Core::new(
             context.clone(),
+            leader_schedule,
             tx_consumer,
             block_manager,
             commit_observer,

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -52,7 +52,7 @@ pub(crate) struct BaseCommitter {
     context: Arc<Context>,
     /// The consensus leader schedule to be used to resolve the leader for a
     /// given round.
-    leader_schedule: LeaderSchedule,
+    leader_schedule: Arc<LeaderSchedule>,
     /// In memory block store representing the dag state
     dag_state: Arc<RwLock<DagState>>,
     /// The options used by this committer
@@ -62,7 +62,7 @@ pub(crate) struct BaseCommitter {
 impl BaseCommitter {
     pub fn new(
         context: Arc<Context>,
-        leader_schedule: LeaderSchedule,
+        leader_schedule: Arc<LeaderSchedule>,
         dag_state: Arc<RwLock<DagState>>,
         options: BaseCommitterOptions,
     ) -> Self {
@@ -444,7 +444,10 @@ mod base_committer_builder {
             };
             BaseCommitter::new(
                 self.context.clone(),
-                LeaderSchedule::new(self.context, LeaderSwapTable::default()),
+                Arc::new(LeaderSchedule::new(
+                    self.context,
+                    LeaderSwapTable::default(),
+                )),
                 self.dag_state,
                 options,
             )

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -397,6 +397,7 @@ impl Display for BaseCommitter {
 #[cfg(test)]
 mod base_committer_builder {
     use super::*;
+    use crate::leader_schedule::LeaderSwapTable;
 
     pub(crate) struct BaseCommitterBuilder {
         context: Arc<Context>,
@@ -443,7 +444,7 @@ mod base_committer_builder {
             };
             BaseCommitter::new(
                 self.context.clone(),
-                LeaderSchedule::new(self.context),
+                LeaderSchedule::new(self.context, LeaderSwapTable::default()),
                 self.dag_state,
                 options,
             )

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -174,7 +174,7 @@ mod tests {
         commit::DEFAULT_WAVE_LENGTH,
         context::Context,
         dag_state::DagState,
-        leader_schedule::LeaderSchedule,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
         test_dag::{build_dag, get_all_uncommitted_leader_blocks},
     };
@@ -189,7 +189,7 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();
@@ -279,7 +279,7 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();
@@ -416,7 +416,7 @@ mod tests {
             context.clone(),
             mem_store.clone(),
         )));
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
         let last_processed_commit_round = 0;
         let last_processed_commit_index = 0;
         let (sender, mut receiver) = unbounded_channel();

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -13,8 +13,6 @@ use parking_lot::RwLock;
 use tokio::sync::{broadcast, watch};
 use tracing::{debug, info, warn};
 
-use crate::stake_aggregator::{QuorumThreshold, StakeAggregator};
-use crate::transaction::TransactionGuard;
 use crate::{
     block::{
         timestamp_utc_ms, Block, BlockAPI, BlockRef, BlockTimestampMs, BlockV1, Round, SignedBlock,
@@ -25,8 +23,9 @@ use crate::{
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
     threshold_clock::ThresholdClock,
-    transaction::TransactionConsumer,
+    transaction::{TransactionConsumer, TransactionGuard},
     universal_committer::{
         universal_committer_builder::UniversalCommitterBuilder, UniversalCommitter,
     },
@@ -579,8 +578,7 @@ mod test {
 
     use super::*;
     use crate::{
-        block::genesis_blocks,
-        block::TestBlock,
+        block::{genesis_blocks, TestBlock},
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI as _,
         storage::{mem_store::MemStore, Store, WriteBatch},

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -186,6 +186,7 @@ mod test {
         context::Context,
         core::CoreSignals,
         dag_state::DagState,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
         transaction::{TransactionClient, TransactionConsumer},
         CommitConsumer,
@@ -214,8 +215,13 @@ mod test {
             dag_state.clone(),
             store,
         );
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
         let core = Core::new(
             context.clone(),
+            leader_schedule,
             transaction_consumer,
             block_manager,
             commit_observer,

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -1,26 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 
+use consensus_config::{Authority, AuthorityIndex, Stake};
+use parking_lot::RwLock;
 use rand::{prelude::SliceRandom, rngs::StdRng, SeedableRng};
 
-use consensus_config::AuthorityIndex;
+use crate::{context::Context, leader_scoring::ReputationScores, Round};
 
-use crate::context::Context;
-
-/// The LeaderSchedule is responsible for producing the leader schedule across
-/// an epoch. For now it is a simple wrapper around Context to provide a leader
-/// for a round deterministically.
-// TODO: complete full leader schedule changes
+/// The `LeaderSchedule` is responsible for producing the leader schedule across
+/// an epoch. The leader schedule is subject to change periodically based on
+/// calculated `ReputationScores` of the authorities.
 #[derive(Clone)]
 pub(crate) struct LeaderSchedule {
     context: Arc<Context>,
+    #[allow(unused)]
+    num_commits_per_schedule: u64,
+    leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
 }
 
+#[allow(unused)]
 impl LeaderSchedule {
-    pub fn new(context: Arc<Context>) -> Self {
-        Self { context }
+    /// The window where the schedule change takes place in consensus. It represents
+    /// number of committed sub dags.
+    /// TODO: move this to protocol config
+    const CONSENSUS_COMMITS_PER_SCHEDULE: u64 = 300;
+
+    pub(crate) fn new(context: Arc<Context>, leader_swap_table: LeaderSwapTable) -> Self {
+        Self {
+            context,
+            num_commits_per_schedule: Self::CONSENSUS_COMMITS_PER_SCHEDULE,
+            leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
+        }
     }
 
     pub fn elect_leader(&self, round: u32, leader_offset: u32) -> AuthorityIndex {
@@ -28,9 +44,13 @@ impl LeaderSchedule {
             // TODO: we need to differentiate the leader strategy in tests, so for
             // some type of testing (ex sim tests) we can use the staked approach.
             if #[cfg(test)] {
-                AuthorityIndex::new_for_test((round + leader_offset) % self.context.committee.size() as u32)
+                let leader = AuthorityIndex::new_for_test((round + leader_offset) % self.context.committee.size() as u32);
+                let table = self.leader_swap_table.read();
+                table.swap(&leader, round, leader_offset).unwrap_or(leader)
             } else {
-                self.elect_leader_stake_based(round, leader_offset)
+                let leader = self.elect_leader_stake_based(round, leader_offset);
+                let table = self.leader_swap_table.read();
+                table.swap(&leader, round, leader_offset).unwrap_or(leader)
             }
         }
     }
@@ -63,28 +83,209 @@ impl LeaderSchedule {
 
         leader_index
     }
+
+    /// Atomically updates the `LeaderSwapTable` with the new provided one. Any
+    /// leader queried from now on will get calculated according to this swap
+    /// table until a new one is provided again.
+    fn update_leader_swap_table(&self, table: LeaderSwapTable) {
+        tracing::trace!("Updating {:?}", table);
+
+        let mut write = self.leader_swap_table.write();
+        *write = table;
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct LeaderSwapTable {
+    /// The list of `f` (by stake) authorities with best scores as those defined
+    /// by the provided `ReputationScores`. Those authorities will be used in the
+    /// position of the `bad_nodes` on the final leader schedule.
+    pub good_nodes: Vec<(AuthorityIndex, Authority)>,
+
+    /// The set of `f` (by stake) authorities with the worst scores as those defined
+    /// by the provided `ReputationScores`. Every time where such authority is elected
+    /// as leader on the schedule, it will swapped by one of the authorities of the
+    /// `good_nodes`.
+    pub bad_nodes: HashMap<AuthorityIndex, Authority>,
+
+    // The scores for which the leader swap table was built from. This struct is
+    // used for debugging purposes. Once `good_nodes` & `bad_nodes` are identified
+    // the `reputation_scores` are no longer needed functionally for the swap table.
+    pub reputation_scores: ReputationScores,
+}
+
+#[allow(unused)]
+impl LeaderSwapTable {
+    // Constructs a new table based on the provided reputation scores. The
+    // `bad_nodes_stake_threshold` designates the total (by stake) nodes that
+    // will be considered as "bad" based on their scores and will be replaced by
+    // good nodes. The `bad_nodes_stake_threshold` should be in the range of [0 - 33].
+    pub fn new(
+        context: Arc<Context>,
+        reputation_scores: ReputationScores,
+        bad_nodes_stake_threshold: u64,
+    ) -> Self {
+        assert!(
+            (0..=33).contains(&bad_nodes_stake_threshold),
+            "The bad_nodes_stake_threshold should be in range [0 - 33], out of bounds parameter detected"
+        );
+
+        // Calculating the good nodes
+        let good_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            reputation_scores
+                .authorities_by_score_desc(context.clone())
+                .into_iter(),
+            bad_nodes_stake_threshold,
+        )
+        .into_iter()
+        .map(|authority| (context.committee.authority_index(&authority), authority))
+        .collect::<Vec<(AuthorityIndex, Authority)>>();
+
+        // Calculating the bad nodes
+        // Reverse the sorted authorities to score ascending so we get the first
+        // low scorers up to the provided stake threshold.
+        let bad_nodes = Self::retrieve_first_nodes(
+            context.clone(),
+            reputation_scores
+                .authorities_by_score_desc(context.clone())
+                .into_iter()
+                .rev(),
+            bad_nodes_stake_threshold,
+        )
+        .into_iter()
+        .map(|authority| (context.committee.authority_index(&authority), authority))
+        .collect::<HashMap<AuthorityIndex, Authority>>();
+
+        good_nodes.iter().for_each(|(idx, good_node)| {
+            tracing::debug!(
+                "Good node {} with score {} for {:?}",
+                good_node.hostname,
+                reputation_scores.scores_per_authority[idx.to_owned()],
+                reputation_scores.commit_range,
+            );
+        });
+
+        bad_nodes.iter().for_each(|(idx, bad_node)| {
+            tracing::debug!(
+                "Bad node {} with score {} for {:?}",
+                bad_node.hostname,
+                reputation_scores.scores_per_authority[idx.to_owned()],
+                reputation_scores.commit_range,
+            );
+        });
+
+        tracing::debug!("Scores used for new LeaderSwapTable: {reputation_scores:?}");
+
+        Self {
+            good_nodes,
+            bad_nodes,
+            reputation_scores,
+        }
+    }
+
+    /// Checks whether the provided leader is a bad performer and needs to be
+    /// swapped in the schedule with a good performer. If not, then the method
+    /// returns None. Otherwise the leader to swap with is returned instead. The
+    /// `leader_round` & `leader_offset` represents the DAG slot on which the
+    /// provided `AuthorityIndex` is a leader on and is used as a seed to random
+    /// function in order to calculate the good node that will swap in that round
+    /// with the bad node. We are intentionally not doing weighted randomness as
+    /// we want to give to all the good nodes equal opportunity to get swapped
+    /// with bad nodes and nothave one node with enough stake end up swapping
+    /// bad nodes more frequently than the others on the final schedule.
+    pub fn swap(
+        &self,
+        leader: &AuthorityIndex,
+        leader_round: Round,
+        leader_offset: u32,
+    ) -> Option<AuthorityIndex> {
+        if self.bad_nodes.contains_key(leader) {
+            let mut seed_bytes = [0u8; 32];
+            seed_bytes[24..28].copy_from_slice(&leader_round.to_le_bytes());
+            seed_bytes[28..32].copy_from_slice(&leader_offset.to_le_bytes());
+            let mut rng = StdRng::from_seed(seed_bytes);
+
+            let (idx, _good_node) = self
+                .good_nodes
+                .choose(&mut rng)
+                .expect("There should be at least one good node available");
+
+            tracing::trace!(
+                "Swapping bad leader {} -> {} for round {}",
+                leader,
+                idx,
+                leader_round
+            );
+
+            return Some(*idx);
+        }
+        None
+    }
+
+    /// Retrieves the first nodes provided by the iterator `authorities` until the
+    /// `stake_threshold` has been reached. The `stake_threshold` should be between
+    /// [0, 100] and expresses the percentage of stake that is considered the cutoff.
+    /// It's the caller's responsibility to ensure that the elements of the `authorities`
+    /// input is already sorted.
+    fn retrieve_first_nodes(
+        context: Arc<Context>,
+        authorities: impl Iterator<Item = (AuthorityIndex, u64)>,
+        stake_threshold: u64,
+    ) -> Vec<Authority> {
+        let mut filtered_authorities = Vec::new();
+
+        let mut stake = 0;
+        for (authority_idx, _score) in authorities {
+            stake += context.committee.stake(authority_idx);
+
+            // If the total accumulated stake has surpassed the stake threshold
+            // then we omit this last authority and we exit the loop. Important to
+            // note that this means if the threshold is too low we may not have
+            // any nodes returned.
+            if stake > (stake_threshold * context.committee.total_stake()) / 100 as Stake {
+                break;
+            }
+
+            let authority = context.committee.authority(authority_idx).to_owned();
+            filtered_authorities.push(authority);
+        }
+
+        filtered_authorities
+    }
+}
+
+impl Debug for LeaderSwapTable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!(
+            "LeaderSwapTable for {:?}, good_nodes:{:?} with stake:{}, bad_nodes:{:?} with stake:{}",
+            self.reputation_scores.commit_range,
+            self.good_nodes
+                .iter()
+                .map(|(idx, _auth)| idx.to_owned())
+                .collect::<Vec<AuthorityIndex>>(),
+            self.good_nodes
+                .iter()
+                .map(|(_idx, auth)| auth.stake)
+                .sum::<Stake>(),
+            self.bad_nodes.keys().map(|idx| idx.to_owned()),
+            self.bad_nodes
+                .values()
+                .map(|auth| auth.stake)
+                .sum::<Stake>(),
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use consensus_config::{local_committee_and_keys, Parameters};
-    use sui_protocol_config::ProtocolConfig;
-
     use super::*;
-    use crate::metrics::test_metrics;
+    use crate::commit::CommitRange;
 
     #[test]
     fn test_elect_leader() {
-        let committee = local_committee_and_keys(0, vec![1, 1, 1, 1]).0;
-        let metrics = test_metrics();
-        let context = Arc::new(Context::new(
-            AuthorityIndex::new_for_test(0),
-            committee,
-            Parameters::default(),
-            ProtocolConfig::get_for_min_version(),
-            metrics,
-        ));
-        let leader_schedule = LeaderSchedule::new(context);
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = LeaderSchedule::new(context, LeaderSwapTable::default());
 
         assert_eq!(
             leader_schedule.elect_leader(0, 0),
@@ -107,16 +308,8 @@ mod tests {
 
     #[test]
     fn test_elect_leader_stake_based() {
-        let committee = local_committee_and_keys(0, vec![1, 1, 1, 1]).0;
-        let metrics = test_metrics();
-        let context = Arc::new(Context::new(
-            AuthorityIndex::new_for_test(0),
-            committee,
-            Parameters::default(),
-            ProtocolConfig::get_for_min_version(),
-            metrics,
-        ));
-        let leader_schedule = LeaderSchedule::new(context);
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = LeaderSchedule::new(context, LeaderSwapTable::default());
 
         assert_eq!(
             leader_schedule.elect_leader_stake_based(0, 0),
@@ -135,5 +328,102 @@ mod tests {
             leader_schedule.elect_leader_stake_based(1, 1),
             leader_schedule.elect_leader_stake_based(1, 2)
         );
+    }
+
+    #[test]
+    fn test_leader_swap_table() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+
+        let bad_nodes_stake_threshold = 33;
+        let reputation_scores = ReputationScores::new(
+            CommitRange::new(0..10),
+            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
+        );
+        let leader_swap_table =
+            LeaderSwapTable::new(context, reputation_scores, bad_nodes_stake_threshold);
+
+        assert_eq!(leader_swap_table.good_nodes.len(), 1);
+        assert_eq!(
+            leader_swap_table.good_nodes[0].0,
+            AuthorityIndex::new_for_test(3)
+        );
+        assert_eq!(leader_swap_table.bad_nodes.len(), 1);
+        assert!(leader_swap_table
+            .bad_nodes
+            .contains_key(&AuthorityIndex::new_for_test(0)));
+    }
+
+    #[test]
+    fn test_leader_swap_table_swap() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+
+        let bad_nodes_stake_threshold = 33;
+        let reputation_scores = ReputationScores::new(
+            CommitRange::new(0..10),
+            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
+        );
+        let leader_swap_table = LeaderSwapTable::new(
+            context.clone(),
+            reputation_scores,
+            bad_nodes_stake_threshold,
+        );
+
+        // Test swapping a bad leader
+        let leader = AuthorityIndex::new_for_test(0);
+        let leader_round = 0;
+        let leader_offset = 0;
+        let swapped_leader = leader_swap_table.swap(&leader, leader_round, leader_offset);
+        assert_eq!(swapped_leader, Some(AuthorityIndex::new_for_test(3)));
+
+        // Test not swapping a good leader
+        let leader = AuthorityIndex::new_for_test(1);
+        let leader_round = 0;
+        let leader_offset = 0;
+        let swapped_leader = leader_swap_table.swap(&leader, leader_round, leader_offset);
+        assert_eq!(swapped_leader, None);
+    }
+
+    #[test]
+    fn test_leader_swap_table_retrieve_first_nodes() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+
+        let authorities = vec![
+            (AuthorityIndex::new_for_test(0), 1),
+            (AuthorityIndex::new_for_test(1), 2),
+            (AuthorityIndex::new_for_test(2), 3),
+            (AuthorityIndex::new_for_test(3), 4),
+        ];
+
+        let stake_threshold = 50;
+        let filtered_authorities = LeaderSwapTable::retrieve_first_nodes(
+            context.clone(),
+            authorities.into_iter(),
+            stake_threshold,
+        );
+
+        assert_eq!(filtered_authorities.len(), 2);
+        assert!(filtered_authorities
+            .contains(context.committee.authority(AuthorityIndex::new_for_test(0))));
+        assert!(filtered_authorities
+            .contains(context.committee.authority(AuthorityIndex::new_for_test(1))));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "The bad_nodes_stake_threshold should be in range [0 - 33], out of bounds parameter detected"
+    )]
+    fn test_leader_swap_table_bad_nodes_stake_threshold_out_of_bounds() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+
+        let bad_nodes_stake_threshold = 34;
+        let reputation_scores = ReputationScores::new(
+            CommitRange::new(0..10),
+            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
+        );
+        LeaderSwapTable::new(context, reputation_scores, bad_nodes_stake_threshold);
     }
 }

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cmp::Ordering, fmt::Debug, sync::Arc};
+
+use consensus_config::AuthorityIndex;
+
+use crate::{commit::CommitRange, context::Context};
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub(crate) struct ReputationScores {
+    /// Score per authority. Vec index is the `AuthorityIndex`.
+    pub scores_per_authority: Vec<u64>,
+    // The range of commits these scores were calculated from.
+    pub commit_range: CommitRange,
+}
+
+#[allow(unused)]
+impl ReputationScores {
+    pub(crate) fn new(commit_range: CommitRange, scores_per_authority: Vec<u64>) -> Self {
+        Self {
+            scores_per_authority,
+            commit_range,
+        }
+    }
+
+    // Returns the authorities in score descending order.
+    pub fn authorities_by_score_desc(&self, context: Arc<Context>) -> Vec<(AuthorityIndex, u64)> {
+        let mut authorities: Vec<_> = self
+            .scores_per_authority
+            .iter()
+            .enumerate()
+            .map(|(index, score)| {
+                (
+                    context
+                        .committee
+                        .to_authority_index(index)
+                        .expect("Should be a valid AuthorityIndex"),
+                    *score,
+                )
+            })
+            .collect();
+
+        authorities.sort_by(|a1, a2| {
+            match a2.1.cmp(&a1.1) {
+                Ordering::Equal => {
+                    // we resolve the score equality deterministically by ordering in authority
+                    // identifier order descending.
+                    a2.0.cmp(&a1.0)
+                }
+                result => result,
+            }
+        });
+
+        authorities
+    }
+
+    pub(crate) fn update_metrics(&self, context: Arc<Context>) {
+        let authorities = self.authorities_by_score_desc(context.clone());
+        for (authority_index, score) in authorities {
+            let authority = context.committee.authority(authority_index);
+            if !authority.hostname.is_empty() {
+                context
+                    .metrics
+                    .node_metrics
+                    .reputation_scores
+                    .with_label_values(&[&authority.hostname])
+                    .set(score as i64);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reputation_scores_authorities_by_score_desc() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let scores = ReputationScores::new(CommitRange::new(1..300), vec![4, 1, 1, 3]);
+        let authorities = scores.authorities_by_score_desc(context);
+        assert_eq!(
+            authorities,
+            vec![
+                (AuthorityIndex::new_for_test(0), 4),
+                (AuthorityIndex::new_for_test(3), 3),
+                (AuthorityIndex::new_for_test(2), 1),
+                (AuthorityIndex::new_for_test(1), 1)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_reputation_scores_update_metrics() {
+        let context = Arc::new(Context::new_for_test(4).0);
+        let scores = ReputationScores::new(CommitRange::new(1..300), vec![1, 2, 4, 3]);
+        scores.update_metrics(context.clone());
+        let metrics = context.metrics.node_metrics.reputation_scores.clone();
+        assert_eq!(
+            metrics
+                .get_metric_with_label_values(&["test_host_0"])
+                .unwrap()
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .get_metric_with_label_values(&["test_host_1"])
+                .unwrap()
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .get_metric_with_label_values(&["test_host_2"])
+                .unwrap()
+                .get(),
+            4
+        );
+        assert_eq!(
+            metrics
+                .get_metric_with_label_values(&["test_host_3"])
+                .unwrap()
+                .get(),
+            3
+        );
+    }
+}

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -17,6 +17,7 @@ mod core_thread;
 mod dag_state;
 mod error;
 mod leader_schedule;
+mod leader_scoring;
 mod leader_timeout;
 mod linearizer;
 mod metrics;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -142,7 +142,7 @@ mod tests {
     use crate::{
         commit::{CommitAPI as _, CommitDigest, DEFAULT_WAVE_LENGTH},
         context::Context,
-        leader_schedule::LeaderSchedule,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,
         test_dag::{build_dag, get_all_uncommitted_leader_blocks},
     };
@@ -157,7 +157,7 @@ mod tests {
             Arc::new(MemStore::new()),
         )));
         let mut linearizer = Linearizer::new(dag_state.clone());
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
@@ -207,7 +207,7 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
         let mut linearizer = Linearizer::new(dag_state.clone());
         let wave_length = DEFAULT_WAVE_LENGTH;
 

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -3,13 +3,14 @@
 
 use std::sync::Arc;
 
-use crate::network::metrics::{NetworkRouteMetrics, QuinnConnectionMetrics};
 use prometheus::{
     register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Histogram,
     HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
+
+use crate::network::metrics::{NetworkRouteMetrics, QuinnConnectionMetrics};
 
 // starts from 1μs, 50μs, 100μs...
 const FINE_GRAINED_LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -99,6 +100,7 @@ pub(crate) struct NodeMetrics {
     pub leader_timeout_total: IntCounter,
     pub missing_blocks_total: IntGauge,
     pub quorum_receive_latency: Histogram,
+    pub reputation_scores: IntGaugeVec,
     pub scope_processing_time: HistogramVec,
     pub sub_dags_per_commit_count: Histogram,
     pub block_suspensions: IntCounterVec,
@@ -264,6 +266,12 @@ impl NodeMetrics {
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
                 registry
+            ).unwrap(),
+            reputation_scores: register_int_gauge_vec_with_registry!(
+                "reputation_scores",
+                "Reputation scores for each authority",
+                &["authority"],
+                registry,
             ).unwrap(),
             scope_processing_time: register_histogram_vec_with_registry!(
                 "scope_processing_time",

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -16,7 +16,7 @@ use crate::{
     commit::DEFAULT_WAVE_LENGTH,
     context::Context,
     dag_state::DagState,
-    leader_schedule::LeaderSchedule,
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
 };
 
 /// DagBuilder API
@@ -88,7 +88,7 @@ pub(crate) struct DagBuilder {
 #[allow(unused)]
 impl DagBuilder {
     pub(crate) fn new(context: Arc<Context>) -> Self {
-        let leader_schedule = LeaderSchedule::new(context.clone());
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
         let genesis_blocks = genesis_blocks(context.clone());
         let genesis: BTreeMap<BlockRef, VerifiedBlock> = genesis_blocks
             .into_iter()

--- a/consensus/core/src/tests/pipelined_committer_tests.rs
+++ b/consensus/core/src/tests/pipelined_committer_tests.rs
@@ -11,6 +11,7 @@ use crate::{
     commit::{LeaderStatus, DEFAULT_WAVE_LENGTH},
     context::Context,
     dag_state::DagState,
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
     universal_committer::universal_committer_builder::UniversalCommitterBuilder,
@@ -776,11 +777,16 @@ fn basic_test_setup() -> (
         context.clone(),
         Arc::new(MemStore::new()),
     )));
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        context.clone(),
+        LeaderSwapTable::default(),
+    ));
 
     // Create committer with pipelining and only 1 leader per leader round
-    let committer = UniversalCommitterBuilder::new(context.clone(), dag_state.clone())
-        .with_pipeline(true)
-        .build();
+    let committer =
+        UniversalCommitterBuilder::new(context.clone(), leader_schedule, dag_state.clone())
+            .with_pipeline(true)
+            .build();
 
     // note: with pipelining and without multi-leader enabled there should be
     // three committers.

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -360,13 +360,21 @@ fn indirect_commit() {
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
     )));
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        dag_builder.context.clone(),
+        LeaderSwapTable::default(),
+    ));
 
     dag_builder.print();
     dag_builder.persist_all_blocks(dag_state.clone());
 
     // Create committer without pipelining and only 1 leader per leader round
-    let committer =
-        UniversalCommitterBuilder::new(dag_builder.context.clone(), dag_state.clone()).build();
+    let committer = UniversalCommitterBuilder::new(
+        dag_builder.context.clone(),
+        leader_schedule,
+        dag_state.clone(),
+    )
+    .build();
     // note: without pipelining or multi-leader enabled there should only be one committer.
     assert!(committer.committers.len() == 1);
 
@@ -743,10 +751,18 @@ fn basic_dag_builder_test_setup() -> TestSetup {
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
     )));
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        dag_builder.context.clone(),
+        LeaderSwapTable::default(),
+    ));
 
     // Create committer without pipelining and only 1 leader per leader round
-    let committer =
-        UniversalCommitterBuilder::new(dag_builder.context.clone(), dag_state.clone()).build();
+    let committer = UniversalCommitterBuilder::new(
+        dag_builder.context.clone(),
+        leader_schedule,
+        dag_state.clone(),
+    )
+    .build();
     // note: without pipelining or multi-leader enabled there should only be one committer.
     assert!(committer.committers.len() == 1);
 

--- a/consensus/core/src/tests/universal_committer_tests.rs
+++ b/consensus/core/src/tests/universal_committer_tests.rs
@@ -11,6 +11,7 @@ use crate::{
     commit::LeaderStatus,
     context::Context,
     dag_state::DagState,
+    leader_schedule::{LeaderSchedule, LeaderSwapTable},
     storage::mem_store::MemStore,
     test_dag::{build_dag, build_dag_layer},
     test_dag_builder::DagBuilder,
@@ -711,9 +712,14 @@ fn basic_test_setup() -> (
         context.clone(),
         Arc::new(MemStore::new()),
     )));
+    let leader_schedule = Arc::new(LeaderSchedule::new(
+        context.clone(),
+        LeaderSwapTable::default(),
+    ));
 
     // Create committer without pipelining and only 1 leader per leader round
-    let committer = UniversalCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+    let committer =
+        UniversalCommitterBuilder::new(context.clone(), leader_schedule, dag_state.clone()).build();
 
     // note: without pipelining or multi-leader enabled there should only be one committer.
     assert!(committer.committers.len() == 1);

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -131,14 +131,13 @@ impl UniversalCommitter {
 pub(crate) mod universal_committer_builder {
     use super::*;
     use crate::{
-        base_committer::BaseCommitterOptions,
-        commit::DEFAULT_WAVE_LENGTH,
-        leader_schedule::{LeaderSchedule, LeaderSwapTable},
+        base_committer::BaseCommitterOptions, commit::DEFAULT_WAVE_LENGTH,
+        leader_schedule::LeaderSchedule,
     };
 
     pub(crate) struct UniversalCommitterBuilder {
         context: Arc<Context>,
-        leader_schedule: LeaderSchedule,
+        leader_schedule: Arc<LeaderSchedule>,
         dag_state: Arc<RwLock<DagState>>,
         wave_length: Round,
         number_of_leaders: usize,
@@ -146,8 +145,11 @@ pub(crate) mod universal_committer_builder {
     }
 
     impl UniversalCommitterBuilder {
-        pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-            let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+        pub(crate) fn new(
+            context: Arc<Context>,
+            leader_schedule: Arc<LeaderSchedule>,
+            dag_state: Arc<RwLock<DagState>>,
+        ) -> Self {
             Self {
                 context,
                 leader_schedule,

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -131,8 +131,9 @@ impl UniversalCommitter {
 pub(crate) mod universal_committer_builder {
     use super::*;
     use crate::{
-        base_committer::BaseCommitterOptions, commit::DEFAULT_WAVE_LENGTH,
-        leader_schedule::LeaderSchedule,
+        base_committer::BaseCommitterOptions,
+        commit::DEFAULT_WAVE_LENGTH,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
     };
 
     pub(crate) struct UniversalCommitterBuilder {
@@ -146,7 +147,7 @@ pub(crate) mod universal_committer_builder {
 
     impl UniversalCommitterBuilder {
         pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-            let leader_schedule = LeaderSchedule::new(context.clone());
+            let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
             Self {
                 context,
                 leader_schedule,


### PR DESCRIPTION
## Description 
This is one of many PRs to implement Leader Scoring & Leader Schedule feature for Mysticeti.
- [Design Doc](https://www.notion.so/mystenlabs/Leader-Schedule-Scoring-538c65cb370b4644944a94485efc4979?pvs=4)
- [Prototype PR](https://github.com/MystenLabs/sui/pull/16975)

Notes:
- `LeaderSwapTable` & `ReputationScores` are mostly the same from the NW implementation
- Kept the `Authority` & `ReputationScores` info in `LeaderSwapTable` mostly for debugging purposes. It is not required functionally

![Screenshot 2024-04-02 at 11 47 28 PM](https://github.com/MystenLabs/sui/assets/97870774/a1a0f0ad-bb4e-4054-9f39-9dcc1137dc7e)

## Test Plan 

unit tests
