### PR TITLE
fix: revert deepbook l2 update

### DIFF
--- a/crates/sui-framework/docs/deepbook/clob_v2.md
+++ b/crates/sui-framework/docs/deepbook/clob_v2.md
@@ -3829,19 +3829,8 @@ The latter is the corresponding depth list
 
     <b>if</b> (price_low &lt; price_low_) price_low = price_low_;
     <b>if</b> (price_high &gt; price_high_) price_high = price_high_;
-    <b>let</b> closest_low = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.bids, price_low);
-    <b>let</b> closest_high = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.bids, price_high);
-    <b>if</b> (price_low &lt;= closest_low){
-        price_low = closest_low;
-    } <b>else</b> {
-        (price_low, _) = <a href="critbit.md#0xdee9_critbit_next_leaf">critbit::next_leaf</a>(&pool.bids, closest_low);
-    };
-    <b>if</b> (price_high &gt;= closest_high){
-        price_high = closest_high;
-    } <b>else</b> {
-        (price_high, _) = <a href="critbit.md#0xdee9_critbit_previous_leaf">critbit::previous_leaf</a>(&pool.bids, closest_high);
-    };
-
+    price_low = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.bids, price_low);
+    price_high = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.bids, price_high);
     <b>while</b> (price_low &lt;= price_high) {
         <b>let</b> depth = <a href="clob_v2.md#0xdee9_clob_v2_get_level2_book_status">get_level2_book_status</a>(
             &pool.bids,
@@ -3893,7 +3882,6 @@ The latter is the corresponding depth list
     <b>let</b> <b>mut</b> depth_vec = <a href="../move-stdlib/vector.md#0x1_vector_empty">vector::empty</a>&lt;u64&gt;();
     <b>if</b> (<a href="critbit.md#0xdee9_critbit_is_empty">critbit::is_empty</a>(&pool.asks)) { <b>return</b> (price_vec, depth_vec) };
     <b>let</b> (price_low_, _) = <a href="critbit.md#0xdee9_critbit_min_leaf">critbit::min_leaf</a>(&pool.asks);
-    <b>let</b> (price_high_, _) = <a href="critbit.md#0xdee9_critbit_max_leaf">critbit::max_leaf</a>(&pool.asks);
 
     // Price_high is less than the lowest leaf in the tree then we <b>return</b> an empty array
     <b>if</b> (price_high &lt; price_low_) {
@@ -3901,20 +3889,10 @@ The latter is the corresponding depth list
     };
 
     <b>if</b> (price_low &lt; price_low_) price_low = price_low_;
+    <b>let</b> (price_high_, _) = <a href="critbit.md#0xdee9_critbit_max_leaf">critbit::max_leaf</a>(&pool.asks);
     <b>if</b> (price_high &gt; price_high_) price_high = price_high_;
-    <b>let</b> closest_low = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.asks, price_low);
-    <b>let</b> closest_high = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.asks, price_high);
-    <b>if</b> (price_low &lt;= closest_low){
-        price_low = closest_low;
-    } <b>else</b> {
-        (price_low, _) = <a href="critbit.md#0xdee9_critbit_next_leaf">critbit::next_leaf</a>(&pool.bids, closest_low);
-    };
-    <b>if</b> (price_high &gt;= closest_high){
-        price_high = closest_high;
-    } <b>else</b> {
-        (price_high, _) = <a href="critbit.md#0xdee9_critbit_previous_leaf">critbit::previous_leaf</a>(&pool.bids, closest_high);
-    };
-
+    price_low = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.asks, price_low);
+    price_high = <a href="critbit.md#0xdee9_critbit_find_closest_key">critbit::find_closest_key</a>(&pool.asks, price_high);
     <b>while</b> (price_low &lt;= price_high) {
         <b>let</b> depth = <a href="clob_v2.md#0xdee9_clob_v2_get_level2_book_status">get_level2_book_status</a>(
             &pool.asks,

--- a/crates/sui-framework/packages/deepbook/sources/clob_v2.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob_v2.move
@@ -2015,19 +2015,8 @@ module deepbook::clob_v2 {
 
         if (price_low < price_low_) price_low = price_low_;
         if (price_high > price_high_) price_high = price_high_;
-        let closest_low = critbit::find_closest_key(&pool.bids, price_low);
-        let closest_high = critbit::find_closest_key(&pool.bids, price_high);
-        if (price_low <= closest_low){
-            price_low = closest_low;
-        } else {
-            (price_low, _) = critbit::next_leaf(&pool.bids, closest_low);
-        };
-        if (price_high >= closest_high){
-            price_high = closest_high;
-        } else {
-            (price_high, _) = critbit::previous_leaf(&pool.bids, closest_high);
-        };
-
+        price_low = critbit::find_closest_key(&pool.bids, price_low);
+        price_high = critbit::find_closest_key(&pool.bids, price_high);
         while (price_low <= price_high) {
             let depth = get_level2_book_status(
                 &pool.bids,
@@ -2059,7 +2048,6 @@ module deepbook::clob_v2 {
         let mut depth_vec = vector::empty<u64>();
         if (critbit::is_empty(&pool.asks)) { return (price_vec, depth_vec) };
         let (price_low_, _) = critbit::min_leaf(&pool.asks);
-        let (price_high_, _) = critbit::max_leaf(&pool.asks);
 
         // Price_high is less than the lowest leaf in the tree then we return an empty array
         if (price_high < price_low_) {
@@ -2067,20 +2055,10 @@ module deepbook::clob_v2 {
         };
 
         if (price_low < price_low_) price_low = price_low_;
+        let (price_high_, _) = critbit::max_leaf(&pool.asks);
         if (price_high > price_high_) price_high = price_high_;
-        let closest_low = critbit::find_closest_key(&pool.asks, price_low);
-        let closest_high = critbit::find_closest_key(&pool.asks, price_high);
-        if (price_low <= closest_low){
-            price_low = closest_low;
-        } else {
-            (price_low, _) = critbit::next_leaf(&pool.bids, closest_low);
-        };
-        if (price_high >= closest_high){
-            price_high = closest_high;
-        } else {
-            (price_high, _) = critbit::previous_leaf(&pool.bids, closest_high);
-        };
-
+        price_low = critbit::find_closest_key(&pool.asks, price_low);
+        price_high = critbit::find_closest_key(&pool.asks, price_high);
         while (price_low <= price_high) {
             let depth = get_level2_book_status(
                 &pool.asks,

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x7a53da1ab16d36835d32fb0b9f069177850468627a0674f43ef00f219775bcbf"
+            id: "0xb8d73ba9ccd8bb489e48d086c6de65bf2e8a6dece2031c707b72e0572cbf2d6e"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xa35d51c60b50e3ea9a1d692d8232792bfc31311d0f536cca58a26f8bb2209066"
+      operation_cap_id: "0xc1181ab7b6bb7dc1b30fd32f6564f43c3f6aa0feb3512104ccfa98e440532680"
       gas_price: 1000
       staking_pool:
-        id: "0x0a7ab5fc2d76a32333b1dd2ccc6ae09a0da2d98309ca380aef1a929b6418ff2e"
+        id: "0x4a63f0211b727d8592b6d2160031db9b3fe3a33960e032cfc9147c4aa95b09e5"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xc8ac4858f8e089c75a9da2bb8adcde10a86c00aeec2e59124eb06e63be6b7d92"
+          id: "0x55c2fd5e205c8fd5e6e7d3ab6a392156b7745a2198251038ffe4a8e85053a997"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb4085c2be8191ebbdc037d5092657951e57d915641a8b5a15b98d7f8d8000193"
+            id: "0x91017aff3ea240e8fcbefa443ce586af86e608556b4ec0a0f0dbbc2237e05647"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x0b3692d645aeb8ced1102eb4a0b3d3b3953fc9b5b7ed1e6e1c585e215fd4ccff"
+          id: "0x97f87aaac2b10d78f23d794d86216bcde2b06a9df9fa95cbb837d8229ddeac8c"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x57b39c7a756ba502c74825ae434e53efa96a69a61da8136960b0095d572600a7"
+      id: "0x1ba124fd3adf6a91b6aa18bddf90ab0bdbcf316b2c094b5918cd8b1127bdf905"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xbe0e6b01a2855784335e17ffc04573d079f011d0b1d3ea1fb2851a47742fa9db"
+    id: "0x41887cfb01647aaf7c3a7a5a669045f9c199909f732877689cf8ad2b361d3ced"
     size: 1
   inactive_validators:
-    id: "0x82452941db36daa9f331fb77efa46dec22865e84578bfbdac397070da05ff800"
+    id: "0x266b63ede3ad70f386ba4adf0361f5343511f28c1fb53f909ec08c6da00ef5d2"
     size: 0
   validator_candidates:
-    id: "0xb51d5a837fcaa13b5a711f7a6492c0753d68d73aff97065828a8d499e9c28941"
+    id: "0x0ab769f5ef122b0de96f2aaaba5e6f6b7db49262da1320e689257700d79d42cf"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x2acd751e7c8905767be429469f5e41e3a2af7d96cc55491b0b6c98a6edb558b2"
+      id: "0xa3307b9009073cba91feef1fd3a54034f22c06af073b05be805ddfa0c4d30b6b"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x69219e53cdee9d242c9e46b639100282eecd71458de1bc1cc70c46fd85672d02"
+      id: "0x96ecc44392bf72a7a88600d1cc244c5db2304058ec25d3382205b9f5b5df839f"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xf987d231a4d09efd784ff01da0a7ea8e0a3f5498b12f2b5ca547960a28bf89d2"
+      id: "0x5b3218cf443b067d23a8916b4df4e33369b0cecc269f10745c5991024c9cff6d"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x97a70561f28ea5c21824bbed837646e7dc08b9d0d16fad4f7d5c934fbbf8b89b"
+    id: "0xeb5cbe6f2cdf03fe71921cc754d555999e8caf567bd69eaaa0d877ee4f5e11e8"
   size: 0
-


### PR DESCRIPTION
## Description 

Reverting change to L2 accessor in Deepbook causing error for market makers.

## Test plan 

How did you test the new or updated feature?

Reverting changes, no testing needed.
## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Deepbook changes will be reverted
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: 
