### PR TITLE
[consensus] Hookup LeaderSchedule change & Recovery paths

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -20,7 +20,7 @@ use crate::{
     core::{Core, CoreSignals},
     core_thread::{ChannelCoreThreadDispatcher, CoreThreadHandle},
     dag_state::DagState,
-    leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    leader_schedule::LeaderSchedule,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
     network::{
@@ -208,9 +208,9 @@ where
             store.clone(),
         );
 
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
 
         let core = Core::new(

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -488,20 +488,8 @@ pub(crate) struct CommitInfo {
     pub(crate) reputation_scores: ReputationScores,
 }
 
-impl CommitInfo {
-    // Returns a new CommitInfo.
-    pub(crate) fn new(committed_rounds: Vec<Round>, reputation_scores: ReputationScores) -> Self {
-        CommitInfo {
-            committed_rounds,
-            reputation_scores,
-        }
-    }
-}
-
 /// CommitRange stores a range of CommitIndex. The range contains the start (inclusive)
 /// and end (exclusive) commit indices and can be ordered for use as the key of a table.
-/// Note: If used as a key for a table it is useful to ensure the key ranges don't
-/// intersect using the provided helper methods so that ordering becomes clear.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CommitRange(Range<CommitIndex>);
 
@@ -653,5 +641,6 @@ mod tests {
         assert!(range1 < range2);
         assert!(range2 < range3);
         assert!(range3 < range4);
+        assert!(range5 < range4);
     }
 }

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -63,6 +63,14 @@ impl CommitObserver {
         &mut self,
         committed_leaders: Vec<VerifiedBlock>,
     ) -> ConsensusResult<Vec<CommittedSubDag>> {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["CommitObserver::handle_commit"])
+            .start_timer();
+
         let committed_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
         let mut sent_sub_dags = vec![];
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -65,7 +65,6 @@ pub(crate) struct Core {
     last_decided_leader: Slot,
     /// The consensus leader schedule to be used to resolve the leader for a
     /// given round.
-    #[allow(unused)]
     leader_schedule: Arc<LeaderSchedule>,
     /// The commit observer is responsible for observing the commits and collecting
     /// + sending subdags over the consensus output channel.
@@ -90,7 +89,6 @@ impl Core {
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         let last_decided_leader = dag_state.read().last_commit_leader();
-
         let committer = UniversalCommitterBuilder::new(
             context.clone(),
             leader_schedule.clone(),
@@ -122,12 +120,12 @@ impl Core {
             context: context.clone(),
             threshold_clock: ThresholdClock::new(0, context.clone()),
             last_proposed_block,
-            transaction_consumer,
             last_included_ancestors,
-            block_manager,
-            committer,
             last_decided_leader,
             leader_schedule,
+            transaction_consumer,
+            block_manager,
+            committer,
             commit_observer,
             signals,
             block_signer,
@@ -446,33 +444,74 @@ impl Core {
             .with_label_values(&["Core::try_commit"])
             .start_timer();
 
+        let mut committed_subdags = Vec::new();
         // TODO: Add optimization to abort early without quorum for a round.
-        let sequenced_leaders = self.committer.try_commit(self.last_decided_leader);
+        loop {
+            // LeaderSchedule has a limit to how many sequenced leaders can be committed
+            // before a change is triggered. Calling into leader schedule will get you
+            // how many commits till next leader change. We will loop back and recalculate
+            // any discarded leaders with the new schedule.
+            let sequenced_leaders = self
+                .committer
+                .try_commit(self.last_decided_leader)
+                .into_iter()
+                .take(
+                    self.leader_schedule
+                        .commits_until_leader_schedule_update(self.dag_state.clone()),
+                )
+                .collect::<Vec<_>>();
 
-        if let Some(last) = sequenced_leaders.last() {
-            self.last_decided_leader = last.get_decided_slot();
-            self.context
-                .metrics
-                .node_metrics
-                .last_decided_leader_round
-                .set(self.last_decided_leader.round as i64);
+            if sequenced_leaders.is_empty() {
+                break;
+            }
+
+            if let Some(last) = sequenced_leaders.last() {
+                self.last_decided_leader = last.get_decided_slot();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .last_decided_leader_round
+                    .set(self.last_decided_leader.round as i64);
+            }
+
+            let committed_leaders = sequenced_leaders
+                .into_iter()
+                .filter_map(|leader| leader.into_committed_block())
+                .collect::<Vec<_>>();
+            if !committed_leaders.is_empty() {
+                debug!(
+                    "Committing leaders: {}",
+                    committed_leaders
+                        .iter()
+                        .map(|b| b.reference().to_string())
+                        .join(",")
+                );
+            }
+
+            // TODO: refcount subdags
+            let subdags = self.commit_observer.handle_commit(committed_leaders)?;
+            self.dag_state
+                .write()
+                .add_unscored_committed_subdags(subdags.clone());
+            committed_subdags.extend(subdags);
+
+            if self
+                .leader_schedule
+                .commits_until_leader_schedule_update(self.dag_state.clone())
+                == 0
+            {
+                let last_commit_index = self.dag_state.read().last_commit_index();
+                tracing::info!(
+                    "Leader schedule change triggered at commit index {last_commit_index}"
+                );
+                self.leader_schedule
+                    .update_leader_schedule(self.dag_state.clone(), &self.committer);
+            } else {
+                break;
+            }
         }
 
-        let committed_leaders = sequenced_leaders
-            .into_iter()
-            .filter_map(|leader| leader.into_committed_block())
-            .collect::<Vec<_>>();
-        if !committed_leaders.is_empty() {
-            debug!(
-                "Committing leaders: {}",
-                committed_leaders
-                    .iter()
-                    .map(|b| b.reference().to_string())
-                    .join(",")
-            );
-        }
-
-        self.commit_observer.handle_commit(committed_leaders)
+        Ok(committed_subdags)
     }
 
     pub(crate) fn get_missing_blocks(&self) -> BTreeSet<BlockRef> {
@@ -659,7 +698,7 @@ mod test {
         block::{genesis_blocks, TestBlock},
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI as _,
-        leader_schedule::LeaderSwapTable,
+        leader_scoring::ReputationScores,
         storage::{mem_store::MemStore, Store, WriteBatch},
         transaction::TransactionClient,
         CommitConsumer, CommitIndex,
@@ -704,9 +743,9 @@ mod test {
             dag_state.clone(),
             Arc::new(NoopBlockVerifier),
         );
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
 
         let (sender, _receiver) = unbounded_channel();
@@ -819,9 +858,9 @@ mod test {
             dag_state.clone(),
             Arc::new(NoopBlockVerifier),
         );
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
 
         let (sender, _receiver) = unbounded_channel();
@@ -913,9 +952,9 @@ mod test {
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let mut block_receiver = signal_receivers.block_broadcast_receiver();
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
 
         let (sender, _receiver) = unbounded_channel();
@@ -1014,9 +1053,9 @@ mod test {
             dag_state.clone(),
             Arc::new(NoopBlockVerifier),
         );
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
 
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
@@ -1172,6 +1211,106 @@ mod test {
         }
     }
 
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_leader_schedule_change() {
+        telemetry_subscribers::init_for_testing();
+        let default_params = Parameters::default();
+
+        // create the cores and their signals for all the authorities
+        let mut cores = create_cores(vec![1, 1, 1, 1]);
+
+        // Now iterate over a few rounds and ensure the corresponding signals are created while network advances
+        let mut last_round_blocks = Vec::new();
+        for round in 1..=30 {
+            let mut this_round_blocks = Vec::new();
+
+            // Wait for min round delay to allow blocks to be proposed.
+            sleep(default_params.min_round_delay).await;
+
+            for (core, signal_receivers, block_receiver, _, _) in &mut cores {
+                // add the blocks from last round
+                // this will trigger a block creation for the round and a signal should be emitted
+                core.add_blocks(last_round_blocks.clone()).unwrap();
+
+                // A "new round" signal should be received given that all the blocks of previous round have been processed
+                let new_round = receive(
+                    Duration::from_secs(1),
+                    signal_receivers.new_round_receiver(),
+                )
+                .await;
+                assert_eq!(new_round, round);
+
+                // Check that a new block has been proposed.
+                let block = tokio::time::timeout(Duration::from_secs(1), block_receiver.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(block.round(), round);
+                assert_eq!(block.author(), core.context.own_index);
+
+                // append the new block to this round blocks
+                this_round_blocks.push(core.last_proposed_block().clone());
+
+                let block = core.last_proposed_block();
+
+                // ensure that produced block is referring to the blocks of last_round
+                assert_eq!(block.ancestors().len(), core.context.committee.size());
+                for ancestor in block.ancestors() {
+                    if block.round() > 1 {
+                        // don't bother with round 1 block which just contains the genesis blocks.
+                        assert!(
+                            last_round_blocks
+                                .iter()
+                                .any(|block| block.reference() == *ancestor),
+                            "Reference from previous round should be added"
+                        );
+                    }
+                }
+            }
+
+            last_round_blocks = this_round_blocks;
+        }
+
+        for (core, _, _, _, store) in cores {
+            // Check commits have been persisted to store
+            let last_commit = store
+                .read_last_commit()
+                .unwrap()
+                .expect("last commit should be set");
+            // There are 28 leader rounds with rounds completed up to and including
+            // round 29. Round 30 blocks will only include their own blocks, so the
+            // 28th leader will not be committed.
+            assert_eq!(last_commit.index(), 27);
+            let all_stored_commits = store.scan_commits((0..CommitIndex::MAX).into()).unwrap();
+            assert_eq!(all_stored_commits.len(), 27);
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .bad_nodes
+                    .len(),
+                1
+            );
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .good_nodes
+                    .len(),
+                1
+            );
+            let expected_reputation_scores =
+                ReputationScores::new((11..21).into(), vec![8, 8, 9, 8]);
+            assert_eq!(
+                core.leader_schedule
+                    .leader_swap_table
+                    .read()
+                    .reputation_scores,
+                expected_reputation_scores
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_core_signals() {
         telemetry_subscribers::init_for_testing();
@@ -1185,9 +1324,10 @@ mod test {
         for round in 1..=10 {
             let mut this_round_blocks = Vec::new();
 
+            // Wait for min round delay to allow blocks to be proposed.
+            sleep(default_params.min_round_delay).await;
+
             for (core, signal_receivers, block_receiver, _, _) in &mut cores {
-                // Wait for min round delay to allow blocks to be proposed.
-                sleep(default_params.min_round_delay).await;
                 // add the blocks from last round
                 // this will trigger a block creation for the round and a signal should be emitted
                 core.add_blocks(last_round_blocks.clone()).unwrap();
@@ -1338,6 +1478,9 @@ mod test {
             context = context
                 .with_committee(committee)
                 .with_authority_index(AuthorityIndex::new_for_test(index as u32));
+            context
+                .protocol_config
+                .set_consensus_bad_nodes_stake_threshold(33);
 
             let context = Arc::new(context);
             let store = Arc::new(MemStore::new());
@@ -1348,11 +1491,10 @@ mod test {
                 dag_state.clone(),
                 Arc::new(NoopBlockVerifier),
             );
-            let leader_schedule = Arc::new(LeaderSchedule::new(
-                context.clone(),
-                LeaderSwapTable::default(),
-            ));
-
+            let leader_schedule = Arc::new(
+                LeaderSchedule::from_store(context.clone(), dag_state.clone())
+                    .with_num_commits_per_schedule(10),
+            );
             let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
             let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone(), None);
             let (signals, signal_receivers) = CoreSignals::new(context.clone());

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -188,7 +188,7 @@ mod test {
         context::Context,
         core::CoreSignals,
         dag_state::DagState,
-        leader_schedule::{LeaderSchedule, LeaderSwapTable},
+        leader_schedule::LeaderSchedule,
         storage::mem_store::MemStore,
         transaction::{TransactionClient, TransactionConsumer},
         CommitConsumer,
@@ -217,9 +217,9 @@ mod test {
             dag_state.clone(),
             store,
         );
-        let leader_schedule = Arc::new(LeaderSchedule::new(
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
-            LeaderSwapTable::default(),
+            dag_state.clone(),
         ));
         let core = Core::new(
             context.clone(),

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -18,7 +18,10 @@ use crate::{
         genesis_blocks, BlockAPI, BlockDigest, BlockRef, BlockTimestampMs, Round, Slot,
         VerifiedBlock, GENESIS_ROUND,
     },
-    commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitVote, TrustedCommit},
+    commit::{
+        load_committed_subdag_from_store, CommitAPI as _, CommitDigest, CommitIndex, CommitInfo,
+        CommitRef, CommitVote, CommittedSubDag, TrustedCommit,
+    },
     context::Context,
     leader_scoring::ReputationScores,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -58,6 +61,11 @@ pub(crate) struct DagState {
     // Last committed rounds per authority.
     last_committed_rounds: Vec<Round>,
 
+    /// The list of committed subdags that have been sequenced by the universal
+    /// committer but have yet to be used to calculate reputation scores for the
+    /// next leader schedule. Until then we consider it as "unscored" subdags.
+    unscored_committed_subdags: Vec<CommittedSubDag>,
+
     // Commit votes pending to be included in new blocks.
     // TODO: limit to 1st commit per round with multi-leader.
     pending_commit_votes: VecDeque<CommitVote>,
@@ -65,6 +73,11 @@ pub(crate) struct DagState {
     // Data to be flushed to storage.
     blocks_to_write: Vec<VerifiedBlock>,
     commits_to_write: Vec<TrustedCommit>,
+
+    // Buffer the reputation scores & last_committed_rounds to be flushed with the
+    // next dag state flush. This is okay because we can recover reputation scores
+    // & last_committed_rounds from the commits as needed.
+    commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
     // Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
@@ -87,15 +100,42 @@ impl DagState {
         let last_commit = store
             .read_last_commit()
             .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
-        let last_committed_rounds = if let Some(commit) = last_commit.as_ref() {
-            let (commit_ref, commit_info) = store
+
+        let mut unscored_committed_subdags = Vec::new();
+
+        let last_committed_rounds = {
+            let commit_info = store
                 .read_last_commit_info()
-                .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e))
-                .unwrap_or_else(|| panic!("Last commit info should be available."));
-            assert_eq!(commit_ref, commit.reference());
-            commit_info.committed_rounds
-        } else {
-            vec![0; num_authorities]
+                .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+            if let Some((commit_ref, commit_info)) = commit_info {
+                let mut committed_rounds = commit_info.committed_rounds;
+                let last_commit = last_commit
+                    .as_ref()
+                    .expect("There exists commit info, so the last commit should exist as well.");
+
+                if last_commit.index() > commit_ref.index {
+                    let committed_blocks = store
+                        .scan_commits(((commit_ref.index + 1)..last_commit.index() + 1).into())
+                        .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e))
+                        .iter()
+                        .flat_map(|commit| {
+                            let committed_subdag =
+                                load_committed_subdag_from_store(store.as_ref(), commit.clone());
+                            unscored_committed_subdags.push(committed_subdag.clone());
+                            committed_subdag.blocks
+                        })
+                        .collect::<Vec<_>>();
+
+                    for block in committed_blocks {
+                        committed_rounds[block.author()] =
+                            max(committed_rounds[block.author()], block.round());
+                    }
+                }
+
+                committed_rounds
+            } else {
+                vec![0; num_authorities]
+            }
         };
 
         let mut state = Self {
@@ -110,6 +150,8 @@ impl DagState {
             pending_commit_votes: VecDeque::new(),
             blocks_to_write: vec![],
             commits_to_write: vec![],
+            commit_info_to_write: vec![],
+            unscored_committed_subdags,
             store,
             cached_rounds,
         };
@@ -561,6 +603,22 @@ impl DagState {
         self.commits_to_write.push(commit);
     }
 
+    pub(crate) fn add_commit_info(&mut self, reputation_scores: ReputationScores) {
+        // We empty the unscored committed subdags to calculate reputation scores.
+        assert!(self.unscored_committed_subdags.is_empty());
+
+        let commit_info = CommitInfo {
+            reputation_scores,
+            committed_rounds: self.last_committed_rounds.clone(),
+        };
+        let last_commit = self
+            .last_commit
+            .as_ref()
+            .expect("Last commit should already be set.");
+        self.commit_info_to_write
+            .push((last_commit.reference(), commit_info));
+    }
+
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {
         let mut votes = Vec::new();
         while !self.pending_commit_votes.is_empty() && votes.len() < limit {
@@ -633,6 +691,7 @@ impl DagState {
         // Flush buffered data to storage.
         let blocks = std::mem::take(&mut self.blocks_to_write);
         let commits = std::mem::take(&mut self.commits_to_write);
+        let commit_info_to_write = std::mem::take(&mut self.commit_info_to_write);
         if blocks.is_empty() && commits.is_empty() {
             return;
         }
@@ -643,24 +702,8 @@ impl DagState {
             commits.len(),
             commits.iter().map(|c| c.reference().to_string()).join(","),
         );
-        let last_commit_info = if commits.is_empty() {
-            None
-        } else {
-            let last_commit_ref = commits.last().as_ref().unwrap().reference();
-            // TODO: Replace this with calculated reputation scores
-            let commit_info = CommitInfo::new(
-                self.last_committed_rounds.clone(),
-                ReputationScores::default(),
-            );
-            Some((last_commit_ref, commit_info))
-        };
         self.store
-            .write(WriteBatch::new(
-                blocks,
-                commits,
-                // TODO: limit to write at most once per commit round with multi-leader.
-                last_commit_info,
-            ))
+            .write(WriteBatch::new(blocks, commits, commit_info_to_write))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {:?}", e));
         self.context
             .metrics
@@ -720,6 +763,39 @@ impl DagState {
         panic!("Fatal error, no quorum has been detected in our DAG on the last two rounds.");
     }
 
+    pub(crate) fn last_reputation_scores_from_store(&self) -> Option<ReputationScores> {
+        let commit_info = self
+            .store
+            .read_last_commit_info()
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+        if let Some((commit_ref, commit_info)) = commit_info {
+            assert!(commit_ref.index <= self.last_commit.as_ref().unwrap().index());
+            Some(commit_info.reputation_scores)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn unscored_committed_subdags_count(&self) -> u64 {
+        self.unscored_committed_subdags.len() as u64
+    }
+
+    #[cfg(test)]
+    pub(crate) fn unscored_committed_subdags(&self) -> Vec<CommittedSubDag> {
+        self.unscored_committed_subdags.clone()
+    }
+
+    pub(crate) fn add_unscored_committed_subdags(
+        &mut self,
+        committed_subdags: Vec<CommittedSubDag>,
+    ) {
+        self.unscored_committed_subdags.extend(committed_subdags);
+    }
+
+    pub(crate) fn take_unscored_committed_subdags(&mut self) -> Vec<CommittedSubDag> {
+        std::mem::take(&mut self.unscored_committed_subdags)
+    }
+
     pub(crate) fn genesis_blocks(&self) -> Vec<VerifiedBlock> {
         self.genesis.values().cloned().collect()
     }
@@ -736,6 +812,11 @@ impl DagState {
     /// round <= the evict round have been cleaned up.
     fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
         commit_round.saturating_sub(cached_rounds)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_last_commit(&mut self, commit: TrustedCommit) {
+        self.last_commit = Some(commit);
     }
 }
 
@@ -1413,6 +1494,17 @@ mod test {
                 dag_state.accept_block(block);
             }
         }
+
+        dag_state.add_commit(TrustedCommit::new_for_test(
+            1 as CommitIndex,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            all_blocks.last().unwrap().reference(),
+            all_blocks
+                .into_iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        ));
 
         // WHEN search for the latest blocks
         let end_round = 4;

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -8,8 +8,7 @@ use typed_store::TypedStoreError;
 
 use crate::{
     block::{BlockRef, Round},
-    commit::Commit,
-    CommitIndex,
+    commit::{Commit, CommitIndex},
 };
 
 /// Errors that can occur when processing blocks, reading from storage, or encountering shutdown.

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -11,20 +11,28 @@ use consensus_config::{AuthorityIndex, Stake};
 use parking_lot::RwLock;
 use rand::{prelude::SliceRandom, rngs::StdRng, SeedableRng};
 
-use crate::{commit::CommitRange, context::Context, leader_scoring::ReputationScores, Round};
+use crate::{
+    context::Context,
+    dag_state::DagState,
+    leader_scoring::{ReputationScoreCalculator, ReputationScores},
+    leader_scoring_strategy::{
+        CertificateScoringStrategy, CertifiedVoteScoringStrategyV1, CertifiedVoteScoringStrategyV2,
+        ScoringStrategy, VoteScoringStrategy,
+    },
+    universal_committer::UniversalCommitter,
+    Round,
+};
 
 /// The `LeaderSchedule` is responsible for producing the leader schedule across
 /// an epoch. The leader schedule is subject to change periodically based on
 /// calculated `ReputationScores` of the authorities.
 #[derive(Clone)]
 pub(crate) struct LeaderSchedule {
+    pub leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
     context: Arc<Context>,
-    #[allow(unused)]
     num_commits_per_schedule: u64,
-    leader_swap_table: Arc<RwLock<LeaderSwapTable>>,
 }
 
-#[allow(unused)]
 impl LeaderSchedule {
     /// The window where the schedule change takes place in consensus. It represents
     /// number of committed sub dags.
@@ -37,6 +45,119 @@ impl LeaderSchedule {
             num_commits_per_schedule: Self::CONSENSUS_COMMITS_PER_SCHEDULE,
             leader_swap_table: Arc::new(RwLock::new(leader_swap_table)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_num_commits_per_schedule(mut self, num_commits_per_schedule: u64) -> Self {
+        self.num_commits_per_schedule = num_commits_per_schedule;
+        self
+    }
+
+    /// Restores the `LeaderSchedule` from storage. It will attempt to retrieve the
+    /// last stored `ReputationScores` and use them to build a `LeaderSwapTable`.
+    pub(crate) fn from_store(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        let leader_swap_table = dag_state.read().last_reputation_scores_from_store().map_or(
+            LeaderSwapTable::default(),
+            |reputation_scores| {
+                LeaderSwapTable::new(
+                    context.clone(),
+                    reputation_scores,
+                    context
+                        .protocol_config
+                        .consensus_bad_nodes_stake_threshold(),
+                )
+            },
+        );
+        // create the schedule
+        Self::new(context, leader_swap_table)
+    }
+
+    pub(crate) fn commits_until_leader_schedule_update(
+        &self,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> usize {
+        let unscored_committed_subdags_count = dag_state.read().unscored_committed_subdags_count();
+        assert!(
+            unscored_committed_subdags_count <= self.num_commits_per_schedule,
+            "Unscored committed subdags count exceeds the number of commits per schedule"
+        );
+        self.num_commits_per_schedule
+            .checked_sub(unscored_committed_subdags_count)
+            .unwrap() as usize
+    }
+
+    pub(crate) fn update_leader_schedule(
+        &self,
+        dag_state: Arc<RwLock<DagState>>,
+        committer: &UniversalCommitter,
+    ) {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["LeaderSchedule::update_leader_schedule"])
+            .start_timer();
+
+        let mut dag_state = dag_state.write();
+        let unscored_subdags = dag_state.take_unscored_committed_subdags();
+
+        // TODO: remove this once scoring strategy is finalized
+        let scoring_strategy =
+            if let Ok(scoring_strategy) = std::env::var("CONSENSUS_SCORING_STRATEGY") {
+                tracing::info!(
+                    "Using scoring strategy {scoring_strategy} for ReputationScoreCalculator"
+                );
+
+                let scoring_strategy: Box<dyn ScoringStrategy> = match scoring_strategy.as_str() {
+                    "vote" => Box::new(VoteScoringStrategy {}),
+                    "certified_vote_v1" => Box::new(CertifiedVoteScoringStrategyV1 {}),
+                    "certified_vote_v2" => Box::new(CertifiedVoteScoringStrategyV2 {}),
+                    "certificate" => Box::new(CertificateScoringStrategy {}),
+                    _ => Box::new(VoteScoringStrategy {}),
+                };
+                scoring_strategy
+            } else {
+                tracing::info!(
+                    "Using scoring strategy VoteScoringStrategy for ReputationScoreCalculator"
+                );
+                Box::new(VoteScoringStrategy {})
+            };
+
+        let score_calculation_timer = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["ReputationScoreCalculator::calculate"])
+            .start_timer();
+        let reputation_scores = ReputationScoreCalculator::new(
+            self.context.clone(),
+            committer,
+            &unscored_subdags,
+            scoring_strategy,
+        )
+        .calculate();
+        drop(score_calculation_timer);
+
+        reputation_scores.update_metrics(self.context.clone());
+
+        self.update_leader_swap_table(LeaderSwapTable::new(
+            self.context.clone(),
+            reputation_scores.clone(),
+            self.context
+                .protocol_config
+                .consensus_bad_nodes_stake_threshold(),
+        ));
+
+        self.context
+            .metrics
+            .node_metrics
+            .num_of_bad_nodes
+            .set(self.leader_swap_table.read().bad_nodes.len() as i64);
+
+        // Buffer score and last commit rounds in dag state to be persisted later
+        dag_state.add_commit_info(reputation_scores);
     }
 
     pub(crate) fn elect_leader(&self, round: u32, leader_offset: u32) -> AuthorityIndex {
@@ -96,7 +217,7 @@ impl LeaderSchedule {
         // of CommitRange(0..0) all future LeaderSwapTables should be calculated
         // from a CommitRange of equal length and immediately following the
         // preceding commit range of the old swap table.
-        if *old_commit_range != CommitRange::new(0..0) {
+        if *old_commit_range != (0..0).into() {
             assert!(
                 old_commit_range.is_next_range(new_commit_range),
                 "The new LeaderSwapTable has an invalid CommitRange. Old LeaderSwapTable {old_commit_range:?} vs new LeaderSwapTable {new_commit_range:?}",
@@ -132,7 +253,6 @@ pub(crate) struct LeaderSwapTable {
     pub(crate) reputation_scores: ReputationScores,
 }
 
-#[allow(unused)]
 impl LeaderSwapTable {
     // Constructs a new table based on the provided reputation scores. The
     // `swap_stake_threshold` designates the total (by stake) nodes that will be
@@ -300,7 +420,12 @@ impl Debug for LeaderSwapTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::CommitRange;
+    use crate::{
+        block::{BlockDigest, BlockRef, BlockTimestampMs, TestBlock, VerifiedBlock},
+        commit::{CommitDigest, CommitInfo, CommitRef, CommittedSubDag, TrustedCommit},
+        storage::{mem_store::MemStore, Store, WriteBatch},
+        universal_committer::universal_committer_builder::UniversalCommitterBuilder,
+    };
 
     #[tokio::test]
     async fn test_elect_leader() {
@@ -351,15 +476,295 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_leader_schedule_from_store() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold(33);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+
+        let leader_timestamp = context.clock.timestamp_utc_ms();
+        let blocks = vec![
+            VerifiedBlock::new_for_test(
+                TestBlock::new(10, 2)
+                    .set_timestamp_ms(leader_timestamp)
+                    .build(),
+            ),
+            VerifiedBlock::new_for_test(TestBlock::new(9, 0).build()),
+            VerifiedBlock::new_for_test(TestBlock::new(9, 2).build()),
+            VerifiedBlock::new_for_test(TestBlock::new(9, 3).build()),
+        ];
+
+        let leader = blocks[0].clone();
+        let leader_ref = leader.reference();
+        let last_commit_index = 10;
+        let last_commit = TrustedCommit::new_for_test(
+            last_commit_index,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            leader_ref,
+            blocks
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        );
+
+        // The CommitInfo for the first 10 commits are written to store. This is the
+        // info that LeaderSchedule will be recovered from
+        let commit_range = (1..11).into();
+        let reputation_scores = ReputationScores::new(commit_range, vec![4, 1, 1, 3]);
+        let committed_rounds = vec![9, 9, 10, 9];
+        let commit_ref = CommitRef::new(10, CommitDigest::MIN);
+        let commit_info = CommitInfo {
+            reputation_scores,
+            committed_rounds,
+        };
+
+        store
+            .write(
+                WriteBatch::default()
+                    .commit_info(vec![(commit_ref, commit_info)])
+                    .blocks(blocks)
+                    .commits(vec![last_commit]),
+            )
+            .unwrap();
+
+        // CommitIndex '11' will be written to store. This should result in the cached
+        // last_committed_rounds & unscored subdags in DagState to be updated with the
+        // latest commit information on recovery.
+        let leader_timestamp = context.clock.timestamp_utc_ms();
+        let blocks = vec![
+            VerifiedBlock::new_for_test(
+                TestBlock::new(11, 3)
+                    .set_timestamp_ms(leader_timestamp)
+                    .build(),
+            ),
+            VerifiedBlock::new_for_test(TestBlock::new(10, 0).build()),
+            VerifiedBlock::new_for_test(TestBlock::new(10, 1).build()),
+            VerifiedBlock::new_for_test(TestBlock::new(10, 3).build()),
+        ];
+
+        let leader = blocks[0].clone();
+        let leader_ref = leader.reference();
+        let last_commit_index = 11;
+        let mut expected_subdag = CommittedSubDag::new(
+            leader_ref,
+            blocks.clone(),
+            leader_timestamp,
+            last_commit_index,
+        );
+        expected_subdag.sort();
+        let expected_unscored_subdags = vec![expected_subdag.clone()];
+        let expected_last_committed_rounds = vec![10, 10, 10, 11];
+        let last_commit = TrustedCommit::new_for_test(
+            last_commit_index,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            leader_ref,
+            blocks
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        );
+        store
+            .write(
+                WriteBatch::default()
+                    .blocks(blocks)
+                    .commits(vec![last_commit]),
+            )
+            .unwrap();
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+
+        // Check that DagState recovery from stored CommitInfo worked correctly
+        assert_eq!(
+            expected_last_committed_rounds,
+            dag_state.read().last_committed_rounds()
+        );
+        let actual_unscored_subdags = dag_state.read().unscored_committed_subdags();
+        assert_eq!(
+            expected_unscored_subdags.len() as u64,
+            dag_state.read().unscored_committed_subdags_count()
+        );
+        let mut actual_subdag = actual_unscored_subdags[0].clone();
+        actual_subdag.sort();
+        assert_eq!(expected_subdag, actual_subdag);
+
+        let leader_schedule = LeaderSchedule::from_store(context.clone(), dag_state.clone());
+
+        // Check that LeaderSchedule recovery from stored CommitInfo worked correctly
+        let leader_swap_table = leader_schedule.leader_swap_table.read();
+        assert_eq!(leader_swap_table.good_nodes.len(), 1);
+        assert_eq!(
+            leader_swap_table.good_nodes[0].0,
+            AuthorityIndex::new_for_test(0)
+        );
+        assert_eq!(leader_swap_table.bad_nodes.len(), 1);
+        assert!(leader_swap_table
+            .bad_nodes
+            .contains_key(&AuthorityIndex::new_for_test(1)));
+    }
+
+    #[tokio::test]
+    async fn test_leader_schedule_commits_until_leader_schedule_update() {
+        telemetry_subscribers::init_for_testing();
+        let context = Arc::new(Context::new_for_test(4).0);
+        let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
+
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let unscored_subdags = vec![CommittedSubDag::new(
+            BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
+            vec![],
+            context.clock.timestamp_utc_ms(),
+            1,
+        )];
+        dag_state
+            .write()
+            .add_unscored_committed_subdags(unscored_subdags);
+
+        let commits_until_leader_schedule_update =
+            leader_schedule.commits_until_leader_schedule_update(dag_state.clone());
+        assert_eq!(commits_until_leader_schedule_update, 299);
+    }
+
+    #[tokio::test]
+    async fn test_leader_schedule_update_leader_schedule() {
+        telemetry_subscribers::init_for_testing();
+        let mut context = Context::new_for_test(4).0;
+        context
+            .protocol_config
+            .set_consensus_bad_nodes_stake_threshold(33);
+        let context = Arc::new(context);
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+
+        // Populate fully connected test blocks for round 0 ~ 4, authorities 0 ~ 3.
+        let max_round: u32 = 4;
+        let num_authorities: u32 = 4;
+
+        let mut blocks = Vec::new();
+        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlock::new(0, author_idx).build();
+                VerifiedBlock::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        blocks.extend(genesis);
+
+        let mut ancestors = genesis_references;
+        let mut leader = None;
+        for round in 1..=max_round {
+            let mut new_ancestors = vec![];
+            for author in 0..num_authorities {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlock::new_for_test(
+                    TestBlock::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .build(),
+                );
+                new_ancestors.push(block.reference());
+
+                // Simulate referenced block which was part of another committed
+                // subdag.
+                if round == 3 && author == 0 {
+                    tracing::info!("Skipping {block} in committed subdags blocks");
+                    continue;
+                }
+
+                blocks.push(block.clone());
+
+                // only write one block for the final round, which is the leader
+                // of the committed subdag.
+                if round == max_round {
+                    leader = Some(block.clone());
+                    break;
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        let leader_block = leader.unwrap();
+        let leader_ref = leader_block.reference();
+        let commit_index = 1;
+
+        let last_commit = TrustedCommit::new_for_test(
+            commit_index,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            leader_ref,
+            blocks
+                .iter()
+                .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+        );
+
+        let unscored_subdags = vec![CommittedSubDag::new(
+            leader_ref,
+            blocks,
+            context.clock.timestamp_utc_ms(),
+            commit_index,
+        )];
+
+        let mut dag_state_write = dag_state.write();
+        dag_state_write.set_last_commit(last_commit);
+        dag_state_write.add_unscored_committed_subdags(unscored_subdags);
+        drop(dag_state_write);
+
+        let committer = UniversalCommitterBuilder::new(
+            context.clone(),
+            leader_schedule.clone(),
+            dag_state.clone(),
+        )
+        .with_pipeline(true)
+        .build();
+
+        assert_eq!(
+            leader_schedule.elect_leader(4, 0),
+            AuthorityIndex::new_for_test(0)
+        );
+
+        leader_schedule.update_leader_schedule(dag_state.clone(), &committer);
+
+        let leader_swap_table = leader_schedule.leader_swap_table.read();
+        assert_eq!(leader_swap_table.good_nodes.len(), 1);
+        assert_eq!(
+            leader_swap_table.good_nodes[0].0,
+            AuthorityIndex::new_for_test(3)
+        );
+        assert_eq!(leader_swap_table.bad_nodes.len(), 1);
+        assert!(leader_swap_table
+            .bad_nodes
+            .contains_key(&AuthorityIndex::new_for_test(0)));
+        assert_eq!(
+            leader_schedule.elect_leader(4, 0),
+            AuthorityIndex::new_for_test(3)
+        );
+    }
+
+    #[tokio::test]
     async fn test_leader_swap_table() {
         telemetry_subscribers::init_for_testing();
         let context = Arc::new(Context::new_for_test(4).0);
 
         let swap_stake_threshold = 33;
-        let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..11),
-            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
-        );
+        let reputation_scores =
+            ReputationScores::new((0..11).into(), (0..4).map(|i| i as u64).collect::<Vec<_>>());
         let leader_swap_table =
             LeaderSwapTable::new(context, reputation_scores, swap_stake_threshold);
 
@@ -380,10 +785,8 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
 
         let swap_stake_threshold = 33;
-        let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..11),
-            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
-        );
+        let reputation_scores =
+            ReputationScores::new((0..11).into(), (0..4).map(|i| i as u64).collect::<Vec<_>>());
         let leader_swap_table =
             LeaderSwapTable::new(context.clone(), reputation_scores, swap_stake_threshold);
 
@@ -449,10 +852,8 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
 
         let swap_stake_threshold = 34;
-        let reputation_scores = ReputationScores::new(
-            CommitRange::new(0..11),
-            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
-        );
+        let reputation_scores =
+            ReputationScores::new((0..11).into(), (0..4).map(|i| i as u64).collect::<Vec<_>>());
         LeaderSwapTable::new(context, reputation_scores, swap_stake_threshold);
     }
 
@@ -462,10 +863,8 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
 
         let swap_stake_threshold = 33;
-        let reputation_scores = ReputationScores::new(
-            CommitRange::new(1..11),
-            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
-        );
+        let reputation_scores =
+            ReputationScores::new((1..11).into(), (0..4).map(|i| i as u64).collect::<Vec<_>>());
         let leader_swap_table =
             LeaderSwapTable::new(context.clone(), reputation_scores, swap_stake_threshold);
 
@@ -475,7 +874,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(11..21),
+            (11..21).into(),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -494,10 +893,8 @@ mod tests {
         let context = Arc::new(Context::new_for_test(4).0);
 
         let swap_stake_threshold = 33;
-        let reputation_scores = ReputationScores::new(
-            CommitRange::new(1..11),
-            (0..4).map(|i| i as u64).collect::<Vec<_>>(),
-        );
+        let reputation_scores =
+            ReputationScores::new((1..11).into(), (0..4).map(|i| i as u64).collect::<Vec<_>>());
         let leader_swap_table =
             LeaderSwapTable::new(context.clone(), reputation_scores, swap_stake_threshold);
 
@@ -507,7 +904,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(11..21),
+            (11..21).into(),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =
@@ -517,7 +914,7 @@ mod tests {
         leader_schedule.update_leader_swap_table(leader_swap_table.clone());
 
         let reputation_scores = ReputationScores::new(
-            CommitRange::new(21..26),
+            (21..26).into(),
             (0..4).map(|i| i as u64).collect::<Vec<_>>(),
         );
         let leader_swap_table =

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -22,7 +22,6 @@ use crate::{
     CommittedSubDag, Round,
 };
 
-#[allow(unused)]
 pub(crate) struct ReputationScoreCalculator<'a> {
     // The range of commits that these scores are calculated from.
     pub(crate) commit_range: CommitRange,
@@ -44,7 +43,6 @@ pub(crate) struct ReputationScoreCalculator<'a> {
     committer: &'a UniversalCommitter,
 }
 
-#[allow(unused)]
 impl<'a> ReputationScoreCalculator<'a> {
     pub(crate) fn new(
         context: Arc<Context>,
@@ -114,7 +112,6 @@ pub(crate) struct ReputationScores {
     pub(crate) commit_range: CommitRange,
 }
 
-#[allow(unused)]
 impl ReputationScores {
     pub(crate) fn new(commit_range: CommitRange, scores_per_authority: Vec<u64>) -> Self {
         Self {
@@ -372,7 +369,7 @@ mod tests {
     #[tokio::test]
     async fn test_reputation_scores_authorities_by_score_desc() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let scores = ReputationScores::new(CommitRange::new(1..300), vec![4, 1, 1, 3]);
+        let scores = ReputationScores::new((1..300).into(), vec![4, 1, 1, 3]);
         let authorities = scores.authorities_by_score_desc(context);
         assert_eq!(
             authorities,
@@ -388,7 +385,7 @@ mod tests {
     #[tokio::test]
     async fn test_reputation_scores_update_metrics() {
         let context = Arc::new(Context::new_for_test(4).0);
-        let scores = ReputationScores::new(CommitRange::new(1..300), vec![1, 2, 4, 3]);
+        let scores = ReputationScores::new((1..300).into(), vec![1, 2, 4, 3]);
         scores.update_metrics(context.clone());
         let metrics = context.metrics.node_metrics.reputation_scores.clone();
         assert_eq!(
@@ -501,7 +498,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 
     #[tokio::test]
@@ -654,6 +651,6 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 }

--- a/consensus/core/src/leader_scoring_strategy.rs
+++ b/consensus/core/src/leader_scoring_strategy.rs
@@ -307,7 +307,6 @@ mod tests {
     use super::*;
     use crate::{
         block::{BlockTimestampMs, TestBlock, VerifiedBlock},
-        commit::CommitRange,
         context::Context,
         dag_state::DagState,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
@@ -329,7 +328,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![2, 1, 1, 1]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 
     #[tokio::test]
@@ -344,7 +343,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![3, 2, 2, 2]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 
     #[tokio::test]
@@ -359,7 +358,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![1, 1, 1, 1]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 
     #[tokio::test]
@@ -374,7 +373,7 @@ mod tests {
         );
         let scores = calculator.calculate();
         assert_eq!(scores.scores_per_authority, vec![5, 5, 5, 5]);
-        assert_eq!(scores.commit_range, CommitRange::new(1..2));
+        assert_eq!(scores.commit_range, (1..2).into());
     }
 
     fn basic_setup() -> (

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -109,6 +109,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) leader_timeout_total: IntCounterVec,
     pub(crate) missing_blocks_total: IntCounter,
     pub(crate) missing_blocks_after_fetch_total: IntCounter,
+    pub(crate) num_of_bad_nodes: IntGauge,
     pub(crate) quorum_receive_latency: Histogram,
     pub(crate) reputation_scores: IntGaugeVec,
     pub(crate) scope_processing_time: HistogramVec,
@@ -307,6 +308,11 @@ impl NodeMetrics {
                 "missing_blocks_after_fetch_total",
                 "Total number of missing blocks after fetching blocks from peer",
                 registry,
+            ).unwrap(),
+            num_of_bad_nodes: register_int_gauge_with_registry!(
+                "num_of_bad_nodes",
+                "The number of bad nodes in the new leader schedule",
+                registry
             ).unwrap(),
             quorum_receive_latency: register_histogram_with_registry!(
                 "quorum_receive_latency",

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -9,10 +9,13 @@ use std::{
 use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
-use super::{CommitInfo, Store, WriteBatch};
+use super::{Store, WriteBatch};
 use crate::{
     block::{BlockAPI as _, BlockDigest, BlockRef, Round, Slot, VerifiedBlock},
-    commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
+    commit::{
+        CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef,
+        TrustedCommit,
+    },
     error::ConsensusResult,
 };
 
@@ -72,11 +75,10 @@ impl Store for MemStore {
                 .insert((commit.index(), commit.digest()), commit);
         }
 
-        // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
-        if let Some((commit_ref, last_commit_info)) = write_batch.last_commit_info {
+        for (commit_ref, commit_info) in write_batch.commit_info {
             inner
                 .commit_info
-                .insert((commit_ref.index, commit_ref.digest), last_commit_info);
+                .insert((commit_ref.index, commit_ref.digest), commit_info);
         }
 
         Ok(())

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -11,8 +11,9 @@ use consensus_config::AuthorityIndex;
 
 use crate::{
     block::{BlockRef, Round, Slot, VerifiedBlock},
-    commit::{CommitIndex, CommitInfo, CommitRange, CommitRef, TrustedCommit},
+    commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
+    CommitIndex,
 };
 
 /// A common interface for consensus storage.
@@ -64,19 +65,19 @@ pub(crate) trait Store: Send + Sync {
 pub(crate) struct WriteBatch {
     pub(crate) blocks: Vec<VerifiedBlock>,
     pub(crate) commits: Vec<TrustedCommit>,
-    pub(crate) last_commit_info: Option<(CommitRef, CommitInfo)>,
+    pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
 }
 
 impl WriteBatch {
     pub(crate) fn new(
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
-        last_commit_info: Option<(CommitRef, CommitInfo)>,
+        commit_info: Vec<(CommitRef, CommitInfo)>,
     ) -> Self {
         WriteBatch {
             blocks,
             commits,
-            last_commit_info,
+            commit_info,
         }
     }
 
@@ -91,6 +92,12 @@ impl WriteBatch {
     #[cfg(test)]
     pub(crate) fn commits(mut self, commits: Vec<TrustedCommit>) -> Self {
         self.commits = commits;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn commit_info(mut self, commit_info: Vec<(CommitRef, CommitInfo)>) -> Self {
+        self.commit_info = commit_info;
         self
     }
 }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -136,12 +136,11 @@ impl Store for RocksDBStore {
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
-        // CommitInfo can be unavailable in tests, or when we decide to skip writing it.
-        if let Some((commit_ref, last_commit_info)) = write_batch.last_commit_info {
+        for (commit_ref, commit_info) in write_batch.commit_info {
             batch
                 .insert_batch(
                     &self.commit_info,
-                    [((commit_ref.index, commit_ref.digest), last_commit_info)],
+                    [((commit_ref.index, commit_ref.digest), commit_info)],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
         }


### PR DESCRIPTION
## Description 
This is one of many PRs to implement Leader Scoring & Leader Schedule feature for Mysticeti.
- [Design Doc](https://www.notion.so/mystenlabs/Leader-Schedule-Scoring-538c65cb370b4644944a94485efc4979?pvs=4)
- [Prototype PR](https://github.com/MystenLabs/sui/pull/16975)

Leader Schedule Change Notes:
- We can choose the scoring strategy via an env var similar to how we are doing for networking. Will submit the workflow changes so this is easily configurable via gh deploy workflows
- In practice it looks like the LeaderSchedule change takes about [250](https://metrics.sui.io/goto/5pPPAExSR?orgId=1)-[500ms](https://metrics.sui.io/goto/qifU0ExIR?orgId=1) depending on the scoring strategy chosen. While this is not negatively impacting performance it does mean that there is additional room for improvement in a follow up PR with how we are traversing the DAG

Recovery Notes:
- We are now only writing `last_commit_rounds` & `reputation_scores` on a leader schedule change. Any commits that happen after that will be accounted for during recovery. 

![Screenshot 2024-04-03 at 10 07 44 PM](https://github.com/MystenLabs/sui/assets/97870774/b1ec55da-13c1-43a6-b3fe-e3c3eeff8843)
![Screenshot 2024-04-03 at 10 07 12 PM](https://github.com/MystenLabs/sui/assets/97870774/bf2804fc-0787-4e8d-a5c4-2e2c855264cb)

## Results
![Screenshot 2024-04-03 at 10 23 41 PM](https://github.com/MystenLabs/sui/assets/97870774/7e14a58d-d455-41f3-8b9f-aeb7142c8fb0)


## Test Plan 

unit tests

