### PR TITLE
[traffic-controller][4/n] Introduce firewall dead man's switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12835,6 +12835,7 @@ dependencies = [
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
+ "sui-macros",
  "sui-open-rpc",
  "sui-open-rpc-macros",
  "sui-protocol-config",

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -16,6 +16,7 @@ use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
+use sui_types::effects::TransactionEvents;
 use sui_types::messages_consensus::ConsensusTransaction;
 use sui_types::messages_grpc::{
     HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
@@ -23,9 +24,9 @@ use sui_types::messages_grpc::{
 };
 use sui_types::multiaddr::Multiaddr;
 use sui_types::sui_system_state::SuiSystemState;
+use sui_types::traffic_control::ServiceResponse;
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 use sui_types::{effects::TransactionEffectsAPI, message_envelope::Message};
-use sui_types::{effects::TransactionEvents, traffic_control::ServiceResponse};
 use sui_types::{error::*, transaction::*};
 use sui_types::{
     fp_ensure,
@@ -268,8 +269,8 @@ impl ValidatorService {
             traffic_controller: policy_config.map(|policy| {
                 Arc::new(TrafficController::spawn(
                     policy,
-                    firewall_config,
                     traffic_controller_metrics,
+                    firewall_config,
                 ))
             }),
         }

--- a/crates/sui-core/src/traffic_controller/metrics.rs
+++ b/crates/sui-core/src/traffic_controller/metrics.rs
@@ -8,6 +8,7 @@ use prometheus::{
 
 #[derive(Clone)]
 pub struct TrafficControllerMetrics {
+    pub tallies: IntCounter,
     pub connection_ip_blocklist_len: IntGauge,
     pub proxy_ip_blocklist_len: IntGauge,
     pub requests_blocked_at_protocol: IntCounter,
@@ -18,6 +19,8 @@ pub struct TrafficControllerMetrics {
 impl TrafficControllerMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
+            tallies: register_int_counter_with_registry!("tallies", "Number of tallies", registry)
+                .unwrap(),
             connection_ip_blocklist_len: register_int_gauge_with_registry!(
                 "connection_ip_blocklist_len",
                 // make the below a multiline string

--- a/crates/sui-core/src/traffic_controller/metrics.rs
+++ b/crates/sui-core/src/traffic_controller/metrics.rs
@@ -14,6 +14,7 @@ pub struct TrafficControllerMetrics {
     pub requests_blocked_at_protocol: IntCounter,
     pub blocks_delegated_to_firewall: IntCounter,
     pub firewall_delegation_request_fail: IntCounter,
+    pub tally_channel_overflow: IntCounter,
 }
 
 impl TrafficControllerMetrics {
@@ -54,6 +55,12 @@ impl TrafficControllerMetrics {
             firewall_delegation_request_fail: register_int_counter_with_registry!(
                 "firewall_delegation_request_fail",
                 "Number of failed http requests to firewall for blocklist delegation",
+                registry
+            )
+            .unwrap(),
+            tally_channel_overflow: register_int_counter_with_registry!(
+                "tally_channel_overflow",
+                "Traffic controller tally channel overflow count",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1184,6 +1184,7 @@ async fn test_handle_certificate_errors() {
         .handle_certificate_v2(ct.clone(), Some(socket_addr))
         .await
         .unwrap_err();
+
     assert_matches!(
         err,
         SuiError::WrongEpoch {

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -9,7 +9,12 @@ use jsonrpsee::{
     core::{client::ClientT, RpcResult},
     rpc_params,
 };
-use sui_core::traffic_controller::{nodefw_test_server::NodeFwTestServer, TrafficController};
+use std::fs::File;
+use std::io::Write;
+use sui_core::traffic_controller::{
+    get_killswitch_state, nodefw_test_server::NodeFwTestServer, KillswitchState, TrafficController,
+    KILLSWITCH_FILENAME,
+};
 use sui_json_rpc_types::{
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
@@ -116,7 +121,7 @@ async fn test_validator_traffic_control_spam_delegated() -> Result<(), anyhow::E
         delegate_error_blocking: false,
         destination_port: 8080,
         killswitch_path: tempfile::tempdir().unwrap().into_path(),
-        killswitch_timeout: 10,
+        killswitch_timeout_secs: 10,
     };
     let network_config = ConfigBuilder::new_with_temp_dir()
         .with_policy_config(Some(policy_config))
@@ -146,7 +151,7 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
         delegate_error_blocking: false,
         destination_port: 9000,
         killswitch_path: tempfile::tempdir().unwrap().into_path(),
-        killswitch_timeout: 10,
+        killswitch_timeout_secs: 10,
     };
     let test_cluster = TestClusterBuilder::new()
         .with_fullnode_policy_config(Some(policy_config))
@@ -158,20 +163,20 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
 
 #[tokio::test]
 async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
-    let n = 10;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 3,
-        spam_policy_type: PolicyType::TestNConnIP(n - 1),
+        spam_policy_type: PolicyType::TestNConnIP(10),
         channel_capacity: 100,
         ..Default::default()
     };
 
     // sink all traffic to trigger dead mans switch
     let killswitch_path = tempfile::tempdir().unwrap().into_path();
-    let killswitch_file = killswitch_path.join("__KILLSWITCH__");
-    assert!(
-        !killswitch_file.exists(),
-        "Expected killswitch file to not yet exist"
+    let killswitch_file = killswitch_path.join(KILLSWITCH_FILENAME);
+    assert_eq!(
+        get_killswitch_state(&killswitch_file),
+        None,
+        "Expected killswitch file to not yet exist",
     );
 
     let firewall_config = RemoteFirewallConfig {
@@ -180,20 +185,82 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
         delegate_error_blocking: false,
         destination_port: 9000,
         killswitch_path: killswitch_path.clone(),
-        killswitch_timeout: 10,
+        killswitch_timeout_secs: 10,
     };
 
     // NOTE: we need to hold onto this tc handle to ensure we don't inadvertently close
     // the receive channel (this would cause traffic controller to exit the loop and thus
     // we will never engage the dead mans switch)
     let _tc = TrafficController::spawn_for_test(policy_config, Some(firewall_config));
+    assert!(
+        matches!(
+            get_killswitch_state(&killswitch_file),
+            Some(KillswitchState::Off)
+        ),
+        "Expected killswitch to be disabled at statup unless previously enabled",
+    );
+
+    // after n seconds with no traffic, the dead mans switch should be engaged
+    let mut killswitch_enabled = false;
     for _ in 0..10 {
-        if killswitch_file.exists() {
-            return Ok(());
+        if get_killswitch_state(&killswitch_file) == Some(KillswitchState::On) {
+            killswitch_enabled = true;
+            break;
         }
         tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     }
-    panic!("Expected killswitch file to exist");
+    assert!(killswitch_enabled, "Expected killswitch to be enabled");
+
+    // if we drop traffic controller and re-instantiate, killswitch should remain disabled
+    for _ in 0..3 {
+        assert!(
+            matches!(
+                get_killswitch_state(&killswitch_file),
+                Some(KillswitchState::On),
+            ),
+            "Expected killswitch to be disabled at statup unless previously enabled",
+        );
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    }
+
+    std::fs::remove_file(&killswitch_file).unwrap();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_traffic_control_manual_set_killswitch() -> Result<(), anyhow::Error> {
+    let killswitch_path = tempfile::tempdir()
+        .unwrap()
+        .into_path()
+        .join(KILLSWITCH_FILENAME);
+    assert_eq!(
+        get_killswitch_state(&killswitch_path),
+        None,
+        "Expected killswitch file to not yet exist",
+    );
+
+    write!(File::create(&killswitch_path).unwrap(), "\nOFf\n")
+        .expect("Failed to write to nodefw killswitch file");
+    assert!(
+        matches!(
+            get_killswitch_state(&killswitch_path),
+            Some(KillswitchState::Off)
+        ),
+        "Expected killswitch to be disabled at statup unless previously enabled",
+    );
+
+    write!(File::create(&killswitch_path).unwrap(), " on\n ")
+        .expect("Failed to write to nodefw killswitch file");
+    assert!(
+        matches!(
+            get_killswitch_state(&killswitch_path),
+            Some(KillswitchState::On)
+        ),
+        "Expected killswitch to be disabled at statup unless previously enabled",
+    );
+
+    std::fs::remove_file(&killswitch_path).unwrap();
+    Ok(())
 }
 
 async fn assert_traffic_control_ok(mut test_cluster: TestCluster) -> Result<(), anyhow::Error> {

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -2,10 +2,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::SocketAddr;
-
 use shared_crypto::intent::Intent;
 use shared_crypto::intent::IntentMessage;
+use std::net::SocketAddr;
 use sui_core::authority_client::AuthorityAPI;
 use sui_macros::sim_test;
 use sui_protocol_config::ProtocolConfig;

--- a/crates/sui-json-rpc-tests/tests/routing_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/routing_tests.rs
@@ -137,6 +137,9 @@ async fn test_disable_routing() {
 //     let mut builder = JsonRpcServerBuilder::new(
 //          "1.5", &Registry::new(), None, None,
 //     );
+//     let mut builder = JsonRpcServerBuilder::new(
+//          "1.5", &Registry::new(), None, None,
+//     );
 //     builder.register_module(TestApiModule).unwrap();
 
 //     let port = get_available_port("0.0.0.0");

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -46,6 +46,7 @@ sui-open-rpc.workspace = true
 sui-open-rpc-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-json-rpc-types.workspace = true
+sui-macros.workspace = true
 sui-transaction-builder.workspace = true
 mysten-metrics.workspace = true
 shared-crypto.workspace = true

--- a/crates/sui-json-rpc/src/axum_router.rs
+++ b/crates/sui-json-rpc/src/axum_router.rs
@@ -60,8 +60,8 @@ impl<L> JsonRpcService<L> {
             traffic_controller: policy_config.map(|policy| {
                 Arc::new(TrafficController::spawn(
                     policy,
-                    remote_fw_config,
                     traffic_controller_metrics,
+                    remote_fw_config,
                 ))
             }),
         }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -310,6 +310,7 @@ impl WriteApiServer for TransactionExecutionApi {
         unimplemented!("Use monitored_execute_transaction_block instead")
     }
 
+    #[instrument(skip(self))]
     async fn monitored_execute_transaction_block(
         &self,
         tx_bytes: Base64,

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -6,7 +6,9 @@ use core::hash::Hash;
 use jsonrpsee::core::server::helpers::MethodResponse;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::fmt::Debug;
+use std::{fmt::Debug, path::PathBuf};
+
+const TRAFFIC_SINK_TIMEOUT_SEC: u64 = 300;
 
 #[derive(Clone, Debug)]
 pub enum ServiceResponse {
@@ -50,7 +52,7 @@ impl ServiceResponse {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RemoteFirewallConfig {
     pub remote_fw_url: String,
@@ -59,6 +61,15 @@ pub struct RemoteFirewallConfig {
     pub delegate_spam_blocking: bool,
     #[serde(default)]
     pub delegate_error_blocking: bool,
+    pub killswitch_path: PathBuf,
+    /// Time in secs, after which no registered ingress traffic
+    /// will trigger dead mans switch to disable any firewalls
+    #[serde(default = "default_killswitch_timeout")]
+    pub killswitch_timeout: u64,
+}
+
+fn default_killswitch_timeout() -> u64 {
+    TRAFFIC_SINK_TIMEOUT_SEC
 }
 
 // Serializable representation of policy types, used in config

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -65,7 +65,7 @@ pub struct RemoteFirewallConfig {
     /// Time in secs, after which no registered ingress traffic
     /// will trigger dead mans switch to disable any firewalls
     #[serde(default = "default_killswitch_timeout")]
-    pub killswitch_timeout: u64,
+    pub killswitch_timeout_secs: u64,
 }
 
 fn default_killswitch_timeout() -> u64 {


### PR DESCRIPTION
## Description 

As in title. The dead man's switch file is expected to have the side effect of disabling relevant firewalls (e.g. BPF)

## Test Plan 

Added test

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
