### PR TITLE
Cleanup and test rework

### DIFF
--- a/crates/sui-framework/docs/bridge/bridge.md
+++ b/crates/sui-framework/docs/bridge/bridge.md
@@ -663,7 +663,7 @@ title: Module `0xb::bridge`
     };
     <b>let</b> <a href="bridge.md#0xb_bridge">bridge</a> = <a href="bridge.md#0xb_bridge_Bridge">Bridge</a> {
         id,
-        inner: <a href="../sui-framework/versioned.md#0x2_versioned_create">versioned::create</a>(<a href="bridge.md#0xb_bridge_CURRENT_VERSION">CURRENT_VERSION</a>, bridge_inner, ctx)
+        inner: <a href="../sui-framework/versioned.md#0x2_versioned_create">versioned::create</a>(<a href="bridge.md#0xb_bridge_CURRENT_VERSION">CURRENT_VERSION</a>, bridge_inner, ctx),
     };
     <a href="../sui-framework/transfer.md#0x2_transfer_share_object">transfer::share_object</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
 }
@@ -679,7 +679,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_init_bridge_committee">init_bridge_committee</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, active_validator_voting_power: <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, u64&gt;, min_stake_participation_percentage: u64, ctx: &<a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_init_bridge_committee">init_bridge_committee</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, active_validator_voting_power: <a href="../sui-framework/vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, u64&gt;, min_stake_participation_percentage: u64, ctx: &<a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -689,19 +689,18 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_init_bridge_committee">init_bridge_committee</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     active_validator_voting_power: VecMap&lt;<b>address</b>, u64&gt;,
     min_stake_participation_percentage: u64,
     ctx: &TxContext
 ) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="bridge.md#0xb_bridge_ENotSystemAddress">ENotSystemAddress</a>);
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
-    <b>if</b> (<a href="../sui-framework/vec_map.md#0x2_vec_map_is_empty">vec_map::is_empty</a>(<a href="committee.md#0xb_committee_committee_members">committee::committee_members</a>(&inner.<a href="committee.md#0xb_committee">committee</a>))) {
-        <a href="committee.md#0xb_committee_try_create_next_committee">committee::try_create_next_committee</a>(
-            &<b>mut</b> inner.<a href="committee.md#0xb_committee">committee</a>,
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
+    <b>if</b> (inner.<a href="committee.md#0xb_committee">committee</a>.committee_members().is_empty()) {
+        inner.<a href="committee.md#0xb_committee">committee</a>.try_create_next_committee(
             active_validator_voting_power,
             min_stake_participation_percentage,
-            ctx
+            ctx,
         )
     }
 }
@@ -717,7 +716,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_committee_registration">committee_registration</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, system_state: &<b>mut</b> <a href="../sui-system/sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, bridge_pubkey_bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, http_rest_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ctx: &<a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_committee_registration">committee_registration</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, system_state: &<b>mut</b> <a href="../sui-system/sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, bridge_pubkey_bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, http_rest_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, ctx: &<a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -727,13 +726,13 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_committee_registration">committee_registration</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     system_state: &<b>mut</b> SuiSystemState,
     bridge_pubkey_bytes: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     http_rest_url: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     ctx: &TxContext
 ) {
-    <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self)
+    <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>)
         .<a href="committee.md#0xb_committee">committee</a>
         .register(system_state, bridge_pubkey_bytes, http_rest_url, ctx);
 }
@@ -749,7 +748,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_register_foreign_token">register_foreign_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, tc: <a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, uc: <a href="../sui-framework/package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>, metadata: &<a href="../sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_register_foreign_token">register_foreign_token</a>&lt;T&gt;(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, tc: <a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;, uc: <a href="../sui-framework/package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>, metadata: &<a href="../sui-framework/coin.md#0x2_coin_CoinMetadata">coin::CoinMetadata</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -758,8 +757,13 @@ title: Module `0xb::bridge`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_register_foreign_token">register_foreign_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>, tc: TreasuryCap&lt;T&gt;, uc: UpgradeCap, metadata: &CoinMetadata&lt;T&gt;) {
-    <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_register_foreign_token">register_foreign_token</a>&lt;T&gt;(
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    tc: TreasuryCap&lt;T&gt;,
+    uc: UpgradeCap,
+    metadata: &CoinMetadata&lt;T&gt;,
+) {
+    <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>)
         .<a href="treasury.md#0xb_treasury">treasury</a>
         .<a href="bridge.md#0xb_bridge_register_foreign_token">register_foreign_token</a>&lt;T&gt;(tc, uc, metadata)
 }
@@ -775,7 +779,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_send_token">send_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, target_chain: u8, target_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, token: <a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_send_token">send_token</a>&lt;T&gt;(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, target_chain: u8, target_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, token: <a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -785,20 +789,20 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_send_token">send_token</a>&lt;T&gt;(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     target_chain: u8,
     target_address: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     token: Coin&lt;T&gt;,
     ctx: &<b>mut</b> TxContext
 ) {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>assert</b>!(!inner.paused, <a href="bridge.md#0xb_bridge_EBridgeUnavailable">EBridgeUnavailable</a>);
     <b>assert</b>!(<a href="chain_ids.md#0xb_chain_ids_is_valid_route">chain_ids::is_valid_route</a>(inner.chain_id, target_chain), <a href="bridge.md#0xb_bridge_EInvalidBridgeRoute">EInvalidBridgeRoute</a>);
-    <b>let</b> amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(<a href="../sui-framework/coin.md#0x2_coin_balance">coin::balance</a>(&token));
+    <b>let</b> amount = token.<a href="../sui-framework/balance.md#0x2_balance">balance</a>().value();
 
-    <b>let</b> bridge_seq_num = <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(inner, <a href="message_types.md#0xb_message_types_token">message_types::token</a>());
-    <b>let</b> token_id = <a href="treasury.md#0xb_treasury_token_id">treasury::token_id</a>&lt;T&gt;(&inner.<a href="treasury.md#0xb_treasury">treasury</a>);
-    <b>let</b> token_amount = <a href="../sui-framework/balance.md#0x2_balance_value">balance::value</a>(<a href="../sui-framework/coin.md#0x2_coin_balance">coin::balance</a>(&token));
+    <b>let</b> bridge_seq_num = inner.<a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(<a href="message_types.md#0xb_message_types_token">message_types::token</a>());
+    <b>let</b> token_id = inner.<a href="treasury.md#0xb_treasury">treasury</a>.token_id&lt;T&gt;();
+    <b>let</b> token_amount = token.<a href="../sui-framework/balance.md#0x2_balance">balance</a>().value();
 
     // create <a href="bridge.md#0xb_bridge">bridge</a> <a href="message.md#0xb_message">message</a>
     <b>let</b> <a href="message.md#0xb_message">message</a> = <a href="message.md#0xb_message_create_token_bridge_message">message::create_token_bridge_message</a>(
@@ -815,23 +819,28 @@ title: Module `0xb::bridge`
     inner.<a href="treasury.md#0xb_treasury">treasury</a>.burn(token);
 
     // Store pending <a href="bridge.md#0xb_bridge">bridge</a> request
-    inner.token_transfer_records.push_back(<a href="message.md#0xb_message">message</a>.key(), <a href="bridge.md#0xb_bridge_BridgeRecord">BridgeRecord</a> {
-        <a href="message.md#0xb_message">message</a>,
-        verified_signatures: <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>(),
-        claimed: <b>false</b>,
-    });
+    inner.token_transfer_records.push_back(
+        <a href="message.md#0xb_message">message</a>.key(),
+        <a href="bridge.md#0xb_bridge_BridgeRecord">BridgeRecord</a> {
+            <a href="message.md#0xb_message">message</a>,
+            verified_signatures: <a href="../move-stdlib/option.md#0x1_option_none">option::none</a>(),
+            claimed: <b>false</b>,
+        },
+    );
 
     // emit <a href="../sui-framework/event.md#0x2_event">event</a>
-    emit(<a href="bridge.md#0xb_bridge_TokenBridgeEvent">TokenBridgeEvent</a> {
-        message_type: <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
-        seq_num: bridge_seq_num,
-        source_chain: inner.chain_id,
-        sender_address: address::to_bytes(ctx.sender()),
-        target_chain,
-        target_address,
-        token_type: token_id,
-        amount: token_amount,
-    });
+    emit(
+        <a href="bridge.md#0xb_bridge_TokenBridgeEvent">TokenBridgeEvent</a> {
+            message_type: <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
+            seq_num: bridge_seq_num,
+            source_chain: inner.chain_id,
+            sender_address: address::to_bytes(ctx.sender()),
+            target_chain,
+            target_address,
+            token_type: token_id,
+            amount: token_amount,
+        },
+    );
 }
 </code></pre>
 
@@ -845,7 +854,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_approve_token_transfer">approve_token_transfer</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="message.md#0xb_message">message</a>: <a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>, signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_approve_token_transfer">approve_token_transfer</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="message.md#0xb_message">message</a>: <a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>, signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
 </code></pre>
 
 
@@ -855,11 +864,11 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_approve_token_transfer">approve_token_transfer</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     <a href="message.md#0xb_message">message</a>: BridgeMessage,
     signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ) {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>assert</b>!(!inner.paused, <a href="bridge.md#0xb_bridge_EBridgeUnavailable">EBridgeUnavailable</a>);
     // verify signatures
     inner.<a href="committee.md#0xb_committee">committee</a>.verify_signatures(<a href="message.md#0xb_message">message</a>, signatures);
@@ -874,14 +883,15 @@ title: Module `0xb::bridge`
     );
 
     <b>let</b> message_key = <a href="message.md#0xb_message">message</a>.key();
-    // retrieve pending <a href="message.md#0xb_message">message</a> <b>if</b> source chain is Sui, the initial <a href="message.md#0xb_message">message</a> must exist on chain.
+    // retrieve pending <a href="message.md#0xb_message">message</a> <b>if</b> source chain is Sui, the initial <a href="message.md#0xb_message">message</a>
+    // must exist on chain
     <b>if</b> (<a href="message.md#0xb_message">message</a>.source_chain() == inner.chain_id) {
         <b>let</b> record = &<b>mut</b> inner.token_transfer_records[message_key];
 
         <b>assert</b>!(record.<a href="message.md#0xb_message">message</a> == <a href="message.md#0xb_message">message</a>, <a href="bridge.md#0xb_bridge_EMalformedMessageError">EMalformedMessageError</a>);
         <b>assert</b>!(!record.claimed, <a href="bridge.md#0xb_bridge_EInvariantSuiInitializedTokenTransferShouldNotBeClaimed">EInvariantSuiInitializedTokenTransferShouldNotBeClaimed</a>);
 
-        // If record already <b>has</b> verified signatures, it means the <a href="message.md#0xb_message">message</a> <b>has</b> been approved.
+        // If record already <b>has</b> verified signatures, it means the <a href="message.md#0xb_message">message</a> <b>has</b> been approved
         // Then we exit early.
         <b>if</b> (record.verified_signatures.is_some()) {
             emit(<a href="bridge.md#0xb_bridge_TokenTransferAlreadyApproved">TokenTransferAlreadyApproved</a> { message_key });
@@ -890,18 +900,22 @@ title: Module `0xb::bridge`
         // Store approval
         record.verified_signatures = <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(signatures)
     } <b>else</b> {
-        // At this point, <b>if</b> this <a href="message.md#0xb_message">message</a> is in token_transfer_records, we know it's already approved
-        // because we only add a <a href="message.md#0xb_message">message</a> <b>to</b> token_transfer_records after verifying the signatures.
+        // At this point, <b>if</b> this <a href="message.md#0xb_message">message</a> is in token_transfer_records, we know
+        // it's already approved because we only add a <a href="message.md#0xb_message">message</a> <b>to</b> token_transfer_records
+        // after verifying the signatures
         <b>if</b> (inner.token_transfer_records.contains(message_key)) {
             emit(<a href="bridge.md#0xb_bridge_TokenTransferAlreadyApproved">TokenTransferAlreadyApproved</a> { message_key });
             <b>return</b>
         };
         // Store <a href="message.md#0xb_message">message</a> and approval
-        inner.token_transfer_records.push_back(message_key, <a href="bridge.md#0xb_bridge_BridgeRecord">BridgeRecord</a> {
-            <a href="message.md#0xb_message">message</a>,
-            verified_signatures: <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(signatures),
-            claimed: <b>false</b>
-        });
+        inner.token_transfer_records.push_back(
+            message_key,
+            <a href="bridge.md#0xb_bridge_BridgeRecord">BridgeRecord</a> {
+                <a href="message.md#0xb_message">message</a>,
+                verified_signatures: <a href="../move-stdlib/option.md#0x1_option_some">option::some</a>(signatures),
+                claimed: <b>false</b>
+            },
+        );
     };
 
     emit(<a href="bridge.md#0xb_bridge_TokenTransferApproved">TokenTransferApproved</a> { message_key });
@@ -918,7 +932,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_token">claim_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_token">claim_token</a>&lt;T&gt;(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
 </code></pre>
 
 
@@ -927,8 +941,20 @@ title: Module `0xb::bridge`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_token">claim_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> TxContext): Coin&lt;T&gt; {
-    <b>let</b> (maybe_token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>, self, source_chain, bridge_seq_num, ctx);
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_token">claim_token</a>&lt;T&gt;(
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock,
+    source_chain: u8,
+    bridge_seq_num: u64,
+    ctx: &<b>mut</b> TxContext,
+): Coin&lt;T&gt; {
+    <b>let</b> (maybe_token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(
+        <a href="../sui-framework/clock.md#0x2_clock">clock</a>,
+        <a href="bridge.md#0xb_bridge">bridge</a>,
+        source_chain,
+        bridge_seq_num,
+        ctx,
+    );
     // Only token owner can claim the token
     <b>assert</b>!(ctx.sender() == owner, <a href="bridge.md#0xb_bridge_EUnauthorisedClaim">EUnauthorisedClaim</a>);
     <b>assert</b>!(maybe_token.is_some(), <a href="bridge.md#0xb_bridge_ETokenAlreadyClaimed">ETokenAlreadyClaimed</a>);
@@ -946,7 +972,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_and_transfer_token">claim_and_transfer_token</a>&lt;T&gt;(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_and_transfer_token">claim_and_transfer_token</a>&lt;T&gt;(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -956,13 +982,13 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_claim_and_transfer_token">claim_and_transfer_token</a>&lt;T&gt;(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock,
     source_chain: u8,
     bridge_seq_num: u64,
-    ctx: &<b>mut</b> TxContext
+    ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> (token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>, self, source_chain, bridge_seq_num, ctx);
+    <b>let</b> (token, owner) = <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>, <a href="bridge.md#0xb_bridge">bridge</a>, source_chain, bridge_seq_num, ctx);
     <b>if</b> (token.is_none()) {
         token.destroy_none();
         <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
@@ -992,7 +1018,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>): &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>): &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>
 </code></pre>
 
 
@@ -1001,11 +1027,11 @@ title: Module `0xb::bridge`
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>): &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> {
-    <b>let</b> version = self.inner.version();
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>): &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> {
+    <b>let</b> version = <a href="bridge.md#0xb_bridge">bridge</a>.inner.version();
     // TODO: Replace this <b>with</b> a lazy <b>update</b> function when we add a new version of the inner <a href="../sui-framework/object.md#0x2_object">object</a>.
     <b>assert</b>!(version == <a href="bridge.md#0xb_bridge_CURRENT_VERSION">CURRENT_VERSION</a>, <a href="bridge.md#0xb_bridge_EWrongInnerVersion">EWrongInnerVersion</a>);
-    <b>let</b> inner: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> = self.inner.load_value_mut();
+    <b>let</b> inner: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> = <a href="bridge.md#0xb_bridge">bridge</a>.inner.load_value_mut();
     <b>assert</b>!(inner.bridge_version == version, <a href="bridge.md#0xb_bridge_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }
@@ -1021,7 +1047,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(self: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>): &<a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>): &<a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>
 </code></pre>
 
 
@@ -1031,13 +1057,13 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_load_inner">load_inner</a>(
-    self: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
 ): &<a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> {
-    <b>let</b> version = self.inner.version();
+    <b>let</b> version = <a href="bridge.md#0xb_bridge">bridge</a>.inner.version();
 
     // TODO: Replace this <b>with</b> a lazy <b>update</b> function when we add a new version of the inner <a href="../sui-framework/object.md#0x2_object">object</a>.
     <b>assert</b>!(version == <a href="bridge.md#0xb_bridge_CURRENT_VERSION">CURRENT_VERSION</a>, <a href="bridge.md#0xb_bridge_EWrongInnerVersion">EWrongInnerVersion</a>);
-    <b>let</b> inner: &<a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> = self.inner.load_value();
+    <b>let</b> inner: &<a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a> = <a href="bridge.md#0xb_bridge">bridge</a>.inner.load_value();
     <b>assert</b>!(inner.bridge_version == version, <a href="bridge.md#0xb_bridge_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }
@@ -1053,7 +1079,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, <b>address</b>)
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(<a href="../sui-framework/clock.md#0x2_clock">clock</a>: &<a href="../sui-framework/clock.md#0x2_clock_Clock">clock::Clock</a>, <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;&gt;, <b>address</b>)
 </code></pre>
 
 
@@ -1064,12 +1090,12 @@ title: Module `0xb::bridge`
 
 <pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_claim_token_internal">claim_token_internal</a>&lt;T&gt;(
     <a href="../sui-framework/clock.md#0x2_clock">clock</a>: &Clock,
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     source_chain: u8,
     bridge_seq_num: u64,
-    ctx: &<b>mut</b> TxContext
+    ctx: &<b>mut</b> TxContext,
 ): (Option&lt;Coin&lt;T&gt;&gt;, <b>address</b>) {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>assert</b>!(!inner.paused, <a href="bridge.md#0xb_bridge_EBridgeUnavailable">EBridgeUnavailable</a>);
 
     <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(source_chain, <a href="message_types.md#0xb_message_types_token">message_types::token</a>(), bridge_seq_num);
@@ -1078,7 +1104,10 @@ title: Module `0xb::bridge`
     // retrieve approved <a href="bridge.md#0xb_bridge">bridge</a> <a href="message.md#0xb_message">message</a>
     <b>let</b> record = &<b>mut</b> inner.token_transfer_records[key];
     // ensure this is a token <a href="bridge.md#0xb_bridge">bridge</a> <a href="message.md#0xb_message">message</a>
-    <b>assert</b>!(&record.<a href="message.md#0xb_message">message</a>.message_type() == <a href="message_types.md#0xb_message_types_token">message_types::token</a>(), <a href="bridge.md#0xb_bridge_EUnexpectedMessageType">EUnexpectedMessageType</a>);
+    <b>assert</b>!(
+        &record.<a href="message.md#0xb_message">message</a>.message_type() == <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),
+        <a href="bridge.md#0xb_bridge_EUnexpectedMessageType">EUnexpectedMessageType</a>,
+    );
     // Ensure it's signed
     <b>assert</b>!(record.verified_signatures.is_some(), <a href="bridge.md#0xb_bridge_EUnauthorisedClaim">EUnauthorisedClaim</a>);
 
@@ -1093,7 +1122,7 @@ title: Module `0xb::bridge`
     };
 
     <b>let</b> target_chain = token_payload.token_target_chain();
-    // ensure target chain matches self.chain_id
+    // ensure target chain matches <a href="bridge.md#0xb_bridge">bridge</a>.chain_id
     <b>assert</b>!(target_chain == inner.chain_id, <a href="bridge.md#0xb_bridge_EUnexpectedChainID">EUnexpectedChainID</a>);
 
     // TODO: why do we check validity of the route here? what <b>if</b> inconsistency?
@@ -1104,11 +1133,22 @@ title: Module `0xb::bridge`
     // get owner <b>address</b>
     <b>let</b> owner = address::from_bytes(token_payload.token_target_address());
     // check token type
-    <b>assert</b>!(<a href="treasury.md#0xb_treasury_token_id">treasury::token_id</a>&lt;T&gt;(&inner.<a href="treasury.md#0xb_treasury">treasury</a>) == token_payload.token_type(), <a href="bridge.md#0xb_bridge_EUnexpectedTokenType">EUnexpectedTokenType</a>);
+    <b>assert</b>!(
+        <a href="treasury.md#0xb_treasury_token_id">treasury::token_id</a>&lt;T&gt;(&inner.<a href="treasury.md#0xb_treasury">treasury</a>) == token_payload.token_type(),
+        <a href="bridge.md#0xb_bridge_EUnexpectedTokenType">EUnexpectedTokenType</a>,
+    );
 
     <b>let</b> amount = token_payload.token_amount();
     // Make sure <a href="../sui-framework/transfer.md#0x2_transfer">transfer</a> is within limit.
-    <b>if</b> (!inner.<a href="limiter.md#0xb_limiter">limiter</a>.check_and_record_sending_transfer&lt;T&gt;(&inner.<a href="treasury.md#0xb_treasury">treasury</a>, <a href="../sui-framework/clock.md#0x2_clock">clock</a>, route, amount)) {
+    <b>if</b> (!inner
+            .<a href="limiter.md#0xb_limiter">limiter</a>
+            .check_and_record_sending_transfer&lt;T&gt;(
+                &inner.<a href="treasury.md#0xb_treasury">treasury</a>,
+                <a href="../sui-framework/clock.md#0x2_clock">clock</a>,
+                route,
+                amount,
+            )
+    ) {
         <b>return</b> (<a href="../move-stdlib/option.md#0x1_option_none">option::none</a>(), owner)
     };
 
@@ -1133,7 +1173,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_execute_system_message">execute_system_message</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="message.md#0xb_message">message</a>: <a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>, signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_execute_system_message">execute_system_message</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, <a href="message.md#0xb_message">message</a>: <a href="message.md#0xb_message_BridgeMessage">message::BridgeMessage</a>, signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
 </code></pre>
 
 
@@ -1143,7 +1183,7 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_execute_system_message">execute_system_message</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     <a href="message.md#0xb_message">message</a>: BridgeMessage,
     signatures: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ) {
@@ -1151,31 +1191,31 @@ title: Module `0xb::bridge`
 
     // TODO: test version mismatch
     <b>assert</b>!(<a href="message.md#0xb_message">message</a>.message_version() == <a href="bridge.md#0xb_bridge_MESSAGE_VERSION">MESSAGE_VERSION</a>, <a href="bridge.md#0xb_bridge_EUnexpectedMessageVersion">EUnexpectedMessageVersion</a>);
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
 
     <b>assert</b>!(<a href="message.md#0xb_message">message</a>.source_chain() == inner.chain_id, <a href="bridge.md#0xb_bridge_EUnexpectedChainID">EUnexpectedChainID</a>);
 
     // check system ops seq number and increment it
-    <b>let</b> expected_seq_num = <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(inner, message_type);
+    <b>let</b> expected_seq_num = inner.<a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(message_type);
     <b>assert</b>!(<a href="message.md#0xb_message">message</a>.seq_num() == expected_seq_num, <a href="bridge.md#0xb_bridge_EUnexpectedSeqNum">EUnexpectedSeqNum</a>);
 
     inner.<a href="committee.md#0xb_committee">committee</a>.verify_signatures(<a href="message.md#0xb_message">message</a>, signatures);
 
     <b>if</b> (message_type == <a href="message_types.md#0xb_message_types_emergency_op">message_types::emergency_op</a>()) {
         <b>let</b> payload = <a href="message.md#0xb_message">message</a>.extract_emergency_op_payload();
-        <a href="bridge.md#0xb_bridge_execute_emergency_op">execute_emergency_op</a>(inner, payload);
+        inner.<a href="bridge.md#0xb_bridge_execute_emergency_op">execute_emergency_op</a>(payload);
     } <b>else</b> <b>if</b> (message_type == <a href="message_types.md#0xb_message_types_committee_blocklist">message_types::committee_blocklist</a>()) {
         <b>let</b> payload = <a href="message.md#0xb_message">message</a>.extract_blocklist_payload();
         inner.<a href="committee.md#0xb_committee">committee</a>.execute_blocklist(payload);
     } <b>else</b> <b>if</b> (message_type == <a href="message_types.md#0xb_message_types_update_bridge_limit">message_types::update_bridge_limit</a>()) {
         <b>let</b> payload = <a href="message.md#0xb_message">message</a>.extract_update_bridge_limit();
-        <a href="bridge.md#0xb_bridge_execute_update_bridge_limit">execute_update_bridge_limit</a>(inner, payload);
+        inner.<a href="bridge.md#0xb_bridge_execute_update_bridge_limit">execute_update_bridge_limit</a>(payload);
     } <b>else</b> <b>if</b> (message_type == <a href="message_types.md#0xb_message_types_update_asset_price">message_types::update_asset_price</a>()) {
         <b>let</b> payload = <a href="message.md#0xb_message">message</a>.extract_update_asset_price();
-        <a href="bridge.md#0xb_bridge_execute_update_asset_price">execute_update_asset_price</a>(inner, payload);
+        inner.<a href="bridge.md#0xb_bridge_execute_update_asset_price">execute_update_asset_price</a>(payload);
     } <b>else</b> <b>if</b> (message_type == <a href="message_types.md#0xb_message_types_add_tokens_on_sui">message_types::add_tokens_on_sui</a>()) {
-        <b>let</b> payload = <a href="message.md#0xb_message_extract_add_tokens_on_sui">message::extract_add_tokens_on_sui</a>(&<a href="message.md#0xb_message">message</a>);
-        <a href="bridge.md#0xb_bridge_execute_add_tokens_on_sui">execute_add_tokens_on_sui</a>(inner, payload);
+        <b>let</b> payload = <a href="message.md#0xb_message">message</a>.extract_add_tokens_on_sui();
+        inner.<a href="bridge.md#0xb_bridge_execute_add_tokens_on_sui">execute_add_tokens_on_sui</a>(payload);
     } <b>else</b> {
         <b>abort</b> <a href="bridge.md#0xb_bridge_EUnexpectedMessageType">EUnexpectedMessageType</a>
     };
@@ -1327,7 +1367,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>, msg_type: u8): u64
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">bridge::BridgeInner</a>, msg_type: u8): u64
 </code></pre>
 
 
@@ -1336,13 +1376,13 @@ title: Module `0xb::bridge`
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a>, msg_type: u8): u64 {
-    <b>if</b> (!self.sequence_nums.contains(&msg_type)) {
-        self.sequence_nums.insert(msg_type, 1);
+<pre><code><b>fun</b> <a href="bridge.md#0xb_bridge_get_current_seq_num_and_increment">get_current_seq_num_and_increment</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_BridgeInner">BridgeInner</a>, msg_type: u8): u64 {
+    <b>if</b> (!<a href="bridge.md#0xb_bridge">bridge</a>.sequence_nums.contains(&msg_type)) {
+        <a href="bridge.md#0xb_bridge">bridge</a>.sequence_nums.insert(msg_type, 1);
         <b>return</b> 0
     };
 
-    <b>let</b> entry = &<b>mut</b> self.sequence_nums[&msg_type];
+    <b>let</b> entry = &<b>mut</b> <a href="bridge.md#0xb_bridge">bridge</a>.sequence_nums[&msg_type];
     <b>let</b> seq_num = *entry;
     *entry = seq_num + 1;
     seq_num
@@ -1359,7 +1399,7 @@ title: Module `0xb::bridge`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
+<pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(<a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">bridge::Bridge</a>, source_chain: u8, bridge_seq_num: u64): u8
 </code></pre>
 
 
@@ -1369,11 +1409,11 @@ title: Module `0xb::bridge`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="bridge.md#0xb_bridge_get_token_transfer_action_status">get_token_transfer_action_status</a>(
-    self: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
+    <a href="bridge.md#0xb_bridge">bridge</a>: &<b>mut</b> <a href="bridge.md#0xb_bridge_Bridge">Bridge</a>,
     source_chain: u8,
     bridge_seq_num: u64,
 ): u8 {
-    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(self);
+    <b>let</b> inner = <a href="bridge.md#0xb_bridge_load_inner_mut">load_inner_mut</a>(<a href="bridge.md#0xb_bridge">bridge</a>);
     <b>let</b> key = <a href="message.md#0xb_message_create_key">message::create_key</a>(
         source_chain,
         <a href="message_types.md#0xb_message_types_token">message_types::token</a>(),

--- a/crates/sui-framework/packages/bridge/sources/bridge.move
+++ b/crates/sui-framework/packages/bridge/sources/bridge.move
@@ -3,9 +3,8 @@
 
 module bridge::bridge {
     use sui::address;
-    use sui::balance;
     use sui::clock::Clock;
-    use sui::coin::{Self, Coin, TreasuryCap, CoinMetadata};
+    use sui::coin::{Coin, TreasuryCap, CoinMetadata};
     use sui::event::emit;
     use sui::linked_table::{Self, LinkedTable};
     use sui::package::UpgradeCap;
@@ -16,18 +15,12 @@ module bridge::bridge {
     use bridge::chain_ids;
     use bridge::committee::{Self, BridgeCommittee};
     use bridge::limiter::{Self, TransferLimiter};
-    use bridge::message::{Self, BridgeMessage, BridgeMessageKey, EmergencyOp, UpdateAssetPrice,
+    use bridge::message::{
+        Self, BridgeMessage, BridgeMessageKey, EmergencyOp, UpdateAssetPrice,
         UpdateBridgeLimit, AddTokenOnSui
     };
     use bridge::message_types;
     use bridge::treasury::{Self, BridgeTreasury};
-
-    #[test_only]
-    use sui::{hex, test_scenario, test_utils::{assert_eq, destroy}};
-    #[test_only]
-    use bridge::treasury::{BTC, ETH};
-    #[test_only]
-    use bridge::message::create_blocklist_message;
 
     const MESSAGE_VERSION: u8 = 1;
 
@@ -39,7 +32,7 @@ module bridge::bridge {
 
     public struct Bridge has key {
         id: UID,
-        inner: Versioned
+        inner: Versioned,
     }
 
     public struct BridgeInner has store {
@@ -67,7 +60,7 @@ module bridge::bridge {
         target_chain: u8,
         target_address: vector<u8>,
         token_type: u8,
-        amount: u64
+        amount: u64,
     }
 
     public struct EmergencyOpEvent has copy, drop {
@@ -77,7 +70,7 @@ module bridge::bridge {
     public struct BridgeRecord has store, drop {
         message: BridgeMessage,
         verified_signatures: Option<vector<vector<u8>>>,
-        claimed: bool
+        claimed: bool,
     }
 
     const EUnexpectedMessageType: u64 = 0;
@@ -134,64 +127,69 @@ module bridge::bridge {
         };
         let bridge = Bridge {
             id,
-            inner: versioned::create(CURRENT_VERSION, bridge_inner, ctx)
+            inner: versioned::create(CURRENT_VERSION, bridge_inner, ctx),
         };
         transfer::share_object(bridge);
     }
 
     #[allow(unused_function)]
     fun init_bridge_committee(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         active_validator_voting_power: VecMap<address, u64>,
         min_stake_participation_percentage: u64,
         ctx: &TxContext
     ) {
         assert!(ctx.sender() == @0x0, ENotSystemAddress);
-        let inner = load_inner_mut(self);
-        if (vec_map::is_empty(committee::committee_members(&inner.committee))) {
-            committee::try_create_next_committee(
-                &mut inner.committee,
+        let inner = load_inner_mut(bridge);
+        if (inner.committee.committee_members().is_empty()) {
+            inner.committee.try_create_next_committee(
                 active_validator_voting_power,
                 min_stake_participation_percentage,
-                ctx
+                ctx,
             )
         }
     }
 
     public fun committee_registration(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         system_state: &mut SuiSystemState,
         bridge_pubkey_bytes: vector<u8>,
         http_rest_url: vector<u8>,
         ctx: &TxContext
     ) {
-        load_inner_mut(self)
+        load_inner_mut(bridge)
             .committee
             .register(system_state, bridge_pubkey_bytes, http_rest_url, ctx);
     }
 
-    public fun register_foreign_token<T>(self: &mut Bridge, tc: TreasuryCap<T>, uc: UpgradeCap, metadata: &CoinMetadata<T>) {
-        load_inner_mut(self)
+    public fun register_foreign_token<T>(
+        bridge: &mut Bridge, 
+        tc: TreasuryCap<T>, 
+        uc: UpgradeCap, 
+        metadata: &CoinMetadata<T>,
+    ) {
+        load_inner_mut(bridge)
             .treasury
             .register_foreign_token<T>(tc, uc, metadata)
     }
 
-    // Create bridge request to send token to other chain, the request will be in pending state until approved
+    // Create bridge request to send token to other chain, the request will be in 
+    // pending state until approved
     public fun send_token<T>(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         target_chain: u8,
         target_address: vector<u8>,
         token: Coin<T>,
         ctx: &mut TxContext
     ) {
-        let inner = load_inner_mut(self);
+        let inner = load_inner_mut(bridge);
         assert!(!inner.paused, EBridgeUnavailable);
         assert!(chain_ids::is_valid_route(inner.chain_id, target_chain), EInvalidBridgeRoute);
-        let amount = balance::value(coin::balance(&token));
+        let amount = token.balance().value();
 
-        let bridge_seq_num = get_current_seq_num_and_increment(inner, message_types::token());
-        let token_id = treasury::token_id<T>(&inner.treasury);
-        let token_amount = balance::value(coin::balance(&token));
+        let bridge_seq_num = inner.get_current_seq_num_and_increment(message_types::token());
+        let token_id = inner.treasury.token_id<T>();
+        let token_amount = token.balance().value();
 
         // create bridge message
         let message = message::create_token_bridge_message(
@@ -208,33 +206,38 @@ module bridge::bridge {
         inner.treasury.burn(token);
 
         // Store pending bridge request
-        inner.token_transfer_records.push_back(message.key(), BridgeRecord {
-            message,
-            verified_signatures: option::none(),
-            claimed: false,
-        });
+        inner.token_transfer_records.push_back(
+            message.key(), 
+            BridgeRecord {
+                message,
+                verified_signatures: option::none(),
+                claimed: false,
+            },
+        );
 
         // emit event
-        emit(TokenBridgeEvent {
-            message_type: message_types::token(),
-            seq_num: bridge_seq_num,
-            source_chain: inner.chain_id,
-            sender_address: address::to_bytes(ctx.sender()),
-            target_chain,
-            target_address,
-            token_type: token_id,
-            amount: token_amount,
-        });
+        emit(
+            TokenBridgeEvent {
+                message_type: message_types::token(),
+                seq_num: bridge_seq_num,
+                source_chain: inner.chain_id,
+                sender_address: address::to_bytes(ctx.sender()),
+                target_chain,
+                target_address,
+                token_type: token_id,
+                amount: token_amount,
+            },
+        );
     }
 
     // Record bridge message approvals in Sui, called by the bridge client
     // If already approved, return early instead of aborting.
     public fun approve_token_transfer(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         message: BridgeMessage,
         signatures: vector<vector<u8>>,
     ) {
-        let inner = load_inner_mut(self);
+        let inner = load_inner_mut(bridge);
         assert!(!inner.paused, EBridgeUnavailable);
         // verify signatures
         inner.committee.verify_signatures(message, signatures);
@@ -249,14 +252,15 @@ module bridge::bridge {
         );
 
         let message_key = message.key();
-        // retrieve pending message if source chain is Sui, the initial message must exist on chain.
+        // retrieve pending message if source chain is Sui, the initial message 
+        // must exist on chain
         if (message.source_chain() == inner.chain_id) {
             let record = &mut inner.token_transfer_records[message_key];
 
             assert!(record.message == message, EMalformedMessageError);
             assert!(!record.claimed, EInvariantSuiInitializedTokenTransferShouldNotBeClaimed);
 
-            // If record already has verified signatures, it means the message has been approved.
+            // If record already has verified signatures, it means the message has been approved
             // Then we exit early.
             if (record.verified_signatures.is_some()) {
                 emit(TokenTransferAlreadyApproved { message_key });
@@ -265,18 +269,22 @@ module bridge::bridge {
             // Store approval
             record.verified_signatures = option::some(signatures)
         } else {
-            // At this point, if this message is in token_transfer_records, we know it's already approved
-            // because we only add a message to token_transfer_records after verifying the signatures.
+            // At this point, if this message is in token_transfer_records, we know
+            // it's already approved because we only add a message to token_transfer_records
+            // after verifying the signatures
             if (inner.token_transfer_records.contains(message_key)) {
                 emit(TokenTransferAlreadyApproved { message_key });
                 return
             };
             // Store message and approval
-            inner.token_transfer_records.push_back(message_key, BridgeRecord {
-                message,
-                verified_signatures: option::some(signatures),
-                claimed: false
-            });
+            inner.token_transfer_records.push_back(
+                message_key, 
+                BridgeRecord {
+                    message,
+                    verified_signatures: option::some(signatures),
+                    claimed: false
+                },
+            );
         };
 
         emit(TokenTransferApproved { message_key });
@@ -284,8 +292,20 @@ module bridge::bridge {
 
     // This function can only be called by the token recipient
     // Abort if the token has already been claimed.
-    public fun claim_token<T>(self: &mut Bridge, clock: &Clock, source_chain: u8, bridge_seq_num: u64, ctx: &mut TxContext): Coin<T> {
-        let (maybe_token, owner) = claim_token_internal<T>(clock, self, source_chain, bridge_seq_num, ctx);
+    public fun claim_token<T>(
+        bridge: &mut Bridge, 
+        clock: &Clock, 
+        source_chain: u8, 
+        bridge_seq_num: u64, 
+        ctx: &mut TxContext,
+    ): Coin<T> {
+        let (maybe_token, owner) = claim_token_internal<T>(
+            clock,
+            bridge, 
+            source_chain, 
+            bridge_seq_num, 
+            ctx,
+        );
         // Only token owner can claim the token
         assert!(ctx.sender() == owner, EUnauthorisedClaim);
         assert!(maybe_token.is_some(), ETokenAlreadyClaimed);
@@ -295,13 +315,13 @@ module bridge::bridge {
     // This function can be called by anyone to claim and transfer the token to the recipient
     // If the token has already been claimed, it will return instead of aborting.
     public fun claim_and_transfer_token<T>(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         clock: &Clock,
         source_chain: u8,
         bridge_seq_num: u64,
-        ctx: &mut TxContext
+        ctx: &mut TxContext,
     ) {
-        let (token, owner) = claim_token_internal<T>(clock, self, source_chain, bridge_seq_num, ctx);
+        let (token, owner) = claim_token_internal<T>(clock, bridge, source_chain, bridge_seq_num, ctx);
         if (token.is_none()) {
             token.destroy_none();
             let key = message::create_key(
@@ -320,24 +340,24 @@ module bridge::bridge {
         )
     }
 
-    fun load_inner_mut(self: &mut Bridge): &mut BridgeInner {
-        let version = self.inner.version();
+    fun load_inner_mut(bridge: &mut Bridge): &mut BridgeInner {
+        let version = bridge.inner.version();
         // TODO: Replace this with a lazy update function when we add a new version of the inner object.
         assert!(version == CURRENT_VERSION, EWrongInnerVersion);
-        let inner: &mut BridgeInner = self.inner.load_value_mut();
+        let inner: &mut BridgeInner = bridge.inner.load_value_mut();
         assert!(inner.bridge_version == version, EWrongInnerVersion);
         inner
     }
 
     #[allow(unused_function)] // TODO: remove annotation after implementing user-facing API
     fun load_inner(
-        self: &Bridge,
+        bridge: &Bridge,
     ): &BridgeInner {
-        let version = self.inner.version();
+        let version = bridge.inner.version();
 
         // TODO: Replace this with a lazy update function when we add a new version of the inner object.
         assert!(version == CURRENT_VERSION, EWrongInnerVersion);
-        let inner: &BridgeInner = self.inner.load_value();
+        let inner: &BridgeInner = bridge.inner.load_value();
         assert!(inner.bridge_version == version, EWrongInnerVersion);
         inner
     }
@@ -346,12 +366,12 @@ module bridge::bridge {
     // Returns Some(Coin) if coin can be claimed. If already claimed, return None
     fun claim_token_internal<T>(
         clock: &Clock,
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
-        ctx: &mut TxContext
+        ctx: &mut TxContext,
     ): (Option<Coin<T>>, address) {
-        let inner = load_inner_mut(self);
+        let inner = load_inner_mut(bridge);
         assert!(!inner.paused, EBridgeUnavailable);
 
         let key = message::create_key(source_chain, message_types::token(), bridge_seq_num);
@@ -360,7 +380,10 @@ module bridge::bridge {
         // retrieve approved bridge message
         let record = &mut inner.token_transfer_records[key];
         // ensure this is a token bridge message
-        assert!(&record.message.message_type() == message_types::token(), EUnexpectedMessageType);
+        assert!(
+            &record.message.message_type() == message_types::token(), 
+            EUnexpectedMessageType,
+        );
         // Ensure it's signed
         assert!(record.verified_signatures.is_some(), EUnauthorisedClaim);
 
@@ -375,7 +398,7 @@ module bridge::bridge {
         };
 
         let target_chain = token_payload.token_target_chain();
-        // ensure target chain matches self.chain_id
+        // ensure target chain matches bridge.chain_id
         assert!(target_chain == inner.chain_id, EUnexpectedChainID);
 
         // TODO: why do we check validity of the route here? what if inconsistency?
@@ -386,11 +409,22 @@ module bridge::bridge {
         // get owner address
         let owner = address::from_bytes(token_payload.token_target_address());
         // check token type
-        assert!(treasury::token_id<T>(&inner.treasury) == token_payload.token_type(), EUnexpectedTokenType);
+        assert!(
+            treasury::token_id<T>(&inner.treasury) == token_payload.token_type(), 
+            EUnexpectedTokenType,
+        );
 
         let amount = token_payload.token_amount();
         // Make sure transfer is within limit.
-        if (!inner.limiter.check_and_record_sending_transfer<T>(&inner.treasury, clock, route, amount)) {
+        if (!inner
+                .limiter
+                .check_and_record_sending_transfer<T>(
+                    &inner.treasury, 
+                    clock, 
+                    route, 
+                    amount,
+                )
+        ) {
             return (option::none(), owner)
         };
 
@@ -405,7 +439,7 @@ module bridge::bridge {
     }
 
     public fun execute_system_message(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         message: BridgeMessage,
         signatures: vector<vector<u8>>,
     ) {
@@ -413,31 +447,31 @@ module bridge::bridge {
 
         // TODO: test version mismatch
         assert!(message.message_version() == MESSAGE_VERSION, EUnexpectedMessageVersion);
-        let inner = load_inner_mut(self);
+        let inner = load_inner_mut(bridge);
 
         assert!(message.source_chain() == inner.chain_id, EUnexpectedChainID);
 
         // check system ops seq number and increment it
-        let expected_seq_num = get_current_seq_num_and_increment(inner, message_type);
+        let expected_seq_num = inner.get_current_seq_num_and_increment(message_type);
         assert!(message.seq_num() == expected_seq_num, EUnexpectedSeqNum);
 
         inner.committee.verify_signatures(message, signatures);
 
         if (message_type == message_types::emergency_op()) {
             let payload = message.extract_emergency_op_payload();
-            execute_emergency_op(inner, payload);
+            inner.execute_emergency_op(payload);
         } else if (message_type == message_types::committee_blocklist()) {
             let payload = message.extract_blocklist_payload();
             inner.committee.execute_blocklist(payload);
         } else if (message_type == message_types::update_bridge_limit()) {
             let payload = message.extract_update_bridge_limit();
-            execute_update_bridge_limit(inner, payload);
+            inner.execute_update_bridge_limit(payload);
         } else if (message_type == message_types::update_asset_price()) {
             let payload = message.extract_update_asset_price();
-            execute_update_asset_price(inner, payload);
+            inner.execute_update_asset_price(payload);
         } else if (message_type == message_types::add_tokens_on_sui()) {
-            let payload = message::extract_add_tokens_on_sui(&message);
-            execute_add_tokens_on_sui(inner, payload);
+            let payload = message.extract_add_tokens_on_sui();
+            inner.execute_add_tokens_on_sui(payload);
         } else {
             abort EUnexpectedMessageType
         };
@@ -500,24 +534,24 @@ module bridge::bridge {
 
     // Verify seq number matches the next expected seq number for the message type,
     // and increment it.
-    fun get_current_seq_num_and_increment(self: &mut BridgeInner, msg_type: u8): u64 {
-        if (!self.sequence_nums.contains(&msg_type)) {
-            self.sequence_nums.insert(msg_type, 1);
+    fun get_current_seq_num_and_increment(bridge: &mut BridgeInner, msg_type: u8): u64 {
+        if (!bridge.sequence_nums.contains(&msg_type)) {
+            bridge.sequence_nums.insert(msg_type, 1);
             return 0
         };
 
-        let entry = &mut self.sequence_nums[&msg_type];
+        let entry = &mut bridge.sequence_nums[&msg_type];
         let seq_num = *entry;
         *entry = seq_num + 1;
         seq_num
     }
 
     public fun get_token_transfer_action_status(
-        self: &mut Bridge,
+        bridge: &mut Bridge,
         source_chain: u8,
         bridge_seq_num: u64,
     ): u8 {
-        let inner = load_inner_mut(self);
+        let inner = load_inner_mut(bridge);
         let key = message::create_key(
             source_chain,
             message_types::token(),
@@ -561,367 +595,175 @@ module bridge::bridge {
         record.verified_signatures
     }
 
+    //
+    // Test only helper functions
+    //
+
     #[test_only]
-    fun new_for_testing(ctx: &mut TxContext, chain_id: u8): Bridge {
+    public fun create_bridge_for_testing(id: UID, chain_id: u8, ctx: &mut TxContext) {
+        create(id, chain_id, ctx);
+    }
+
+    #[test_only]
+    public fun new_for_testing(chain_id: u8, ctx: &mut TxContext): Bridge {
+        let id = object::new(ctx);
         let bridge_inner = BridgeInner {
             bridge_version: CURRENT_VERSION,
             message_version: MESSAGE_VERSION,
             chain_id,
-            sequence_nums: vec_map::empty<u8, u64>(),
+            sequence_nums: vec_map::empty(),
             committee: committee::create(ctx),
-            treasury: treasury::mock_for_test(ctx),
-            token_transfer_records: linked_table::new<BridgeMessageKey, BridgeRecord>(ctx),
+            treasury: treasury::create(ctx),
+            token_transfer_records: linked_table::new(ctx),
             limiter: limiter::new(),
             paused: false,
         };
-        Bridge {
-            id: object::new(ctx),
-            inner: versioned::create(CURRENT_VERSION, bridge_inner, ctx)
+        let mut bridge = Bridge {
+            id,
+            inner: versioned::create(CURRENT_VERSION, bridge_inner, ctx),
+        };
+        bridge.setup_treasury_for_testing();
+        bridge
+    }
+
+    #[test_only]
+    public fun setup_treasury_for_testing(bridge: &mut Bridge) {
+        bridge.load_inner_mut().treasury.setup_for_testing();
+    }
+
+    #[test_only]
+    public fun test_init_bridge_committee(
+        bridge: &mut Bridge,
+        active_validator_voting_power: VecMap<address, u64>,
+        min_stake_participation_percentage: u64,
+        ctx: &TxContext
+    ) {
+        init_bridge_committee(
+            bridge,
+            active_validator_voting_power,
+            min_stake_participation_percentage,
+            ctx,
+        );
+    }
+
+    #[test_only]
+    public fun new_bridge_record_for_testing(
+        message: BridgeMessage,
+        verified_signatures: Option<vector<vector<u8>>>,
+        claimed: bool,
+    ): BridgeRecord {
+        BridgeRecord {
+            message,
+            verified_signatures,
+            claimed
         }
     }
 
-    #[test]
-    #[expected_failure(abort_code = EUnexpectedChainID)]
-    fun test_system_msg_incorrect_chain_id() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = scenario.ctx();
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let blocklist = create_blocklist_message(chain_ids::sui_mainnet(), 0, 0, vector[]);
-        execute_system_message(&mut bridge, blocklist, vector[]);
-        destroy(bridge);
-        scenario.end();
-    }
-
-    #[test]
-    fun test_get_current_seq_num_and_increment() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-
-        let inner = load_inner_mut(&mut bridge);
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::committee_blocklist()), 0);
-        assert_eq(*vec_map::get(&inner.sequence_nums, &message_types::committee_blocklist()), 1);
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::committee_blocklist()), 1);
-
-        // other message type nonce does not change
-        assert!(!vec_map::contains(&inner.sequence_nums, &message_types::token()), 99);
-        assert!(!vec_map::contains(&inner.sequence_nums, &message_types::emergency_op()), 99);
-        assert!(!vec_map::contains(&inner.sequence_nums, &message_types::update_bridge_limit()), 99);
-        assert!(!vec_map::contains(&inner.sequence_nums, &message_types::update_asset_price()), 99);
-
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::token()), 0);
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::emergency_op()), 0);
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::update_bridge_limit()), 0);
-        assert_eq(get_current_seq_num_and_increment(inner, message_types::update_asset_price()), 0);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
-    }
-
-    #[test]
-    fun test_execute_update_bridge_limit() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_mainnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let inner = load_inner_mut(&mut bridge);
-
-        // Assert the starting limit is a different value
-        assert!(limiter::get_route_limit(&inner.limiter, &chain_ids::get_route(chain_ids::eth_mainnet(), chain_ids::sui_mainnet())) != 1, 0);
-        // now shrink to 1 for SUI mainnet -> ETH mainnet
-        let msg = message::create_update_bridge_limit_message(
-            chain_ids::sui_mainnet(), // receiving_chain
-            0,
-            chain_ids::eth_mainnet(), // sending_chain
-            1,
-        );
-        let payload = message::extract_update_bridge_limit(&msg);
-        execute_update_bridge_limit(inner, payload);
-
-        // should be 1 now
-        assert_eq(limiter::get_route_limit(&inner.limiter, &chain_ids::get_route(chain_ids::eth_mainnet(), chain_ids::sui_mainnet())), 1);
-        // other routes are not impacted
-        assert!(limiter::get_route_limit(&inner.limiter, &chain_ids::get_route(chain_ids::eth_sepolia(), chain_ids::sui_testnet())) != 1, 0);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = EUnexpectedChainID)]
-    fun test_execute_update_bridge_limit_abort_with_unexpected_chain_id() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let inner = load_inner_mut(&mut bridge);
-
-        // shrink to 1 for SUI mainnet -> ETH mainnet
-        let msg = message::create_update_bridge_limit_message(
-            chain_ids::sui_mainnet(), // receiving_chain
-            0,
-            chain_ids::eth_mainnet(), // sending_chain
-            1,
-        );
-        let payload = message::extract_update_bridge_limit(&msg);
-        // This abort because the receiving_chain (sui_mainnet) is not the same as the bridge's chain_id (sui_devnet)
-        execute_update_bridge_limit(inner, payload);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
-    }
-
-
-    #[test]
-    fun test_execute_update_asset_price() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let inner = bridge.load_inner_mut();
-
-        // Assert the starting limit is a different value
-        assert!(inner.treasury.notional_value<BTC>() != 1_001_000_000, 0);
-        // now change it to 100_001_000
-        let msg = message::create_update_asset_price_message(
-            inner.treasury.token_id<BTC>(),
-            chain_ids::sui_mainnet(),
-            0,
-            1_001_000_000,
-        );
-        let payload = message::extract_update_asset_price(&msg);
-        execute_update_asset_price(inner, payload);
-
-        // should be 1_001_000_000 now
-        assert_eq(inner.treasury.notional_value<BTC>(), 1_001_000_000);
-        // other assets are not impacted
-        assert!(inner.treasury.notional_value<ETH>() != 1_001_000_000, 0);
-
-        destroy(bridge);
-        scenario.end();
+    #[test_only]
+    public fun test_load_inner_mut(bridge: &mut Bridge): &mut BridgeInner {
+        bridge.load_inner_mut()
     }
 
     #[test_only]
-    fun freeze_bridge(bridge: &mut Bridge) {
-        let inner = load_inner_mut(bridge);
-        // freeze it
-        let msg = message::create_emergency_op_message(
-            chain_ids::sui_testnet(),
-            0, // seq num
-            0, // freeze op
-        );
-        let payload = message::extract_emergency_op_payload(&msg);
-        execute_emergency_op(inner, payload);
-        assert!(inner.paused, 0);
+    public fun test_load_inner(bridge: &Bridge): &BridgeInner {
+        bridge.load_inner()
     }
 
     #[test_only]
-    fun unfreeze_bridge(bridge: &mut Bridge) {
-        let inner = load_inner_mut(bridge);
-        // unfreeze it
-        let msg = message::create_emergency_op_message(
-            chain_ids::sui_testnet(),
-            1, // seq num, this is supposed to be the next seq num but it's not what we test here
-            1, // unfreeze op
-        );
-        let payload = message::extract_emergency_op_payload(&msg);
-        execute_emergency_op(inner, payload);
-        assert!(!inner.paused, 0);
+    public fun test_get_token_transfer_action_signatures(
+        bridge: &mut Bridge,
+        source_chain: u8,
+        bridge_seq_num: u64,
+    ): Option<vector<vector<u8>>> {
+        bridge.get_token_transfer_action_signatures(source_chain, bridge_seq_num)
     }
 
-    #[test]
-    fun test_execute_emergency_op() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-
-        assert!(!load_inner_mut(&mut bridge).paused, 0);
-        freeze_bridge(&mut bridge);
-
-        assert!(load_inner_mut(&mut bridge).paused, 0);
-        unfreeze_bridge(&mut bridge);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun inner_limiter(bridge_inner: &BridgeInner): &TransferLimiter {
+        &bridge_inner.limiter
     }
 
-    #[test]
-    #[expected_failure(abort_code = EBridgeNotPaused)]
-    fun test_execute_emergency_op_abort_when_not_frozen() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-
-        assert!(!load_inner_mut(&mut bridge).paused, 0);
-        // unfreeze it, should abort
-        unfreeze_bridge(&mut bridge);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun inner_treasury(bridge_inner: &BridgeInner): &BridgeTreasury {
+        &bridge_inner.treasury
     }
 
-    #[test]
-    #[expected_failure(abort_code = EBridgeUnavailable)]
-    fun test_execute_send_token_frozen() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-
-        assert!(!load_inner_mut(&mut bridge).paused, 0);
-        freeze_bridge(&mut bridge);
-
-        let eth_address = b"01234"; // it does not really matter
-        let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
-        send_token(
-            &mut bridge,
-            chain_ids::eth_sepolia(), 
-            eth_address,
-            btc,
-            ctx,
-        );
-
-        destroy(bridge);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun inner_paused(bridge_inner: &BridgeInner): bool {
+        bridge_inner.paused
     }
 
-    #[test]
-    #[expected_failure(abort_code = EInvalidBridgeRoute)]
-    fun test_execute_send_token_invalid_route() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-
-        let eth_address = b"01234"; // it does not really matter
-        let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
-        send_token(
-            &mut bridge,
-            chain_ids::eth_mainnet(), 
-            eth_address,
-            btc,
-            ctx,
-        );
-
-        destroy(bridge);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun inner_token_transfer_records(
+        bridge_inner: &mut BridgeInner,
+    ): &mut LinkedTable<BridgeMessageKey, BridgeRecord> {
+        &mut bridge_inner.token_transfer_records
     }
 
-    #[test]
-    #[expected_failure(abort_code = EBridgeAlreadyPaused)]
-    fun test_execute_emergency_op_abort_when_already_frozen() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let inner = load_inner_mut(&mut bridge);
-
-        // initially it's unfrozen
-        assert!(!inner.paused, 0);
-        // freeze it
-        let msg = message::create_emergency_op_message(
-            chain_ids::sui_testnet(),
-            0, // seq num
-            0, // freeze op
-        );
-        let payload = message::extract_emergency_op_payload(&msg);
-        execute_emergency_op(inner, payload);
-
-        // should be frozen now
-        assert!(inner.paused, 0);
-
-        // freeze it again, should abort
-        let msg = message::create_emergency_op_message(
-            chain_ids::sui_testnet(),
-            1, // seq num, this is supposed to be the next seq num but it's not what we test here
-            0, // unfreeze op
-        );
-        let payload = message::extract_emergency_op_payload(&msg);
-        execute_emergency_op(inner, payload);
-
-        destroy(bridge);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun test_execute_emergency_op(
+        bridge_inner: &mut BridgeInner, 
+        payload: EmergencyOp,
+    ) {
+        bridge_inner.execute_emergency_op(payload)
     }
 
+    #[test_only]
+    public fun sequence_nums(bridge_inner: &BridgeInner): &VecMap<u8, u64> {
+        &bridge_inner.sequence_nums
+    }
 
-    // TODO: Add tests for execute_system_message, including message validation and effects check
+    #[test_only]
+    public fun assert_paused(bridge_inner: &BridgeInner, error: u64) {
+        assert!(bridge_inner.paused, error);
+    }
 
-    #[test]
-    fun test_get_token_transfer_action_status() {
-        let mut scenario = test_scenario::begin(@0x0);
-        let ctx = test_scenario::ctx(&mut scenario);
-        let chain_id = chain_ids::sui_testnet();
-        let mut bridge = new_for_testing(ctx, chain_id);
-        let coin = coin::mint_for_testing<ETH>(12345, ctx);
+    #[test_only]
+    public fun assert_not_paused(bridge_inner: &BridgeInner, error: u64) {
+        assert!(!bridge_inner.paused, error);
+    }
 
-        // Test when pending
-        let message = message::create_token_bridge_message(
-            chain_ids::sui_testnet(), // source chain
-            10, // seq_num
-            address::to_bytes(ctx.sender()), // sender address
-            chain_ids::eth_sepolia(), // target_chain
-            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
-            1u8, // token_type
-            balance::value(coin::balance(&coin))
-        );
+    #[test_only]
+    public fun test_get_current_seq_num_and_increment(
+        bridge_inner: &mut BridgeInner, 
+        msg_type: u8,
+    ): u64 {
+        get_current_seq_num_and_increment(bridge_inner, msg_type)
+    }
 
-        let key = message::key(&message);
-        linked_table::push_back(&mut load_inner_mut(&mut bridge).token_transfer_records, key, BridgeRecord {
-            message,
-            verified_signatures: option::none(),
-            claimed: false,
-        });
-        assert_eq(get_token_transfer_action_status(&mut bridge, chain_id, 10), TRANSFER_STATUS_PENDING);
-        assert_eq(get_token_transfer_action_signatures(&mut bridge, chain_id, 10), option::none());
+    #[test_only]
+    public fun test_execute_update_bridge_limit(
+        inner: &mut BridgeInner, 
+        payload: UpdateBridgeLimit,
+    ) {
+        execute_update_bridge_limit(inner, payload)
+    }
 
-        // Test when ready for claim
-        let message = message::create_token_bridge_message(
-            chain_ids::sui_testnet(), // source chain
-            11, // seq_num
-            address::to_bytes(ctx.sender()), // sender address
-            chain_ids::eth_sepolia(), // target_chain
-            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
-            1u8, // token_type
-            balance::value(coin::balance(&coin))
-        );
-        let key = message::key(&message);
-        linked_table::push_back(&mut load_inner_mut(&mut bridge).token_transfer_records, key, BridgeRecord {
-            message,
-            verified_signatures: option::some(vector[]),
-            claimed: false,
-        });
-        assert_eq(get_token_transfer_action_status(&mut bridge, chain_id, 11), TRANSFER_STATUS_APPROVED);
-        assert_eq(get_token_transfer_action_signatures(&mut bridge, chain_id, 11), option::some(vector[]));
+    #[test_only]
+    public fun test_execute_update_asset_price(
+        inner: &mut BridgeInner, 
+        payload: UpdateAssetPrice,
+    ) {
+        execute_update_asset_price(inner, payload)
+    }
 
-        // Test when already claimed
-        let message = message::create_token_bridge_message(
-            chain_ids::sui_testnet(), // source chain
-            12, // seq_num
-            address::to_bytes(ctx.sender()), // sender address
-            chain_ids::eth_sepolia(), // target_chain
-            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
-            1u8, // token_type
-            balance::value(coin::balance(&coin))
-        );
-        let key = message::key(&message);
-        linked_table::push_back(&mut load_inner_mut(&mut bridge).token_transfer_records, key, BridgeRecord {
-            message,
-            verified_signatures: option::some(vector[b"1234"]),
-            claimed: true,
-        });
-        assert_eq(get_token_transfer_action_status(&mut bridge, chain_id, 12), TRANSFER_STATUS_CLAIMED);
-        assert_eq(get_token_transfer_action_signatures(&mut bridge, chain_id, 12), option::some(vector[b"1234"]));
+    #[test_only]
+    public fun transfer_status_pending(): u8 {
+        TRANSFER_STATUS_PENDING
+    }
 
-        // Test when message not found
-        assert_eq(get_token_transfer_action_status(&mut bridge, chain_id, 13), TRANSFER_STATUS_NOT_FOUND);
-        assert_eq(get_token_transfer_action_signatures(&mut bridge, chain_id, 13), option::none());
+    #[test_only]
+    public fun transfer_status_approved(): u8 {
+        TRANSFER_STATUS_APPROVED
+    }
 
-        destroy(bridge);
-        coin::burn_for_testing(coin);
-        test_scenario::end(scenario);
+    #[test_only]
+    public fun transfer_status_claimed(): u8 {
+        TRANSFER_STATUS_CLAIMED
+    }
+
+    #[test_only]
+    public fun transfer_status_not_found(): u8 {
+        TRANSFER_STATUS_NOT_FOUND
     }
 }

--- a/crates/sui-framework/packages/bridge/sources/committee.move
+++ b/crates/sui-framework/packages/bridge/sources/committee.move
@@ -3,12 +3,8 @@
 
 #[allow(unused_use)]
 module bridge::committee {
-    use std::option;
-    use std::vector;
-
     use sui::ecdsa_k1;
     use sui::event::emit;
-    use sui::tx_context::{Self, TxContext};
     use sui::vec_map::{Self, VecMap};
     use sui::vec_set;
     use sui_system::sui_system;

--- a/crates/sui-framework/packages/bridge/sources/treasury.move
+++ b/crates/sui-framework/packages/bridge/sources/treasury.move
@@ -14,7 +14,6 @@ module bridge::treasury {
     use sui::event::emit;
     use sui::hex;
     use sui::math;
-    use sui::object;
     use sui::object_bag::{Self, ObjectBag};
     use sui::package;
     use sui::package::UpgradeCap;
@@ -189,9 +188,19 @@ module bridge::treasury {
     public struct USDC {}
 
     #[test_only]
-    public fun mock_for_test(ctx: &mut TxContext): BridgeTreasury {
-        let mut treasury = create(ctx);
+    public fun new_for_testing(ctx: &mut TxContext): BridgeTreasury {
+        create(ctx)
+    }
 
+    #[test_only]
+    public fun mock_for_test(ctx: &mut TxContext): BridgeTreasury {
+        let mut treasury = new_for_testing(ctx);
+        treasury.setup_for_testing();
+        treasury
+    }
+
+    #[test_only]
+    public fun setup_for_testing(treasury: &mut BridgeTreasury) {
         treasury.supported_tokens.insert(type_name::get<BTC>(), BridgeTokenMetadata{
             id: 1,
             decimal_multiplier: 100_000_000,
@@ -221,6 +230,5 @@ module bridge::treasury {
         treasury.id_token_type_map.insert(2, type_name::get<ETH>());
         treasury.id_token_type_map.insert(3, type_name::get<USDC>());
         treasury.id_token_type_map.insert(4, type_name::get<USDT>());
-        treasury
     }
 }

--- a/crates/sui-framework/packages/bridge/tests/bridge_tests.move
+++ b/crates/sui-framework/packages/bridge/tests/bridge_tests.move
@@ -1,0 +1,713 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::bridge_tests {
+    use bridge::bridge::{
+        assert_not_paused, assert_paused, create_bridge_for_testing, execute_system_message,
+        get_token_transfer_action_status, inner_limiter, inner_paused, 
+        inner_treasury, inner_token_transfer_records, new_bridge_record_for_testing, 
+        new_for_testing, send_token, test_execute_emergency_op, test_init_bridge_committee,
+        test_get_current_seq_num_and_increment, test_execute_update_asset_price, 
+        test_execute_update_bridge_limit, test_get_token_transfer_action_signatures,
+        test_load_inner_mut, transfer_status_approved, transfer_status_claimed,
+        transfer_status_not_found, transfer_status_pending, 
+        Bridge,
+    };
+    use bridge::chain_ids; 
+    use bridge::message::{Self, create_blocklist_message};
+    use bridge::message_types;
+    use bridge::treasury::{BTC, ETH};
+
+    use sui::address;
+    use sui::balance;
+    use sui::coin::{Self, Coin};
+    use sui::hex;
+    use sui::test_scenario::{Self, Scenario};
+    use sui::test_utils::destroy;
+
+    use sui_system::{
+        governance_test_utils::{
+            advance_epoch_with_reward_amounts,
+            create_sui_system_state_for_testing,
+            create_validator_for_testing,
+        },
+        sui_system::{
+            validator_voting_powers_for_testing,
+            SuiSystemState,
+        },
+    };
+
+    #[test_only]
+    const VALIDATOR1_PUBKEY: vector<u8> = b"029bef8d556d80e43ae7e0becb3a7e6838b95defe45896ed6075bb9035d06c9964";
+    #[test_only]
+    const VALIDATOR2_PUBKEY: vector<u8> = b"033e99a541db69bd32040dfe5037fbf5210dafa8151a71e21c5204b05d95ce0a62";
+
+    // common error start code for unexpected errors in tests (assertions). 
+    // If more than one assert in a test needs to use an unexpected error code,
+    // use this as the starting error and add 1 to subsequent errors
+    const UNEXPECTED_ERROR: u64 = 10293847; 
+    // use on tests that fail to save cleanup
+    const TEST_DONE: u64 = 74839201; 
+
+    //
+    // Utility functions
+    //
+
+    // Info to set up a validator 
+    public struct ValidatorInfo has copy, drop {
+        validator: address,
+        stake_amount: u64,
+    }
+
+    // Add a validator to the chain
+    fun setup_validators(
+        scenario: &mut Scenario, 
+        validators_info: vector<ValidatorInfo>,
+        sender: address,
+    ) {
+        scenario.next_tx(sender);
+        let ctx = scenario.ctx();
+        let mut validators = vector::empty();
+        let mut count = validators_info.length();
+        while (count > 0) {
+            count = count - 1;
+            validators.push_back(create_validator_for_testing(
+                validators_info[count].validator,
+                validators_info[count].stake_amount,
+                ctx,
+            ));
+        };
+        create_sui_system_state_for_testing(validators, 0, 0, ctx);
+        advance_epoch_with_reward_amounts(0, 0, scenario);
+    }
+
+    // Set up an environment for the bridge with a set of
+    // validators, a bridge with a treasury and a committee.
+    // Save the Bridge as a shared object.
+    fun create_bridge_default(scenario: &mut Scenario) {
+        let sender = @0x0;
+
+        let validators = vector[
+            ValidatorInfo { validator: @0xA, stake_amount: 100 },
+            ValidatorInfo { validator: @0xB, stake_amount: 100 },
+            ValidatorInfo { validator: @0xC, stake_amount: 100 },
+        ];
+        setup_validators(scenario, validators, sender);
+
+        create_bridge(scenario, sender);
+    }
+
+    // Create a bridge and set up a treasury
+    fun create_bridge(scenario: &mut Scenario, sender: address) {
+        scenario.next_tx(sender);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        create_bridge_for_testing(object::new(ctx), chain_id, ctx);
+
+        scenario.next_tx(sender);
+        let mut bridge = scenario.take_shared<Bridge>();
+        bridge.setup_treasury_for_testing();
+
+        test_scenario::return_shared(bridge);
+    }
+
+    // Register two committee members
+    fun register_committee(scenario: &mut Scenario) {
+        scenario.next_tx(@0x0);
+        let mut bridge = scenario.take_shared<Bridge>();
+        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+
+        // register committee member `0xA`
+        scenario.next_tx(@0xA);
+        bridge.committee_registration(
+            &mut system_state,
+            hex::decode(VALIDATOR1_PUBKEY),
+            b"",
+            scenario.ctx(),
+        );
+
+        // register committee member `0xC`
+        scenario.next_tx(@0xC);
+        bridge.committee_registration(
+            &mut system_state,
+            hex::decode(VALIDATOR2_PUBKEY),
+            b"",
+            scenario.ctx(),
+        );
+
+        test_scenario::return_shared(bridge);
+        test_scenario::return_shared(system_state);
+    }
+
+    // Init the bridge committee
+    fun init_committee(scenario: &mut Scenario, sender: address) {
+        // init committee
+        scenario.next_tx(sender);
+        let mut bridge = scenario.take_shared<Bridge>();
+        let mut system_state = test_scenario::take_shared<SuiSystemState>(scenario);
+        let voting_powers = validator_voting_powers_for_testing(&mut system_state);
+        bridge.test_init_bridge_committee(
+            voting_powers,
+            50,
+            scenario.ctx(),
+        );
+        test_scenario::return_shared(bridge);
+        test_scenario::return_shared(system_state);
+    }
+
+    // Freeze the bridge
+    fun freeze_bridge(bridge: &mut Bridge, error: u64) {
+        let inner = bridge.test_load_inner_mut();
+        // freeze it
+        let msg = message::create_emergency_op_message(
+            chain_ids::sui_testnet(),
+            0, // seq num
+            0, // freeze op
+        );
+        let payload = msg.extract_emergency_op_payload();
+        inner.test_execute_emergency_op(payload);
+        inner.assert_paused(error);
+    }
+
+    // unfreeze the bridge
+    fun unfreeze_bridge(bridge: &mut Bridge, error: u64) {
+        let inner = bridge.test_load_inner_mut();
+        // unfreeze it
+        let msg = message::create_emergency_op_message(
+            chain_ids::sui_testnet(),
+            1, // seq num, this is supposed to be the next seq num but it's not what we test here
+            1, // unfreeze op
+        );
+        let payload = msg.extract_emergency_op_payload();
+        inner.test_execute_emergency_op(payload);
+        inner.assert_not_paused(error);
+    }
+
+    #[test]
+    fun test_bridge_create() {
+        let mut scenario = test_scenario::begin(@0x0);
+        create_bridge_default(&mut scenario);
+
+        scenario.next_tx(@0xAAAA);
+        let mut bridge = scenario.take_shared<Bridge>();
+        let inner = bridge.test_load_inner_mut();
+        inner.assert_not_paused(UNEXPECTED_ERROR);
+        assert!(inner.inner_token_transfer_records().length() == 0, UNEXPECTED_ERROR + 1);
+
+        test_scenario::return_shared(bridge);
+        scenario.end();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::ENotSystemAddress)]
+    fun test_bridge_create_non_system_addr() {
+        let mut scenario = test_scenario::begin(@0x1);
+        create_bridge(&mut scenario, @0x1);
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    fun test_init_committee() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        create_bridge_default(&mut scenario);
+        register_committee(&mut scenario);
+        init_committee(&mut scenario, @0x0);
+
+        scenario.end();
+    }
+
+    #[test]
+    fun test_init_committee_twice() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        create_bridge_default(&mut scenario);
+        register_committee(&mut scenario);
+        init_committee(&mut scenario, @0x0);
+        init_committee(&mut scenario, @0x0); // second time is a no-op
+
+        scenario.end();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::ENotSystemAddress)]
+    fun test_init_committee_non_system_addr() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        create_bridge_default(&mut scenario);
+        register_committee(&mut scenario);
+        init_committee(&mut scenario, @0xA);
+
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::committee::ECommitteeAlreadyInitiated)]
+    fun test_register_committee_after_init() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        create_bridge_default(&mut scenario);
+        register_committee(&mut scenario);
+        init_committee(&mut scenario, @0x0);
+        register_committee(&mut scenario);
+
+
+        abort TEST_DONE
+    }
+
+    // #[test]
+    // fun test_register_foreign_token() {
+    //     let mut scenario = test_scenario::begin(@0x0);
+
+    //     create_bridge_default(&mut scenario);
+    //     register_committee(&mut scenario);
+    //     init_committee(&mut scenario, @0x0);
+
+    //     scenario.next_tx(@0xAAAA);
+    //     let mut bridge = scenario.take_shared<Bridge>();
+    //     bridge.register_foreign_token<T>(
+    //         tc: TreasuryCap<T>,
+    //         uc: UpgradeCap,
+    //         metadata: &CoinMetadata<T>,
+    //     );
+
+    //     scenario.end();
+    // }
+
+    // #[test]
+    // fun test_execute_send_token() {
+    //     let mut scenario = test_scenario::begin(@0x0);
+
+    //     create_bridge_default(&mut scenario);
+    //     register_committee(&mut scenario);
+    //     init_committee(&mut scenario, @0x0);
+
+    //     scenario.next_tx(@0xAAAA);
+    //     let mut bridge = scenario.take_shared<Bridge>();
+    //     let eth_address = b"01234"; // it does not really matter
+    //     let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, scenario.ctx());
+    //     bridge.send_token(
+    //         chain_ids::eth_sepolia(),
+    //         eth_address,
+    //         btc,
+    //         scenario.ctx(),
+    //     );
+    //     test_scenario::return_shared(bridge);
+
+    //     scenario.end();
+    // }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EBridgeUnavailable)]
+    fun test_execute_send_token_frozen() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        assert!(!bridge.test_load_inner_mut().inner_paused(), UNEXPECTED_ERROR);
+        freeze_bridge(&mut bridge, UNEXPECTED_ERROR + 1);
+
+        let eth_address = b"01234"; // it does not really matter
+        let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
+        bridge.send_token(
+            chain_ids::eth_sepolia(),
+            eth_address,
+            btc,
+            ctx,
+        );
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EInvalidBridgeRoute)]
+    fun test_execute_send_token_invalid_route() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        let eth_address = b"01234"; // it does not really matter
+        let btc: Coin<BTC> = coin::mint_for_testing<BTC>(1, ctx);
+        bridge.send_token(
+            chain_ids::eth_mainnet(),
+            eth_address,
+            btc,
+            ctx,
+        );
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EUnexpectedChainID)]
+    fun test_system_msg_incorrect_chain_id() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let blocklist = create_blocklist_message(chain_ids::sui_mainnet(), 0, 0, vector[]);
+        bridge.execute_system_message(blocklist, vector[]);
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    fun test_get_seq_num_and_increment() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        let inner = bridge.test_load_inner_mut();
+        assert!(
+            inner.test_get_current_seq_num_and_increment(
+                message_types::committee_blocklist(),
+            ) == 0,
+            UNEXPECTED_ERROR,
+        );
+        assert!(
+            inner.sequence_nums()[&message_types::committee_blocklist()] == 1,
+            UNEXPECTED_ERROR + 1,
+        );
+        assert!(
+            inner.test_get_current_seq_num_and_increment(
+                message_types::committee_blocklist(),
+            ) == 1,
+            UNEXPECTED_ERROR + 2,
+        );
+        // other message type nonce does not change
+        assert!(
+            !inner.sequence_nums().contains(&message_types::token()), 
+            UNEXPECTED_ERROR + 3,
+        );
+        assert!(
+            !inner.sequence_nums().contains(&message_types::emergency_op()), 
+            UNEXPECTED_ERROR + 4,
+        );
+        assert!(
+            !inner.sequence_nums().contains(&message_types::update_bridge_limit()), 
+            UNEXPECTED_ERROR + 5,
+        );
+        assert!(
+            !inner.sequence_nums().contains(&message_types::update_asset_price()), 
+            UNEXPECTED_ERROR + 6,
+        );
+        assert!(
+            inner.test_get_current_seq_num_and_increment(message_types::token()) == 0,
+            UNEXPECTED_ERROR + 7,
+        );
+        assert!(
+            inner.test_get_current_seq_num_and_increment(
+                message_types::emergency_op(),
+            ) == 0,
+            UNEXPECTED_ERROR + 8,
+        );
+        assert!(
+            inner.test_get_current_seq_num_and_increment(
+                message_types::update_bridge_limit(),
+            ) == 0,
+            UNEXPECTED_ERROR + 6,
+        );
+        assert!(
+            inner.test_get_current_seq_num_and_increment(
+                message_types::update_asset_price(),
+            ) == 0,
+            UNEXPECTED_ERROR + 7,
+        );
+
+        destroy(bridge);
+        scenario.end();
+    }
+
+    #[test]
+    fun test_update_limit() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_mainnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let inner = bridge.test_load_inner_mut();
+
+        // Assert the starting limit is a different value
+        assert!(
+            inner.inner_limiter().get_route_limit(
+                &chain_ids::get_route(
+                    chain_ids::eth_mainnet(), 
+                    chain_ids::sui_mainnet(),
+                ),
+            ) != 1, 
+            UNEXPECTED_ERROR,
+        );
+        // now shrink to 1 for SUI mainnet -> ETH mainnet
+        let msg = message::create_update_bridge_limit_message(
+            chain_ids::sui_mainnet(), // receiving_chain
+            0,
+            chain_ids::eth_mainnet(), // sending_chain
+            1,
+        );
+        let payload = msg.extract_update_bridge_limit();
+        inner.test_execute_update_bridge_limit(payload);
+
+        // should be 1 now
+        assert!(
+            inner.inner_limiter().get_route_limit(
+                &chain_ids::get_route(
+                    chain_ids::eth_mainnet(), 
+                    chain_ids::sui_mainnet()
+                ),
+            ) == 1, 
+            UNEXPECTED_ERROR + 1,
+        );
+        // other routes are not impacted
+        assert!(
+            inner.inner_limiter().get_route_limit(
+                &chain_ids::get_route(
+                    chain_ids::eth_sepolia(), 
+                    chain_ids::sui_testnet(),
+                ),
+            ) != 1, 
+            UNEXPECTED_ERROR + 2,
+        );
+
+        destroy(bridge);
+        scenario.end();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EUnexpectedChainID)]
+    fun test_execute_update_bridge_limit_abort_with_unexpected_chain_id() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let inner = bridge.test_load_inner_mut();
+
+        // shrink to 1 for SUI mainnet -> ETH mainnet
+        let msg = message::create_update_bridge_limit_message(
+            chain_ids::sui_mainnet(), // receiving_chain
+            0,
+            chain_ids::eth_mainnet(), // sending_chain
+            1,
+        );
+        let payload = msg.extract_update_bridge_limit();
+        // This abort because the receiving_chain (sui_mainnet) is not the same as
+        // the bridge's chain_id (sui_devnet)
+        inner.test_execute_update_bridge_limit(payload);
+
+        abort TEST_DONE
+    }
+
+
+    #[test]
+    fun test_update_asset_price() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let inner = bridge.test_load_inner_mut();
+
+        // Assert the starting limit is a different value
+        assert!(
+            inner.inner_treasury().notional_value<BTC>() != 1_001_000_000, 
+            UNEXPECTED_ERROR,
+        );
+        // now change it to 100_001_000
+        let msg = message::create_update_asset_price_message(
+            inner.inner_treasury().token_id<BTC>(),
+            chain_ids::sui_mainnet(),
+            0,
+            1_001_000_000,
+        );
+        let payload = msg.extract_update_asset_price();
+        inner.test_execute_update_asset_price(payload);
+
+        // should be 1_001_000_000 now
+        assert!(
+            inner.inner_treasury().notional_value<BTC>() == 1_001_000_000,
+            UNEXPECTED_ERROR + 1,
+        );
+        // other assets are not impacted
+        assert!(
+            inner.inner_treasury().notional_value<ETH>() != 1_001_000_000, 
+            UNEXPECTED_ERROR + 2,
+        );
+
+        destroy(bridge);
+        scenario.end();
+    }
+
+    #[test]
+    fun test_test_execute_emergency_op() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        assert!(!bridge.test_load_inner_mut().inner_paused(), UNEXPECTED_ERROR);
+        freeze_bridge(&mut bridge, UNEXPECTED_ERROR + 1);
+
+        assert!(bridge.test_load_inner_mut().inner_paused(), UNEXPECTED_ERROR + 2);
+        unfreeze_bridge(&mut bridge, UNEXPECTED_ERROR + 3);
+
+        destroy(bridge);
+        scenario.end();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EBridgeNotPaused)]
+    fun test_test_execute_emergency_op_abort_when_not_frozen() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+
+        assert!(!bridge.test_load_inner_mut().inner_paused(), UNEXPECTED_ERROR);
+        // unfreeze it, should abort
+        unfreeze_bridge(&mut bridge, UNEXPECTED_ERROR + 1);
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bridge::bridge::EBridgeAlreadyPaused)]
+    fun test_test_execute_emergency_op_abort_when_already_frozen() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let inner = bridge.test_load_inner_mut();
+
+        // initially it's unfrozen
+        assert!(!inner.inner_paused(), UNEXPECTED_ERROR);
+        // freeze it
+        let msg = message::create_emergency_op_message(
+            chain_ids::sui_testnet(),
+            0, // seq num
+            0, // freeze op
+        );
+        let payload = msg.extract_emergency_op_payload();
+        inner.test_execute_emergency_op(payload);
+
+        // should be frozen now
+        assert!(inner.inner_paused(), UNEXPECTED_ERROR + 1);
+
+        // freeze it again, should abort
+        let msg = message::create_emergency_op_message(
+            chain_ids::sui_testnet(),
+            1, // seq num, should be the next seq num but it's not what we test here
+            0, // unfreeze op
+        );
+        let payload = msg.extract_emergency_op_payload();
+        inner.test_execute_emergency_op(payload);
+
+        abort TEST_DONE
+    }
+
+    #[test]
+    fun test_get_token_transfer_action_status() {
+        let mut scenario = test_scenario::begin(@0x0);
+        let ctx = scenario.ctx();
+        let chain_id = chain_ids::sui_testnet();
+        let mut bridge = new_for_testing(chain_id, ctx);
+        let coin = coin::mint_for_testing<ETH>(12345, ctx);
+
+        // Test when pending
+        let message = message::create_token_bridge_message(
+            chain_ids::sui_testnet(), // source chain
+            10, // seq_num
+            address::to_bytes(ctx.sender()), // sender address
+            chain_ids::eth_sepolia(), // target_chain
+            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
+            1u8, // token_type
+            coin.balance().value(),
+        );
+
+        let key = message.key();
+        bridge.test_load_inner_mut().inner_token_transfer_records().push_back(
+            key, 
+            new_bridge_record_for_testing(message, option::none(), false),
+        );
+        assert!(
+            bridge.get_token_transfer_action_status(chain_id, 10)
+                == transfer_status_pending(),
+            UNEXPECTED_ERROR,
+        );
+        assert!(
+            bridge.test_get_token_transfer_action_signatures(chain_id, 10) == option::none(),
+            UNEXPECTED_ERROR + 1,  
+        );
+
+        // Test when ready for claim
+        let message = message::create_token_bridge_message(
+            chain_ids::sui_testnet(), // source chain
+            11, // seq_num
+            address::to_bytes(ctx.sender()), // sender address
+            chain_ids::eth_sepolia(), // target_chain
+            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
+            1u8, // token_type
+            balance::value(coin::balance(&coin))
+        );
+        let key = message.key();
+        bridge.test_load_inner_mut().inner_token_transfer_records().push_back(
+            key, 
+            new_bridge_record_for_testing(message, option::some(vector[]), false),
+        );
+        assert!(
+            bridge.get_token_transfer_action_status(chain_id, 11)
+                == transfer_status_approved(),
+            UNEXPECTED_ERROR + 2,
+        );
+        assert!(
+            bridge.test_get_token_transfer_action_signatures(chain_id, 11)
+                == option::some(vector[]),
+            UNEXPECTED_ERROR + 3,
+        );
+
+        // Test when already claimed
+        let message = message::create_token_bridge_message(
+            chain_ids::sui_testnet(), // source chain
+            12, // seq_num
+            address::to_bytes(ctx.sender()), // sender address
+            chain_ids::eth_sepolia(), // target_chain
+            hex::decode(b"00000000000000000000000000000000000000c8"), // target_address
+            1u8, // token_type
+            balance::value(coin::balance(&coin))
+        );
+        let key = message.key();
+        bridge.test_load_inner_mut().inner_token_transfer_records().push_back(
+            key, 
+            new_bridge_record_for_testing(message, option::some(vector[b"1234"]), true),
+        );
+        assert!(
+            bridge.get_token_transfer_action_status(chain_id, 12)
+                == transfer_status_claimed(),
+            UNEXPECTED_ERROR + 3,
+        );
+        assert!(
+            bridge.test_get_token_transfer_action_signatures(chain_id, 12) 
+                == option::some(vector[b"1234"]),
+            UNEXPECTED_ERROR + 4,
+        );
+
+        // Test when message not found
+        assert!(
+            bridge.get_token_transfer_action_status(chain_id, 13)
+                == transfer_status_not_found(),
+            UNEXPECTED_ERROR + 5,
+        );
+        assert!(
+            bridge.test_get_token_transfer_action_signatures(chain_id, 13)
+                == option::none(),
+            UNEXPECTED_ERROR + 6,
+        );
+
+        destroy(bridge);
+        coin.burn_for_testing();
+        scenario.end();
+    }
+}
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x184c225960c87ae43eb3c5cd1ea2dbccc69671801109e831d5105f80e757be8d"
+            id: "0x5b79876c8cc186f9afc8f13a284c68b7b6a2b4d68210d8b85c0f83e823d140ce"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x715caba3b07dd53e7fdcd0ab87ee8814ca660975b9bace91fca5bfd57788fa18"
+      operation_cap_id: "0xfccedd4dd551d5f8a94d845a1118fe6cf7fe8233044558fc7fcef2d0b9a4fb34"
       gas_price: 1000
       staking_pool:
-        id: "0x812f345c692cf5904b4dcc7433e33d1f15aa77dcf4b4772967d4f908250574b4"
+        id: "0xcefdcdfa0cae823796538837ca9c2244d024e1840d917cdae530207e60beb668"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x7cf3835ae0b39100af1f22749c30bde0ac317ed38984bb652efa7923ebeea250"
+          id: "0x8af2c507f208b99b500710edb7ed7fa73577bad88e0af9bf4c1aadf675d1eaf9"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x12075bdb093e6ec66333fc87eb311c2585054af41685cbc84a62efdf83aa83db"
+            id: "0xd74e2ef4e6adf0b27b1b8e0bbae3b61d0a9b89455cb05e848f1a1fea1ef47d85"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xbc3cea5e909fa0fd5494e9890b2ca2f64dcabefa5911fc6703bf3a3a2132b488"
+          id: "0xb800a80e64fa7837cdb5eac59ffdd89e1a22cdfdd75cf2af0778a90acdb94f26"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x6ccfdcdbee0e1c052050a4725fc2155069e7f3e1a29b0a56e4cb53ca3d2da219"
+      id: "0xcb485785f60ef6709c7ecc0cbc2a56bb87566bd76b0183925d86c0e0650360fa"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x09e5b16439107d11526d80398807c7b3e82fb9a1358099e84118702836fa5022"
+    id: "0xf25acb8823048a7f19df69f0eae4e8ed8113fd15056f622b0c2bacdf539a5385"
     size: 1
   inactive_validators:
-    id: "0x06fe6cfbc8520beecbb137ffb5fe652636b758f1fbb3270625da15cc96d90a32"
+    id: "0x5bb36cbd13b1348fb27d8c6fe804d09c168baa2ff9ee0d37c8d31ed3e75bfdc9"
     size: 0
   validator_candidates:
-    id: "0xda256fc9a4f0cd633b9759b449669186f91a8a604869aa579b08f565015c33f6"
+    id: "0x7ed4f7d9ed6b209cc2e593c5f6b6583c4246e5d3dac4d97e97de55b5fa4ec8e6"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x4e10b371e3ef364aeb1303d013210ffea142ef7d25646b77e2e65aa3542d1e19"
+      id: "0xa7c1077b6cfa330ed41b027e0429415d239e6d2974c60fc2b1cddf6615f7ace9"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x8a5091f2c333673eb5510d4ec7bc4f33aba73221ff139ded7a901bb198c8e349"
+      id: "0xc37bf09939f72b014bbbe039dc6a8110a0cce02f7e46fe19c034b29f7849290e"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x17cf4ea3a9ca19a7983d34e55ca053586200758c76ae59d78625ddcf86de7668"
+      id: "0x9f28f4bcd7675fb6f2aca7a63cacb40d7ea14269b0f640841c8370a7476fb5be"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x66f2d5d9532ac6b276ba6e169b4ee8a3ddf524a67f20998543141814374d5ae6"
+    id: "0xff7b8ceb675d95a10c09b83b16b83504b7c1ead1cd15fe0248ba5deace662939"
   size: 0
+


### PR DESCRIPTION
## Description 

More Move2024 cleanup and formatting.
Moved tests out of `bridge.move` in its own test directory.
We will transition all tests to that model as we work towards 100% test coverage.

## Test plan 

This is mostly tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
