### PR TITLE
[docs] Updated IDE installation instructions

### DIFF
--- a/docs/content/guides/developer/getting-started/sui-environment.mdx
+++ b/docs/content/guides/developer/getting-started/sui-environment.mdx
@@ -38,15 +38,11 @@ You can interact with the Sui network through two official SDKs (TypeScript SDK 
 
 ## Move IDEs and plugins
 
-The recommended IDE for Move development is Visual Studio Code with the `move-analyzer` extension. Follow the Visual Studio Marketplace instructions to install the move-analyzer extension, then install the `move-analyzer` language server:
-
-```shell
-cargo install --git https://github.com/MystenLabs/sui.git move-analyzer
-```
+The recommended IDE for Move development is Visual Studio Code with the Move extension [available](https://marketplace.visualstudio.com/items?itemName=mysten.move) in the Visual Studio Marketplace. Follow the Visual Studio Marketplace instructions to install the extension.
 
 See more [IDE options](https://github.com/MystenLabs/awesome-move#ides) in the [Awesome Move](https://github.com/MystenLabs/awesome-move) documentation.
 
-After you install VS Code and the `move-analyzer` extension, check out the [Move code examples](https://github.com/MystenLabs/sui/tree/main/examples/move).
+After you install VS Code and the `Move` extension, check out the [Move code examples](https://github.com/MystenLabs/sui/tree/main/examples/move).
 
 To test or run a Move example on Sui, use the `sui move` command from the Sui CLI.
 


### PR DESCRIPTION
## Description 

Updated IDE installation instructions by linking the recommended VSCode extension and removing move-analyzer installation instructions which are no longer necessary as the extension bundles it automatically. I think leaving them there, while potentially useful, would be confusing - instructions on how to install move-analyzer by-hand are included in the extension's troubleshooting guide in the VS Marketplace.
