### PR TITLE
Add metric to track the number of deferred transactions in consensus handler

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -267,6 +267,7 @@ pub struct AuthorityMetrics {
     pub consensus_handler_processed: IntCounterVec,
     pub consensus_handler_num_low_scoring_authorities: IntGauge,
     pub consensus_handler_scores: IntGaugeVec,
+    pub consensus_handler_deferred_transactions: IntCounter,
     pub consensus_committed_subdags: IntCounterVec,
     pub consensus_committed_messages: IntGaugeVec,
     pub consensus_committed_user_transactions: IntGaugeVec,
@@ -640,6 +641,11 @@ impl AuthorityMetrics {
                 "consensus_handler_scores",
                 "scores from consensus for each authority",
                 &["authority"],
+                registry,
+            ).unwrap(),
+            consensus_handler_deferred_transactions: register_int_counter_with_registry!(
+                "consensus_handler_deferred_transactions",
+                "Number of transactions deferred by consensus handler",
                 registry,
             ).unwrap(),
             consensus_committed_subdags: register_int_counter_vec_with_registry!(

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -372,7 +372,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
-            &authority.metrics.skipped_consensus_txns,
+            &authority.metrics,
         )
         .await
         .unwrap();
@@ -395,7 +395,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
-            &authority.metrics.skipped_consensus_txns,
+            &authority.metrics,
         )
         .await
         .unwrap();
@@ -423,7 +423,7 @@ pub async fn send_batch_consensus_no_execution(
             transactions,
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_cache_reader().as_ref(),
-            &authority.metrics.skipped_consensus_txns,
+            &authority.metrics,
         )
         .await
         .unwrap()

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -452,7 +452,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 self.cache_reader.as_ref(),
                 round,
                 timestamp,
-                &self.metrics.skipped_consensus_txns,
+                &self.metrics,
             )
             .await
             .expect("Unrecoverable error in consensus handler");

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -130,7 +130,7 @@ async fn submit_transaction_to_consensus_adapter() {
                     vec![SequencedConsensusTransaction::new_test(transaction.clone())],
                     &Arc::new(CheckpointServiceNoop {}),
                     self.0.get_cache_reader().as_ref(),
-                    &self.0.metrics.skipped_consensus_txns,
+                    &self.0.metrics,
                 )
                 .await?;
             Ok(())


### PR DESCRIPTION
## Description 

The metric is added to AuthorityMetrics instead of EpochMetrics. So this PR also does some pluming to make `process_consensus_transactions` to take AuthorityMetrics.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
