### PR TITLE
Update h2 to 0.3.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5052,9 +5052,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
## Description 

Fix to:
```
error[vulnerability] Degradation of service in h2 servers with CONTINUATION Flood
```

## Test Plan 

`cargo deny check advisories` must pass
