### PR TITLE
Aw/unit test module check fix

### DIFF
--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -967,7 +967,11 @@ fn run(
         match cur {
             PassResult::Parser(prog) => {
                 let eprog = {
-                    let prog = unit_test::filter_test_members::program(compilation_env, prog);
+                    let prog = unit_test::filter_test_members::program(
+                        compilation_env,
+                        pre_compiled_lib.clone(),
+                        prog,
+                    );
                     let prog = verification_attribute_filter::program(compilation_env, prog);
                     expansion::translate::program(compilation_env, pre_compiled_lib.clone(), prog)
                 };

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -2,6 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_ir_types::location::{sp, Loc};
+use move_symbol_pool::Symbol;
+
 use crate::{
     command_line::compiler::FullyCompiledProgram,
     diag,
@@ -11,8 +14,6 @@ use crate::{
     },
     shared::{known_attributes, CompilationEnv},
 };
-use move_ir_types::location::{sp, Loc};
-use move_symbol_pool::Symbol;
 
 use std::sync::Arc;
 

--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -2,10 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_ir_types::location::{sp, Loc};
-use move_symbol_pool::Symbol;
-
 use crate::{
+    command_line::compiler::FullyCompiledProgram,
     diag,
     parser::{
         ast::{self as P, NamePath, PathEntry},
@@ -13,6 +11,10 @@ use crate::{
     },
     shared::{known_attributes, CompilationEnv},
 };
+use move_ir_types::location::{sp, Loc};
+use move_symbol_pool::Symbol;
+
+use std::sync::Arc;
 
 struct Context<'env> {
     env: &'env mut CompilationEnv,
@@ -84,8 +86,12 @@ const STDLIB_ADDRESS_NAME: Symbol = symbol!("std");
 // This filters out all test, and test-only annotated module member from `prog` if the `test` flag
 // in `compilation_env` is not set. If the test flag is set, no filtering is performed, and instead
 // a test plan is created for use by the testing framework.
-pub fn program(compilation_env: &mut CompilationEnv, prog: P::Program) -> P::Program {
-    if !check_has_unit_test_module(compilation_env, &prog) {
+pub fn program(
+    compilation_env: &mut CompilationEnv,
+    pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
+    prog: P::Program,
+) -> P::Program {
+    if !check_has_unit_test_module(compilation_env, pre_compiled_lib, &prog) {
         return prog;
     }
 
@@ -94,9 +100,8 @@ pub fn program(compilation_env: &mut CompilationEnv, prog: P::Program) -> P::Pro
     filter_program(&mut context, prog)
 }
 
-fn check_has_unit_test_module(compilation_env: &mut CompilationEnv, prog: &P::Program) -> bool {
-    let has_unit_test_module = prog
-        .lib_definitions
+fn has_unit_test_module(prog: &P::Program) -> bool {
+    prog.lib_definitions
         .iter()
         .chain(prog.source_definitions.iter())
         .any(|pkg| match &pkg.def {
@@ -113,7 +118,20 @@ fn check_has_unit_test_module(compilation_env: &mut CompilationEnv, prog: &P::Pr
                     }
             }
             _ => false,
-        });
+        })
+}
+
+fn check_has_unit_test_module(
+    compilation_env: &mut CompilationEnv,
+    pre_compiled_lib: Option<Arc<FullyCompiledProgram>>,
+    prog: &P::Program,
+) -> bool {
+    let has_unit_test_module = has_unit_test_module(prog)
+        || if let Some(p) = pre_compiled_lib {
+            has_unit_test_module(&p.parser)
+        } else {
+            false
+        };
 
     if !has_unit_test_module && compilation_env.flags().is_testing() {
         if let Some(P::PackageDefinition { def, .. }) = prog


### PR DESCRIPTION
## Description 

The `UnitTest` module check should also take pre-compiled libraries into consideration

## Test Plan 

Verified that the missing `UnitTest` module diag is no longer incorrectly produced when pre-compiled libs are inspected