### PR TITLE
allow output for command output for batch replay

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -3,7 +3,7 @@
 
 use clap::*;
 use colored::Colorize;
-use sui::client_commands::SuiClientCommands::{ProfileTransaction, ReplayTransaction};
+use sui::client_commands::SuiClientCommands::{ProfileTransaction, ReplayBatch, ReplayTransaction};
 use sui::sui_commands::SuiCommand;
 use sui_types::exit_main;
 use tracing::debug;
@@ -57,6 +57,14 @@ async fn main() {
         }
 
         SuiCommand::Client {
+            cmd: Some(ReplayBatch { .. }),
+            ..
+        } => telemetry_subscribers::TelemetryConfig::new()
+            .with_log_level("info")
+            .with_env()
+            .init(),
+
+        SuiCommand::Client {
             cmd: Some(ReplayTransaction {
                 gas_info, ptb_info, ..
             }),
@@ -73,6 +81,7 @@ async fn main() {
             }
             config.init()
         }
+
         SuiCommand::Client {
             cmd: Some(ProfileTransaction { .. }),
             ..


### PR DESCRIPTION
## Description 

Previously the replay-batch command output was not getting printed to the console because the wrong log level was set. This fixes the level.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
