### PR TITLE
Better settlement finality logging

### DIFF
--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -785,13 +785,15 @@ where
                 TX_TYPE_SHARED_OBJ_TX
             }])
             .observe(settlement_finality_latency);
-        if settlement_finality_latency >= 8.0 || settlement_finality_latency <= 0.1 {
-            debug!(
-                ?tx_digest,
-                "Settlement finality latency is out of expected range: {}",
-                settlement_finality_latency
-            );
-        }
+        let is_out_of_expected_range =
+            settlement_finality_latency >= 8.0 || settlement_finality_latency <= 0.1;
+        debug!(
+            ?tx_digest,
+            ?is_single_writer_tx,
+            ?is_out_of_expected_range,
+            "QuorumDriver settlement finality latency: {:.3} seconds",
+            settlement_finality_latency
+        );
 
         quorum_driver.notify(&transaction, &Ok(response), old_retry_times + 1);
     }


### PR DESCRIPTION
## Description 

Log every settlement finality. This is a small overhead given that it's just one extra log line per finalized transaction. Log whether it's a single_writer transaction as well. This will help eye ball transactions for regressions.

## Test Plan 

CI

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
