### PR TITLE
Remove effects v1 logic from latest temp store

### DIFF
--- a/crates/sui-e2e-tests/tests/object_deletion_tests.rs
+++ b/crates/sui-e2e-tests/tests/object_deletion_tests.rs
@@ -5,70 +5,14 @@
 mod sim_only_tests {
     use std::path::PathBuf;
     use std::time::Duration;
-    use sui_core::authority::authority_store_tables::LiveObject;
-    use sui_core::state_accumulator::AccumulatorStore;
     use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
     use sui_macros::sim_test;
     use sui_node::SuiNode;
-    use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
     use sui_test_transaction_builder::publish_package;
     use sui_types::messages_checkpoint::CheckpointSequenceNumber;
     use sui_types::{base_types::ObjectID, digests::TransactionDigest};
     use test_cluster::{TestCluster, TestClusterBuilder};
     use tokio::time::timeout;
-
-    /// This test checks that after we enable simplified_unwrap_then_delete, we no longer depend
-    /// on wrapped tombstones when generating effects and using effects.
-    #[sim_test]
-    async fn test_no_more_dependency_on_wrapped_tombstone() {
-        let mut _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_simplified_unwrap_then_delete(false);
-            config
-        });
-
-        let test_cluster = TestClusterBuilder::new()
-            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
-                ProtocolVersion::MAX.as_u64(),
-                ProtocolVersion::MAX_ALLOWED.as_u64(),
-            ))
-            .build()
-            .await;
-
-        let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
-
-        let child_id = create_owned_child(&test_cluster, package_id).await;
-        wrap_child(&test_cluster, package_id, object_id, child_id).await;
-        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 1);
-
-        // At this point, we should have a wrapped tombstone in the db of every node.
-
-        drop(_guard);
-        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-            config.set_simplified_unwrap_then_delete(true);
-            config
-        });
-        // At this epoch change, we should be re-accumulating without wrapped tombstone and now
-        // flips the feature flag simplified_unwrap_then_delete to true.
-        test_cluster.trigger_reconfiguration().await;
-
-        // Remove the wrapped tombstone on some nodes but not all.
-        for (idx, validator) in test_cluster.swarm.validator_nodes().enumerate() {
-            validator.get_node_handle().unwrap().with(|node| {
-                let db = node.state().database_for_testing().clone();
-                assert_eq!(count_wrapped_tombstone(&node), 1);
-                if idx % 2 == 0 {
-                    db.remove_all_versions_of_object(child_id);
-                    assert_eq!(count_wrapped_tombstone(&node), 0);
-                }
-            })
-        }
-
-        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
-        assert_eq!(effects.modified_at_versions().len(), 2);
-        assert_eq!(effects.unwrapped_then_deleted().len(), 1);
-
-        test_cluster.trigger_reconfiguration().await;
-    }
 
     // Tests that object pruning can prune objects correctly.
     // Specifically, we first wrap a child object into a root object (tests wrap tombstone),
@@ -89,7 +33,7 @@ mod sim_only_tests {
 
         fullnode
             .with_async(|node| async {
-                // Wait until the wraping transaction is included in checkpoint.
+                // Wait until the wrapping transaction is included in checkpoint.
                 let checkpoint = timeout(
                     Duration::from_secs(60),
                     wait_until_txn_in_checkpoint(node, &wrap_child_txn_digest),
@@ -303,21 +247,6 @@ mod sim_only_tests {
             .unwrap();
         assert_eq!(effects.deleted().len(), 1);
         effects
-    }
-
-    fn count_fullnode_wrapped_tombstones(test_cluster: &TestCluster) -> usize {
-        test_cluster
-            .fullnode_handle
-            .sui_node
-            .with(|node| count_wrapped_tombstone(node))
-    }
-
-    fn count_wrapped_tombstone(node: &SuiNode) -> usize {
-        let store = node.state().get_execution_cache();
-        store
-            .iter_cached_live_object_set_for_testing(true)
-            .filter(|o| matches!(o, LiveObject::Wrapped(_)))
-            .count()
     }
 
     async fn wait_until_txn_in_checkpoint(

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2172,14 +2172,7 @@ impl ProtocolConfig {
     pub fn set_accept_zklogin_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_zklogin_in_multisig = val
     }
-    #[cfg(msim)]
-    pub fn set_simplified_unwrap_then_delete(&mut self, val: bool) {
-        self.feature_flags.simplified_unwrap_then_delete = val;
-        if val == false {
-            // Given that we will never enable effect V2 before turning on simplified_unwrap_then_delete, we also need to disable effect V2 here.
-            self.set_enable_effects_v2(false);
-        }
-    }
+
     pub fn set_shared_object_deletion(&mut self, val: bool) {
         self.feature_flags.shared_object_deletion = val;
     }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -10,7 +10,6 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::VersionDigest;
 use sui_types::committee::EpochId;
-use sui_types::digests::ObjectDigest;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::execution::{
     DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, SharedInput,
@@ -213,145 +212,8 @@ impl<'backing> TemporaryStore<'backing> {
             }
         }
 
-        if self.protocol_config.enable_effects_v2() {
-            self.into_effects_v2(
-                shared_object_refs,
-                transaction_digest,
-                transaction_dependencies,
-                gas_cost_summary,
-                status,
-                gas_charger,
-                epoch,
-            )
-        } else {
-            let shared_object_refs = shared_object_refs
-                .into_iter()
-                .map(|shared_input| match shared_input {
-                    SharedInput::Existing(oref) => oref,
-                    SharedInput::Deleted(_) => {
-                        unreachable!("Shared object deletion not supported in effects v1")
-                    }
-                })
-                .collect();
-            self.into_effects_v1(
-                shared_object_refs,
-                transaction_digest,
-                transaction_dependencies,
-                gas_cost_summary,
-                status,
-                gas_charger,
-                epoch,
-            )
-        }
-    }
+        assert!(self.protocol_config.enable_effects_v2());
 
-    fn into_effects_v1(
-        self,
-        shared_object_refs: Vec<ObjectRef>,
-        transaction_digest: &TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
-        gas_cost_summary: GasCostSummary,
-        status: ExecutionStatus,
-        gas_charger: &mut GasCharger,
-        epoch: EpochId,
-    ) -> (InnerTemporaryStore, TransactionEffects) {
-        let updated_gas_object_info = if let Some(coin_id) = gas_charger.gas_coin() {
-            let object = &self.execution_results.written_objects[&coin_id];
-            (object.compute_object_reference(), object.owner)
-        } else {
-            (
-                (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
-                Owner::AddressOwner(SuiAddress::default()),
-            )
-        };
-        let lampot_version = self.lamport_timestamp;
-
-        let mut created = vec![];
-        let mut mutated = vec![];
-        let mut unwrapped = vec![];
-        let mut deleted = vec![];
-        let mut unwrapped_then_deleted = vec![];
-        let mut wrapped = vec![];
-        // It is important that we constructs `modified_at_versions` and `deleted_at_versions`
-        // separately, and merge them latter to achieve the exact same order as in v1.
-        let mut modified_at_versions = vec![];
-        let mut deleted_at_versions = vec![];
-        self.execution_results
-            .written_objects
-            .iter()
-            .for_each(|(id, object)| {
-                let object_ref = object.compute_object_reference();
-                let owner = object.owner;
-                if let Some(old_object_meta) = self.get_object_modified_at(id) {
-                    modified_at_versions.push((*id, old_object_meta.version));
-                    mutated.push((object_ref, owner));
-                } else if self.execution_results.created_object_ids.contains(id) {
-                    created.push((object_ref, owner));
-                } else {
-                    unwrapped.push((object_ref, owner));
-                }
-            });
-        self.execution_results
-            .modified_objects
-            .iter()
-            .filter(|id| !self.execution_results.written_objects.contains_key(id))
-            .for_each(|id| {
-                let old_object_meta = self.get_object_modified_at(id).unwrap();
-                deleted_at_versions.push((*id, old_object_meta.version));
-                if self.execution_results.deleted_object_ids.contains(id) {
-                    deleted.push((*id, lampot_version, ObjectDigest::OBJECT_DIGEST_DELETED));
-                } else {
-                    wrapped.push((*id, lampot_version, ObjectDigest::OBJECT_DIGEST_WRAPPED));
-                }
-            });
-        self.execution_results
-            .deleted_object_ids
-            .iter()
-            .filter(|id| !self.execution_results.modified_objects.contains(id))
-            .for_each(|id| {
-                unwrapped_then_deleted.push((
-                    *id,
-                    lampot_version,
-                    ObjectDigest::OBJECT_DIGEST_DELETED,
-                ));
-            });
-        modified_at_versions.extend(deleted_at_versions);
-
-        let inner = self.into_inner();
-        let effects = TransactionEffects::new_from_execution_v1(
-            status,
-            epoch,
-            gas_cost_summary,
-            modified_at_versions,
-            shared_object_refs,
-            *transaction_digest,
-            created,
-            mutated,
-            unwrapped,
-            deleted,
-            unwrapped_then_deleted,
-            wrapped,
-            updated_gas_object_info,
-            if inner.events.data.is_empty() {
-                None
-            } else {
-                Some(inner.events.digest())
-            },
-            transaction_dependencies.into_iter().collect(),
-        );
-        (inner, effects)
-    }
-
-    fn into_effects_v2(
-        self,
-        shared_object_refs: Vec<SharedInput>,
-        transaction_digest: &TransactionDigest,
-        transaction_dependencies: BTreeSet<TransactionDigest>,
-        gas_cost_summary: GasCostSummary,
-        status: ExecutionStatus,
-        gas_charger: &mut GasCharger,
-        epoch: EpochId,
-    ) -> (InnerTemporaryStore, TransactionEffects) {
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
         // Gas coins are guaranteed to be at least size 1 and if more than 1
@@ -544,32 +406,11 @@ impl<'backing> TemporaryStore<'backing> {
     }
 
     pub fn estimate_effects_size_upperbound(&self) -> usize {
-        if self.protocol_config.enable_effects_v2() {
-            TransactionEffects::estimate_effects_size_upperbound_v2(
-                self.execution_results.written_objects.len(),
-                self.execution_results.modified_objects.len(),
-                self.input_objects.len(),
-            )
-        } else {
-            let num_deletes = self.execution_results.deleted_object_ids.len()
-                + self
-                    .execution_results
-                    .modified_objects
-                    .iter()
-                    .filter(|id| {
-                        // Filter for wrapped objects.
-                        !self.execution_results.written_objects.contains_key(id)
-                            && !self.execution_results.deleted_object_ids.contains(id)
-                    })
-                    .count();
-            // In the worst case, the number of deps is equal to the number of input objects
-            TransactionEffects::estimate_effects_size_upperbound_v1(
-                self.execution_results.written_objects.len(),
-                self.mutable_input_refs.len(),
-                num_deletes,
-                self.input_objects.len(),
-            )
-        }
+        TransactionEffects::estimate_effects_size_upperbound_v2(
+            self.execution_results.written_objects.len(),
+            self.execution_results.modified_objects.len(),
+            self.input_objects.len(),
+        )
     }
 
     pub fn written_objects_size(&self) -> usize {


### PR DESCRIPTION
## Description 

No longer needed in the latest temp store since v2 is always enabled.

## Test Plan 

CI
---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
