### PR TITLE
default archive bucket to use no-sign-request

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -347,12 +347,6 @@ pub enum ToolCommand {
         /// Only applicable if `--snapshot-bucket-type` is "file".
         #[clap(long = "snapshot-path")]
         snapshot_path: Option<PathBuf>,
-        /// Archival bucket name. If not specified, defaults are
-        /// based on value of `--network` flag.
-        #[clap(long = "archive-bucket")]
-        archive_bucket: Option<String>,
-        #[clap(long = "archive-bucket-type", default_value = "s3")]
-        archive_bucket_type: ObjectStoreType,
         /// If true, no authentication is needed for snapshot restores
         #[clap(
             long = "no-sign-request",
@@ -713,8 +707,6 @@ impl ToolCommand {
                 snapshot_bucket,
                 snapshot_bucket_type,
                 snapshot_path,
-                archive_bucket,
-                archive_bucket_type,
                 no_sign_request,
                 latest,
                 verbose,
@@ -818,28 +810,77 @@ impl ToolCommand {
                     }
                 };
 
-                let archive_bucket = archive_bucket.or_else(|| match network {
-                    Chain::Mainnet => Some(
-                        env::var("MAINNET_ARCHIVE_BUCKET")
-                            .unwrap_or("mysten-mainnet-archives".to_string()),
-                    ),
-                    Chain::Testnet => Some(
-                        env::var("TESTNET_ARCHIVE_BUCKET")
-                            .unwrap_or("mysten-testnet-archives".to_string()),
-                    ),
-                    Chain::Unknown => {
-                        panic!("Cannot generate default archive bucket for unknown network");
+                let archive_bucket = Some(
+                    env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET").unwrap_or_else(|_| match network {
+                        Chain::Mainnet => "mysten-mainnet-archives".to_string(),
+                        Chain::Testnet => "mysten-testnet-archives".to_string(),
+                        Chain::Unknown => {
+                            panic!("Cannot generate default archive bucket for unknown network");
+                        }
+                    }),
+                );
+
+                let mut custom_archive_enabled = false;
+                if let Ok(custom_archive_check) = env::var("CUSTOM_ARCHIVE_BUCKET") {
+                    if custom_archive_check == "true" {
+                        custom_archive_enabled = true;
                     }
-                });
-                let aws_region =
-                    Some(env::var("AWS_ARCHIVE_REGION").unwrap_or("us-west-2".to_string()));
-                let archive_store_config = match archive_bucket_type {
-                    ObjectStoreType::S3 => ObjectStoreConfig {
+                }
+                let archive_store_config = if custom_archive_enabled {
+                    let aws_region = Some(
+                        env::var("FORMAL_SNAPSHOT_ARCHIVE_REGION")
+                            .unwrap_or("us-west-2".to_string()),
+                    );
+
+                    let archive_bucket_type = env::var("FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE").expect("If setting `CUSTOM_ARCHIVE_BUCKET=true` Must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE, and credentials");
+                    match archive_bucket_type.to_ascii_lowercase().as_str()
+                    {
+                        "s3" => ObjectStoreConfig {
+                            object_store: Some(ObjectStoreType::S3),
+                            bucket: archive_bucket.filter(|s| !s.is_empty()),
+                            aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
+                            aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
+                            aws_region,
+                            aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
+                            aws_virtual_hosted_style_request: env::var(
+                                "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
+                            )
+                            .ok()
+                            .and_then(|b| b.parse().ok())
+                            .unwrap_or(false),
+                            object_store_connection_limit: 50,
+                            no_sign_request: false,
+                            ..Default::default()
+                        },
+                        "gcs" => ObjectStoreConfig {
+                            object_store: Some(ObjectStoreType::GCS),
+                            bucket: archive_bucket,
+                            google_service_account: env::var(
+                                "GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH",
+                            )
+                            .ok(),
+                            object_store_connection_limit: 50,
+                            no_sign_request: false,
+                            ..Default::default()
+                        },
+                        "azure" => ObjectStoreConfig {
+                            object_store: Some(ObjectStoreType::Azure),
+                            bucket: archive_bucket,
+                            azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
+                            azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY")
+                                .ok(),
+                            object_store_connection_limit: 50,
+                            no_sign_request: false,
+                            ..Default::default()
+                        },
+                        _ => panic!("If setting `CUSTOM_ARCHIVE_BUCKET=true` must set FORMAL_SNAPSHOT_ARCHIVE_BUCKET_TYPE to one of 'gcs', 'azure', or 's3' "),
+                    }
+                } else {
+                    // if not explictly overriden, just default to the permissionless archive store
+                    ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),
                         bucket: archive_bucket.filter(|s| !s.is_empty()),
-                        aws_access_key_id: env::var("AWS_ARCHIVE_ACCESS_KEY_ID").ok(),
-                        aws_secret_access_key: env::var("AWS_ARCHIVE_SECRET_ACCESS_KEY").ok(),
-                        aws_region: aws_region.filter(|s| !s.is_empty()),
+                        aws_region: Some("us-west-2".to_string()),
                         aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
                         aws_virtual_hosted_style_request: env::var(
                             "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
@@ -848,29 +889,8 @@ impl ToolCommand {
                         .and_then(|b| b.parse().ok())
                         .unwrap_or(false),
                         object_store_connection_limit: 200,
-                        no_sign_request,
+                        no_sign_request: true,
                         ..Default::default()
-                    },
-                    ObjectStoreType::GCS => ObjectStoreConfig {
-                        object_store: Some(ObjectStoreType::GCS),
-                        bucket: archive_bucket,
-                        google_service_account: env::var("GCS_ARCHIVE_SERVICE_ACCOUNT_FILE_PATH")
-                            .ok(),
-                        object_store_connection_limit: 200,
-                        no_sign_request,
-                        ..Default::default()
-                    },
-                    ObjectStoreType::Azure => ObjectStoreConfig {
-                        object_store: Some(ObjectStoreType::Azure),
-                        bucket: archive_bucket,
-                        azure_storage_account: env::var("AZURE_ARCHIVE_STORAGE_ACCOUNT").ok(),
-                        azure_storage_access_key: env::var("AZURE_ARCHIVE_STORAGE_ACCESS_KEY").ok(),
-                        object_store_connection_limit: 200,
-                        no_sign_request,
-                        ..Default::default()
-                    },
-                    ObjectStoreType::File => {
-                        panic!("Download from local filesystem is not supported")
                     }
                 };
                 let latest_available_epoch =


### PR DESCRIPTION
## Description 

@tharbert and @chris-gorham pointed out that the use of the archival bucket is pretty confusing in formal snapshots. This PR attempts to make usage easier by defaulting to the web/zero auth endpoint unless explicitly setting `CUSTOM_ARCHIVE_BUCKET=true`

## Test Plan 
Testing on a testnet host with the formal snapshot restore ansible task
