### PR TITLE
Add pagination to getOwnedKiosks method of kioskClient

### DIFF
--- a/.changeset/bright-ravens-provide.md
+++ b/.changeset/bright-ravens-provide.md
@@ -2,4 +2,4 @@
 '@mysten/kiosk': patch
 ---
 
-Adds pagination option for owned kiosk lookup
+Adds pagination option for owned kiosks lookup

--- a/.changeset/bright-ravens-provide.md
+++ b/.changeset/bright-ravens-provide.md
@@ -1,0 +1,5 @@
+---
+'@mysten/kiosk': patch
+---
+
+Adds pagination option for owned kiosk lookup

--- a/sdk/kiosk/src/client/kiosk-client.ts
+++ b/sdk/kiosk/src/client/kiosk-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiClient } from '@mysten/sui.js/client';
+import type { PaginationArguments, SuiClient } from '@mysten/sui.js/client';
 
 import {
 	FLOOR_PRICE_RULE_ADDRESS,
@@ -54,13 +54,21 @@ export class KioskClient {
 	/**
 	 * Get an addresses's owned kiosks.
 	 * @param address The address for which we want to retrieve the kiosks.
+	 * @param pagination Optional pagination arguments.
 	 * @returns An Object containing all the `kioskOwnerCap` objects as well as the kioskIds.
 	 */
-	async getOwnedKiosks({ address }: { address: string }): Promise<OwnedKiosks> {
+	async getOwnedKiosks({
+		address,
+		pagination,
+	}: {
+		address: string;
+		pagination?: PaginationArguments<string>;
+	}): Promise<OwnedKiosks> {
 		const personalPackageId =
 			this.packageIds?.personalKioskRulePackageId || PERSONAL_KIOSK_RULE_ADDRESS[this.network];
 
 		return getOwnedKiosks(this.client, address, {
+			pagination,
 			personalKioskType: personalPackageId
 				? `${personalPackageId}::personal_kiosk::PersonalKioskCap`
 				: '',


### PR DESCRIPTION
## Description 

Adds pagination to the `getOwnedKiosks` method of the `kioskClient`.
The method `getOwnedKiosks` of the `src/query/kiosk.ts` that is being used by the `kioskClient` under the hood, is already accepting the optional pagination arguments, but the method of the `kioskClient`, does not.
This PR adds the optional pagination arguments to the method of the `kioskClient`, and then passes them to the underlying method.

## Test plan 

This PR adds two tests to the e2e tests of the Kiosk SDK, to test the pagination added on the `getOwnedKiosks` method.
Run `pnpm prepare:e2e` to run the localnet, and then `pnpm test:e2e` to run the tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
