### PR TITLE
chore: move sui-framework to dev-dep in sui-json

### DIFF
--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -13,7 +13,6 @@ serde.workspace = true
 serde_json.workspace = true
 schemars.workspace = true
 
-sui-framework.workspace = true
 sui-types.workspace = true
 
 move-binary-format.workspace = true
@@ -25,3 +24,4 @@ fastcrypto = { workspace = true }
 test-fuzz.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
 sui-move-build.workspace = true
+sui-framework.workspace = true


### PR DESCRIPTION
## Description 

`sui-framework` should only be a dev dep for `sui-json`. It's causing circular dependencies in additions of my one of my working branches.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
