### PR TITLE
Drop marker in db checkpoint which has state snapshot

### DIFF
--- a/crates/sui-snapshot/src/uploader.rs
+++ b/crates/sui-snapshot/src/uploader.rs
@@ -157,6 +157,17 @@ impl StateSnapshotUploader {
                 )
                 .await?;
                 info!("State snapshot completed for epoch: {epoch}");
+            } else {
+                let bytes = Bytes::from_static(b"success");
+                let state_snapshot_completed_marker =
+                    db_path.child(STATE_SNAPSHOT_COMPLETED_MARKER);
+                put(
+                    &self.db_checkpoint_store.clone(),
+                    &state_snapshot_completed_marker,
+                    bytes.clone(),
+                )
+                .await?;
+                info!("State snapshot skipped for epoch: {epoch}");
             }
         }
         Ok(())


### PR DESCRIPTION
## Description 

In state snapshot uploader, we want to drop success marker in db checkpoints which already have state snapshot. This will unblock db checkpoint to not wait indefinitely if state snapshots already exist