### PR TITLE
Add missing network param to EnokiFlow

### DIFF
--- a/.changeset/sweet-gorillas-remember.md
+++ b/.changeset/sweet-gorillas-remember.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+Add missing network param to enokiflow

--- a/sdk/enoki/src/EnokiFlow.ts
+++ b/sdk/enoki/src/EnokiFlow.ts
@@ -108,11 +108,13 @@ export class EnokiFlow {
 		provider: AuthProvider;
 		clientId: string;
 		redirectUrl: string;
+		network?: 'mainnet' | 'testnet' | 'devnet';
 		extraParams?: Record<string, unknown>;
 	}) {
 		const ephemeralKeyPair = new Ed25519Keypair();
 		const { nonce, randomness, maxEpoch, estimatedExpiration } =
 			await this.#enokiClient.createZkLoginNonce({
+				network: input.network,
 				ephemeralPublicKey: ephemeralKeyPair.getPublicKey(),
 			});
 
@@ -255,7 +257,7 @@ export class EnokiFlow {
 	}
 
 	// TODO: Should this return the proof if it already exists?
-	async getProof() {
+	async getProof({ network }: { network?: 'mainnet' | 'testnet' } = {}) {
 		const zkp = await this.getSession();
 		const { salt } = this.$zkLoginState.get();
 
@@ -274,6 +276,7 @@ export class EnokiFlow {
 		const ephemeralKeyPair = Ed25519Keypair.fromSecretKey(fromB64(zkp.ephemeralKeyPair));
 
 		const proof = await this.#enokiClient.createZkLoginZkp({
+			network,
 			jwt: zkp.jwt,
 			maxEpoch: zkp.maxEpoch,
 			randomness: zkp.randomness,


### PR DESCRIPTION
## Description 

This was missing from the `EnokiFlow` APIs, adding in a couple places to fix this.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and do not break anything, you can skip the following section. Otherwise, please briefly describe what has changed under the Release Notes section.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
