### PR TITLE
[move-compiler] Added dot chain parsing resilience

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2691,7 +2691,9 @@ impl<'a> TypingSymbolicator<'a> {
                 self.exp_symbols(exp, scope);
                 self.add_type_id_use_def(t);
             }
-
+            E::InvalidAccess(e) => {
+                self.exp_symbols(e, scope);
+            }
             _ => (),
         }
     }
@@ -6801,7 +6803,7 @@ fn partial_dot_test() {
 
     let ide_files_layer: VfsPath = MemoryFS::new().into();
     let (symbols_opt, _) = get_symbols(
-        &mut BTreeMap::new(),
+        Arc::new(Mutex::new(BTreeMap::new())),
         ide_files_layer,
         path.as_path(),
         LintLevel::None,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -6874,13 +6874,28 @@ fn partial_dot_test() {
         "PartialDot::M1::AnotherStruct\nanother_field: PartialDot::M1::SomeStruct",
         Some((1, 18, "M1.move")),
     );
+    // struct-typed second part of incomplete dot chain `s.another_field.` (followed by a list of
+    // parameters and a semi-colon: `s.another_field.(7, 42);`)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        2,
+        14,
+        22,
+        "M1.move",
+        6,
+        8,
+        "M1.move",
+        "PartialDot::M1::AnotherStruct\nanother_field: PartialDot::M1::SomeStruct",
+        Some((1, 18, "M1.move")),
+    );
     // struct-typed first part of incomplete dot chain `s.` (no `;` but followed by `}` on the next
     // line)
     assert_use_def(
         mod_symbols,
         &symbols,
         1,
-        14,
+        15,
         20,
         "M1.move",
         9,

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -6791,3 +6791,100 @@ fn partial_function_test() {
         None,
     );
 }
+
+#[test]
+/// Tests if partial dot chains are symbolicated correctly.
+fn partial_dot_test() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    path.push("tests/partial-dot");
+
+    let ide_files_layer: VfsPath = MemoryFS::new().into();
+    let (symbols_opt, _) = get_symbols(
+        &mut BTreeMap::new(),
+        ide_files_layer,
+        path.as_path(),
+        LintLevel::None,
+    )
+    .unwrap();
+    let symbols = symbols_opt.unwrap();
+
+    let mut fpath = path.clone();
+    fpath.push("sources/M1.move");
+    let cpath = dunce::canonicalize(&fpath).unwrap();
+
+    let mod_symbols = symbols.file_use_defs.get(&cpath).unwrap();
+
+    // struct-typed first part of incomplete dot chain `s.;`
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        10,
+        20,
+        "M1.move",
+        9,
+        12,
+        "M1.move",
+        "s: PartialDot::M1::AnotherStruct",
+        Some((5, 18, "M1.move")),
+    );
+    // struct-typed first part of incomplete dot chain `s.another_field.;`
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        11,
+        20,
+        "M1.move",
+        9,
+        12,
+        "M1.move",
+        "s: PartialDot::M1::AnotherStruct",
+        Some((5, 18, "M1.move")),
+    );
+    // struct-typed second part of incomplete dot chain `s.another_field.;`
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        2,
+        11,
+        22,
+        "M1.move",
+        6,
+        8,
+        "M1.move",
+        "PartialDot::M1::AnotherStruct\nanother_field: PartialDot::M1::SomeStruct",
+        Some((1, 18, "M1.move")),
+    );
+    // struct-typed second part of incomplete dot chain `s.another_field.` (no `;` but followed by
+    // `let` on the next line)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        2,
+        12,
+        22,
+        "M1.move",
+        6,
+        8,
+        "M1.move",
+        "PartialDot::M1::AnotherStruct\nanother_field: PartialDot::M1::SomeStruct",
+        Some((1, 18, "M1.move")),
+    );
+    // struct-typed first part of incomplete dot chain `s.` (no `;` but followed by `}` on the next
+    // line)
+    assert_use_def(
+        mod_symbols,
+        &symbols,
+        1,
+        14,
+        20,
+        "M1.move",
+        9,
+        12,
+        "M1.move",
+        "s: PartialDot::M1::AnotherStruct",
+        Some((5, 18, "M1.move")),
+    );
+}

--- a/external-crates/move/crates/move-analyzer/tests/partial-dot/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/partial-dot/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "PartialDot"
+version = "0.0.1"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+PartialDot = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/partial-dot/sources/M1.move
+++ b/external-crates/move/crates/move-analyzer/tests/partial-dot/sources/M1.move
@@ -1,0 +1,17 @@
+module PartialDot::M1 {
+    public struct SomeStruct has drop {
+        some_field: u64
+    }
+
+    public struct AnotherStruct has drop {
+        another_field: SomeStruct
+    }
+
+    fun foo(s: AnotherStruct) {
+        let _tmp1 = s.;
+        let _tmp2 = s.another_field.;
+        let _tmp3 = s.another_field.
+        let _tmp4 = s; // statement skipped due to unexpected `let`
+        let _tmp5 = s.
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/partial-dot/sources/M1.move
+++ b/external-crates/move/crates/move-analyzer/tests/partial-dot/sources/M1.move
@@ -12,6 +12,7 @@ module PartialDot::M1 {
         let _tmp2 = s.another_field.;
         let _tmp3 = s.another_field.
         let _tmp4 = s; // statement skipped due to unexpected `let`
-        let _tmp5 = s.
+        let _tmp5 = s.another_field.(7, 42);
+        let _tmp6 = s.
     }
 }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -327,7 +327,7 @@ pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Name),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
-    DotUnresolved(Box<ExpDotted>), // dot where Name could not be parsed
+    DotUnresolved(Loc, Box<ExpDotted>), // dot where Name could not be parsed
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
@@ -1735,7 +1735,7 @@ impl AstDebug for ExpDotted_ {
                 w.comma(&rhs.value, |w, e| e.ast_debug(w));
                 w.write("]");
             }
-            D::DotUnresolved(e) => {
+            D::DotUnresolved(_, e) => {
                 e.ast_debug(w);
                 w.write("")
             }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -327,6 +327,7 @@ pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Name),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
+    DotUnresolved(Box<ExpDotted>), // dot where Name could not be parsed
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
@@ -1733,6 +1734,10 @@ impl AstDebug for ExpDotted_ {
                 w.write("[");
                 w.comma(&rhs.value, |w, e| e.ast_debug(w));
                 w.write("]");
+            }
+            D::DotUnresolved(e) => {
+                e.ast_debug(w);
+                w.write("")
             }
         }
     }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -1737,7 +1737,7 @@ impl AstDebug for ExpDotted_ {
             }
             D::DotUnresolved(_, e) => {
                 e.ast_debug(w);
-                w.write("")
+                w.write(".")
             }
         }
     }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -2632,13 +2632,15 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
                 EE::UnresolvedError
             }
         },
-        pdotted_ @ PE::Dot(_, _) => match exp_dotted(context, Box::new(sp(loc, pdotted_))) {
-            Some(edotted) => EE::ExpDotted(E::DottedUsage::Use, edotted),
-            None => {
-                assert!(context.env().has_errors());
-                EE::UnresolvedError
+        pdotted_ @ (PE::Dot(_, _) | PE::DotUnresolved(_)) => {
+            match exp_dotted(context, Box::new(sp(loc, pdotted_))) {
+                Some(edotted) => EE::ExpDotted(E::DottedUsage::Use, edotted),
+                None => {
+                    assert!(context.env().has_errors());
+                    EE::UnresolvedError
+                }
             }
-        },
+        }
 
         pdotted_ @ PE::Index(_, _) => {
             let cur_pkg = context.current_package();
@@ -2738,6 +2740,7 @@ fn exp_cast(context: &mut Context, in_parens: bool, plhs: Box<P::Exp>, pty: P::T
 
             PE::DotCall(lhs, _, _, _, _)
             | PE::Dot(lhs, _)
+            | PE::DotUnresolved(lhs)
             | PE::Index(lhs, _)
             | PE::Borrow(_, lhs)
             | PE::Dereference(lhs) => ambiguous_cast(lhs),
@@ -2854,7 +2857,7 @@ fn move_or_copy_path_(context: &mut Context, case: PathCase, pe: Box<P::Exp>) ->
                 return None;
             }
         }
-        E::ExpDotted_::Dot(_, _) | E::ExpDotted_::Index(_, _) => {
+        E::ExpDotted_::Dot(_, _) | E::ExpDotted_::DotUnresolved(_) | E::ExpDotted_::Index(_, _) => {
             let current_package = context.current_package();
             context
                 .env()
@@ -2891,6 +2894,10 @@ fn exp_dotted(context: &mut Context, pdotted: Box<P::Exp>) -> Option<Box<E::ExpD
                 .map(|arg| *exp(context, Box::new(arg)))
                 .collect::<Vec<_>>();
             EE::Index(lhs, sp(argloc, args))
+        }
+        PE::DotUnresolved(plhs) => {
+            let lhs = exp_dotted(context, plhs)?;
+            EE::DotUnresolved(lhs)
         }
         pe_ => EE::Exp(exp(context, Box::new(sp(loc, pe_)))),
     };

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -2632,7 +2632,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
                 EE::UnresolvedError
             }
         },
-        pdotted_ @ (PE::Dot(_, _) | PE::DotUnresolved(_)) => {
+        pdotted_ @ (PE::Dot(_, _) | PE::DotUnresolved(_, _)) => {
             match exp_dotted(context, Box::new(sp(loc, pdotted_))) {
                 Some(edotted) => EE::ExpDotted(E::DottedUsage::Use, edotted),
                 None => {
@@ -2740,7 +2740,7 @@ fn exp_cast(context: &mut Context, in_parens: bool, plhs: Box<P::Exp>, pty: P::T
 
             PE::DotCall(lhs, _, _, _, _)
             | PE::Dot(lhs, _)
-            | PE::DotUnresolved(lhs)
+            | PE::DotUnresolved(_, lhs)
             | PE::Index(lhs, _)
             | PE::Borrow(_, lhs)
             | PE::Dereference(lhs) => ambiguous_cast(lhs),
@@ -2857,7 +2857,9 @@ fn move_or_copy_path_(context: &mut Context, case: PathCase, pe: Box<P::Exp>) ->
                 return None;
             }
         }
-        E::ExpDotted_::Dot(_, _) | E::ExpDotted_::DotUnresolved(_) | E::ExpDotted_::Index(_, _) => {
+        E::ExpDotted_::Dot(_, _)
+        | E::ExpDotted_::DotUnresolved(_, _)
+        | E::ExpDotted_::Index(_, _) => {
             let current_package = context.current_package();
             context
                 .env()
@@ -2895,9 +2897,9 @@ fn exp_dotted(context: &mut Context, pdotted: Box<P::Exp>) -> Option<Box<E::ExpD
                 .collect::<Vec<_>>();
             EE::Index(lhs, sp(argloc, args))
         }
-        PE::DotUnresolved(plhs) => {
+        PE::DotUnresolved(loc, plhs) => {
             let lhs = exp_dotted(context, plhs)?;
-            EE::DotUnresolved(lhs)
+            EE::DotUnresolved(loc, lhs)
         }
         pe_ => EE::Exp(exp(context, Box::new(sp(loc, pe_)))),
     };

--- a/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/detect_dead_code.rs
@@ -532,7 +532,8 @@ fn value(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::UnaryExp(_, base_exp)
         | E::Borrow(_, base_exp, _)
         | E::Cast(base_exp, _)
-        | E::TempBorrow(_, base_exp) => value_report!(base_exp),
+        | E::TempBorrow(_, base_exp)
+        | E::InvalidAccess(base_exp) => value_report!(base_exp),
 
         E::BorrowLocal(_, _) => None,
 
@@ -746,6 +747,7 @@ fn statement(context: &mut Context, e: &T::Exp) -> Option<ControlFlow> {
         | E::ErrorConstant(_)
         | E::Move { .. }
         | E::Copy { .. }
+        | E::InvalidAccess(_)
         | E::UnresolvedError => value(context, e),
 
         E::Value(_) | E::Unit { .. } => None,

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -1850,7 +1850,7 @@ fn value(
             context.env.add_diag(ice!((eloc, "ICE unexpanded use")));
             error_exp(eloc)
         }
-        E::UnresolvedError => {
+        E::UnresolvedError | E::InvalidAccess(_) => {
             assert!(context.env.has_errors());
             make_exp(HE::UnresolvedError)
         }
@@ -2203,6 +2203,7 @@ fn statement(context: &mut Context, block: &mut Block, e: T::Exp) {
         | E::Move { .. }
         | E::Copy { .. }
         | E::UnresolvedError
+        | E::InvalidAccess(_)
         | E::NamedBlock(_, _)) => value_statement(context, block, make_exp(e_)),
 
         E::Value(_) | E::Unit { .. } => (),

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -356,7 +356,7 @@ pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Field),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
-    DotUnresolved(Box<ExpDotted>), // dot where Field could not be parsed
+    DotUnresolved(Loc, Box<ExpDotted>), // Dot (and its location) where Field could not be parsed
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
@@ -1883,7 +1883,7 @@ impl AstDebug for ExpDotted_ {
                 w.comma(args, |w, e| e.ast_debug(w));
                 w.write(")");
             }
-            D::DotUnresolved(e) => {
+            D::DotUnresolved(_, e) => {
                 e.ast_debug(w);
                 w.write(".")
             }

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -356,6 +356,7 @@ pub enum ExpDotted_ {
     Exp(Box<Exp>),
     Dot(Box<ExpDotted>, Field),
     Index(Box<ExpDotted>, Spanned<Vec<Exp>>),
+    DotUnresolved(Box<ExpDotted>), // dot where Field could not be parsed
 }
 pub type ExpDotted = Spanned<ExpDotted_>;
 
@@ -1881,6 +1882,10 @@ impl AstDebug for ExpDotted_ {
                 w.write("(");
                 w.comma(args, |w, e| e.ast_debug(w));
                 w.write(")");
+            }
+            D::DotUnresolved(e) => {
+                e.ast_debug(w);
+                w.write(".")
             }
         }
     }

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -400,7 +400,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => exp_dotted(context, ed),
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -400,7 +400,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => exp_dotted(context, ed),
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2445,8 +2445,8 @@ fn dotted(context: &mut Context, edot: E::ExpDotted) -> Option<N::ExpDotted> {
             }
         }
         E::ExpDotted_::Dot(d, f) => N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f)),
-        E::ExpDotted_::DotUnresolved(d) => {
-            N::ExpDotted_::DotUnresolved(Box::new(dotted(context, *d)?))
+        E::ExpDotted_::DotUnresolved(loc, d) => {
+            N::ExpDotted_::DotUnresolved(loc, Box::new(dotted(context, *d)?))
         }
         E::ExpDotted_::Index(inner, args) => {
             let args = call_args(context, args);
@@ -3655,7 +3655,7 @@ fn remove_unused_bindings_exp_dotted(
 ) {
     match ed_ {
         N::ExpDotted_::Exp(e) => remove_unused_bindings_exp(context, used, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => {
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => {
             remove_unused_bindings_exp_dotted(context, used, ed)
         }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2445,6 +2445,9 @@ fn dotted(context: &mut Context, edot: E::ExpDotted) -> Option<N::ExpDotted> {
             }
         }
         E::ExpDotted_::Dot(d, f) => N::ExpDotted_::Dot(Box::new(dotted(context, *d)?), Field(f)),
+        E::ExpDotted_::DotUnresolved(d) => {
+            N::ExpDotted_::DotUnresolved(Box::new(dotted(context, *d)?))
+        }
         E::ExpDotted_::Index(inner, args) => {
             let args = call_args(context, args);
             let inner = Box::new(dotted(context, *inner)?);
@@ -3652,7 +3655,9 @@ fn remove_unused_bindings_exp_dotted(
 ) {
     match ed_ {
         N::ExpDotted_::Exp(e) => remove_unused_bindings_exp(context, used, e),
-        N::ExpDotted_::Dot(ed, _) => remove_unused_bindings_exp_dotted(context, used, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => {
+            remove_unused_bindings_exp_dotted(context, used, ed)
+        }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             for e in es {
                 remove_unused_bindings_exp(context, used, e);

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -624,8 +624,8 @@ pub enum Exp_ {
     // Internal node marking an error was added to the error list
     // This is here so the pass can continue even when an error is hit
     UnresolvedError,
-    // e.X (where X is not a valid tok after dot and cannot be parsed)
-    DotUnresolved(Box<Exp>),
+    // e.X, where X is not a valid tok after dot and cannot be parsed (includes location of the dot)
+    DotUnresolved(Loc, Box<Exp>),
 }
 pub type Exp = Spanned<Exp_>;
 
@@ -2105,7 +2105,7 @@ impl AstDebug for Exp_ {
                 w.write(&s.value);
             }
             E::UnresolvedError => w.write("_|_"),
-            E::DotUnresolved(e) => {
+            E::DotUnresolved(_, e) => {
                 e.ast_debug(w);
                 w.write(".");
             }

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -624,6 +624,8 @@ pub enum Exp_ {
     // Internal node marking an error was added to the error list
     // This is here so the pass can continue even when an error is hit
     UnresolvedError,
+    // e.X (where X is not a valid tok after dot and cannot be parsed)
+    DotUnresolved(Box<Exp>),
 }
 pub type Exp = Spanned<Exp_>;
 
@@ -2103,6 +2105,10 @@ impl AstDebug for Exp_ {
                 w.write(&s.value);
             }
             E::UnresolvedError => w.write("_|_"),
+            E::DotUnresolved(e) => {
+                e.ast_debug(w);
+                w.write(".");
+            }
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -1568,13 +1568,6 @@ fn parse_sequence(context: &mut Context) -> Result<Sequence, Box<Diagnostic>> {
     // sequence and proceed with parsing top-level definition (assume the second scenario).
     if !context.at_stop_set() || context.tokens.at(Tok::RBrace) {
         context.advance(); // consume (the RBrace)
-        if context.tokens.text.starts_with("module a::m {") {
-            eprintln!(
-                "CONSUME: {:?} DIAGS {}",
-                context.tokens.peek(),
-                context.env.count_diags()
-            );
-        }
     }
     Ok((uses, seq, last_semicolon_loc, Box::new(eopt)))
 }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2590,7 +2590,7 @@ fn parse_dot_or_index_chain(context: &mut Context) -> Result<Exp, Box<Diagnostic
                     _ => match parse_identifier(context) {
                         Err(diag) => {
                             context.add_diag(*diag);
-                            Exp_::DotUnresolved(Box::new(lhs))
+                            Exp_::DotUnresolved(loc, Box::new(lhs))
                         }
                         Ok(n) => {
                             if is_start_of_call_after_function_name(context, &n) {

--- a/external-crates/move/crates/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/ast.rs
@@ -233,6 +233,9 @@ pub enum UnannotatedExp_ {
     Cast(Box<Exp>, Box<Type>),
     Annotate(Box<Exp>, Box<Type>),
 
+    // unfinished dot access (e.g. `some_field.`)
+    InvalidAccess(Box<Exp>),
+
     ErrorConstant(Option<ConstantName>),
     UnresolvedError,
 }
@@ -818,6 +821,10 @@ impl AstDebug for UnannotatedExp_ {
                 w.write(": ");
                 ty.ast_debug(w);
                 w.write(")");
+            }
+            E::InvalidAccess(e) => {
+                e.ast_debug(w);
+                w.write(".");
             }
             E::UnresolvedError => w.write("_|_"),
             E::ErrorConstant(constant) => {

--- a/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/dependency_ordering.rs
@@ -477,6 +477,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             exp(context, e);
             type_(context, ty)
         }
+        E::InvalidAccess(e) => exp(context, e),
         E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -270,7 +270,8 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::Dereference(er)
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
-        | E::TempBorrow(_, er) => exp(context, er),
+        | E::TempBorrow(_, er)
+        | E::InvalidAccess(er) => exp(context, er),
         E::Mutate(el, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/infinite_instantiations.rs
@@ -276,7 +276,8 @@ fn exp(context: &mut Context, e: &T::Exp) {
         | E::Dereference(er)
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
-        | E::TempBorrow(_, er) => exp(context, er),
+        | E::TempBorrow(_, er)
+        | E::InvalidAccess(er) => exp(context, er),
         E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
             exp(context, el);
             exp(context, er)

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -630,7 +630,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
 fn recolor_exp_dotted(ctx: &mut Recolor, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => recolor_exp(ctx, e),
-        N::ExpDotted_::Dot(ed, _) => recolor_exp_dotted(ctx, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => recolor_exp_dotted(ctx, ed),
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             recolor_exp_dotted(ctx, ed);
             for e in es {
@@ -1093,7 +1093,7 @@ fn builtin_function(context: &mut Context, sp!(_, bf_): &mut N::BuiltinFunction)
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => exp_dotted(context, ed),
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -630,7 +630,9 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
 fn recolor_exp_dotted(ctx: &mut Recolor, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => recolor_exp(ctx, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => recolor_exp_dotted(ctx, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => {
+            recolor_exp_dotted(ctx, ed)
+        }
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             recolor_exp_dotted(ctx, ed);
             for e in es {
@@ -1093,7 +1095,7 @@ fn builtin_function(context: &mut Context, sp!(_, bf_): &mut N::BuiltinFunction)
 fn exp_dotted(context: &mut Context, sp!(_, ed_): &mut N::ExpDotted) {
     match ed_ {
         N::ExpDotted_::Exp(e) => exp(context, e),
-        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(ed) => exp_dotted(context, ed),
+        N::ExpDotted_::Dot(ed, _) | N::ExpDotted_::DotUnresolved(_, ed) => exp_dotted(context, ed),
         N::ExpDotted_::Index(ed, sp!(_, es)) => {
             exp_dotted(context, ed);
             for e in es {

--- a/external-crates/move/crates/move-compiler/src/typing/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/visitor.rs
@@ -222,6 +222,7 @@ pub trait TypingVisitorContext {
             E::TempBorrow(_, e) => self.visit_exp(e),
             E::Cast(e, _) => self.visit_exp(e),
             E::Annotate(e, _) => self.visit_exp(e),
+            E::InvalidAccess(e) => self.visit_exp(e),
             E::Unit { .. }
             | E::Value(_)
             | E::Move { .. }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
@@ -1,0 +1,45 @@
+error[E03010]: unbound field
+   ┌─ tests/move_2024/parser/dot_incomplete.move:12:21
+   │
+12 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
+   │                     ^^ Unbound field '' in 'a::m::AnotherStruct'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/dot_incomplete.move:12:23
+   │
+12 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
+   │                       ^
+   │                       │
+   │                       Unexpected ';'
+   │                       Expected an identifier
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/parser/dot_incomplete.move:13:21
+   │
+13 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
+   │                     ^^^^^^^^^^^^^^^^ Unbound field '' in 'a::m::SomeStruct'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/dot_incomplete.move:13:37
+   │
+13 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
+   │                                     ^
+   │                                     │
+   │                                     Unexpected ';'
+   │                                     Expected an identifier
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/parser/dot_incomplete.move:14:21
+   │
+14 │         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
+   │                     ^^^^^^^^^^^^^^^^ Unbound field '' in 'a::m::SomeStruct'
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/dot_incomplete.move:15:9
+   │
+15 │         let _tmp4 = s;
+   │         ^^^
+   │         │
+   │         Unexpected 'let'
+   │         Expected an identifier
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
@@ -1,9 +1,3 @@
-error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/dot_incomplete.move:12:21
-   │
-12 │         let _tmp1 = s.;                // incomplete with `;` (next line should parse)
-   │                     ^^ Unbound field '' in 'a::m::AnotherStruct'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:12:23
    │
@@ -12,12 +6,6 @@ error[E01002]: unexpected token
    │                       │
    │                       Unexpected ';'
    │                       Expected an identifier
-
-error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/dot_incomplete.move:13:21
-   │
-13 │         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
-   │                     ^^^^^^^^^^^^^^^^ Unbound field '' in 'a::m::SomeStruct'
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:13:37
@@ -28,12 +16,6 @@ error[E01002]: unexpected token
    │                                     Unexpected ';'
    │                                     Expected an identifier
 
-error[E03010]: unbound field
-   ┌─ tests/move_2024/parser/dot_incomplete.move:14:21
-   │
-14 │         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
-   │                     ^^^^^^^^^^^^^^^^ Unbound field '' in 'a::m::SomeStruct'
-
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:15:9
    │
@@ -42,4 +24,13 @@ error[E01002]: unexpected token
    │         │
    │         Unexpected 'let'
    │         Expected an identifier
+
+error[E01002]: unexpected token
+   ┌─ tests/move_2024/parser/dot_incomplete.move:17:5
+   │
+17 │     }
+   │     ^
+   │     │
+   │     Unexpected '}'
+   │     Expected an identifier
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.exp
@@ -5,7 +5,7 @@ error[E01002]: unexpected token
    │                       ^
    │                       │
    │                       Unexpected ';'
-   │                       Expected an identifier
+   │                       Expected an identifier or a decimal number
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:13:37
@@ -14,7 +14,7 @@ error[E01002]: unexpected token
    │                                     ^
    │                                     │
    │                                     Unexpected ';'
-   │                                     Expected an identifier
+   │                                     Expected an identifier or a decimal number
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:15:9
@@ -23,7 +23,7 @@ error[E01002]: unexpected token
    │         ^^^
    │         │
    │         Unexpected 'let'
-   │         Expected an identifier
+   │         Expected an identifier or a decimal number
 
 error[E01002]: unexpected token
    ┌─ tests/move_2024/parser/dot_incomplete.move:17:5
@@ -32,5 +32,5 @@ error[E01002]: unexpected token
    │     ^
    │     │
    │     Unexpected '}'
-   │     Expected an identifier
+   │     Expected an identifier or a decimal number
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.move
@@ -1,0 +1,19 @@
+module a::m {
+
+    public struct SomeStruct has drop {
+        some_field: u64
+    }
+
+    public struct AnotherStruct has drop {
+        another_field: SomeStruct
+    }
+
+    fun foo(s: AnotherStruct) {
+        let _tmp1 = s.;                // incomplete with `;` (next line should parse)
+        let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
+        let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
+        let _tmp4 = s;
+    }
+
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/dot_incomplete.move
@@ -13,7 +13,6 @@ module a::m {
         let _tmp2 = s.another_field.;  // incomplete with `;` (next line should parse)
         let _tmp3 = s.another_field.   // incomplete without `;` (unexpected `let`)
         let _tmp4 = s;
+        let _tmp = s.                  // incomplete without `;` (unexpected `}`)
     }
-
-
 }

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/let_binding_missing_semicolon.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/let_binding_missing_semicolon.move
@@ -1,5 +1,5 @@
 module 0x42::M {
     fun f() {
-        let x // Test a missing semicolon
+        let _x // Test a missing semicolon
     }
 }


### PR DESCRIPTION
## Description 

This PR adds parsing resilience to dot chains (e.g., `some_struct.some_field`). It's a pre-requisite to adding auto-completion for struct fields and struct functions (aka methods) to the IDE.

Implementation-wise, I was also trying making `parse_identifier` parser-resilient (have it always return a value instead of `Result`). This does not quite work, though, since in `parse_dot_or_index_chain` we need to know that if an identifier fails to parse, we should stop parsing the chain itself. If the `parse_identifier` never returns an error, we would simply continue parsing the chain and generate weird errors.

## Test plan 

An additional compiler test has been added. Also a symbolicator test has been added to verify that prefixes of partially parsed dot chains are parsed correctly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Developers might see more compiler diagnostics as dot chain (e.g., `some_struct.some_field`) parsing errors no longer prevent compilation and diagnostics from the compiler reaching later compilation stages where additional diagnostics may be generated. 
- [ ] Rust SDK: 
