### PR TITLE
[Release Notes] Script to extract release notes in the new format

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import subprocess
+import json
+import os
+import re
+import sys
+
+if len(sys.argv) < 2:
+    #      0         1         2         3         4         5         6         7         8
+    #      012345678901234567890123456789012345678901234567890123456789012345678901234567890
+    print("Usage: ./release_notes.py <ancestor-sha>", file=sys.stderr)
+    print()
+    print("Extract release notes from git commits from <ancestor-sha> (exclusive) to HEAD", file=sys.stderr)
+    print("(inclusive).", file=sys.stderr)
+    sys.exit(1)
+
+
+def git(*args):
+    return subprocess.check_output(["git"] + list(args)).decode()
+
+
+RE_HEADING = re.compile(
+    r"#+ Release notes(.*)",
+    re.DOTALL | re.IGNORECASE,
+)
+
+RE_CHECK = re.compile(
+    r"^\s*-\s*\[.\]",
+    re.MULTILINE,
+)
+
+RE_NOTE = re.compile(
+    r"^\s*-\s*\[x\]\s*([^:]+):",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+before = sys.argv[1]
+results = []
+
+for commit in git("log", "--pretty=format:%H", f"{before}..HEAD").split("\n"):
+for message in TEST_COMMITS:
+    message = git("show", "-s", "--format=%B", commit)
+
+    match = RE_HEADING.search(message)
+    if not match:
+        continue
+
+    start = 0
+    notes = match.group(1)
+    result = {"sha": commit, "notes": {}}
+
+    while True:
+        # Find the next checked release note
+        match = RE_NOTE.search(notes, start)
+        if not match:
+            break
+
+        impacted = match.group(1)
+        begin = match.end()
+
+        # Find the end of the note, or the end of the commit
+        match = RE_CHECK.search(notes, begin)
+        end = match.start() if match else len(notes)
+
+        result["notes"][impacted] = notes[begin:end].strip()
+        start = end
+
+    if result["notes"]:
+        results.append(result)
+
+json.dump(results, sys.stdout, indent=2)

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -39,7 +39,6 @@ before = sys.argv[1]
 results = []
 
 for commit in git("log", "--pretty=format:%H", f"{before}..HEAD").split("\n"):
-for message in TEST_COMMITS:
     message = git("show", "-s", "--format=%B", commit)
 
     match = RE_HEADING.search(message)

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,24 +1,22 @@
 #!/usr/bin/env python3
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
-import subprocess
+import argparse
+from collections import defaultdict
 import json
 import os
 import re
+import subprocess
 import sys
+from typing import NamedTuple
 
-if len(sys.argv) < 2:
-    #      0         1         2         3         4         5         6         7         8
-    #      012345678901234567890123456789012345678901234567890123456789012345678901234567890
-    print("Usage: ./release_notes.py <ancestor-sha>", file=sys.stderr)
-    print()
-    print("Extract release notes from git commits from <ancestor-sha> (exclusive) to HEAD", file=sys.stderr)
-    print("(inclusive).", file=sys.stderr)
-    sys.exit(1)
+RE_NUM = re.compile("[0-9_]+")
 
-
-def git(*args):
-    return subprocess.check_output(["git"] + list(args)).decode()
-
+RE_PR = re.compile(
+    "^.*\(#(\d+)\)$",
+    re.MULTILINE,
+)
 
 RE_HEADING = re.compile(
     r"#+ Release notes(.*)",
@@ -31,41 +29,260 @@ RE_CHECK = re.compile(
 )
 
 RE_NOTE = re.compile(
-    r"^\s*-\s*\[x\]\s*([^:]+):",
+    r"^\s*-\s*\[( |x)?\]\s*([^:]+):",
     re.MULTILINE | re.IGNORECASE,
 )
 
-before = sys.argv[1]
-results = []
+# Only commits that affect changes in these directories will be
+# considered when generating release notes.
+INTERESTING_DIRECTORIES = [
+    "crates",
+    "dashboards",
+    "doc",
+    "docker",
+    "external-crates",
+    "kiosk",
+    "narwhal",
+    "nre",
+    "sui-execution",
+]
 
-for commit in git("log", "--pretty=format:%H", f"{before}..HEAD").split("\n"):
+# Start release notes with these sections, if they contain relevant
+# information (helps us keep a consistent order for impact areas we
+# know about).
+NOTE_ORDER = [
+    "Protocol",
+    "Nodes (Validators and Full nodes)",
+    "Indexer",
+    "JSON-RPC",
+    "GraphQL",
+    "CLI",
+    "Rust SDK",
+]
+
+class Note(NamedTuple):
+    checked: bool
+    note: str
+
+def parse_args():
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract release notes from git commits. Check help for the "
+            "`generate` and `check` subcommands for more information."
+        ),
+    )
+
+    sub_parser = parser.add_subparsers(dest="command")
+
+    generate_p = sub_parser.add_parser(
+        "generate",
+        description="Generate release notes from git commits.",
+    )
+
+    generate_p.add_argument(
+        "from",
+        help="The commit to start from (exclusive)",
+    )
+
+    generate_p.add_argument(
+        "to",
+        nargs="?",
+        default="HEAD",
+        help="The commit to end at (inclusive), defaults to HEAD.",
+    )
+
+    check_p = sub_parser.add_parser(
+        "check",
+        description=(
+            "Check if the release notes section of a givne commit is complete, "
+            "i.e. that every impacted component has a non-empty note."
+        ),
+    )
+
+    check_p.add_argument(
+        "commit",
+        nargs="?",
+        default="HEAD",
+        help="The commit to check, defaults to HEAD.",
+    )
+
+    return vars(parser.parse_args())
+
+
+def git(*args):
+    """Run a git command and return the output as a string."""
+    return subprocess.check_output(["git"] + list(args)).decode().strip()
+
+
+def extract_notes(commit):
+    """Get release notes from a commit message.
+
+    Find the 'Release notes' section in the commit message, and
+    extract the notes for each impacted area (area that has been
+    ticked).
+
+    Returns a tuple of the PR number and a dictionary of impacted
+    areas mapped to their release note. Each release note indicates
+    whether it has a note and whether it was checked (ticked).
+
+    """
     message = git("show", "-s", "--format=%B", commit)
 
+    # Extract PR number
+    match = RE_PR.match(message)
+    pr = match.group(1) if match else None
+    result = {}
+
+    # Find the release notes section
     match = RE_HEADING.search(message)
     if not match:
-        continue
+        return pr, result
 
     start = 0
     notes = match.group(1)
-    result = {"sha": commit, "notes": {}}
 
     while True:
-        # Find the next checked release note
+        # Find the next possible release note
         match = RE_NOTE.search(notes, start)
         if not match:
             break
 
-        impacted = match.group(1)
+        checked = match.group(1)
+        impacted = match.group(2)
         begin = match.end()
 
         # Find the end of the note, or the end of the commit
         match = RE_CHECK.search(notes, begin)
         end = match.start() if match else len(notes)
 
-        result["notes"][impacted] = notes[begin:end].strip()
+        result[impacted] = Note(
+            checked = checked in 'xX',
+            note = notes[begin:end].strip(),
+        )
         start = end
 
-    if result["notes"]:
-        results.append(result)
+    return pr, result
 
-json.dump(results, sys.stdout, indent=2)
+
+def extract_protocol_version(commit):
+    """Find the max protocol version at this commit.
+
+    Assumes that it is being called from the root of the sui repository."""
+    for line in git("show", f"{commit}:crates/sui-protocol-config/src/lib.rs").splitlines():
+        if "const MAX_PROTOCOL_VERSION" not in line:
+            continue
+
+        _, _, assign = line.partition("=")
+        if not assign:
+            continue
+
+        match = RE_NUM.search(assign)
+        if not match:
+            continue
+
+        return match[0]
+
+
+def print_changelog(pr, log):
+    if pr:
+        print(f"https://github.com/MystenLabs/sui/pull/{pr}:")
+    print(log)
+
+
+def do_check(commit):
+    """Check if the release notes section of a given commit is complete.
+
+    This means that every impacted component has a non-empty note,
+    every note is attached to a checked checkbox, and every impact
+    area is known.
+
+    """
+
+    _, notes = extract_notes(commit)
+    issues = []
+    for impacted, note in notes.items():
+        if impacted not in NOTE_ORDER:
+            issues.append(f" - Found unfamiliar impact area '{impacted}'.")
+
+        if note.checked and not note.note:
+            issues.append(f" - '{impacted}' is checked but has no release note.")
+
+        if not note.checked and note.note:
+            issues.append(f" - '{impacted}' has a release note but is not checked: {note.note}")
+
+    if not issues:
+        return
+
+    print(f"Found issues with release notes in {commit}:")
+    for issue in issues:
+        print(issue)
+    sys.exit(1)
+
+
+def do_generate(from_, to):
+    """Generate release notes from git commits.
+
+    This will extract the release notes from all commits between
+    `from_` (exclusive) and `to` (inclusive), and print out a markdown
+    snippet with a heading for each impact area that has a note,
+    followed by a list of its relevant changelog.
+
+    Only looks for commits affecting INTERESTING_DIRECTORIES.
+
+    Additionally injects the current protocol version into the
+    "Protocol" changelog.
+
+    """
+    results = defaultdict(list)
+
+    root = git("rev-parse", "--show-toplevel")
+    os.chdir(root)
+
+    protocol_version = extract_protocol_version(to) or "XX"
+
+    commits = git(
+        "log", "--pretty=format:%H",
+        f"{from_}..{to}",
+        "--", *INTERESTING_DIRECTORIES,
+    ).strip();
+
+    if not commits:
+        return
+
+    for commit in commits.split("\n"):
+        pr, notes = extract_notes(commit)
+        for impacted, note in notes.items():
+            if note.checked:
+                results[impacted].append((pr, note.note))
+
+    # Print the impact areas we know about first
+    for impacted in NOTE_ORDER:
+        notes = results.pop(impacted, None)
+        if not notes:
+            continue
+
+        print(f"## {impacted}")
+
+        if impacted == "Protocol":
+            print(f"Sui Protocol Version in this release: {protocol_version}")
+        print()
+
+        for pr, note in reversed(notes):
+            print_changelog(pr, note)
+            print()
+
+    # Print any remaining impact areas
+    for impacted, notes in results.items():
+        print(f"## {impacted}\n")
+        for pr, note in reversed(notes):
+            print_changelog(pr, note)
+            print()
+
+
+args = parse_args()
+if args["command"]== "generate":
+    do_generate(args["from"], args["to"])
+elif args["command"] == "check":
+    do_check(args["commit"])


### PR DESCRIPTION
## Description

Script extracts release notes in the new format where a single PR can contain different breaking changes for each functional area

## Test Plan

Tested manually against a set of local commits.

Example output from `generate` command:

```
## Protocol
Sui Protocol Version in this release: 43

https://github.com/MystenLabs/sui/pull/42:
Bumped protocol version to 42

https://github.com/MystenLabs/sui/pull/9001:
You get a release note

## Nodes (Validators and Full nodes)

https://github.com/MystenLabs/sui/pull/44:


## Indexer

https://github.com/MystenLabs/sui/pull/9001:
You get a release note

## JSON-RPC

https://github.com/MystenLabs/sui/pull/42:
Made some sweeping changes, to:
  - Foo
  - Bar

## CLI

https://github.com/MystenLabs/sui/pull/9001:
Everybody gets release notes
```

Example output from `check` command (if there are issues):

```
Found issues with release notes in amnn/test-release-notes^:
 - 'Protocol' has a release note but is not checked: An important message, can't miss!
 - 'Nodes (Validators and Full nodes)' is checked but has no release note.
```