### PR TITLE
Making protocol compatibility script more verbose

### DIFF
--- a/scripts/compatibility/check-protocol-compatibility.sh
+++ b/scripts/compatibility/check-protocol-compatibility.sh
@@ -44,8 +44,12 @@ ORIGIN_COMMIT=$(echo "$TOP_VERSION" | cut -d- -f2)
 
 git fetch -q || exit 1
 SOURCE_COMMIT=$(git rev-parse HEAD)
+SOURCE_BRANCH=$(git branch -a --contains "$SOURCE_COMMIT" | head -n 1 | cut -d' ' -f2-)
 
-echo "Checking protocol compatibility of $SOURCE_COMMIT with $NETWORK ($ORIGIN_COMMIT)"
+echo "Source commit: $SOURCE_COMMIT"
+echo "Source branch: $SOURCE_BRANCH"
+
+echo "Checking protocol compatibility with $NETWORK ($ORIGIN_COMMIT)"
 
 # put code to check if git client is clean into function
 function check_git_clean {

--- a/scripts/compatibility/check-protocol-compatibility.sh
+++ b/scripts/compatibility/check-protocol-compatibility.sh
@@ -42,31 +42,10 @@ echo "Using most frequent version $TOP_VERSION for compatibility check"
 # TOP_VERSION looks like "1.0.0-ae1212baf8", split out the commit hash
 ORIGIN_COMMIT=$(echo "$TOP_VERSION" | cut -d- -f2)
 
-echo "Checking protocol compatibility with $NETWORK ($ORIGIN_COMMIT)"
-
 git fetch -q || exit 1
+SOURCE_COMMIT=$(git rev-parse HEAD)
 
-if [ "$NETWORK" == "mainnet" ]; then
-  # expand $ORIGIN_COMMIT to full sha
-  ORIGIN_COMMIT=$(git rev-parse "$ORIGIN_COMMIT") || exit 1
-
-  # HACK: a commit was released with broken snapshot tests. Substitute the commit with the
-  # tests fixed.
-  if [ "$ORIGIN_COMMIT" == 5fd1242217d68ff726f9eab1fb7b1a1edac3ce48 -o "$ORIGIN_COMMIT" == cdd690331047d8c19eccc784e1d27ba42a0ed428 ]; then
-    ORIGIN_COMMIT="d951895b90014b58cfd7734e3a5a25d7a37ee9b7"
-  fi
-fi
-
-if [ "$NETWORK" == "testnet" ]; then
-  # expand $ORIGIN_COMMIT to full sha
-  ORIGIN_COMMIT=$(git rev-parse "$ORIGIN_COMMIT") || exit 1
-
-  # HACK: a commit was released with broken snapshot tests. Substitute the commit with the
-  # tests fixed.
-  if [ "$ORIGIN_COMMIT" == 10da1ccdde8b12e700a7bc22dddf2992f532bd00 ]; then
-    ORIGIN_COMMIT="bf41cca24aa65b1a94aef25bc916678ca00f3017"
-  fi
-fi
+echo "Checking protocol compatibility of $SOURCE_COMMIT with $NETWORK ($ORIGIN_COMMIT)"
 
 # put code to check if git client is clean into function
 function check_git_clean {


### PR DESCRIPTION
## Description 
* Making protocol compatibility script more verbose when a failure occurs since it does not output the source commit on main and or release branches
* Remove hacky code

## Test Plan 
```
eugene@eugene-dev ~/code/sui/ (ebmifa/make_protocol_compotibility_script_more_verbose) $ ./scripts/compatibility/check-protocol-compatibility.sh mainnet
Found following versions on mainnet:
     80 1.21.1-a67a73bcfab3
     34 1.21.1-a67a73bcfa
      1 1.21.1-3b488a9df005

Using most frequent version 1.21.1-a67a73bcfab3 for compatibility check
Source commit: c2c22e7e9f0b56a16cc54dde46d537f0658e72ea
Source branch: ebmifa/make_protocol_compotibility_script_more_verbose
Checking protocol compatibility with mainnet (a67a73bcfab3)
Checking out mainnet snapshot files
Checking for changes to snapshot files matching *__Mainnet_version_*
HEAD is now at c2c22e7e9f Making it more verbose
Running snapshot tests...
    Finished test [unoptimized + debuginfo] target(s) in 0.36s
     Running unittests src/lib.rs (target/debug/deps/sui_protocol_config-b2b07029980b4bfd)

running 1 test
test test::snapshot_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.35s
```
