### PR TITLE
[Consensus] support swapping protocols between epochs

### DIFF
--- a/.github/workflows/mysticeti.yml
+++ b/.github/workflows/mysticeti.yml
@@ -26,8 +26,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  # Enable Mysticeti in tests.
-  CONSENSUS: "mysticeti"
+  # Swap between Narwhal and Mysticeti each epoch.
+  CONSENSUS: "swap_each_epoch"
 
   CARGO_TERM_COLOR: always
   # Disable incremental compilation.

--- a/.github/workflows/simulator-nightly-mysticeti.yml
+++ b/.github/workflows/simulator-nightly-mysticeti.yml
@@ -20,8 +20,8 @@ on:
         default: "30"
 
 env:
-  # Enable Mysticeti in tests.
-  CONSENSUS: "mysticeti"
+  # Swap between Narwhal and Mysticeti each epoch.
+  CONSENSUS: "swap_each_epoch"
 
   SUI_REF: "${{ github.event.inputs.sui_ref || 'main' }}"
   TEST_NUM: "${{ github.event.inputs.test_num || '30' }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,6 +7764,7 @@ dependencies = [
  "futures",
  "lru 0.10.0",
  "mysten-common",
+ "mysten-metrics",
  "narwhal-config",
  "narwhal-test-utils",
  "narwhal-types",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1022,6 +1022,13 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         assert!(self.is_fullnode(epoch_store));
+        // NOTE: the fullnode can change epoch during local execution. It should not cause
+        // data inconsistency, but can be problematic for certain tests.
+        // The check below mitigates the issue, but it is not a fundamental solution to
+        // avoid race between local execution and reconfiguration.
+        if self.epoch_store.load().epoch() != epoch_store.epoch() {
+            return Err(SuiError::EpochEnded(epoch_store.epoch()));
+        }
         let _metrics_guard = self
             .metrics
             .execute_certificate_with_effects_latency

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2490,7 +2490,7 @@ impl AuthorityPerEpochStore {
         }
         let mut batch = self
             .db_batch()
-            .expect("Consensus should not be processed past end of epoch");
+            .expect("Failed to create DBBatch for processing consensus transactions");
 
         // Load transactions deferred from previous commits.
         let deferred_txs: Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)> = self

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -200,6 +200,14 @@ fn update_index_and_hash(
     true
 }
 
+impl<C> Drop for ConsensusHandler<C> {
+    fn drop(&mut self) {
+        // Assuming ConsensusHandler only gets dropped at process shutdown and epoch change,
+        // it is safe to try to release db handles if epoch has advanced.
+        self.epoch_store.release_db_handles();
+    }
+}
+
 #[async_trait]
 impl<C: CheckpointServiceNotify + Send + Sync> ExecutionState for ConsensusHandler<C> {
     /// This function will be called by Narwhal, after Narwhal sequenced this certificate.

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -61,7 +61,7 @@ enum ProtocolManager {
 }
 
 impl ProtocolManager {
-    /// Creates a new narwhal manager enum.
+    /// Creates a new narwhal manager.
     pub fn new_narwhal(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,
@@ -79,7 +79,7 @@ impl ProtocolManager {
         Self::Narwhal(NarwhalManager::new(narwhal_config, metrics))
     }
 
-    /// Creates a new mysticeti manager enum.
+    /// Creates a new mysticeti manager.
     pub fn new_mysticeti(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -1,23 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::consensus_adapter::SubmitToConsensus;
 use crate::consensus_handler::ConsensusHandlerInitializer;
 use crate::consensus_manager::mysticeti_manager::MysticetiManager;
 use crate::consensus_manager::narwhal_manager::{NarwhalConfiguration, NarwhalManager};
 use crate::consensus_validator::SuiTxValidator;
 use crate::mysticeti_adapter::LazyMysticetiClient;
+use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::traits::KeyPair as _;
 use mysten_metrics::RegistryService;
+use narwhal_worker::LazyNarwhalClient;
 use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use sui_config::node::ConsensusProtocol;
 use sui_config::{ConsensusConfig, NodeConfig};
-use sui_protocol_config::ProtocolVersion;
+use sui_protocol_config::{ConsensusChoice, ProtocolVersion};
 use sui_types::committee::EpochId;
+use sui_types::error::SuiResult;
+use sui_types::messages_consensus::ConsensusTransaction;
 use tokio::sync::{Mutex, MutexGuard};
+use tokio::time::{sleep, timeout};
+use tracing::info;
 
 pub mod mysticeti_manager;
 pub mod narwhal_manager;
@@ -28,19 +36,12 @@ pub(crate) enum Running {
     False,
 }
 
-/// An enum to easily differentiate between the chosen consensus engine
-#[enum_dispatch]
-pub enum ConsensusManager {
-    Narwhal(NarwhalManager),
-    Mysticeti(MysticetiManager),
-}
-
 #[async_trait]
-#[enum_dispatch(ConsensusManager)]
+#[enum_dispatch(ProtocolManager)]
 pub trait ConsensusManagerTrait {
     async fn start(
         &self,
-        config: &NodeConfig,
+        node_config: &NodeConfig,
         epoch_store: Arc<AuthorityPerEpochStore>,
         consensus_handler_initializer: ConsensusHandlerInitializer,
         tx_validator: SuiTxValidator,
@@ -49,16 +50,23 @@ pub trait ConsensusManagerTrait {
     async fn shutdown(&self);
 
     async fn is_running(&self) -> bool;
-
-    fn get_storage_base_path(&self) -> PathBuf;
 }
 
-impl ConsensusManager {
-    /// Create a new narwhal manager and wrap it around the Manager enum
+// Wraps the underlying consensus protocol managers to make calling
+// the ConsensusManagerTrait easier.
+#[enum_dispatch]
+enum ProtocolManager {
+    Narwhal(NarwhalManager),
+    Mysticeti(MysticetiManager),
+}
+
+impl ProtocolManager {
+    /// Creates a new narwhal manager enum.
     pub fn new_narwhal(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
+        metrics: Arc<ConsensusManagerMetrics>,
     ) -> Self {
         let narwhal_config = NarwhalConfiguration {
             primary_keypair: config.protocol_key_pair().copy(),
@@ -68,28 +76,235 @@ impl ConsensusManager {
             parameters: consensus_config.narwhal_config().to_owned(),
             registry_service: registry_service.clone(),
         };
-
-        let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
-
         Self::Narwhal(NarwhalManager::new(narwhal_config, metrics))
     }
 
+    /// Creates a new mysticeti manager enum.
     pub fn new_mysticeti(
         config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
+        metrics: Arc<ConsensusManagerMetrics>,
         client: Arc<LazyMysticetiClient>,
     ) -> Self {
-        let metrics = ConsensusManagerMetrics::new(&registry_service.default_registry());
-
         Self::Mysticeti(MysticetiManager::new(
             config.worker_key_pair().copy(),
             config.network_key_pair().copy(),
             consensus_config.db_path().to_path_buf(),
-            metrics,
             registry_service.clone(),
+            metrics,
             client,
         ))
+    }
+}
+
+/// Used by Sui validator to start consensus protocol for each epoch.
+pub struct ConsensusManager {
+    consensus_config: ConsensusConfig,
+    narwhal_manager: ProtocolManager,
+    mysticeti_manager: ProtocolManager,
+    narwhal_client: Arc<LazyNarwhalClient>,
+    mysticeti_client: Arc<LazyMysticetiClient>,
+    active: parking_lot::Mutex<Vec<bool>>,
+    consensus_client: Arc<ConsensusClient>,
+}
+
+impl ConsensusManager {
+    pub fn new(
+        node_config: &NodeConfig,
+        consensus_config: &ConsensusConfig,
+        registry_service: &RegistryService,
+        consensus_client: Arc<ConsensusClient>,
+    ) -> Self {
+        let metrics = Arc::new(ConsensusManagerMetrics::new(
+            &registry_service.default_registry(),
+        ));
+        let narwhal_client = Arc::new(LazyNarwhalClient::new(
+            consensus_config.address().to_owned(),
+        ));
+        let narwhal_manager = ProtocolManager::new_narwhal(
+            node_config,
+            consensus_config,
+            registry_service,
+            metrics.clone(),
+        );
+        let mysticeti_client = Arc::new(LazyMysticetiClient::new());
+        let mysticeti_manager = ProtocolManager::new_mysticeti(
+            node_config,
+            consensus_config,
+            registry_service,
+            metrics,
+            mysticeti_client.clone(),
+        );
+        Self {
+            consensus_config: consensus_config.clone(),
+            narwhal_manager,
+            mysticeti_manager,
+            narwhal_client,
+            mysticeti_client,
+            active: parking_lot::Mutex::new(vec![false; 2]),
+            consensus_client,
+        }
+    }
+
+    pub fn get_storage_base_path(&self) -> PathBuf {
+        self.consensus_config.db_path().to_path_buf()
+    }
+
+    // Picks the consensus protocol based on the protocol config and the epoch.
+    fn pick_protocol(&self, epoch_store: &AuthorityPerEpochStore) -> ConsensusProtocol {
+        let protocol_config = epoch_store.protocol_config();
+        if protocol_config.version >= ProtocolVersion::new(36) {
+            if let Ok(consensus_choice) = std::env::var("CONSENSUS") {
+                match consensus_choice.to_lowercase().as_str() {
+                    "narwhal" => return ConsensusProtocol::Narwhal,
+                    "mysticeti" => return ConsensusProtocol::Mysticeti,
+                    "swap_each_epoch" => {
+                        let protocol = if epoch_store.epoch() % 2 == 0 {
+                            ConsensusProtocol::Narwhal
+                        } else {
+                            ConsensusProtocol::Mysticeti
+                        };
+                        return protocol;
+                    }
+                    _ => {
+                        info!("Invalid consensus choice {} in env var. Continue to pick consensus with protocol config", consensus_choice);
+                    }
+                };
+            }
+        }
+
+        match protocol_config.consensus_choice() {
+            ConsensusChoice::Narwhal => ConsensusProtocol::Narwhal,
+            ConsensusChoice::Mysticeti => ConsensusProtocol::Mysticeti,
+            ConsensusChoice::SwapEachEpoch => {
+                if epoch_store.epoch() % 2 == 0 {
+                    ConsensusProtocol::Narwhal
+                } else {
+                    ConsensusProtocol::Mysticeti
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ConsensusManagerTrait for ConsensusManager {
+    async fn start(
+        &self,
+        node_config: &NodeConfig,
+        epoch_store: Arc<AuthorityPerEpochStore>,
+        consensus_handler_initializer: ConsensusHandlerInitializer,
+        tx_validator: SuiTxValidator,
+    ) {
+        let protocol_manager = {
+            let mut active = self.active.lock();
+            active.iter().enumerate().for_each(|(index, active)| {
+                assert!(
+                    !*active,
+                    "Cannot start consensus. ConsensusManager protocol {index} is already running"
+                );
+            });
+            let protocol = self.pick_protocol(&epoch_store);
+            info!("Starting consensus protocol {protocol:?} ...");
+            match protocol {
+                ConsensusProtocol::Narwhal => {
+                    active[0] = true;
+                    self.consensus_client.set(self.narwhal_client.clone());
+                    &self.narwhal_manager
+                }
+                ConsensusProtocol::Mysticeti => {
+                    active[1] = true;
+                    self.consensus_client.set(self.mysticeti_client.clone());
+                    &self.mysticeti_manager
+                }
+            }
+        };
+
+        protocol_manager
+            .start(
+                node_config,
+                epoch_store,
+                consensus_handler_initializer,
+                tx_validator,
+            )
+            .await
+    }
+
+    async fn shutdown(&self) {
+        let prev_active = {
+            let mut active = self.active.lock();
+            std::mem::replace(&mut *active, vec![false; 2])
+        };
+        if prev_active[0] {
+            self.narwhal_manager.shutdown().await;
+        }
+        if prev_active[1] {
+            self.mysticeti_manager.shutdown().await;
+        }
+        self.consensus_client.clear();
+    }
+
+    async fn is_running(&self) -> bool {
+        let active = self.active.lock();
+        active.iter().any(|i| *i)
+    }
+}
+
+#[derive(Default)]
+pub struct ConsensusClient {
+    // An extra layer of Arc<> is needed as required by ArcSwapAny.
+    client: ArcSwapOption<Arc<dyn SubmitToConsensus>>,
+}
+
+impl ConsensusClient {
+    pub fn new() -> Self {
+        Self {
+            client: ArcSwapOption::empty(),
+        }
+    }
+
+    async fn get(&self) -> Arc<Arc<dyn SubmitToConsensus>> {
+        const START_TIMEOUT: Duration = Duration::from_secs(30);
+        const RETRY_INTERVAL: Duration = Duration::from_millis(100);
+        if let Ok(client) = timeout(START_TIMEOUT, async {
+            loop {
+                let Some(client) = self.client.load_full() else {
+                    sleep(RETRY_INTERVAL).await;
+                    continue;
+                };
+                return client;
+            }
+        })
+        .await
+        {
+            return client;
+        }
+
+        panic!(
+            "Timed out after {:?} waiting for Consensus to start!",
+            START_TIMEOUT,
+        );
+    }
+
+    pub fn set(&self, client: Arc<dyn SubmitToConsensus>) {
+        self.client.store(Some(Arc::new(client)));
+    }
+
+    pub fn clear(&self) {
+        self.client.store(None);
+    }
+}
+
+#[async_trait]
+impl SubmitToConsensus for ConsensusClient {
+    async fn submit_to_consensus(
+        &self,
+        transaction: &ConsensusTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        let client = self.get().await;
+        client.submit_to_consensus(transaction, epoch_store).await
     }
 }
 

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -35,7 +35,7 @@ pub struct MysticetiManager {
     network_keypair: NetworkKeyPair,
     storage_base_path: PathBuf,
     running: Mutex<Running>,
-    metrics: ConsensusManagerMetrics,
+    metrics: Arc<ConsensusManagerMetrics>,
     registry_service: RegistryService,
     authority: ArcSwapOption<(ConsensusAuthority, RegistryID)>,
     // Use a shared lazy mysticeti client so we can update the internal mysticeti
@@ -51,8 +51,8 @@ impl MysticetiManager {
         protocol_keypair: ed25519::Ed25519KeyPair,
         network_keypair: ed25519::Ed25519KeyPair,
         storage_base_path: PathBuf,
-        metrics: ConsensusManagerMetrics,
         registry_service: RegistryService,
+        metrics: Arc<ConsensusManagerMetrics>,
         client: Arc<LazyMysticetiClient>,
     ) -> Self {
         Self {
@@ -198,9 +198,5 @@ impl ConsensusManagerTrait for MysticetiManager {
 
     async fn is_running(&self) -> bool {
         Running::False != *self.running.lock().await
-    }
-
-    fn get_storage_base_path(&self) -> PathBuf {
-        self.storage_base_path.clone()
     }
 }

--- a/crates/sui-core/src/consensus_manager/narwhal_manager.rs
+++ b/crates/sui-core/src/consensus_manager/narwhal_manager.rs
@@ -44,12 +44,14 @@ pub struct NarwhalManager {
     worker_nodes: WorkerNodes,
     storage_base_path: PathBuf,
     running: Mutex<Running>,
-    metrics: ConsensusManagerMetrics,
-    store_cache_metrics: CertificateStoreCacheMetrics,
+    metrics: Arc<ConsensusManagerMetrics>,
+    registry_service: RegistryService,
+    // NarwhalManager creates and unregisters the store cache metrics.
+    store_cache_metrics: parking_lot::Mutex<Option<Arc<CertificateStoreCacheMetrics>>>,
 }
 
 impl NarwhalManager {
-    pub fn new(config: NarwhalConfiguration, metrics: ConsensusManagerMetrics) -> Self {
+    pub fn new(config: NarwhalConfiguration, metrics: Arc<ConsensusManagerMetrics>) -> Self {
         // Create the Narwhal Primary with configuration
         let primary_node =
             PrimaryNode::new(config.parameters.clone(), config.registry_service.clone());
@@ -57,9 +59,6 @@ impl NarwhalManager {
         // Create Narwhal Workers with configuration
         let worker_nodes =
             WorkerNodes::new(config.registry_service.clone(), config.parameters.clone());
-
-        let store_cache_metrics =
-            CertificateStoreCacheMetrics::new(&config.registry_service.default_registry());
 
         Self {
             primary_node,
@@ -70,7 +69,8 @@ impl NarwhalManager {
             storage_base_path: config.storage_base_path,
             running: Mutex::new(Running::False),
             metrics,
-            store_cache_metrics,
+            registry_service: config.registry_service.clone(),
+            store_cache_metrics: parking_lot::Mutex::new(None),
         }
     }
 
@@ -121,9 +121,15 @@ impl ConsensusManagerTrait for NarwhalManager {
             .address;
         let worker_cache = system_state.get_narwhal_worker_cache(transactions_addr);
 
+        // Register store cache metrics.
+        let store_cache_metrics = Arc::new(CertificateStoreCacheMetrics::new(
+            self.registry_service.clone(),
+        ));
+        *self.store_cache_metrics.lock() = Some(store_cache_metrics.clone());
+
         // Create a new store
         let store_path = self.get_store_path(epoch);
-        let store = NodeStorage::reopen(store_path, Some(self.store_cache_metrics.clone()));
+        let store = NodeStorage::reopen(store_path, Some(store_cache_metrics));
 
         // Create a new client.
         let network_client = NetworkClient::new_from_keypair(&self.network_keypair);
@@ -216,14 +222,13 @@ impl ConsensusManagerTrait for NarwhalManager {
 
         self.primary_node.shutdown().await;
         self.worker_nodes.shutdown().await;
+        if let Some(store_cache_metrics) = self.store_cache_metrics.lock().take() {
+            store_cache_metrics.unregister();
+        }
     }
 
     async fn is_running(&self) -> bool {
         let running = self.running.lock().await;
         Running::False != *running
-    }
-
-    fn get_storage_base_path(&self) -> PathBuf {
-        self.storage_base_path.clone()
     }
 }

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -51,12 +51,14 @@ pub async fn execution_process(
         let certificate;
         let expected_effects_digest;
         let txn_ready_time;
+        let epoch;
         tokio::select! {
             result = rx_ready_certificates.recv() => {
                 if let Some(pending_cert) = result {
                     certificate = pending_cert.certificate;
                     expected_effects_digest = pending_cert.expected_effects_digest;
                     txn_ready_time = pending_cert.stats.ready_time.unwrap();
+                    epoch = pending_cert.epoch;
                 } else {
                     // Should only happen after the AuthorityState has shut down and tx_ready_certificate
                     // has been dropped by TransactionManager.
@@ -80,11 +82,24 @@ pub async fn execution_process(
         };
         authority.metrics.execution_driver_dispatch_queue.dec();
 
-        // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
-        let epoch_store = authority.load_epoch_store_one_call_per_task();
-
         let digest = *certificate.digest();
         trace!(?digest, "Pending certificate execution activated.");
+
+        // A single execution driver process runs across epochs. After epoch change,
+        // transactions from the previous epoch cannot be executed correctly so it is better
+        // to skip execution gracefully.
+        // This should not happen on validators, but possibe on fullnodes with local execution
+        // in tests.
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
+        if epoch != epoch_store.epoch() {
+            // This certificate is for a different epoch. Ignore it.
+            error!(
+                ?digest,
+                "Ignoring certificate from different epoch ({epoch} instead of {}) for execution ...",
+                epoch_store.epoch()
+            );
+            continue;
+        }
 
         let limit = limit.clone();
         // hold semaphore permit until task completes. unwrap ok because we never close

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -88,8 +88,9 @@ pub async fn execution_process(
         // A single execution driver process runs across epochs. After epoch change,
         // transactions from the previous epoch cannot be executed correctly so it is better
         // to skip execution gracefully.
-        // This should not happen on validators, but possibe on fullnodes with local execution
-        // in tests.
+        // Mismatched epoch should not happen on validators or on fullnode with checkpoint executions.
+        // But it is possibe in tests on fullnodes with local executions. The execution failure because
+        // of mismatched epoch would not be graceful downstream, so it is better to skip execution here.
         let epoch_store = authority.load_epoch_store_one_call_per_task();
         if epoch != epoch_store.epoch() {
             // This certificate is for a different epoch. Ignore it.

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -83,8 +83,6 @@ pub struct PendingCertificate {
     pub waiting_input_objects: BTreeSet<InputKey>,
     // Stores stats about this transaction.
     pub stats: PendingCertificateStats,
-    // Epoch when enqueued, after which the certificate should no longer be executed.
-    pub epoch: EpochId,
 }
 
 struct CacheInner {
@@ -552,7 +550,6 @@ impl TransactionManager {
                     enqueue_time: pending_cert_enqueue_time,
                     ready_time: None,
                 },
-                epoch: epoch_store.epoch(),
             });
         }
 

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -83,6 +83,8 @@ pub struct PendingCertificate {
     pub waiting_input_objects: BTreeSet<InputKey>,
     // Stores stats about this transaction.
     pub stats: PendingCertificateStats,
+    // Epoch when enqueued, after which the certificate should no longer be executed.
+    pub epoch: EpochId,
 }
 
 struct CacheInner {
@@ -550,6 +552,7 @@ impl TransactionManager {
                     enqueue_time: pending_cert_enqueue_time,
                     ready_time: None,
                 },
+                epoch: epoch_store.epoch(),
             });
         }
 

--- a/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -42,7 +42,7 @@ async fn test_mysticeti_manager() {
             .build()
             .await;
 
-        let metrics = ConsensusManagerMetrics::new(&Registry::new());
+        let metrics = Arc::new(ConsensusManagerMetrics::new(&Registry::new()));
         let epoch_store = state.epoch_store_for_testing();
         let client = Arc::new(LazyMysticetiClient::default());
 
@@ -50,8 +50,8 @@ async fn test_mysticeti_manager() {
             config.worker_key_pair().copy(),
             config.network_key_pair().copy(),
             consensus_config.db_path().to_path_buf(),
-            metrics,
             registry_service,
+            metrics,
             client,
         );
 

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -126,7 +126,7 @@ async fn test_narwhal_manager() {
             registry_service,
         };
 
-        let metrics = ConsensusManagerMetrics::new(&Registry::new());
+        let metrics = Arc::new(ConsensusManagerMetrics::new(&Registry::new()));
         let epoch_store = state.epoch_store_for_testing();
 
         let narwhal_manager = NarwhalManager::new(narwhal_config, metrics);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -12,7 +12,6 @@ use arc_swap::ArcSwap;
 use fastcrypto_zkp::bn254::zk_login::JwkId;
 use fastcrypto_zkp::bn254::zk_login::OIDCProvider;
 use futures::TryFutureExt;
-use narwhal_worker::LazyNarwhalClient;
 use prometheus::Registry;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
@@ -25,13 +24,13 @@ use std::time::Duration;
 use sui_core::authority::RandomnessRoundReceiver;
 use sui_core::authority::CHAIN_IDENTIFIER;
 use sui_core::consensus_adapter::SubmitToConsensus;
+use sui_core::consensus_manager::ConsensusClient;
 use sui_core::epoch::randomness::RandomnessManager;
 use sui_core::execution_cache::ExecutionCacheMetrics;
 use sui_core::execution_cache::NotifyReadWrapper;
 use sui_json_rpc::ServerType;
 use sui_json_rpc_api::JsonRpcMetrics;
 use sui_network::randomness;
-use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::ConciseableName;
 use sui_types::crypto::RandomnessRound;
 use sui_types::digests::ChainIdentifier;
@@ -55,7 +54,7 @@ use narwhal_network::metrics::MetricsMakeCallbackHandler;
 use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use sui_archival::reader::ArchiveReaderBalancer;
 use sui_archival::writer::ArchiveWriter;
-use sui_config::node::{ConsensusProtocol, DBCheckpointConfig, RunWithRange};
+use sui_config::node::{DBCheckpointConfig, RunWithRange};
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::object_storage_config::{ObjectStoreConfig, ObjectStoreType};
 use sui_config::{ConsensusConfig, NodeConfig};
@@ -207,7 +206,6 @@ use simulator::*;
 #[cfg(msim)]
 pub use simulator::set_jwk_injector;
 use sui_core::consensus_handler::ConsensusHandlerInitializer;
-use sui_core::mysticeti_adapter::LazyMysticetiClient;
 use sui_types::execution_config_utils::to_binary_config;
 
 pub struct SuiNode {
@@ -1087,70 +1085,18 @@ impl SuiNode {
             .as_mut()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
 
-        // Only allow overriding the consensus protocol, if the protocol version supports
-        // fields needed by Mysticeti.
-        if epoch_store.protocol_config().version >= ProtocolVersion::new(36) {
-            if let Ok(consensus_choice) = std::env::var("CONSENSUS") {
-                let consensus_protocol = match consensus_choice.as_str() {
-                    "narwhal" => ConsensusProtocol::Narwhal,
-                    "mysticeti" => ConsensusProtocol::Mysticeti,
-                    "swap_each_epoch" => {
-                        if epoch_store.epoch() % 2 == 0 {
-                            ConsensusProtocol::Narwhal
-                        } else {
-                            ConsensusProtocol::Mysticeti
-                        }
-                    }
-                    _ => {
-                        let consensus = consensus_config.protocol.clone();
-                        warn!("Consensus env var was set to an invalid choice, using default consensus protocol {consensus:?}");
-                        consensus
-                    }
-                };
-                info!("Constructing consensus protocol {consensus_protocol:?}...");
-                consensus_config.protocol = consensus_protocol;
-            }
-        }
-
-        // TODO (mysticeti): Move protocol choice to a protocol config flag.
-        let (consensus_adapter, consensus_manager) = match consensus_config.protocol {
-            ConsensusProtocol::Narwhal => {
-                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
-                    &committee,
-                    consensus_config,
-                    state.name,
-                    connection_monitor_status.clone(),
-                    &registry_service.default_registry(),
-                    epoch_store.protocol_config().clone(),
-                    Arc::new(LazyNarwhalClient::new(
-                        consensus_config.address().to_owned(),
-                    )),
-                ));
-                let consensus_manager =
-                    ConsensusManager::new_narwhal(&config, consensus_config, registry_service);
-                (consensus_adapter, consensus_manager)
-            }
-            ConsensusProtocol::Mysticeti => {
-                let client = Arc::new(LazyMysticetiClient::new());
-
-                let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
-                    &committee,
-                    consensus_config,
-                    state.name,
-                    connection_monitor_status.clone(),
-                    &registry_service.default_registry(),
-                    epoch_store.protocol_config().clone(),
-                    client.clone(),
-                ));
-                let consensus_manager = ConsensusManager::new_mysticeti(
-                    &config,
-                    consensus_config,
-                    registry_service,
-                    client,
-                );
-                (consensus_adapter, consensus_manager)
-            }
-        };
+        let client = Arc::new(ConsensusClient::new());
+        let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+            &committee,
+            consensus_config,
+            state.name,
+            connection_monitor_status.clone(),
+            &registry_service.default_registry(),
+            epoch_store.protocol_config().clone(),
+            client.clone(),
+        ));
+        let consensus_manager =
+            ConsensusManager::new(&config, consensus_config, registry_service, client);
 
         let mut consensus_epoch_data_remover =
             EpochDataRemover::new(consensus_manager.get_storage_base_path());

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -402,6 +402,11 @@ struct FeatureFlags {
     // Controls the behavior of per object congestion control in consensus handler.
     #[serde(skip_serializing_if = "PerObjectCongestionControlMode::is_none")]
     per_object_congestion_control_mode: PerObjectCongestionControlMode,
+
+    // The policy to pick consensus algorithm.
+    #[serde(skip_serializing_if = "ConsensusChoice::is_narwhal")]
+    consensus_choice: ConsensusChoice,
+
     // Set the upper bound allowed for max_epoch in zklogin signature.
     #[serde(skip_serializing_if = "Option::is_none")]
     zklogin_max_epoch_upper_bound_delta: Option<u64>,
@@ -442,6 +447,21 @@ pub enum PerObjectCongestionControlMode {
 impl PerObjectCongestionControlMode {
     pub fn is_none(&self) -> bool {
         matches!(self, PerObjectCongestionControlMode::None)
+    }
+}
+
+// Configuration options for consensus algorithm.
+#[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Debug)]
+pub enum ConsensusChoice {
+    #[default]
+    Narwhal,
+    SwapEachEpoch,
+    Mysticeti,
+}
+
+impl ConsensusChoice {
+    pub fn is_narwhal(&self) -> bool {
+        matches!(self, ConsensusChoice::Narwhal)
     }
 }
 
@@ -1226,6 +1246,10 @@ impl ProtocolConfig {
 
     pub fn per_object_congestion_control_mode(&self) -> PerObjectCongestionControlMode {
         self.feature_flags.per_object_congestion_control_mode
+    }
+
+    pub fn consensus_choice(&self) -> ConsensusChoice {
+        self.feature_flags.consensus_choice
     }
 }
 
@@ -2212,6 +2236,10 @@ impl ProtocolConfig {
 
     pub fn set_per_object_congestion_control_mode(&mut self, val: PerObjectCongestionControlMode) {
         self.feature_flags.per_object_congestion_control_mode = val;
+    }
+
+    pub fn set_consensus_choice(&mut self, val: ConsensusChoice) {
+        self.feature_flags.consensus_choice = val;
     }
 
     pub fn set_max_accumulated_txn_cost_per_object_in_checkpoint(&mut self, val: u64) {

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -554,8 +554,8 @@ pub enum SuiError {
     // Epoch related errors.
     #[error("Validator temporarily stopped processing transactions due to epoch change")]
     ValidatorHaltedAtEpochEnd,
-    #[error("Validator has stopped operations for this epoch")]
-    EpochEnded,
+    #[error("Operations for epoch {0} have ended")]
+    EpochEnded(EpochId),
     #[error("Error when advancing epoch: {:?}", error)]
     AdvanceEpochError { error: String },
 

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -70,7 +70,7 @@ impl Executor {
         let arc_metrics = Arc::new(metrics);
 
         // Spawn the subscriber.
-        let subscriber_handle = spawn_subscriber(
+        let subscriber_handles = spawn_subscriber(
             authority_id,
             worker_cache,
             committee,
@@ -86,7 +86,7 @@ impl Executor {
         // Return the handle.
         info!("Consensus subscriber successfully started");
 
-        Ok(subscriber_handle)
+        Ok(subscriber_handles)
     }
 }
 

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -112,7 +112,6 @@ async fn run_notify<State: ExecutionState + Send + Sync + 'static>(
             _ = rx_shutdown.receiver.recv() => {
                 return
             }
-
         }
     }
 }

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -554,7 +554,7 @@ async fn run(
 
     // Make the data store.
     let certificate_store_cache_metrics =
-        CertificateStoreCacheMetrics::new(&registry_service.default_registry());
+        Arc::new(CertificateStoreCacheMetrics::new(registry_service.clone()));
     let store = NodeStorage::reopen(store_path, Some(certificate_store_cache_metrics.clone()));
 
     let client = NetworkClient::new_from_keypair(&primary_network_keypair);

--- a/narwhal/storage/Cargo.toml
+++ b/narwhal/storage/Cargo.toml
@@ -12,6 +12,7 @@ tempfile.workspace = true
 fastcrypto.workspace = true
 fastcrypto-tbls.workspace = true
 mysten-common.workspace = true
+mysten-metrics.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 tracing.workspace = true

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -67,7 +67,7 @@ impl NodeStorage {
     /// Open or reopen all the storage of the node.
     pub fn reopen<Path: AsRef<std::path::Path> + Send>(
         store_path: Path,
-        certificate_store_cache_metrics: Option<CertificateStoreCacheMetrics>,
+        certificate_store_cache_metrics: Option<Arc<CertificateStoreCacheMetrics>>,
     ) -> Self {
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");


### PR DESCRIPTION
## Description 

This helps to ensure that coverage for Narwhal in testnet is maintained while rolling out Mysticeti. Support for this policy has been added to both `ProtocolConfig` and environmental variables (in an earlier PR). And this policy (`swap_each_epoch`) is enabled in Mysticeti CI.

The implementation involves wrapping `NarwhalManager` and `MysticetiManager` within a `ConsensusManager` struct, which selects the appropriate consensus protocol to use.

MysticetiManager was updated to wait for consensus handler task to exist during shutdown.

## Test plan 

CI
private testnet: no crash after >90 epoch changes with 5min epoch duration.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
