### PR TITLE
[consensus] Add ReputationScoreCalculator & ScoringStrategy

### DIFF
--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -357,7 +357,7 @@ mod tests {
 
         let swap_stake_threshold = 33;
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..10),
+            CommitRange::new(0..11),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -381,7 +381,7 @@ mod tests {
 
         let swap_stake_threshold = 33;
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..10),
+            CommitRange::new(0..11),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -450,7 +450,7 @@ mod tests {
 
         let swap_stake_threshold = 34;
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..10),
+            CommitRange::new(0..11),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         LeaderSwapTable::new(context, reputation_scores, swap_stake_threshold);
@@ -463,7 +463,7 @@ mod tests {
 
         let swap_stake_threshold = 33;
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(1..10),
+            CommitRange::new(1..11),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -475,7 +475,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(11..20),
+            CommitRange::new(11..21),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "The new LeaderSwapTable has an invalid CommitRange. Old LeaderSwapTable CommitRange(11..20) vs new LeaderSwapTable CommitRange(21..25)"
+        expected = "The new LeaderSwapTable has an invalid CommitRange. Old LeaderSwapTable CommitRange(11..21) vs new LeaderSwapTable CommitRange(21..26)"
     )]
     fn test_update_bad_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
@@ -495,7 +495,7 @@ mod tests {
 
         let swap_stake_threshold = 33;
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(1..10),
+            CommitRange::new(1..11),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -507,7 +507,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(11..20),
+            CommitRange::new(11..21),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -517,7 +517,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(21..25),
+            CommitRange::new(21..26),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -1,12 +1,120 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{cmp::Ordering, fmt::Debug, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    ops::Bound::{Excluded, Included},
+    sync::Arc,
+};
 
 use consensus_config::AuthorityIndex;
 use serde::{Deserialize, Serialize};
+use itertools::Itertools;
 
-use crate::{commit::CommitRange, context::Context};
+use crate::{
+    block::{BlockAPI, BlockDigest, BlockRef, Slot, VerifiedBlock},
+    commit::CommitRange,
+    context::Context,
+    leader_scoring_strategy::ScoringStrategy,
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+    universal_committer::UniversalCommitter,
+    CommittedSubDag, Round,
+};
+
+#[allow(unused)]
+pub(crate) struct ReputationScoreCalculator<'a> {
+    // The range of commits that these scores are calculated from.
+    pub(crate) commit_range: CommitRange,
+    // The scores per authority. Vec index is the `AuthorityIndex`.
+    pub(crate) scores_per_authority: Vec<u64>,
+
+    // As leaders are sequenced the subdags are collected and cached in `DagState`.
+    // Then when there are enough commits to trigger a `LeaderSchedule` change,
+    // the subdags are then combined into one `UnscoredSubdag` so that we can
+    // calculate the scores for the leaders in this subdag.
+    unscored_subdag: UnscoredSubdag,
+    // There are multiple scoring strategies that can be used to calculate the scores
+    // and the `ReputationScoreCalculator` is responsible for applying the strategy.
+    // For now this is dynamic while we are experimenting but eventually we can
+    // replace this with the final strategy that works best.
+    scoring_strategy: Box<dyn ScoringStrategy>,
+    // We use the `UniversalCommitter` to elect the leaders from the `UnscoredSubdag`
+    // that need to be scored.
+    committer: &'a UniversalCommitter,
+}
+
+#[allow(unused)]
+impl<'a> ReputationScoreCalculator<'a> {
+    pub(crate) fn new(
+        context: Arc<Context>,
+        committer: &'a UniversalCommitter,
+        unscored_subdags: &Vec<CommittedSubDag>,
+        scoring_strategy: Box<dyn ScoringStrategy>,
+    ) -> Self {
+        let num_authorities = context.committee.size();
+        let scores_per_authority = vec![0_u64; num_authorities];
+
+        assert!(
+            !unscored_subdags.is_empty(),
+            "Attempted to calculate scores with no unscored subdags"
+        );
+
+        let unscored_subdag = UnscoredSubdag::new(context.clone(), unscored_subdags);
+
+        let commit_indexes = unscored_subdags
+            .iter()
+            .map(|subdag| subdag.commit_index)
+            .collect::<Vec<_>>();
+        let (min_commit_index, max_commit_index) =
+            commit_indexes.iter().minmax().into_option().unwrap();
+        let commit_range = CommitRange::new(*min_commit_index..*max_commit_index);
+
+        Self {
+            unscored_subdag,
+            committer,
+            commit_range,
+            scoring_strategy,
+            scores_per_authority,
+        }
+    }
+
+    pub(crate) fn calculate(&mut self) -> ReputationScores {
+        let leader_rounds = self.unscored_subdag.get_leader_rounds();
+        let (min_leader_round, max_leader_round) =
+            leader_rounds.iter().minmax().into_option().unwrap();
+        let scoring_round_range = self
+            .scoring_strategy
+            .leader_scoring_round_range(*min_leader_round, *max_leader_round);
+
+        for leader_round in scoring_round_range {
+            for committer in self.committer.get_committers() {
+                tracing::info!(
+                    "Electing leader for round {leader_round} with committer {committer}"
+                );
+                if let Some(leader_slot) = committer.elect_leader(leader_round) {
+                    tracing::info!("Calculating score for leader {leader_slot}");
+                    self.add_scores(self.scoring_strategy.calculate_scores_for_leader(
+                        &self.unscored_subdag,
+                        leader_slot,
+                        committer,
+                    ))
+                }
+            }
+        }
+
+        ReputationScores::new(self.commit_range.clone(), self.scores_per_authority.clone())
+    }
+
+    fn add_scores(&mut self, scores: Vec<u64>) {
+        assert_eq!(scores.len(), self.scores_per_authority.len());
+
+        for (authority_idx, score) in scores.iter().enumerate() {
+            self.scores_per_authority[authority_idx] += *score;
+        }
+    }
+}
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ReputationScores {
@@ -26,7 +134,10 @@ impl ReputationScores {
     }
 
     // Returns the authorities in score descending order.
-    pub fn authorities_by_score_desc(&self, context: Arc<Context>) -> Vec<(AuthorityIndex, u64)> {
+    pub(crate) fn authorities_by_score_desc(
+        &self,
+        context: Arc<Context>,
+    ) -> Vec<(AuthorityIndex, u64)> {
         let mut authorities: Vec<_> = self
             .scores_per_authority
             .iter()
@@ -75,9 +186,160 @@ impl ReputationScores {
     }
 }
 
+pub(crate) struct UnscoredSubdag {
+    pub context: Arc<Context>,
+    pub blocks: BTreeMap<BlockRef, VerifiedBlock>,
+}
+
+impl UnscoredSubdag {
+    pub(crate) fn new(context: Arc<Context>, subdags: &[CommittedSubDag]) -> Self {
+        let blocks = subdags
+            .iter()
+            .flat_map(|subdag| subdag.blocks.iter())
+            .map(|block| (block.reference(), block.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        assert!(
+            !blocks.is_empty(),
+            "Attempted to create UnscoredSubdag with no blocks"
+        );
+
+        Self { context, blocks }
+    }
+
+    // Skip genesis round as we don't produce leaders for that round.
+    pub(crate) fn get_leader_rounds(&self) -> Vec<Round> {
+        self.blocks
+            .keys()
+            .map(|block_ref| block_ref.round)
+            .filter(|round| *round != 0)
+            .collect::<Vec<_>>()
+    }
+
+    pub(crate) fn find_supported_block(
+        &self,
+        leader_slot: Slot,
+        from: &VerifiedBlock,
+    ) -> Option<BlockRef> {
+        if from.round() < leader_slot.round {
+            return None;
+        }
+        for ancestor in from.ancestors() {
+            if Slot::from(*ancestor) == leader_slot {
+                return Some(*ancestor);
+            }
+            // Weak links may point to blocks with lower round numbers than strong links.
+            if ancestor.round <= leader_slot.round {
+                continue;
+            }
+            if let Some(ancestor) = self.get_block(ancestor) {
+                if let Some(support) = self.find_supported_block(leader_slot, &ancestor) {
+                    return Some(support);
+                }
+            } else {
+                // TODO: Add unit test for this case once dagbuilder is ready.
+                tracing::info!(
+                    "Potential vote's ancestor block not found in unscored committed subdags: {:?}",
+                    ancestor
+                );
+                return None;
+            }
+        }
+        None
+    }
+
+    pub(crate) fn is_vote(
+        &self,
+        potential_vote: &VerifiedBlock,
+        leader_block: &VerifiedBlock,
+    ) -> bool {
+        let reference = leader_block.reference();
+        let leader_slot = Slot::from(reference);
+        self.find_supported_block(leader_slot, potential_vote) == Some(reference)
+    }
+
+    pub(crate) fn is_certificate(
+        &self,
+        potential_certificate: &VerifiedBlock,
+        leader_block: &VerifiedBlock,
+        all_votes: &mut HashMap<BlockRef, bool>,
+    ) -> bool {
+        let mut votes_stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        for reference in potential_certificate.ancestors() {
+            let is_vote = if let Some(is_vote) = all_votes.get(reference) {
+                *is_vote
+            } else if let Some(potential_vote) = self.get_block(reference) {
+                let is_vote = self.is_vote(&potential_vote, leader_block);
+                all_votes.insert(*reference, is_vote);
+                is_vote
+            } else {
+                tracing::info!(
+                    "Potential vote not found in unscored committed subdags: {:?}",
+                    reference
+                );
+                false
+            };
+
+            if is_vote {
+                tracing::trace!("{reference} is a vote for {leader_block}");
+                if votes_stake_aggregator.add(reference.author, &self.context.committee) {
+                    tracing::trace!(
+                        "{potential_certificate} is a certificate for leader {leader_block}"
+                    );
+                    return true;
+                }
+            } else {
+                tracing::trace!("{reference} is not a vote for {leader_block}",);
+            }
+        }
+        tracing::trace!("{potential_certificate} is not a certificate for leader {leader_block}");
+        false
+    }
+
+    pub(crate) fn get_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlock> {
+        let mut blocks = vec![];
+        for (_block_ref, block) in self.blocks.range((
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
+            Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MAX)),
+        )) {
+            blocks.push(block.clone())
+        }
+        blocks
+    }
+
+    pub(crate) fn get_blocks_at_round(&self, round: Round) -> Vec<VerifiedBlock> {
+        let mut blocks = vec![];
+        for (_block_ref, block) in self.blocks.range((
+            Included(BlockRef::new(round, AuthorityIndex::ZERO, BlockDigest::MIN)),
+            Excluded(BlockRef::new(
+                round + 1,
+                AuthorityIndex::ZERO,
+                BlockDigest::MIN,
+            )),
+        )) {
+            blocks.push(block.clone())
+        }
+        blocks
+    }
+
+    pub(crate) fn get_block(&self, block_ref: &BlockRef) -> Option<VerifiedBlock> {
+        self.blocks.get(block_ref).cloned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use parking_lot::RwLock;
+
     use super::*;
+    use crate::{
+        block::{timestamp_utc_ms, BlockTimestampMs, TestBlock},
+        dag_state::DagState,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
+        leader_scoring_strategy::VoteScoringStrategy,
+        storage::mem_store::MemStore,
+        universal_committer::universal_committer_builder::UniversalCommitterBuilder,
+    };
 
     #[test]
     fn test_reputation_scores_authorities_by_score_desc() {
@@ -129,5 +391,243 @@ mod tests {
                 .get(),
             3
         );
+    }
+
+    #[test]
+    fn test_reputation_score_calculator() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        // Populate fully connected test blocks for round 0 ~ 4, authorities 0 ~ 3.
+        let max_round: u32 = 4;
+        let num_authorities: u32 = 4;
+
+        let mut blocks = Vec::new();
+        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlock::new(0, author_idx).build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        blocks.extend(genesis);
+
+        let mut ancestors = genesis_references;
+        let mut leader = None;
+        for round in 1..=max_round {
+            let mut new_ancestors = vec![];
+            for author in 0..num_authorities {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+                new_ancestors.push(block.reference());
+                blocks.push(block.clone());
+
+                // only write one block for the final round, which is the leader
+                // of the committed subdag.
+                if round == max_round {
+                    leader = Some(block.clone());
+                    break;
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        let leader_block = leader.unwrap();
+        let leader_ref = leader_block.reference();
+        let commit_index = 1;
+
+        let unscored_subdags = vec![CommittedSubDag::new(
+            leader_ref,
+            blocks,
+            timestamp_utc_ms(),
+            commit_index,
+        )];
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(VoteScoringStrategy {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempted to calculate scores with no unscored subdags")]
+    fn test_reputation_score_calculator_no_subdags() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        let unscored_subdags = vec![];
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(VoteScoringStrategy {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![0, 0, 0, 0]);
+        assert_eq!(scores.commit_range, CommitRange::new(0..0));
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempted to create UnscoredSubdag with no blocks")]
+    fn test_reputation_score_calculator_no_subdag_blocks() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        let blocks = vec![];
+        let unscored_subdags = vec![CommittedSubDag::new(
+            BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
+            blocks,
+            timestamp_utc_ms(),
+            1,
+        )];
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(VoteScoringStrategy {}),
+        );
+        calculator.calculate();
+    }
+
+    #[test]
+    fn test_scoring_with_missing_block_in_subdag() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        let mut blocks = Vec::new();
+        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlock::new(0, author_idx).build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        blocks.extend(genesis);
+
+        let mut ancestors = genesis_references;
+        let mut leader = None;
+        for round in 1..=4 {
+            let mut new_ancestors = vec![];
+            for author in 0..4 {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+                new_ancestors.push(block.reference());
+
+                // Simulate referenced block which was part of another committed
+                // subdag.
+                if round == 1 && author == 0 {
+                    tracing::info!("Skipping {block} in committed subdags blocks");
+                    continue;
+                }
+
+                blocks.push(block.clone());
+
+                if round == 4 && author == 0 {
+                    leader = Some(block.clone());
+                    break;
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        let leader_block = leader.unwrap();
+        let leader_ref = leader_block.reference();
+        let commit_index = 1;
+
+        let unscored_subdags = vec![CommittedSubDag::new(
+            leader_ref,
+            blocks,
+            timestamp_utc_ms(),
+            commit_index,
+        )];
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(VoteScoringStrategy {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
     }
 }

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -1,0 +1,449 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, ops::Range};
+
+use crate::{
+    base_committer::BaseCommitter,
+    block::{BlockAPI, BlockRef, Slot},
+    leader_scoring::UnscoredSubdag,
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+};
+
+pub(crate) trait ScoringStrategy {
+    fn calculate_scores_for_leader(
+        &self,
+        subdag: &UnscoredSubdag,
+        leader_slot: Slot,
+        committer: &BaseCommitter,
+    ) -> Vec<u64>;
+
+    // Based on the scoring strategy there is a minimum number of rounds required
+    // for the scores to be calculated. This method allows that to be set by the
+    // scoring strategy.
+    fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32>;
+}
+
+/// This scoring strategy is like `CertifiedVoteScoringStrategyV1` but instead of
+/// only giving one point for each vote that is included in 2f+1 certificates. We
+/// give a score equal to the amount of stake of all certificates that included
+/// the vote.
+pub(crate) struct CertifiedVoteScoringStrategyV2 {}
+
+impl ScoringStrategy for CertifiedVoteScoringStrategyV2 {
+    fn calculate_scores_for_leader(
+        &self,
+        subdag: &UnscoredSubdag,
+        leader_slot: Slot,
+        committer: &BaseCommitter,
+    ) -> Vec<u64> {
+        let num_authorities = subdag.context.committee.size();
+        let mut scores_per_authority = vec![0_u64; num_authorities];
+
+        let wave = committer.wave_number(leader_slot.round);
+        let decision_round = committer.decision_round(wave);
+
+        let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
+
+        if leader_blocks.is_empty() {
+            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            return scores_per_authority;
+        }
+
+        // At this point we are guaranteed that there is only one leader per slot
+        // because we are operating on committed subdags.
+        assert!(leader_blocks.len() == 1);
+
+        let leader_block = leader_blocks.first().unwrap();
+
+        let decision_blocks = subdag.get_blocks_at_round(decision_round);
+
+        let mut all_votes: HashMap<BlockRef, (bool, StakeAggregator<QuorumThreshold>)> =
+            HashMap::new();
+        for potential_cert in decision_blocks {
+            let authority = potential_cert.reference().author;
+            for reference in potential_cert.ancestors() {
+                if let Some((is_vote, stake_agg)) = all_votes.get_mut(reference) {
+                    if *is_vote {
+                        stake_agg.add(authority, &subdag.context.committee);
+                    }
+                } else if let Some(potential_vote) = subdag.get_block(reference) {
+                    let is_vote = subdag.is_vote(&potential_vote, leader_block);
+                    let mut stake_agg = StakeAggregator::<QuorumThreshold>::new();
+                    stake_agg.add(authority, &subdag.context.committee);
+                    all_votes.insert(*reference, (is_vote, stake_agg));
+                } else {
+                    tracing::info!(
+                        "Potential vote not found in unscored committed subdags: {:?}",
+                        reference
+                    );
+                };
+            }
+        }
+
+        for (vote_ref, (is_vote, stake_agg)) in all_votes {
+            if is_vote {
+                let authority = vote_ref.author;
+                tracing::info!(
+                    "Found a certified vote {vote_ref} for leader {leader_block} from authority {authority}"
+                );
+                tracing::info!(
+                    "[{}] scores +{} reputation for {authority}!",
+                    subdag.context.own_index,
+                    stake_agg.stake()
+                );
+                scores_per_authority[authority] += stake_agg.stake();
+            }
+        }
+
+        scores_per_authority
+    }
+
+    fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        assert!(min_round < max_round - 1);
+        min_round..max_round.saturating_sub(1)
+    }
+}
+
+/// This scoring strategy gives one point for each authority vote that is included
+/// in 2f+1 certificates. We are calling this a certified vote.
+pub(crate) struct CertifiedVoteScoringStrategyV1 {}
+
+impl ScoringStrategy for CertifiedVoteScoringStrategyV1 {
+    fn calculate_scores_for_leader(
+        &self,
+        subdag: &UnscoredSubdag,
+        leader_slot: Slot,
+        committer: &BaseCommitter,
+    ) -> Vec<u64> {
+        let num_authorities = subdag.context.committee.size();
+        let mut scores_per_authority = vec![0_u64; num_authorities];
+
+        let wave = committer.wave_number(leader_slot.round);
+        let decision_round = committer.decision_round(wave);
+
+        let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
+
+        if leader_blocks.is_empty() {
+            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            return scores_per_authority;
+        }
+
+        // At this point we are guaranteed that there is only one leader per slot
+        // because we are operating on committed subdags.
+        assert!(leader_blocks.len() == 1);
+
+        let leader_block = leader_blocks.first().unwrap();
+
+        let decision_blocks = subdag.get_blocks_at_round(decision_round);
+
+        let mut all_votes: HashMap<BlockRef, (bool, StakeAggregator<QuorumThreshold>)> =
+            HashMap::new();
+        for potential_cert in decision_blocks {
+            let authority = potential_cert.reference().author;
+            for reference in potential_cert.ancestors() {
+                if let Some((is_vote, stake_agg)) = all_votes.get_mut(reference) {
+                    if *is_vote {
+                        stake_agg.add(authority, &subdag.context.committee);
+                    }
+                } else if let Some(potential_vote) = subdag.get_block(reference) {
+                    let is_vote = subdag.is_vote(&potential_vote, leader_block);
+                    let mut stake_agg = StakeAggregator::<QuorumThreshold>::new();
+                    stake_agg.add(authority, &subdag.context.committee);
+                    all_votes.insert(*reference, (is_vote, stake_agg));
+                } else {
+                    tracing::info!(
+                        "Potential vote not found in unscored committed subdags: {:?}",
+                        reference
+                    );
+                };
+            }
+        }
+
+        for (vote_ref, (is_vote, stake_agg)) in all_votes {
+            if is_vote && stake_agg.reached_threshold(&subdag.context.committee) {
+                let authority = vote_ref.author;
+                tracing::info!(
+                    "Found a certified vote {vote_ref} for leader {leader_block} from authority {authority}"
+                );
+                tracing::info!(
+                    "[{}] scores +1 reputation for {authority}!",
+                    subdag.context.own_index
+                );
+                scores_per_authority[authority] += 1;
+            }
+        }
+
+        scores_per_authority
+    }
+
+    fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        assert!(min_round < max_round - 1);
+        min_round..max_round.saturating_sub(1)
+    }
+}
+
+// This scoring strategy will give one point to any votes for the leader.
+pub(crate) struct VoteScoringStrategy {}
+
+impl ScoringStrategy for VoteScoringStrategy {
+    fn calculate_scores_for_leader(
+        &self,
+        subdag: &UnscoredSubdag,
+        leader_slot: Slot,
+        _committer: &BaseCommitter,
+    ) -> Vec<u64> {
+        let num_authorities = subdag.context.committee.size();
+        let mut scores_per_authority = vec![0_u64; num_authorities];
+        let voting_round = leader_slot.round + 1;
+
+        let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
+
+        if leader_blocks.is_empty() {
+            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            return scores_per_authority;
+        }
+
+        // At this point we are guaranteed that there is only one leader per slot
+        // because we are operating on committed subdags.
+        assert!(leader_blocks.len() == 1);
+
+        let leader_block = leader_blocks.first().unwrap();
+
+        let voting_blocks = subdag.get_blocks_at_round(voting_round);
+        for potential_vote in voting_blocks {
+            if subdag.is_vote(&potential_vote, leader_block) {
+                let authority = potential_vote.author();
+                tracing::info!(
+                    "Found a vote {} for leader {leader_block} from authority {authority}",
+                    potential_vote.reference()
+                );
+                tracing::info!(
+                    "[{}] scores +1 reputation for {authority}!",
+                    subdag.context.own_index
+                );
+                scores_per_authority[authority] += 1;
+            }
+        }
+
+        scores_per_authority
+    }
+
+    fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        assert!(min_round < max_round);
+        min_round..max_round
+    }
+}
+
+// This scoring strategy will give one point to any certificates for the leader.
+pub(crate) struct CertificateScoringStrategy {}
+
+impl ScoringStrategy for CertificateScoringStrategy {
+    fn calculate_scores_for_leader(
+        &self,
+        subdag: &UnscoredSubdag,
+        leader_slot: Slot,
+        committer: &BaseCommitter,
+    ) -> Vec<u64> {
+        let num_authorities = subdag.context.committee.size();
+        let mut scores_per_authority = vec![0_u64; num_authorities];
+
+        let wave = committer.wave_number(leader_slot.round);
+        let decision_round = committer.decision_round(wave);
+
+        let leader_blocks = subdag.get_blocks_at_slot(leader_slot);
+
+        if leader_blocks.is_empty() {
+            tracing::info!("[{}] No block for leader slot {leader_slot} in this set of unscored committed subdags, skip scoring", subdag.context.own_index);
+            return scores_per_authority;
+        }
+
+        // At this point we are guaranteed that there is only one leader per slot
+        // because we are operating on committed subdags.
+        assert!(leader_blocks.len() == 1);
+
+        let leader_block = leader_blocks.first().unwrap();
+
+        let decision_blocks = subdag.get_blocks_at_round(decision_round);
+        let mut all_votes = HashMap::new();
+        for potential_cert in decision_blocks {
+            let authority = potential_cert.reference().author;
+            if subdag.is_certificate(&potential_cert, leader_block, &mut all_votes) {
+                tracing::info!(
+                    "Found a certificate {} for leader {leader_block} from authority {authority}",
+                    potential_cert.reference()
+                );
+                tracing::info!(
+                    "[{}] scores +1 reputation for {authority}!",
+                    subdag.context.own_index
+                );
+                scores_per_authority[authority] += 1;
+            }
+        }
+
+        scores_per_authority
+    }
+
+    fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        assert!(min_round < max_round - 1);
+        min_round..max_round.saturating_sub(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+
+    use super::*;
+    use crate::{
+        block::{timestamp_utc_ms, BlockTimestampMs, TestBlock, VerifiedBlock},
+        commit::CommitRange,
+        context::Context,
+        dag_state::DagState,
+        leader_schedule::{LeaderSchedule, LeaderSwapTable},
+        leader_scoring::ReputationScoreCalculator,
+        storage::mem_store::MemStore,
+        universal_committer::universal_committer_builder::UniversalCommitterBuilder,
+        CommittedSubDag,
+    };
+
+    #[test]
+    fn test_certificate_scoring_strategy() {
+        let (context, committer, unscored_subdags) = basic_setup();
+
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(CertificateScoringStrategy {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![2, 1, 1, 1]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+    }
+
+    #[test]
+    fn test_vote_scoring_strategy() {
+        let (context, committer, unscored_subdags) = basic_setup();
+
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(VoteScoringStrategy {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+    }
+
+    #[test]
+    fn test_certified_vote_scoring_strategy_v1() {
+        let (context, committer, unscored_subdags) = basic_setup();
+
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(CertifiedVoteScoringStrategyV1 {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![1, 1, 1, 1]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+    }
+
+    #[test]
+    fn test_certified_vote_scoring_strategy_v2() {
+        let (context, committer, unscored_subdags) = basic_setup();
+
+        let mut calculator = ReputationScoreCalculator::new(
+            context.clone(),
+            &committer,
+            &unscored_subdags,
+            Box::new(CertifiedVoteScoringStrategyV2 {}),
+        );
+        let scores = calculator.calculate();
+        assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);
+        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+    }
+
+    fn basic_setup() -> (
+        Arc<Context>,
+        crate::universal_committer::UniversalCommitter,
+        Vec<CommittedSubDag>,
+    ) {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        // Populate fully connected test blocks for round 0 ~ 4, authorities 0 ~ 3.
+        let max_round: u32 = 4;
+        let num_authorities: u32 = 4;
+
+        let mut blocks = Vec::new();
+        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlock::new(0, author_idx).build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        blocks.extend(genesis);
+
+        let mut ancestors = genesis_references;
+        let mut leader = None;
+        for round in 1..=max_round {
+            let mut new_ancestors = vec![];
+            for author in 0..num_authorities {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+                new_ancestors.push(block.reference());
+                blocks.push(block.clone());
+
+                // only write one block for the final round, which is the leader
+                // of the committed subdag.
+                if round == max_round {
+                    leader = Some(block.clone());
+                    break;
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        let leader_block = leader.unwrap();
+        let leader_ref = leader_block.reference();
+        let commit_index = 1;
+
+        let unscored_subdags = vec![CommittedSubDag::new(
+            leader_ref,
+            blocks,
+            timestamp_utc_ms(),
+            commit_index,
+        )];
+        (context, committer, unscored_subdags)
+    }
+}

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -100,6 +100,8 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV2 {
     }
 
     fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        // To be able to calculate scores using certified votes we require +1 round
+        // for the votes on the leader and +1 round for the certificates of those votes.
         assert!(min_round < max_round - 1);
         min_round..max_round.saturating_sub(1)
     }
@@ -178,6 +180,8 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV1 {
     }
 
     fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        // To be able to calculate scores using certified votes we require +1 round
+        // for the votes on the leader and +1 round for the certificates of those votes.
         assert!(min_round < max_round - 1);
         min_round..max_round.saturating_sub(1)
     }
@@ -230,6 +234,8 @@ impl ScoringStrategy for VoteScoringStrategy {
     }
 
     fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        // To be able to calculate scores using votes we require +1 round
+        // for the votes on the leader.
         assert!(min_round < max_round);
         min_round..max_round
     }
@@ -285,6 +291,8 @@ impl ScoringStrategy for CertificateScoringStrategy {
     }
 
     fn leader_scoring_round_range(&self, min_round: u32, max_round: u32) -> Range<u32> {
+        // To be able to calculate scores using certificates we require +1 round
+        // for the votes on the leader and +1 round for the certificates of those votes.
         assert!(min_round < max_round - 1);
         min_round..max_round.saturating_sub(1)
     }

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -154,7 +154,7 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV1 {
                     stake_agg.add(authority, &subdag.context.committee);
                     all_votes.insert(*reference, (is_vote, stake_agg));
                 } else {
-                    tracing::info!(
+                    tracing::trace!(
                         "Potential vote not found in unscored committed subdags: {:?}",
                         reference
                     );
@@ -165,10 +165,10 @@ impl ScoringStrategy for CertifiedVoteScoringStrategyV1 {
         for (vote_ref, (is_vote, stake_agg)) in all_votes {
             if is_vote && stake_agg.reached_threshold(&subdag.context.committee) {
                 let authority = vote_ref.author;
-                tracing::info!(
+                tracing::trace!(
                     "Found a certified vote {vote_ref} for leader {leader_block} from authority {authority}"
                 );
-                tracing::info!(
+                tracing::trace!(
                     "[{}] scores +1 reputation for {authority}!",
                     subdag.context.own_index
                 );
@@ -218,11 +218,11 @@ impl ScoringStrategy for VoteScoringStrategy {
         for potential_vote in voting_blocks {
             if subdag.is_vote(&potential_vote, leader_block) {
                 let authority = potential_vote.author();
-                tracing::info!(
+                tracing::trace!(
                     "Found a vote {} for leader {leader_block} from authority {authority}",
                     potential_vote.reference()
                 );
-                tracing::info!(
+                tracing::trace!(
                     "[{}] scores +1 reputation for {authority}!",
                     subdag.context.own_index
                 );
@@ -329,7 +329,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![2, 1, 1, 1]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+        assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+        assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
     #[test]
@@ -359,7 +359,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![1, 1, 1, 1]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+        assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
     #[test]
@@ -374,7 +374,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..1));
+        assert_eq!(scores.commit_range, CommitRange::new(1..2));
     }
 
     fn basic_setup() -> (

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -306,7 +306,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block::{timestamp_utc_ms, BlockTimestampMs, TestBlock, VerifiedBlock},
+        block::{BlockTimestampMs, TestBlock, VerifiedBlock},
         commit::CommitRange,
         context::Context,
         dag_state::DagState,
@@ -449,7 +449,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             leader_ref,
             blocks,
-            timestamp_utc_ms(),
+            context.clock.timestamp_utc_ms(),
             commit_index,
         )];
         (context, committer, unscored_subdags)

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -18,6 +18,7 @@ mod dag_state;
 mod error;
 mod leader_schedule;
 mod leader_scoring;
+mod leader_scoring_strategy;
 mod leader_timeout;
 mod linearizer;
 mod metrics;

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-use std::marker::PhantomData;
+use std::{collections::BTreeSet, marker::PhantomData};
 
 use consensus_config::{AuthorityIndex, Committee, Stake};
 

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -104,6 +104,11 @@ impl UniversalCommitter {
             .collect()
     }
 
+    /// Return list of committers
+    pub(crate) fn get_committers(&self) -> Vec<&BaseCommitter> {
+        self.committers.iter().collect()
+    }
+
     /// Update metrics.
     fn update_metrics(&self, leader: &LeaderStatus, decision: Decision) {
         let authority = leader.authority().to_string();


### PR DESCRIPTION
## Description 
This is one of many PRs to implement Leader Scoring & Leader Schedule feature for Mysticeti.
- [Design Doc](https://www.notion.so/mystenlabs/Leader-Schedule-Scoring-538c65cb370b4644944a94485efc4979?pvs=4)
- [Prototype PR](https://github.com/MystenLabs/sui/pull/16975)

Notes:
- Unscored subdags will eventually be cached in `DagState` and when there are enough commits to trigger a leader schedule change the `ReputationScoreCalculator` will be used to calculate the `ReputationScores`. As can be seen in the flow diagram below.
- Added multiple scoring strategies so that we can experiment with them quickly until we decided on the strategy that is best to use. By default we will use the `VoteScoringStrategy` when everything is hooked up as it had the best early [results](https://metrics.sui.io/goto/yeUlNPxIR?orgId=1).
- We are sharing the `UniversalCommitter` inside of the `ReputationScoreCalculator` so we have consistency with the leaders that we elect when scoring.

![Screenshot 2024-04-03 at 7 59 09 PM](https://github.com/MystenLabs/sui/assets/97870774/b91931ab-7f92-49e8-90ea-2d0e8476d1d8)

## Test Plan 

unit tests
