### PR TITLE
[move-2024] Allow spacing in some type argument positions

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -524,19 +524,25 @@ fn parse_name_access_chain<'a, F: Fn() -> &'a str>(
     item_description: F,
 ) -> Result<NameAccessChain, Box<Diagnostic>> {
     ok_with_loc!(context, {
-        let global_name = if context.tokens.peek() == Tok::ColonColon {
-            context.tokens.advance()?;
-            true
-        } else {
-            false
-        };
         parse_name_access_chain_(
             context,
             macros_allowed,
             tyargs_allowed,
-            global_name,
+            false,
             item_description,
         )?
+    })
+}
+
+// Parse a module access allowing whitespace for type arguments.
+// Implicitly allows parsing of type arguments.
+fn parse_name_access_chain_with_tyarg_whitespace<'a, F: Fn() -> &'a str>(
+    context: &mut Context,
+    macros_allowed: bool,
+    item_description: F,
+) -> Result<NameAccessChain, Box<Diagnostic>> {
+    ok_with_loc!(context, {
+        parse_name_access_chain_(context, macros_allowed, true, true, item_description)?
     })
 }
 
@@ -545,13 +551,22 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
     context: &mut Context,
     macros_allowed: bool,
     tyargs_allowed: bool,
-    global_name: bool,
+    tyargs_whitespace_allowed: bool,
     item_description: F,
 ) -> Result<NameAccessChain_, Box<Diagnostic>> {
     use LeadingNameAccess_ as LN;
+
+    let global_name = if context.tokens.peek() == Tok::ColonColon {
+        context.tokens.advance()?;
+        true
+    } else {
+        false
+    };
+
     let ln = parse_leading_name_access_(context, global_name, &item_description)?;
 
-    let (mut is_macro, mut tys) = parse_macro_opt_and_tyargs_opt(context, ln.loc)?;
+    let (mut is_macro, mut tys) =
+        parse_macro_opt_and_tyargs_opt(context, tyargs_whitespace_allowed, ln.loc)?;
     if let Some(loc) = &is_macro {
         if !macros_allowed {
             let msg = format!(
@@ -632,7 +647,8 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
             " after an address in a module access chain",
         )?;
         let name = parse_identifier(context)?;
-        let (mut is_macro, mut tys) = parse_macro_opt_and_tyargs_opt(context, name.loc)?;
+        let (mut is_macro, mut tys) =
+            parse_macro_opt_and_tyargs_opt(context, tyargs_whitespace_allowed, name.loc)?;
         if let Some(loc) = &is_macro {
             if !macros_allowed {
                 context.env.add_diag(diag!(
@@ -667,6 +683,7 @@ fn parse_name_access_chain_<'a, F: Fn() -> &'a str>(
 
 fn parse_macro_opt_and_tyargs_opt(
     context: &mut Context,
+    tyargs_whitespace_allowed: bool,
     end_loc: Loc,
 ) -> Result<(Option<Loc>, Option<Spanned<Vec<Type>>>), Box<Diagnostic>> {
     let mut is_macro = None;
@@ -683,7 +700,9 @@ fn parse_macro_opt_and_tyargs_opt(
     //   treat it as the start of a list of type arguments.
     // Otherwise, assume that the '<' is a boolean operator.
     let _start_loc = context.tokens.start_loc();
-    if context.tokens.peek() == Tok::Less && (context.at_end(end_loc) || is_macro.is_some()) {
+    if context.tokens.peek() == Tok::Less
+        && (context.at_end(end_loc) || is_macro.is_some() || tyargs_whitespace_allowed)
+    {
         let start_loc = context.tokens.start_loc();
         let loc = make_loc(context.tokens.file_hash(), start_loc, start_loc);
         let tys_ = parse_optional_type_args(context)
@@ -1035,12 +1054,9 @@ fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
     // The item description specified here should include the special case above for
     // variable names, because if the current context cannot be parsed as a struct name
     // it is possible that the user intention was to use a variable name.
-    let ty = parse_name_access_chain(
-        context,
-        /* macros */ false,
-        /* tyargs */ true,
-        || "a variable or struct name",
-    )?;
+    let ty = parse_name_access_chain_with_tyarg_whitespace(context, /* macros */ false, || {
+        "a variable or struct name"
+    })?;
     let args = if context.tokens.peek() == Tok::LParen {
         let current_loc = current_token_loc(context.tokens);
         context.env.check_feature(
@@ -2312,7 +2328,7 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
 
 fn parse_type_(
     context: &mut Context,
-    _whitespace_sensitive_ty_args: bool,
+    whitespace_sensitive_ty_args: bool,
 ) -> Result<Type, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
     let t = match context.tokens.peek() {
@@ -2371,12 +2387,20 @@ fn parse_type_(
             ));
         }
         _ => {
-            let tn = parse_name_access_chain(
-                context,
-                /* macros */ false,
-                /* tyargs */ true,
-                || "a type name",
-            )?;
+            let tn = if whitespace_sensitive_ty_args {
+                parse_name_access_chain(
+                    context,
+                    /* macros */ false,
+                    /* tyargs */ true,
+                    || "a type name",
+                )?
+            } else {
+                parse_name_access_chain_with_tyarg_whitespace(
+                    context,
+                    /* macros */ false,
+                    || "a type name",
+                )?
+            };
             Type_::Apply(Box::new(tn))
         }
     };

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/complex_as.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/complex_as.exp
@@ -1,0 +1,8 @@
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_2024/parser/complex_as.move:6:18
+  │
+6 │         let _x = x as Cup<u8>;
+  │                  ^    ------- Found: '0x42::m::Cup<u8>'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+  │                  │     
+  │                  Invalid argument to 'as'
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/complex_as.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/complex_as.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    public struct Cup<T>(T)
+
+    fun main(x: u64): bool {
+        let _x = x as Cup<u8>;
+        x as u64 < 0
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/positional_struct_explicit_type_args.exp
@@ -1,12 +1,3 @@
-error[E01002]: unexpected token
-   ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:11:17
-   │
-11 │         let Foo <u64>(_) = Foo(0);
-   │                 ^
-   │                 │
-   │                 Unexpected '<'
-   │                 Expected '{'
-
 error[E03003]: unbound module member
    ┌─ tests/move_2024/parser/positional_struct_explicit_type_args.move:16:17
    │


### PR DESCRIPTION
## Description 

This undoes some of the opinionated parsing introduced in #16922 

## Test Plan 

Test updates, plus a new one.

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
