### PR TITLE
Remove signal feature in tokio cron scheduler

### DIFF
--- a/crates/sui-security-watchdog/Cargo.toml
+++ b/crates/sui-security-watchdog/Cargo.toml
@@ -13,7 +13,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tokio-cron-scheduler = { version = "0.10.0", features = ["signal"] }
+tokio-cron-scheduler = { version = "0.10.0"}
 anyhow.workspace = true
 chrono.workspace = true
 snowflake-api = { version = "0.7.0"}

--- a/crates/sui-security-watchdog/src/scheduler.rs
+++ b/crates/sui-security-watchdog/src/scheduler.rs
@@ -60,13 +60,7 @@ pub struct SchedulerService {
 
 impl SchedulerService {
     pub async fn new(config: &SecurityWatchdogConfig, registry: &Registry) -> anyhow::Result<Self> {
-        let mut scheduler = JobScheduler::new().await?;
-        scheduler.shutdown_on_ctrl_c();
-        scheduler.set_shutdown_handler(Box::new(|| {
-            Box::pin(async move {
-                info!("Scheduler shut down complete");
-            })
-        }));
+        let scheduler = JobScheduler::new().await?;
         Ok(Self {
             scheduler,
             query_runner: Arc::new(SnowflakeQueryRunner::from_config(config)?),


### PR DESCRIPTION
## Description 

Remove signal as it is breaking windows build, we don't really need it
